### PR TITLE
fix(docs): add missing --transport flag for mcp-proxy in add-on docs

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -69,7 +69,7 @@ Then add to your Claude Desktop configuration file:
   "mcpServers": {
     "home-assistant": {
       "command": "mcp-proxy",
-      "args": ["http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw"]
+      "args": ["--transport", "streamablehttp", "http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw"]
     }
   }
 }
@@ -79,7 +79,7 @@ Replace the URL in `args` with the one from your add-on logs.
 
 **Restart Claude Desktop** after saving the configuration.
 
-**How it works:** mcp-proxy converts the HTTP/SSE endpoint to stdio that Claude Desktop can use.
+**How it works:** mcp-proxy converts the HTTP endpoint to stdio that Claude Desktop can use.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Add `--transport streamablehttp` flag to mcp-proxy configuration example in add-on DOCS.md
- Fix misleading "HTTP/SSE" text to just "HTTP"

The add-on uses `streamable-http` transport, but the Claude Desktop configuration was missing the transport flag. Since mcp-proxy defaults to SSE, users were getting 400 Bad Request errors.

Fixes #93

## Test plan
- [ ] Verify the updated mcp-proxy command works with the add-on

🤖 Generated with [Claude Code](https://claude.com/claude-code)