### PR TITLE
fix: write JSON config without UTF-8 BOM on Windows

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -98,11 +98,13 @@ if (Test-Path $ConfigFile) {
 
     # For simplicity, we write the clean config (merging would require complex JSON handling)
     # The backup preserves any other MCP servers the user had
-    $JsonConfig | Set-Content $ConfigFile -Encoding UTF8
+    # Use .NET to write UTF-8 without BOM (PowerShell's -Encoding UTF8 adds BOM which breaks JSON parsers)
+    [System.IO.File]::WriteAllText($ConfigFile, $JsonConfig)
     Write-Host "  Configuration updated successfully" -ForegroundColor White
 } else {
     # Create new config file
-    $JsonConfig | Set-Content $ConfigFile -Encoding UTF8
+    # Use .NET to write UTF-8 without BOM (PowerShell's -Encoding UTF8 adds BOM which breaks JSON parsers)
+    [System.IO.File]::WriteAllText($ConfigFile, $JsonConfig)
     Write-Host "  Created new configuration file" -ForegroundColor White
 }
 Write-Host "  Claude Desktop configured" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Fixed Windows installer creating invalid JSON config file
- PowerShell's `Set-Content -Encoding UTF8` adds a BOM (Byte Order Mark)
- Claude Desktop JSON parser rejects files with BOM, showing "Unexpected token" error

## Fix
Replaced `Set-Content -Encoding UTF8` with `[System.IO.File]::WriteAllText()` which writes UTF-8 without BOM.

## Test plan
- [ ] Run installer on Windows: `irm https://raw.githubusercontent.com/homeassistant-ai/ha-mcp/fix/utf8-bom-issue/scripts/install-windows.ps1 | iex`
- [ ] Verify Claude Desktop loads without JSON error

🤖 Generated with [Claude Code](https://claude.com/claude-code)