### PR TITLE
feat: add graceful shutdown on SIGTERM/SIGINT signals

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1,7 +1,20 @@
 """Home Assistant MCP Server."""
 
+import asyncio
+import logging
 import os
+import signal
 import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Shutdown configuration
+SHUTDOWN_TIMEOUT_SECONDS = 2.0
+
+# Global shutdown state
+_shutdown_event: asyncio.Event | None = None
+_shutdown_in_progress = False
 
 
 def _create_server():
@@ -22,18 +35,145 @@ def _get_mcp():
     return _server.mcp
 
 
+def _get_server():
+    """Get the server instance, creating if needed."""
+    global _server
+    if _server is None:
+        _server = _create_server()
+    return _server
+
+
 # For module-level access (e.g., fastmcp.json referencing ha_mcp.__main__:mcp)
 # This is accessed when the module is imported, so we need deferred creation
 class _DeferredMCP:
     """Wrapper that defers MCP creation until actually accessed."""
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(_get_mcp(), name)
 
-    def run(self, *args, **kwargs):
+    def run(self, *args: Any, **kwargs: Any) -> None:
         return _get_mcp().run(*args, **kwargs)
 
 
 mcp = _DeferredMCP()
+
+
+async def _cleanup_resources() -> None:
+    """Clean up all server resources gracefully."""
+    global _server
+
+    logger.info("Cleaning up server resources...")
+
+    # Close WebSocket listener service if running
+    try:
+        from ha_mcp.client.websocket_listener import stop_websocket_listener
+        await stop_websocket_listener()
+        logger.debug("WebSocket listener stopped")
+    except Exception as e:
+        logger.debug(f"WebSocket listener cleanup: {e}")
+
+    # Close WebSocket manager connections
+    try:
+        from ha_mcp.client.websocket_client import websocket_manager
+        await websocket_manager.disconnect()
+        logger.debug("WebSocket manager disconnected")
+    except Exception as e:
+        logger.debug(f"WebSocket manager cleanup: {e}")
+
+    # Close the server's HTTP client
+    if _server is not None:
+        try:
+            await _server.close()
+            logger.debug("Server closed")
+        except Exception as e:
+            logger.debug(f"Server cleanup: {e}")
+
+    logger.info("Server resources cleaned up")
+
+
+def _signal_handler(signum: int, frame: Any) -> None:
+    """Handle shutdown signals (SIGTERM, SIGINT).
+
+    This handler initiates graceful shutdown on first signal.
+    On second signal, forces immediate exit.
+    """
+    global _shutdown_in_progress, _shutdown_event
+
+    sig_name = signal.Signals(signum).name
+
+    if _shutdown_in_progress:
+        # Second signal - force exit
+        logger.warning(f"Received {sig_name} again, forcing exit")
+        sys.exit(1)
+
+    _shutdown_in_progress = True
+    logger.info(f"Received {sig_name}, initiating graceful shutdown...")
+
+    # Signal the shutdown event if we have an event loop
+    if _shutdown_event is not None:
+        try:
+            loop = asyncio.get_running_loop()
+            loop.call_soon_threadsafe(_shutdown_event.set)
+        except RuntimeError:
+            # No running event loop, just exit
+            sys.exit(0)
+
+
+def _setup_signal_handlers() -> None:
+    """Set up signal handlers for graceful shutdown."""
+    # Register signal handlers
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+
+async def _run_with_graceful_shutdown() -> None:
+    """Run the MCP server with graceful shutdown support."""
+    global _shutdown_event
+
+    _shutdown_event = asyncio.Event()
+
+    # Create a task for the MCP server
+    server_task = asyncio.create_task(_get_mcp().run_async())
+
+    # Wait for either the server to complete or a shutdown signal
+    shutdown_task = asyncio.create_task(_shutdown_event.wait())
+
+    try:
+        done, pending = await asyncio.wait(
+            [server_task, shutdown_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # If shutdown was signaled, cancel the server task
+        if shutdown_task in done:
+            logger.info("Shutdown signal received, stopping server...")
+            server_task.cancel()
+            try:
+                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning("Server did not stop within timeout")
+            except asyncio.CancelledError:
+                pass
+
+    except asyncio.CancelledError:
+        logger.info("Server task cancelled")
+    finally:
+        # Clean up resources with timeout
+        try:
+            await asyncio.wait_for(
+                _cleanup_resources(),
+                timeout=SHUTDOWN_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            logger.warning("Resource cleanup timed out")
+
+        # Cancel any remaining tasks
+        for task in [server_task, shutdown_task]:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
 
 # CLI entry point (for pyproject.toml) - use FastMCP's built-in runner
@@ -44,7 +184,22 @@ def main() -> None:
         from ha_mcp.smoke_test import main as smoke_test_main
         sys.exit(smoke_test_main())
 
-    _get_mcp().run()
+    # Set up signal handlers before running
+    _setup_signal_handlers()
+
+    # Run with graceful shutdown support
+    try:
+        asyncio.run(_run_with_graceful_shutdown())
+    except KeyboardInterrupt:
+        # Handle case where KeyboardInterrupt is raised before our handler
+        logger.info("Interrupted, exiting")
+    except SystemExit:
+        raise
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        sys.exit(1)
+
+    sys.exit(0)
 
 
 # HTTP entry point for web clients
@@ -56,6 +211,97 @@ def _get_http_runtime() -> tuple[int, str]:
     return port, path
 
 
+async def _run_http_with_graceful_shutdown(
+    transport: str,
+    host: str,
+    port: int,
+    path: str,
+) -> None:
+    """Run HTTP server with graceful shutdown support."""
+    global _shutdown_event
+
+    _shutdown_event = asyncio.Event()
+
+    # Create a task for the MCP server
+    server_task = asyncio.create_task(
+        _get_mcp().run_async(
+            transport=transport,
+            host=host,
+            port=port,
+            path=path,
+        )
+    )
+
+    # Wait for either the server to complete or a shutdown signal
+    shutdown_task = asyncio.create_task(_shutdown_event.wait())
+
+    try:
+        done, pending = await asyncio.wait(
+            [server_task, shutdown_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        # If shutdown was signaled, cancel the server task
+        if shutdown_task in done:
+            logger.info("Shutdown signal received, stopping HTTP server...")
+            server_task.cancel()
+            try:
+                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning("HTTP server did not stop within timeout")
+            except asyncio.CancelledError:
+                pass
+
+    except asyncio.CancelledError:
+        logger.info("HTTP server task cancelled")
+    finally:
+        # Clean up resources with timeout
+        try:
+            await asyncio.wait_for(
+                _cleanup_resources(),
+                timeout=SHUTDOWN_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            logger.warning("Resource cleanup timed out")
+
+        # Cancel any remaining tasks
+        for task in [server_task, shutdown_task]:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+
+def _run_http_server(transport: str) -> None:
+    """Common runner for HTTP-based transports."""
+    port, path = _get_http_runtime()
+
+    # Set up signal handlers before running
+    _setup_signal_handlers()
+
+    # Run with graceful shutdown support
+    try:
+        asyncio.run(
+            _run_http_with_graceful_shutdown(
+                transport=transport,
+                host="0.0.0.0",
+                port=port,
+                path=path,
+            )
+        )
+    except KeyboardInterrupt:
+        logger.info("Interrupted, exiting")
+    except SystemExit:
+        raise
+    except Exception as e:
+        logger.error(f"HTTP server error: {e}")
+        sys.exit(1)
+
+    sys.exit(0)
+
+
 def main_web() -> None:
     """Run server over HTTP for web-capable MCP clients.
 
@@ -65,15 +311,7 @@ def main_web() -> None:
     - MCP_PORT (optional, default: 8086)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
-
-    port, path = _get_http_runtime()
-
-    mcp.run(
-        transport="streamable-http",
-        host="0.0.0.0",
-        port=port,
-        path=path,
-    )
+    _run_http_server("streamable-http")
 
 
 def main_sse() -> None:
@@ -85,15 +323,7 @@ def main_sse() -> None:
     - MCP_PORT (optional, default: 8086)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
-
-    port, path = _get_http_runtime()
-
-    mcp.run(
-        transport="sse",
-        host="0.0.0.0",
-        port=port,
-        path=path,
-    )
+    _run_http_server("sse")
 
 
 if __name__ == "__main__":

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -1,0 +1,365 @@
+"""Unit tests for graceful shutdown signal handling.
+
+These tests verify that the server properly handles SIGTERM and SIGINT signals,
+exiting cleanly within the expected timeout period.
+"""
+
+import asyncio
+import os
+import signal
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestSignalHandlerSetup:
+    """Tests for signal handler registration."""
+
+    def test_setup_signal_handlers_registers_sigterm(self):
+        """Signal handlers should register SIGTERM handler."""
+        from ha_mcp.__main__ import _setup_signal_handlers, _signal_handler
+
+        with patch("signal.signal") as mock_signal:
+            _setup_signal_handlers()
+            # Check that SIGTERM handler was registered
+            calls = [call for call in mock_signal.call_args_list if call[0][0] == signal.SIGTERM]
+            assert len(calls) == 1
+            assert calls[0][0][1] == _signal_handler
+
+    def test_setup_signal_handlers_registers_sigint(self):
+        """Signal handlers should register SIGINT handler."""
+        from ha_mcp.__main__ import _setup_signal_handlers, _signal_handler
+
+        with patch("signal.signal") as mock_signal:
+            _setup_signal_handlers()
+            # Check that SIGINT handler was registered
+            calls = [call for call in mock_signal.call_args_list if call[0][0] == signal.SIGINT]
+            assert len(calls) == 1
+            assert calls[0][0][1] == _signal_handler
+
+
+class TestSignalHandler:
+    """Tests for the signal handler function."""
+
+    def test_first_signal_sets_shutdown_in_progress(self):
+        """First signal should set shutdown_in_progress flag."""
+        import ha_mcp.__main__ as main_module
+
+        # Reset global state
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = None
+
+        # Call signal handler
+        main_module._signal_handler(signal.SIGTERM, None)
+
+        assert main_module._shutdown_in_progress is True
+
+    def test_first_signal_with_event_sets_event(self):
+        """First signal should set shutdown event if available."""
+        import ha_mcp.__main__ as main_module
+
+        # Reset global state
+        main_module._shutdown_in_progress = False
+
+        # Create a mock event
+        mock_event = MagicMock()
+        main_module._shutdown_event = mock_event
+
+        # Mock the event loop
+        mock_loop = MagicMock()
+        with patch("asyncio.get_running_loop", return_value=mock_loop):
+            main_module._signal_handler(signal.SIGTERM, None)
+
+        # Verify event.set was scheduled
+        mock_loop.call_soon_threadsafe.assert_called_once_with(mock_event.set)
+
+    def test_second_signal_forces_exit(self):
+        """Second signal should force immediate exit."""
+        import ha_mcp.__main__ as main_module
+
+        # Set up as if first signal was already received
+        main_module._shutdown_in_progress = True
+        main_module._shutdown_event = None
+
+        # Second signal should call sys.exit(1)
+        with pytest.raises(SystemExit) as exc_info:
+            main_module._signal_handler(signal.SIGINT, None)
+
+        assert exc_info.value.code == 1
+
+    def test_signal_without_event_loop_exits(self):
+        """Signal without event loop should exit gracefully."""
+        import ha_mcp.__main__ as main_module
+
+        # Reset global state
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = MagicMock()
+
+        # Make get_running_loop raise RuntimeError (no running loop)
+        with patch("asyncio.get_running_loop", side_effect=RuntimeError("no running loop")):
+            with pytest.raises(SystemExit) as exc_info:
+                main_module._signal_handler(signal.SIGTERM, None)
+
+        assert exc_info.value.code == 0
+
+
+class TestCleanupResources:
+    """Tests for resource cleanup function."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stops_websocket_listener(self):
+        """Cleanup should stop the WebSocket listener service."""
+        import ha_mcp.__main__ as main_module
+
+        mock_stop = AsyncMock()
+
+        with patch("ha_mcp.client.websocket_listener.stop_websocket_listener", mock_stop):
+            with patch("ha_mcp.client.websocket_client.websocket_manager", MagicMock(disconnect=AsyncMock())):
+                main_module._server = None
+                await main_module._cleanup_resources()
+                mock_stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_disconnects_websocket_manager(self):
+        """Cleanup should disconnect the WebSocket manager."""
+        import ha_mcp.__main__ as main_module
+
+        mock_manager = MagicMock()
+        mock_manager.disconnect = AsyncMock()
+
+        with patch("ha_mcp.client.websocket_listener.stop_websocket_listener", AsyncMock()):
+            with patch("ha_mcp.client.websocket_client.websocket_manager", mock_manager):
+                main_module._server = None
+                await main_module._cleanup_resources()
+
+                mock_manager.disconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_server(self):
+        """Cleanup should close the server if it exists."""
+        import ha_mcp.__main__ as main_module
+
+        mock_server = MagicMock()
+        mock_server.close = AsyncMock()
+        main_module._server = mock_server
+
+        with patch("ha_mcp.client.websocket_listener.stop_websocket_listener", AsyncMock()):
+            with patch("ha_mcp.client.websocket_client.websocket_manager", MagicMock(disconnect=AsyncMock())):
+                await main_module._cleanup_resources()
+
+                mock_server.close.assert_called_once()
+
+        # Reset global state
+        main_module._server = None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_handles_exceptions_gracefully(self):
+        """Cleanup should handle exceptions without crashing."""
+        import ha_mcp.__main__ as main_module
+
+        # Make everything raise exceptions
+        with patch("ha_mcp.client.websocket_listener.stop_websocket_listener", AsyncMock(side_effect=Exception("test error"))):
+            with patch("ha_mcp.client.websocket_client.websocket_manager", MagicMock(disconnect=AsyncMock(side_effect=Exception("test error")))):
+                main_module._server = None
+                # Should not raise
+                await main_module._cleanup_resources()
+
+
+class TestShutdownTimeout:
+    """Tests for shutdown timeout configuration."""
+
+    def test_shutdown_timeout_is_two_seconds(self):
+        """Shutdown timeout should be 2 seconds as per requirements."""
+        from ha_mcp.__main__ import SHUTDOWN_TIMEOUT_SECONDS
+
+        assert SHUTDOWN_TIMEOUT_SECONDS == 2.0
+
+
+class TestGracefulShutdownIntegration:
+    """Integration tests for graceful shutdown behavior."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_event_cancels_server_task(self):
+        """Setting shutdown event should cancel the server task."""
+        import ha_mcp.__main__ as main_module
+
+        # Create a mock MCP that runs forever
+        mock_mcp = MagicMock()
+
+        async def mock_run_async():
+            await asyncio.sleep(100)  # Simulate long-running server
+
+        mock_mcp.run_async = mock_run_async
+
+        with patch.object(main_module, "_get_mcp", return_value=mock_mcp):
+            with patch.object(main_module, "_cleanup_resources", new_callable=AsyncMock):
+                # Reset state
+                main_module._shutdown_event = None
+                main_module._shutdown_in_progress = False
+
+                # Start the server in a task
+                server_coro = main_module._run_with_graceful_shutdown()
+                server_task = asyncio.create_task(server_coro)
+
+                # Give it time to start
+                await asyncio.sleep(0.1)
+
+                # Trigger shutdown
+                if main_module._shutdown_event:
+                    main_module._shutdown_event.set()
+
+                # Wait for shutdown with timeout
+                try:
+                    await asyncio.wait_for(server_task, timeout=3.0)
+                except TimeoutError:
+                    pytest.fail("Server did not shut down within timeout")
+                except asyncio.CancelledError:
+                    pass  # Expected
+
+    @pytest.mark.asyncio
+    async def test_cleanup_called_on_shutdown(self):
+        """Resource cleanup should be called on shutdown."""
+        import ha_mcp.__main__ as main_module
+
+        cleanup_called = asyncio.Event()
+
+        async def mock_cleanup():
+            cleanup_called.set()
+
+        mock_mcp = MagicMock()
+
+        async def mock_run_async():
+            await asyncio.sleep(100)
+
+        mock_mcp.run_async = mock_run_async
+
+        with patch.object(main_module, "_get_mcp", return_value=mock_mcp):
+            with patch.object(main_module, "_cleanup_resources", side_effect=mock_cleanup):
+                main_module._shutdown_event = None
+                main_module._shutdown_in_progress = False
+
+                server_task = asyncio.create_task(main_module._run_with_graceful_shutdown())
+
+                await asyncio.sleep(0.1)
+
+                if main_module._shutdown_event:
+                    main_module._shutdown_event.set()
+
+                try:
+                    await asyncio.wait_for(server_task, timeout=3.0)
+                except (TimeoutError, asyncio.CancelledError):
+                    pass
+
+                # Verify cleanup was called
+                assert cleanup_called.is_set(), "Cleanup was not called"
+
+
+class TestMainEntryPoint:
+    """Tests for the main entry point function."""
+
+    def test_smoke_test_flag_runs_smoke_test(self):
+        """--smoke-test flag should run smoke test instead of server."""
+        from ha_mcp.__main__ import main
+
+        mock_smoke_test = MagicMock(return_value=0)
+
+        with patch.object(sys, "argv", ["ha-mcp", "--smoke-test"]):
+            with patch("ha_mcp.smoke_test.main", mock_smoke_test):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+                assert exc_info.value.code == 0
+                mock_smoke_test.assert_called_once()
+
+    def test_main_sets_up_signal_handlers(self):
+        """Main should set up signal handlers before running."""
+        import ha_mcp.__main__ as main_module
+
+        setup_called = False
+
+        def mock_setup():
+            nonlocal setup_called
+            setup_called = True
+
+        # Reset global state to avoid test pollution
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = None
+
+        with patch.object(main_module, "_setup_signal_handlers", side_effect=mock_setup):
+            with patch.object(main_module, "_run_with_graceful_shutdown", new_callable=AsyncMock):
+                with pytest.raises(SystemExit):
+                    main_module.main()
+
+        assert setup_called, "Signal handlers were not set up"
+
+
+class TestHTTPEntryPoints:
+    """Tests for HTTP entry points (main_web, main_sse)."""
+
+    def test_main_web_uses_streamable_http_transport(self):
+        """main_web should use streamable-http transport."""
+        import ha_mcp.__main__ as main_module
+
+        transport_used = None
+
+        def mock_run_http(transport):
+            nonlocal transport_used
+            transport_used = transport
+            raise SystemExit(0)
+
+        # Reset global state
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = None
+
+        with patch.object(main_module, "_run_http_server", side_effect=mock_run_http):
+            with pytest.raises(SystemExit):
+                main_module.main_web()
+
+        assert transport_used == "streamable-http"
+
+    def test_main_sse_uses_sse_transport(self):
+        """main_sse should use sse transport."""
+        import ha_mcp.__main__ as main_module
+
+        transport_used = None
+
+        def mock_run_http(transport):
+            nonlocal transport_used
+            transport_used = transport
+            raise SystemExit(0)
+
+        # Reset global state
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = None
+
+        with patch.object(main_module, "_run_http_server", side_effect=mock_run_http):
+            with pytest.raises(SystemExit):
+                main_module.main_sse()
+
+        assert transport_used == "sse"
+
+    def test_http_runtime_uses_env_vars(self):
+        """HTTP runtime should read port and path from environment."""
+        from ha_mcp.__main__ import _get_http_runtime
+
+        with patch.dict(os.environ, {"MCP_PORT": "9000", "MCP_SECRET_PATH": "/custom"}):
+            port, path = _get_http_runtime()
+
+        assert port == 9000
+        assert path == "/custom"
+
+    def test_http_runtime_uses_defaults(self):
+        """HTTP runtime should use defaults when env vars not set."""
+        from ha_mcp.__main__ import _get_http_runtime
+
+        # Clear any existing env vars
+        env = os.environ.copy()
+        env.pop("MCP_PORT", None)
+        env.pop("MCP_SECRET_PATH", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            port, path = _get_http_runtime()
+
+        assert port == 8086
+        assert path == "/mcp"


### PR DESCRIPTION
## Summary

- Add proper signal handlers for SIGTERM and SIGINT signals
- First signal initiates graceful shutdown (completes within 2 seconds)
- Second signal forces immediate exit
- Clean up all resources (WebSocket connections, HTTP clients) on shutdown
- Apply graceful shutdown to all entry points (stdio, HTTP, SSE)
- Add comprehensive unit tests (19 new tests) for signal handling

## Problem

When the binary receives a kill signal (SIGTERM/SIGINT), it should exit immediately on the first attempt. Previously, it may have required multiple kill signals or taken too long to shut down.

## Solution

The implementation adds:
1. Signal handlers that track shutdown state
2. Async cleanup with timeout (2 seconds max)
3. Resource cleanup in the correct order (WebSocket listener -> WebSocket manager -> HTTP client)
4. Support for force exit on second signal

## Test plan

- [x] Unit tests pass (19 new tests, 118 total)
- [x] Server exits within 2 seconds of receiving SIGTERM
- [x] Server exits within 2 seconds of receiving SIGINT (Ctrl+C)
- [x] No error messages on clean shutdown
- [x] Resources properly released (connections closed)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)