### PR TITLE
chore(ci): group GitHub Actions dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Update Python dependencies via uv (reads uv.lock)
   - package-ecosystem: "uv"


### PR DESCRIPTION
## What does this PR do?

Adds a `groups` config to the `github-actions` dependabot ecosystem so all GitHub Actions version bumps are batched into a single PR instead of one PR per action.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [x] All automated tests pass (`uv run pytest`)

## Checklist
- [ ] I have updated documentation if needed