### PR TITLE
fix(ci): support squash merge format in notify workflow

### DIFF
--- a/.github/workflows/notify-dev-channel.yml
+++ b/.github/workflows/notify-dev-channel.yml
@@ -29,12 +29,13 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%B)
           echo "Commit message: $COMMIT_MSG"
 
-          # Extract PR number from merge commit
+          # Extract PR number from commit message
           # GitHub merge commits have format: "Merge pull request #123 from user/branch"
-          PR_NUM=$(echo "$COMMIT_MSG" | grep -oP 'Merge pull request #\K\d+' || echo "")
+          # GitHub squash merges have format: "Title with (#123)" in first line
+          PR_NUM=$(echo "$COMMIT_MSG" | head -1 | grep -oP '(?:Merge pull request #|[[(]#)\K\d+' || echo "")
 
           if [ -z "$PR_NUM" ]; then
-            echo "No PR number found in merge commit. Skipping notification."
+            echo "No PR number found in commit message. Skipping notification."
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi


### PR DESCRIPTION
## Problem

The notify workflow failed to trigger on PR #485 merge because it only recognized regular merge commits with format "Merge pull request #123".

When using , GitHub creates squash commits with format "Title (#123)" instead.

## Solution

Updated the regex to match **both** formats:
- Regular merge: 
- Squash merge: 

## Testing

Tested regex with both formats:
```bash
echo "Merge pull request #123 from user/branch" | grep -oP '(?:Merge pull request #|[[(]#)\K\d+'
# Output: 123 ✓

echo "Fix: Title (#485)" | grep -oP '(?:Merge pull request #|[[(]#)\K\d+'
# Output: 485 ✓
```

## Impact

After this fix, the workflow will correctly:
- Post dev channel testing comments to PRs merged with 
- Post comments to linked issues
- Work with both merge strategies

## Related

- Fixes notification for PR #485 (which failed to trigger)
- Enables continuing with remaining PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)