### PR TITLE
fix: pin fastmcp<3.0.0 to prevent silent server crashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=2.11.0",
+    "fastmcp>=2.11.0,<3.0.0",  # Pin: v3.0.0 has breaking changes (see #644, #645, #648)
     "httpx[socks]>=0.27.0,<1.0",
     'jq>=1.8.0; sys_platform != "win32"',
     "pydantic>=2.5.0",


### PR DESCRIPTION
## What does this PR do?

Pins the `fastmcp` dependency to `<3.0.0` to prevent ha-mcp from silently crashing on startup.

[FastMCP 3.0.0](https://github.com/PrefectHQ/fastmcp/releases/tag/v3.0.0) was released on 2026-02-18 with breaking changes (removed constructor kwargs, removed `_tool_manager` attribute, provider/transform architecture redesign). Because ha-mcp declared `fastmcp>=2.11.0` with no upper bound, `uvx` and `pip` began resolving to 3.0.0 overnight — breaking all new installations and any existing user whose cache expired.

The server starts and receives the MCP `initialize` message but then crashes silently (exit code 1, no stderr output), making this extremely difficult to diagnose.

**Changes:**

- `pyproject.toml`: `fastmcp>=2.11.0` → `fastmcp>=2.11.0,<3.0.0`

Users who applied the workaround (`--with fastmcp<3.0.0` in their uvx args) will continue to work fine — the constraints are compatible. They can remove the workaround after upgrading to a release containing this fix.

A follow-up effort to migrate ha-mcp to FastMCP 3.x should lift this pin.

Closes #644
Closes #645
Closes #648

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

This is a one-line dependency constraint change. No code logic is modified.

## Checklist
- [x] I have updated documentation if needed