### PR TITLE
feat(addon): log package version on startup

### DIFF
--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -127,6 +127,14 @@ def main() -> int:
 
     # Import and run MCP server directly
     try:
+        try:
+            from importlib.metadata import version
+
+            pkg_version = version("ha-mcp")
+            log_info(f"📦 ha-mcp package version: {pkg_version}")
+        except Exception:
+            log_info("📦 ha-mcp package version: unknown")
+
         log_info("Importing ha_mcp module...")
         from ha_mcp.__main__ import mcp
 


### PR DESCRIPTION
This PR adds logging of the installed `ha-mcp` package version to the add-on startup script.

This is critical for verifying which version of the codebase is actually running inside the add-on container, especially when debugging issues like #414 where fixes seem to be applied but behavior suggests an older version.