### PR TITLE
fix(build): include tests package for hamcp-test-env script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ ha-mcp-web = "ha_mcp.__main__:main_web"
 ha-mcp-sse = "ha_mcp.__main__:main_sse"
 
 [tool.setuptools]
-package-dir = {"" = "src"}
-packages = { find = { where = ["src"], include = ["ha_mcp*"] } }
+package-dir = {"" = "src", "tests" = "tests"}
+packages = { find = { where = ["src", "."], include = ["ha_mcp*", "tests"] } }
 
 [tool.setuptools.package-data]
 ha_mcp = ["py.typed"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.0.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Fixed `ModuleNotFoundError: No module named 'tests'` when running `uv run hamcp-test-env`
- Added `tests` package to setuptools package discovery in pyproject.toml

The `hamcp-test-env` entry point references `tests.test_env_manager:main` but the tests directory was not included in the package configuration.

## Test plan
- [x] Verified `uv run hamcp-test-env --help` works after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)