### PR TITLE
fix(ci): checkout actual hotfix branch instead of PR merge commit

### DIFF
--- a/.github/workflows/pr-validate-hotfix.yml
+++ b/.github/workflows/pr-validate-hotfix.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Validate hotfix is based on stable tag
         run: |


### PR DESCRIPTION
## Summary
Fixes the hotfix validation workflow that was incorrectly flagging valid hotfix branches as being based on master.

## Problem
The workflow was checking out the PR merge commit (which GitHub creates by merging hotfix with master), not the actual hotfix branch. This caused the merge base calculation to always be master itself, triggering false positives.

## Solution
Added `ref: ${{ github.head_ref }}` to explicitly checkout the hotfix branch instead of the merge commit.

## Testing
- [x] Workflow will be tested by PR #369

## Related Issues
Blocks #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)