### PR TITLE
fix: add pagination and limit to logbook tool to prevent oversized responses

### DIFF
--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -61,6 +61,9 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         effective_limit = limit if limit is not None else DEFAULT_LOGBOOK_LIMIT
         effective_limit = max(1, min(effective_limit, MAX_LOGBOOK_LIMIT))
 
+        # Ensure offset is non-negative
+        offset = max(0, offset)
+
         # Calculate start time
         if end_time:
             end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))

--- a/tests/src/e2e/tools/test_logbook.py
+++ b/tests/src/e2e/tools/test_logbook.py
@@ -149,14 +149,11 @@ async def test_logbook_pagination_with_offset(mcp_client):
 
     if first_entries and second_entries:
         # Compare first entry of each page - should be different
-        first_entry = first_entries[0] if first_entries else None
-        second_entry = second_entries[0] if second_entries else None
-
-        if first_entry and second_entry:
-            # Entries should be different
-            assert first_entry != second_entry, (
-                "First and second page should have different entries"
-            )
+        first_entry = first_entries[0]
+        second_entry = second_entries[0]
+        assert first_entry != second_entry, (
+            "First and second page should have different entries"
+        )
 
     logger.info(
         f"Pagination working: page 1 has {len(first_entries)} entries, "


### PR DESCRIPTION
## Summary
- Added default limit of 50 entries to logbook tool (configurable up to 500)
- Added `offset` parameter for pagination support
- Added `has_more` indicator and `pagination_hint` for multi-page navigation
- Response now includes `returned_entries`, `limit`, `offset`, and `has_more` metadata

## Test plan
- [x] Added comprehensive e2e tests in `tests/src/e2e/tools/test_logbook.py`
- [ ] CI tests pass
- [ ] Manual testing with large logbook queries

Closes #82

Generated with [Claude Code](https://claude.com/claude-code)