### PR TITLE
fix: apply LOG_LEVEL environment variable to Python logging

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -266,6 +266,14 @@ def main() -> None:
         from ha_mcp.smoke_test import main as smoke_test_main
         sys.exit(smoke_test_main())
 
+    # Configure logging before server creation
+    from ha_mcp.config import get_settings
+    settings = get_settings()
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level),
+        format='%(asctime)s %(name)s %(levelname)s: %(message)s'
+    )
+
     # Set up signal handlers before running
     _setup_signal_handlers()
 
@@ -393,6 +401,14 @@ def main_web() -> None:
     - MCP_PORT (optional, default: 8086)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
+    # Configure logging before server creation
+    from ha_mcp.config import get_settings
+    settings = get_settings()
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level),
+        format='%(asctime)s %(name)s %(levelname)s: %(message)s'
+    )
+
     _run_http_server("streamable-http")
 
 
@@ -405,6 +421,14 @@ def main_sse() -> None:
     - MCP_PORT (optional, default: 8086)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
+    # Configure logging before server creation
+    from ha_mcp.config import get_settings
+    settings = get_settings()
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level),
+        format='%(asctime)s %(name)s %(levelname)s: %(message)s'
+    )
+
     _run_http_server("sse")
 
 

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -620,7 +620,6 @@ class HomeAssistantClient:
         self, ws_client: Any, message: dict[str, Any]
     ) -> dict[str, Any]:
         """Handle render_template WebSocket command with event-based response."""
-        import json
 
         # Generate our own message ID to track the response
         message_id = ws_client.get_next_message_id()
@@ -687,7 +686,7 @@ class HomeAssistantClient:
                         "template": message.get("template"),
                     }
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 ws_client.cancel_render_template_event(message_id)
                 return {
                     "success": False,
@@ -695,7 +694,7 @@ class HomeAssistantClient:
                     "template": message.get("template"),
                 }
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             ws_client.cancel_pending_response(message_id)
             ws_client.cancel_render_template_event(message_id)
             return {

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -449,7 +449,7 @@ class HomeAssistantWebSocketClient:
                 )
                 return {"success": True, **response}
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self.cancel_pending_response(message_id)
             raise Exception("Command timeout")
         except Exception:

--- a/src/ha_mcp/smoke_test.py
+++ b/src/ha_mcp/smoke_test.py
@@ -81,7 +81,7 @@ def main() -> int:
 
         if tool_count < 50:
             errors.append(f"Too few tools discovered: {tool_count} (expected 50+)")
-            print(f"  ✗ Tool count too low (expected 50+)")
+            print("  ✗ Tool count too low (expected 50+)")
         else:
             # List a few tool names as examples
             tool_names = list(mcp._tool_manager._tools.keys())[:5]
@@ -100,7 +100,7 @@ def main() -> int:
     else:
         print("SMOKE TEST PASSED: All checks successful!")
         print(f"  - All {len(critical_imports)} critical libraries imported")
-        print(f"  - Server instantiated successfully")
+        print("  - Server instantiated successfully")
         print(f"  - {tool_count} tools discovered")
         return 0
 


### PR DESCRIPTION
## Summary

- Adds logging configuration in all three entry points (`main()`, `main_web()`, `main_sse()`)
- Uses `settings.log_level` from config to configure Python's logging system via `logging.basicConfig()`
- Includes minor ruff auto-fixes (unused imports, deprecated asyncio.TimeoutError)

## Problem

The `LOG_LEVEL` environment variable was validated in `config.py` but never actually applied to Python's logging system. Setting `LOG_LEVEL=DEBUG` had no effect on log output.

## Solution

Added logging configuration before server creation in each entry point that:
1. Imports `get_settings()` from config
2. Retrieves the validated `log_level` setting
3. Configures `logging.basicConfig()` with the appropriate level and format

## Test plan

- [x] Code passes ruff linting
- [ ] CI tests pass
- [ ] Manual testing: Set `LOG_LEVEL=DEBUG` and verify debug logs appear
- [ ] Manual testing: Set `LOG_LEVEL=INFO` and verify only info+ logs appear

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)