### PR TITLE
chore: add MCP tool annotations (readOnlyHint, destructiveHint)

### DIFF
--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -205,7 +205,7 @@ def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 error_response["name"] = name
             return error_response
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_area(
         area_id: Annotated[
@@ -428,7 +428,7 @@ def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 error_response["name"] = name
             return error_response
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_floor(
         floor_id: Annotated[

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -273,7 +273,7 @@ def register_calendar_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "suggestions": suggestions,
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_calendar_event(
         entity_id: Annotated[

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -221,7 +221,7 @@ def register_config_automation_tools(mcp: Any, client: Any, **kwargs: Any) -> No
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_automation(
         identifier: Annotated[

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -523,7 +523,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_delete_dashboard(
         dashboard_id: Annotated[

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -467,7 +467,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_helper(
         helper_type: Annotated[

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -198,7 +198,7 @@ def register_config_script_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_script(
         script_id: Annotated[

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -245,7 +245,7 @@ def register_group_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_group(
         object_id: Annotated[

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -244,7 +244,7 @@ def register_label_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_config_remove_label(
         label_id: Annotated[

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -495,7 +495,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "device_id": device_id,
             }
 
-    @mcp.tool()
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_remove_device(
         device_id: Annotated[

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -188,7 +188,7 @@ def register_service_tools(mcp, client, **kwargs):
                 },
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"readOnlyHint": True})
     async def ha_get_operation_status(
         operation_id: str, timeout_seconds: int = 10
     ) -> dict[str, Any]:
@@ -227,7 +227,7 @@ def register_service_tools(mcp, client, **kwargs):
         )
         return cast(dict[str, Any], result)
 
-    @mcp.tool
+    @mcp.tool(annotations={"readOnlyHint": True})
     async def ha_get_bulk_status(operation_ids: list[str]) -> dict[str, Any]:
         """Check status of multiple WebSocket-monitored operations."""
         result = await device_tools.get_bulk_operation_status(

--- a/src/ha_mcp/tools/tools_todo.py
+++ b/src/ha_mcp/tools/tools_todo.py
@@ -455,7 +455,7 @@ def register_todo_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_remove_todo_item(
         entity_id: Annotated[

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -298,7 +298,7 @@ def register_zone_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             }
 
-    @mcp.tool
+    @mcp.tool(annotations={"destructiveHint": True})
     @log_tool_usage
     async def ha_delete_zone(
         zone_id: Annotated[


### PR DESCRIPTION
## Summary
- Adds `readOnlyHint: True` annotation to 2 missing tools (ha_get_operation_status, ha_get_bulk_status)
- Adds `destructiveHint: True` annotation to all 13 delete/remove tools
- Ensures AI clients can properly identify read-only vs destructive operations

## Changes
**readOnlyHint added to:**
- `ha_get_operation_status`
- `ha_get_bulk_status`

**destructiveHint added to:**
- `ha_config_remove_area`, `ha_config_remove_floor`
- `ha_config_remove_calendar_event`
- `ha_config_remove_automation`
- `ha_config_delete_dashboard`
- `ha_config_remove_helper`
- `ha_config_remove_script`
- `ha_config_remove_group`
- `ha_config_remove_label`
- `ha_remove_todo_item`
- `ha_delete_zone`
- `ha_remove_device`

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)