### PR TITLE
fix: make jq optional on Windows ARM64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.11.0",
     "httpx>=0.27.0",
-    "jq>=1.8.0",
+    'jq>=1.8.0; sys_platform != "win32" or platform_machine != "ARM64"',
     'textdistance[extras]>=4.6.0; platform_machine != "arm64" and platform_machine != "aarch64" and platform_machine != "ARM64"',
     'textdistance>=4.6.0; platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ARM64"',
     "pydantic>=2.5.0",

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Annotated, Any, cast
 
 import httpx
-import jq
 from pydantic import Field
 
 from ..config import get_global_settings
@@ -21,6 +20,18 @@ from .helpers import log_tool_usage
 from .util_helpers import parse_json_param
 
 logger = logging.getLogger(__name__)
+
+# Try to import jq - it's not available on Windows ARM64
+try:
+    import jq
+
+    JQ_AVAILABLE = True
+except ImportError:
+    JQ_AVAILABLE = False
+    logger.warning(
+        "jq library not available - jq_transform features will be disabled. "
+        "This is expected on Windows ARM64 where jq cannot be compiled."
+    )
 
 # Card documentation base URL
 CARD_DOCS_BASE_URL = (
@@ -110,6 +121,15 @@ def _apply_jq_transform(
         - On success: (dict, None)
         - On failure: (None, error_string)
     """
+    # Check if jq is available
+    if not JQ_AVAILABLE:
+        return None, (
+            "jq_transform is not available - jq library could not be imported. "
+            "This is a known limitation on Windows ARM64 where jq cannot be compiled. "
+            "Please use the 'config' parameter for full config replacement instead, "
+            "or use ha-mcp on Windows x64, Linux, or macOS where jq is supported."
+        )
+
     try:
         # Compile and validate the jq expression
         program = jq.compile(expression)


### PR DESCRIPTION
## Summary

Fixes #357 by making the `jq` dependency optional on Windows ARM64 where it cannot be compiled.

## Changes

1. **pyproject.toml**: Added platform marker to exclude jq on Windows ARM64
   - Uses marker: `sys_platform != "win32" or platform_machine != "ARM64"`
   - jq installs automatically on all platforms EXCEPT Windows ARM64
   - No breaking changes for existing users

2. **tools_config_dashboards.py**: Graceful handling of missing jq
   - Try/except on import with warning log
   - `_apply_jq_transform()` checks `JQ_AVAILABLE` flag
   - Returns clear error message when jq_transform used without jq

## Behavior

### Platforms where jq IS installed (unchanged):
- ✅ Linux (all architectures)
- ✅ macOS (x64 and ARM64)
- ✅ Windows x64
- ✅ Windows x86

### Platforms where jq is SKIPPED:
- ❌ Windows ARM64

## Error Message

When a Windows ARM64 user tries to use `jq_transform`:

```
jq_transform is not available - jq library could not be imported. 
This is a known limitation on Windows ARM64 where jq cannot be compiled. 
Please use the 'config' parameter for full config replacement instead, 
or use ha-mcp on Windows x64, Linux, or macOS where jq is supported.
```

## Testing

- ✅ Python syntax validated
- ✅ Platform marker logic verified for all platforms
- ✅ Error handling tested

## Alternative Considered

Building custom wheels for Windows ARM64 using cibuildwheel was considered but rejected due to:
- High complexity (2-3 weeks effort)
- Ongoing maintenance burden
- Low Windows ARM64 market share
- Feature is brand new (PR #333), usage patterns unknown

This solution provides immediate relief with minimal code changes while keeping the door open for custom wheel builds in the future if demand warrants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)