### PR TITLE
fix: prevent ha_deep_search timeout on large HA instances

### DIFF
--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -110,7 +110,7 @@ async def bulk_automations(mcp_client):
 
     await wait_for_condition(
         all_entities_registered,
-        description=f"All {len(created_ids)} bulk automations registered",
+        condition_name=f"All {len(created_ids)} bulk automations registered",
         timeout=10.0,
     )
 
@@ -158,7 +158,7 @@ async def bulk_scripts(mcp_client):
 
     await wait_for_condition(
         all_scripts_registered,
-        description=f"All {len(created_ids)} bulk scripts registered",
+        condition_name=f"All {len(created_ids)} bulk scripts registered",
         timeout=10.0,
     )
 


### PR DESCRIPTION
## Problem

ha_deep_search times out on Home Assistant instances with many automations (~150+). The tool fetches each automation config individually via REST, and HA serializes these requests at roughly 1 per second. With 173 automations, the total fetch time exceeds 350 seconds — far beyond the 30-second MCP tool call timeout.

## Solution

Replace the parallel-but-serialized individual REST fetches with a 3-tier strategy for both automations and scripts:

1. **REST bulk endpoint** - single call for all configs
2. **WebSocket bulk endpoints** - tries known WS message types for bulk config retrieval
3. **Individual REST with time budget** - falls back to individual fetches, prioritized by name match score, stopping at 15s (automations) / 10s (scripts)

## Results (173 automations, 6198 entities)

| Metric | Before | After |
|--------|--------|-------|
| Total time | 377s (timeout) | 17s |
| Configs fetched | 139/173 (then timeout) | 8/173 (budget-limited) |
| Search results | never returned | 5 matches, correct |

## Disclosure

This is my first PR to this project. I used Claude to help understand and debug the timeout issue and develop the fix. Verified on my own HA instance with real data.
