### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize all text files to LF in the repository
+* text=auto eol=lf
+
 # Treat haconfig directory as binary (no merging)
 tests/initial_test_state/** binary merge=ours
 


### PR DESCRIPTION
Adds `* text=auto eol=lf` to prevent CRLF line endings from entering the repo, which causes full-file diffs that destroy git blame. Discovered via PR #589 review.

## What does this PR do?

<!-- Brief description of your changes -->

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
