### PR TITLE
fix: exclude jq dependency on all Windows platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.11.0",
     "httpx>=0.27.0",
-    'jq>=1.8.0; sys_platform != "win32" or platform_machine != "ARM64"',
+    'jq>=1.8.0; sys_platform != "win32"',
     'textdistance[extras]>=4.6.0; platform_machine != "arm64" and platform_machine != "aarch64" and platform_machine != "ARM64"',
     'textdistance>=4.6.0; platform_machine == "arm64" or platform_machine == "aarch64" or platform_machine == "ARM64"',
     "pydantic>=2.5.0",


### PR DESCRIPTION
## Summary
Fixes #357 - Windows installation failures due to jq compilation requirements

## Problem
The jq package requires C compilation which fails on Windows without Visual Studio Build Tools. The previous condition `sys_platform != "win32" or platform_machine != "ARM64"` only excluded Windows ARM64, leaving x64 Windows still trying to compile jq.

## Solution
Changed the dependency condition to `sys_platform != "win32"` to exclude jq on all Windows platforms.

## Changes
- Updated `pyproject.toml` dependency condition for jq to exclude all Windows platforms

## Testing
- [x] Verified condition logic excludes all Windows platforms (both x64 and ARM64)
- [x] Verified condition allows jq on Linux and macOS

## Related Issues
Closes #357
Supersedes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)