### PR TITLE
feat: add ha_get_resource_url tool for Cloudflare Worker resource hosting

### DIFF
--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -1,0 +1,209 @@
+"""
+Resource hosting tools for Home Assistant MCP server.
+
+This module provides tools for converting inline JavaScript and CSS code into
+hosted URLs via a Cloudflare Worker, enabling AI assistants to inject custom
+resources into Home Assistant dashboards.
+
+See: https://github.com/homeassistant-ai/ha-mcp/issues/266
+"""
+
+import base64
+import logging
+from typing import Any, Literal
+
+from .helpers import log_tool_usage
+
+logger = logging.getLogger(__name__)
+
+# Cloudflare Worker URL for resource hosting
+WORKER_BASE_URL = "https://ha-mcp-resources.workers.dev"
+
+# Maximum URL length (conservative estimate based on Cloudflare limits)
+# URL path limit is ~16KB, leaving room for query params
+MAX_ENCODED_LENGTH = 16000
+
+# Approximate size limit for the original content (~12KB before base64 encoding)
+# Base64 encoding increases size by ~33%
+APPROX_MAX_CONTENT_SIZE = 12000
+
+
+def register_resources_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register resource hosting tools."""
+
+    @mcp.tool(
+        annotations={
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "tags": ["resources", "dashboard"],
+            "title": "Get Resource URL",
+        }
+    )
+    @log_tool_usage
+    async def ha_get_resource_url(
+        content: str,
+        resource_type: Literal["module", "js", "css"] = "module",
+    ) -> dict[str, Any]:
+        """
+        Convert inline JavaScript or CSS code to a hosted URL via Cloudflare Worker.
+
+        This tool enables AI assistants to inject custom JavaScript modules, scripts,
+        or CSS stylesheets into Home Assistant dashboards without requiring filesystem
+        access. The code is base64-encoded and served from a Cloudflare Worker with
+        appropriate MIME types and CORS headers.
+
+        **Parameters:**
+        - content: The JavaScript or CSS code to host (max ~12KB)
+        - resource_type: Type of resource being hosted:
+          - "module": ES6 JavaScript module (application/javascript, for import statements)
+          - "js": Regular JavaScript (application/javascript)
+          - "css": CSS stylesheet (text/css)
+
+        **Returns:**
+        - url: The hosted URL that can be used in dashboard configurations
+        - size: Size of the original content in bytes
+        - encoded_size: Size of the base64-encoded content
+        - resource_type: The type of resource
+
+        **Use Cases:**
+
+        **Simple Custom Card Styling:**
+        ```python
+        result = ha_get_resource_url(
+            content='''
+                .my-custom-card {
+                    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                    border-radius: 16px;
+                    padding: 20px;
+                }
+            ''',
+            resource_type="css"
+        )
+        # Use result["url"] in dashboard resources
+        ```
+
+        **Small Utility Script:**
+        ```python
+        result = ha_get_resource_url(
+            content='''
+                export function formatTemperature(value, unit = "C") {
+                    const temp = parseFloat(value);
+                    if (unit === "F") {
+                        return `${((temp * 9/5) + 32).toFixed(1)}\\u00B0F`;
+                    }
+                    return `${temp.toFixed(1)}\\u00B0C`;
+                }
+            ''',
+            resource_type="module"
+        )
+        # Import in custom card: import { formatTemperature } from 'result["url"]'
+        ```
+
+        **Theme Customization:**
+        ```python
+        result = ha_get_resource_url(
+            content='''
+                :root {
+                    --primary-color: #03a9f4;
+                    --accent-color: #ff5722;
+                    --primary-background-color: #1a1a2e;
+                }
+            ''',
+            resource_type="css"
+        )
+        ```
+
+        **Limitations:**
+        - Maximum content size: ~12KB (due to URL length limits)
+        - Not suitable for complex custom cards (use filesystem approach instead)
+        - Content is public (no authentication on the worker)
+        - URLs may be long due to base64 encoding
+
+        **Important Notes:**
+        - This tool does NOT require Home Assistant connection
+        - URLs are deterministic (same content = same URL)
+        - The Cloudflare Worker decodes the base64 and serves with correct MIME type
+        - CORS headers are set to allow cross-origin loading
+
+        **Related:**
+        - For larger files or complex cards, use filesystem access (Issue #194)
+        - For dashboard configuration, see ha_update_dashboard_view
+        """
+        # Validate content is provided
+        if not content or not content.strip():
+            return {
+                "success": False,
+                "error": "Content cannot be empty",
+                "suggestions": [
+                    "Provide JavaScript or CSS code as the content parameter",
+                    "Ensure the content is not just whitespace",
+                ],
+            }
+
+        # Check content size before encoding
+        content_bytes = content.encode("utf-8")
+        content_size = len(content_bytes)
+
+        if content_size > APPROX_MAX_CONTENT_SIZE:
+            return {
+                "success": False,
+                "error": f"Content too large: {content_size} bytes (max ~{APPROX_MAX_CONTENT_SIZE} bytes)",
+                "size": content_size,
+                "suggestions": [
+                    "Reduce the size of your JavaScript or CSS code",
+                    "For larger files, use filesystem access instead (Issue #194)",
+                    "Consider minifying the code to reduce size",
+                    "Split large code into multiple smaller modules",
+                ],
+            }
+
+        # Base64 encode the content using URL-safe encoding
+        try:
+            encoded = base64.urlsafe_b64encode(content_bytes).decode("ascii")
+        except Exception as e:
+            logger.error(f"Failed to encode content: {e}")
+            return {
+                "success": False,
+                "error": f"Failed to encode content: {str(e)}",
+                "suggestions": [
+                    "Ensure the content is valid UTF-8 text",
+                    "Check for any binary or non-text content",
+                ],
+            }
+
+        encoded_size = len(encoded)
+
+        # Final check on encoded length
+        if encoded_size > MAX_ENCODED_LENGTH:
+            return {
+                "success": False,
+                "error": f"Encoded content too large: {encoded_size} characters (max {MAX_ENCODED_LENGTH})",
+                "size": content_size,
+                "encoded_size": encoded_size,
+                "suggestions": [
+                    "Reduce the size of your JavaScript or CSS code",
+                    "For larger files, use filesystem access instead (Issue #194)",
+                    "Consider minifying the code to reduce size",
+                ],
+            }
+
+        # Construct the URL
+        url = f"{WORKER_BASE_URL}/{encoded}?type={resource_type}"
+
+        logger.info(
+            f"Created resource URL: type={resource_type}, size={content_size}, encoded_size={encoded_size}"
+        )
+
+        return {
+            "success": True,
+            "url": url,
+            "size": content_size,
+            "encoded_size": encoded_size,
+            "resource_type": resource_type,
+            "worker_base_url": WORKER_BASE_URL,
+            "notes": [
+                "URL is deterministic - same content produces same URL",
+                "Content is served with appropriate MIME type and CORS headers",
+                "For ES6 modules, use resource_type='module'",
+            ],
+        }

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -1,0 +1,345 @@
+"""Unit tests for resource hosting tools module."""
+
+import base64
+
+import pytest
+from unittest.mock import MagicMock
+
+from ha_mcp.tools.tools_resources import (
+    register_resources_tools,
+    WORKER_BASE_URL,
+    MAX_ENCODED_LENGTH,
+    APPROX_MAX_CONTENT_SIZE,
+)
+
+
+class TestHaGetResourceUrl:
+    """Test ha_get_resource_url tool."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        """Create a mock MCP server."""
+        mcp = MagicMock()
+        self.registered_tool = None
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tool = func
+                return func
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock Home Assistant client."""
+        return MagicMock()
+
+    @pytest.fixture
+    def registered_tool(self, mock_mcp, mock_client):
+        """Register tools and return the ha_create_resource_url function."""
+        register_resources_tools(mock_mcp, mock_client)
+        return self.registered_tool
+
+    # --- Success Cases ---
+
+    @pytest.mark.asyncio
+    async def test_create_css_resource_url(self, registered_tool):
+        """Test creating a CSS resource URL."""
+        css_content = """
+            .my-card {
+                background: #333;
+                border-radius: 8px;
+            }
+        """
+        result = await registered_tool(content=css_content, resource_type="css")
+
+        assert result["success"] is True
+        assert "url" in result
+        assert result["url"].startswith(WORKER_BASE_URL)
+        assert "?type=css" in result["url"]
+        assert result["resource_type"] == "css"
+        assert result["size"] > 0
+        assert result["encoded_size"] > 0
+
+    @pytest.mark.asyncio
+    async def test_create_module_resource_url(self, registered_tool):
+        """Test creating an ES6 module resource URL."""
+        js_content = """
+            export function formatValue(val) {
+                return val.toFixed(2);
+            }
+        """
+        result = await registered_tool(content=js_content, resource_type="module")
+
+        assert result["success"] is True
+        assert "?type=module" in result["url"]
+        assert result["resource_type"] == "module"
+
+    @pytest.mark.asyncio
+    async def test_create_js_resource_url(self, registered_tool):
+        """Test creating a regular JavaScript resource URL."""
+        js_content = "console.log('Hello, Home Assistant!');"
+        result = await registered_tool(content=js_content, resource_type="js")
+
+        assert result["success"] is True
+        assert "?type=js" in result["url"]
+        assert result["resource_type"] == "js"
+
+    @pytest.mark.asyncio
+    async def test_default_resource_type_is_module(self, registered_tool):
+        """Test that default resource_type is 'module'."""
+        result = await registered_tool(content="export const x = 1;")
+
+        assert result["success"] is True
+        assert "?type=module" in result["url"]
+        assert result["resource_type"] == "module"
+
+    @pytest.mark.asyncio
+    async def test_url_contains_base64_encoded_content(self, registered_tool):
+        """Test that URL contains base64-encoded content."""
+        content = "test content"
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+
+        # Extract encoded part from URL (between base URL and query params)
+        url = result["url"]
+        encoded_part = url.replace(f"{WORKER_BASE_URL}/", "").split("?")[0]
+
+        # Verify it's valid base64 that decodes to original content
+        decoded = base64.urlsafe_b64decode(encoded_part).decode("utf-8")
+        assert decoded == content
+
+    @pytest.mark.asyncio
+    async def test_deterministic_url_for_same_content(self, registered_tool):
+        """Test that same content produces same URL."""
+        content = "const x = 42;"
+
+        result1 = await registered_tool(content=content)
+        result2 = await registered_tool(content=content)
+
+        assert result1["url"] == result2["url"]
+
+    @pytest.mark.asyncio
+    async def test_different_content_produces_different_url(self, registered_tool):
+        """Test that different content produces different URLs."""
+        result1 = await registered_tool(content="const x = 1;")
+        result2 = await registered_tool(content="const x = 2;")
+
+        assert result1["url"] != result2["url"]
+
+    @pytest.mark.asyncio
+    async def test_size_fields_are_accurate(self, registered_tool):
+        """Test that size fields accurately reflect content size."""
+        content = "Hello, World!"
+        content_bytes = content.encode("utf-8")
+        expected_size = len(content_bytes)
+        expected_encoded_size = len(base64.urlsafe_b64encode(content_bytes))
+
+        result = await registered_tool(content=content)
+
+        assert result["size"] == expected_size
+        assert result["encoded_size"] == expected_encoded_size
+
+    @pytest.mark.asyncio
+    async def test_unicode_content_is_handled(self, registered_tool):
+        """Test that Unicode content is properly encoded."""
+        content = "const greeting = 'Hello, World!';"
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+        # Verify the encoded content can be decoded back
+        url = result["url"]
+        encoded_part = url.replace(f"{WORKER_BASE_URL}/", "").split("?")[0]
+        decoded = base64.urlsafe_b64decode(encoded_part).decode("utf-8")
+        assert decoded == content
+
+    @pytest.mark.asyncio
+    async def test_multiline_content(self, registered_tool):
+        """Test handling of multiline content."""
+        content = """
+        // Line 1
+        const a = 1;
+        // Line 2
+        const b = 2;
+        """
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+        assert result["size"] == len(content.encode("utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_result_includes_worker_base_url(self, registered_tool):
+        """Test that result includes worker base URL for reference."""
+        result = await registered_tool(content="x")
+
+        assert result["worker_base_url"] == WORKER_BASE_URL
+
+    @pytest.mark.asyncio
+    async def test_result_includes_notes(self, registered_tool):
+        """Test that result includes helpful notes."""
+        result = await registered_tool(content="x")
+
+        assert "notes" in result
+        assert isinstance(result["notes"], list)
+        assert len(result["notes"]) > 0
+
+    # --- Error Cases ---
+
+    @pytest.mark.asyncio
+    async def test_empty_content_returns_error(self, registered_tool):
+        """Test that empty content returns an error."""
+        result = await registered_tool(content="")
+
+        assert result["success"] is False
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+        assert "suggestions" in result
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_content_returns_error(self, registered_tool):
+        """Test that whitespace-only content returns an error."""
+        result = await registered_tool(content="   \n\t  ")
+
+        assert result["success"] is False
+        assert "empty" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_content_too_large_returns_error(self, registered_tool):
+        """Test that content exceeding size limit returns error."""
+        # Create content larger than the limit
+        large_content = "x" * (APPROX_MAX_CONTENT_SIZE + 1000)
+
+        result = await registered_tool(content=large_content)
+
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+        assert "size" in result
+        assert "suggestions" in result
+
+    @pytest.mark.asyncio
+    async def test_error_includes_helpful_suggestions(self, registered_tool):
+        """Test that errors include helpful suggestions."""
+        result = await registered_tool(content="")
+
+        assert "suggestions" in result
+        assert isinstance(result["suggestions"], list)
+        assert len(result["suggestions"]) > 0
+
+    # --- Edge Cases ---
+
+    @pytest.mark.asyncio
+    async def test_content_at_size_limit(self, registered_tool):
+        """Test content exactly at the size limit."""
+        # Content just under the limit should succeed
+        content = "x" * (APPROX_MAX_CONTENT_SIZE - 100)
+
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_special_characters_in_content(self, registered_tool):
+        """Test handling of special characters."""
+        content = """
+            const regex = /[a-z]+/g;
+            const url = 'https://example.com?foo=bar&baz=qux';
+            const html = '<div class="test">&amp;</div>';
+        """
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+        # Verify roundtrip
+        url = result["url"]
+        encoded_part = url.replace(f"{WORKER_BASE_URL}/", "").split("?")[0]
+        decoded = base64.urlsafe_b64decode(encoded_part).decode("utf-8")
+        assert decoded == content
+
+    @pytest.mark.asyncio
+    async def test_base64_urlsafe_encoding(self, registered_tool):
+        """Test that URL-safe base64 encoding is used."""
+        # Content that would produce +/= in standard base64
+        content = "test>>>test"
+
+        result = await registered_tool(content=content)
+
+        assert result["success"] is True
+        url = result["url"]
+        # URL-safe base64 should not contain + or /
+        encoded_part = url.replace(f"{WORKER_BASE_URL}/", "").split("?")[0]
+        assert "+" not in encoded_part
+        assert "/" not in encoded_part
+
+    @pytest.mark.asyncio
+    async def test_single_character_content(self, registered_tool):
+        """Test handling of minimal content."""
+        result = await registered_tool(content="x")
+
+        assert result["success"] is True
+        assert result["size"] == 1
+
+
+class TestResourceToolsRegistration:
+    """Test that resource tools are properly registered."""
+
+    def test_register_resources_tools_creates_tool(self):
+        """Test that register_resources_tools registers the tool."""
+        mcp = MagicMock()
+        registered_tools = []
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                registered_tools.append(func.__name__)
+                return func
+            return wrapper
+
+        mcp.tool = tool_decorator
+        client = MagicMock()
+
+        register_resources_tools(mcp, client)
+
+        assert "ha_get_resource_url" in registered_tools
+
+    def test_tool_has_correct_annotations(self):
+        """Test that tool is registered with correct annotations."""
+        mcp = MagicMock()
+        captured_annotations = {}
+
+        def tool_decorator(*args, **kwargs):
+            captured_annotations.update(kwargs.get("annotations", {}))
+            def wrapper(func):
+                return func
+            return wrapper
+
+        mcp.tool = tool_decorator
+        client = MagicMock()
+
+        register_resources_tools(mcp, client)
+
+        assert captured_annotations.get("readOnlyHint") is True
+        assert captured_annotations.get("idempotentHint") is True
+        assert "resources" in captured_annotations.get("tags", [])
+        assert "dashboard" in captured_annotations.get("tags", [])
+
+
+class TestConstants:
+    """Test module constants are properly defined."""
+
+    def test_worker_base_url_is_https(self):
+        """Test that worker URL uses HTTPS."""
+        assert WORKER_BASE_URL.startswith("https://")
+
+    def test_max_encoded_length_is_reasonable(self):
+        """Test that max encoded length allows useful content."""
+        # Should allow at least 10KB of content
+        assert MAX_ENCODED_LENGTH >= 10000
+
+    def test_approx_max_content_size_accounts_for_base64_overhead(self):
+        """Test that content size limit accounts for base64 expansion."""
+        # Base64 encoding increases size by exactly 4/3 (1.333...)
+        # So max content * 4/3 should be <= max encoded length
+        # Using ceiling division to be safe
+        expected_encoded = (APPROX_MAX_CONTENT_SIZE * 4 + 2) // 3
+        assert expected_encoded <= MAX_ENCODED_LENGTH


### PR DESCRIPTION
Closes #266

## Summary

- Adds new MCP tool `ha_get_resource_url` for converting inline JavaScript/CSS to hosted URLs via Cloudflare Worker
- Enables AI assistants to inject custom resources into Home Assistant dashboards without filesystem access
- Tool is purely client-side (no Home Assistant API calls required)

## Changes

- **`src/ha_mcp/tools/tools_resources.py`**: New tool module implementing:
  - Base64 URL-safe encoding of content
  - Support for `module`, `js`, and `css` resource types
  - Size validation (~12KB limit to stay within URL length constraints)
  - Deterministic URLs (same content produces same URL)
  - Comprehensive error handling with helpful suggestions

- **`tests/src/unit/test_tools_resources.py`**: 25 unit tests covering:
  - Success cases for all resource types
  - URL encoding verification
  - Size limit enforcement
  - Error handling
  - Edge cases (unicode, special characters, etc.)

## Implementation Notes

- Tool renamed from `ha_create_resource_url` (as specified in issue) to `ha_get_resource_url` to comply with project naming conventions for read-only tools
- The tool is marked with `readOnlyHint: True` since it doesn't modify any server state
- Worker base URL: `https://ha-mcp-resources.workers.dev`

## Test Plan

- [x] All 25 new unit tests pass
- [x] Existing annotation tests pass (tool naming convention check)
- [x] Ruff linting passes
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)