### PR TITLE
chore: Add Anthropic's MCP builder skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/anthropic-agent-skills"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with Anthropic's `anthropic-agent-skills` plugin marketplace
- This makes the **mcp-builder** skill available to all contributors — a guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools
- Supports both Python (FastMCP) and Node/TypeScript (MCP SDK)
- Relevant since this project is itself an MCP server

## How it works
The `extraKnownMarketplaces` field in `.claude/settings.json` registers Anthropic's plugin marketplace. When contributors open the project with Claude Code, the marketplace plugins (including `example-skills` which contains the mcp-builder skill) become available automatically.

## Test plan
- [x] Verified the plugin loads correctly after restarting Claude Code
- [ ] Verify a fresh clone picks up the marketplace config

🤖 Generated with [Claude Code](https://claude.com/claude-code)