### PR TITLE
fix: respect FASTMCP_SHOW_CLI_BANNER env var for banner control

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -207,8 +207,13 @@ async def _run_with_graceful_shutdown() -> None:
 
     _shutdown_event = asyncio.Event()
 
+    # Respect FastMCP's show_cli_banner setting
+    # Users can disable banner via FASTMCP_SHOW_CLI_BANNER=false
+    import fastmcp
+    show_banner = fastmcp.settings.show_cli_banner
+
     # Create a task for the MCP server
-    server_task = asyncio.create_task(_get_mcp().run_async())
+    server_task = asyncio.create_task(_get_mcp().run_async(show_banner=show_banner))
 
     # Wait for either the server to complete or a shutdown signal
     shutdown_task = asyncio.create_task(_shutdown_event.wait())
@@ -312,6 +317,11 @@ async def _run_http_with_graceful_shutdown(
 
     _shutdown_event = asyncio.Event()
 
+    # Respect FastMCP's show_cli_banner setting
+    # Users can disable banner via FASTMCP_SHOW_CLI_BANNER=false
+    import fastmcp
+    show_banner = fastmcp.settings.show_cli_banner
+
     # Create a task for the MCP server
     server_task = asyncio.create_task(
         _get_mcp().run_async(
@@ -319,6 +329,7 @@ async def _run_http_with_graceful_shutdown(
             host=host,
             port=port,
             path=path,
+            show_banner=show_banner,
         )
     )
 


### PR DESCRIPTION
## Summary

- Pass `show_banner` setting from `fastmcp.settings.show_cli_banner` to `run_async()` for both stdio and HTTP transports
- Users can now disable the FastMCP banner by setting `FASTMCP_SHOW_CLI_BANNER=false` in their environment
- Useful for MCP clients like Google Antigravity that may have issues with stderr output during initialization

## Background

The FastMCP banner is correctly printed to stderr (not stdout), but some MCP clients treat any stderr output as "unexpected server output" and fail to initialize properly. This fix allows users to disable the banner entirely via environment variable.

### Configuration for Antigravity

```json
{
  "mcpServers": {
    "home-assistant": {
      "command": "uvx",
      "args": ["ha-mcp@latest"],
      "env": {
        "HOMEASSISTANT_URL": "http://your-ha-url:8123",
        "HOMEASSISTANT_TOKEN": "your-long-lived-token",
        "FASTMCP_SHOW_CLI_BANNER": "false"
      }
    }
  }
}
```

## Test plan

- [x] Verify `FASTMCP_SHOW_CLI_BANNER=false` suppresses banner on stdio transport
- [x] Verify banner still shows when env var is not set (default behavior)
- [ ] CI passes

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)