### PR TITLE
fix(ci): add debug output and re-check draft status before publishing

### DIFF
--- a/.github/workflows/_build-and-release.yml
+++ b/.github/workflows/_build-and-release.yml
@@ -191,6 +191,7 @@ jobs:
           fi
 
           IS_DRAFT=$(echo "$RELEASE_INFO" | jq -r '.draft')
+          echo "Release $TAG draft status before upload: $IS_DRAFT"
 
           # Upload all binaries
           gh release upload "$TAG" \
@@ -202,9 +203,16 @@ jobs:
 
           echo "✓ Uploaded binaries to $TAG"
 
+          # Re-check draft status after upload (in case it changed)
+          RELEASE_INFO_AFTER=$(gh api repos/${{ github.repository }}/releases/tags/$TAG 2>/dev/null || echo "")
+          IS_DRAFT_AFTER=$(echo "$RELEASE_INFO_AFTER" | jq -r '.draft')
+          echo "Release $TAG draft status after upload: $IS_DRAFT_AFTER"
+
           # If release is still draft, publish it
-          if [ "$IS_DRAFT" = "true" ]; then
+          if [ "$IS_DRAFT_AFTER" = "true" ]; then
             echo "Publishing draft release..."
             gh release edit "$TAG" --draft=false
             echo "✓ Published release $TAG"
+          else
+            echo "Release is already published, skipping publish step"
           fi


### PR DESCRIPTION
## Problem

Releases were not being automatically published after binaries were uploaded. Both v5.1.0 and v6.0.0 remained as drafts even though the workflow completed successfully.

## Root Cause

The draft status check was happening before uploading binaries, and the workflow was checking `IS_DRAFT` from that pre-upload check to decide whether to publish. The "Publishing draft release..." message never appeared in logs.

## Solution

1. **Added debug output** showing draft status before and after upload
2. **Re-check draft status** after uploading binaries
3. **Use post-upload status** (`IS_DRAFT_AFTER`) for the publish decision
4. **Added clear messaging** about whether release is being published or skipped

## Testing

This change will be tested in the next release workflow run. The debug output will help identify why the original check was failing.

## Manual Fix Applied

- Manually published v6.0.0 
- Manually published v5.1.0

Future releases should auto-publish with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)