### PR TITLE
fix: webhook proxy Dockerfile COPY paths for Supervisor builds

### DIFF
--- a/homeassistant-addon-webhook-proxy/Dockerfile
+++ b/homeassistant-addon-webhook-proxy/Dockerfile
@@ -6,8 +6,8 @@
 
 FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
 
-COPY homeassistant-addon-webhook-proxy/start.py /
-COPY homeassistant-addon-webhook-proxy/mcp_proxy /opt/mcp_proxy
+COPY start.py /
+COPY mcp_proxy /opt/mcp_proxy
 
 ARG BUILD_VERSION
 ARG BUILD_ARCH

--- a/homeassistant-addon-webhook-proxy/config.yaml
+++ b/homeassistant-addon-webhook-proxy/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa / Webhook Proxy for HA MCP"
 description: "Remote access proxy via Nabu Casa or any reverse proxy (Cloudflare, DuckDNS, nginx)"
-version: "1.0.0"
+version: "1.0.1"
 slug: "ha_mcp_webhook_proxy"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 arch:


### PR DESCRIPTION
## Summary
- HA Supervisor builds addons from inside the addon directory, so COPY paths must be relative to the addon root (`start.py`), not the repo root (`homeassistant-addon-webhook-proxy/start.py`)
- Fixes #724

## Changes
- `homeassistant-addon-webhook-proxy/Dockerfile`: Changed `COPY homeassistant-addon-webhook-proxy/start.py /` → `COPY start.py /` (same for `mcp_proxy`)

## Test plan
- [ ] Install webhook proxy addon from this branch — should build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)