### PR TITLE
Revert "fix: remove redundant asyncio.sleep calls in E2E helper tests"

### DIFF
--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -7,6 +7,7 @@ Tests the complete lifecycle of input_* helpers including:
 - Type-specific parameter validation
 """
 
+import asyncio
 import logging
 
 import pytest
@@ -241,7 +242,19 @@ class TestInputNumberCRUD:
         cleanup_tracker.track("input_number", entity_id)
         logger.info(f"Created input_number: {entity_id}")
 
+        # Give HA a moment to process entity registration before polling
+
+
+        await asyncio.sleep(5)
+
+
+
+        # Wait for entity to be registered (existence only, not specific state)
+
+
         entity_ready = await wait_for_entity_registration(mcp_client, entity_id)
+
+
         assert entity_ready, f"Entity {entity_id} not registered within timeout"
 
         # VERIFY via state
@@ -334,7 +347,19 @@ class TestInputSelectCRUD:
         cleanup_tracker.track("input_select", entity_id)
         logger.info(f"Created input_select: {entity_id}")
 
+        # Give HA a moment to process entity registration before polling
+
+
+        await asyncio.sleep(5)
+
+
+
+        # Wait for entity to be registered (existence only, not specific state)
+
+
         entity_ready = await wait_for_entity_registration(mcp_client, entity_id)
+
+
         assert entity_ready, f"Entity {entity_id} not registered within timeout"
 
         # VERIFY via state
@@ -420,7 +445,19 @@ class TestInputTextCRUD:
         cleanup_tracker.track("input_text", entity_id)
         logger.info(f"Created input_text: {entity_id}")
 
+        # Give HA a moment to process entity registration before polling
+
+
+        await asyncio.sleep(5)
+
+
+
+        # Wait for entity to be registered (existence only, not specific state)
+
+
         entity_ready = await wait_for_entity_registration(mcp_client, entity_id)
+
+
         assert entity_ready, f"Entity {entity_id} not registered within timeout"
 
         # DELETE
@@ -816,7 +853,7 @@ class TestTimerCRUD:
             mcp_client, entity_id, "idle", timeout=10
         )
         assert state_reached, f"Timer {entity_id} not registered in idle state within timeout"
-        logger.info("Timer initial state: idle")
+        logger.info(f"Timer initial state: idle")
 
         # START timer
         start_result = await mcp_client.call_tool(


### PR DESCRIPTION
Reverts homeassistant-ai/ha-mcp#470