### PR TITLE
fix(ci): robust release publishing logic

### DIFF
--- a/.github/workflows/_build-and-release.yml
+++ b/.github/workflows/_build-and-release.yml
@@ -203,16 +203,8 @@ jobs:
 
           echo "✓ Uploaded binaries to $TAG"
 
-          # Re-check draft status after upload (in case it changed)
-          RELEASE_INFO_AFTER=$(gh api repos/${{ github.repository }}/releases/tags/$TAG 2>/dev/null || echo "")
-          IS_DRAFT_AFTER=$(echo "$RELEASE_INFO_AFTER" | jq -r '.draft')
-          echo "Release $TAG draft status after upload: $IS_DRAFT_AFTER"
-
-          # If release is still draft, publish it
-          if [ "$IS_DRAFT_AFTER" = "true" ]; then
-            echo "Publishing draft release..."
-            gh release edit "$TAG" --draft=false
-            echo "✓ Published release $TAG"
-          else
-            echo "Release is already published, skipping publish step"
-          fi
+          echo "Publishing release..."
+          # Always attempt to undraft. This is safe and idempotent.
+          # If it's already published, this does nothing but returns success.
+          gh release edit "$TAG" --draft=false
+          echo "✓ Published release $TAG"


### PR DESCRIPTION
## Description

Fixes a race condition/error in the release workflow where checking the draft status via  could fail or return unexpected results, preventing the release from being published (undrafted).

Instead of checking the status (which is fragile), we now unconditionally run , which is idempotent and safe.

## Changes

- Simplified  to remove complex API check.
- Ensures releases are always published after binary upload.

## Related Issues

- Fixes issue where v6.3.0 remained a draft despite successful build.
