### PR TITLE
fix(ci): add explicit permissions to prepare job

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,6 +16,8 @@ jobs:
   prepare:
     name: Prepare release metadata
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- Add `contents: read` permission to the `prepare` job in release-publish workflow
- Fixes CodeQL alert #18 about missing workflow permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)