### PR TITLE
refactor: auto-discover tool modules to prevent merge conflicts

### DIFF
--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -349,13 +349,14 @@ async def restore_backup(
                 pass  # Ignore errors during cleanup
 
 
-def register_backup_tools(mcp: "FastMCP", client: HomeAssistantClient) -> None:
+def register_backup_tools(mcp: "FastMCP", client: HomeAssistantClient, **kwargs) -> None:
     """
     Register backup and restore tools with the MCP server.
 
     Args:
         mcp: FastMCP server instance
         client: Home Assistant REST client
+        **kwargs: Additional arguments (ignored, for auto-discovery compatibility)
     """
     # Generate dynamic backup description based on BACKUP_HINT config
     backup_hint_text = _get_backup_hint_text()

--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -1,37 +1,27 @@
 """
 Tools registry for Smart MCP Server - manages registration of all MCP tools.
 
-This module acts as an orchestrator, importing and coordinating tool registration
-from specialized modules.
+This module uses auto-discovery to find and register all tool modules.
+Adding a new tools module is simple:
+1. Create tools_*.py file with a register_*_tools(mcp, client, **kwargs) function
+2. The function will be auto-discovered and called during registration
+
+No changes to this file are needed when adding new tool modules!
 """
 
+import importlib
+import logging
+import pkgutil
+from pathlib import Path
 from typing import Any
 
-from .backup import register_backup_tools
-from .tools_addons import register_addon_tools
-from .tools_areas import register_area_tools
-from .tools_blueprints import register_blueprint_tools
-from .tools_calendar import register_calendar_tools
-from .tools_camera import register_camera_tools
-from .tools_config_automations import register_config_automation_tools
-from .tools_config_dashboards import register_config_dashboard_tools
-from .tools_config_helpers import register_config_helper_tools
-from .tools_config_scripts import register_config_script_tools
-from .tools_groups import register_group_tools
-from .tools_history import register_history_tools
-from .tools_integrations import register_integration_tools
-from .tools_labels import register_label_tools
-from .tools_registry import register_registry_tools
-from .tools_search import register_search_tools
-from .tools_service import register_service_tools
-from .tools_services import register_services_tools
-from .tools_system import register_system_tools
-from .tools_todo import register_todo_tools
-from .tools_traces import register_trace_tools
-from .tools_updates import register_update_tools
-from .tools_utility import register_utility_tools
-from .tools_zha import register_zha_tools
-from .tools_zones import register_zone_tools
+logger = logging.getLogger(__name__)
+
+# Modules that don't follow the tools_*.py naming convention
+# These are handled explicitly for backward compatibility
+EXPLICIT_MODULES = {
+    "backup": "register_backup_tools",
+}
 
 
 class ToolsRegistry:
@@ -45,72 +35,59 @@ class ToolsRegistry:
         self.device_tools = server.device_tools
 
     def register_all_tools(self) -> None:
-        """Register all tools with the MCP server."""
-        # Register search and discovery tools
-        register_search_tools(self.mcp, self.client, self.smart_tools)
+        """Register all tools with the MCP server using auto-discovery."""
+        # Build kwargs with all available dependencies
+        kwargs = {
+            "smart_tools": self.smart_tools,
+            "device_tools": self.device_tools,
+        }
 
-        # Register service call and operation monitoring tools
-        register_service_tools(self.mcp, self.client, self.device_tools)
+        registered_count = 0
 
-        # Register service discovery tools
-        register_services_tools(self.mcp, self.client)
+        # Auto-discover and register tools_*.py modules
+        package_path = Path(__file__).parent
+        for module_info in pkgutil.iter_modules([str(package_path)]):
+            module_name = module_info.name
 
-        # Register config management tools (helpers, scripts, automations, dashboards)
-        register_config_helper_tools(self.mcp, self.client)
-        register_config_script_tools(self.mcp, self.client)
-        register_config_automation_tools(self.mcp, self.client)
-        register_config_dashboard_tools(self.mcp, self.client)
+            # Skip non-tool modules
+            if not module_name.startswith("tools_"):
+                continue
 
-        # Register utility tools (logbook, templates, docs)
-        register_utility_tools(self.mcp, self.client)
+            # Skip the registry itself (tools_registry.py is entity/device registry tools)
+            # Note: tools_registry.py contains ha_list_devices, etc. - not this file
+            try:
+                module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
 
-        # Register history tools (state history, statistics)
-        register_history_tools(self.mcp, self.client)
+                # Find the register function (convention: register_*_tools)
+                register_func = None
+                for attr_name in dir(module):
+                    if attr_name.startswith("register_") and attr_name.endswith("_tools"):
+                        register_func = getattr(module, attr_name)
+                        break
 
-        # Register update management tools
-        register_update_tools(self.mcp, self.client)
+                if register_func:
+                    register_func(self.mcp, self.client, **kwargs)
+                    registered_count += 1
+                    logger.debug(f"Registered tools from {module_name}")
+                else:
+                    logger.warning(
+                        f"Module {module_name} has no register_*_tools function"
+                    )
 
-        # Register backup tools
-        register_backup_tools(self.mcp, self.client)
+            except Exception as e:
+                logger.error(f"Failed to register tools from {module_name}: {e}")
+                raise
 
-        # Register integration management tools
-        register_integration_tools(self.mcp, self.client)
+        # Register explicit modules (those not following tools_*.py convention)
+        for module_name, func_name in EXPLICIT_MODULES.items():
+            try:
+                module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
+                register_func = getattr(module, func_name)
+                register_func(self.mcp, self.client, **kwargs)
+                registered_count += 1
+                logger.debug(f"Registered tools from {module_name}")
+            except Exception as e:
+                logger.error(f"Failed to register tools from {module_name}: {e}")
+                raise
 
-        # Register system management tools (restart, reload, health)
-        register_system_tools(self.mcp, self.client)
-
-        # Register area and floor management tools
-        register_area_tools(self.mcp, self.client)
-
-        # Register entity and device registry tools
-        register_registry_tools(self.mcp, self.client)
-
-        # Register zone management tools
-        register_zone_tools(self.mcp, self.client)
-
-        # Register group management tools
-        register_group_tools(self.mcp, self.client)
-
-        # Register label management tools
-        register_label_tools(self.mcp, self.client)
-
-        # Register todo/shopping list tools
-        register_todo_tools(self.mcp, self.client)
-
-        # Register calendar tools
-        register_calendar_tools(self.mcp, self.client)
-
-        # Register blueprint tools
-        register_blueprint_tools(self.mcp, self.client)
-
-        # Register trace/debug tools
-        register_trace_tools(self.mcp, self.client)
-
-        # Register ZHA (Zigbee Home Automation) device detection tools
-        register_zha_tools(self.mcp, self.client)
-
-        # Register add-on management tools (Supervisor only)
-        register_addon_tools(self.mcp, self.client)
-
-        # Register camera tools
-        register_camera_tools(self.mcp, self.client)
+        logger.info(f"Auto-discovery registered tools from {registered_count} modules")

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -251,13 +251,14 @@ async def list_available_addons(
                 pass
 
 
-def register_addon_tools(mcp: Any, client: HomeAssistantClient) -> None:
+def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs) -> None:
     """
     Register add-on management tools with the MCP server.
 
     Args:
         mcp: FastMCP server instance
         client: Home Assistant REST client
+        **kwargs: Additional arguments (ignored, for auto-discovery compatibility)
     """
 
     @mcp.tool(annotations={"readOnlyHint": True})

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -12,8 +12,11 @@ from .helpers import log_tool_usage
 from .util_helpers import add_timezone_metadata, parse_string_list_param
 
 
-def register_search_tools(mcp, client, smart_tools, **kwargs):
+def register_search_tools(mcp, client, **kwargs):
     """Register search and discovery tools with the MCP server."""
+    smart_tools = kwargs.get("smart_tools")
+    if not smart_tools:
+        raise ValueError("smart_tools is required for search tools registration")
 
     @mcp.tool(annotations={"readOnlyHint": True})
     @log_tool_usage

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -4,15 +4,17 @@ Service call and device operation tools for Home Assistant MCP server.
 This module provides service execution and WebSocket-enabled operation monitoring tools.
 """
 
-from typing import Annotated, Any, cast
+from typing import Any, cast
 
-from pydantic import Field
 
 from .util_helpers import parse_json_param
 
 
-def register_service_tools(mcp, client, device_tools, **kwargs):
+def register_service_tools(mcp, client, **kwargs):
     """Register service call and operation monitoring tools with the MCP server."""
+    device_tools = kwargs.get("device_tools")
+    if not device_tools:
+        raise ValueError("device_tools is required for service tools registration")
 
     @mcp.tool
     async def ha_call_service(


### PR DESCRIPTION
## Summary
- Replace explicit imports and calls in registry.py with auto-discovery pattern
- Use `pkgutil.iter_modules` to find all `tools_*.py` modules dynamically
- Standardize all register functions to use `**kwargs` for uniform signatures

## Motivation
When multiple PRs add new tool modules simultaneously, they all need to modify `registry.py` (adding imports and register calls), causing merge conflicts. This is especially problematic with parallel development using git worktrees.

## How it works now
Adding a new tools module only requires:
1. Create `tools_*.py` with a `register_*_tools(mcp, client, **kwargs)` function
2. **No changes to registry.py needed!**

The registry auto-discovers modules using:
```python
for module_info in pkgutil.iter_modules([str(package_path)]):
    if module_name.startswith("tools_"):
        module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
        # Find and call register_*_tools function
```

## Changes
- `registry.py`: Replaced 25 explicit imports/calls with auto-discovery loop (88% rewrite)
- `tools_search.py`: Extract `smart_tools` from kwargs instead of positional arg
- `tools_service.py`: Extract `device_tools` from kwargs instead of positional arg
- `backup.py`, `tools_addons.py`: Added `**kwargs` for compatibility

## Test plan
- [x] Verified all 25 modules are discovered and validated
- [x] Linting passes (`ruff check`)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)