### PR TITLE
feat: Add label management tools

### DIFF
--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -12,6 +12,7 @@ from .tools_config_automations import register_config_automation_tools
 from .tools_config_dashboards import register_config_dashboard_tools
 from .tools_config_helpers import register_config_helper_tools
 from .tools_config_scripts import register_config_script_tools
+from .tools_labels import register_label_tools
 from .tools_search import register_search_tools
 from .tools_service import register_service_tools
 from .tools_utility import register_utility_tools
@@ -50,3 +51,6 @@ class ToolsRegistry:
 
         # Register backup tools
         register_backup_tools(self.mcp, self.client)
+
+        # Register label management tools
+        register_label_tools(self.mcp, self.client)

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -1,0 +1,400 @@
+"""
+Label management tools for Home Assistant.
+
+This module provides tools for listing, creating, updating, and deleting
+Home Assistant labels, as well as assigning labels to entities.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from .helpers import log_tool_usage
+from .util_helpers import parse_string_list_param
+
+logger = logging.getLogger(__name__)
+
+
+def register_label_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register Home Assistant label management tools."""
+
+    @mcp.tool(annotations={"readOnlyHint": True})
+    @log_tool_usage
+    async def ha_list_labels() -> dict[str, Any]:
+        """
+        List all Home Assistant labels with their configurations.
+
+        Returns complete configuration for all labels including:
+        - ID (label_id)
+        - Name
+        - Color (optional)
+        - Icon (optional)
+        - Description (optional)
+
+        Labels are a flexible tagging system in Home Assistant that can be used
+        to categorize and organize entities, devices, and areas.
+
+        EXAMPLES:
+        - List all labels: ha_list_labels()
+
+        Use ha_create_label() to create new labels.
+        Use ha_assign_label() to assign labels to entities.
+        """
+        try:
+            message: dict[str, Any] = {
+                "type": "config/label_registry/list",
+            }
+
+            result = await client.send_websocket_message(message)
+
+            if result.get("success"):
+                labels = result.get("result", [])
+                return {
+                    "success": True,
+                    "count": len(labels),
+                    "labels": labels,
+                    "message": f"Found {len(labels)} label(s)",
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": f"Failed to list labels: {result.get('error', 'Unknown error')}",
+                }
+
+        except Exception as e:
+            logger.error(f"Error listing labels: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to list labels: {str(e)}",
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify WebSocket connection is active",
+                ],
+            }
+
+    @mcp.tool
+    @log_tool_usage
+    async def ha_create_label(
+        name: Annotated[str, Field(description="Display name for the label")],
+        color: Annotated[
+            str | None,
+            Field(
+                description="Color for the label (e.g., 'red', 'blue', 'green', or hex like '#FF5733')",
+                default=None,
+            ),
+        ] = None,
+        icon: Annotated[
+            str | None,
+            Field(
+                description="Material Design Icon (e.g., 'mdi:tag', 'mdi:label')",
+                default=None,
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(
+                description="Description of the label's purpose",
+                default=None,
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        """
+        Create a new Home Assistant label.
+
+        Labels are a flexible tagging system that can be applied to entities,
+        devices, and areas for organization and automation purposes.
+
+        EXAMPLES:
+        - Create simple label: ha_create_label("Critical")
+        - Create colored label: ha_create_label("Outdoor", color="green")
+        - Create label with icon: ha_create_label("Battery Powered", icon="mdi:battery")
+        - Create full label: ha_create_label("Security", color="red", icon="mdi:shield", description="Security-related devices")
+
+        After creating a label, use ha_assign_label() to assign it to entities.
+        """
+        try:
+            message: dict[str, Any] = {
+                "type": "config/label_registry/create",
+                "name": name,
+            }
+
+            if color:
+                message["color"] = color
+            if icon:
+                message["icon"] = icon
+            if description:
+                message["description"] = description
+
+            result = await client.send_websocket_message(message)
+
+            if result.get("success"):
+                label_data = result.get("result", {})
+                return {
+                    "success": True,
+                    "label_id": label_data.get("label_id"),
+                    "label_data": label_data,
+                    "message": f"Successfully created label: {name}",
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": f"Failed to create label: {result.get('error', 'Unknown error')}",
+                    "name": name,
+                }
+
+        except Exception as e:
+            logger.error(f"Error creating label: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to create label: {str(e)}",
+                "name": name,
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify the label name is valid",
+                    "Check if a label with this name already exists",
+                ],
+            }
+
+    @mcp.tool
+    @log_tool_usage
+    async def ha_update_label(
+        label_id: Annotated[
+            str,
+            Field(description="ID of the label to update"),
+        ],
+        name: Annotated[
+            str | None,
+            Field(
+                description="New display name for the label",
+                default=None,
+            ),
+        ] = None,
+        color: Annotated[
+            str | None,
+            Field(
+                description="New color for the label (e.g., 'red', 'blue', or hex like '#FF5733')",
+                default=None,
+            ),
+        ] = None,
+        icon: Annotated[
+            str | None,
+            Field(
+                description="New Material Design Icon (e.g., 'mdi:tag', 'mdi:label')",
+                default=None,
+            ),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(
+                description="New description for the label",
+                default=None,
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        """
+        Update an existing Home Assistant label.
+
+        Updates the properties of a label. Only provided fields will be updated;
+        fields not specified will retain their current values.
+
+        EXAMPLES:
+        - Update name: ha_update_label("my_label_id", name="New Name")
+        - Update color: ha_update_label("my_label_id", color="blue")
+        - Update multiple: ha_update_label("my_label_id", name="Updated", icon="mdi:star", color="gold")
+
+        Use ha_list_labels() to find label IDs.
+        """
+        try:
+            # Check if at least one field to update is provided
+            if not any([name, color, icon, description]):
+                return {
+                    "success": False,
+                    "error": "At least one field (name, color, icon, or description) must be provided for update",
+                    "label_id": label_id,
+                }
+
+            message: dict[str, Any] = {
+                "type": "config/label_registry/update",
+                "label_id": label_id,
+            }
+
+            if name is not None:
+                message["name"] = name
+            if color is not None:
+                message["color"] = color
+            if icon is not None:
+                message["icon"] = icon
+            if description is not None:
+                message["description"] = description
+
+            result = await client.send_websocket_message(message)
+
+            if result.get("success"):
+                label_data = result.get("result", {})
+                return {
+                    "success": True,
+                    "label_id": label_id,
+                    "label_data": label_data,
+                    "message": f"Successfully updated label: {label_id}",
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": f"Failed to update label: {result.get('error', 'Unknown error')}",
+                    "label_id": label_id,
+                }
+
+        except Exception as e:
+            logger.error(f"Error updating label: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to update label: {str(e)}",
+                "label_id": label_id,
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify the label_id exists using ha_list_labels()",
+                ],
+            }
+
+    @mcp.tool
+    @log_tool_usage
+    async def ha_delete_label(
+        label_id: Annotated[
+            str,
+            Field(description="ID of the label to delete"),
+        ],
+    ) -> dict[str, Any]:
+        """
+        Delete a Home Assistant label.
+
+        Removes the label from the label registry. This will also remove the label
+        from all entities, devices, and areas that have it assigned.
+
+        EXAMPLES:
+        - Delete label: ha_delete_label("my_label_id")
+
+        Use ha_list_labels() to find label IDs.
+
+        **WARNING:** Deleting a label will remove it from all assigned entities.
+        This action cannot be undone.
+        """
+        try:
+            message: dict[str, Any] = {
+                "type": "config/label_registry/delete",
+                "label_id": label_id,
+            }
+
+            result = await client.send_websocket_message(message)
+
+            if result.get("success"):
+                return {
+                    "success": True,
+                    "label_id": label_id,
+                    "message": f"Successfully deleted label: {label_id}",
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": f"Failed to delete label: {result.get('error', 'Unknown error')}",
+                    "label_id": label_id,
+                }
+
+        except Exception as e:
+            logger.error(f"Error deleting label: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to delete label: {str(e)}",
+                "label_id": label_id,
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify the label_id exists using ha_list_labels()",
+                ],
+            }
+
+    @mcp.tool
+    @log_tool_usage
+    async def ha_assign_label(
+        entity_id: Annotated[
+            str,
+            Field(description="Entity ID to assign labels to (e.g., 'light.living_room')"),
+        ],
+        labels: Annotated[
+            str | list[str],
+            Field(
+                description="Label ID(s) to assign. Can be a single label ID string, "
+                "a list of label IDs, or a JSON array string (e.g., '[\"label1\", \"label2\"]')"
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """
+        Assign labels to an entity.
+
+        Sets the labels for an entity. This replaces any existing labels on the entity
+        with the provided list. To add to existing labels, first get the current labels
+        and include them in the new list.
+
+        EXAMPLES:
+        - Assign single label: ha_assign_label("light.bedroom", "critical")
+        - Assign multiple labels: ha_assign_label("light.bedroom", ["critical", "outdoor"])
+        - Clear all labels: ha_assign_label("light.bedroom", [])
+
+        Use ha_list_labels() to find available label IDs.
+        Use ha_search_entities() to find entity IDs.
+
+        **NOTE:** This sets the complete list of labels for the entity. Any labels
+        not included in the list will be removed from the entity.
+        """
+        try:
+            # Parse labels parameter - can be string, list, or JSON string
+            parsed_labels = parse_string_list_param(labels, "labels")
+
+            # Ensure we have a list
+            if parsed_labels is None:
+                parsed_labels = []
+            elif isinstance(parsed_labels, str):
+                parsed_labels = [parsed_labels]
+
+            message: dict[str, Any] = {
+                "type": "config/entity_registry/update",
+                "entity_id": entity_id,
+                "labels": parsed_labels,
+            }
+
+            result = await client.send_websocket_message(message)
+
+            if result.get("success"):
+                entity_entry = result.get("result", {}).get("entity_entry", {})
+                return {
+                    "success": True,
+                    "entity_id": entity_id,
+                    "labels": parsed_labels,
+                    "entity_data": entity_entry,
+                    "message": f"Successfully assigned {len(parsed_labels)} label(s) to {entity_id}",
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": f"Failed to assign labels: {result.get('error', 'Unknown error')}",
+                    "entity_id": entity_id,
+                    "labels": parsed_labels,
+                }
+
+        except ValueError as e:
+            return {
+                "success": False,
+                "error": f"Invalid labels parameter: {e}",
+                "entity_id": entity_id,
+            }
+        except Exception as e:
+            logger.error(f"Error assigning labels: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to assign labels: {str(e)}",
+                "entity_id": entity_id,
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify the entity_id exists using ha_search_entities()",
+                    "Verify the label IDs exist using ha_list_labels()",
+                ],
+            }

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -31,6 +31,7 @@ markers =
     device: device control tests
     script: script orchestration tests
     helper: helper integration tests
+    labels: label management tests
     convenience: convenience tools tests (scene, weather, energy, docs)
     error_handling: error handling and edge case tests
     cleanup: tests that create entities needing cleanup

--- a/tests/src/e2e/workflows/labels/__init__.py
+++ b/tests/src/e2e/workflows/labels/__init__.py
@@ -1,0 +1,1 @@
+"""Label management E2E tests."""

--- a/tests/src/e2e/workflows/labels/test_lifecycle.py
+++ b/tests/src/e2e/workflows/labels/test_lifecycle.py
@@ -1,0 +1,460 @@
+"""
+Label Lifecycle E2E Tests
+
+Tests the complete label workflow: Create -> Update -> Assign -> Delete
+This represents the critical user journey for Home Assistant label management.
+
+Note: Tests are designed to work with the Docker test environment.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from ...utilities.assertions import (
+    assert_mcp_success,
+    parse_mcp_result,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.labels
+@pytest.mark.cleanup
+class TestLabelLifecycle:
+    """Test complete label management workflows."""
+
+    async def _find_test_entity(self, mcp_client) -> str:
+        """
+        Find a suitable entity for testing label assignment.
+
+        Returns entity_id of a suitable entity for testing.
+        """
+        # Search for light entities (common and safe to modify)
+        search_result = await mcp_client.call_tool(
+            "ha_search_entities",
+            {"query": "light", "domain_filter": "light", "limit": 10},
+        )
+
+        search_data = parse_mcp_result(search_result)
+
+        # Handle nested data structure
+        if "data" in search_data:
+            results = search_data.get("data", {}).get("results", [])
+        else:
+            results = search_data.get("results", [])
+
+        if not results:
+            pytest.skip("No light entities available for testing")
+
+        # Prefer demo entities
+        for entity in results:
+            entity_id = entity.get("entity_id", "")
+            if "demo" in entity_id.lower() or "test" in entity_id.lower():
+                logger.info(f"Using demo/test entity: {entity_id}")
+                return entity_id
+
+        # Fall back to first available
+        entity_id = results[0].get("entity_id", "")
+        if not entity_id:
+            pytest.skip("No valid entity found for testing")
+
+        logger.info(f"Using first available entity: {entity_id}")
+        return entity_id
+
+    async def _cleanup_test_labels(self, mcp_client, label_ids: list[str]) -> None:
+        """Clean up test labels after test completion."""
+        for label_id in label_ids:
+            try:
+                await mcp_client.call_tool(
+                    "ha_delete_label",
+                    {"label_id": label_id},
+                )
+                logger.info(f"Cleaned up label: {label_id}")
+            except Exception as e:
+                logger.warning(f"Failed to cleanup label {label_id}: {e}")
+
+    async def test_basic_label_lifecycle(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create label -> List -> Update -> Delete
+
+        This test validates the fundamental label workflow that most
+        users will follow when organizing their Home Assistant setup.
+        """
+        created_label_ids = []
+
+        try:
+            # 1. LIST: Get initial label count
+            logger.info("Listing initial labels...")
+            list_result = await mcp_client.call_tool("ha_list_labels", {})
+            list_data = assert_mcp_success(list_result, "list labels")
+            initial_count = list_data.get("count", 0)
+            logger.info(f"Initial label count: {initial_count}")
+
+            # 2. CREATE: Create a new label
+            label_name = "E2E Test Label"
+            logger.info(f"Creating label: {label_name}")
+            create_result = await mcp_client.call_tool(
+                "ha_create_label",
+                {
+                    "name": label_name,
+                    "color": "blue",
+                    "icon": "mdi:test-tube",
+                    "description": "Label created by E2E test",
+                },
+            )
+
+            create_data = assert_mcp_success(create_result, "create label")
+            label_id = create_data.get("label_id")
+            assert label_id, "Label ID should be returned after creation"
+            created_label_ids.append(label_id)
+            logger.info(f"Created label with ID: {label_id}")
+
+            # 3. LIST: Verify label was created
+            await asyncio.sleep(1)  # Allow for propagation
+            list_result = await mcp_client.call_tool("ha_list_labels", {})
+            list_data = assert_mcp_success(list_result, "list labels after create")
+            new_count = list_data.get("count", 0)
+            assert new_count == initial_count + 1, (
+                f"Label count should increase by 1. Was {initial_count}, now {new_count}"
+            )
+
+            # Find our label in the list
+            labels = list_data.get("labels", [])
+            our_label = next(
+                (lbl for lbl in labels if lbl.get("label_id") == label_id), None
+            )
+            assert our_label, f"Created label {label_id} not found in label list"
+            assert our_label.get("name") == label_name, "Label name mismatch"
+            assert our_label.get("color") == "blue", "Label color mismatch"
+            assert our_label.get("icon") == "mdi:test-tube", "Label icon mismatch"
+            logger.info("Label verified in list")
+
+            # 4. UPDATE: Update the label
+            new_name = "E2E Test Label Updated"
+            logger.info(f"Updating label to: {new_name}")
+            update_result = await mcp_client.call_tool(
+                "ha_update_label",
+                {
+                    "label_id": label_id,
+                    "name": new_name,
+                    "color": "green",
+                    "icon": "mdi:star",
+                },
+            )
+
+            update_data = assert_mcp_success(update_result, "update label")
+            logger.info("Label updated successfully")
+
+            # 5. VERIFY: Check update was applied
+            await asyncio.sleep(1)
+            list_result = await mcp_client.call_tool("ha_list_labels", {})
+            list_data = assert_mcp_success(list_result, "list labels after update")
+            labels = list_data.get("labels", [])
+            our_label = next(
+                (lbl for lbl in labels if lbl.get("label_id") == label_id), None
+            )
+            assert our_label, f"Updated label {label_id} not found"
+            assert our_label.get("name") == new_name, "Updated name not reflected"
+            assert our_label.get("color") == "green", "Updated color not reflected"
+            assert our_label.get("icon") == "mdi:star", "Updated icon not reflected"
+            logger.info("Label update verified")
+
+            # 6. DELETE: Delete the label
+            logger.info(f"Deleting label: {label_id}")
+            delete_result = await mcp_client.call_tool(
+                "ha_delete_label",
+                {"label_id": label_id},
+            )
+
+            delete_data = assert_mcp_success(delete_result, "delete label")
+            created_label_ids.remove(label_id)  # Remove from cleanup list
+            logger.info("Label deleted successfully")
+
+            # 7. VERIFY: Label is gone
+            await asyncio.sleep(1)
+            list_result = await mcp_client.call_tool("ha_list_labels", {})
+            list_data = assert_mcp_success(list_result, "list labels after delete")
+            final_count = list_data.get("count", 0)
+            assert final_count == initial_count, (
+                f"Label count should return to {initial_count}, got {final_count}"
+            )
+
+            labels = list_data.get("labels", [])
+            our_label = next(
+                (lbl for lbl in labels if lbl.get("label_id") == label_id), None
+            )
+            assert our_label is None, f"Deleted label {label_id} still exists"
+            logger.info("Label deletion verified")
+
+        finally:
+            # Cleanup any remaining test labels
+            await self._cleanup_test_labels(mcp_client, created_label_ids)
+
+    async def test_label_assignment_to_entity(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create label -> Assign to entity -> Verify -> Clear assignment
+
+        This test validates the label assignment workflow for entities.
+        """
+        created_label_ids = []
+        test_entity = None
+
+        try:
+            # Find a test entity
+            test_entity = await self._find_test_entity(mcp_client)
+            logger.info(f"Using test entity: {test_entity}")
+
+            # 1. CREATE: Create a label for testing
+            label_name = "E2E Assignment Test"
+            logger.info(f"Creating label: {label_name}")
+            create_result = await mcp_client.call_tool(
+                "ha_create_label",
+                {
+                    "name": label_name,
+                    "color": "red",
+                    "icon": "mdi:tag",
+                },
+            )
+
+            create_data = assert_mcp_success(create_result, "create label")
+            label_id = create_data.get("label_id")
+            assert label_id, "Label ID should be returned"
+            created_label_ids.append(label_id)
+            logger.info(f"Created label: {label_id}")
+
+            # 2. ASSIGN: Assign label to entity
+            logger.info(f"Assigning label {label_id} to entity {test_entity}")
+            assign_result = await mcp_client.call_tool(
+                "ha_assign_label",
+                {
+                    "entity_id": test_entity,
+                    "labels": [label_id],
+                },
+            )
+
+            assign_data = assert_mcp_success(assign_result, "assign label")
+            logger.info("Label assigned successfully")
+
+            # 3. VERIFY: Check assignment in entity data
+            entity_data = assign_data.get("entity_data", {})
+            assigned_labels = entity_data.get("labels", [])
+            assert label_id in assigned_labels, (
+                f"Label {label_id} should be in entity labels. Got: {assigned_labels}"
+            )
+            logger.info("Label assignment verified")
+
+            # 4. CLEAR: Remove labels from entity
+            logger.info(f"Clearing labels from entity {test_entity}")
+            clear_result = await mcp_client.call_tool(
+                "ha_assign_label",
+                {
+                    "entity_id": test_entity,
+                    "labels": [],  # Empty list clears all labels
+                },
+            )
+
+            clear_data = assert_mcp_success(clear_result, "clear labels")
+            entity_data = clear_data.get("entity_data", {})
+            assigned_labels = entity_data.get("labels", [])
+            assert len(assigned_labels) == 0, (
+                f"Entity should have no labels. Got: {assigned_labels}"
+            )
+            logger.info("Labels cleared from entity")
+
+        finally:
+            # Cleanup test labels
+            await self._cleanup_test_labels(mcp_client, created_label_ids)
+
+    async def test_multiple_labels_assignment(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create multiple labels -> Assign all to entity -> Verify
+
+        This test validates assigning multiple labels at once.
+        """
+        created_label_ids = []
+        test_entity = None
+
+        try:
+            # Find a test entity
+            test_entity = await self._find_test_entity(mcp_client)
+            logger.info(f"Using test entity: {test_entity}")
+
+            # 1. CREATE: Create multiple labels
+            label_configs = [
+                {"name": "E2E Multi Label 1", "color": "red"},
+                {"name": "E2E Multi Label 2", "color": "green"},
+                {"name": "E2E Multi Label 3", "color": "blue"},
+            ]
+
+            for config in label_configs:
+                create_result = await mcp_client.call_tool(
+                    "ha_create_label",
+                    config,
+                )
+                create_data = assert_mcp_success(
+                    create_result, f"create label {config['name']}"
+                )
+                label_id = create_data.get("label_id")
+                created_label_ids.append(label_id)
+                logger.info(f"Created label: {label_id}")
+
+            # 2. ASSIGN: Assign all labels to entity
+            logger.info(f"Assigning {len(created_label_ids)} labels to {test_entity}")
+            assign_result = await mcp_client.call_tool(
+                "ha_assign_label",
+                {
+                    "entity_id": test_entity,
+                    "labels": created_label_ids,
+                },
+            )
+
+            assign_data = assert_mcp_success(assign_result, "assign multiple labels")
+            entity_data = assign_data.get("entity_data", {})
+            assigned_labels = entity_data.get("labels", [])
+
+            for label_id in created_label_ids:
+                assert label_id in assigned_labels, (
+                    f"Label {label_id} should be assigned. Got: {assigned_labels}"
+                )
+            logger.info(f"All {len(created_label_ids)} labels assigned successfully")
+
+            # 3. PARTIAL UPDATE: Replace with subset of labels
+            subset_labels = created_label_ids[:2]  # First two labels only
+            logger.info(f"Updating to subset of labels: {subset_labels}")
+            update_result = await mcp_client.call_tool(
+                "ha_assign_label",
+                {
+                    "entity_id": test_entity,
+                    "labels": subset_labels,
+                },
+            )
+
+            update_data = assert_mcp_success(update_result, "update labels subset")
+            entity_data = update_data.get("entity_data", {})
+            assigned_labels = entity_data.get("labels", [])
+
+            assert len(assigned_labels) == 2, (
+                f"Entity should have 2 labels. Got: {len(assigned_labels)}"
+            )
+            for label_id in subset_labels:
+                assert label_id in assigned_labels, (
+                    f"Label {label_id} should be assigned"
+                )
+            assert created_label_ids[2] not in assigned_labels, (
+                "Third label should be removed"
+            )
+            logger.info("Label subset update verified")
+
+            # 4. CLEAR: Clear all labels
+            await mcp_client.call_tool(
+                "ha_assign_label",
+                {
+                    "entity_id": test_entity,
+                    "labels": [],
+                },
+            )
+            logger.info("Labels cleared from entity")
+
+        finally:
+            # Cleanup test labels
+            await self._cleanup_test_labels(mcp_client, created_label_ids)
+
+
+@pytest.mark.labels
+class TestLabelValidation:
+    """Test label validation and error handling."""
+
+    async def test_update_nonexistent_label(self, mcp_client):
+        """Test updating a label that doesn't exist."""
+        logger.info("Testing update of nonexistent label...")
+
+        update_result = await mcp_client.call_tool(
+            "ha_update_label",
+            {
+                "label_id": "nonexistent_label_id_12345",
+                "name": "New Name",
+            },
+        )
+
+        update_data = parse_mcp_result(update_result)
+        assert not update_data.get("success"), (
+            "Updating nonexistent label should fail"
+        )
+        logger.info("Nonexistent label update correctly rejected")
+
+    async def test_delete_nonexistent_label(self, mcp_client):
+        """Test deleting a label that doesn't exist."""
+        logger.info("Testing delete of nonexistent label...")
+
+        delete_result = await mcp_client.call_tool(
+            "ha_delete_label",
+            {"label_id": "nonexistent_label_id_12345"},
+        )
+
+        delete_data = parse_mcp_result(delete_result)
+        assert not delete_data.get("success"), (
+            "Deleting nonexistent label should fail"
+        )
+        logger.info("Nonexistent label delete correctly rejected")
+
+    async def test_assign_to_nonexistent_entity(self, mcp_client):
+        """Test assigning label to entity that doesn't exist."""
+        logger.info("Testing assign to nonexistent entity...")
+
+        assign_result = await mcp_client.call_tool(
+            "ha_assign_label",
+            {
+                "entity_id": "light.nonexistent_entity_12345",
+                "labels": ["some_label"],
+            },
+        )
+
+        assign_data = parse_mcp_result(assign_result)
+        assert not assign_data.get("success"), (
+            "Assigning to nonexistent entity should fail"
+        )
+        logger.info("Nonexistent entity assignment correctly rejected")
+
+    async def test_update_without_changes(self, mcp_client):
+        """Test that update requires at least one field to change."""
+        logger.info("Testing update without any fields...")
+
+        update_result = await mcp_client.call_tool(
+            "ha_update_label",
+            {"label_id": "some_label"},
+        )
+
+        update_data = parse_mcp_result(update_result)
+        assert not update_data.get("success"), (
+            "Update without any fields should fail"
+        )
+        error_msg = str(update_data.get("error", "")).lower()
+        assert "at least one field" in error_msg or "must be provided" in error_msg, (
+            f"Error should mention missing fields. Got: {update_data.get('error')}"
+        )
+        logger.info("Update without fields correctly rejected")
+
+
+@pytest.mark.labels
+async def test_label_list_empty_state(mcp_client):
+    """
+    Test: List labels returns proper structure even when empty.
+
+    This is a basic sanity check that the list endpoint works.
+    """
+    logger.info("Testing label list...")
+
+    list_result = await mcp_client.call_tool("ha_list_labels", {})
+    list_data = assert_mcp_success(list_result, "list labels")
+
+    # Check structure
+    assert "count" in list_data, "Response should include count"
+    assert "labels" in list_data, "Response should include labels array"
+    assert isinstance(list_data["labels"], list), "Labels should be a list"
+    assert list_data["count"] == len(list_data["labels"]), (
+        "Count should match labels array length"
+    )
+
+    logger.info(f"Label list returned {list_data['count']} labels")


### PR DESCRIPTION
## Summary
- Adds 5 new MCP tools for managing Home Assistant labels:
  - `ha_list_labels`: List all labels with their configurations
  - `ha_create_label`: Create new labels with color, icon, description
  - `ha_update_label`: Update existing label properties  
  - `ha_delete_label`: Delete labels from the registry
  - `ha_assign_label`: Assign labels to entities

## Test plan
- [x] Created comprehensive E2E test suite (`tests/src/e2e/workflows/labels/test_lifecycle.py`)
- [x] Tests cover full label lifecycle (create -> update -> delete)
- [x] Tests cover label assignment to entities
- [x] Tests cover multiple label assignment
- [x] Tests cover error handling for invalid operations
- [x] All 8 tests pass locally
- [ ] Wait for CI to pass

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)