### PR TITLE
fix(addon-dev): upgrade hassio_role to admin (retry)

### DIFF
--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -11,7 +11,7 @@ init: false
 startup: application
 boot: manual
 hassio_api: true
-hassio_role: homeassistant
+hassio_role: admin
 homeassistant_api: true
 host_network: true
 image: "ghcr.io/homeassistant-ai/ha-mcp-addon-dev-{arch}"


### PR DESCRIPTION
This PR upgrades the `hassio_role` to `admin` in the dev add-on configuration.

The previous attempt with `homeassistant` role was insufficient to resolve the 405 Method Not Allowed error on DELETE operations for configuration endpoints. It appears the Supervisor proxy requires full `admin` privileges for these specific API calls.

Related to #414.