### PR TITLE
fix: use per-client credentials for WebSocket in OAuth mode

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -684,8 +684,10 @@ class HomeAssistantClient:
     async def send_websocket_message(self, message: dict[str, Any]) -> dict[str, Any]:
         """Send message via WebSocket and wait for response.
 
-        Uses the global WebSocket singleton to avoid race conditions from
-        parallel tool calls creating multiple simultaneous connections.
+        Uses a per-client WebSocket connection keyed to the client's own
+        credentials (base_url + token). This ensures OAuth mode uses the
+        real HA credentials from the token claims, not the global sentinel
+        settings.
         """
         from .websocket_client import get_websocket_client
 
@@ -694,8 +696,10 @@ class HomeAssistantClient:
 
         for attempt in range(max_retries):
             try:
-                # Use singleton WebSocket client (shared, reused connection)
-                ws_client = await get_websocket_client()
+                # Use per-client WebSocket keyed to this client's credentials
+                ws_client = await get_websocket_client(
+                    url=self.base_url, token=self.token
+                )
 
                 # Special handling for render_template which returns an event with the actual result
                 if message.get("type") == "render_template":

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -554,10 +554,15 @@ class HomeAssistantWebSocketClient:
 
 
 class WebSocketManager:
-    """Singleton manager for Home Assistant WebSocket connections."""
+    """Singleton manager for Home Assistant WebSocket connections.
+
+    Maintains a pool of WebSocket connections keyed by (url, token) so that
+    multiple OAuth users can have concurrent connections without interfering
+    with each other.
+    """
 
     _instance = None
-    _client = None
+    _clients: dict[str, HomeAssistantWebSocketClient]
     _current_loop: asyncio.AbstractEventLoop | None = None
     _lock: asyncio.Lock | None = None
     _lock_loop: asyncio.AbstractEventLoop | None = None
@@ -566,6 +571,7 @@ class WebSocketManager:
     def __new__(cls) -> "WebSocketManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
+            cls._instance._clients = {}
             cls._instance._lock = None
             cls._instance._lock_loop = None
             cls._instance._client_factory = HomeAssistantWebSocketClient
@@ -600,12 +606,23 @@ class WebSocketManager:
             self._lock_loop = current_loop
             logger.debug("Created new WebSocketManager lock for current event loop")
 
