### PR TITLE
fix(ci): use RELEASE_TOKEN for tag creation to bypass rulesets

### DIFF
--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -71,13 +71,15 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        # Use RELEASE_TOKEN (PAT/App token with bypass permissions) if available, fallback to GITHUB_TOKEN
+        token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
     - name: Python Semantic Release
       id: semantic
       uses: python-semantic-release/python-semantic-release@v10.5.2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Use RELEASE_TOKEN to bypass tag creation restrictions
+        github_token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         verbosity: "2"
         # Don't create GitHub release here - we'll create a draft below
         vcs_release: "false"
@@ -85,7 +87,7 @@ jobs:
     - name: Create draft GitHub release
       if: steps.semantic.outputs.released == 'true'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       run: |
         VERSION="${{ steps.semantic.outputs.version }}"
         TAG="v${VERSION}"


### PR DESCRIPTION
## Problem

Organization-level tag protection rulesets prevent  from creating release tags, causing semantic-release to fail with:

```
remote: error: GH013: Repository rule violations found for refs/tags/v5.0.0
remote: - Cannot create ref due to creations being restricted.
```

## Solution

Add support for  secret (PAT or GitHub App token with bypass permissions) while maintaining backward compatibility with .

## Changes

- Use `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN` for checkout token
- Use `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN` for semantic-release
- Use `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN` for gh CLI operations

## Setup Instructions

To enable automated releases:

1. **Create a token with bypass permissions:**
   - **Option A (PAT):** Create a Personal Access Token from an org admin account with `contents: write` scope
   - **Option B (GitHub App):** Create a GitHub App with bypass permissions and install it on the repo

2. **Add to repository secrets:**
   ```bash
   gh secret set RELEASE_TOKEN --body "YOUR_TOKEN_HERE"
   ```

3. **Configure bypass actor in ruleset:**
   - For PAT: Add the admin user as bypass actor
   - For App: Add the GitHub App as bypass actor

## Testing

After merging and configuring RELEASE_TOKEN:
```bash
gh workflow run semver-release.yml
```

## Backward Compatibility

Falls back to `GITHUB_TOKEN` if `RELEASE_TOKEN` is not set, maintaining existing behavior for repositories without tag protection rulesets.