### PR TITLE
docs: clarify manual branch testing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ claude mcp add-json home-assistant '{
 > **Windows users:** Follow the [Windows UV setup guide](docs/Windows-uv-guide.md)
 
 **Prerequisites:**
-- [UV package manager](https://docs.astral.sh/uv/getting-started/installation/) and [Git binary](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-  - Windows: winget install astral-sh.uv Git.Git -e
-  - MacOS: brew install git uv
+- [UV package manager](https://docs.astral.sh/uv/getting-started/installation/)
+  - Windows: winget install astral-sh.uv -e
+  - MacOS: brew install uv
 - Your Home assistant URL (ex: http://localhost:8123) for HOMEASSISTANT_URL variable
 - A Home Assistant long-lived access token (Profile → Security → Long-Lived Access Tokens) for HOMEASSISTANT_TOKEN variable
 
@@ -209,7 +209,7 @@ claude mcp add-json home-assistant '{
   "mcpServers": {
     "Home Assistant": {
       "command": "uvx",
-      "args": ["--from=git+https://github.com/homeassistant-ai/ha-mcp", "ha-mcp"],
+      "args": ["ha-mcp"],
       "env": {
         "HOMEASSISTANT_URL": "http://localhost:8123",
         "HOMEASSISTANT_TOKEN": "your_long_lived_token"
@@ -229,7 +229,7 @@ Note: replace both HOMEASSISTANT_URL and HOMEASSISTANT_TOKEN with your values.
 claude mcp add --transport stdio home-assistant \
   --env HOMEASSISTANT_URL=http://localhost:8123 \
   --env HOMEASSISTANT_TOKEN=your_long_lived_token \
-  -- uvx --from=git+https://github.com/homeassistant-ai/ha-mcp ha-mcp
+  -- uvx ha-mcp
 ```
 
 </details>
@@ -245,7 +245,7 @@ set HOMEASSISTANT_URL=http://localhost:8123
 set HOMEASSISTANT_TOKEN=your_long_lived_token
 set MCP_PORT=8086
 set MCP_SECRET_PATH=/__my_secret__
-uvx --from=git+https://github.com/homeassistant-ai/ha-mcp ha-mcp-web
+uvx --from ha-mcp ha-mcp-web
 ```
 Others:
 ```bash
@@ -253,7 +253,7 @@ export HOMEASSISTANT_URL=http://localhost:8123
 export HOMEASSISTANT_TOKEN=your_long_lived_token
 export MCP_PORT=8086
 export MCP_SECRET_PATH=/__my_secret__
-uvx --from=git+https://github.com/homeassistant-ai/ha-mcp ha-mcp-web
+uvx --from ha-mcp ha-mcp-web
 ```
 
 Web client required https and a public URL. You need to use a proxy in front of `http://localhost:8086`.

--- a/docs/Windows-uv-guide.md
+++ b/docs/Windows-uv-guide.md
@@ -4,12 +4,12 @@ _Based on steps shared by @kingbear2._
 
 This guide walks through running the ha-mcp server locally on Windows with Claude using the [uv](https://docs.astral.sh/uv/) package manager. Expect the process to take about 10 minutes.
 
-## 1. Install uv and git
+## 1. Install uv
 
 Open **PowerShell** or **cmd** and run:
 
 ```powershell
-winget install astral-sh.uv Git.Git -e
+winget install astral-sh.uv -e
 ```
 
 ## 2. Configure Claude Desktop
@@ -22,7 +22,7 @@ winget install astral-sh.uv Git.Git -e
       "mcpServers": {
         "Home Assistant": {
           "command": "uvx",
-          "args": ["--from=git+https://github.com/homeassistant-ai/ha-mcp", "ha-mcp"],
+          "args": ["ha-mcp"],
           "env": {
             "HOMEASSISTANT_URL": "http://homeassistant.local:8123",
             "HOMEASSISTANT_TOKEN": "your_long_lived_token"

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,28 @@ uv run pytest tests/src/e2e/basic/ -v               # Basic connectivity
 uv run pytest tests/src/e2e/workflows/automation/ -v # Automation tests
 ```
 
+### Manual Branch Testing
+
+Need to validate unpublished changes from a feature branch? Use `uvx` with the
+Git URL so you can run the project directly from that branch:
+
+```bash
+# FastMCP STDIO entry point
+uvx --from git+https://github.com/homeassistant-ai/ha-mcp.git@branchname ha-mcp
+
+# FastMCP HTTP server
+uvx --from git+https://github.com/homeassistant-ai/ha-mcp.git@branchname ha-mcp-web
+```
+
+Replace `branchname` with the branch you want to exercise (for example,
+`feature/manual-test-instructions`). If you are working from a fork, swap
+`homeassistant-ai` with your GitHub username to target your repository in both
+commands. When using these commands, adapt the corresponding `uvx` setup in
+[README.md → Method 3: Running Python with UV](../README.md#method-3-running-python-with-uv)
+so your environment variables and client configuration match the guidance in the
+main installation instructions. This ensures your manual testing matches the
+code under review.
+
 ## 📁 Structure
 
 ```


### PR DESCRIPTION
## Summary
- clarify that the manual branch command for `ha-mcp` runs the STDIO entry point
- remind contributors to align their manual testing setup with the README Method 3 instructions when using git-based uvx commands

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_690bec3da2b4832c9bc49065e0301c1a