### PR TITLE
fix(ci): gate codex autofix workflow via mode

### DIFF
--- a/.github/workflows/pr-codex-autofix.yml
+++ b/.github/workflows/pr-codex-autofix.yml
@@ -6,14 +6,13 @@ on:
     types: [completed]
 
 env:
-  WORKFLOW_ENABLED: 'false'
   CODEX_AUTOFIX_MODE: ${{ vars.CODEX_AUTOFIX_MODE || 'async' }}
 
 jobs:
   enqueue-async-worker:
     if: >
       ${{
-        env.WORKFLOW_ENABLED == 'true' &&
+        !(env.CODEX_AUTOFIX_MODE == 'disabled') &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.head_repository.id == github.repository_id &&
         env.CODEX_AUTOFIX_MODE == 'async'
@@ -109,7 +108,7 @@ jobs:
   summarize-pr-context:
     if: >
       ${{
-        env.WORKFLOW_ENABLED == 'true' &&
+        !(env.CODEX_AUTOFIX_MODE == 'disabled') &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.head_repository.id == github.repository_id &&
         env.CODEX_AUTOFIX_MODE == 'sync'
@@ -132,7 +131,7 @@ jobs:
 
   auto-fix:
     needs: summarize-pr-context
-    if: ${{ env.WORKFLOW_ENABLED == 'true' && needs.summarize-pr-context.result == 'success' }}
+    if: ${{ !(env.CODEX_AUTOFIX_MODE == 'disabled') && needs.summarize-pr-context.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- remove the WORKFLOW_ENABLED flag from the PR Codex autofix workflow
- gate the async and sync jobs when `CODEX_AUTOFIX_MODE` is set to `disabled`

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690bf95c8bf8832c8910e1b883581457)