### PR TITLE
feat(debug): add verbose logging and connection test for add-on

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -121,8 +121,13 @@ class HomeAssistantClient:
         # Ensure endpoint doesn't start with a slash to properly join with base_url
         endpoint = endpoint.lstrip("/")
 
+        logger.info(f"API Request: {method} {endpoint} (Base: {self.httpx_client.base_url})")
+
         try:
             response = await self.httpx_client.request(method, endpoint, **kwargs)
+            logger.info(f"API Response: {response.status_code} {response.url}")
+
+            # Handle authentication errors
 
             # Handle authentication errors
             if response.status_code == 401:


### PR DESCRIPTION
This PR adds comprehensive debug logging to help diagnose issue #414.

1.  **`rest_client.py`**: Logs all API requests (Method, URL) and response codes at INFO level.
2.  **`homeassistant-addon/start.py`**: Adds a startup connectivity test that tries to hit the Supervisor API directly with a `DELETE` request to mimic the failing scenario.

This will produce detailed logs in the Add-on output that will confirm:
- The exact URL being constructed by `httpx`.
- Whether the Supervisor proxy accepts `DELETE` requests when called directly.