### PR TITLE
fix: handle menu-based config entry flows for group helpers

### DIFF
--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -1,7 +1,15 @@
 """
 E2E tests for Config Entry Flow API.
+
+Tests cover:
+- Schema retrieval for form-based and menu-based helpers
+- Creating helpers that use single-step form flows (min_max)
+- Creating helpers that use menu-then-form flows (group)
+- Error handling for missing menu selections
+- Deletion of config-entry-based helpers
 """
 
+import asyncio
 import logging
 
 import pytest
@@ -9,6 +17,35 @@ import pytest
 from tests.src.e2e.utilities.assertions import assert_mcp_success, safe_call_tool
 
 logger = logging.getLogger(__name__)
+
+
+async def _find_config_entry(mcp_client, domain: str, title: str) -> str | None:
+    """Find config entry ID by domain and title.
+
+    Searches the integration list for an entry matching both domain and title.
+    Returns the entry_id if found, None otherwise.
+    """
+    result = await mcp_client.call_tool(
+        "ha_get_integration", {"domain": domain}
+    )
+    data = assert_mcp_success(result, f"List {domain} integrations")
+
+    for entry in data.get("entries", []):
+        if entry.get("title") == title:
+            return entry.get("entry_id")
+    return None
+
+
+async def _delete_config_entry(mcp_client, entry_id: str) -> None:
+    """Delete a config entry by ID, ignoring errors."""
+    try:
+        await safe_call_tool(
+            mcp_client,
+            "ha_delete_config_entry",
+            {"entry_id": entry_id, "confirm": True},
+        )
+    except Exception:
+        logger.warning(f"Failed to delete config entry {entry_id}")
 
 
 @pytest.mark.asyncio
@@ -91,16 +128,8 @@ class TestConfigEntryFlow:
                     f"{helper_type}: form with {len(data.get('data_schema', []))} fields"
                 )
 
-    # Note: Actual ha_create_config_entry_helper tests are intentionally limited
-    # because they require specific configuration for each helper type.
-    # These tests would need to be expanded once we understand the exact
-    # flow requirements for each of the 15 supported helpers.
-
     async def test_create_config_entry_helper_exists(self, mcp_client):
         """Test that ha_create_config_entry_helper tool exists."""
-        # This is a basic sanity check that the tool is registered
-        # We don't actually call it because we don't know valid configs yet
-
         # Try to call with minimal/invalid config to verify tool exists
         data = await safe_call_tool(
             mcp_client,
@@ -109,11 +138,178 @@ class TestConfigEntryFlow:
         )
 
         # We expect this to fail (invalid config), but it proves tool exists
-        # and validates the structure
         assert "success" in data, "Tool should return a result with success field"
