### PR TITLE
docs: strengthen MCP tool docstring guidelines

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -94,11 +94,41 @@ return create_error_response(
 Flag HIGH severity if errors use plain exceptions or dict returns instead of structured errors from `errors.py`.
 
 
+## MCP Tool Docstrings
+
+Tool docstrings are the **primary interface between the LLM and the tool**. In MCP, the LLM reads the tool description to decide when and how to call it — a vague or inaccurate docstring leads to missed discovery, wrong usage, and incorrect calls. Treat them as first-class API contracts.
+
+**Flag MEDIUM severity when a new or modified tool has a docstring that:**
+- Does not start with an action verb (`"""Returns...` → should be `"""Get...`)
+- Is missing or a single line for non-trivial tools
+- Uses inaccurate HA vocabulary (wrong domain names, service names, entity ID format)
+- Fails to mention related tools the user would naturally need next (e.g. a create tool that doesn't reference the corresponding get/list tool)
+- Embeds extensive documentation that should be deferred to `ha_get_domain_docs()` instead
+
+**Good docstring checklist:**
+- Starts with action verb + one-sentence summary of what the tool does
+- Includes 2-5 concrete examples showing `ha_tool(param)` calls with realistic values
+- For tools with multiple modes (list vs get), shows both clearly
+- Mentions gotchas or non-obvious limitations (e.g. YAML-defined zones won't appear in storage-based APIs)
+- Points to the next natural step in the workflow (e.g. after `ha_search_entities`, call `ha_get_state`)
+- Defers complex schemas to `ha_get_domain_docs('<domain>')` rather than embedding them
+
+**Required HA vocabulary (flag if wrong):**
+- Entity IDs: `domain.slug` format — `light.living_room`, not `living-room` or `/light/living_room`
+- Domains: `light`, `switch`, `climate`, `automation`, `script`, `input_boolean`, `input_number`, `sensor`, etc.
+- Services: `turn_on`, `turn_off`, `toggle`, `set_temperature` — not `activate`, `enable`, `switch`
+- Hierarchy: areas (rooms) → devices (hardware) → entities (controllable units)
+- Config entries = integrations; helpers = `input_*` domain entities created via UI
+
+**Discoverability — flag MEDIUM if missing on workflow-entry tools:**
+- Search/list tools should hint at the follow-up tool for details
+- Create tools should mention the corresponding get/list tool to verify the result
+- Complex-schema tools (`ha_config_set_automation`, etc.) must point to `ha_get_domain_docs()`
+
 ## Code Conventions
 
-1. **Tool descriptions**: Use action verbs, keep concise
-2. **Async/await**: Use consistently for I/O operations
-3. **Type hints**: Required for all function signatures
+1. **Async/await**: Use consistently for I/O operations
+2. **Type hints**: Required for all function signatures
 
 ## Documentation Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,9 +529,70 @@ def register_<domain>_tools(mcp, client, **kwargs):
     @mcp.tool(annotations={"readOnlyHint": True, "idempotentHint": True})
     @log_tool_usage
     async def ha_<verb>_<noun>(param: str) -> dict[str, Any]:
-        """One-line summary starting with action verb."""
-        # For complex schemas, add: "Use ha_get_domain_docs('<domain>') for details."
+        """<Action verb> <what this tool does in one sentence>.
+
+        <Optional: when to use this vs related tools, or key behavioral distinction>
+
+        EXAMPLES:
+        - <minimal call>: ha_<verb>_<noun>(required_param)
+        - <common variant>: ha_<verb>_<noun>(required_param, optional=value) - why you'd use this
+
+        <Optional NOTE/IMPORTANT about gotcha, limitation, or surprising behavior>
+        """
 ```
+
+### Tool Docstrings
+
+Tool docstrings are the **primary interface between the LLM and the tool**. The LLM reads them to decide when and how to call each tool — accuracy and clarity directly affect quality of AI-assisted home automation. This is not optional documentation; it is the API contract.
+
+**What every non-trivial tool docstring must include:**
+
+| Element | Required | Notes |
+|---------|----------|-------|
+| Action verb opening | Always | `Get`, `List`, `Search`, `Create`, `Update`, `Delete`, `Execute` — never `Returns` |
+| One-line summary | Always | What the tool does, not how it does it |
+| Concrete examples | Always | 2-5 realistic calls with real-looking values (e.g. `light.living_room`) |
+| Related tools | When applicable | Next step in the workflow, or the alternative for a different use case |
+| Gotchas / limitations | When they exist | Non-obvious behavior that would cause wrong usage |
+| Schema pointer | Complex schemas | `Use ha_get_domain_docs('<domain>') for full schema` — never embed the schema inline |
+
+**HA vocabulary — always use correct terms:**
+- Entity IDs: `domain.slug` (e.g. `light.living_room`, `climate.thermostat`)
+- Domains: `light`, `switch`, `climate`, `automation`, `script`, `input_boolean`, `sensor`, `cover`, `media_player`, etc.
+- Services: `turn_on`, `turn_off`, `toggle`, `set_temperature` — not `activate`, `enable`, `switch`
+- Hierarchy: areas (rooms) contain devices (physical hardware) which expose entities (controllable units)
+- Config entries = integrations (e.g. Zigbee, Z-Wave); helpers = `input_*` entities created via UI
+
+**Discoverability — connecting tools into workflows:**
+
+A tool is only as useful as how easily an LLM can discover it at the right moment. Make each tool point forward:
+
+```python
+# Search/list → point to detail tool
+"""Search entities by name, area, domain, or state.
+
+NEXT: Use ha_get_state(entity_id) for full state and attributes of a specific entity.
+"""
+
+# Create → point to verify tool
+"""Create an input_boolean helper entity.
+
+After creation, use ha_list_helpers(domain_filter="input_boolean") to confirm it registered.
+"""
+
+# Complex schema → point to docs tool
+"""Create or update a Home Assistant automation.
+
+For the full trigger/condition/action schema, call ha_get_domain_docs('automation').
+"""
+```
+
+**What NOT to put in docstrings:**
+- Full JSON schemas or configuration reference — use `ha_get_domain_docs()`
+- Parameter descriptions already covered by `Field(description=...)` Pydantic annotations
+- Implementation details or internal logic
+
+**Boy Scout rule:** Always improve the docstring of any tool you touch. Added a parameter? Add an example using it. Fixed a bug? Add a NOTE about the gotcha.
 
 ### Safety Annotations
 | Annotation | Default | Use For |


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Added `### Tool Docstrings` subsection under Writing MCP Tools with a structured table of required elements, correct HA vocabulary reference, discoverability patterns (search→detail, create→verify, complex schema→docs), and explicit "what NOT to include" list. Updated the tool structure template to show a complete docstring skeleton instead of a one-liner placeholder.
- **.gemini/styleguide.md**: Replaced the one-liner "Tool descriptions: Use action verbs, keep concise" with a full `## MCP Tool Docstrings` section that gives Gemini Code Assist actionable MEDIUM-severity flags: missing action verb, wrong HA vocabulary, missing related-tool hints on workflow-entry tools, and embedded schemas that should defer to `ha_get_domain_docs()`.

## Motivation

Tool docstrings are the primary interface between the LLM and MCP tools. Vague or inaccurate descriptions lead to missed discovery and wrong usage. Neither the styleguide nor AGENTS.md gave enough guidance for contributors or reviewers to consistently produce good docstrings.

## Test plan
- [ ] Read AGENTS.md `### Tool Docstrings` section — guidance is clear and actionable
- [ ] Read `.gemini/styleguide.md` `## MCP Tool Docstrings` section — flags are specific enough for automated review

🤖 Generated with [Claude Code](https://claude.com/claude-code)