### PR TITLE
fix: align add-on schema with HA docs

### DIFF
--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -23,22 +23,9 @@ image: "ghcr.io/homeassistant-ai/ha-mcp-addon-{arch}"
 # Options for user configuration
 options:
   backup_hint: "normal"
-  secret_path: ""
 schema:
-  backup_hint:
-    required: false
-    advanced: true
-    default: "normal"
-    description: "Controls when backups are suggested before operations."
-    options:
-      - "strong"
-      - "normal"
-      - "weak"
-      - "auto"
-  secret_path:
-    required: false
-    advanced: true
-    description: "Custom secret path (overrides auto-generated). Leave empty for auto-generation."
+  backup_hint: list(strong|normal|weak|auto)
+  secret_path: str?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -61,10 +61,10 @@ def get_or_create_secret_path(data_dir: Path, custom_path: str = "") -> str:
 
     # Generate new secret path
     new_path = generate_secret_path()
+    log_info("Generated new secret path with 128-bit entropy")
     try:
         data_dir.mkdir(parents=True, exist_ok=True)
         secret_file.write_text(new_path)
-        log_info(f"Generated new secret path with 128-bit entropy")
         return new_path
     except Exception as e:
         log_error(f"Failed to save secret path: {e}")

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -1,0 +1,9 @@
+---
+configuration:
+  backup_hint:
+    name: Backup hint
+    description: Controls when backup reminders are shown before risky operations.
+  secret_path:
+    name: Secret path override
+    description: |
+      Optional custom HTTP path for the MCP server. Leave empty to use the auto-generated secure path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,8 @@ ha-mcp = "ha_mcp.__main__:main"
 hamcp-test-env = "tests.test_env_manager:main"
 
 [tool.setuptools]
-packages = ["ha_mcp"]
-
-[tool.setuptools.package-dir]
-ha_mcp = "src/ha_mcp"
+package-dir = {"" = "src"}
+packages = { find = { where = ["src"], include = ["ha_mcp*"] } }
 
 [tool.setuptools.package-data]
 ha_mcp = ["py.typed"]

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -58,14 +58,18 @@ class TestAddonStructure:
         assert "ports" in config, "ports section required for HTTP transport"
         assert "9583/tcp" in config["ports"], "port 9583/tcp must be exposed"
 
-        # Verify secret_path configuration (advanced option for custom overrides)
-        assert "secret_path" in config["options"], "options must include secret_path field"
-        assert config["options"]["secret_path"] == "", "default secret_path should be empty (auto-generate)"
+        # Verify secret_path configuration (optional advanced override)
+        assert "secret_path" not in config["options"], \
+            "secret_path should be optional and omitted so Supervisor treats it as advanced"
         assert "secret_path" in config["schema"], "schema must include secret_path field"
+        assert config["schema"]["secret_path"] == "str?", \
+            "secret_path schema should be optional string (str?)"
 
         # Verify backup_hint configuration
         assert "backup_hint" in config["options"], "options must include backup_hint field"
         assert config["options"]["backup_hint"] == "normal", "default backup_hint should be normal"
+        assert config["schema"]["backup_hint"] == "list(strong|normal|weak|auto)", \
+            "backup_hint schema must enumerate allowed values"
 
         # Verify architectures (only 64-bit platforms supported by uv image)
         expected_archs = ["amd64", "aarch64"]

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "3.1.3"
+version = "3.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- align schema syntax with Supervisor expectations using list()/str? strings (per https://developers.home-assistant.io/docs/add-ons/configuration#options--schema)
- keep default backup_hint while dropping empty secret_path default so option remains optional
- teach packaging to include new client/tools subpackages and add translations/en.yaml so UI retains field descriptions; confirmed pattern via `gh search code "list(" --filename config.yaml --repo home-assistant/addons`

## Testing
- uv run pytest tests/addon
