### PR TITLE
fix: validate label IDs in ha_manage_entity_labels to prevent silent failures

### DIFF
--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -692,7 +692,7 @@ def register_label_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         }
 
                     available_labels = label_list_result.get("result", [])
-                    available_label_ids = {lbl.get("label_id") for lbl in available_labels}
+                    available_label_ids = {lbl['label_id'] for lbl in available_labels if isinstance(lbl, dict) and 'label_id' in lbl}
 
                     # Check for non-existent labels
                     invalid_labels = [lbl for lbl in parsed_labels if lbl not in available_label_ids]

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -3,7 +3,6 @@
 import os
 import stat
 import yaml
-import pytest
 
 try:
     import tomllib  # Python 3.11+

--- a/tests/initial_test_state/custom_components/hacs/base.py
+++ b/tests/initial_test_state/custom_components/hacs/base.py
@@ -61,7 +61,6 @@ from .exceptions import (
 from .repositories import REPOSITORY_CLASSES
 from .repositories.base import HACS_MANIFEST_KEYS_TO_EXPORT, REPOSITORY_KEYS_TO_EXPORT
 from .utils.file_system import async_exists
-from .utils.json import json_loads
 from .utils.logger import LOGGER
 from .utils.queue_manager import QueueManager
 from .utils.store import async_load_from_store, async_save_to_store

--- a/tests/initial_test_state/custom_components/hacs/data_client.py
+++ b/tests/initial_test_state/custom_components/hacs/data_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout

--- a/tests/initial_test_state/custom_components/hacs/repositories/base.py
+++ b/tests/initial_test_state/custom_components/hacs/repositories/base.py
@@ -34,7 +34,6 @@ from ..utils.decode import decode_content
 from ..utils.decorator import concurrent
 from ..utils.file_system import async_exists, async_remove, async_remove_directory
 from ..utils.filters import filter_content_return_one_of_type
-from ..utils.github_graphql_query import GET_REPOSITORY_RELEASES
 from ..utils.json import json_loads
 from ..utils.logger import LOGGER
 from ..utils.path import is_safe

--- a/tests/initial_test_state/custom_components/hacs/repositories/integration.py
+++ b/tests/initial_test_state/custom_components/hacs/repositories/integration.py
@@ -180,7 +180,7 @@ class HacsIntegrationRepository(HacsRepository):
             else f"{self.content.path.remote}/{RepositoryFile.MAINIFEST_JSON}"
         )
 
-        if not manifest_path in (x.full_path for x in self.tree):
+        if manifest_path not in (x.full_path for x in self.tree):
             raise HacsException(f"No {RepositoryFile.MAINIFEST_JSON} file found '{manifest_path}'")
 
         response = await self.hacs.async_github_api_method(

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -74,7 +74,6 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     HACS requires the frontend (~51MB) to be present to fully initialize.
     This is not committed to git to keep the repo size manageable.
     """
-    import subprocess
     import tarfile
     import urllib.request
 

--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -8,7 +8,6 @@ Note: Tests are designed to work with both Docker test environment (localhost:81
 and production environments. Entity references are dynamically discovered.
 """
 
-import asyncio
 import logging
 
 import pytest

--- a/tests/src/e2e/workflows/automation/test_traces.py
+++ b/tests/src/e2e/workflows/automation/test_traces.py
@@ -5,7 +5,6 @@ Tests the automation trace functionality: Create automation → Trigger → Get 
 Verifies that ha_get_automation_traces returns non-empty traces after automation runs.
 """
 
-import asyncio
 import logging
 
 import pytest

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -9,7 +9,6 @@ Note: Tests are designed to work with both Docker test environment (localhost:81
 and production environments. Blueprint availability may vary.
 """
 
-import asyncio
 import logging
 
 import pytest
@@ -380,7 +379,7 @@ async def test_blueprint_automation_lifecycle(mcp_client):
             error_msg = str(create_result.get("error", {}).get("message", ""))
             # If error is about missing blueprint inputs, our validation passed! HA rejected it.
             if "Missing input" in error_msg or "input" in error_msg.lower():
-                logger.info(f"✅ Our validation passed (config reached HA), HA rejected due to missing blueprint inputs as expected")
+                logger.info("✅ Our validation passed (config reached HA), HA rejected due to missing blueprint inputs as expected")
                 logger.info("✅ Blueprint automation lifecycle test completed (validation works)")
                 return
             # If error is about missing trigger/action, our fix didn't work

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -853,7 +853,7 @@ class TestTimerCRUD:
             mcp_client, entity_id, "idle", timeout=10
         )
         assert state_reached, f"Timer {entity_id} not registered in idle state within timeout"
-        logger.info(f"Timer initial state: idle")
+        logger.info("Timer initial state: idle")
 
         # START timer
         start_result = await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -12,7 +12,6 @@ import logging
 import pytest
 
 from ...utilities.assertions import assert_mcp_success, parse_mcp_result
-from ...utilities.wait_helpers import wait_for_condition
 
 logger = logging.getLogger(__name__)
 

--- a/tests/src/e2e/workflows/convenience/test_backup.py
+++ b/tests/src/e2e/workflows/convenience/test_backup.py
@@ -14,7 +14,6 @@ Tests for backup MCP tools that provide safety mechanisms:
 These tools are critical for configuration safety and disaster recovery.
 """
 
-import asyncio
 import logging
 import time
 
@@ -78,7 +77,7 @@ class TestBackupTools:
                 size_mb = data["size_bytes"] / (1024 * 1024)
                 logger.info(f"📦 Backup size: {size_mb:.2f} MB")
 
-            logger.info(f"✅ Backup test completed successfully")
+            logger.info("✅ Backup test completed successfully")
 
         except Exception as e:
             logger.error(f"❌ Backup creation test failed: {e}")
@@ -127,7 +126,7 @@ class TestBackupTools:
             # Verify backup completed (tool waits for completion)
             assert "completed" in data["status"].lower(), f"Backup did not complete: {data['status']}"
 
-            logger.info(f"✅ Custom name backup test completed successfully")
+            logger.info("✅ Custom name backup test completed successfully")
 
         except Exception as e:
             logger.error(f"❌ Custom name backup creation test failed: {e}")

--- a/tests/src/e2e/workflows/core/test_history.py
+++ b/tests/src/e2e/workflows/core/test_history.py
@@ -6,7 +6,7 @@ state change history and long-term statistics.
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
@@ -65,7 +65,7 @@ class TestGetHistory:
         logger.info("Testing ha_get_history with ISO datetime")
 
         # Use yesterday as start time
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        yesterday = datetime.now(UTC) - timedelta(days=1)
         start_time = yesterday.isoformat()
 
         result = await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -24,7 +24,6 @@ Tests are designed for the Docker Home Assistant test environment.
 import logging
 import os
 import uuid
-from typing import Any
 
 import pytest
 

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -17,7 +17,7 @@ import logging
 
 import pytest
 
-from ...utilities.assertions import assert_mcp_success, assert_mcp_failure, parse_mcp_result
+from ...utilities.assertions import parse_mcp_result
 
 logger = logging.getLogger(__name__)
 
@@ -604,7 +604,7 @@ class TestMcpToolsInstallation:
         if data.get("already_installed"):
             logger.info(f"ha_mcp_tools already installed: {data.get('version')}")
         else:
-            logger.info(f"ha_mcp_tools installed successfully")
+            logger.info("ha_mcp_tools installed successfully")
             assert "note" in data, "Should include note about restart"
 
         # Verify services list is provided

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -320,7 +320,7 @@ class TestDeviceUpdate:
         update_data = parse_mcp_result(update_result)
 
         assert update_data.get("success"), f"Failed to update labels: {update_data}"
-        logger.info(f"Labels update command succeeded")
+        logger.info("Labels update command succeeded")
 
         # Verify the response structure contains labels field
         updated_entry = update_data.get("device_entry", {})

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 
-import pytest
 
 
 class TestConfigErrorHandling:

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -4,7 +4,6 @@ These tests focus on the pure Python utility functions that don't require
 Home Assistant dependencies.
 """
 
-import os
 import sys
 import pytest
 from pathlib import Path

--- a/tests/src/unit/test_errors.py
+++ b/tests/src/unit/test_errors.py
@@ -4,7 +4,6 @@ These tests verify that error codes, error responses, and helper functions
 work correctly to provide informative, structured error messages.
 """
 
-import pytest
 
 from ha_mcp.errors import (
     DEFAULT_SUGGESTIONS,

--- a/tests/src/unit/test_search_fallback.py
+++ b/tests/src/unit/test_search_fallback.py
@@ -5,7 +5,6 @@ Tests the graceful degradation search methods:
 - _partial_results_search: Last resort entity listing
 """
 
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -7,11 +7,9 @@ Every tool MUST have exactly one of:
 Additionally, every tool SHOULD have a title for UI display.
 """
 
-import ast
 import re
 from pathlib import Path
 
-import pytest
 
 
 def get_tools_dir() -> Path:
@@ -218,4 +216,4 @@ class TestToolAnnotations:
         # This is a warning, not a hard failure - some tools might legitimately be destructive
         # even without obvious naming
         if suspicious:
-            print(f"\nNote: These destructive tools don't have typical modifying names:\n  " + "\n  ".join(suspicious))
+            print("\nNote: These destructive tools don't have typical modifying names:\n  " + "\n  ".join(suspicious))

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -1,6 +1,5 @@
 """Unit tests for tools_updates module."""
 
-import pytest
 
 from ha_mcp.tools.tools_updates import _categorize_update, _supports_release_notes
 

--- a/tests/test_docker/test_docker_build.py
+++ b/tests/test_docker/test_docker_build.py
@@ -1,7 +1,6 @@
 """Test Docker image builds successfully and contains expected components."""
 
 import subprocess
-import pytest
 
 
 class TestDockerBuild:

--- a/tests/test_docker/test_docker_compose.py
+++ b/tests/test_docker/test_docker_compose.py
@@ -2,7 +2,6 @@
 
 import os
 import yaml
-import pytest
 
 
 class TestDockerCompose:

--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -237,12 +237,12 @@ class HomeAssistantTestEnvironment:
             print(f"\n🌐 Web UI: {self.ha_url}")
             print(f"   Username: {self.test_user}")
             print(f"   Password: {self.test_password}")
-            print(f"\n📋 Copy-paste for testing:")
+            print("\n📋 Copy-paste for testing:")
             print(f"   export HOMEASSISTANT_URL={self.ha_url}")
             print(f"   export HOMEASSISTANT_TOKEN={self.ha_token}")
-            print(f"\n🔑 Full API Token:")
+            print("\n🔑 Full API Token:")
             print(f"   {self.ha_token}")
-            print(f"\n🐳 Container Status: Running")
+            print("\n🐳 Container Status: Running")
             print("📊 API Health: ", end="")
 
             try:


### PR DESCRIPTION
Closes #475

## Summary

Adds label ID validation to `ha_manage_entity_labels` to prevent silent failures when attempting to assign non-existent labels. Previously, the tool would report success while failing to apply invalid labels AND hide all existing labels in the UI.

## Changes

- Added label ID validation in `ha_manage_entity_labels` before entity operations
- Fetches available labels from label registry via WebSocket API
- Returns clear error message listing non-existent label IDs when validation fails
- Provides helpful suggestions pointing users to `ha_config_get_label()` and `ha_config_set_label()`
- Added comprehensive E2E tests covering:
  - Rejection of non-existent label IDs
  - Rejection of mixed valid/invalid labels (the exact Issue #475 scenario)
  - Helpful error messages with suggestions
  - Empty label list still allowed for clearing labels
- Improved robustness based on Gemini Code Assist review:
  - Added type checking for label list items to prevent AttributeError
  - Enhanced test assertions to verify exact invalid label lists
  - Ensured both helper tool suggestions are validated

## Test Plan

- All new validation tests pass (4 tests)
- Existing label CRUD tests still pass
- Validation happens before entity lookup, preventing any entity registry modifications when labels are invalid
- All CI checks passing including E2E tests on both ubuntu-latest and ubuntu-24.04-arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)