### PR TITLE
fix(deps): switch dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,8 +45,8 @@ updates:
       prefix: "ci"
       include: "scope"
 
-  # Update Python dependencies via pip (reads pyproject.toml)
-  - package-ecosystem: "pip"
+  # Update Python dependencies via uv (reads uv.lock)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Switch dependabot package-ecosystem from `pip` to `uv`
- Dependabot pip doesn't support `uv.lock`, resulting in no Python dependency updates
- Dependabot officially supports `uv` since [March 2025](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/)

This enables automatic updates for ~50 outdated dependencies including fastmcp, mcp, pydantic, and dev tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)