### PR TITLE
docs: add ha_deep_search tool to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 ### 🔍 Discover, Search and Query
 - **Fuzzy Entity Search**: Comprehensive search with similar words tolerance
+- **Deep Configuration Search**: Search within automation triggers, script sequences, and helper configurations
 - **AI-Optimized System Overview**: Complete system analysis showing entity counts, areas, and device status
 - **Intelligent Entity Matching**: Advanced search across all Home Assistant entities with partial name matching
 - **Template Evaluation**: Evaluate Home Assistant templates for dynamic data processing and calculations
@@ -301,6 +302,7 @@ claude mcp add-json home-assistant '{
 | Tool | Description | Example |
 |------|-------------|---------|
 | `ha_search_entities` | Comprehensive entity search with fuzzy matching | `ha_search_entities("lumiere salon")` |
+| `ha_deep_search` | Search within automation/script/helper configurations | `ha_deep_search("light.turn_on")` |
 | `ha_get_overview` | AI-optimized system overview with entity counts | `ha_get_overview()` |
 
 ### Core Home Assistant API Tools

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -10,6 +10,7 @@ This add-on enables AI assistants (Claude, ChatGPT, etc.) to control your Home A
 - **Zero Configuration** - Automatically discovers Home Assistant connection
 - **Secure by Default** - Auto-generated secret paths with 128-bit entropy
 - **Fuzzy Search** - Find entities even with typos
+- **Deep Search** - Search within automation triggers, script sequences, and helper configs
 - **Backup & Restore** - Safe configuration management
 
 Full features and documentation: https://github.com/homeassistant-ai/ha-mcp
@@ -265,6 +266,7 @@ The add-on provides 20+ MCP tools for controlling Home Assistant:
 
 ### Core Tools
 - `ha_search_entities` - Fuzzy entity search
+- `ha_deep_search` - Search within automation/script/helper configurations
 - `ha_get_overview` - System overview
 - `ha_get_state` - Entity state with details
 - `ha_call_service` - Universal service control


### PR DESCRIPTION
## Summary

Add missing documentation for the `ha_deep_search` tool introduced in PR #19.

This tool searches within automation triggers, script sequences, and helper configurations - not just entity names. It was accidentally omitted from the documentation when the feature was merged.

## Changes

- ✅ Add `ha_deep_search` to README.md Search & Discovery Tools table
- ✅ Add "Deep Configuration Search" to README.md features list  
- ✅ Add `ha_deep_search` to addon DOCS.md Core Tools section
- ✅ Add "Deep Search" to addon DOCS.md key features

## Impact

- Documentation only - no code changes
- Makes the `ha_deep_search` tool discoverable by users

🤖 Generated with [Claude Code](https://claude.com/claude-code)