### PR TITLE
fix: fetch addon stats from /addons/{slug}/stats endpoint

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -175,7 +175,7 @@ async def list_addons(
                         "memory_usage": s.get("memory_usage"),
                         "memory_limit": s.get("memory_limit"),
                     }
-            except (ToolError, Exception) as exc:
+            except Exception as exc:
                 logger.warning("Failed to fetch stats for addon %s: %s", slug, exc)
             return slug, None
 

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -1,4 +1,4 @@
-"""Unit tests for add-on tools (_call_addon_api and _call_addon_ws error paths)."""
+"""Unit tests for add-on tools (_call_addon_api, _call_addon_ws, and list_addons)."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,7 +8,7 @@ import pytest
 import websockets.exceptions
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.tools_addons import _call_addon_api, _call_addon_ws
+from ha_mcp.tools.tools_addons import _call_addon_api, _call_addon_ws, list_addons
 
 # Standard mock return for a running addon with Ingress support
 _RUNNING_ADDON_INFO = {
@@ -50,7 +50,10 @@ class TestCallAddonApiErrors:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "traversal" in result["error"]["message"].lower() or ".." in result["error"]["message"]
+        assert (
+            "traversal" in result["error"]["message"].lower()
+            or ".." in result["error"]["message"]
+        )
 
     @pytest.mark.asyncio
     async def test_path_traversal_middle_segment(self):
@@ -74,7 +77,10 @@ class TestCallAddonApiErrors:
             patch(
                 "ha_mcp.tools.tools_addons.get_addon_info",
                 new_callable=AsyncMock,
-                return_value={"success": False, "error": {"code": "RESOURCE_NOT_FOUND", "message": "Not found"}},
+                return_value={
+                    "success": False,
+                    "error": {"code": "RESOURCE_NOT_FOUND", "message": "Not found"},
+                },
             ),
             pytest.raises(ToolError) as exc_info,
         ):
@@ -91,14 +97,20 @@ class TestCallAddonApiErrors:
         client = _make_mock_client()
         error_response = {
             "success": False,
-            "error": {"code": "RESOURCE_NOT_FOUND", "message": "Add-on 'fake_addon' not found"},
+            "error": {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Add-on 'fake_addon' not found",
+            },
         }
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=error_response,
-        ), pytest.raises(ToolError) as exc_info:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=error_response,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_api(client, "fake_addon", "/api/test")
 
         result = _parse_tool_error(exc_info)
@@ -110,19 +122,22 @@ class TestCallAddonApiErrors:
         """Should raise ToolError when add-on doesn't support Ingress."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": False,
-                    "state": "started",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": False,
+                        "state": "started",
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_api(client, "test_addon", "/api/test")
 
         result = _parse_tool_error(exc_info)
@@ -134,20 +149,23 @@ class TestCallAddonApiErrors:
         """Should raise ToolError when add-on is not running."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": True,
-                    "state": "stopped",
-                    "ingress_entry": "/api/hassio_ingress/abc123",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "stopped",
+                        "ingress_entry": "/api/hassio_ingress/abc123",
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_api(client, "test_addon", "/api/test")
 
         result = _parse_tool_error(exc_info)
@@ -160,67 +178,84 @@ class TestCallAddonApiErrors:
         """Should raise ToolError when add-on has Ingress but no entry path."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": True,
-                    "state": "started",
-                    "ingress_entry": "",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "started",
+                        "ingress_entry": "",
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_api(client, "test_addon", "/api/test")
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "ingress_entry" in result["error"]["message"].lower() or "ingress" in result["error"]["message"].lower()
+        assert (
+            "ingress_entry" in result["error"]["message"].lower()
+            or "ingress" in result["error"]["message"].lower()
+        )
 
     @pytest.mark.asyncio
     async def test_addon_missing_network_info(self):
         """Should raise ToolError when add-on is missing ip_address or ingress_port."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": True,
-                    "state": "started",
-                    "ip_address": "",
-                    "ingress_port": None,
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "started",
+                        "ip_address": "",
+                        "ingress_port": None,
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_api(client, "test_addon", "/api/test")
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "network info" in result["error"]["message"].lower() or "ip_address" in str(result).lower()
+        assert (
+            "network info" in result["error"]["message"].lower()
+            or "ip_address" in str(result).lower()
+        )
 
     @pytest.mark.asyncio
     async def test_http_timeout(self):
         """Should raise ToolError when add-on API doesn't respond."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO,