-
-        # If it succeeded unexpectedly, that's also fine - means empty config worked
-        # If it failed, that's expected - we're just testing tool existence
         logger.info(
             f"Tool response (expected to fail with invalid config): {data.get('success')}"
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+@pytest.mark.slow
+class TestConfigEntryFlowMenuBased:
+    """Test menu-based config entry flow helpers (e.g. group).
+
+    These helpers present a menu step first (select group type), then
+    a form step for the actual configuration. This tests the fix for
+    issue #548 where menu-based flows always failed.
+    """
+
+    async def test_create_group_helper_light(self, mcp_client, cleanup_tracker):
+        """Test creating a light group helper via menu-based flow.
+
+        The group helper flow:
+        1. Menu step: select group type (light, switch, cover, etc.)
+        2. Form step: provide name, entities, and options
+        3. create_entry: success
+        """
+        helper_name = "E2E Test Light Group"
+
+        result = await mcp_client.call_tool(
+            "ha_create_config_entry_helper",
+            {
+                "helper_type": "group",
+                "config": {
+                    "group_type": "light",
+                    "name": helper_name,
+                    "entities": ["light.bed_light", "light.ceiling_lights"],
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create light group helper")
+
+        assert data.get("domain") == "group", f"Expected domain 'group': {data}"
+        assert data.get("entry_id"), f"Missing entry_id: {data}"
+        entry_id = data["entry_id"]
+        cleanup_tracker.track("config_entry", entry_id)
+        logger.info(f"Created light group helper: {data.get('title')} ({entry_id})")
+
+        # Wait for HA to register the entity
+        await asyncio.sleep(2)
+
+        # Verify the config entry exists
+        verify_result = await mcp_client.call_tool(
+            "ha_get_integration", {"entry_id": entry_id}
+        )
+        verify_data = assert_mcp_success(verify_result, "Verify group config entry")
+        assert verify_data.get("entry", {}).get("domain") == "group"
+        logger.info("Light group config entry verified")
+
+        # Clean up
+        await _delete_config_entry(mcp_client, entry_id)
+
+    async def test_create_group_helper_switch(self, mcp_client, cleanup_tracker):
+        """Test creating a switch group helper via menu-based flow."""
+        helper_name = "E2E Test Switch Group"
+
+        result = await mcp_client.call_tool(
+            "ha_create_config_entry_helper",
+            {
+                "helper_type": "group",
+                "config": {
+                    "group_type": "switch",
+                    "name": helper_name,
+                    "entities": [],
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create switch group helper")
+
+        assert data.get("entry_id"), f"Missing entry_id: {data}"
+        entry_id = data["entry_id"]
+        cleanup_tracker.track("config_entry", entry_id)
+        logger.info(f"Created switch group helper: {data.get('title')} ({entry_id})")
+
+        # Clean up
+        await asyncio.sleep(1)
+        await _delete_config_entry(mcp_client, entry_id)
+
+    async def test_create_group_helper_next_step_id(self, mcp_client, cleanup_tracker):
+        """Test creating a group helper using 'next_step_id' key instead of 'group_type'."""
+        helper_name = "E2E Test Cover Group"
+
+        result = await mcp_client.call_tool(
+            "ha_create_config_entry_helper",
+            {
+                "helper_type": "group",
+                "config": {
+                    "next_step_id": "cover",
+                    "name": helper_name,
+                    "entities": [],
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create cover group helper via next_step_id")
+
+        assert data.get("entry_id"), f"Missing entry_id: {data}"
+        entry_id = data["entry_id"]
+        cleanup_tracker.track("config_entry", entry_id)
+        logger.info(f"Created cover group helper: {data.get('title')} ({entry_id})")
+
+        # Clean up
+        await asyncio.sleep(1)
+        await _delete_config_entry(mcp_client, entry_id)
+
+    async def test_create_group_helper_missing_menu_selection(self, mcp_client):
+        """Test that missing menu selection returns helpful error with options."""
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_create_config_entry_helper",
+            {
+                "helper_type": "group",
+                "config": {
+                    "name": "Missing Menu Selection",
+                    "entities": ["light.bed_light"],
+                },
+            },
+        )
+
+        # Should fail because no group_type / next_step_id was provided
+        assert not data.get("success"), f"Should have failed: {data}"
+        assert "menu" in str(data.get("error", "")).lower() or "menu_options" in data, (
+            f"Error should mention menu: {data}"
+        )
+        logger.info(f"Missing menu selection properly rejected: {data.get('error')}")
+
+        # Verify that menu_options are included in the error for discoverability
+        if "menu_options" in data:
+            logger.info(f"Available menu options: {data['menu_options']}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+@pytest.mark.slow
+class TestConfigEntryFlowFormBased:
+    """Test single-step form-based config entry flow helpers (e.g. min_max)."""
+
+    async def test_create_min_max_helper(self, mcp_client, cleanup_tracker):
+        """Test creating a min_max helper via single-step form flow.
+
+        The min_max helper flow:
+        1. Form step: provide name, entity_ids, type (min/max/mean/etc.)
+        2. create_entry: success
+        """
+        helper_name = "E2E Test Min Max"
+
+        result = await mcp_client.call_tool(
+            "ha_create_config_entry_helper",
+            {
+                "helper_type": "min_max",
+                "config": {
+                    "name": helper_name,
+                    "entity_ids": ["sensor.dht_sensor_temperature"],
+                    "type": "max",
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create min_max helper")
+
+        assert data.get("domain") == "min_max", f"Expected domain 'min_max': {data}"
+        assert data.get("entry_id"), f"Missing entry_id: {data}"
+        entry_id = data["entry_id"]
+        cleanup_tracker.track("config_entry", entry_id)
+        logger.info(f"Created min_max helper: {data.get('title')} ({entry_id})")
+
+        # Clean up
+        await asyncio.sleep(1)
+        await _delete_config_entry(mcp_client, entry_id)


### PR DESCRIPTION
## Summary

Fixes `_handle_flow_steps` in `tools_config_entry_flow.py` which failed for all menu-based config entry flows (e.g., the **group** helper).

The group helper's Config Entry Flow starts with a **menu step** (select group type: light, switch, cover, etc.), followed by a **form step** (name, entities, options). The existing code:
1. Did not recognize `"menu"` result types -- they fell through to the `else` branch
2. Sent the entire config dict on every step -- but menu steps expect `{"next_step_id": "..."}` while form steps expect field values
3. Returned an error on `"form"` steps encountered after the first submission, instead of continuing the flow

### Changes

- **Rewrite `_handle_flow_steps`** to accept the initial step result from `start_config_flow`, enabling correct identification of the first step type (menu vs form)
- **Handle `"menu"` result type** by extracting `group_type`/`next_step_id`/`menu_option` from config and submitting `{"next_step_id": ...}`
- **Handle `"form"` result type** by submitting remaining config fields (stripping menu selection keys) instead of erroring
- **Fix silent `None` returns** on exceptions by adding `return` to `exception_to_structured_error` calls
- **Improve `ha_get_helper_schema`** note for menu-based helpers to guide callers
- **Add E2E tests** for menu-based group creation (light, switch, cover), missing menu selection errors, and form-based min_max creation

Closes #548

## Test plan

- [ ] `uv run ruff check` passes (verified locally)
- [ ] `uv run mypy src/ha_mcp/tools/tools_config_entry_flow.py` passes (verified locally)
- [ ] E2E tests in `test_config_entry_flow.py` pass for:
  - [ ] Light group helper via menu flow (`group_type: "light"`)
  - [ ] Switch group helper via menu flow (`group_type: "switch"`)
  - [ ] Cover group helper via `next_step_id` key
  - [ ] Missing menu selection returns actionable error with available options
  - [ ] Min/max helper via single-step form flow

Generated with [Claude Code](https://claude.com/claude-code)