+    @staticmethod
+    def _client_key(url: str, token: str) -> str:
+        """Create a cache key from credentials."""
+        import hashlib
+
+        return hashlib.sha256(f"{url.rstrip('/')}:{token}".encode()).hexdigest()
+
     async def get_client(
         self,
         url: str | None = None,
         token: str | None = None,
     ) -> HomeAssistantWebSocketClient:
         """Get WebSocket client, creating connection if needed.
+
+        Maintains a pool of connections keyed by credentials. In OAuth mode,
+        each user gets their own connection. In non-OAuth mode, the global
+        settings are used as the key.
 
         Args:
             url: Optional HA URL. If provided with token, uses these
@@ -621,12 +638,13 @@ class WebSocketManager:
             raise Exception("Lock not initialized")
         async with self._lock:
             if self._current_loop is not None and self._current_loop != current_loop:
-                if self._client:
+                # Event loop changed — disconnect all clients
+                for client in self._clients.values():
                     try:
-                        await self._client.disconnect()
+                        await client.disconnect()
                     except Exception:
                         pass
-                    self._client = None
+                self._clients.clear()
 
             self._current_loop = current_loop
 
@@ -639,35 +657,38 @@ class WebSocketManager:
                 ws_url = settings.homeassistant_url
                 ws_token = settings.homeassistant_token
 
-            # If existing client is connected with different credentials, disconnect
-            if self._client and self._client.is_connected:
-                if self._client.base_url == ws_url.rstrip("/") and self._client.token == ws_token:
-                    return self._client
-                # Credentials changed (different OAuth user), reconnect
-                logger.info("WebSocket credentials changed, reconnecting")
-                await self._client.disconnect()
-                self._client = None
+            key = self._client_key(ws_url, ws_token)
+
+            # Return existing connected client for these credentials
+            existing = self._clients.get(key)
+            if existing and existing.is_connected:
+                return existing
+
+            # Remove stale client if present
+            if existing:
+                self._clients.pop(key, None)
 
             factory = self._client_factory or HomeAssistantWebSocketClient
-            self._client = factory(ws_url, ws_token)
+            client = factory(ws_url, ws_token)
 
-            connected = await self._client.connect()
+            connected = await client.connect()
             if not connected:
                 raise Exception("Failed to connect to Home Assistant WebSocket")
 
-            return self._client
+            self._clients[key] = client
+            return client
 
     async def disconnect(self) -> None:
-        """Disconnect WebSocket client."""
+        """Disconnect all WebSocket clients."""
         self._ensure_lock()
 
         if not self._lock:
             raise Exception("Lock not initialized")
         async with self._lock:
-            if self._client:
-                await self._client.disconnect()
-                self._client = None
-                self._current_loop = None
+            for client in self._clients.values():
+                await client.disconnect()
+            self._clients.clear()
+            self._current_loop = None
 
 
 # Global WebSocket manager instance

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -8,6 +8,7 @@ This module handles WebSocket connections to Home Assistant for:
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import time
@@ -553,16 +554,21 @@ class HomeAssistantWebSocketClient:
 
 
 
+MAX_POOL_SIZE = 50
+
+
 class WebSocketManager:
     """Singleton manager for Home Assistant WebSocket connections.
 
     Maintains a pool of WebSocket connections keyed by (url, token) so that
     multiple OAuth users can have concurrent connections without interfering
