### PR TITLE
feat: add all helpers with WebSocket API support

### DIFF
--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -945,21 +945,21 @@ class TestZoneCRUD:
         logger.info("Zone cleanup complete")
 
     async def test_zone_requires_coordinates(self, mcp_client):
-        """Test that zone requires latitude and longitude."""
-        logger.info("Testing zone without coordinates (should fail)")
+        """Test that zone requires latitude and longitude (validated by HA)."""
+        logger.info("Testing zone without coordinates (HA should reject)")
 
         result = await mcp_client.call_tool(
             "ha_config_set_helper",
             {
                 "helper_type": "zone",
                 "name": "E2E No Coords Zone",
-                # Missing required latitude/longitude
+                # Missing required latitude/longitude - HA will validate
             },
         )
 
         data = parse_mcp_result(result)
         assert data.get("success") is False, f"Should fail without coordinates: {data}"
-        logger.info("Zone properly requires coordinates")
+        logger.info("HA properly validates required zone coordinates")
 
 
 @pytest.mark.asyncio
@@ -986,13 +986,12 @@ class TestPersonCRUD:
 
         helper_name = "E2E Test Person"
 
-        # CREATE person
+        # CREATE person (note: person doesn't support icon parameter)
         create_result = await mcp_client.call_tool(
             "ha_config_set_helper",
             {
                 "helper_type": "person",
                 "name": helper_name,
-                "icon": "mdi:account",
             },
         )
 


### PR DESCRIPTION
## Summary

Adds support for **all 12 Home Assistant helpers with Collection WebSocket API**, adapted to context engineering principles.

**New helpers (6):**
- **counter**: increment/decrement/reset (initial, min, max, step)
- **timer**: countdown timers (duration, restore)
- **schedule**: weekly time ranges (monday-sunday)
- **zone**: geographical zones (latitude, longitude, radius, passive)
- **person**: linked to device trackers (user_id, device_trackers, picture)
- **tag**: NFC/QR tags (tag_id, description)

**Context engineering adaptations:**
- Removed duplicate validation (e.g., zone lat/long) - HA returns clear errors
- Don't pass unsupported params (icon for person/tag)
- Simplified docstring - points to `ha_get_domain_docs()` for details
- Kept explicit parameters (Sonnet testing showed they improve model confidence vs generic config dict)

**Why explicit params over generic `config: dict`?**
Tested with no-context Sonnet agent - explicit params let model proceed with high confidence without needing to call `ha_get_domain_docs()` first. The tool signature serves as inline documentation.

## Not included: Config Entry Flow helpers

The following helpers use a **different API** (Config Entry Flow instead of Collection WebSocket):
- template, group, utility_meter, derivative, min_max, threshold, integration, statistics, trend, random, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat

These require multi-step form interactions via `/api/config/config_entries/flow`. Tracked in #324.

## Test plan
- [x] E2E tests for counter, timer, schedule CRUD
- [x] E2E tests for zone, person, tag CRUD
- [x] Zone validation delegated to HA (test confirms HA rejects missing coords)
- [x] CI passes

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)