### PR TITLE
refactor: standardize MCP tool error handling and fix test compatibility

### DIFF
--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from ..errors import ErrorCode, create_error_response
 from .helpers import log_tool_usage
 from .util_helpers import parse_string_list_param
 
@@ -120,7 +121,10 @@ def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             try:
                 parsed_aliases = parse_string_list_param(aliases, "aliases")
             except ValueError as e:
-                return {"success": False, "error": f"Invalid aliases parameter: {e}"}
+                return create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid aliases parameter: {e}",
+                )
 
             # Determine if this is a create or update operation
             if area_id:
@@ -348,7 +352,10 @@ def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             try:
                 parsed_aliases = parse_string_list_param(aliases, "aliases")
             except ValueError as e:
-                return {"success": False, "error": f"Invalid aliases parameter: {e}"}
+                return create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid aliases parameter: {e}",
+                )
 
             # Determine if this is a create or update operation
             if floor_id:

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -12,6 +12,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
+from ..errors import ErrorCode, create_error_response
 from .helpers import log_tool_usage
 from .util_helpers import parse_string_list_param
 
@@ -385,7 +386,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 labels = parse_string_list_param(labels, "labels")
                 options = parse_string_list_param(options, "options")
             except ValueError as e:
-                return {"success": False, "error": f"Invalid list parameter: {e}"}
+                return create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid list parameter: {e}",
+                )
 
             # Determine if this is a create or update based on helper_id
             action = "update" if helper_id else "create"

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from ..errors import ErrorCode, create_error_response
 from .helpers import exception_to_structured_error, log_tool_usage
 from .util_helpers import coerce_bool_param, parse_string_list_param
 
@@ -111,7 +112,10 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 try:
                     parsed_aliases = parse_string_list_param(aliases, "aliases")
                 except ValueError as e:
