### PR TITLE
feat: improve ha_report_issue with title, duplicate check, and markdown formatting

### DIFF
--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -11,6 +11,7 @@ import platform
 import sys
 from pathlib import Path
 from typing import Annotated, Any
+from urllib.parse import quote_plus
 
 from pydantic import Field
 
@@ -20,6 +21,10 @@ from ..utils.usage_logger import AVG_LOG_ENTRIES_PER_TOOL, get_recent_logs, get_
 from .helpers import log_tool_usage
 
 logger = logging.getLogger(__name__)
+
+# GitHub issue template URLs
+RUNTIME_BUG_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.md"
+AGENT_BEHAVIOR_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior_feedback.md"
 
 
 def _detect_installation_method() -> str:
@@ -232,7 +237,7 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         # Generate search keywords and URLs for duplicate check
         search_keywords = _generate_search_keywords(diagnostic_info, recent_logs)
         duplicate_check_urls = [
-            f"https://github.com/homeassistant-ai/ha-mcp/issues?q=is%3Aissue+{keyword.replace(' ', '+')}"
+            f"https://github.com/homeassistant-ai/ha-mcp/issues?q=is%3Aissue+{quote_plus(keyword)}"
             for keyword in search_keywords[:3]  # Limit to top 3 keywords
         ]
 
@@ -271,8 +276,8 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "   a. Show the suggested_title (user can edit if needed)\n"
                 "   b. Present the chosen template IN A MARKDOWN CODE BLOCK (```markdown...```) for easy copy/paste\n"
                 "   c. PROMINENTLY display the submission URL at the top:\n"
-                "      - Runtime bugs: https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.md\n"
-                "      - Agent behavior: https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior_feedback.md\n"
+                f"      - Runtime bugs: {RUNTIME_BUG_URL}\n"
+                f"      - Agent behavior: {AGENT_BEHAVIOR_URL}\n"
                 "   d. Ask them to fill in the description sections\n"
                 "   e. Remind them to follow the anonymization_guide to protect their privacy\n\n"
                 "CRITICAL: Always present templates in markdown code blocks (```markdown...```) so users can copy/paste easily!"
@@ -358,24 +363,22 @@ def _generate_bug_title(
     2. Otherwise, use generic template based on connection status
     3. Truncate to ~60 chars max
     """
+    title = ""
     # Try to get the most recent error directly from logs
     for log in reversed(recent_logs):
         error_msg = log.get("error_message")
         if error_msg:
             tool_name = log.get("tool_name", "unknown")
-            # Create title: "tool_name: error (truncated)"
             title = f"{tool_name}: {error_msg}"
-            # Truncate to ~60 chars, trying to preserve words
-            if len(title) > 60:
-                title = title[:57] + "..."
-            return title
+            break
 
-    # No errors - check connection status
-    conn_status = diagnostic_info.get("connection_status", "Unknown")
-    if "Error" in conn_status or "Failed" in conn_status:
-        title = f"Connection issue: {conn_status}"
-    else:
-        title = "Issue with ha-mcp"
+    if not title:
+        # No errors - check connection status
+        conn_status = diagnostic_info.get("connection_status", "Unknown")
+        if "Error" in conn_status or "Failed" in conn_status:
+            title = f"Connection issue: {conn_status}"
+        else:
+            title = "Issue with ha-mcp"
 
     # Truncate to ~60 chars, trying to preserve words
     if len(title) > 60:
@@ -393,41 +396,37 @@ def _generate_search_keywords(
 
     Returns a list of keywords to search for similar issues.
     """
-    keywords = []
+    keywords = set()
 
-    # Add error-based keywords
-    error_messages = _extract_error_messages(recent_logs)
-    if error_messages:
-        # Get the most recent error
-        last_error = error_messages[-1]
-        # Extract tool name
-        parts = last_error.split(": ", 2)
-        if len(parts) >= 2:
-            tool_name = parts[1]
-            keywords.append(tool_name)
-        # Extract key error terms
-        if len(parts) >= 3:
-            error_msg = parts[2]
-            # Common error patterns
-            if "connection" in error_msg.lower():
-                keywords.append("connection")
-            if "timeout" in error_msg.lower():
-                keywords.append("timeout")
-            if "authentication" in error_msg.lower() or "auth" in error_msg.lower():
-                keywords.append("authentication")
-            if "not found" in error_msg.lower():
-                keywords.append("not found")
+    # Find the most recent error from logs
+    last_error_log = next((log for log in reversed(recent_logs) if log.get("error_message")), None)
+
+    if last_error_log:
+        tool_name = last_error_log.get("tool_name")
+        if tool_name:
+            keywords.add(tool_name)
+
+        error_msg = last_error_log.get("error_message", "").lower()
+        # Common error patterns
+        if "connection" in error_msg:
+            keywords.add("connection")
+        if "timeout" in error_msg:
+            keywords.add("timeout")
+        if "authentication" in error_msg or "auth" in error_msg:
+            keywords.add("authentication")
+        if "not found" in error_msg:
+            keywords.add("not found")
 
     # Add connection-based keywords
     conn_status = diagnostic_info.get("connection_status", "Unknown")
     if "Error" in conn_status or "Failed" in conn_status:
-        keywords.append("connection")
+        keywords.add("connection")
 
     # Default to generic search if no specific keywords
     if not keywords:
-        keywords.append("bug")
+        keywords.add("bug")
 
-    return keywords
+    return list(keywords)
 
 
 def _generate_runtime_bug_template(
@@ -473,7 +472,7 @@ def _generate_runtime_bug_template(
 > All environment info and logs below were collected automatically.
 
 **Submit this report at:**
-https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.md
+{RUNTIME_BUG_URL}
 
 ---
 
@@ -564,7 +563,7 @@ def _generate_agent_behavior_template(
 > Tool call history was collected automatically to help analyze agent behavior.
 
 **Submit this feedback at:**
-https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior_feedback.md
+{AGENT_BEHAVIOR_URL}
 
 ---
 


### PR DESCRIPTION
Closes #467

## Summary
- Added automatic title generation based on error messages or connection status (~60 chars max)
- Added duplicate check URLs for searching similar issues before submission
- Updated agent instructions to present reports in markdown code blocks for easy copy/paste
- Added search keywords generation for duplicate detection
- Prominently displays GitHub submission URLs in instructions

## Implementation Details

### Title Generation
- Extracts most recent error from tool call logs
- Falls back to connection status if no errors
- Truncates to ~60 characters maximum

### Duplicate Check
- Generates relevant search keywords from errors and diagnostics
- Creates GitHub issue search URLs (up to 3 keywords)
- Agents can use WebFetch or gh CLI to check for duplicates

### Agent Workflow
Updated instructions guide agents to:
1. Check for duplicates FIRST (before presenting template)
2. Determine which template to use (runtime bug vs agent behavior)
3. Present report in markdown code block for easy copy/paste
4. Display submission URL prominently

## Testing
- Added 5 new test cases for title generation, duplicate check URLs, and updated instructions
- All 12 tests pass
- Code passes ruff linter checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)