### PR TITLE
fix: route person/zone/tag updates to config store APIs

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -667,7 +667,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 # Person and zone have entity registry entries with unique_id
                 # used as the config store identifier. Tags use their own tag
                 # registry and don't have entity registry entries.
-                config_store_types = {"person", "zone", "tag"}
+                config_store_types = {"person", "zone"}
 
                 updated_data: dict[str, Any] = {}
 
@@ -847,7 +847,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "entity_id": entity_id,
                     }
 
-                    if name:
+                    if name is not None:
                         update_msg["name"] = name
                     if icon:
                         update_msg["icon"] = icon

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1426,7 +1426,6 @@ class TestTagCRUD:
         )
         create_data = assert_mcp_success(create_result, "Create tag for update test")
         tag_id = create_data.get("helper_data", {}).get("id") or test_tag_id
-        entity_id = get_entity_id_from_response(create_data, "tag")
         cleanup_tracker.track("tag", tag_id)
         logger.info(f"Created tag: {tag_id}")
 


### PR DESCRIPTION
## Summary

`ha_config_set_helper` update path for person, zone, and tag helper types was using only `config/entity_registry/update`, which stores UI metadata (name, icon, area, labels) but **silently drops domain-specific configuration data**.

This means:
- **Person** entities lost `device_trackers`, `user_id`, and `picture` on update
- **Zone** entities lost `latitude`, `longitude`, `radius`, and `passive` on update
- **Tag** entities lost `description` on update

### Root Cause

Home Assistant uses a **dual-store architecture** for these entity types:

1. **Entity Registry** (`config/entity_registry/update`) — stores UI metadata (name, icon, area, labels)
2. **Config Store** (`person/update`, `zone/update`, `tag/update`) — stores domain-specific configuration

The existing code only hit store #1 for all helper types, which works for standard helpers (`input_*`, `counter`, `timer`, `schedule`) since their config lives in the entity registry. But person, zone, and tag store their domain config in separate config stores.

### Fix

- Detect `person`, `zone`, and `tag` helper types
- Look up `unique_id` from entity registry (needed as the config store identifier)
- Route to the appropriate config store API (`person/update`, `zone/update`, `tag/update`)
- Still update entity registry for `icon`/`area_id`/`labels` when provided
- Standard helper types (`input_*`, `counter`, `timer`, `schedule`) continue using entity registry updates as before (no change)

### Implementation Notes

- **Person API is full-replace** (not patch): current config is fetched via `person/list`, merged with new values, then sent. This is necessary because `person/update` requires all fields.
- `person/list` returns `{"storage": [...], "config": [...]}` — only `storage` persons (UI-managed) are editable via this API
- Zone and tag APIs support partial updates (only changed fields need to be sent)
- Added null-check on `unique_id` to prevent confusing errors if registry entry lacks it

## Test plan

- [ ] Update a person entity's `device_trackers` via `ha_config_set_helper` — verify trackers persist
- [ ] Update a zone entity's coordinates via `ha_config_set_helper` — verify lat/lng/radius persist
- [ ] Update a tag entity's `description` via `ha_config_set_helper` — verify description persists
- [ ] Update a standard helper (e.g., `input_boolean`) name/icon — verify existing behavior unchanged
- [ ] Update a person with only `name` change — verify `device_trackers` are preserved (merge logic)
- [ ] Attempt to update a non-existent person/zone/tag — verify clean error message