-        ), patch(
-            "ha_mcp.tools.tools_addons.httpx.AsyncClient",
-        ) as mock_httpx:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
             mock_http_client = AsyncMock()
             mock_http_client.request.side_effect = httpx.TimeoutException("timed out")
-            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(ToolError) as exc_info:
@@ -228,23 +263,33 @@ class TestCallAddonApiErrors:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "timeout" in result["error"]["message"].lower() or "timed out" in str(result).lower()
+        assert (
+            "timeout" in result["error"]["message"].lower()
+            or "timed out" in str(result).lower()
+        )
 
     @pytest.mark.asyncio
     async def test_http_connection_error(self):
         """Should raise ToolError when can't reach add-on."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO,
-        ), patch(
-            "ha_mcp.tools.tools_addons.httpx.AsyncClient",
-        ) as mock_httpx:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
             mock_http_client = AsyncMock()
-            mock_http_client.request.side_effect = httpx.ConnectError("Connection refused")
-            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_http_client.request.side_effect = httpx.ConnectError(
+                "Connection refused"
+            )
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
             mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(ToolError) as exc_info:
@@ -252,7 +297,10 @@ class TestCallAddonApiErrors:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "connect" in result["error"]["message"].lower() or "connection" in str(result).lower()
+        assert (
+            "connect" in result["error"]["message"].lower()
+            or "connection" in str(result).lower()
+        )
 
 
 # Standard mock return for a running addon with Ingress support (for WS tests)
@@ -282,7 +330,10 @@ class TestCallAddonWsErrors:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "traversal" in result["error"]["message"].lower() or ".." in result["error"]["message"]
+        assert (
+            "traversal" in result["error"]["message"].lower()
+            or ".." in result["error"]["message"]
+        )
 
     @pytest.mark.asyncio
     async def test_ws_addon_not_found(self):
@@ -290,14 +341,20 @@ class TestCallAddonWsErrors:
         client = _make_mock_client()
         error_response = {
             "success": False,
-            "error": {"code": "RESOURCE_NOT_FOUND", "message": "Add-on 'fake_addon' not found"},
+            "error": {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Add-on 'fake_addon' not found",
+            },
         }
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=error_response,
-        ), pytest.raises(ToolError) as exc_info:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=error_response,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_ws(client, "fake_addon", "/compile")
 
         result = _parse_tool_error(exc_info)
@@ -309,19 +366,22 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when add-on doesn't support Ingress and no port override."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": False,
-                    "state": "started",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": False,
+                        "state": "started",
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_ws(client, "test_addon", "/compile")
 
         result = _parse_tool_error(exc_info)
@@ -333,25 +393,30 @@ class TestCallAddonWsErrors:
         """Should succeed past Ingress check when port override is provided."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": False,
-                    "state": "started",
-                    "ip_address": "172.30.33.99",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": False,
+                        "state": "started",
+                        "ip_address": "172.30.33.99",
+                    },
                 },
-            },
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             # Simulate a quick connection that closes immediately
             mock_ws = AsyncMock()
-            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(None, None)
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
             mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
             mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -366,20 +431,23 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when add-on is not running."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": True,
-                    "state": "stopped",
-                    "ingress_entry": "/api/hassio_ingress/abc123",
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "stopped",
+                        "ingress_entry": "/api/hassio_ingress/abc123",
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_ws(client, "test_addon", "/compile")
 
         result = _parse_tool_error(exc_info)
@@ -391,13 +459,16 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when WebSocket handshake fails."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws_connect.return_value.__aenter__ = AsyncMock(
                 side_effect=websockets.exceptions.InvalidHandshake("403 Forbidden"),
             )
@@ -415,21 +486,28 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when connection closes during send."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws = AsyncMock()
-            mock_ws.send.side_effect = websockets.exceptions.ConnectionClosed(None, None)
+            mock_ws.send.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
             mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
             mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(ToolError) as exc_info:
                 await _call_addon_ws(
-                    client, "test_addon", "/compile",
+                    client,
+                    "test_addon",
+                    "/compile",
                     body={"type": "spawn", "configuration": "test.yaml"},
                 )
 
@@ -442,13 +520,16 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when can't connect to add-on WebSocket."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws_connect.return_value.__aenter__ = AsyncMock(
                 side_effect=OSError("Connection refused"),
             )
