### PR TITLE
Fix release manifest validation workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -163,21 +163,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --quiet jsonschema
-          python - <<'PY'
-          import json
-          import urllib.request
-          from jsonschema import validate
-
-          schema_url = "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json"
-          with urllib.request.urlopen(schema_url) as resp:
-              schema = json.load(resp)
-
-          with open("server.json", "r", encoding="utf-8") as fh:
-              data = json.load(fh)
-
-          validate(instance=data, schema=schema)
-          print("server.json schema validation succeeded")
-          PY
+          python scripts/validate_server_manifest.py server.json
 
       - name: Login to MCP Registry
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}

--- a/scripts/validate_server_manifest.py
+++ b/scripts/validate_server_manifest.py
@@ -1,0 +1,48 @@
+"""Validate MCP server manifest against the published JSON schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+from jsonschema import validate
+
+
+SCHEMA_URL = "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json"
+
+
+def fetch_schema(url: str) -> dict:
+    """Fetch the JSON schema from the provided URL."""
+    with urllib.request.urlopen(url) as response:  # type: ignore[arg-type]
+        return json.load(response)
+
+
+def load_manifest(path: Path) -> dict:
+    """Load a local JSON manifest file."""
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="Path to the server manifest JSON file")
+    parser.add_argument(
+        "--schema-url",
+        default=SCHEMA_URL,
+        help="URL for the MCP server manifest JSON schema (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    schema = fetch_schema(args.schema_url)
+    manifest = load_manifest(args.manifest)
+
+    validate(instance=manifest, schema=schema)
+    print("server.json schema validation succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable script to validate the MCP server manifest against the published schema
- update the release-publish workflow to invoke the script instead of embedding a heredoc block

## Testing
- python scripts/validate_server_manifest.py server.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fe6b35f30832caaaddd9c8393ee86)