### PR TITLE
feat: add HA token authentication for add-on

### DIFF
--- a/homeassistant-addon/README.md
+++ b/homeassistant-addon/README.md
@@ -25,6 +25,7 @@ AI assistant integration for Home Assistant via Model Context Protocol (MCP).
 backup_hint: normal
 port: 9583
 path: /mcp
+require_auth: false
 ```
 
 ### port
@@ -40,6 +41,42 @@ URL path for the MCP endpoint (default: /mcp).
 Example: `http://192.168.1.100:9583/mcp`
 
 **Security Note**: If your Home Assistant is accessible from the internet or untrusted networks, change the path to a secret value (e.g., `/my-secret-mcp-endpoint-8a7f3b2c`). The path acts as a shared secret - only those who know it can access the MCP server.
+
+### require_auth
+
+Enable Home Assistant token authentication (default: false).
+
+When enabled, clients must provide a valid Home Assistant long-lived access token via the `Authorization: Bearer <token>` header. The add-on validates tokens against the Home Assistant API.
+
+**Creating a Long-Lived Access Token:**
+
+1. In Home Assistant, go to your Profile → Security
+2. Scroll to "Long-Lived Access Tokens"
+3. Click "Create Token"
+4. Give it a name (e.g., "MCP Server")
+5. Copy the token immediately (you won't see it again)
+
+**Client Configuration Example (Claude Desktop):**
+
+```json
+{
+  "mcpServers": {
+    "home-assistant": {
+      "url": "http://homeassistant.local:9583/mcp",
+      "headers": {
+        "Authorization": "Bearer eyJhbGci...your-token-here"
+      }
+    }
+  }
+}
+```
+
+**Security Considerations:**
+
+- **Defense in Depth**: Combine with a secret path for additional security
+- **Token Management**: Tokens can be revoked in Home Assistant UI anytime
+- **Network Security**: Still recommended to keep the add-on on a trusted network
+- **Optional**: Leave disabled if your HA is only accessible on a secure local network
 
 ### backup_hint
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -23,10 +23,12 @@ options:
   backup_hint: "normal"
   port: 9583
   path: "/mcp"
+  require_auth: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   port: port
   path: str
+  require_auth: bool
 # Add-on exposes HTTP port for MCP communication
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -26,6 +26,7 @@ def main() -> int:
     backup_hint = "normal"  # default
     port = 9583  # default
     path = "/mcp"  # default
+    require_auth = False  # default
 
     if config_file.exists():
         try:
@@ -34,12 +35,14 @@ def main() -> int:
             backup_hint = config.get("backup_hint", "normal")
             port = config.get("port", 9583)
             path = config.get("path", "/mcp")
+            require_auth = config.get("require_auth", False)
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
 
     log_info(f"Backup hint mode: {backup_hint}")
     log_info(f"HTTP port: {port}")
     log_info(f"MCP path: {path}")
+    log_info(f"Require authentication: {require_auth}")
 
     # Set up environment for ha-mcp
     os.environ["HOMEASSISTANT_URL"] = "http://supervisor/core"
@@ -55,6 +58,13 @@ def main() -> int:
 
     log_info(f"Home Assistant URL: {os.environ['HOMEASSISTANT_URL']}")
     log_info("Authentication configured via Supervisor token")
+
+    # Configure MCP authentication if required
+    if require_auth:
+        log_info("MCP Authentication: ENABLED (HA token validation)")
+        os.environ["FASTMCP_SERVER_AUTH"] = "ha_mcp.auth.ha_token_verifier.HATokenVerifier"
+    else:
+        log_info("MCP Authentication: DISABLED (use secret path for security)")
     log_info(f"Launching ha-mcp in HTTP mode on 0.0.0.0:{port}{path}")
     log_info("")
     log_info("=" * 70)

--- a/src/ha_mcp/auth/__init__.py
+++ b/src/ha_mcp/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Home Assistant authentication for MCP server."""
+
+from ha_mcp.auth.ha_token_verifier import HATokenVerifier
+
+__all__ = ["HATokenVerifier"]

--- a/src/ha_mcp/auth/ha_token_verifier.py
+++ b/src/ha_mcp/auth/ha_token_verifier.py
@@ -1,0 +1,93 @@
+"""Home Assistant token verification for add-on authentication.
+
+This module provides token validation against Home Assistant's API
+using the Supervisor proxy. This only works when running as a Home Assistant add-on.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import httpx
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+if TYPE_CHECKING:
+    pass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HATokenVerifier(TokenVerifier):
+    """Validates Home Assistant long-lived access tokens.
+
+    This verifier works only in Home Assistant add-on context where
+    the Supervisor proxy is available at http://supervisor/core/api/.
+
+    Users provide their HA long-lived access token (created in Profile → Security),
+    and this verifier validates it against the Home Assistant API.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        required_scopes: list[str] | None = None,
+    ):
+        """Initialize the HA token verifier.
+
+        Args:
+            base_url: Ignored - add-on always uses http://supervisor/core/api/
+            required_scopes: Scopes required for all requests (currently unused)
+        """
+        super().__init__(base_url=base_url, required_scopes=required_scopes or [])
+
+        # Verify we're running in add-on context
+        if not os.getenv("SUPERVISOR_TOKEN"):
+            _LOGGER.warning(
+                "SUPERVISOR_TOKEN not found - HATokenVerifier only works in add-on context"
+            )
+
+        self.ha_api_url = "http://supervisor/core/api/"
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Verify a Home Assistant long-lived access token.
+
+        Args:
+            token: The HA long-lived access token to validate
+
+        Returns:
+            AccessToken if valid, None if invalid or expired
+
+        Note:
+            This makes a request to the Home Assistant API using the token.
+            If the API returns 200, the token is valid. If 401, it's invalid.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(
+                    self.ha_api_url,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                if resp.status_code == 200:
+                    _LOGGER.debug("Token validation successful")
+                    return AccessToken(
+                        token=token,
+                        client_id="ha-user",
+                        scopes=self.required_scopes,
+                    )
+                elif resp.status_code == 401:
+                    _LOGGER.warning("Token validation failed: invalid token")
+                    return None
+                else:
+                    _LOGGER.error(
+                        f"Token validation failed: unexpected status {resp.status_code}"
+                    )
+                    return None
+
+        except httpx.HTTPError as e:
+            _LOGGER.error(f"Token validation failed: {e}")
+            return None
+        except Exception as e:
+            _LOGGER.error(f"Unexpected error during token validation: {e}")
+            return None

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -54,6 +54,11 @@ class TestAddonStructure:
         assert config["options"]["path"] == "/mcp", "default path should be /mcp"
         assert "path" in config["schema"], "schema must include path field"
 
+        # Verify authentication configuration
+        assert "require_auth" in config["options"], "options must include require_auth field"
+        assert config["options"]["require_auth"] is False, "default require_auth should be false"
+        assert "require_auth" in config["schema"], "schema must include require_auth field"
+
         # Verify architectures (only 64-bit platforms supported by uv image)
         expected_archs = ["amd64", "aarch64"]
         assert all(arch in config["arch"] for arch in expected_archs)

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Home Assistant authentication."""

--- a/tests/auth/test_ha_token_verifier.py
+++ b/tests/auth/test_ha_token_verifier.py
@@ -1,0 +1,131 @@
+"""Tests for Home Assistant token verification."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ha_mcp.auth.ha_token_verifier import HATokenVerifier
+
+
+class TestHATokenVerifier:
+    """Test Home Assistant token verifier."""
+
+    @pytest.fixture
+    def mock_supervisor_token(self):
+        """Mock SUPERVISOR_TOKEN environment variable."""
+        with patch.dict(os.environ, {"SUPERVISOR_TOKEN": "mock-supervisor-token"}):
+            yield
+
+    @pytest.fixture
+    def verifier(self, mock_supervisor_token):
+        """Create a HATokenVerifier instance."""
+        return HATokenVerifier()
+
+    async def test_init_with_supervisor_token(self, mock_supervisor_token):
+        """Test initialization with SUPERVISOR_TOKEN present."""
+        verifier = HATokenVerifier()
+        assert verifier.ha_api_url == "http://supervisor/core/api/"
+        assert verifier.required_scopes == []
+
+    async def test_init_without_supervisor_token(self):
+        """Test initialization without SUPERVISOR_TOKEN (warning logged)."""
+        with patch.dict(os.environ, {}, clear=True):
+            verifier = HATokenVerifier()
+            assert verifier.ha_api_url == "http://supervisor/core/api/"
+
+    async def test_verify_token_valid(self, verifier):
+        """Test token verification with valid token."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("valid-token")
+
+        assert result is not None
+        assert result.client_id == "ha-user"
+        assert result.scopes == []
+
+        # Verify the API was called with correct headers
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert call_args[0][0] == "http://supervisor/core/api/"
+        assert call_args[1]["headers"]["Authorization"] == "Bearer valid-token"
+
+    async def test_verify_token_invalid(self, verifier):
+        """Test token verification with invalid token (401)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("invalid-token")
+
+        assert result is None
+
+    async def test_verify_token_unexpected_status(self, verifier):
+        """Test token verification with unexpected status code."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("some-token")
+
+        assert result is None
+
+    async def test_verify_token_network_error(self, verifier):
+        """Test token verification with network error."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.HTTPError("Connection failed"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("some-token")
+
+        assert result is None
+
+    async def test_verify_token_unexpected_exception(self, verifier):
+        """Test token verification with unexpected exception."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=Exception("Unexpected error"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("some-token")
+
+        assert result is None
+
+    async def test_verify_token_with_required_scopes(self, mock_supervisor_token):
+        """Test token verification with required scopes."""
+        verifier = HATokenVerifier(required_scopes=["read", "write"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await verifier.verify_token("valid-token")
+
+        assert result is not None
+        assert result.scopes == ["read", "write"]


### PR DESCRIPTION
## Summary

Adds optional Home Assistant token authentication to the add-on, enabling validation of HA long-lived access tokens against the Home Assistant API.

- Add `require_auth` configuration option (default: false) for backwards compatibility
- Implement `HATokenVerifier` that validates tokens via Supervisor proxy (add-on only)
- Users can create tokens in HA UI (Profile → Security) and revoke them anytime
- Supports defense-in-depth: combine token auth with secret path for additional security

## Test Plan

- [x] All 8 HATokenVerifier unit tests passing
- [x] Add-on structure tests updated and passing
- [x] Ruff linting clean
- [ ] Manual testing: Install add-on with `require_auth: true`
- [ ] Manual testing: Verify token validation works with valid HA token
- [ ] Manual testing: Verify invalid tokens are rejected

## Client Configuration Example

```json
{
  "mcpServers": {
    "home-assistant": {
      "url": "http://homeassistant.local:9583/mcp",
      "headers": {
        "Authorization": "Bearer eyJhbGci...your-ha-token"
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)