### PR TITLE
fix: add --version/-V flag to CLI

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -255,6 +255,12 @@ async def _run_with_graceful_shutdown() -> None:
 # CLI entry point (for pyproject.toml) - use FastMCP's built-in runner
 def main() -> None:
     """Run server via CLI using FastMCP's stdio transport."""
+    # Handle --version flag early, before server creation requires config
+    if "--version" in sys.argv or "-V" in sys.argv:
+        from importlib.metadata import version
+        print(f"ha-mcp {version('ha-mcp')}")
+        sys.exit(0)
+
     # Check for smoke test flag
     if "--smoke-test" in sys.argv:
         from ha_mcp.smoke_test import main as smoke_test_main


### PR DESCRIPTION
## Summary
- Add `--version` and `-V` CLI flags that work without requiring configuration
- Previously, running `ha-mcp --version` crashed because it tried to create the server, which requires `HOMEASSISTANT_URL` and `HOMEASSISTANT_TOKEN`
- Now version flags are handled early, before any server initialization

## Test plan
- [x] `ha-mcp --version` outputs version without requiring env vars
- [x] `ha-mcp -V` outputs version without requiring env vars
- [x] Lint passes
- [x] No new mypy errors introduced

Related to #290 (addresses the `--version` crash, original read-only filesystem issue was already fixed in PR #196)

🤖 Generated with [Claude Code](https://claude.com/claude-code)