### PR TITLE
refactor(__main__): fix security issues, bugs, and reduce duplication

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -6,11 +6,13 @@ truststore.inject_into_ssl()
 
 import asyncio  # noqa: E402
 import copy  # noqa: E402
+import hashlib  # noqa: E402
 import logging  # noqa: E402
 import os  # noqa: E402
 import signal  # noqa: E402
 import stat  # noqa: E402
 import sys  # noqa: E402
+import threading  # noqa: E402
 from typing import Any  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,7 @@ class OAuthProxyClient:
     def __init__(self, auth_provider):
         self._auth_provider = auth_provider
         self._oauth_clients = {}
+        self._lock = threading.Lock()
 
     def _get_oauth_client(self):
         """Get the OAuth client for the current request context."""
@@ -43,22 +46,32 @@ class OAuthProxyClient:
         claims = token.claims
 
         if not claims or "ha_url" not in claims or "ha_token" not in claims:
-            logger.error(f"No HA credentials in token claims: {claims}")
+            logger.error(f"OAuth token missing HA credentials. Keys present: {list(claims.keys()) if claims else []}")
             raise RuntimeError("No Home Assistant credentials in OAuth token claims")
 
         ha_url = claims["ha_url"]
         ha_token = claims["ha_token"]
 
-        # Create or reuse client for these credentials
-        client_key = f"{ha_url}:{ha_token}"
-        if client_key not in self._oauth_clients:
-            self._oauth_clients[client_key] = HomeAssistantClient(
-                base_url=ha_url,
-                token=ha_token,
-            )
-            logger.info(f"Created OAuth client for {ha_url}")
+        # Hash credentials for cache key to avoid raw tokens appearing in dict keys
+        client_key = hashlib.sha256(f"{ha_url}:{ha_token}".encode()).hexdigest()
 
-        return self._oauth_clients[client_key]
+        with self._lock:
+            if client_key not in self._oauth_clients:
+                self._oauth_clients[client_key] = HomeAssistantClient(
+                    base_url=ha_url,
+                    token=ha_token,
+                )
+                logger.info(f"Created OAuth client for {ha_url}")
+
+            return self._oauth_clients[client_key]
+
+    async def close(self) -> None:
+        """Close all cached OAuth clients to release httpx connection pools."""
+        with self._lock:
+            clients = list(self._oauth_clients.values())
+            self._oauth_clients.clear()
+        for client in clients:
+            await client.close()
 
     def __getattr__(self, name):
         """Forward all attribute access to the OAuth client."""
@@ -164,7 +177,10 @@ def _check_stdin_available() -> bool:
 
 
 def _handle_config_error(error: Exception) -> None:
-    """Handle configuration errors with a user-friendly message."""
+    """Handle configuration errors with a user-friendly message and exit.
+
+    Always calls sys.exit(1) — never returns normally.
+    """
     from pydantic import ValidationError
 
     if isinstance(error, ValidationError):
@@ -203,19 +219,64 @@ For setup instructions, see:
     sys.exit(1)
 
 
