### PR TITLE
docs: clarify that the MCP URL appears in the add-on logs, not HA logs

### DIFF
--- a/site/src/content/deployment/ha-addon.md
+++ b/site/src/content/deployment/ha-addon.md
@@ -9,9 +9,9 @@ order: 3
 ## Overview
 
 The easiest way to run ha-mcp if you use Home Assistant OS. The add-on:
-- Auto-discovers Home Assistant connection
-- Generates secure secret path automatically
-- No token configuration needed
+- Auto-discovers the Home Assistant connection
+- Generates a secure secret path automatically
+- Configures the token automatically
 
 ## Installation
 
@@ -25,7 +25,10 @@ The easiest way to run ha-mcp if you use Home Assistant OS. The add-on:
 
 3. **Start** the add-on
 
-4. **Check the logs** for your MCP server URL:
+4. **Check the add-on logs** for your MCP server URL:
+
+   > **Note:** These are the **add-on logs**, not the main Home Assistant logs.
+   > Navigate to **Settings → Add-ons → Home Assistant MCP Server → Logs** tab.
 
    ```
    MCP Server URL: http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw
@@ -33,7 +36,7 @@ The easiest way to run ha-mcp if you use Home Assistant OS. The add-on:
 
 ## Using the Add-on URL
 
-Configure your AI client with the URL from the logs.
+Configure your AI client with the URL from the add-on logs.
 
 **For Claude Desktop** (requires mcp-proxy):
 


### PR DESCRIPTION
## What does this PR do?

Clarifies that the MCP server URL appears in the **add-on logs**, not the main Home Assistant system logs. Users were searching the HA logs for the URL and finding nothing, as reported in discussion #686.

Changes to `site/src/content/deployment/ha-addon.md`:
- Step 4 now says "Check the **add-on logs**" instead of "Check the logs"
- Added a note with the navigation path: **Settings → Add-ons → Home Assistant MCP Server → Logs** tab
- Updated the follow-up sentence to say "add-on logs" for consistency
- Minor copy-edits to the Overview bullet points

Related to discussion: https://github.com/homeassistant-ai/ha-mcp/discussions/686

## Type of change
- [ ] 🐛 Bug fix
- [x] 📚 Documentation
- [ ] ✨ New feature
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed