### PR TITLE
docs: update contributors section with recent contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **[@sergeykad](https://github.com/sergeykad)** — Dashboard card-level CRUD operations, better changelogs and removed the dependency to textdistance/numpy.
 - **[@konradwalsh](https://github.com/konradwalsh)** — Financial support via [GitHub Sponsors](https://github.com/sponsors/julienld). Thank you! ☕
 - **[@cj-elevate](https://github.com/cj-elevate)** — Integration & entity management tools (enable/disable/delete).
-- **[@kingpanther13](https://github.com/kingpanther13)** — Native solutions guidance to reduce template overuse.
+- **[@kingpanther13](https://github.com/kingpanther13)** — Dev channel documentation, bulk control validation, OAuth 2.1 docs, tool consolidation, error handling improvements, and native solutions guidance.
+- **[@Danm72](https://github.com/Danm72)** — Entity registry tools (`ha_set_entity`, `ha_get_entity`) for managing entity properties.
 - **[@Raygooo](https://github.com/Raygooo)** — SOCKS proxy support.
 
 ---


### PR DESCRIPTION
Updates README contributors section based on PRs merged in the last 2 weeks.

## New Contributors

**@Danm72**
- Entity registry tools (`ha_set_entity`, `ha_get_entity`)
- Enables managing entity properties: area assignment, names, icons, enabled/hidden state, aliases
- PR #469

## Updated Contributors

**@kingpanther13** - Expanded description to reflect recent significant contributions:
- Dev channel documentation (PR #476)
- Bulk control validation (PR #473)
- OAuth 2.1 documentation (PR #460)
- Tool consolidation (PR #453)
- Error handling improvements (PR #452)
- Native solutions guidance (original contribution)

## Process

Reviewed all merged PRs from the last 2 weeks and identified:
- New contributors with significant feature additions
- Existing contributors with expanded contributions beyond original description

Contributors are credited based on merged work, not just opened PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)