### PR TITLE
fix: add socks support to httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.11.0",
-    "httpx>=0.27.0",
+    "httpx[socks]>=0.27.0",
     'jq>=1.8.0; sys_platform != "win32"',
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
When using a SOCKS proxy, httpx requires the 'socks' extra to function correctly. This fix updates the dependency to 'httpx[socks]' to ensure ha-mcp works out-of-the-box in proxy environments.