+def _validate_standard_credentials(settings) -> None:
+    """Exit with error if HA credentials are OAuth sentinels in standard (non-OAuth) mode."""
+    from ha_mcp.config import OAUTH_MODE_TOKEN, OAUTH_MODE_URL
+
+    missing_vars = []
+    if settings.homeassistant_url == OAUTH_MODE_URL:
+        missing_vars.append("  - HOMEASSISTANT_URL")
+    if settings.homeassistant_token == OAUTH_MODE_TOKEN:
+        missing_vars.append("  - HOMEASSISTANT_TOKEN")
+
+    if missing_vars:
+        print(
+            _CONFIG_ERROR_MESSAGE.format(missing_vars="\n".join(missing_vars)),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _get_show_banner() -> bool:
+    """Check if CLI banner should be shown (respects FASTMCP_SHOW_CLI_BANNER env var)."""
+    import fastmcp
+
+    return fastmcp.settings.show_cli_banner
+
+
+def _setup_standard_mode() -> None:
+    """Validate credentials and configure logging for standard (non-OAuth) modes."""
+    from ha_mcp.config import get_settings
+
+    settings = get_settings()
+    _validate_standard_credentials(settings)
+    _setup_logging(settings.log_level)
+
+
+def _http_run_kwargs(transport: str, port: int, path: str) -> dict:
+    """Build common run_async kwargs for HTTP-based transports."""
+    return {
+        "transport": transport,
+        "host": "0.0.0.0",
+        "port": port,
+        "path": path,
+        "show_banner": _get_show_banner(),
+        "stateless_http": True,
+        "uvicorn_config": {"log_config": _get_timestamped_uvicorn_log_config()},
+    }
+
+
 def _create_server():
     """Create server instance (deferred to avoid import during smoke test)."""
+    from pydantic import ValidationError
+
     try:
         from ha_mcp.server import HomeAssistantSmartMCPServer  # type: ignore[import-not-found]
 
         return HomeAssistantSmartMCPServer()
-    except Exception as e:
-        # Check if this is a pydantic validation error (missing env vars)
-        from pydantic import ValidationError
-
-        if isinstance(e, ValidationError):
-            _handle_config_error(e)
-        raise
+    except ValidationError as e:
+        _handle_config_error(e)
+        raise  # _handle_config_error calls sys.exit, but satisfy type checker
 
 
 # Lazy server creation - only create when needed
@@ -245,9 +306,6 @@ class _DeferredMCP:
 
     def __getattr__(self, name: str) -> Any:
         return getattr(_get_mcp(), name)
-
-    def run(self, *args: Any, **kwargs: Any) -> None:
-        return _get_mcp().run(*args, **kwargs)
 
 
 mcp = _DeferredMCP()
@@ -294,8 +352,10 @@ async def _cleanup_resources() -> None:
 
         await stop_websocket_listener()
         logger.debug("WebSocket listener stopped")
+    except ImportError:
+        logger.debug("WebSocket listener module not available")
     except Exception as e:
-        logger.debug(f"WebSocket listener cleanup: {e}")
+        logger.warning(f"WebSocket listener cleanup failed: {e}")
 
     # Close WebSocket manager connections
     try:
@@ -303,8 +363,10 @@ async def _cleanup_resources() -> None:
 
         await websocket_manager.disconnect()
         logger.debug("WebSocket manager disconnected")
+    except ImportError:
+        logger.debug("WebSocket manager module not available")
     except Exception as e:
-        logger.debug(f"WebSocket manager cleanup: {e}")
+        logger.warning(f"WebSocket manager cleanup failed: {e}")
 
     # Close the server's HTTP client
     if _server is not None:
@@ -312,9 +374,78 @@ async def _cleanup_resources() -> None:
             await _server.close()
             logger.debug("Server closed")
         except Exception as e:
-            logger.debug(f"Server cleanup: {e}")
+            logger.warning(f"Server cleanup failed: {e}")
 
     logger.info("Server resources cleaned up")
+
+
+async def _cancel_tasks(*tasks: asyncio.Task) -> None:
+    """Cancel tasks and wait for completion, swallowing CancelledError."""
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+
+async def _run_with_shutdown(server_coro) -> None:
+    """Run a server coroutine with graceful shutdown support.
+
+    Handles signal-based shutdown, resource cleanup, and task cancellation.
+    """
+    global _shutdown_event
+
+    _shutdown_event = asyncio.Event()
+
+    server_task = asyncio.create_task(server_coro)
+    shutdown_task = asyncio.create_task(_shutdown_event.wait())
+
+    try:
+        done, pending = await asyncio.wait(
+            [server_task, shutdown_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if shutdown_task in done:
+            logger.info("Shutdown signal received, stopping server...")
+            server_task.cancel()
+            try:
+                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning("Server did not stop within timeout")
+            except asyncio.CancelledError:
+                pass
+
+    except asyncio.CancelledError:
+        logger.info("Server task cancelled")
+    finally:
+        try:
+            await asyncio.wait_for(
+                _cleanup_resources(), timeout=SHUTDOWN_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            logger.warning("Resource cleanup timed out")
+
+        await _cancel_tasks(server_task, shutdown_task)
+
+
+def _run_entrypoint(coro, label: str) -> None:
+    """Run an async entrypoint with standard exception handling."""
+    _setup_signal_handlers()
+
+    try:
+        asyncio.run(coro)
+    except KeyboardInterrupt:
+        logger.info("Interrupted, exiting")
+    except SystemExit:
+        raise
+    except Exception as e:
+        logger.error(f"{label} error: {e}")
+        sys.exit(1)
+
+    sys.exit(0)
 
 
 def _signal_handler(signum: int, frame: Any) -> None:
@@ -354,58 +485,7 @@ def _setup_signal_handlers() -> None:
 
 async def _run_with_graceful_shutdown() -> None:
     """Run the MCP server with graceful shutdown support."""
-    global _shutdown_event
-
-    _shutdown_event = asyncio.Event()
-
-    # Respect FastMCP's show_cli_banner setting
-    # Users can disable banner via FASTMCP_SHOW_CLI_BANNER=false
-    import fastmcp
-
-    show_banner = fastmcp.settings.show_cli_banner
-
-    # Create a task for the MCP server
-    server_task = asyncio.create_task(_get_mcp().run_async(show_banner=show_banner))
-
-    # Wait for either the server to complete or a shutdown signal
-    shutdown_task = asyncio.create_task(_shutdown_event.wait())
-
-    try:
-        done, pending = await asyncio.wait(
-            [server_task, shutdown_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        # If shutdown was signaled, cancel the server task
-        if shutdown_task in done:
-            logger.info("Shutdown signal received, stopping server...")
-            server_task.cancel()
-            try:
-                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
-            except TimeoutError:
-                logger.warning("Server did not stop within timeout")
-            except asyncio.CancelledError:
-                pass
-
-    except asyncio.CancelledError:
-        logger.info("Server task cancelled")
-    finally:
-        # Clean up resources with timeout
-        try:
-            await asyncio.wait_for(
-                _cleanup_resources(), timeout=SHUTDOWN_TIMEOUT_SECONDS
-            )
-        except TimeoutError:
-            logger.warning("Resource cleanup timed out")
-
-        # Cancel any remaining tasks
-        for task in [server_task, shutdown_task]:
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+    await _run_with_shutdown(_get_mcp().run_async(show_banner=_get_show_banner()))
 
 
 # CLI entry point (for pyproject.toml) - use FastMCP's built-in runner
@@ -429,46 +509,17 @@ def main() -> None:
 
     settings = get_settings()
 
-    # In standard mode (not OAuth), validate that real credentials are provided
-    # The config has defaults for OAuth mode, but standard mode requires real values
     # Check config FIRST so users see helpful config errors before stdin errors
-    missing_vars = []
-    if settings.homeassistant_url == "http://oauth-mode":
-        missing_vars.append("  - HOMEASSISTANT_URL")
-    if settings.homeassistant_token == "oauth-mode-token":
-        missing_vars.append("  - HOMEASSISTANT_TOKEN")
-
-    if missing_vars:
-        print(
-            _CONFIG_ERROR_MESSAGE.format(missing_vars="\n".join(missing_vars)),
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    _validate_standard_credentials(settings)
 
     # Check if stdin is available (fails in Docker without -i flag)
-    # This check comes after config validation so users see config errors first
     if not _check_stdin_available():
         print(_STDIN_ERROR_MESSAGE, file=sys.stderr)
         sys.exit(1)
 
     _setup_logging(settings.log_level)
 
-    # Set up signal handlers before running
-    _setup_signal_handlers()
-
-    # Run with graceful shutdown support
-    try:
-        asyncio.run(_run_with_graceful_shutdown())
-    except KeyboardInterrupt:
-        # Handle case where KeyboardInterrupt is raised before our handler
-        logger.info("Interrupted, exiting")
-    except SystemExit:
-        raise
-    except Exception as e:
-        logger.error(f"Server error: {e}")
-        sys.exit(1)
-
-    sys.exit(0)
+    _run_entrypoint(_run_with_graceful_shutdown(), "Server")
 
 
 def main_dev() -> None:
@@ -487,80 +538,25 @@ def _get_http_runtime(default_port: int = 8086) -> tuple[int, str]:
         default_port: Default port to use if MCP_PORT env var is not set.
     """
 
-    port = int(os.getenv("MCP_PORT", str(default_port)))
+    port_str = os.getenv("MCP_PORT", str(default_port))
+    try:
+        port = int(port_str)
+    except ValueError:
+        logger.error(f"Invalid MCP_PORT value: {port_str!r}. Must be an integer.")
+        sys.exit(1)
     path = os.getenv("MCP_SECRET_PATH", "/mcp")
     return port, path
 
 
 async def _run_http_with_graceful_shutdown(
     transport: str,
-    host: str,
     port: int,
     path: str,
 ) -> None:
     """Run HTTP server with graceful shutdown support."""
-    global _shutdown_event
-
-    _shutdown_event = asyncio.Event()
-
-    # Respect FastMCP's show_cli_banner setting
-    # Users can disable banner via FASTMCP_SHOW_CLI_BANNER=false
-    import fastmcp
-
-    show_banner = fastmcp.settings.show_cli_banner
-
-    # Create a task for the MCP server
-    server_task = asyncio.create_task(
-        _get_mcp().run_async(
-            transport=transport,
-            host=host,
-            port=port,
-            path=path,
-            show_banner=show_banner,
-            stateless_http=True,  # Enable stateless mode for horizontal scaling and restart resilience
-            uvicorn_config={"log_config": _get_timestamped_uvicorn_log_config()},
-        )
+    await _run_with_shutdown(
+        _get_mcp().run_async(**_http_run_kwargs(transport, port, path))
     )
-
-    # Wait for either the server to complete or a shutdown signal
-    shutdown_task = asyncio.create_task(_shutdown_event.wait())
-
-    try:
-        done, pending = await asyncio.wait(
-            [server_task, shutdown_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        # If shutdown was signaled, cancel the server task
-        if shutdown_task in done:
-            logger.info("Shutdown signal received, stopping HTTP server...")
-            server_task.cancel()
-            try:
-                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
-            except TimeoutError:
-                logger.warning("HTTP server did not stop within timeout")
-            except asyncio.CancelledError:
-                pass
-
-    except asyncio.CancelledError:
-        logger.info("HTTP server task cancelled")
-    finally:
-        # Clean up resources with timeout
-        try:
-            await asyncio.wait_for(
-                _cleanup_resources(), timeout=SHUTDOWN_TIMEOUT_SECONDS
-            )
-        except TimeoutError:
-            logger.warning("Resource cleanup timed out")
-
-        # Cancel any remaining tasks
-        for task in [server_task, shutdown_task]:
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
 
 
 def _run_http_server(transport: str, default_port: int = 8086) -> None:
@@ -572,28 +568,10 @@ def _run_http_server(transport: str, default_port: int = 8086) -> None:
     """
     port, path = _get_http_runtime(default_port)
 
-    # Set up signal handlers before running
-    _setup_signal_handlers()
-
-    # Run with graceful shutdown support
-    try:
-        asyncio.run(
-            _run_http_with_graceful_shutdown(
-                transport=transport,
-                host="0.0.0.0",
-                port=port,
-                path=path,
-            )
-        )
-    except KeyboardInterrupt:
-        logger.info("Interrupted, exiting")
-    except SystemExit:
-        raise
-    except Exception as e:
-        logger.error(f"HTTP server error: {e}")
-        sys.exit(1)
-
-    sys.exit(0)
+    _run_entrypoint(
+        _run_http_with_graceful_shutdown(transport, port, path),
+        "HTTP server",
+    )
 
 
 def main_web() -> None:
@@ -605,27 +583,7 @@ def main_web() -> None:
     - MCP_PORT (optional, default: 8086)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
-    # Configure logging before server creation
-    from ha_mcp.config import get_settings
-
-    settings = get_settings()
-
-    # Validate credentials (required in non-OAuth HTTP mode)
-    missing_vars = []
-    if settings.homeassistant_url == "http://oauth-mode":
-        missing_vars.append("  - HOMEASSISTANT_URL")
-    if settings.homeassistant_token == "oauth-mode-token":
-        missing_vars.append("  - HOMEASSISTANT_TOKEN")
-
-    if missing_vars:
-        print(
-            _CONFIG_ERROR_MESSAGE.format(missing_vars="\n".join(missing_vars)),
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    _setup_logging(settings.log_level)
-
+    _setup_standard_mode()
     _run_http_server("streamable-http", default_port=8086)
 
 
@@ -638,27 +596,7 @@ def main_sse() -> None:
     - MCP_PORT (optional, default: 8087)
     - MCP_SECRET_PATH (optional, default: "/mcp")
     """
-    # Configure logging before server creation
-    from ha_mcp.config import get_settings
-
-    settings = get_settings()
-
-    # Validate credentials (required in non-OAuth SSE mode)
-    missing_vars = []
-    if settings.homeassistant_url == "http://oauth-mode":
-        missing_vars.append("  - HOMEASSISTANT_URL")
-    if settings.homeassistant_token == "oauth-mode-token":
-        missing_vars.append("  - HOMEASSISTANT_TOKEN")
-
-    if missing_vars:
-        print(
-            _CONFIG_ERROR_MESSAGE.format(missing_vars="\n".join(missing_vars)),
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    _setup_logging(settings.log_level)
-
+    _setup_standard_mode()
     _run_http_server("sse", default_port=8087)
 
 
@@ -686,8 +624,7 @@ def main_oauth() -> None:
         logging.getLogger(logger_name).setLevel(getattr(logging, log_level))
     logger.info(f"OAuth mode logging configured at {log_level} level")
 
-    port = int(os.getenv("MCP_PORT", "8086"))
-    path = os.getenv("MCP_SECRET_PATH", "/mcp")
+    port, path = _get_http_runtime(default_port=8086)
     base_url = os.getenv("MCP_BASE_URL")
 
     if not base_url:
@@ -697,20 +634,7 @@ def main_oauth() -> None:
         )
         sys.exit(1)
 
-    # Set up signal handlers
-    _setup_signal_handlers()
-
-    try:
-        asyncio.run(_run_oauth_server(base_url, port, path))
-    except KeyboardInterrupt:
-        logger.info("Interrupted, exiting")
-    except SystemExit:
-        raise
-    except Exception as e:
-        logger.error(f"OAuth server error: {e}")
-        sys.exit(1)
-
-    sys.exit(0)
+    _run_entrypoint(_run_oauth_server(base_url, port, path), "OAuth server")
 
 
 async def _run_oauth_server(base_url: str, port: int, path: str) -> None:
@@ -721,12 +645,8 @@ async def _run_oauth_server(base_url: str, port: int, path: str) -> None:
         port: Port to listen on
         path: MCP endpoint path
     """
-    global _shutdown_event
-
     from ha_mcp.auth import HomeAssistantOAuthProvider
     from ha_mcp.server import HomeAssistantSmartMCPServer
-
-    _shutdown_event = asyncio.Event()
 
     # Create OAuth provider
     auth_provider = HomeAssistantOAuthProvider(
@@ -734,76 +654,25 @@ async def _run_oauth_server(base_url: str, port: int, path: str) -> None:
         service_documentation_url="https://github.com/homeassistant-ai/ha-mcp",
     )
 
-    # Create full HomeAssistantSmartMCPServer with OAuth authentication
-    # In OAuth mode, we don't require pre-configured HA credentials in environment.
-    # Instead, tools will get credentials from the OAuth provider per-request.
-    # The Settings class now has defaults that work for OAuth mode.
-
-    # Create proxy client that dynamically forwards to OAuth clients
-    # This is necessary because tools capture a reference to the client at registration time.
+    # In OAuth mode, credentials come from the OAuth consent form per-request.
+    # The proxy client extracts them from token claims on each tool invocation.
     proxy_client = OAuthProxyClient(auth_provider)
 
-    # Create server with the proxy client
-    server = HomeAssistantSmartMCPServer(client=proxy_client)
-    mcp = server.mcp
+    global _server
+    _server = HomeAssistantSmartMCPServer(client=proxy_client)
+    mcp = _server.mcp
+    mcp.auth = auth_provider
 
     logger.info("Server created with OAuthProxyClient")
 
-    # Add OAuth authentication to the MCP server
-    mcp.auth = auth_provider
-
-    # Get tool count (get_tools is async, but we can count registered tools)
     tools = await mcp.get_tools()
     logger.info(
         f"Starting OAuth-enabled MCP server with {len(tools)} tools on {base_url}{path}"
     )
 
-    # Respect FastMCP's show_cli_banner setting for consistency
-    import fastmcp
-
-    show_banner = fastmcp.settings.show_cli_banner
-
-    # Run server
-    server_task = asyncio.create_task(
-        mcp.run_async(
-            transport="streamable-http",
-            host="0.0.0.0",
-            port=port,
-            path=path,
-            show_banner=show_banner,
-            stateless_http=True,  # Enable stateless mode for horizontal scaling and restart resilience
-            uvicorn_config={"log_config": _get_timestamped_uvicorn_log_config()},
-        )
+    await _run_with_shutdown(
+        mcp.run_async(**_http_run_kwargs("streamable-http", port, path))
     )
-
-    shutdown_task = asyncio.create_task(_shutdown_event.wait())
-
-    try:
-        done, pending = await asyncio.wait(
-            [server_task, shutdown_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        if shutdown_task in done:
-            logger.info("Shutdown signal received, stopping OAuth server...")
-            server_task.cancel()
-            try:
-                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
-            except TimeoutError:
-                logger.warning("OAuth server did not stop within timeout")
-            except asyncio.CancelledError:
-                pass
-
-    except asyncio.CancelledError:
-        logger.info("OAuth server task cancelled")
-    finally:
-        for task in [server_task, shutdown_task]:
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
 
 
 if __name__ == "__main__":

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -18,6 +18,10 @@ project_root = Path(__file__).parent.parent.parent
 # Demo server: https://ha-mcp-demo-server.qc-h.net (login: mcp/mcp, resets weekly)
 DEMO_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxOTE5ZTZlMTVkYjI0Mzk2YTQ4YjFiZTI1MDM1YmU2YSIsImlhdCI6MTc1NzI4OTc5NiwiZXhwIjoyMDcyNjQ5Nzk2fQ.Yp9SSAjm2gvl9Xcu96FFxS8SapHxWAVzaI0E3cD9xac"
 
+# OAuth mode sentinel values — when these are present, HA credentials come from OAuth tokens
+OAUTH_MODE_URL = "http://oauth-mode"
+OAUTH_MODE_TOKEN = "oauth-mode-token"
+
 # Support for different environment files via HAMCP_ENV_FILE
 env_file = os.getenv("HAMCP_ENV_FILE", ".env")
 env_path = project_root / env_file
@@ -37,8 +41,8 @@ class Settings(BaseSettings):
 
     # Home Assistant connection
     # In OAuth mode, these are optional and provided per-request
-    homeassistant_url: str = Field(default="http://oauth-mode", alias="HOMEASSISTANT_URL")
-    homeassistant_token: str = Field(default="oauth-mode-token", alias="HOMEASSISTANT_TOKEN")
+    homeassistant_url: str = Field(default=OAUTH_MODE_URL, alias="HOMEASSISTANT_URL")
+    homeassistant_token: str = Field(default=OAUTH_MODE_TOKEN, alias="HOMEASSISTANT_TOKEN")
 
     # Server configuration
     timeout: int = Field(30, alias="HA_TIMEOUT")
@@ -85,7 +89,7 @@ class Settings(BaseSettings):
     def validate_homeassistant_url(cls, v: str) -> str:
         """Ensure URL is properly formatted."""
         # Allow OAuth mode placeholder
-        if v == "http://oauth-mode":
+        if v == OAUTH_MODE_URL:
             return v
         if not v.startswith(("http://", "https://")):
             raise ValueError("Home Assistant URL must start with http:// or https://")
@@ -96,7 +100,7 @@ class Settings(BaseSettings):
     def validate_homeassistant_token(cls, v: str) -> str:
         """Ensure token is not empty. Use 'demo' for public demo environment."""
         # Allow OAuth mode placeholder
-        if v == "oauth-mode-token":
+        if v == OAUTH_MODE_TOKEN:
             return v
         if not v or v == "your_long_lived_access_token_here":
             raise ValueError("Home Assistant token must be provided")

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -484,3 +484,13 @@ class TestHTTPEntryPoints:
 
         assert port == 8086
         assert path == "/mcp"
+
+    def test_http_runtime_invalid_port_exits(self):
+        """Non-integer MCP_PORT should cause sys.exit(1)."""
+        from ha_mcp.__main__ import _get_http_runtime
+
+        with patch.dict(os.environ, {"MCP_PORT": "not-a-number"}):
+            with pytest.raises(SystemExit) as exc_info:
+                _get_http_runtime()
+
+        assert exc_info.value.code == 1


### PR DESCRIPTION
Security fixes:
- Hash OAuth client cache keys with SHA-256 to avoid raw tokens in dict keys
- Log only claim keys (not values) on OAuth credential errors
- Add threading.Lock to OAuthProxyClient for thread-safe cache access

Bug fixes:
- Add missing _cleanup_resources() call in OAuth shutdown path
- Split cleanup except blocks: ImportError (DEBUG) vs Exception (WARNING)
- Catch ValidationError directly in _create_server instead of broad Exception
- Add port validation in _get_http_runtime (invalid MCP_PORT now exits cleanly)

Deduplication (~140 lines removed):
- Extract _validate_standard_credentials() replacing 3 inline blocks
- Extract _get_show_banner() replacing 3 inline fastmcp imports
- Extract _setup_standard_mode() for main_web/main_sse credential+logging setup
- Extract _http_run_kwargs() for HTTP transport run_async configuration
- Extract _cancel_tasks() replacing 3 inline task cancellation loops
- Extract _run_with_shutdown() consolidating 3 shutdown orchestration copies
- Extract _run_entrypoint() consolidating 3 asyncio.run+exception patterns
- Move OAuth sentinel strings to config.py constants (OAUTH_MODE_URL/TOKEN)
- Remove redundant _DeferredMCP.run() method (__getattr__ already handles it)
- Use _get_http_runtime() in main_oauth() instead of duplicating env var reads

## What does this PR do?

<!-- Brief description of your changes -->

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
