### PR TITLE
fix(ci): fix changelog extraction producing empty release notes

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -78,8 +78,8 @@ jobs:
         VERSION="${{ steps.semantic.outputs.version }}"
         TAG="v${VERSION}"
 
-        # Extract changelog for this version
-        awk "/^## v${VERSION}/,/^## v[0-9]/" CHANGELOG.md | head -n -1 > release_notes.md
+        # Extract changelog for this version (content between version headers)
+        awk -v ver="## v${VERSION}" '$0 ~ "^"ver {found=1; next} found && /^## v[0-9]/ {exit} found' CHANGELOG.md > release_notes.md
         if [ ! -s release_notes.md ]; then
           echo "Hotfix Release v${VERSION}" > release_notes.md
           echo "" >> release_notes.md

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -149,8 +149,8 @@ jobs:
         VERSION="${{ steps.semantic.outputs.version }}"
         TAG="v${VERSION}"
 
-        # Extract changelog for this version
-        awk "/^## v${VERSION}/,/^## v[0-9]/" CHANGELOG.md | head -n -1 > release_notes.md
+        # Extract changelog for this version (content between version headers)
+        awk -v ver="## v${VERSION}" '$0 ~ "^"ver {found=1; next} found && /^## v[0-9]/ {exit} found' CHANGELOG.md > release_notes.md
         if [ ! -s release_notes.md ]; then
           echo "Release v${VERSION}" > release_notes.md
         fi


### PR DESCRIPTION
## Summary

- Fix awk range command in release workflows that produces empty release notes
- The `awk "/^## vX.Y.Z/,/^## v[0-9]/"` pattern matches the version header as both start AND end (since `## v6.7.2` also matches `## v[0-9]`), outputting only that one line — then `head -n -1` strips it, leaving an empty file
- Replace with flag-based awk that correctly extracts content between version headers

**Affected workflows:** `semver-release.yml`, `hotfix-release.yml`

Closes #706

## Test plan

- [x] Verified new awk command extracts correct content from current `CHANGELOG.md` (tested locally against v6.7.2 section)
- [ ] Next stable/hotfix release should include full changelog in GitHub release notes instead of generic fallback


🤖 Generated with [Claude Code](https://claude.com/claude-code)