### PR TITLE
fix: normalize automation config field names (trigger/triggers)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.7.1"
+version = "4.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Home Assistant YAML accepts both singular ('trigger', 'action', 'condition') and plural ('triggers', 'actions', 'conditions') field names
- AI assistants may provide either form, causing validation failures
- Adds normalization step that converts plural to singular before validation

## Test plan
- [ ] Test creating automation with plural field names (`triggers`, `actions`)
- [ ] Test creating automation with singular field names (`trigger`, `action`)
- [ ] Verify both forms work correctly

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)