-                    return {"success": False, "error": f"Invalid aliases parameter: {e}"}
+                    return create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Invalid aliases parameter: {e}",
+                    )
 
             # Build update message
             message: dict[str, Any] = {

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from ..errors import ErrorCode, create_error_response
 from .helpers import log_tool_usage
 from .util_helpers import coerce_bool_param, parse_string_list_param
 
@@ -784,7 +785,10 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             try:
                 parsed_labels = parse_string_list_param(labels, "labels")
             except ValueError as e:
-                return {"success": False, "error": f"Invalid labels parameter: {e}"}
+                return create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid labels parameter: {e}",
+                )
 
         # Delegate to internal implementation
         return await _update_device_internal(

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -187,7 +187,7 @@ def register_update_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         return result
 
-    @mcp.tool(annotations={"idempotentHint": True, "readOnlyHint": True, "tags": ["update"], "title": "Get Updates"})
+    @mcp.tool(annotations={"idempotentHint": True, "openWorldHint": True, "readOnlyHint": True, "tags": ["update"], "title": "Get Updates"})
     @log_tool_usage
     async def ha_get_updates(
         entity_id: Annotated[

--- a/src/ha_mcp/tools/tools_voice_assistant.py
+++ b/src/ha_mcp/tools/tools_voice_assistant.py
@@ -21,6 +21,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
+from ..errors import ErrorCode, create_error_response
 from .helpers import log_tool_usage
 from .util_helpers import coerce_bool_param, parse_string_list_param
 
@@ -188,7 +189,10 @@ def register_voice_assistant_tools(mcp: Any, client: Any, **kwargs: Any) -> None
                 }
 
         except ValueError as e:
-            return {"success": False, "error": str(e)}
+            return create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                str(e),
+            )
         except Exception as e:
             logger.error(f"Error updating entity exposure: {e}")
             return {

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -40,10 +40,10 @@ class TestAddonStartup:
             .with_volume_mapping(str(addon_config.parent), "/data", mode="ro")
         )
 
-        # Build the image first
+        # Build the image first (use as_posix() for Windows compatibility)
         container.get_docker_client().client.images.build(
             path=str(context_path),
-            dockerfile=str(dockerfile_path),
+            dockerfile=dockerfile_path.as_posix(),
             tag="ha-mcp-addon-test",
             rm=True,
             buildargs={
@@ -115,13 +115,13 @@ class TestAddonStartup:
             .with_volume_mapping(str(config_file.parent), "/data", mode="rw")
         )
 
-        # Build if not already built
+        # Build if not already built (use as_posix() for Windows compatibility)
         try:
             container.get_docker_client().client.images.get("ha-mcp-addon-test")
         except Exception:
             container.get_docker_client().client.images.build(
                 path=str(context_path),
-                dockerfile=str(dockerfile_path),
+                dockerfile=dockerfile_path.as_posix(),
                 tag="ha-mcp-addon-test",
                 rm=True,
                 buildargs={
@@ -162,13 +162,13 @@ class TestAddonStartup:
             .with_volume_mapping(str(addon_config.parent), "/data", mode="ro")
         )
 
-        # Build if not already built
+        # Build if not already built (use as_posix() for Windows compatibility)
         try:
             container.get_docker_client().client.images.get("ha-mcp-addon-test")
         except Exception:
             container.get_docker_client().client.images.build(
                 path=str(context_path),
-                dockerfile=str(dockerfile_path),
+                dockerfile=dockerfile_path.as_posix(),
                 tag="ha-mcp-addon-test",
                 rm=True,
                 buildargs={

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -2,6 +2,9 @@
 
 import os
 import stat
+import sys
+
+import pytest
 import yaml
 
 try:
@@ -79,6 +82,7 @@ class TestAddonStructure:
         assert not any(arch in config["arch"] for arch in unsupported_archs), \
             "32-bit platforms not supported by uv base image"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix permissions not applicable on Windows")
     def test_start_script_executable(self):
         """Verify start.py has executable permissions."""
         start_py = f"{ADDON_DIR}/start.py"

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -18,7 +18,10 @@ production-level functionality and compatibility.
 import ast
 import json
 import logging
+import sys
 from typing import Any
+
+import pytest
 
 # Import test utilities
 from tests.src.e2e.utilities.assertions import MCPAssertions
@@ -359,6 +362,7 @@ class TestDashboardDocumentationTools:
         logger.info("ha_get_card_documentation (invalid) test passed")
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="jq library not available on Windows")
 class TestJqTransformAndFindCard:
     """E2E tests for jq_transform and ha_dashboard_find_card."""
 

--- a/tests/src/unit/test_tools_voice_assistant.py
+++ b/tests/src/unit/test_tools_voice_assistant.py
@@ -373,7 +373,8 @@ class TestHaExposeEntity:
         )
 
         assert result["success"] is False
-        assert "should_expose" in result["error"].lower() or "boolean" in result["error"].lower()
+        error_msg = result["error"]["message"] if isinstance(result["error"], dict) else result["error"]
+        assert "should_expose" in error_msg.lower() or "boolean" in error_msg.lower()
 
     # ==================== API Error Handling Tests ====================
 


### PR DESCRIPTION
- Replace 6 inline error dicts with create_error_response() factory
- Add openWorldHint: True to ha_get_updates (calls GitHub API)
- Update test to handle new structured error format
- Fix Windows compatibility in addon tests (Path.as_posix for Docker)
- Skip Unix permission test on Windows
- Skip jq tests on Windows (jq library not available)

Affected tools:
- tools_areas.py: 2 fixes (ha_set_area, ha_set_floor)
- tools_config_helpers.py: 1 fix (ha_config_set_helper)
- tools_entities.py: 1 fix (ha_update_entity)
- tools_registry.py: 1 fix (ha_update_device)
- tools_voice_assistant.py: 1 fix (ha_set_entity_exposure)
- tools_updates.py: add openWorldHint annotation

## What does this PR do?

<!-- Brief description of your changes -->

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