@@ -459,20 +540,26 @@ class TestCallAddonWsErrors:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "connect" in result["error"]["message"].lower() or "connection" in str(result).lower()
+        assert (
+            "connect" in result["error"]["message"].lower()
+            or "connection" in str(result).lower()
+        )
 
     @pytest.mark.asyncio
     async def test_ws_collects_messages(self):
         """Should collect text messages and parse JSON ones."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws = AsyncMock()
             # Simulate 3 messages then connection close
             mock_ws.recv.side_effect = [
@@ -498,13 +585,16 @@ class TestCallAddonWsErrors:
         """Should strip ANSI escape codes from messages."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws = AsyncMock()
             mock_ws.recv.side_effect = [
                 "\x1b[32mSUCCESS\x1b[0m Build complete",
@@ -523,13 +613,16 @@ class TestCallAddonWsErrors:
         """Should skip binary WebSocket frames."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws = AsyncMock()
             mock_ws.recv.side_effect = [
                 b"\x00\x01\x02",  # binary frame, should be skipped
@@ -550,13 +643,16 @@ class TestCallAddonWsErrors:
         """With wait_for_close=False, should return after silence timeout."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value=_RUNNING_ADDON_INFO_WS,
-        ), patch(
-            "ha_mcp.tools.tools_addons.websockets.connect",
-        ) as mock_ws_connect:
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
             mock_ws = AsyncMock()
             # First message arrives, then silence (TimeoutError)
             mock_ws.recv.side_effect = [
@@ -567,8 +663,11 @@ class TestCallAddonWsErrors:
             mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
 
             result = await _call_addon_ws(
-                client, "test_addon", "/events",
-                wait_for_close=False, timeout=10,
+                client,
+                "test_addon",
+                "/events",
+                wait_for_close=False,
+                timeout=10,
             )
 
         assert result["success"] is True
@@ -580,23 +679,199 @@ class TestCallAddonWsErrors:
         """Should raise ToolError when add-on is missing ip_address."""
         client = _make_mock_client()
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_addon_info",
-            new_callable=AsyncMock,
-            return_value={
-                "success": True,
-                "addon": {
-                    "name": "Test Addon",
-                    "slug": "test_addon",
-                    "ingress": True,
-                    "state": "started",
-                    "ip_address": "",
-                    "ingress_port": None,
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "started",
+                        "ip_address": "",
+                        "ingress_port": None,
+                    },
                 },
-            },
-        ), pytest.raises(ToolError) as exc_info:
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await _call_addon_ws(client, "test_addon", "/compile")
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "network info" in result["error"]["message"].lower() or "ip_address" in str(result).lower()
+        assert (
+            "network info" in result["error"]["message"].lower()
+            or "ip_address" in str(result).lower()
+        )
+
+
+# Mock Supervisor API responses for list_addons tests
+_ADDONS_LIST_RESPONSE = {
+    "success": True,
+    "result": {
+        "addons": [
+            {
+                "name": "Matter Server",
+                "slug": "core_matter_server",
+                "description": "Matter support",
+                "version": "8.3.0",
+                "state": "started",
+                "update_available": False,
+                "repository": "core",
+            },
+            {
+                "name": "Music Assistant",
+                "slug": "music_assistant",
+                "description": "Music player",
+                "version": "1.4.0",
+                "state": "started",
+                "update_available": False,
+                "repository": "community",
+            },
+            {
+                "name": "Stopped Addon",
+                "slug": "stopped_addon",
+                "description": "Not running",
+                "version": "1.0.0",
+                "state": "stopped",
+                "update_available": False,
+                "repository": "core",
+            },
+        ],
+    },
+}
+
+_MATTER_STATS_RESPONSE = {
+    "success": True,
+    "result": {
+        "cpu_percent": 0.5,
+        "memory_percent": 2.0,
+        "memory_usage": 163987456,
+        "memory_limit": 8312754176,
+    },
+}
+
+_MUSIC_STATS_RESPONSE = {
+    "success": True,
+    "result": {
+        "cpu_percent": 1.2,
+        "memory_percent": 10.8,
+        "memory_usage": 896094208,
+        "memory_limit": 8312754176,
+    },
+}
+
+
+class TestListAddonsStats:
+    """Tests for list_addons with include_stats=True."""
+
+    @pytest.mark.asyncio
+    async def test_include_stats_returns_real_data(self):
+        """Running addons should have real stats from /addons/{slug}/stats."""
+        client = _make_mock_client()
+
+        async def mock_supervisor_api(client, endpoint, **kwargs):
+            if endpoint == "/addons":
+                return _ADDONS_LIST_RESPONSE
+            if endpoint == "/addons/core_matter_server/stats":
+                return _MATTER_STATS_RESPONSE
+            if endpoint == "/addons/music_assistant/stats":
+                return _MUSIC_STATS_RESPONSE
+            return {"success": False}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            side_effect=mock_supervisor_api,
+        ):
+            result = await list_addons(client, include_stats=True)
+
+        assert result["success"] is True
+        addons = {a["slug"]: a for a in result["addons"]}
+
+        # Running addons should have real stats
+        matter_stats = addons["core_matter_server"]["stats"]
+        assert matter_stats is not None
+        assert matter_stats["cpu_percent"] == 0.5
+        assert matter_stats["memory_usage"] == 163987456
+
+        music_stats = addons["music_assistant"]["stats"]
+        assert music_stats is not None
+        assert music_stats["memory_percent"] == 10.8
+
+    @pytest.mark.asyncio
+    async def test_stopped_addon_gets_none_stats(self):
+        """Stopped addons should get stats=None without making an API call."""
+        client = _make_mock_client()
+        stats_calls = []
+
+        async def mock_supervisor_api(client, endpoint, **kwargs):
+            if endpoint == "/addons":
+                return _ADDONS_LIST_RESPONSE
+            stats_calls.append(endpoint)
+            if endpoint == "/addons/core_matter_server/stats":
+                return _MATTER_STATS_RESPONSE
+            if endpoint == "/addons/music_assistant/stats":
+                return _MUSIC_STATS_RESPONSE
+            return {"success": False}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            side_effect=mock_supervisor_api,
+        ):
+            result = await list_addons(client, include_stats=True)
+
+        addons = {a["slug"]: a for a in result["addons"]}
+
+        # Stopped addon should have None stats
+        assert addons["stopped_addon"]["stats"] is None
+
+        # Should NOT have made a stats call for the stopped addon
+        assert "/addons/stopped_addon/stats" not in stats_calls
+
+    @pytest.mark.asyncio
+    async def test_one_addon_stats_failure_does_not_break_others(self):
+        """If one addon's stats fetch fails, others should still return stats."""
+        client = _make_mock_client()
+
+        async def mock_supervisor_api(client, endpoint, **kwargs):
+            if endpoint == "/addons":
+                return _ADDONS_LIST_RESPONSE
+            if endpoint == "/addons/core_matter_server/stats":
+                raise Exception("Connection reset")
+            if endpoint == "/addons/music_assistant/stats":
+                return _MUSIC_STATS_RESPONSE
+            return {"success": False}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            side_effect=mock_supervisor_api,
+        ):
+            result = await list_addons(client, include_stats=True)
+
+        assert result["success"] is True
+        addons = {a["slug"]: a for a in result["addons"]}
+
+        # Failed addon should have None stats
+        assert addons["core_matter_server"]["stats"] is None
+
+        # Other addon should still have real stats
+        music_stats = addons["music_assistant"]["stats"]
+        assert music_stats is not None
+        assert music_stats["memory_percent"] == 10.8
+
+    @pytest.mark.asyncio
+    async def test_no_stats_key_without_include_stats(self):
+        """When include_stats=False, addons should not have a stats key."""
+        client = _make_mock_client()
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            return_value=_ADDONS_LIST_RESPONSE,
+        ):
+            result = await list_addons(client, include_stats=False)
+
+        assert result["success"] is True
+        for addon in result["addons"]:
+            assert "stats" not in addon


### PR DESCRIPTION
## What does this PR do?

The include_stats parameter on ha_get_addon was reading cpu_percent, memory_percent, etc. from the /addons list response, but that endpoint doesn't include stats fields — they were always null.

The Supervisor API exposes per-addon stats at /addons/{slug}/stats. This fix calls that endpoint for each running addon when include_stats=True.

Tested against a live HAOS instance via the supervisor/api WebSocket command — the endpoint returns cpu_percent, memory_usage, memory_limit, memory_percent, network_rx/tx, and blk_read/write.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
