### PR TITLE
fix: add error handling to ha_deep_search

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -347,8 +347,21 @@ def register_search_tools(mcp, client, **kwargs):
         """
         # Parse search_types to handle JSON string input from MCP clients
         parsed_search_types = parse_string_list_param(search_types, "search_types")
-        result = await smart_tools.deep_search(query, parsed_search_types, limit)
-        return cast(dict[str, Any], result)
+        try:
+            result = await smart_tools.deep_search(query, parsed_search_types, limit)
+            return cast(dict[str, Any], result)
+        except Exception as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "query": query,
+                "search_types": parsed_search_types,
+                "suggestions": [
+                    "Check Home Assistant connection",
+                    "Verify automation/script/helper configurations exist",
+                    "Try a simpler search query",
+                ],
+            }
 
     @mcp.tool(annotations={"idempotentHint": True, "readOnlyHint": True, "tags": ["search"], "title": "Get Entity State"})
     @log_tool_usage


### PR DESCRIPTION
## Summary
- Adds try/except wrapper around `smart_tools.deep_search()` call in `ha_deep_search` tool
- Returns structured error response with exception details and helpful suggestions when deep search fails
- Fixes intermittent execution failures where tool works on first call but fails on subsequent calls

Closes #209

## Test plan
- [ ] Verify normal deep search functionality still works
- [ ] Test error handling by inducing failure (e.g., connection issues)
- [ ] Confirm error response contains expected fields: success, error, query, search_types, suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)