### PR TITLE
fix: resolve entity_id to unique_id for trace lookup

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.8.0"
+version = "4.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- **Root cause identified:** Home Assistant stores traces using the automation's `unique_id`, not the entity_id. Our code was using the object_id from entity_id (e.g., `plantes_chambre_cedule_10h_18h` from `automation.plantes_chambre_cedule_10h_18h`), which doesn't match when unique_id differs (common with UI-created automations).

- **Fix:** Added `_resolve_trace_item_id()` helper that queries the entity registry to resolve entity_id → unique_id before making trace API calls

- **Fallback:** If unique_id lookup fails (e.g., for YAML automations without explicit IDs), falls back to object_id for backwards compatibility

## Test plan

- [ ] Verify traces are returned for UI-created automations (where unique_id is a UUID)
- [ ] Verify traces still work for YAML automations (where unique_id may equal object_id)
- [ ] Verify fallback works when entity registry lookup fails

Fixes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)