### PR TITLE
feat: add ha_get_automation_traces tool for debugging automations

### DIFF
--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -11,7 +11,6 @@ from .backup import register_backup_tools
 from .tools_areas import register_area_tools
 from .tools_blueprints import register_blueprint_tools
 from .tools_calendar import register_calendar_tools
-from .tools_traces import register_trace_tools
 from .tools_config_automations import register_config_automation_tools
 from .tools_config_dashboards import register_config_dashboard_tools
 from .tools_config_helpers import register_config_helper_tools
@@ -24,6 +23,7 @@ from .tools_service import register_service_tools
 from .tools_services import register_services_tools
 from .tools_system import register_system_tools
 from .tools_todo import register_todo_tools
+from .tools_traces import register_trace_tools
 from .tools_updates import register_update_tools
 from .tools_utility import register_utility_tools
 from .tools_zones import register_zone_tools

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -225,17 +225,17 @@ def _format_detailed_trace(
     # Extract trigger information
     trigger_trace = trace.get("trace", {}).get("trigger", [])
     if trigger_trace:
-        trigger_step = trigger_trace[0] if trigger_trace else {}
+        trigger_step = trigger_trace[0]
         trigger_vars = trigger_step.get("variables", {}).get("trigger", {})
         result["trigger"] = {
             "platform": trigger_vars.get("platform"),
             "description": trigger_vars.get("description"),
         }
-        # Add state change details if present
+        # Add state change details if present (use safe dictionary access)
         if "to_state" in trigger_vars:
-            result["trigger"]["to_state"] = trigger_vars["to_state"].get("state")
+            result["trigger"]["to_state"] = trigger_vars.get("to_state", {}).get("state")
         if "from_state" in trigger_vars:
-            result["trigger"]["from_state"] = trigger_vars["from_state"].get("state")
+            result["trigger"]["from_state"] = trigger_vars.get("from_state", {}).get("state")
         if "entity_id" in trigger_vars:
             result["trigger"]["entity_id"] = trigger_vars["entity_id"]
 


### PR DESCRIPTION
## Summary

- Adds new `ha_get_automation_traces` MCP tool for retrieving execution traces from Home Assistant
- Uses WebSocket API (`trace/list` and `trace/get` commands) for real-time trace access
- Supports both automations and scripts (via entity_id prefix detection)
- Provides two modes: list recent traces (summary) or get detailed trace (full execution info)

## Features

The tool helps debug common automation issues by providing visibility into:
- What triggered the automation
- Which conditions passed or failed  
- What actions were executed and any errors
- Variable values during execution

## Usage Examples

List recent traces:
```python
ha_get_automation_traces("automation.motion_light")
```

Get detailed trace:
```python
ha_get_automation_traces("automation.motion_light", run_id="1705312800.123456")
```

## Test Plan

- [ ] Verify tool appears in MCP server tool list
- [ ] Test listing traces for an automation that has run
- [ ] Test retrieving detailed trace with run_id
- [ ] Test error handling for non-existent automation
- [ ] Test with scripts (script.* entity_id)

Closes #161

Generated with [Claude Code](https://claude.com/claude-code)