### PR TITLE
feat: add Codex CLI support to setup wizard

### DIFF
--- a/site/src/content/clients/codex.md
+++ b/site/src/content/clients/codex.md
@@ -21,12 +21,11 @@ Codex CLI supports MCP servers via TOML configuration with stdio and HTTP stream
 ### stdio Configuration (Local)
 
 ```toml
-[[mcp.servers]]
-name = "home-assistant"
+[mcp_servers.home-assistant]
 command = "uvx"
 args = ["ha-mcp@latest"]
 
-[mcp.servers.env]
+[mcp_servers.home-assistant.env]
 HOMEASSISTANT_URL = "{{HOMEASSISTANT_URL}}"
 HOMEASSISTANT_TOKEN = "{{HOMEASSISTANT_TOKEN}}"
 ```
@@ -34,21 +33,17 @@ HOMEASSISTANT_TOKEN = "{{HOMEASSISTANT_TOKEN}}"
 ### Streamable HTTP Configuration (Network/Remote)
 
 ```toml
-[[mcp.servers]]
-name = "home-assistant"
+[mcp_servers.home-assistant]
 url = "{{MCP_SERVER_URL}}"
-transport = "http-stream"
 ```
 
 ### With Authentication
 
 ```toml
-[[mcp.servers]]
-name = "home-assistant"
+[mcp_servers.home-assistant]
 url = "{{MCP_SERVER_URL}}"
-transport = "http-stream"
 
-[mcp.servers.headers]
+[mcp_servers.home-assistant.headers]
 Authorization = "Bearer {{API_TOKEN}}"
 ```
 
@@ -57,19 +52,13 @@ Authorization = "Bearer {{API_TOKEN}}"
 ### stdio (Local)
 
 ```bash
-codex mcp add homeassistant \
-  --command uvx \
-  --args ha-mcp@latest \
-  --env HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \
-  --env HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}}
+codex mcp add homeassistant --env HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} --env HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} -- uvx ha-mcp@latest
 ```
 
 ### HTTP Streaming (Network/Remote)
 
 ```bash
-codex mcp add home-assistant \
-  --url {{MCP_SERVER_URL}} \
-  --transport http-stream
+codex mcp add home-assistant --url {{MCP_SERVER_URL}}
 ```
 
 ## Management Commands
@@ -78,11 +67,11 @@ codex mcp add home-assistant \
 # List configured servers
 codex mcp list
 
+# Show server details
+codex mcp get home-assistant
+
 # Remove a server
 codex mcp remove home-assistant
-
-# Update server configuration
-codex mcp update home-assistant --env HOMEASSISTANT_URL={{NEW_URL}}
 ```
 
 ## Notes

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1396,20 +1396,12 @@ mcpServers:
         // Codex CLI
         if (isStdio) {
           if (isDocker) {
-            config = `codex mcp add homeassistant \\
-  --command docker \\
-  --args "run,--rm,-i,-e,HOMEASSISTANT_URL={{HOMEASSISTANT_URL}},-e,HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}},ghcr.io/homeassistant-ai/ha-mcp:latest"`;
+            config = `codex mcp add homeassistant --env HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} --env HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} -- docker run --rm -i ghcr.io/homeassistant-ai/ha-mcp:latest`;
           } else {
-            config = `codex mcp add homeassistant \\
-  --command uvx \\
-  --args ha-mcp@latest \\
-  --env HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} \\
-  --env HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}}`;
+            config = `codex mcp add homeassistant --env HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} --env HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}} -- uvx ha-mcp@latest`;
           }
         } else {
-          config = `codex mcp add home-assistant \\
-  --url ${mcpUrl} \\
-  --transport http-stream`;
+          config = `codex mcp add home-assistant --url ${mcpUrl}`;
         }
       } else {
         // Claude Code


### PR DESCRIPTION
## Summary
Add Codex (OpenAI CLI) as a client option in the setup wizard.

## Changes
- ✅ Add `codex.md` client definition with TOML config format
- ✅ Support stdio and streamable-http transports (no SSE)
- ✅ Add configuration generation in setup.astro
- ✅ Correct Codex CLI syntax (tested with actual tool)
- ✅ Windows-compatible commands (no backslashes)
- ✅ Uses OpenAI logo (already exists)

## Testing
- [x] Site builds without errors
- [x] Codex appears in client list
- [x] Configuration generation works for stdio and HTTP
- [x] Commands tested with actual `codex mcp add` tool
- [x] Verified correct TOML format in `~/.codex/config.toml`

## Screenshots
N/A - Setup wizard UI, see live demo

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)