### PR TITLE
fix(ci): inject GITHUB_TOKEN into HACS for reliable E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,3 +92,4 @@ jobs:
         echo "✅ Full E2E test suite passed"
       env:
         HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -144,6 +144,7 @@ jobs:
         echo "✅ Full E2E test suite passed"
       env:
         HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Docker and Add-on validation
   docker-validation:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -17,6 +17,7 @@ Protection against accidental real-HA usage is instead ensured by:
 """
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -171,6 +172,21 @@ def ha_container_with_fresh_config():
 
     # Copy all files from initial_test_state
     shutil.copytree(initial_state_path, config_path, dirs_exist_ok=True)
+
+    # Inject GITHUB_TOKEN into HACS config entry if available.
+    # Without a valid token HACS disables itself, causing flaky test skips.
+    # In CI the automatic GITHUB_TOKEN provides sufficient read access.
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token:
+        storage_file = config_path / ".storage" / "core.config_entries"
+        if storage_file.exists():
+            ce_data = json.loads(storage_file.read_text())
+            for entry in ce_data.get("data", {}).get("entries", []):
+                if entry.get("domain") == "hacs":
+                    entry["data"] = {"token": github_token}
+                    logger.info("Injected GITHUB_TOKEN into HACS config entry")
+                    break
+            storage_file.write_text(json.dumps(ce_data, indent=2))
 
     # Ensure proper permissions for Home Assistant
     _setup_config_permissions(config_path)


### PR DESCRIPTION
## What does this PR do?

Injects the CI-provided `GITHUB_TOKEN` into the HACS config entry before the testcontainer starts, so HACS doesn't disable itself due to missing token.

Without a valid token, HACS enters a disabled state causing flaky test skips from rate limiting, auth failures, and initialization races. The automatic `GITHUB_TOKEN` in GitHub Actions has sufficient read access for HACS to query repos, search the store, etc.

### Changes

1. **`tests/src/e2e/conftest.py`**: After `copytree` of initial test state, reads `core.config_entries`, finds the HACS entry, and injects the token into `data.token`
2. **`.github/workflows/pr.yml`**: Passes `GITHUB_TOKEN` env var to the E2E test step
3. **`.github/workflows/e2e-tests.yml`**: Same for post-merge E2E workflow

### Why this works

HACS stores its GitHub token in the HA config entry's `data` field. The test state ships with `"data": {}` (no token), so HACS enters a disabled state. By injecting the token before the container starts, HACS initializes normally.

Related to #366

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed