### PR TITLE
fix: return helpful error message for YAML script delete attempts

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -766,11 +766,21 @@ class HomeAssistantClient:
                 "result": response.get("result", "ok"),
                 "operation": "deleted",
             }
-        except Exception as e:
-            if "404" in str(e):
+        except HomeAssistantAPIError as e:
+            if e.status_code == 404:
                 raise HomeAssistantAPIError(
                     f"Script not found: {script_id}", status_code=404
                 )
+            elif e.status_code == 405:
+                raise HomeAssistantAPIError(
+                    f"Cannot delete script '{script_id}': This script is defined in YAML configuration files "
+                    f"(e.g., scripts.yaml or configuration.yaml) and cannot be deleted via the API. "
+                    f"Only UI-created scripts can be deleted through this method. "
+                    f"To remove YAML-defined scripts, edit the configuration file directly.",
+                    status_code=405,
+                )
+            raise
+        except Exception as e:
             raise
 
 

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -212,6 +212,13 @@ def register_config_script_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - Delete script: ha_config_remove_script("old_script")
         - Delete script: ha_config_remove_script("temporary_script")
 
+        **IMPORTANT LIMITATION:**
+        This tool can only delete scripts created via the Home Assistant UI.
+        Scripts defined in YAML configuration files (scripts.yaml or configuration.yaml)
+        cannot be deleted through the API and will return a 405 Method Not Allowed error.
+
+        To remove YAML-defined scripts, you must edit the configuration file directly.
+
         **WARNING:** Deleting a script that is used by automations may cause those automations to fail.
         """
         try:

--- a/tests/src/unit/test_rest_client_scripts.py
+++ b/tests/src/unit/test_rest_client_scripts.py
@@ -1,0 +1,161 @@
+"""Unit tests for REST client script-related methods.
+
+These tests verify error handling for script configuration operations,
+especially the 405 Method Not Allowed error for YAML-defined scripts.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantClient,
+)
+
+
+class TestDeleteScriptConfig:
+    """Tests for delete_script_config error handling."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock HomeAssistantClient for testing."""
+        with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+            client = HomeAssistantClient()
+            client.base_url = "http://test.local:8123"
+            client.token = "test-token"
+            client.timeout = 30
+            client.httpx_client = MagicMock()
+            return client
+
+    @pytest.mark.asyncio
+    async def test_delete_script_success(self, mock_client):
+        """Successful script deletion should return success response."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.delete_script_config("test_script")
+
+        assert result["success"] is True
+        assert result["script_id"] == "test_script"
+        assert result["operation"] == "deleted"
+        mock_client._request.assert_called_once_with(
+            "DELETE", "config/script/config/test_script"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_script_not_found_404(self, mock_client):
+        """404 error should raise HomeAssistantAPIError with 'not found' message."""
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not found",
+                status_code=404,
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.delete_script_config("nonexistent_script")
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_script_yaml_mode_405(self, mock_client):
+        """405 error should raise HomeAssistantAPIError with helpful YAML message.
+
+        This tests the fix for issue #261 where YAML-mode scripts cannot be
+        deleted via the API and return 405 Method Not Allowed.
+        """
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 405 - Method Not Allowed",
+                status_code=405,
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.delete_script_config("yaml_defined_script")
+
+        error = exc_info.value
+        assert error.status_code == 405
+
+        # Verify the error message is helpful and mentions YAML
+        error_message = str(error)
+        assert "yaml" in error_message.lower()
+        assert "cannot be deleted" in error_message.lower() or "cannot delete" in error_message.lower()
+        assert "configuration" in error_message.lower()
+
+        # Verify it mentions UI-created scripts as the alternative
+        assert "ui" in error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_script_other_error_propagates(self, mock_client):
+        """Other API errors should propagate unchanged."""
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 500 - Internal Server Error",
+                status_code=500,
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.delete_script_config("test_script")
+
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_delete_script_generic_exception_propagates(self, mock_client):
+        """Non-API exceptions should propagate."""
+        mock_client._request = AsyncMock(
+            side_effect=RuntimeError("Unexpected error")
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await mock_client.delete_script_config("test_script")
+
+        assert "Unexpected error" in str(exc_info.value)
+
+
+class TestGetScriptConfig:
+    """Tests for get_script_config error handling."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock HomeAssistantClient for testing."""
+        with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+            client = HomeAssistantClient()
+            client.base_url = "http://test.local:8123"
+            client.token = "test-token"
+            client.timeout = 30
+            client.httpx_client = MagicMock()
+            return client
+
+    @pytest.mark.asyncio
+    async def test_get_script_success(self, mock_client):
+        """Successful script retrieval should return config."""
+        mock_config = {
+            "alias": "Test Script",
+            "sequence": [{"delay": {"seconds": 1}}],
+            "mode": "single",
+        }
+        mock_client._request = AsyncMock(return_value=mock_config)
+
+        result = await mock_client.get_script_config("test_script")
+
+        assert result["success"] is True
+        assert result["script_id"] == "test_script"
+        assert result["config"] == mock_config
+
+    @pytest.mark.asyncio
+    async def test_get_script_not_found_404(self, mock_client):
+        """404 error should raise HomeAssistantAPIError."""
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not found",
+                status_code=404,
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_script_config("nonexistent_script")
+
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
Closes #261

## Summary
- Added specific handling for 405 Method Not Allowed errors when attempting to delete YAML-defined scripts
- The error message now clearly explains that YAML-mode scripts cannot be deleted via the API and guides users to the correct solution
- Updated the `ha_config_remove_script` tool docstring to document this limitation upfront

## Problem
Users calling `ha_config_remove_script` on YAML-defined scripts would receive a generic error or (worse) a misleading success response, when the underlying API returns 405 Method Not Allowed. This is because Home Assistant's config API can only manage UI-created scripts, not those defined in `scripts.yaml` or `configuration.yaml`.

## Solution
1. **Better error handling in `delete_script_config`**: The method now catches 405 errors specifically and raises a `HomeAssistantAPIError` with a helpful message explaining:
   - That the script is defined in YAML configuration files
   - That only UI-created scripts can be deleted via the API
   - That users should edit the configuration file directly to remove YAML scripts

2. **Updated tool documentation**: The `ha_config_remove_script` docstring now includes an "IMPORTANT LIMITATION" section that documents this behavior upfront.

3. **Unit tests**: Added comprehensive tests for the 405 error handling and other script deletion scenarios.

## Test Plan
- [x] Unit tests pass locally
- [x] Test covers 405 error handling specifically 
- [x] Test verifies the error message mentions YAML and configuration
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)