### PR TITLE
docs: simplify ha_call_service docstring (117→34 lines)

### DIFF
--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -52,7 +52,7 @@ def register_service_tools(mcp, client, **kwargs):
         **Parameters:**
         - **domain**: Service domain (light, climate, automation, etc.)
         - **service**: Service name (turn_on, set_temperature, trigger, etc.)
-        - **entity_id**: Optional - target entity. Omit to affect all entities in domain
+        - **entity_id**: Optional target entity. For some services (e.g., light.turn_off), omitting this targets all entities in the domain
         - **data**: Optional dict of service-specific parameters
         - **return_response**: Set to True for services that return data
 


### PR DESCRIPTION
Closes #367

## Summary
- Simplified `ha_call_service` docstring from 117 lines to 34 lines (70% reduction)
- Applied progressive disclosure principles to reduce cognitive load
- Removed domain-specific examples (light, climate, media_player, cover, etc.)
- Added clear reference to `ha_get_domain_docs()` for detailed documentation

## Changes

**Before:** 117-line docstring with extensive examples for:
- Light control (brightness, color temperature)
- Climate control (temperature, modes)
- Automation control
- Scene activation
- Input helpers
- Media players
- Cover controls
- Scripts
- Services with response data

**After:** 34-line focused docstring with:
- Brief tool description
- 4 essential usage examples
- Clear parameter documentation
- Reference to `ha_get_domain_docs()` for detailed docs
- Hints for related tools (`ha_get_state()`, `ha_search_entities()`)

## Context Engineering Rationale

This follows the context engineering principles from `CLAUDE.md`:
- **Favor statelessness & on-demand docs** over front-loading all examples
- **Progressive disclosure** - show essentials first, guide to detailed docs
- **Trust model knowledge** - models already know common HA service patterns
- **Reduce cognitive load** - shorter tool descriptions = faster tool discovery

The detailed examples are still available via `ha_get_domain_docs("light")`, `ha_get_domain_docs("climate")`, etc.

## Testing
- No functional changes, only documentation
- Verified linting passes
- CI will validate E2E tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)