-    with each other.
+    with each other.  The pool is bounded to ``MAX_POOL_SIZE`` entries; when
+    this limit is exceeded the least-recently-used connection is evicted.
     """
 
     _instance = None
     _clients: dict[str, HomeAssistantWebSocketClient]
+    _last_used: dict[str, float]
     _current_loop: asyncio.AbstractEventLoop | None = None
     _lock: asyncio.Lock | None = None
     _lock_loop: asyncio.AbstractEventLoop | None = None
@@ -572,6 +578,7 @@ class WebSocketManager:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._clients = {}
+            cls._instance._last_used = {}
             cls._instance._lock = None
             cls._instance._lock_loop = None
             cls._instance._client_factory = HomeAssistantWebSocketClient
@@ -609,8 +616,6 @@ class WebSocketManager:
     @staticmethod
     def _client_key(url: str, token: str) -> str:
         """Create a cache key from credentials."""
-        import hashlib
-
         return hashlib.sha256(f"{url.rstrip('/')}:{token}".encode()).hexdigest()
 
     async def get_client(
@@ -645,6 +650,7 @@ class WebSocketManager:
                     except Exception:
                         pass
                 self._clients.clear()
+                self._last_used.clear()
 
             self._current_loop = current_loop
 
@@ -662,11 +668,13 @@ class WebSocketManager:
             # Return existing connected client for these credentials
             existing = self._clients.get(key)
             if existing and existing.is_connected:
+                self._last_used[key] = time.monotonic()
                 return existing
 
             # Remove stale client if present
             if existing:
                 self._clients.pop(key, None)
+                self._last_used.pop(key, None)
 
             factory = self._client_factory or HomeAssistantWebSocketClient
             client = factory(ws_url, ws_token)
@@ -676,6 +684,22 @@ class WebSocketManager:
                 raise Exception("Failed to connect to Home Assistant WebSocket")
 
             self._clients[key] = client
+            self._last_used[key] = time.monotonic()
+
+            # Evict least-recently-used connection if over limit
+            if len(self._clients) > MAX_POOL_SIZE:
+                oldest_key = min(self._last_used, key=self._last_used.get)
+                stale = self._clients.pop(oldest_key, None)
+                self._last_used.pop(oldest_key, None)
+                if stale:
+                    try:
+                        await stale.disconnect()
+                    except Exception:
+                        logger.warning(
+                            "Error disconnecting evicted WebSocket client",
+                            exc_info=True,
+                        )
+
             return client
 
     async def disconnect(self) -> None:
@@ -686,8 +710,14 @@ class WebSocketManager:
             raise Exception("Lock not initialized")
         async with self._lock:
             for client in self._clients.values():
-                await client.disconnect()
+                try:
+                    await client.disconnect()
+                except Exception:
+                    logger.warning(
+                        "Error disconnecting WebSocket client", exc_info=True
+                    )
             self._clients.clear()
+            self._last_used.clear()
             self._current_loop = None
 
 

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -600,8 +600,19 @@ class WebSocketManager:
             self._lock_loop = current_loop
             logger.debug("Created new WebSocketManager lock for current event loop")
 
-    async def get_client(self) -> HomeAssistantWebSocketClient:
-        """Get WebSocket client, creating connection if needed."""
+    async def get_client(
+        self,
+        url: str | None = None,
+        token: str | None = None,
+    ) -> HomeAssistantWebSocketClient:
+        """Get WebSocket client, creating connection if needed.
+
+        Args:
+            url: Optional HA URL. If provided with token, uses these
+                 credentials instead of global settings. This is required
+                 for OAuth mode where each request has its own credentials.
+            token: Optional HA token. Must be provided with url.
+        """
         current_loop = asyncio.get_event_loop()
 
         self._ensure_lock()
@@ -619,14 +630,26 @@ class WebSocketManager:
 
             self._current_loop = current_loop
 
-            if self._client and self._client.is_connected:
-                return self._client
+            # Determine credentials to use
+            if url and token:
+                ws_url = url
+                ws_token = token
+            else:
+                settings = get_global_settings()
+                ws_url = settings.homeassistant_url
+                ws_token = settings.homeassistant_token
 
-            settings = get_global_settings()
+            # If existing client is connected with different credentials, disconnect
+            if self._client and self._client.is_connected:
+                if self._client.base_url == ws_url.rstrip("/") and self._client.token == ws_token:
+                    return self._client
+                # Credentials changed (different OAuth user), reconnect
+                logger.info("WebSocket credentials changed, reconnecting")
+                await self._client.disconnect()
+                self._client = None
+
             factory = self._client_factory or HomeAssistantWebSocketClient
-            self._client = factory(
-                settings.homeassistant_url, settings.homeassistant_token
-            )
+            self._client = factory(ws_url, ws_token)
 
             connected = await self._client.connect()
             if not connected:
@@ -651,6 +674,14 @@ class WebSocketManager:
 websocket_manager = WebSocketManager()
 
 
-async def get_websocket_client() -> HomeAssistantWebSocketClient:
-    """Get the global WebSocket client instance."""
-    return await websocket_manager.get_client()
+async def get_websocket_client(
+    url: str | None = None,
+    token: str | None = None,
+) -> HomeAssistantWebSocketClient:
+    """Get the global WebSocket client instance.
+
+    Args:
+        url: Optional HA URL for per-client credentials (OAuth mode).
+        token: Optional HA token for per-client credentials (OAuth mode).
+    """
+    return await websocket_manager.get_client(url=url, token=token)

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -925,3 +925,83 @@ class TestOAuthProxyClient:
 
             mock_client_instance.close.assert_called_once()
             assert len(proxy._oauth_clients) == 0
+
+    @pytest.mark.asyncio
+    async def test_oauth_websocket_uses_per_client_credentials(self, mock_auth_provider, mock_access_token):
+        """Test that send_websocket_message passes OAuth credentials to WebSocket client."""
+        from ha_mcp.__main__ import OAuthProxyClient
+
+        proxy = OAuthProxyClient(mock_auth_provider)
+
+        with patch("fastmcp.server.dependencies.get_access_token", return_value=mock_access_token), \
+             patch("ha_mcp.client.websocket_client.get_websocket_client", new_callable=AsyncMock) as mock_get_ws:
+            mock_ws = AsyncMock()
+            mock_ws.send_command.return_value = {"type": "result", "success": True, "result": {}}
+            mock_get_ws.return_value = mock_ws
+
+            await proxy.send_websocket_message({"type": "get_states"})
+
+            # WebSocket client must be created with the OAuth user's credentials
+            mock_get_ws.assert_awaited_once_with(
+                url="http://homeassistant.local:8123",
+                token="test_ha_token_xyz",
+            )
+
+
+class TestWebSocketManagerPool:
+    """Tests for WebSocketManager connection pooling."""
+
+    @pytest.fixture(autouse=True)
+    def reset_manager(self):
+        """Reset the WebSocketManager singleton between tests."""
+        from ha_mcp.client.websocket_client import WebSocketManager
+
+        WebSocketManager._instance = None
+        yield
+        WebSocketManager._instance = None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_oauth_users_get_separate_connections(self):
+        """Test that different OAuth users get separate WebSocket connections."""
+        from ha_mcp.client.websocket_client import WebSocketManager
+
+        mock_client_a = MagicMock()
+        mock_client_a.is_connected = True
+        mock_client_a.connect = AsyncMock(return_value=True)
+        mock_client_a.base_url = "http://ha.local:8123"
+        mock_client_a.token = "token_user_a"
+
+        mock_client_b = MagicMock()
+        mock_client_b.is_connected = True
+        mock_client_b.connect = AsyncMock(return_value=True)
+        mock_client_b.base_url = "http://ha.local:8123"
+        mock_client_b.token = "token_user_b"
+
+        call_count = 0
+
+        def factory(url, token):
+            nonlocal call_count
+            call_count += 1
+            if token == "token_user_a":
+                return mock_client_a
+            return mock_client_b
+
+        manager = WebSocketManager()
+        manager.configure(client_factory=factory)
+
+        # User A connects
+        client_a = await manager.get_client(url="http://ha.local:8123", token="token_user_a")
+        assert client_a is mock_client_a
+
+        # User B connects — should NOT disconnect user A
+        client_b = await manager.get_client(url="http://ha.local:8123", token="token_user_b")
+        assert client_b is mock_client_b
+        assert mock_client_a.disconnect.call_count == 0
+
+        # Both connections created
+        assert call_count == 2
+
+        # User A again — should reuse existing connection
+        client_a2 = await manager.get_client(url="http://ha.local:8123", token="token_user_a")
+        assert client_a2 is mock_client_a
+        assert call_count == 2  # No new connection

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -1005,3 +1005,78 @@ class TestWebSocketManagerPool:
         client_a2 = await manager.get_client(url="http://ha.local:8123", token="token_user_a")
         assert client_a2 is mock_client_a
         assert call_count == 2  # No new connection
+
+    @pytest.mark.asyncio
+    async def test_pool_evicts_lru_when_over_max_size(self):
+        """Test that the pool evicts the least-recently-used client when full."""
+        from ha_mcp.client import websocket_client
+        from ha_mcp.client.websocket_client import WebSocketManager
+
+        original_max = websocket_client.MAX_POOL_SIZE
+        websocket_client.MAX_POOL_SIZE = 2  # Small limit for testing
+
+        try:
+            clients_created: list[MagicMock] = []
+
+            def factory(url, token):
+                mock = MagicMock()
+                mock.is_connected = True
+                mock.connect = AsyncMock(return_value=True)
+                mock.disconnect = AsyncMock()
+                mock.base_url = url
+                mock.token = token
+                clients_created.append(mock)
+                return mock
+
+            manager = WebSocketManager()
+            manager.configure(client_factory=factory)
+
+            # Fill pool to capacity
+            await manager.get_client(url="http://ha.local:8123", token="token_1")
+            await manager.get_client(url="http://ha.local:8123", token="token_2")
+            assert len(manager._clients) == 2
+
+            # Adding a third should evict the LRU (token_1)
+            await manager.get_client(url="http://ha.local:8123", token="token_3")
+            assert len(manager._clients) == 2
+            # token_1 client should have been disconnected
+            clients_created[0].disconnect.assert_awaited_once()
+        finally:
+            websocket_client.MAX_POOL_SIZE = original_max
+
+    @pytest.mark.asyncio
+    async def test_disconnect_handles_individual_client_errors(self):
+        """Test that disconnect() continues if one client raises."""
+        from ha_mcp.client.websocket_client import WebSocketManager
+
+        mock_client_a = MagicMock()
+        mock_client_a.is_connected = True
+        mock_client_a.connect = AsyncMock(return_value=True)
+        mock_client_a.disconnect = AsyncMock(side_effect=Exception("boom"))
+
+        mock_client_b = MagicMock()
+        mock_client_b.is_connected = True
+        mock_client_b.connect = AsyncMock(return_value=True)
+        mock_client_b.disconnect = AsyncMock()
+
+        call_count = 0
+
+        def factory(url, token):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_client_a
+            return mock_client_b
+
+        manager = WebSocketManager()
+        manager.configure(client_factory=factory)
+
+        await manager.get_client(url="http://ha.local:8123", token="token_a")
+        await manager.get_client(url="http://ha.local:8123", token="token_b")
+
+        # disconnect() should not raise even though client_a throws
+        await manager.disconnect()
+
+        mock_client_a.disconnect.assert_awaited_once()
+        mock_client_b.disconnect.assert_awaited_once()
+        assert len(manager._clients) == 0


### PR DESCRIPTION
## Summary

- **Bug**: `ha_get_device` (and all WebSocket-dependent tools) fail in OAuth mode with "Failed to connect to Home Assistant WebSocket"
- **Root cause**: `send_websocket_message()` uses the global `WebSocketManager` singleton which reads credentials from `get_global_settings()` — in OAuth mode those are sentinel values (`http://oauth-mode` / `oauth-mode-token`), not real HA credentials
- **Fix**: Pass the client's own `base_url` and `token` to `get_websocket_client()` so the WebSocket connection uses the same real credentials from OAuth token claims that REST calls use

## Evidence

**Working tools** (REST API): `ha_get_overview`, `ha_search_entities`, `ha_config_get_automation` — all use `client._request()` which goes through `OAuthProxyClient` → per-request `HomeAssistantClient` with real credentials.

**Broken tools** (WebSocket): `ha_get_device` calls `client.send_websocket_message()` → `get_websocket_client()` → `WebSocketManager.get_client()` → `get_global_settings()` → sentinel values → connection failure.

**Code path**:
1. `OAuthProxyClient.__getattr__("send_websocket_message")` forwards to real `HomeAssistantClient`
2. `HomeAssistantClient.send_websocket_message()` calls `get_websocket_client()` (global singleton)
3. `WebSocketManager.get_client()` reads from `get_global_settings()` → `http://oauth-mode` (sentinel)
4. WebSocket connection attempt to `ws://oauth-mode/api/websocket` fails

## Changes

- `rest_client.py`: `send_websocket_message()` now passes `self.base_url` and `self.token` to `get_websocket_client()`
- `websocket_client.py`: `get_websocket_client()` and `WebSocketManager.get_client()` accept optional `url`/`token` params. When provided, uses those instead of global settings. Reconnects automatically if credentials change (different OAuth user).

## Test plan

- [x] All 618 unit tests pass
- [x] Linting passes (`ruff check`)
- [ ] E2E tests (require Docker)
- [ ] Manual test: connect via OAuth mode and call `ha_get_device`

🤖 Generated with [Claude Code](https://claude.com/claude-code)