### PR TITLE
fix: surface connection errors in ha_get_overview instead of returning empty data

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -4,6 +4,7 @@ Smart search tools for Home Assistant MCP server.
 
 import asyncio
 import logging
+import random
 import time
 from typing import Any
 
@@ -387,9 +388,20 @@ class SmartSearchTools:
                 return_exceptions=True,
             )
 
-            # Process results, handling any exceptions gracefully
-            entities = results[0] if not isinstance(results[0], Exception) else []
-            services = results[1] if not isinstance(results[1], Exception) else []
+            # Entities are mandatory — surface connection/auth errors immediately.
+            # Services failure is logged at warning (affects total count and service catalog).
+            # Registry failures are logged at debug (area enrichment only).
+            if isinstance(results[0], Exception):
+                raise results[0]
+
+            entities = results[0]
+            partial_warnings: list[str] = []
+            if isinstance(results[1], Exception):
+                logger.warning(f"Could not fetch services: {results[1]}")
+                partial_warnings.append(f"Services unavailable: {results[1]}")
+                services = []
+            else:
+                services = results[1]
 
             # Handle area registry result
             area_registry: list[dict[str, Any]] = []
@@ -537,8 +549,6 @@ class SmartSearchTools:
             }
 
             # Prepare domain stats with entity filtering and truncation info
-            import random
-
             formatted_domain_stats = {}
             for domain, stats in sorted_domains:
                 all_entities = stats["all_entities"]
@@ -569,7 +579,7 @@ class SmartSearchTools:
                 }
 
             # Build base response
-            base_response = {
+            base_response: dict[str, Any] = {
                 "success": True,
                 "system_summary": {
                     "total_entities": len(entities),
@@ -581,6 +591,10 @@ class SmartSearchTools:
                 "area_analysis": area_stats,  # Now included in all detail levels
                 "ai_insights": ai_insights,
             }
+
+            if partial_warnings:
+                base_response["partial"] = True
+                base_response["warnings"] = partial_warnings
 
             # Add level-specific fields
             if detail_level == "full":

--- a/tests/src/unit/test_performance_parallelization.py
+++ b/tests/src/unit/test_performance_parallelization.py
@@ -8,9 +8,10 @@ Tests observable behavior of performance optimizations:
 """
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.smart_search import SmartSearchTools
 
@@ -211,6 +212,7 @@ class TestGetSystemOverview:
             result = await tools.get_system_overview(detail_level="standard")
 
         assert result["success"] is True
+        assert "partial" not in result
         assert result["system_summary"]["total_entities"] == 2
         assert result["system_summary"]["total_areas"] == 2
 
@@ -257,6 +259,41 @@ class TestGetSystemOverview:
         assert result["success"] is True
         assert result["system_summary"]["total_entities"] == 2
         assert result["system_summary"]["total_areas"] == 0
+
+    @pytest.mark.asyncio
+    async def test_entities_fetch_failure_raises_error(self, sample_services):
+        """When get_states() fails, surface the error instead of returning 0 entities.
+
+        Regression test for issue #811: ha_get_overview returned success with
+        total_entities=0 when the HA connection was broken, masking the real error.
+        """
+        client = MockClient(entities=[], services=sample_services)
+        client.get_states = AsyncMock(side_effect=ConnectionError("Connection refused"))
+
+        with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+            mock_settings.return_value.fuzzy_threshold = 60
+            tools = SmartSearchTools(client=client)
+            with pytest.raises(ToolError):
+                await tools.get_system_overview(detail_level="minimal")
+
+    @pytest.mark.asyncio
+    async def test_services_fetch_failure_continues_with_empty_services(
+        self, sample_entities, sample_services
+    ):
+        """When get_services() fails, the overview still succeeds with total_services=0."""
+        client = MockClient(entities=sample_entities, services=sample_services)
+        client.get_services = AsyncMock(side_effect=ConnectionError("Connection refused"))
+
+        with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+            mock_settings.return_value.fuzzy_threshold = 60
+            tools = SmartSearchTools(client=client)
+            result = await tools.get_system_overview(detail_level="minimal")
+
+        assert result["success"] is True
+        assert result["partial"] is True
+        assert any("Services unavailable" in w for w in result["warnings"])
+        assert result["system_summary"]["total_entities"] == 2
+        assert result["system_summary"]["total_services"] == 0
 
     @pytest.mark.asyncio
     async def test_resolves_area_through_device_registry(self, sample_services):


### PR DESCRIPTION
## What does this PR do?

Fixes #811 — `ha_get_overview` was returning `success: true` with `total_entities: 0` when the HA connection was broken, making it look like an empty install rather than a connectivity problem.

**Root cause:** `asyncio.gather(..., return_exceptions=True)` captured the exception from `get_states()` silently. The tool then returned an empty but "successful" response.

**Changes:**

- **Entities fetch failure** → raises immediately via the existing `exception_to_structured_error` handler, producing a proper `ToolError` with connection troubleshooting suggestions
- **Services fetch failure** → logs at warning and sets `partial: true` + `warnings[]` in the response so callers can distinguish a real zero-service HA from a fetch failure
- **`get_config` swallow** → pre-existing `except Exception` already logged at warning; no change needed
- **`import random`** → moved from inside function body to module level

**Tests added:**
- `test_entities_fetch_failure_raises_error` — regression test for #811 core bug
- `test_services_fetch_failure_continues_with_empty_services` — verifies `partial: true` + `warnings[]` on services failure
- `assert "partial" not in result` added to happy-path test to catch regressions

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed