### PR TITLE
Fix Gemini CLI and Antigravity instructions

### DIFF
--- a/site/src/content/clients/antigravity.md
+++ b/site/src/content/clients/antigravity.md
@@ -27,8 +27,7 @@ Google Antigravity supports MCP servers via the built-in MCP Store and custom co
 ```json
 {
   "mcpServers": {
-    "home-assistant": {
-      "command": "uvx",
+    "homeassistant": {
       "args": ["ha-mcp@latest"],
       "env": {
         "HOMEASSISTANT_URL": "{{HOMEASSISTANT_URL}}",
@@ -51,7 +50,7 @@ Google Antigravity supports MCP servers via the built-in MCP Store and custom co
 ```json
 {
   "mcpServers": {
-    "home-assistant": {
+    "homeassistant": {
       "serverUrl": "{{MCP_SERVER_URL}}"
     }
   }

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -83,10 +83,10 @@ Gemini CLI uses `httpUrl` key for HTTP streaming transport:
 ### stdio (Local)
 
 ```bash
-gemini mcp add \
+gemini mcp add --scope user homeassistant \
   -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \
   -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} \
-  home-assistant uvx ha-mcp@latest
+  uvx -- ha-mcp@latest
 ```
 
 ### HTTP (Network/Remote)

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1384,17 +1384,16 @@ mcpServers:
         // Gemini CLI
         if (isStdio) {
           if (isDocker) {
-            config = `gemini mcp add home-assistant docker -- \\
-  run --rm -i \\
-  -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \\
-  -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} \\
-  ghcr.io/homeassistant-ai/ha-mcp:latest`;
-          } else {
-            config = `gemini mcp add home-assistant uvx -- \\
-  -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \\
-  -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} \\
-  ha-mcp@latest`;
-          }
+                        config = `gemini mcp add --scope user homeassistant docker -- \\
+              run --rm -i \\
+              -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \\
+              -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} \\
+              ghcr.io/homeassistant-ai/ha-mcp:latest`;
+                        } else {
+                        config = `gemini mcp add --scope user homeassistant \\
+              -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \\
+              -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} \\
+              uvx -- ha-mcp@latest`;          }
         } else {
           config = `gemini mcp add --transport http home-assistant ${mcpUrl}`;
         }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
@@ -402,7 +402,7 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "4.21.0"
+version = "4.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
This PR fixes the Gemini CLI instructions to correctly handle environment variables and adds the  flag. It also updates the Antigravity client instructions to remove hyphens from the server name, as suggested in issue #318.