### PR TITLE
fix(addon-dev): upgrade hassio_role to homeassistant

### DIFF
--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -11,7 +11,7 @@ init: false
 startup: application
 boot: manual
 hassio_api: true
-hassio_role: default
+hassio_role: homeassistant
 homeassistant_api: true
 host_network: true
 image: "ghcr.io/homeassistant-ai/ha-mcp-addon-dev-{arch}"


### PR DESCRIPTION
This PR upgrades the `hassio_role` to `homeassistant` in the dev add-on configuration.

Investigation into issue #414 revealed that the `default` role was insufficient for the Supervisor Core API proxy to allow `DELETE` requests on Home Assistant configuration endpoints (automations, scripts), resulting in a 405 Method Not Allowed error.

Setting the role to `homeassistant` grants the add-on the necessary permissions to manage these entities via the REST API while adhering to least privilege principles (avoiding full `admin` role).

Related to #414.