### PR TITLE
fix: apply domain filter before fuzzy search, not after

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -36,7 +36,7 @@ class SmartSearchTools:
         self.fuzzy_searcher = create_fuzzy_searcher(threshold=fuzzy_threshold)
 
     async def smart_entity_search(
-        self, query: str, limit: int = 10, include_attributes: bool = False
+        self, query: str, limit: int = 10, include_attributes: bool = False, domain_filter: str | None = None
     ) -> dict[str, Any]:
         """
         Advanced entity search with fuzzy matching and typo tolerance.
@@ -45,6 +45,7 @@ class SmartSearchTools:
             query: Search query (can be partial, with typos)
             limit: Maximum number of results
             include_attributes: Whether to include full entity attributes
+            domain_filter: Optional domain to filter entities before search (e.g., "light", "sensor")
 
         Returns:
             Dictionary with search results and metadata
@@ -52,6 +53,14 @@ class SmartSearchTools:
         try:
             # Get all entities
             entities = await self.client.get_states()
+
+            # Filter by domain BEFORE fuzzy search if domain_filter provided
+            # This ensures fuzzy search only looks at entities in the target domain
+            if domain_filter:
+                entities = [
+                    e for e in entities
+                    if e.get("entity_id", "").startswith(f"{domain_filter}.")
+                ]
 
             # Perform fuzzy search
             matches = self.fuzzy_searcher.search_entities(entities, query, limit)

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -311,7 +311,7 @@ def register_search_tools(mcp, client, **kwargs):
 
             # Step 1: Try fuzzy search
             try:
-                result = await smart_tools.smart_entity_search(query, limit)
+                result = await smart_tools.smart_entity_search(query, limit, domain_filter=domain_filter)
                 search_type = "fuzzy_search"
             except Exception as fuzzy_error:
                 logger.warning(f"Fuzzy search failed, trying exact match: {fuzzy_error}")
@@ -341,13 +341,8 @@ def register_search_tools(mcp, client, **kwargs):
             if "matches" in result:
                 result["results"] = result.pop("matches")
 
-            # Apply domain filter if provided (for fuzzy search results)
-            if domain_filter and "results" in result and search_type == "fuzzy_search":
-                filtered_results = [
-                    r for r in result["results"] if r.get("domain") == domain_filter
-                ]
-                result["results"] = filtered_results
-                result["total_matches"] = len(filtered_results)
+            # Add domain_filter to result if it was provided (for API consistency)
+            if domain_filter:
                 result["domain_filter"] = domain_filter
 
             # Group by domain if requested


### PR DESCRIPTION
## Summary

Fixes bug where searching with `domain_filter` + `query` returns 0 results even when matching entities exist.

**Root Cause**: Domain filtering was applied AFTER fuzzy search had already limited results, so if other domains scored higher, target domain entities were excluded from results.

**Example Bug:**
```
Search: query="salon", domain_filter="light"
Entity exists: light.salon_lampe_gauche
Result: 0 matches ❌

Why: sensor.salon_* scored higher → filled top 10 results → domain filter excluded them → 0 results
```

## Solution

Filter entities by domain **BEFORE** fuzzy search, not after:

1. **Added `domain_filter` parameter** to `smart_entity_search()`
2. **Pre-filter entities** by domain before calling fuzzy search
3. **Pass `domain_filter`** from `tools_search.py` to `smart_entity_search()`
4. **Removed post-filtering** code that was causing the bug

## Changes

### `src/ha_mcp/tools/smart_search.py`
- Added `domain_filter: str | None = None` parameter
- Filter entities before fuzzy search:
  ```python
  if domain_filter:
      entities = [e for e in entities if e.get("entity_id", "").startswith(f"{domain_filter}.")]
  ```

### `src/ha_mcp/tools/tools_search.py`
- Pass domain_filter to search: `smart_entity_search(query, limit, domain_filter=domain_filter)`
- Removed buggy post-filtering code
- Keep `domain_filter` field in response for API compatibility

## Test Results

All 11 search tests passing:
```
✅ test_search_entities_basic_query
✅ test_search_entities_empty_query_with_domain_filter  
✅ test_search_entities_domain_filter_with_query  
✅ test_search_entities_limit_respected
... (8 more tests)
```

## Impact

**Before**: `query="salon", domain_filter="light"` → 0 results  
**After**: `query="salon", domain_filter="light"` → finds `light.salon_lampe_gauche` ✅

Fuzzy search now only looks at entities in the target domain, ensuring relevant matches within the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)