### PR TITLE
fix: pin httpx to <1.0 to prevent incompatible prerelease versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.11.0",
-    "httpx[socks]>=0.27.0",
+    "httpx[socks]>=0.27.0,<1.0",
     'jq>=1.8.0; sys_platform != "win32"',
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
@@ -407,7 +407,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "jq", marker = "sys_platform != 'win32'" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -436,7 +436,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=45.0.7" },
     { name = "fastmcp", specifier = ">=2.11.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27.0,<1.0" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.8.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -487,6 +487,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -1395,6 +1400,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Fixes critical import error when using `uvx --prerelease=allow ha-mcp` caused by httpx 1.0.dev3 breaking API changes.

## Problem

When using the `--prerelease` or `--pre` flag with uvx, the dependency resolver pulls in `httpx==1.0.dev3` which has breaking changes:
- ❌ `httpx.TransportError` was removed/renamed
- ❌ `httpx_sse` (transitive dependency) expects `httpx.TransportError` to exist
- ❌ Import fails: `AttributeError: module 'httpx' has no attribute 'TransportError'`

## Error Trace
```
warning: The package httpx==1.0.dev3 does not have an extra named socks
...
File "httpx_sse/_exceptions.py", line 4, in <module>
  class SSEError(httpx.TransportError):
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'httpx' has no attribute 'TransportError'
```

## Solution

Pin httpx to `<1.0` to exclude incompatible prerelease versions:

```toml
"httpx[socks]>=0.27.0,<1.0"
```

## Testing

Before fix:
```bash
$ uvx --pre ha-mcp --version
AttributeError: module 'httpx' has no attribute 'TransportError'
```

After fix:
```bash
$ uvx --pre ha-mcp --version
ha-mcp 6.3.1
```

## Related

- Related to #450 which added `httpx[socks]` support
- Affects users using `--prerelease` flag with uvx/uv
- Stable version (6.3.1) not affected

## Type of change
- [x] 🐛 Bug fix (critical - import failure)
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change