### PR TITLE
fix(client): fix REST API path resolution for Add-on compatibility

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -76,8 +76,9 @@ class HomeAssistantClient:
             self.timeout = timeout if timeout is not None else 30  # Default timeout
 
         # Create HTTP client with authentication headers
+        # Add trailing slash to base_url to ensure relative paths are joined correctly
         self.httpx_client = httpx.AsyncClient(
-            base_url=f"{self.base_url}/api",
+            base_url=f"{self.base_url}/api/",
             headers={
                 "Authorization": f"Bearer {self.token}",
                 "Content-Type": "application/json",
@@ -117,6 +118,9 @@ class HomeAssistantClient:
             HomeAssistantAuthError: Authentication failed
             HomeAssistantAPIError: API error
         """
+        # Ensure endpoint doesn't start with a slash to properly join with base_url
+        endpoint = endpoint.lstrip("/")
+
         try:
             response = await self.httpx_client.request(method, endpoint, **kwargs)
 


### PR DESCRIPTION
This PR fixes a bug in the REST client that caused API requests to be incorrectly resolved when using the Supervisor proxy (`http://supervisor/core/api`).

**The Issue:**
The `httpx.AsyncClient` was initialized with a `base_url` like `http://supervisor/core/api` (no trailing slash). Individual API calls used paths starting with a slash (e.g., `/config/automation/...`). According to RFC 3986 (and `httpx` implementation), a path starting with a slash is resolved against the **domain root**, not the base path. 

This caused requests to hit `http://supervisor/config/automation/...` instead of `http://supervisor/core/api/config/automation/...`. The Supervisor API supports some `GET` and `POST` operations on these paths (possibly by luck or internal fallback), but returns **405 Method Not Allowed** for `DELETE`.

**The Fix:**
1. Added a trailing slash to the `base_url`.
2. Added `.lstrip('/')` to all endpoints in the `_request` method to ensure they are always resolved relative to the `base_url`.

This ensures that all requests consistently hit the Home Assistant Core API via the Supervisor proxy.

Related to #414.