### PR TITLE
Deduplicate dev dependency definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,22 +35,6 @@ dependencies = [
     "websockets>=12.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=5.0.0",
-    "black>=23.0.0",
-    "isort>=5.12.0",
-    "mypy>=1.5.0",
-    "ruff>=0.1.0",
-    "testcontainers>=4.13.0",
-    "pytest-xdist>=3.8.0",
-    "docker>=7.1.0",
-    "requests>=2.25.0",
-    "build>=1.2.2",
-]
-
 [project.urls]
 "Homepage" = "https://github.com/homeassistant-ai/ha-mcp"
 "Bug Tracker" = "https://github.com/homeassistant-ai/ha-mcp/issues"
@@ -174,15 +158,19 @@ asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [
+    "black>=23.0.0",
+    "build>=1.2.2",
     "docker>=7.1.0",
+    "isort>=5.12.0",
     "mypy>=1.17.0",
     "psutil>=7.0.0",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.1.0",
+    "pytest-cov>=5.0.0",
     "pytest-xdist>=3.8.0",
+    "requests>=2.25.0",
     "ruff>=0.12.12",
     "testcontainers>=4.13.0",
-    "build>=1.2.2",
 ]
 
 # Semantic versioning configuration


### PR DESCRIPTION
## Summary
- remove the duplicated dev optional-dependency block from `pyproject.toml`
- consolidate the remaining development tools into the `dependency-groups.dev` list used by uv

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd426ca490832ca08e7ba1b98f9382