### PR TITLE
fix: use system CA certificates for SSL verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     'textdistance>=4.6.0; platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ARM64"',
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",
+    "truststore>=0.10.0",
     "websockets>=12.0",
 ]
 

--- a/site/src/content/deployment/docker.md
+++ b/site/src/content/deployment/docker.md
@@ -59,6 +59,30 @@ docker rm ha-mcp
 docker pull ghcr.io/homeassistant-ai/ha-mcp:latest
 ```
 
+## Custom SSL Certificates
+
+If your Home Assistant is behind a reverse proxy with self-signed certificates, you need to provide a CA bundle that includes both your custom CA and the standard root CAs.
+
+### Create Combined CA Bundle
+
+```bash
+# Get the default CA bundle and append your custom CA
+cat $(python3 -m certifi) /path/to/your-ca.crt > combined-ca-bundle.crt
+```
+
+### Run with Custom CA
+
+```bash
+docker run -d --name ha-mcp \
+  -p 8086:8086 \
+  -e HOMEASSISTANT_URL=https://homeassistant.example.com \
+  -e HOMEASSISTANT_TOKEN=your_token \
+  -e SSL_CERT_FILE=/certs/ca-bundle.crt \
+  -v /path/to/combined-ca-bundle.crt:/certs/ca-bundle.crt:ro \
+  ghcr.io/homeassistant-ai/ha-mcp:latest \
+  fastmcp run fastmcp-http.json
+```
+
 ## Requirements
 
 - Docker or Docker Desktop installed

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1,11 +1,14 @@
 """Home Assistant MCP Server."""
 
-import asyncio
-import logging
-import os
-import signal
-import sys
-from typing import Any
+import truststore
+truststore.inject_into_ssl()
+
+import asyncio  # noqa: E402
+import logging  # noqa: E402
+import os  # noqa: E402
+import signal  # noqa: E402
+import sys  # noqa: E402
+from typing import Any  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.14.0"
+version = "4.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -382,6 +382,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "textdistance" },
     { name = "textdistance", extra = ["extras"], marker = "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'" },
+    { name = "truststore" },
     { name = "websockets" },
 ]
 
@@ -410,6 +411,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "textdistance", marker = "platform_machine == 'ARM64' or platform_machine == 'aarch64' or platform_machine == 'arm64'", specifier = ">=4.6.0" },
     { name = "textdistance", extras = ["extras"], marker = "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'", specifier = ">=4.6.0" },
+    { name = "truststore", specifier = ">=0.10.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
 
@@ -1313,6 +1315,15 @@ extras = [
     { name = "numpy", marker = "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "pyxdameraulevenshtein", marker = "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "rapidfuzz", marker = "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `truststore` library to use native system certificate stores instead of bundled certifi certificates
- Users with self-signed certificates can now add their CA to the OS trust store
- Document Docker usage with custom CA certificates via `SSL_CERT_FILE` environment variable

## How It Works

**Python package (uvx/pip):** Add your CA to your OS trust store:
- macOS: Keychain Access
- Linux: `update-ca-certificates`
- Windows: certmgr.msc

**Docker:** Set `SSL_CERT_FILE` to a combined bundle containing your CA + standard CAs

## Changes

- `pyproject.toml`: Add `truststore>=0.10.0` dependency
- `src/ha_mcp/__main__.py`: Inject truststore at startup
- `site/src/content/deployment/docker.md`: Document custom SSL certificates

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)