### PR TITLE
fix: pin httpx to <1.0 to prevent incompatible prerelease versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.11.0",
-    "httpx[socks]>=0.27.0",
+    "httpx[socks]>=0.27.0,<1.0",
     'jq>=1.8.0; sys_platform != "win32"',
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
@@ -443,7 +443,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=45.0.7" },
     { name = "fastmcp", specifier = ">=2.11.0" },
-    { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27.0,<1.0" },
     { name = "jq", marker = "sys_platform != 'win32'", specifier = ">=1.8.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## What does this PR do?

Fixes critical import error when using `uvx --prerelease=allow ha-mcp` caused by httpx 1.0.dev3 breaking API changes.

## Problem

When using the `--prerelease` or `--pre` flag with uvx, the dependency resolver pulls in `httpx==1.0.dev3` which has breaking changes:
- ❌ `httpx.TransportError` was removed/renamed
- ❌ `httpx_sse` (transitive dependency) expects `httpx.TransportError` to exist
- ❌ Import fails: `AttributeError: module 'httpx' has no attribute 'TransportError'`

## Error Trace
```
warning: The package httpx==1.0.dev3 does not have an extra named socks
...
File "httpx_sse/_exceptions.py", line 4, in <module>
  class SSEError(httpx.TransportError):
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'httpx' has no attribute 'TransportError'
```

## Solution

Pin httpx to `<1.0` to exclude incompatible prerelease versions:

```toml
"httpx[socks]>=0.27.0,<1.0"
```

## Testing

Before fix:
```bash
$ uvx --pre ha-mcp --version
AttributeError: module 'httpx' has no attribute 'TransportError'
```

After fix:
```bash
$ uvx --pre ha-mcp --version
ha-mcp 6.3.1
```

## Related

- Related to #450 which added `httpx[socks]` support
- Affects users using `--prerelease` flag with uvx/uv
- Stable version (6.3.1) not affected

## Type of change
- [x] 🐛 Bug fix (critical - import failure)
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change