### PR TITLE
Fix ha_get_system_health missing data (fixes #690)

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -740,91 +740,43 @@ class HomeAssistantClient:
         self, ws_client: Any, message: dict[str, Any]
     ) -> dict[str, Any]:
         """Handle render_template WebSocket command with event-based response."""
-
-        # Generate our own message ID to track the response
-        message_id = ws_client.get_next_message_id()
-
-        # Construct the full message with proper ID
-        full_message = {
-            "id": message_id,
-            "type": "render_template",
-            "template": message.get("template"),
-            "timeout": message.get("timeout", 3),
-            "report_errors": message.get("report_errors", True),
-        }
-
-        # Create futures for both result and event responses
-        result_future = ws_client.register_pending_response(message_id)
-        event_future = ws_client.register_event_response(message_id)
-
-        # Use WebSocket client's send helper to transmit the message
-        try:
-            await ws_client.send_json_message(full_message)
-        except Exception as e:
-            ws_client.cancel_pending_response(message_id)
-            ws_client.cancel_event_response(message_id)
-            raise e
+        template_timeout = message.get("timeout", 3)
 
         try:
-            # Wait for the initial result response (should be success with null result)
-            result_response = await asyncio.wait_for(
-                result_future, timeout=message.get("timeout", 3) + 2
+            _, event_response = await ws_client.send_command_with_event(
+                "render_template",
+                wait_timeout=template_timeout + 2,
+                template=message.get("template"),
+                timeout=template_timeout,
+                report_errors=message.get("report_errors", True),
             )
-            logger.debug(f"WebSocket render_template result: {result_response}")
+            logger.debug(f"WebSocket render_template event: {event_response}")
 
-            if not result_response.get("success"):
-                ws_client.cancel_event_response(message_id)
-                error = result_response.get("error", "Unknown error")
+            # Extract template result from event
+            if "event" in event_response and "result" in event_response["event"]:
+                template_result = event_response["event"]["result"]
+                listeners_info = event_response["event"].get("listeners", {})
+
                 return {
-                    "success": False,
-                    "error": str(error),
+                    "success": True,
+                    "result": template_result,
                     "template": message.get("template"),
+                    "listeners": listeners_info,
                 }
-
-            # Wait for the event with the actual template result
-            try:
-                event_response = await asyncio.wait_for(
-                    event_future, timeout=message.get("timeout", 3) + 1
-                )
-                logger.debug(f"WebSocket render_template event: {event_response}")
-
-                # Extract template result from event
-                if "event" in event_response and "result" in event_response["event"]:
-                    template_result = event_response["event"]["result"]
-                    listeners_info = event_response["event"].get("listeners", {})
-
-                    return {
-                        "success": True,
-                        "result": template_result,
-                        "template": message.get("template"),
-                        "listeners": listeners_info,
-                    }
-                else:
-                    return {
-                        "success": False,
-                        "error": "Invalid event response format",
-                        "template": message.get("template"),
-                    }
-
-            except TimeoutError:
-                ws_client.cancel_event_response(message_id)
+            else:
                 return {
                     "success": False,
-                    "error": "Event timeout - template result not received",
+                    "error": "Invalid event response format",
                     "template": message.get("template"),
                 }
 
         except TimeoutError:
-            ws_client.cancel_pending_response(message_id)
-            ws_client.cancel_event_response(message_id)
             return {
                 "success": False,
-                "error": "Command timeout",
+                "error": "Event timeout - template result not received",
                 "template": message.get("template"),
             }
         except Exception as e:
-            ws_client.cancel_pending_response(message_id)
-            ws_client.cancel_event_response(message_id)
             return {
                 "success": False,
                 "error": str(e),

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -456,6 +456,71 @@ class HomeAssistantWebSocketClient:
             self.cancel_pending_response(message_id)
             raise
 
+    async def send_command_with_event(
+        self,
+        command_type: str,
+        wait_timeout: float = 10.0,
+        **kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Send a command that returns a result followed by an event response.
+
+        Some HA WebSocket commands (e.g. system_health/info, render_template)
+        reply with an immediate result message and then deliver the actual data
+        in a subsequent event message sharing the same message ID.
+
+        Args:
+            command_type: Type of command to send.
+            wait_timeout: Seconds to wait for each response phase.
+            **kwargs: Additional fields merged into the outgoing message.
+
+        Returns:
+            A (result_response, event_response) tuple.
+        """
+        if not self._state.is_ready:
+            raise Exception("WebSocket not authenticated")
+
+        message_id = self.get_next_message_id()
+        message = {"id": message_id, "type": command_type, **kwargs}
+
+        result_future = self.register_pending_response(message_id)
+        event_future = self.register_event_response(message_id)
+
+        try:
+            await self.send_json_message(message)
+        except Exception:
+            self.cancel_pending_response(message_id)
+            self.cancel_event_response(message_id)
+            raise
+
+        try:
+            result_response = await asyncio.wait_for(
+                result_future, timeout=wait_timeout
+            )
+        except TimeoutError:
+            self.cancel_pending_response(message_id)
+            self.cancel_event_response(message_id)
+            raise
+
+        if not result_response.get("success"):
+            self.cancel_event_response(message_id)
+            error = result_response.get("error", {})
+            error_msg = (
+                error.get("message", str(error))
+                if isinstance(error, dict)
+                else str(error)
+            )
+            raise Exception(f"Command failed: {error_msg}")
+
+        try:
+            event_response = await asyncio.wait_for(
+                event_future, timeout=wait_timeout
+            )
+        except TimeoutError:
+            self.cancel_event_response(message_id)
+            raise
+
+        return result_response, event_response
+
     async def subscribe_events(self, event_type: str | None = None) -> int:
         """Subscribe to Home Assistant events.
 

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -7,7 +7,6 @@ This module provides tools for Home Assistant system administration including:
 - System health monitoring
 """
 
-import asyncio
 import logging
 from typing import Any
 
@@ -334,47 +333,23 @@ def register_system_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "Failed to connect to Home Assistant WebSocket",
                 ))
 
-            # Generate message ID for tracking the response and event
-            message_id = ws_client.get_next_message_id()
-            full_message = {
-                "id": message_id,
-                "type": "system_health/info"
-            }
-
-            # Create futures for both result and event responses
-            result_future = ws_client.register_pending_response(message_id)
-            event_future = ws_client.register_event_response(message_id)
-
+            # system_health/info returns a result + follow-up event
             try:
-                await ws_client.send_json_message(full_message)
-            except Exception as e:
-                ws_client.cancel_pending_response(message_id)
-                ws_client.cancel_event_response(message_id)
-                raise e
-
-            try:
-                # Wait for the initial result response (should be success with null result)
-                result_response = await asyncio.wait_for(result_future, timeout=10.0)
-
-                if not result_response.get("success"):
-                    ws_client.cancel_event_response(message_id)
-                    raise_tool_error(create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result_response.get("error", "Failed to retrieve system health"),
-                    ))
-
-                # Wait for the event response containing the actual health data
-                event_response = await asyncio.wait_for(event_future, timeout=10.0)
-
-                # Extract health info from event
-                health_info = event_response.get("event", {})
-
-            except asyncio.TimeoutError:
-                ws_client.cancel_event_response(message_id)
+                _, event_response = await ws_client.send_command_with_event(
+                    "system_health/info", wait_timeout=10.0
+                )
+            except TimeoutError:
                 raise_tool_error(create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
                     "Timeout waiting for system health data",
                 ))
+            except Exception as e:
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    str(e),
+                ))
+
+            health_info = event_response.get("event", {})
 
             return {
                 "success": True,


### PR DESCRIPTION
## What does this PR do?

Fixes #690 — `ha_get_system_health()` succeeds but returns no data (0 components).

The root cause is that the HA `system_health/info` WebSocket command returns a success response with `null` data immediately, then sends the actual health data in a subsequent `event` message. The existing code only read the initial result.

**Changes:**
- Generalized the render_template-specific event handling in the WebSocket client (`_render_template_events` → `_event_responses`) so any command can await a follow-up event
- Added `send_command_with_event()` helper on `WebSocketClient` to encapsulate the two-part (result + event) WS pattern with proper future lifecycle and cleanup
- Refactored both `_handle_render_template` and `ha_get_system_health` to use the shared helper, eliminating code duplication
- Fixed Ruff UP041 lint (`asyncio.TimeoutError` → builtin `TimeoutError`)
- Fixed missing `cancel_pending_response` in timeout error handler

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed