### PR TITLE
fix(ci): filter artifact downloads to skip Docker build cache

### DIFF
--- a/.github/workflows/_build-and-release.yml
+++ b/.github/workflows/_build-and-release.yml
@@ -169,6 +169,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
+          pattern: ha-mcp-*
           path: artifacts
 
       - name: Display artifact structure


### PR DESCRIPTION
Fixes artifact download timeout in reusable workflow.

## Issue  

The upload job was timing out while trying to download ALL artifacts, including Docker build cache artifacts from the Docker buildx action.

## Fix

Added  to the artifact download step to only download binary artifacts we actually need.

## Testing

Will be tested automatically when merged - the next dev release will use the fixed workflow.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)