### PR TITLE
fix: fetch Core release notes from GitHub releases API

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.7.4"
+version = "4.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Fixes ha_get_release_notes returning null for Home Assistant Core updates
- For Core update entities, fetches release notes directly from GitHub API using the version tag
- When release notes are unavailable, includes a helpful message with the release_url so users can view them manually

## Problem

The existing `ha_get_release_notes` function:
1. Tries WebSocket `update/release_notes` - returns null for Core
2. Falls back to parsing `release_url` as a GitHub URL - fails because Core uses blog URLs (`https://www.home-assistant.io/latest-release-notes/`)

## Solution

Added special handling for Home Assistant Core:
1. Detect Core entities by checking if `entity_id` contains "core"
2. Fetch release notes from: `https://api.github.com/repos/home-assistant/core/releases/tags/{version}`
3. Improved fallback message to include the release_url for manual viewing

## Test plan

- [ ] Verify with `ha_get_release_notes(entity_id="update.home_assistant_core_update")` returns release notes from GitHub API
- [ ] Verify other update entities (OS, add-ons) still work correctly
- [ ] Verify fallback message includes release_url when notes unavailable

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)