### PR TITLE
docs: update README and addon docs for new v4.x tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 ### 🔧 Manage
 - **Automations and Scripts**: Create, modify, delete, enable/disable, and trigger automations
 - **Helper Entities**: Manage input_boolean, input_number, input_select, input_text, input_datetime, input_button
+- **Groups**: Create and manage entity groups for batch control
 - **Dashboards**: Create, update, delete Lovelace dashboards with strategy support
 - **Areas and Floors**: Organize your smart home with areas and floor hierarchy
 - **Labels**: Create and assign labels to entities and areas
@@ -56,6 +57,14 @@
 - **Blueprints**: Import and manage automation/script blueprints
 - **Device Registry**: View and manage device information
 - **Backup and Restore**: Create fast local backups and restore with safety mechanisms
+- **Add-ons**: List installed and available add-ons (Supervisor only)
+
+### 📊 Monitor & Debug
+- **State History**: Query entity state changes over time with flexible time ranges
+- **Long-term Statistics**: Access sensor statistics for energy, climate, and other data
+- **Camera Snapshots**: Capture and retrieve images from camera entities
+- **Automation Traces**: Debug automations by viewing execution traces
+- **Zigbee/ZHA Devices**: Inspect ZHA devices with endpoints and cluster details
 
 ---
 
@@ -283,7 +292,7 @@ Use the public url provided and add your secret path like so `https://XYZ.tryclo
 
 ---
 
-## 🛠️ Available Tools (71 tools)
+## 🛠️ Available Tools (82 tools)
 
 <details>
 <summary><b>🔍 Search & Discovery (4 tools)</b></summary>
@@ -390,6 +399,16 @@ Use the public url provided and add your secret path like so `https://XYZ.tryclo
 </details>
 
 <details>
+<summary><b>👥 Groups (3 tools)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_config_list_groups` | List all entity groups |
+| `ha_config_set_group` | Create/update entity group |
+| `ha_config_remove_group` | Delete entity group |
+</details>
+
+<details>
 <summary><b>✅ Todo Lists (5 tools)</b></summary>
 
 | Tool | Description |
@@ -431,6 +450,49 @@ Use the public url provided and add your secret path like so `https://XYZ.tryclo
 | `ha_update_device` | Update device properties |
 | `ha_remove_device` | Remove device from registry |
 | `ha_rename_entity` | Rename entity ID |
+</details>
+
+<details>
+<summary><b>📡 ZHA & Integration Tools (2 tools)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_get_zha_devices` | List ZHA (Zigbee) devices with endpoints and clusters |
+| `ha_get_entity_integration_source` | Get integration source for any entity |
+</details>
+
+<details>
+<summary><b>🔌 Add-ons (2 tools)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_list_addons` | List installed add-ons (Supervisor only) |
+| `ha_list_available_addons` | List available add-ons from repositories |
+</details>
+
+<details>
+<summary><b>📷 Camera (1 tool)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_get_camera_image` | Capture and retrieve camera snapshot |
+</details>
+
+<details>
+<summary><b>📈 History & Statistics (2 tools)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_get_history` | Query entity state history with time range |
+| `ha_get_statistics` | Get long-term statistics for sensors |
+</details>
+
+<details>
+<summary><b>🐞 Automation Traces (1 tool)</b></summary>
+
+| Tool | Description |
+|------|-------------|
+| `ha_get_automation_traces` | Get execution traces for automation debugging |
 </details>
 
 <details>

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -4,7 +4,7 @@ AI assistant integration for Home Assistant via Model Context Protocol (MCP).
 
 ## About
 
-This add-on enables AI assistants (Claude, ChatGPT, etc.) to control your Home Assistant installation through the Model Context Protocol (MCP). It provides 70+ tools for device control, automation management, entity search, calendars, todo lists, dashboards, backup/restore, and system queries.
+This add-on enables AI assistants (Claude, ChatGPT, etc.) to control your Home Assistant installation through the Model Context Protocol (MCP). It provides 80+ tools for device control, automation management, entity search, calendars, todo lists, dashboards, backup/restore, history/statistics, camera snapshots, and system queries.
 
 **Key Features:**
 - **Zero Configuration** - Automatically discovers Home Assistant connection
@@ -262,7 +262,7 @@ If the add-on is slow or unresponsive:
 
 ## Available Tools
 
-The add-on provides 70+ MCP tools for controlling Home Assistant:
+The add-on provides 80+ MCP tools for controlling Home Assistant:
 
 ### Core Tools
 - `ha_search_entities` - Fuzzy entity search
@@ -276,6 +276,7 @@ The add-on provides 70+ MCP tools for controlling Home Assistant:
 - **Helpers**: `ha_config_list_helpers`, `ha_config_set_helper`, `ha_config_remove_helper`
 - **Scripts**: `ha_config_get_script`, `ha_config_set_script`, `ha_config_remove_script`
 - **Automations**: `ha_config_get_automation`, `ha_config_set_automation`, `ha_config_remove_automation`
+- **Groups**: `ha_config_list_groups`, `ha_config_set_group`, `ha_config_remove_group`
 - **Dashboards**: `ha_config_list_dashboards`, `ha_config_get_dashboard`, `ha_config_set_dashboard`, `ha_config_delete_dashboard`
 - **Areas & Floors**: `ha_config_list_areas`, `ha_config_set_area`, `ha_config_remove_area`, `ha_config_list_floors`, `ha_config_set_floor`, `ha_config_remove_floor`
 - **Labels**: `ha_config_list_labels`, `ha_config_set_label`, `ha_config_remove_label`, `ha_assign_label`
@@ -290,6 +291,20 @@ The add-on provides 70+ MCP tools for controlling Home Assistant:
 - `ha_get_operation_status` - Check operation status
 - `ha_list_devices`, `ha_get_device`, `ha_update_device`, `ha_remove_device`
 - `ha_rename_entity` - Rename entity ID
+
+### History & Monitoring
+- `ha_get_history` - Query entity state history with time ranges
+- `ha_get_statistics` - Long-term statistics for sensors (energy, climate, etc.)
+- `ha_get_automation_traces` - Execution traces for automation debugging
+- `ha_get_camera_image` - Capture camera snapshots
+
+### ZHA & Integration Tools
+- `ha_get_zha_devices` - List ZHA (Zigbee) devices with endpoints and clusters
+- `ha_get_entity_integration_source` - Get integration source for any entity
+
+### Add-ons (Supervisor only)
+- `ha_list_addons` - List installed add-ons
+- `ha_list_available_addons` - List available add-ons from repositories
 
 ### System & Updates
 - `ha_check_config`, `ha_restart`, `ha_reload_core`


### PR DESCRIPTION
## Summary
- Update tool count from 71 to 82 tools
- Add documentation for 11 new tools added in v4.1-v4.7 releases:
  - **Groups** (3 tools): `ha_config_list_groups`, `ha_config_set_group`, `ha_config_remove_group`
  - **ZHA & Integration Tools** (2 tools): `ha_get_zha_devices`, `ha_get_entity_integration_source`
  - **Add-ons** (2 tools): `ha_list_addons`, `ha_list_available_addons`
  - **Camera** (1 tool): `ha_get_camera_image`
  - **History & Statistics** (2 tools): `ha_get_history`, `ha_get_statistics`
  - **Automation Traces** (1 tool): `ha_get_automation_traces`
- Add new "Monitor & Debug" feature section in README
- Update addon DOCS.md with same tool additions

## Test plan
- [x] README.md updated with new tool sections
- [x] homeassistant-addon/DOCS.md updated with matching tool list
- [ ] Visual review of markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)