### PR TITLE
fix: improve error handling for missing env variables

### DIFF
--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -18,20 +18,14 @@ project_root = Path(__file__).parent.parent.parent
 env_file = os.getenv("HAMCP_ENV_FILE", ".env")
 env_path = project_root / env_file
 
-# Load the specified environment file
+# Load the specified environment file (silently, since env vars may come from other sources)
 if env_path.exists():
     load_dotenv(env_path)
-    print(f"[ENV] Loaded environment from: {env_path}")
 else:
     # Fallback to default .env
     default_env_path = project_root / ".env"
     if default_env_path.exists():
         load_dotenv(default_env_path)
-        print(f"[ENV] Fallback: Loaded environment from: {default_env_path}")
-    else:
-        print(
-            f"[ENV] WARNING: No environment file found. Tried: {env_path}, {default_env_path}"
-        )
 
 
 class Settings(BaseSettings):

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -1,0 +1,115 @@
+"""Unit tests for configuration handling."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+class TestConfigErrorHandling:
+    """Test configuration error handling and user-friendly messages."""
+
+    def test_missing_env_vars_shows_friendly_message(self):
+        """When HOMEASSISTANT_URL and TOKEN are missing, show friendly error."""
+        # Run ha-mcp without any env vars set
+        env = os.environ.copy()
+        # Remove any HA env vars that might be set
+        env.pop("HOMEASSISTANT_URL", None)
+        env.pop("HOMEASSISTANT_TOKEN", None)
+        env.pop("HAMCP_ENV_FILE", None)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ha_mcp"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Should exit with error code
+        assert result.returncode != 0
+
+        # Should show friendly message, not raw stacktrace
+        stderr = result.stderr
+        assert "Configuration Error" in stderr
+        assert "HOMEASSISTANT_URL" in stderr
+        assert "HOMEASSISTANT_TOKEN" in stderr
+        assert "Long-Lived Access Tokens" in stderr
+        assert "github.com/homeassistant-ai/ha-mcp" in stderr
+
+        # Should NOT show raw pydantic validation error
+        assert "pydantic_core._pydantic_core.ValidationError" not in stderr
+        assert "Field required [type=missing" not in stderr
+
+    def test_missing_only_url_shows_that_var(self):
+        """When only HOMEASSISTANT_URL is missing, show that in message."""
+        env = os.environ.copy()
+        env.pop("HOMEASSISTANT_URL", None)
+        env.pop("HAMCP_ENV_FILE", None)
+        env["HOMEASSISTANT_TOKEN"] = "test_token_value"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ha_mcp"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode != 0
+        assert "HOMEASSISTANT_URL" in result.stderr
+
+    def test_missing_only_token_shows_that_var(self):
+        """When only HOMEASSISTANT_TOKEN is missing, show that in message."""
+        env = os.environ.copy()
+        env.pop("HOMEASSISTANT_TOKEN", None)
+        env.pop("HAMCP_ENV_FILE", None)
+        env["HOMEASSISTANT_URL"] = "http://test.local:8123"
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ha_mcp"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode != 0
+        assert "HOMEASSISTANT_TOKEN" in result.stderr
+
+    def test_no_env_file_warning_removed(self):
+        """No warning should be shown when .env file is missing."""
+        env = os.environ.copy()
+        env.pop("HOMEASSISTANT_URL", None)
+        env.pop("HOMEASSISTANT_TOKEN", None)
+        env.pop("HAMCP_ENV_FILE", None)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ha_mcp"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Should NOT contain the old noisy warning
+        combined_output = result.stdout + result.stderr
+        assert "[ENV] WARNING: No environment file found" not in combined_output
+
+    def test_smoke_test_still_works(self):
+        """Smoke test should work with dummy credentials."""
+        env = os.environ.copy()
+        # Smoke test sets its own dummy credentials
+        env.pop("HAMCP_ENV_FILE", None)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "ha_mcp", "--smoke-test"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0
+        assert "SMOKE TEST PASSED" in result.stdout


### PR DESCRIPTION
## Summary
- Removes the noisy `[ENV] WARNING: No environment file found` message that confused users (env vars may come from other sources like Docker, shell environment, etc.)
- Replaces cryptic pydantic ValidationError stacktraces with a clear, user-friendly error message when `HOMEASSISTANT_URL` or `HOMEASSISTANT_TOKEN` are missing
- Includes setup instructions and link to documentation directly in the error message

## Before
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for Settings
HOMEASSISTANT_URL
  Field required [type=missing, input_value={}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
...
```

## After
```
==============================================================================
                    Home Assistant MCP Server - Configuration Error
==============================================================================

Missing required environment variables:
  - HOMEASSISTANT_URL
  - HOMEASSISTANT_TOKEN

To fix this, you need to provide your Home Assistant connection details:

  1. HOMEASSISTANT_URL - Your Home Assistant instance URL
     Example: http://homeassistant.local:8123

  2. HOMEASSISTANT_TOKEN - A long-lived access token
     Get one from: Home Assistant -> Profile -> Long-Lived Access Tokens

Configuration options:
  - Set environment variables directly:
      export HOMEASSISTANT_URL=http://homeassistant.local:8123
      export HOMEASSISTANT_TOKEN=your_token_here

  - Or create a .env file in the project directory (copy from .env.example)

For detailed setup instructions, see:
  https://github.com/homeassistant-ai/ha-mcp#-installation

==============================================================================
```

## Test plan
- [x] Unit tests added for configuration error handling
- [x] Smoke test still passes
- [x] All existing unit tests pass
- [ ] CI checks pass

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)