### PR TITLE
fix: OAuth token refresh broken and state lost on container restart

### DIFF
--- a/src/ha_mcp/auth/provider.py
+++ b/src/ha_mcp/auth/provider.py
@@ -242,7 +242,7 @@ class HomeAssistantOAuthProvider(OAuthProvider):
                 try:
                     os.close(tmp_fd)
                 except OSError:
-                    pass
+                    pass  # Best-effort cleanup; fd may already be closed
             if tmp_path is not None:
                 try:
                     tmp_path.unlink()

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -895,7 +895,6 @@ class TestOAuthStatePersistence:
     @pytest.mark.asyncio
     async def test_expired_tokens_pruned_on_load(self, tmp_path):
         """Test that expired refresh tokens are not loaded from disk."""
-        import json
 
         state = {
             "clients": {},


### PR DESCRIPTION
## What does this PR do?

Fixes #787 — OAuth token refresh is broken (produces invalid access tokens) and all OAuth state is lost on container restart, forcing users to re-authenticate repeatedly.

**Root cause:** Three bugs in `exchange_refresh_token`, all present since the original OAuth implementation (PR #368):

1. **Token refresh generates invalid tokens** — `exchange_refresh_token` created random `ha_access_*` strings instead of stateless base64-encoded tokens. `load_access_token` can't decode them → 401 Unauthorized after the first hour.

2. **Credential mapping is wrong** — `_refresh_to_access_map` stored `client_id` instead of the actual access token string, so HA credentials could never be recovered during refresh.

3. **No disk persistence** — All OAuth state (clients, refresh tokens, mappings) was stored in in-memory Python dicts. Container restart = complete state loss.

**Fix:**

- `exchange_refresh_token` now decodes the HA token from the old stateless access token via `_decode_credentials` and encodes a new one via `_encode_credentials`
- `exchange_authorization_code` correctly maps refresh_token → access_token (not client_id)
- Added disk persistence via `~/.ha-mcp/oauth_state.json` (atomic writes via tmp+rename, loaded on init)
- State file uses restrictive permissions (0o600 file, 0o700 directory)
- Orphaned `.tmp` files cleaned up on save failure
- Expired refresh tokens pruned during load
- Removed dead `_access_to_refresh_map` (never populated in stateless flow)
- Added `state_dir` constructor parameter for configurability

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)
- [x] Docker integration test: full OAuth flow via curl (register → authorize → consent → exchange → refresh → chained refresh → restart → refresh after restart)

## Checklist
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)