### PR TITLE
fix: restore safe_call_tool import in logbook E2E tests

### DIFF
--- a/tests/src/e2e/tools/test_logbook.py
+++ b/tests/src/e2e/tools/test_logbook.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from ..utilities.assertions import assert_mcp_success
+from ..utilities.assertions import assert_mcp_success, safe_call_tool
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- PR #710 removed the `safe_call_tool` import from `test_logbook.py` but 4 tests still reference it
- This causes `NameError: name 'safe_call_tool' is not defined` in E2E on master
- One-line fix: re-add `safe_call_tool` to the import

**Failing tests on master:**
- `test_logbook_pagination_with_offset`
- `test_logbook_negative_offset`
- `test_logbook_has_more_indicator`
- `test_logbook_response_metadata`

**Failed run:** https://github.com/homeassistant-ai/ha-mcp/actions/runs/23050377572

## Type of change
- [x] Bug fix

## Test plan
- [ ] E2E tests pass (the 4 broken tests should resolve with the import restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)