### PR TITLE
fix: disable VCS release via GitHub Action input

### DIFF
--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -31,6 +31,8 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         verbosity: "2"
+        # Don't create GitHub release here - build-binary.yml will create it with binaries
+        vcs_release: "false"
 
     - name: Copy changelog to addon directory
       if: steps.semantic.outputs.released == 'true'


### PR DESCRIPTION
## Summary

Final fix for binary releases. The `pyproject.toml` config for `upload_to_vcs_release` wasn't being respected by the GitHub Action. This PR uses the action's direct input parameter `vcs_release: "false"` which is documented to work.

### Previous attempts
- PR #249: Added workflow_run trigger - ✅ works
- PR #252: Use gh release upload - ❌ immutable release error
- PR #254: Create release from build-binary - ❌ release already exists
- PR #255: Delete and recreate release - ❌ tag locked by immutable release
- **This PR**: Disable VCS release at action level - should work

### How this works
1. SemVer Release runs with `vcs_release: "false"` → creates tag but NO release
2. Build and Release Binaries runs → creates fresh release with all binaries

Sources:
- [python-semantic-release GitHub Actions docs](https://python-semantic-release.readthedocs.io/en/latest/configuration/automatic-releases/github-actions.html)

## Test plan

- [ ] Next merge should create release with binaries on the release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)