### PR TITLE
docs: update uvx instructions to use @latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Choose the installation method that best fits your setup:
   "mcpServers": {
     "Home Assistant": {
       "command": "uvx",
-      "args": ["ha-mcp"],
+      "args": ["ha-mcp@latest"],
       "env": {
         "HOMEASSISTANT_URL": "http://localhost:8123",
         "HOMEASSISTANT_TOKEN": "your_long_lived_token"
@@ -137,7 +137,7 @@ Note: replace both HOMEASSISTANT_URL and HOMEASSISTANT_TOKEN with your values.
 
 **One-click install:**
 
-[![Install in VSCode](https://img.shields.io/badge/VSCode-Install_Home_Assistant_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22Home%20Assistant%22%2C%22inputs%22%3A%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22homeassistant-url%22%2C%22description%22%3A%22Your%20Home%20Assistant%20URL%20(ex%3A%20http%3A%2F%2Fhomeassistant.local%3A8123)%22%2C%22default%22%3A%22http%3A%2F%2Fhomeassistant.local%3A8123%22%2C%22password%22%3Afalse%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22homeassistant-token%22%2C%22description%22%3A%22Your%20long%20lived%20access%20token%20(generate%20in%20your%20profile%20page%2C%20Security%20tab)%22%2C%22password%22%3Atrue%7D%5D%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22ha-mcp%22%5D%2C%22env%22%3A%7B%22HOMEASSISTANT_URL%22%3A%22%24%7Binput%3Ahomeassistant-url%7D%22%2C%22HOMEASSISTANT_TOKEN%22%3A%22%24%7Binput%3Ahomeassistant-token%7D%22%7D%7D)
+[![Install in VSCode](https://img.shields.io/badge/VSCode-Install_Home_Assistant_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22Home%20Assistant%22%2C%22inputs%22%3A%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22homeassistant-url%22%2C%22description%22%3A%22Your%20Home%20Assistant%20URL%20(ex%3A%20http%3A%2F%2Fhomeassistant.local%3A8123)%22%2C%22default%22%3A%22http%3A%2F%2Fhomeassistant.local%3A8123%22%2C%22password%22%3Afalse%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22homeassistant-token%22%2C%22description%22%3A%22Your%20long%20lived%20access%20token%20(generate%20in%20your%20profile%20page%2C%20Security%20tab)%22%2C%22password%22%3Atrue%7D%5D%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22ha-mcp%40latest%22%5D%2C%22env%22%3A%7B%22HOMEASSISTANT_URL%22%3A%22%24%7Binput%3Ahomeassistant-url%7D%22%2C%22HOMEASSISTANT_TOKEN%22%3A%22%24%7Binput%3Ahomeassistant-token%7D%22%7D%7D)
 
 Clicking the button will prompt you for your Home Assistant URL and token.
 
@@ -150,7 +150,7 @@ Clicking the button will prompt you for your Home Assistant URL and token.
 claude mcp add --transport stdio home-assistant \
   --env HOMEASSISTANT_URL=http://localhost:8123 \
   --env HOMEASSISTANT_TOKEN=your_long_lived_token \
-  -- uvx ha-mcp
+  -- uvx ha-mcp@latest
 ```
 
 </details>
@@ -166,7 +166,7 @@ set HOMEASSISTANT_URL=http://localhost:8123
 set HOMEASSISTANT_TOKEN=your_long_lived_token
 set MCP_PORT=8086
 set MCP_SECRET_PATH=/__my_secret__
-uvx --from ha-mcp ha-mcp-web
+uvx --from ha-mcp@latest ha-mcp-web
 ```
 Others:
 ```bash
@@ -174,7 +174,7 @@ export HOMEASSISTANT_URL=http://localhost:8123
 export HOMEASSISTANT_TOKEN=your_long_lived_token
 export MCP_PORT=8086
 export MCP_SECRET_PATH=/__my_secret__
-uvx --from ha-mcp ha-mcp-web
+uvx --from ha-mcp@latest ha-mcp-web
 ```
 
 Web client required https and a public URL. You need to use a proxy in front of `http://localhost:8086`.

--- a/docs/Windows-uv-guide.md
+++ b/docs/Windows-uv-guide.md
@@ -27,7 +27,7 @@ winget install astral-sh.uv -e
       "mcpServers": {
         "Home Assistant": {
           "command": "uvx",
-          "args": ["ha-mcp"],
+          "args": ["ha-mcp@latest"],
           "env": {
             "HOMEASSISTANT_URL": "http://homeassistant.local:8123",
             "HOMEASSISTANT_TOKEN": "your_long_lived_token"

--- a/docs/macOS-uv-guide.md
+++ b/docs/macOS-uv-guide.md
@@ -40,7 +40,7 @@ uvx --version
       "mcpServers": {
         "Home Assistant": {
           "command": "uvx",
-          "args": ["ha-mcp"],
+          "args": ["ha-mcp@latest"],
           "env": {
             "HOMEASSISTANT_URL": "http://homeassistant.local:8123",
             "HOMEASSISTANT_TOKEN": "your_long_lived_token"


### PR DESCRIPTION
## Summary
- Updates all uvx instructions to use `ha-mcp@latest` instead of `ha-mcp`
- Ensures users always get the latest version when running via uvx
- Avoids issues like the read-only filesystem bug fixed in v4.7.4

## Files Changed
- README.md (Claude Desktop, Claude Code, VSCode button, web clients)
- docs/macOS-uv-guide.md  
- docs/Windows-uv-guide.md

## Test plan
- [x] Verify all uvx references updated correctly
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)