### PR TITLE
fix: query area/entity registries for accurate area count in overview

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.7.1"
+version = "4.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- `ha_get_overview` was returning `total_areas: 0` because it looked for `area_id` in entity state attributes
- Home Assistant stores area assignments in the entity registry, not state attributes
- Now queries `config/area_registry/list` for total area count
- Now queries `config/entity_registry/list` for entity-to-area mappings

## Test plan
- [ ] Call `ha_get_overview()` and verify `total_areas` matches actual area count
- [ ] Verify `area_analysis` shows entities grouped by area
- [ ] Test with different detail levels

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)