### PR TITLE
fix(internal): prevent issue triage timeout on complex issues

### DIFF
--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: should_run
     if: needs.should_run.outputs.should_run == 'true'
-    timeout-minutes: 10
+    timeout-minutes: 12
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -332,7 +332,7 @@ jobs:
           settings: |
             {
               "model": {
-                "maxSessionTurns": 50
+                "maxSessionTurns": 20
               },
               "tools": {
                 "core": [
@@ -417,6 +417,7 @@ jobs:
             - `google_web_search <query>` - Search web for error messages or external docs
 
             **Critical Rules:**
+            - **TIME BUDGET**: You have ~8 minutes. Limit yourself to ~10 tool calls total. If you can't find something after 2 searches, move on. Focus on the single most likely root cause.
             - **YOU ARE READ-ONLY**: You cannot modify files, create PRs, or make code changes
             - If you identify a fix, provide it as a diff in the Technical Analysis section
             - ONLY reference file paths you actually found with `grep` or `find`


### PR DESCRIPTION
## What does this PR do?

Prevents Gemini issue triage from timing out on complex issues. The full analysis step on issue #831 ran for 9m23s and was cancelled by the 10-minute job timeout because `maxSessionTurns: 50` allowed unbounded codebase exploration.

Three-layer fix:
- **Hard cap**: Reduce `maxSessionTurns` from 50 to 20 (limits Gemini CLI turns)
- **Soft cap**: Add TIME BUDGET prompt instruction (~10 tool calls, move on after 2 failed searches)
- **Safety margin**: Increase job `timeout-minutes` from 10 to 12

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed