### PR TITLE
fix: create GitHub release from build-binary workflow

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -235,13 +235,29 @@ jobs:
       - name: List artifacts
         run: find artifacts -type f
 
-      - name: Upload binaries to release
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract changelog section for this version
+          # Look for ## v{version} and extract until next ## v or end
+          awk "/^## v${VERSION}/,/^## v[0-9]/" CHANGELOG.md | head -n -1 > release_notes.md
+          # If no specific section found, use a default message
+          if [ ! -s release_notes.md ]; then
+            echo "Release v${VERSION}" > release_notes.md
+          fi
+          echo "=== Release Notes ==="
+          cat release_notes.md
+
+      - name: Create GitHub release with binaries
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "v${{ steps.version.outputs.version }}" \
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release_notes.md \
             artifacts/ha-mcp-linux/ha-mcp-linux \
             artifacts/ha-mcp-windows/ha-mcp-windows.exe \
             artifacts/ha-mcp-macos-arm64/ha-mcp-macos-arm64 \
-            artifacts/ha-mcp-mcpb/ha-mcp.mcpb \
-            --clobber
+            artifacts/ha-mcp-mcpb/ha-mcp.mcpb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,4 +204,5 @@ allow_zero_version = false
 
 # Branch and tag configuration
 branch = "master"
-upload_to_vcs_release = true
+# GitHub release is created by build-binary.yml workflow to include binaries
+upload_to_vcs_release = false


### PR DESCRIPTION
## Summary

Fixes the issue where binary assets cannot be uploaded to releases because releases created by `python-semantic-release` become immediately immutable.

**Previous errors:**
- v4.11.4: `target_commitish cannot be changed when release is immutable`
- v4.11.5: `Cannot upload assets to an immutable release`

**Solution:** Instead of trying to upload assets to an existing release, have the build-binary workflow create the entire GitHub release with binaries from the start.

### Changes

1. **pyproject.toml**: Set `upload_to_vcs_release = false` - semantic-release will still create tags and bump versions, but won't create GitHub releases
2. **build-binary.yml**: Create the GitHub release using `gh release create` with binaries included, plus changelog notes extracted from CHANGELOG.md

### Flow after this change

1. Push to master triggers SemVer Release
2. SemVer Release creates tag (e.g., v4.11.6) but no GitHub release
3. SemVer Release completion triggers Build and Release Binaries
4. Build and Release Binaries builds on all platforms
5. Build and Release Binaries creates GitHub release with all binaries attached

## Test plan

- [ ] Next merge should create a release with binaries on the release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)