### PR TITLE
fix: correct semantic-release v10 config and add release fallback

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -249,13 +249,23 @@ jobs:
           echo "=== Release Notes ==="
           cat release_notes.md
 
-      - name: Create GitHub release with binaries
+      - name: Create or update GitHub release with binaries
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
+          TAG="v${VERSION}"
+
+          # Check if release already exists (may be immutable from semantic-release)
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG already exists, deleting to recreate with binaries..."
+            # Delete the release but keep the tag
+            gh release delete "$TAG" --yes
+          fi
+
+          echo "Creating release $TAG with binaries..."
+          gh release create "$TAG" \
+            --title "$TAG" \
             --notes-file release_notes.md \
             artifacts/ha-mcp-linux/ha-mcp-linux \
             artifacts/ha-mcp-windows/ha-mcp-windows.exe \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,5 +204,8 @@ allow_zero_version = false
 
 # Branch and tag configuration
 branch = "master"
+
+# Publish configuration (v10 syntax)
+[tool.semantic_release.publish]
 # GitHub release is created by build-binary.yml workflow to include binaries
 upload_to_vcs_release = false


### PR DESCRIPTION
## Summary

Fixes the binary release upload failures by:

1. **Correcting semantic-release v10 config**: The `upload_to_vcs_release` setting must be under `[tool.semantic_release.publish]` section for v10, not directly under `[tool.semantic_release]`

2. **Adding release fallback**: If a release already exists (from semantic-release creating it despite the config), delete and recreate it with binaries instead of trying to upload to an immutable release

### Previous errors

- v4.11.4: `target_commitish cannot be changed when release is immutable`
- v4.11.5: `Cannot upload assets to an immutable release`
- v4.11.6: `a release with the same tag name already exists`

### How this PR fixes it

With correct v10 config:
- semantic-release will only create the tag, not the GitHub release
- build-binary workflow creates the release with all binaries attached

With the fallback:
- If semantic-release still creates a release, build-binary deletes it and recreates with binaries
- This handles edge cases and ensures binaries are always included

## Test plan

- [ ] Next merge creates release with binaries on the release page

Sources:
- [python-semantic-release v10 docs](https://python-semantic-release.readthedocs.io/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)