### PR TITLE
fix: use gh release upload to avoid target_commitish conflict

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -236,11 +236,12 @@ jobs:
         run: find artifacts -type f
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          files: |
-            artifacts/ha-mcp-linux/ha-mcp-linux
-            artifacts/ha-mcp-windows/ha-mcp-windows.exe
-            artifacts/ha-mcp-macos-arm64/ha-mcp-macos-arm64
-            artifacts/ha-mcp-mcpb/ha-mcp.mcpb
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "v${{ steps.version.outputs.version }}" \
+            artifacts/ha-mcp-linux/ha-mcp-linux \
+            artifacts/ha-mcp-windows/ha-mcp-windows.exe \
+            artifacts/ha-mcp-macos-arm64/ha-mcp-macos-arm64 \
+            artifacts/ha-mcp-mcpb/ha-mcp.mcpb \
+            --clobber


### PR DESCRIPTION
## Summary

Fixes the release upload failure from PR #249. The `softprops/action-gh-release` action was trying to update the release's `target_commitish` when uploading files, which fails because releases created by SemVer Release are already published and immutable.

**Error from v4.11.4:**
```
target_commitish cannot be changed when release is immutable
```

**Fix:** Switch to using `gh release upload --clobber` which only uploads assets without modifying release metadata.

## Test plan

- [ ] Merge and verify binaries appear on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)