### PR TITLE
feat: add server icon to FastMCP configuration

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from fastmcp import FastMCP
+from mcp.types import Icon
 
 from .client.rest_client import HomeAssistantClient
 from .config import get_global_settings
@@ -16,6 +17,20 @@ from .tools.smart_search import create_smart_search_tools
 from .tools.registry import ToolsRegistry
 
 logger = logging.getLogger(__name__)
+
+# Server icon configuration using GitHub-hosted images
+# These icons are bundled in packaging/mcpb/ and also available via GitHub raw URLs
+SERVER_ICONS = [
+    Icon(
+        src="https://raw.githubusercontent.com/homeassistant-ai/ha-mcp/master/packaging/mcpb/icon.svg",
+        mimeType="image/svg+xml",
+    ),
+    Icon(
+        src="https://raw.githubusercontent.com/homeassistant-ai/ha-mcp/master/packaging/mcpb/icon-128.png",
+        mimeType="image/png",
+        sizes=["128x128"],
+    ),
+]
 
 
 class HomeAssistantSmartMCPServer(EnhancedToolsMixin, EnhancedPromptsMixin):
@@ -38,8 +53,8 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin, EnhancedPromptsMixin):
             self.settings = None  # type: ignore[assignment]
             self.client = client
 
-        # Create FastMCP server
-        self.mcp = FastMCP(name=server_name, version=server_version)
+        # Create FastMCP server with Home Assistant icons for client UI display
+        self.mcp = FastMCP(name=server_name, version=server_version, icons=SERVER_ICONS)
 
         # Initialize smart tools
         self.smart_tools = create_smart_search_tools(self.client)

--- a/tests/addon/test_server_config.py
+++ b/tests/addon/test_server_config.py
@@ -1,0 +1,66 @@
+"""Test MCP server configuration and metadata."""
+
+from mcp.types import Icon
+
+
+class TestServerIcons:
+    """Verify server icon configuration meets MCP requirements."""
+
+    def test_server_icons_defined(self):
+        """Check that SERVER_ICONS is defined and properly structured."""
+        from ha_mcp.server import SERVER_ICONS
+
+        assert SERVER_ICONS is not None, "SERVER_ICONS must be defined"
+        assert isinstance(SERVER_ICONS, list), "SERVER_ICONS must be a list"
+        assert len(SERVER_ICONS) > 0, "SERVER_ICONS must contain at least one icon"
+
+    def test_icons_are_valid_mcp_icon_types(self):
+        """Check that all icons are valid MCP Icon objects."""
+        from ha_mcp.server import SERVER_ICONS
+
+        for i, icon in enumerate(SERVER_ICONS):
+            assert isinstance(icon, Icon), f"Icon at index {i} must be an mcp.types.Icon"
+
+    def test_icons_have_required_fields(self):
+        """Check that all icons have required 'src' field."""
+        from ha_mcp.server import SERVER_ICONS
+
+        for i, icon in enumerate(SERVER_ICONS):
+            assert icon.src, f"Icon at index {i} must have a non-empty 'src' field"
+            # src should be a URL pointing to GitHub raw content
+            assert icon.src.startswith("https://"), "Icon src must be an HTTPS URL"
+
+    def test_icons_have_valid_mime_types(self):
+        """Check that icons have valid MIME types when specified."""
+        from ha_mcp.server import SERVER_ICONS
+
+        valid_image_types = {"image/png", "image/svg+xml", "image/jpeg", "image/webp"}
+        for i, icon in enumerate(SERVER_ICONS):
+            if icon.mimeType:
+                assert icon.mimeType in valid_image_types, (
+                    f"Icon at index {i} has invalid mimeType: {icon.mimeType}"
+                )
+
+    def test_icons_include_svg_format(self):
+        """Check that at least one SVG icon is included for scalability."""
+        from ha_mcp.server import SERVER_ICONS
+
+        svg_icons = [icon for icon in SERVER_ICONS if icon.mimeType == "image/svg+xml"]
+        assert len(svg_icons) > 0, "Should include at least one SVG icon for scalability"
+
+    def test_icons_include_raster_format(self):
+        """Check that at least one raster icon (PNG) is included for compatibility."""
+        from ha_mcp.server import SERVER_ICONS
+
+        raster_icons = [icon for icon in SERVER_ICONS if icon.mimeType == "image/png"]
+        assert len(raster_icons) > 0, "Should include at least one PNG icon for compatibility"
+
+    def test_icon_urls_point_to_correct_repository(self):
+        """Check that icon URLs point to the ha-mcp repository."""
+        from ha_mcp.server import SERVER_ICONS
+
+        expected_base = "https://raw.githubusercontent.com/homeassistant-ai/ha-mcp/"
+        for i, icon in enumerate(SERVER_ICONS):
+            assert icon.src.startswith(expected_base), (
+                f"Icon at index {i} should point to homeassistant-ai/ha-mcp repository"
+            )


### PR DESCRIPTION
## Summary
- Add Home Assistant icons to the MCP server configuration for improved visual identification in MCP clients
- Pass icons to FastMCP constructor using `mcp.types.Icon` objects
- Include both SVG (for scalability) and PNG (for compatibility) formats
- Icons hosted on GitHub raw URLs pointing to existing icons in `packaging/mcpb/`

## Changes
- `src/ha_mcp/server.py`: Add `SERVER_ICONS` constant and pass to `FastMCP()` constructor
- `tests/addon/test_server_config.py`: Add comprehensive tests for icon configuration

## Test plan
- [x] All new tests pass locally
- [x] Lint checks pass (`ruff check`)
- [x] Server module imports successfully with new icons
- [ ] CI checks pass

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)