### PR TITLE
Fix: Add mcp>=1.24.0 for protocol version 2025-11-25 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.11.0,<3.0.0",  # Pin: v3.0.0 has breaking changes (see #644, #645, #648)
+    "mcp>=1.24.0",  # Required for protocol version 2025-11-25 support (see #651)
     "httpx[socks]>=0.27.0,<1.0",
     'jq>=1.8.0; sys_platform != "win32"',
     "pydantic>=2.5.0",


### PR DESCRIPTION
## Problem
Claude Desktop 1.1.3541 sends `protocolVersion: "2025-11-25"` which causes the server to crash on initialize.

## Root Cause
MCP library versions older than 1.24.0 don't support protocol version 2025-11-25 (they only support up to "2025-06-18").

## Solution
Add explicit dependency on `mcp>=1.24.0` in pyproject.toml to ensure the server supports the new protocol version.

## Test Result
Local tests pass.

Fixes #651