### PR TITLE
fix: enable e2e filesystem tests and fix ha_mcp_tools integration

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -402,7 +402,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Create parent directories if needed
             if create_dirs:
                 await hass.async_add_executor_job(
-                    target_file.parent.mkdir, parents=True, exist_ok=True
+                    lambda: target_file.parent.mkdir(parents=True, exist_ok=True)
                 )
 
             # Check parent directory exists
@@ -597,7 +597,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if do_backup and raw_content:
                 backup_dir = config_dir / "www" / "yaml_backups"
                 await hass.async_add_executor_job(
-                    backup_dir.mkdir, parents=True, exist_ok=True
+                    lambda: backup_dir.mkdir(parents=True, exist_ok=True)
                 )
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 safe_name = normalized.replace(os.sep, "_")
@@ -661,7 +661,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Create parent directories if needed (for new package files)
             if not target_file.parent.exists():
                 await hass.async_add_executor_job(
-                    target_file.parent.mkdir, parents=True, exist_ok=True
+                    lambda: target_file.parent.mkdir(parents=True, exist_ok=True)
                 )
 
             # Atomic write: write to temp file, then rename into place

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -13,6 +13,7 @@ The tools will gracefully fail with installation instructions if the component i
 Feature Flag: Set HAMCP_ENABLE_FILESYSTEM_TOOLS=true to enable these tools.
 """
 
+import json
 import logging
 import os
 from typing import Annotated, Any
@@ -22,7 +23,7 @@ from pydantic import Field
 
 from ..errors import ErrorCode, create_error_response
 from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
-from .util_helpers import add_timezone_metadata, coerce_bool_param, coerce_int_param
+from .util_helpers import coerce_bool_param, coerce_int_param, unwrap_service_response
 
 logger = logging.getLogger(__name__)
 
@@ -174,18 +175,14 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
             # The service returns the response directly
             if isinstance(result, dict):
-                return await add_timezone_metadata(client, result)
+                return unwrap_service_response(result)
 
-            return await add_timezone_metadata(
-                client,
-                {
-                    "success": True,
-                    "path": path,
-                    "pattern": pattern,
-                    "files": [],
-                    "count": 0,
-                    "note": "Unexpected response format from service",
-                },
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Unexpected response format from list_files service",
+                    context={"path": path},
+                )
             )
 
         except ToolError:
@@ -289,15 +286,14 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
 
             if isinstance(result, dict):
-                return await add_timezone_metadata(client, result)
+                return unwrap_service_response(result)
 
-            return await add_timezone_metadata(
-                client,
-                {
-                    "success": False,
-                    "error": "Unexpected response format from service",
-                    "path": path,
-                },
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Unexpected response format from read_file service",
+                    context={"path": path},
+                )
             )
 
         except ToolError:
@@ -419,15 +415,14 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
 
             if isinstance(result, dict):
-                return await add_timezone_metadata(client, result)
+                return unwrap_service_response(result)
 
-            return await add_timezone_metadata(
-                client,
-                {
-                    "success": False,
-                    "error": "Unexpected response format from service",
-                    "path": path,
-                },
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Unexpected response format from write_file service",
+                    context={"path": path},
+                )
             )
 
         except ToolError:
@@ -503,20 +498,15 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             confirm_bool = coerce_bool_param(confirm, "confirm", default=False)
 
             if not confirm_bool:
-                return await add_timezone_metadata(
-                    client,
-                    {
-                        "success": False,
-                        "error": "Deletion not confirmed",
-                        "message": (
-                            "You must set confirm=True to delete a file. "
-                            "This is a safety measure to prevent accidental deletions."
-                        ),
-                        "path": path,
-                        "suggestions": [
-                            f"Call ha_delete_file(path='{path}', confirm=True) to proceed",
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Deletion not confirmed. Set confirm=True to delete a file.",
+                        suggestions=[
+                            f"Call ha_delete_file(path={json.dumps(path)}, confirm=True) to proceed",
                         ],
-                    },
+                        context={"path": path},
+                    )
                 )
 
             # Check if custom component is available
@@ -534,15 +524,14 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
 
             if isinstance(result, dict):
-                return await add_timezone_metadata(client, result)
+                return unwrap_service_response(result)
 
-            return await add_timezone_metadata(
-                client,
-                {
-                    "success": False,
-                    "error": "Unexpected response format from service",
-                    "path": path,
-                },
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Unexpected response format from delete_file service",
+                    context={"path": path},
+                )
             )
 
         except ToolError:

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -24,7 +24,7 @@ from .tools_filesystem import (
     MCP_TOOLS_DOMAIN,
     _assert_mcp_tools_available,
 )
-from .util_helpers import add_timezone_metadata, coerce_bool_param
+from .util_helpers import coerce_bool_param, unwrap_service_response
 
 logger = logging.getLogger(__name__)
 
@@ -179,9 +179,10 @@ def register_yaml_config_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
 
             if isinstance(result, dict):
+                result = unwrap_service_response(result)
                 if not result.get("success", True):
                     raise_tool_error(result)
-                return await add_timezone_metadata(client, result)
+                return result
 
             raise_tool_error(
                 create_error_response(

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -232,6 +232,17 @@ def parse_string_list_param(
     raise ValueError(f"{param_name} must be string, list, or None")
 
 
+def unwrap_service_response(result: dict[str, Any]) -> dict[str, Any]:
+    """Extract service_response from HA call_service result.
+
+    HA's call_service with return_response wraps results in
+    {"changed_states": [...], "service_response": {...}}.
+    Returns service_response if present and is a dict, otherwise the original result.
+    """
+    sr = result.get("service_response")
+    return sr if isinstance(sr, dict) else result
+
+
 async def add_timezone_metadata(client: Any, data: dict[str, Any]) -> dict[str, Any]:
     """Add Home Assistant timezone to tool responses for local time context."""
     try:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,15 @@
+# E2E Test Infrastructure
+
+## Custom Component (ha_mcp_tools)
+
+- Component is installed into the Docker container by `_install_custom_component` in `src/e2e/conftest.py`
+- HA's `call_service(return_response=True)` wraps results in `{"changed_states": [], "service_response": {...}}` — tools unwrap this with `result.get("service_response", result)` before returning
+- `hass.async_add_executor_job` only passes positional args — use `lambda:` wrappers for calls needing kwargs (e.g., `mkdir(parents=True, exist_ok=True)`)
+- HA Docker image uses `annotatedyaml` (PyYAML wrapper), NOT `ruamel.yaml` — custom components needing ruamel must declare it in `manifest.json` requirements
+- Feature flags (`ENABLE_YAML_CONFIG_EDITING`, `HAMCP_ENABLE_FILESYSTEM_TOOLS`) are set in `ha_container_with_fresh_config` fixture
+
+## Test Patterns
+
+- Tests expecting tool **success**: use `mcp.call_tool_success()` inside `MCPAssertions` context
+- Tests expecting tool **failure**: use `safe_call_tool()` directly (catches `ToolError`, returns parsed dict)
+- Service availability checks should use `safe_call_tool` to probe, not `call_tool_success`

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -125,48 +125,39 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
             logger.warning("HACS tests may be skipped without the frontend")
 
 
-def _install_mcp_proxy_component(config_path: Path) -> None:
-    """Dynamically install mcp_proxy from the webhook proxy addon source.
+def _install_custom_component(
+    config_path: Path,
+    component_src: Path,
+    domain: str,
+    title: str,
+) -> bool:
+    """Install a custom component into the test HA config.
 
-    Copies the integration source, writes the test config file, and injects
-    a config entry into HA storage. This avoids duplicating source files in
-    initial_test_state and survives test environment rebuilds.
+    Copies component source into custom_components/<domain> and injects a
+    config entry so HA loads it on startup. Returns True if installed.
     """
-    import json
+    if not component_src.exists():
+        logger.info("%s source not found — skipping installation", domain)
+        return False
 
-    repo_root = Path(__file__).parent.parent.parent.parent
-    addon_mcp_proxy = repo_root / "homeassistant-addon-webhook-proxy" / "mcp_proxy"
-
-    if not addon_mcp_proxy.exists():
-        logger.info("mcp_proxy addon source not found — skipping installation")
-        return
-
-    # Copy component source
-    dest = config_path / "custom_components" / "mcp_proxy"
+    dest = config_path / "custom_components" / domain
     dest.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(addon_mcp_proxy, dest, dirs_exist_ok=True)
-
-    # Write config file (target_url points at HA's own API for testing)
-    proxy_config = {
-        "target_url": "http://localhost:8123/api/",
-        "webhook_id": "mcp_e2e_test_webhook_proxy",
-    }
-    (config_path / ".mcp_proxy_config.json").write_text(json.dumps(proxy_config))
+    shutil.copytree(component_src, dest, dirs_exist_ok=True)
 
     # Inject config entry if not already present
     storage_file = config_path / ".storage" / "core.config_entries"
     if storage_file.exists():
         data = json.loads(storage_file.read_text())
         entries = data.get("data", {}).get("entries", [])
-        if not any(e.get("domain") == "mcp_proxy" for e in entries):
+        if not any(e.get("domain") == domain for e in entries):
             entries.append(
                 {
                     "created_at": "2025-09-07T23:56:28.040744+00:00",
                     "data": {},
                     "disabled_by": None,
                     "discovery_keys": {},
-                    "domain": "mcp_proxy",
-                    "entry_id": "e2e_test_mcp_proxy_entry",
+                    "domain": domain,
+                    "entry_id": f"e2e_test_{domain}_entry",
                     "minor_version": 1,
                     "modified_at": "2025-09-07T23:56:28.040747+00:00",
                     "options": {},
@@ -174,14 +165,15 @@ def _install_mcp_proxy_component(config_path: Path) -> None:
                     "pref_disable_polling": False,
                     "source": "import",
                     "subentries": [],
-                    "title": "MCP Webhook Proxy",
-                    "unique_id": "mcp_proxy",
+                    "title": title,
+                    "unique_id": domain,
                     "version": 1,
                 }
             )
             storage_file.write_text(json.dumps(data, indent=2))
 
-    logger.info("Installed mcp_proxy component from addon source")
+    logger.info("Installed %s component", domain)
+    return True
 
 
 @pytest.fixture(scope="session")
@@ -247,8 +239,28 @@ def ha_container_with_fresh_config():
                     break
             storage_file.write_text(json.dumps(ce_data, indent=2))
 
-    # Install mcp_proxy from addon source (avoids duplicating files in test state)
-    _install_mcp_proxy_component(config_path)
+    # Install custom components from repo source
+    repo_root = Path(__file__).parent.parent.parent.parent
+    if _install_custom_component(
+        config_path,
+        repo_root / "homeassistant-addon-webhook-proxy" / "mcp_proxy",
+        "mcp_proxy",
+        "MCP Webhook Proxy",
+    ):
+        # mcp_proxy needs a config file pointing at HA's own API
+        proxy_config = {
+            "target_url": "http://localhost:8123/api/",
+            "webhook_id": "mcp_e2e_test_webhook_proxy",
+        }
+        (config_path / ".mcp_proxy_config.json").write_text(
+            json.dumps(proxy_config)
+        )
+    _install_custom_component(
+        config_path,
+        repo_root / "custom_components" / "ha_mcp_tools",
+        "ha_mcp_tools",
+        "HA MCP Tools",
+    )
 
     # Ensure proper permissions for Home Assistant
     _setup_config_permissions(config_path)
@@ -295,6 +307,9 @@ def ha_container_with_fresh_config():
         # Set environment variables for the dynamic URL so WebSocket client uses correct port
         os.environ["HOMEASSISTANT_URL"] = base_url
         os.environ["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
+        # Enable feature flags for e2e tests
+        os.environ["ENABLE_YAML_CONFIG_EDITING"] = "true"
+        os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = "true"
 
         # Reset cached settings so WebSocket client picks up the dynamic URL
         import ha_mcp.config

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -47,12 +47,10 @@ def parse_mcp_result(result) -> dict[str, Any]:
         if hasattr(result.content[0], "text"):
             response_text = result.content[0].text
             try:
-                return json.loads(response_text)
+                parsed = json.loads(response_text)
+                return parsed
             except json.JSONDecodeError:
-                try:
-                    return eval(response_text)
-                except Exception:
-                    return {"raw_response": response_text}
+                return {"raw_response": response_text}
         return {"content": str(result.content[0])}
     return {"error": "No content in result"}
 
@@ -112,10 +110,8 @@ def assert_mcp_success(result, operation_name: str = "operation"):
     data = parse_mcp_result(result)
 
     # Handle different success indicators
-    # Some tools return success in the top level, others in data.success
     success_indicators = [
         data.get("success") is True,
-        data.get("data", {}).get("success") is True,
         # If no explicit success field but has data and no error, consider success
         ("data" in data and data.get("error") is None and data.get("success") is None),
         # Bulk operations success: has operational data without explicit success field
@@ -135,8 +131,7 @@ def assert_mcp_success(result, operation_name: str = "operation"):
     ]
 
     if not any(success_indicators):
-        error_msg = data.get("error") or data.get("data", {}).get(
-            "error", "Unknown error"
+        error_msg = data.get("error", "Unknown error"
         )
         suggestions = data.get("suggestions", [])
 

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -106,7 +106,7 @@ async def _check_mcp_tools_service_available(mcp_client) -> tuple[bool, str | No
             return False, "ha_mcp_tools custom component not installed in Home Assistant"
 
         # Check for success
-        inner_data = data.get("data", data)
+        inner_data = data
         if inner_data.get("success") is True:
             return True, None
 
@@ -191,7 +191,7 @@ class TestListFiles:
             )
 
             # Check response structure
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"List files failed: {data}"
             assert "files" in data, f"Missing files in response: {data}"
             assert "count" in data, f"Missing count in response: {data}"
@@ -219,7 +219,7 @@ class TestListFiles:
                 {"path": "www/", "pattern": "*.jpg"},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"List files failed: {data}"
 
             # All returned files should match the pattern
@@ -234,37 +234,27 @@ class TestListFiles:
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "List files in disallowed dir")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            # Try to list files in root config directory (not allowed)
-            result_data = await mcp.call_tool_success(
-                "ha_list_files",
-                {"path": "./"},
-            )
+        # Try to list files in root config directory (not allowed)
+        data = await safe_call_tool(mcp_client_with_filesystem, "ha_list_files", {"path": "./"})
 
-            data = result_data.get("data", result_data)
-            # Should fail with security error
-            assert data.get("success") is False, f"Should have failed: {data}"
-            assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
-                f"Wrong error message: {data.get('error')}"
-            )
-            logger.info("Correctly rejected listing disallowed directory")
+        # Should fail with security error
+        assert data.get("success") is False, f"Should have failed: {data}"
+        assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
+            f"Wrong error message: {data.get('error')}"
+        )
+        logger.info("Correctly rejected listing disallowed directory")
 
     async def test_list_files_path_traversal_blocked(self, mcp_client_with_filesystem):
         """Test that path traversal attempts are blocked."""
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Path traversal blocked")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            # Try path traversal
-            result_data = await mcp.call_tool_success(
-                "ha_list_files",
-                {"path": "www/../"},
-            )
+        # Try path traversal
+        data = await safe_call_tool(mcp_client_with_filesystem, "ha_list_files", {"path": "www/../"})
 
-            data = result_data.get("data", result_data)
-            # Should fail with security error
-            assert data.get("success") is False, f"Path traversal should fail: {data}"
-            logger.info("Correctly blocked path traversal attempt")
+        # Should fail with security error
+        assert data.get("success") is False, f"Path traversal should fail: {data}"
+        logger.info("Correctly blocked path traversal attempt")
 
 
 @pytest.mark.filesystem
@@ -282,7 +272,7 @@ class TestReadFile:
                 {"path": "configuration.yaml"},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Read file failed: {data}"
             assert "content" in data, f"Missing content in response: {data}"
 
@@ -305,7 +295,7 @@ class TestReadFile:
                 {"path": "secrets.yaml"},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Read file failed: {data}"
 
             content = data.get("content", "")
@@ -330,7 +320,7 @@ class TestReadFile:
                 {"path": "www/"},
             )
 
-            list_data = list_result.get("data", list_result)
+            list_data = list_result
             files = list_data.get("files", [])
 
             # Skip binary files - look for text files
@@ -347,7 +337,7 @@ class TestReadFile:
                 {"path": f"www/{file_to_read['name']}"},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Read file failed: {data}"
             logger.info(f"Successfully read www/{file_to_read['name']}")
 
@@ -356,34 +346,28 @@ class TestReadFile:
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Read nonexistent file")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            result_data = await mcp.call_tool_success(
-                "ha_read_file",
-                {"path": "nonexistent_file_xyz123.yaml"},
-            )
+        data = await safe_call_tool(
+            mcp_client_with_filesystem, "ha_read_file", {"path": "nonexistent_file_xyz123.yaml"}
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should have failed: {data}"
-            assert "not exist" in data.get("error", "").lower() or "not allowed" in data.get("error", "").lower(), (
-                f"Wrong error: {data.get('error')}"
-            )
-            logger.info("Correctly handled nonexistent file")
+        assert data.get("success") is False, f"Should have failed: {data}"
+        assert "not exist" in data.get("error", "").lower() or "not allowed" in data.get("error", "").lower(), (
+            f"Wrong error: {data.get('error')}"
+        )
+        logger.info("Correctly handled nonexistent file")
 
     async def test_read_disallowed_file(self, mcp_client_with_filesystem):
         """Test reading a file outside allowed paths."""
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Read disallowed file")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            # Try to read /etc/passwd (path traversal attempt)
-            result_data = await mcp.call_tool_success(
-                "ha_read_file",
-                {"path": "../../../etc/passwd"},
-            )
+        # Try to read /etc/passwd (path traversal attempt)
+        data = await safe_call_tool(
+            mcp_client_with_filesystem, "ha_read_file", {"path": "../../../etc/passwd"}
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should have failed: {data}"
-            logger.info("Correctly blocked read of disallowed file")
+        assert data.get("success") is False, f"Should have failed: {data}"
+        logger.info("Correctly blocked read of disallowed file")
 
 
 @pytest.mark.filesystem
@@ -408,7 +392,7 @@ class TestWriteFile:
                 },
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Write file failed: {data}"
             assert data.get("created") is True, f"Should be marked as created: {data}"
 
@@ -421,7 +405,7 @@ class TestWriteFile:
                 {"path": f"www/{test_filename}"},
             )
 
-            read_data = read_result.get("data", read_result)
+            read_data = read_result
             assert read_data.get("success") is True, f"Read back failed: {read_data}"
             assert read_data.get("content") == test_content, (
                 f"Content mismatch: {read_data.get('content')}"
@@ -450,25 +434,26 @@ class TestWriteFile:
                 {"path": f"www/{test_filename}", "content": "Original content"},
             )
 
-            # Try to overwrite without flag (should fail)
-            result_data = await mcp.call_tool_success(
-                "ha_write_file",
-                {"path": f"www/{test_filename}", "content": "New content", "overwrite": False},
-            )
+        # Try to overwrite without flag (should fail)
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_write_file",
+            {"path": f"www/{test_filename}", "content": "New content", "overwrite": False},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should have failed without overwrite: {data}"
-            assert "exists" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
+        assert data.get("success") is False, f"Should have failed without overwrite: {data}"
+        assert "exists" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
 
-            logger.info("Correctly blocked overwrite without flag")
+        logger.info("Correctly blocked overwrite without flag")
 
+        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
             # Now overwrite with flag (should succeed)
             result_data = await mcp.call_tool_success(
                 "ha_write_file",
                 {"path": f"www/{test_filename}", "content": "New content", "overwrite": True},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Overwrite with flag should work: {data}"
 
             logger.info("Successfully overwrote file with flag")
@@ -494,7 +479,7 @@ class TestWriteFile:
                 {"path": test_path, "content": "Nested file content", "create_dirs": True},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Write with create_dirs failed: {data}"
 
             logger.info(f"Successfully created nested file {test_path}")
@@ -505,7 +490,7 @@ class TestWriteFile:
                 {"path": test_path},
             )
 
-            read_data = read_result.get("data", read_result)
+            read_data = read_result
             assert read_data.get("success") is True, f"Read nested file failed: {read_data}"
 
             # Clean up - delete the file first
@@ -534,27 +519,30 @@ class TestDeleteFile:
                 {"path": f"www/{test_filename}", "content": "To be deleted"},
             )
 
-            # Try to delete without confirmation (should fail)
-            result_data = await mcp.call_tool_success(
-                "ha_delete_file",
-                {"path": f"www/{test_filename}", "confirm": False},
-            )
+        # Try to delete without confirmation (should fail)
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_delete_file",
+            {"path": f"www/{test_filename}", "confirm": False},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should require confirmation: {data}"
-            assert "confirm" in data.get("error", "").lower() or "not confirmed" in data.get("message", "").lower(), (
-                f"Wrong error message: {data}"
-            )
+        assert data.get("success") is False, f"Should require confirmation: {data}"
+        error = data.get("error", {})
+        error_msg = error.get("message", "") if isinstance(error, dict) else str(error)
+        assert "not confirmed" in error_msg.lower(), (
+            f"Wrong error message: {data}"
+        )
 
-            logger.info("Correctly required confirmation for delete")
+        logger.info("Correctly required confirmation for delete")
 
+        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
             # Now delete with confirmation
             result_data = await mcp.call_tool_success(
                 "ha_delete_file",
                 {"path": f"www/{test_filename}", "confirm": True},
             )
 
-            data = result_data.get("data", result_data)
+            data = result_data
             assert data.get("success") is True, f"Delete with confirmation should work: {data}"
 
             logger.info("Successfully deleted file with confirmation")
@@ -564,17 +552,16 @@ class TestDeleteFile:
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Delete nonexistent file")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            result_data = await mcp.call_tool_success(
-                "ha_delete_file",
-                {"path": "www/nonexistent_file_xyz123.txt", "confirm": True},
-            )
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_delete_file",
+            {"path": "www/nonexistent_file_xyz123.txt", "confirm": True},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should have failed: {data}"
-            assert "not exist" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
+        assert data.get("success") is False, f"Should have failed: {data}"
+        assert "not exist" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
 
-            logger.info("Correctly handled delete of nonexistent file")
+        logger.info("Correctly handled delete of nonexistent file")
 
 
 @pytest.mark.filesystem
@@ -586,77 +573,73 @@ class TestSecurityBoundaries:
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Cannot write to config")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            result_data = await mcp.call_tool_success(
-                "ha_write_file",
-                {"path": "configuration.yaml", "content": "# Malicious content", "overwrite": True},
-            )
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_write_file",
+            {"path": "configuration.yaml", "content": "# Malicious content", "overwrite": True},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should block writing to config: {data}"
-            assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
-                f"Wrong error message: {data.get('error')}"
-            )
+        assert data.get("success") is False, f"Should block writing to config: {data}"
+        assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
+            f"Wrong error message: {data.get('error')}"
+        )
 
-            logger.info("Correctly blocked write to configuration.yaml")
+        logger.info("Correctly blocked write to configuration.yaml")
 
     async def test_cannot_write_to_secrets_yaml(self, mcp_client_with_filesystem):
         """Test that writing to secrets.yaml is blocked."""
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Cannot write to secrets")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            result_data = await mcp.call_tool_success(
-                "ha_write_file",
-                {"path": "secrets.yaml", "content": "malicious_secret: hacked", "overwrite": True},
-            )
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_write_file",
+            {"path": "secrets.yaml", "content": "malicious_secret: hacked", "overwrite": True},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should block writing to secrets: {data}"
+        assert data.get("success") is False, f"Should block writing to secrets: {data}"
 
-            logger.info("Correctly blocked write to secrets.yaml")
+        logger.info("Correctly blocked write to secrets.yaml")
 
     async def test_cannot_delete_configuration_files(self, mcp_client_with_filesystem):
         """Test that deleting configuration files is blocked."""
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Cannot delete config")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            # Try to delete configuration.yaml
-            result_data = await mcp.call_tool_success(
-                "ha_delete_file",
-                {"path": "configuration.yaml", "confirm": True},
-            )
+        # Try to delete configuration.yaml
+        data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_delete_file",
+            {"path": "configuration.yaml", "confirm": True},
+        )
 
-            data = result_data.get("data", result_data)
-            assert data.get("success") is False, f"Should block deleting config: {data}"
+        assert data.get("success") is False, f"Should block deleting config: {data}"
 
-            logger.info("Correctly blocked delete of configuration.yaml")
+        logger.info("Correctly blocked delete of configuration.yaml")
 
     async def test_cannot_access_files_outside_config(self, mcp_client_with_filesystem):
         """Test that files outside config directory cannot be accessed."""
         service_check = await _check_mcp_tools_service_available(mcp_client_with_filesystem)
         _skip_if_component_not_installed(service_check, "Cannot access outside config")
 
-        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
-            # Try various path traversal attacks
-            malicious_paths = [
-                "../../../etc/passwd",
-                "/etc/passwd",
-                "www/../../etc/passwd",
-                "www/../../../etc/hosts",
-            ]
+        # Try various path traversal attacks
+        malicious_paths = [
+            "../../../etc/passwd",
+            "/etc/passwd",
+            "www/../../etc/passwd",
+            "www/../../../etc/hosts",
+        ]
 
-            for path in malicious_paths:
-                result_data = await mcp.call_tool_success(
-                    "ha_read_file",
-                    {"path": path},
-                )
+        for path in malicious_paths:
+            data = await safe_call_tool(
+                mcp_client_with_filesystem,
+                "ha_read_file",
+                {"path": path},
+            )
 
-                data = result_data.get("data", result_data)
-                assert data.get("success") is False, f"Should block path traversal {path}: {data}"
+            assert data.get("success") is False, f"Should block path traversal {path}: {data}"
 
-            logger.info("Correctly blocked all path traversal attempts")
+        logger.info("Correctly blocked all path traversal attempts")
 
 
 @pytest.mark.filesystem
@@ -679,7 +662,7 @@ class TestFullCRUDWorkflow:
                 {"path": test_path, "content": ".test { color: red; }"},
             )
 
-            create_data = create_result.get("data", create_result)
+            create_data = create_result
             assert create_data.get("success") is True
             assert create_data.get("created") is True
             logger.info(f"   Created {test_path}")
@@ -691,7 +674,7 @@ class TestFullCRUDWorkflow:
                 {"path": test_path},
             )
 
-            read_data = read_result.get("data", read_result)
+            read_data = read_result
             assert read_data.get("success") is True
             assert read_data.get("content") == ".test { color: red; }"
             logger.info("   Content verified")
@@ -703,7 +686,7 @@ class TestFullCRUDWorkflow:
                 {"path": "www/", "pattern": "crud_test_*.css"},
             )
 
-            list_data = list_result.get("data", list_result)
+            list_data = list_result
             assert list_data.get("success") is True
             files = list_data.get("files", [])
             assert any(f["name"] == test_filename for f in files), f"File not in listing: {files}"
@@ -716,7 +699,7 @@ class TestFullCRUDWorkflow:
                 {"path": test_path, "content": ".test { color: blue; background: white; }", "overwrite": True},
             )
 
-            update_data = update_result.get("data", update_result)
+            update_data = update_result
             assert update_data.get("success") is True
             assert update_data.get("created") is False  # Not created, updated
             logger.info("   File updated")
@@ -727,7 +710,7 @@ class TestFullCRUDWorkflow:
                 {"path": test_path},
             )
 
-            read_data2 = read_result2.get("data", read_result2)
+            read_data2 = read_result2
             assert "background: white" in read_data2.get("content", "")
             logger.info("   Update verified")
 
@@ -738,22 +721,22 @@ class TestFullCRUDWorkflow:
                 {"path": test_path, "confirm": True},
             )
 
-            delete_data = delete_result.get("data", delete_result)
+            delete_data = delete_result
             assert delete_data.get("success") is True
             logger.info("   File deleted")
 
-            # Verify deletion
-            final_read = await mcp.call_tool_success(
-                "ha_read_file",
-                {"path": test_path},
-            )
+        # Verify deletion
+        final_data = await safe_call_tool(
+            mcp_client_with_filesystem,
+            "ha_read_file",
+            {"path": test_path},
+        )
 
-            final_data = final_read.get("data", final_read)
-            assert final_data.get("success") is False
-            assert "not exist" in final_data.get("error", "").lower() or "not allowed" in final_data.get("error", "").lower()
-            logger.info("   Deletion verified")
+        assert final_data.get("success") is False
+        assert "not exist" in final_data.get("error", "").lower() or "not allowed" in final_data.get("error", "").lower()
+        logger.info("   Deletion verified")
 
-            logger.info("Complete CRUD lifecycle test PASSED")
+        logger.info("Complete CRUD lifecycle test PASSED")
 
 
 @pytest.mark.filesystem
@@ -786,8 +769,8 @@ class TestMcpToolsComponentNotInstalled:
                 )
 
                 # Should fail with helpful message about installing component
-                if data.get("success") is False or data.get("data", {}).get("success") is False:
-                    error = data.get("error", {}) or data.get("data", {}).get("error", {})
+                if data.get("success") is False:
+                    error = data.get("error", {})
                     error_msg = error.get("message", "") if isinstance(error, dict) else str(error)
                     error_code = error.get("code", "") if isinstance(error, dict) else ""
 

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -96,6 +96,7 @@ def _skip_if_unavailable(result: tuple[bool, str | None], test_name: str):
         pytest.skip(f"{test_name}: {error}")
 
 
+
 # ---------------------------------------------------------------------------
 # Feature flag / registration
 # ---------------------------------------------------------------------------
@@ -143,60 +144,60 @@ class TestYamlConfigSecurity:
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Path traversal")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "add",
-                    "content": "- sensor:\n    - name: test\n      state: 'ok'",
-                    "file": "../etc/passwd",
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, f"Path traversal should fail: {data}"
-            logger.info("Correctly blocked path traversal")
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "add",
+                "content": "- sensor:\n    - name: test\n      state: 'ok'",
+                "file": "../etc/passwd",
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, f"Path traversal should fail: {data}"
+        logger.info("Correctly blocked path traversal")
 
     async def test_disallowed_file_rejected(self, mcp_client_with_yaml_config):
         """Files outside the allowlist must be rejected."""
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Disallowed file")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "add",
-                    "content": "- sensor:\n    - name: test\n      state: 'ok'",
-                    "file": "automations.yaml",
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, f"Disallowed file should fail: {data}"
-            assert "not allowed" in inner.get("error", "").lower()
-            logger.info("Correctly rejected disallowed file")
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "add",
+                "content": "- sensor:\n    - name: test\n      state: 'ok'",
+                "file": "automations.yaml",
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, f"Disallowed file should fail: {data}"
+        assert "not allowed" in inner.get("error", "").lower()
+        logger.info("Correctly rejected disallowed file")
 
     async def test_blocked_key_rejected(self, mcp_client_with_yaml_config):
         """Keys not in the allowlist must be rejected."""
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Blocked key")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            # 'homeassistant' is not in ALLOWED_YAML_KEYS
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "homeassistant",
-                    "action": "replace",
-                    "content": "name: Hacked",
-                    "file": "configuration.yaml",
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, f"Blocked key should fail: {data}"
-            assert "not in the allowed list" in inner.get("error", "").lower()
-            logger.info("Correctly rejected blocked key")
+        # 'homeassistant' is not in ALLOWED_YAML_KEYS
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "homeassistant",
+                "action": "replace",
+                "content": "name: Hacked",
+                "file": "configuration.yaml",
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, f"Blocked key should fail: {data}"
+        assert "not in the allowed list" in inner.get("error", "").lower()
+        logger.info("Correctly rejected blocked key")
 
     async def test_helper_keys_not_allowed(self, mcp_client_with_yaml_config):
         """Keys manageable via ha_config_set_helper must not be in the allowlist."""
@@ -215,23 +216,23 @@ class TestYamlConfigSecurity:
             "schedule",
         ]
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            for key in helper_keys:
-                data = await mcp.call_tool_success(
-                    TOOL_NAME,
-                    {
-                        "yaml_path": key,
-                        "action": "add",
-                        "content": "test: true",
-                        "file": "configuration.yaml",
-                        "backup": False,
-                    },
-                )
-                inner = data.get("data", data)
-                assert inner.get("success") is False, (
-                    f"Helper key '{key}' should be rejected: {data}"
-                )
-            logger.info("All helper-manageable keys correctly rejected")
+        for key in helper_keys:
+            data = await safe_call_tool(
+                mcp_client_with_yaml_config,
+                TOOL_NAME,
+                {
+                    "yaml_path": key,
+                    "action": "add",
+                    "content": "test: true",
+                    "file": "configuration.yaml",
+                    "backup": False,
+                },
+            )
+            inner = data
+            assert inner.get("success") is False, (
+                f"Helper key '{key}' should be rejected: {data}"
+            )
+        logger.info("All helper-manageable keys correctly rejected")
 
 
 # ---------------------------------------------------------------------------
@@ -248,65 +249,65 @@ class TestYamlConfigValidation:
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Null content")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            # "null" parses to None via yaml.safe_load
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "add",
-                    "content": "null",
-                    "file": "packages/_test_null.yaml",
-                    "backup": False,
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, (
-                f"Null content should be rejected: {data}"
-            )
-            logger.info("Correctly rejected null content")
+        # "null" parses to None via yaml.safe_load
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "add",
+                "content": "null",
+                "file": "packages/_test_null.yaml",
+                "backup": False,
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, (
+            f"Null content should be rejected: {data}"
+        )
+        logger.info("Correctly rejected null content")
 
     async def test_invalid_yaml_rejected(self, mcp_client_with_yaml_config):
         """Invalid YAML syntax must be rejected."""
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Invalid YAML")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "add",
-                    "content": "  bad:\n yaml: [\n  unclosed",
-                    "file": "packages/_test_invalid.yaml",
-                    "backup": False,
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, (
-                f"Invalid YAML should be rejected: {data}"
-            )
-            logger.info("Correctly rejected invalid YAML")
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "add",
+                "content": "  bad:\n yaml: [\n  unclosed",
+                "file": "packages/_test_invalid.yaml",
+                "backup": False,
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, (
+            f"Invalid YAML should be rejected: {data}"
+        )
+        logger.info("Correctly rejected invalid YAML")
 
     async def test_missing_content_for_add(self, mcp_client_with_yaml_config):
         """add/replace actions require content."""
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Missing content")
 
-        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "add",
-                    "file": "packages/_test_no_content.yaml",
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, (
-                f"Missing content should fail: {data}"
-            )
-            logger.info("Correctly rejected missing content")
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "add",
+                "file": "packages/_test_no_content.yaml",
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, (
+            f"Missing content should fail: {data}"
+        )
+        logger.info("Correctly rejected missing content")
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +337,7 @@ class TestYamlConfigOperations:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Add should succeed: {data}"
             assert inner.get("action") == "add"
             logger.info("Successfully added template to new package file")
@@ -372,7 +373,7 @@ class TestYamlConfigOperations:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Replace should succeed: {data}"
             assert inner.get("action") == "replace"
             logger.info("Successfully replaced template key")
@@ -407,7 +408,7 @@ class TestYamlConfigOperations:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Remove should succeed: {data}"
             assert inner.get("action") == "remove"
             logger.info("Successfully removed template key")
@@ -430,27 +431,29 @@ class TestYamlConfigOperations:
                 },
             )
 
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "template",
-                    "action": "remove",
-                    "file": "packages/_e2e_test_remove_missing.yaml",
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, (
-                f"Removing nonexistent key should fail: {data}"
-            )
-            logger.info("Correctly rejected removing nonexistent key")
+        # Now attempt to remove a key that doesn't exist — expect failure
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "template",
+                "action": "remove",
+                "file": "packages/_e2e_test_remove_missing.yaml",
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, (
+            f"Removing nonexistent key should fail: {data}"
+        )
+        logger.info("Correctly rejected removing nonexistent key")
 
     async def test_add_type_mismatch_errors(self, mcp_client_with_yaml_config):
         """Adding with type mismatch (e.g., list + dict) should error, not silently replace."""
         service_check = await _check_service_available(mcp_client_with_yaml_config)
         _skip_if_unavailable(service_check, "Type mismatch")
 
+        # Create a file with a list value
         async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
-            # Create a file with a list value
             await mcp.call_tool_success(
                 TOOL_NAME,
                 {
@@ -462,23 +465,24 @@ class TestYamlConfigOperations:
                 },
             )
 
-            # Try to add a dict to the existing list
-            data = await mcp.call_tool_success(
-                TOOL_NAME,
-                {
-                    "yaml_path": "sensor",
-                    "action": "add",
-                    "content": "key: value",
-                    "file": "packages/_e2e_test_mismatch.yaml",
-                    "backup": False,
-                },
-            )
-            inner = data.get("data", data)
-            assert inner.get("success") is False, (
-                f"Type mismatch should error: {data}"
-            )
-            assert "type mismatch" in inner.get("error", "").lower()
-            logger.info("Correctly errored on type mismatch")
+        # Try to add a dict to the existing list — expect failure
+        data = await safe_call_tool(
+            mcp_client_with_yaml_config,
+            TOOL_NAME,
+            {
+                "yaml_path": "sensor",
+                "action": "add",
+                "content": "key: value",
+                "file": "packages/_e2e_test_mismatch.yaml",
+                "backup": False,
+            },
+        )
+        inner = data
+        assert inner.get("success") is False, (
+            f"Type mismatch should error: {data}"
+        )
+        assert "type mismatch" in inner.get("error", "").lower()
+        logger.info("Correctly errored on type mismatch")
 
 
 # ---------------------------------------------------------------------------
@@ -521,7 +525,7 @@ class TestYamlConfigSafeguards:
                     "backup": True,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Replace should succeed: {data}"
             assert inner.get("backup_path"), (
                 f"Backup path should be present: {data}"
@@ -547,7 +551,7 @@ class TestYamlConfigSafeguards:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Add should succeed: {data}"
             # config_check should be present (ok, errors, or unavailable)
             assert "config_check" in inner, (
@@ -573,7 +577,7 @@ class TestYamlConfigSafeguards:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Add should succeed: {data}"
             assert inner.get("post_action") == "reload_available", (
                 f"template should have post_action=reload_available: {data}"
@@ -602,7 +606,7 @@ class TestYamlConfigSafeguards:
                     "backup": False,
                 },
             )
-            inner = data.get("data", data)
+            inner = data
             assert inner.get("success") is True, f"Add should succeed: {data}"
             assert inner.get("post_action") == "restart_required", (
                 f"shell_command should have post_action=restart_required: {data}"

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -1,5 +1,6 @@
 """Unit tests for tools_filesystem module."""
 
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -223,7 +224,7 @@ class TestHaListFilesTool:
                 {"path": "www/", "pattern": "*.css"},
                 return_response=True,
             )
-            assert result["data"]["success"] is True
+            assert result["success"] is True
 
 
 class TestHaReadFileTool:
@@ -346,7 +347,7 @@ class TestHaWriteFileTool:
                 },
                 return_response=True,
             )
-            assert result["data"]["success"] is True
+            assert result["success"] is True
 
 
 class TestHaDeleteFileTool:
@@ -381,10 +382,11 @@ class TestHaDeleteFileTool:
 
         if registered_func:
             inner_func = registered_func.__wrapped__ if hasattr(registered_func, '__wrapped__') else registered_func
-            result = await inner_func(path="www/test.css", confirm=False)
+            with pytest.raises(ToolError) as exc_info:
+                await inner_func(path="www/test.css", confirm=False)
 
-            assert result["data"]["success"] is False
-            assert "not confirmed" in result["data"]["error"].lower()
+            error_data = json.loads(str(exc_info.value))
+            assert "not confirmed" in error_data["error"]["message"].lower()
             # Service should not have been called
             client.call_service.assert_not_called()
 
@@ -431,4 +433,4 @@ class TestHaDeleteFileTool:
                 {"path": "www/test.css"},
                 return_response=True,
             )
-            assert result["data"]["success"] is True
+            assert result["success"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes three root causes that prevented all 40 filesystem e2e tests from running (they were always skipped):

1. **ha_mcp_tools component never installed in Docker test container** — Unified the existing `_install_mcp_proxy_component` into a generic `_install_custom_component` helper and used it to install `ha_mcp_tools` alongside `mcp_proxy`.

2. **`async_add_executor_job` kwargs bug** — `mkdir(parents=True, exist_ok=True)` kwargs were silently ignored because `async_add_executor_job` only passes positional args. Fixed with lambda wrappers (3 occurrences).

3. **`service_response` nesting not unwrapped** — HA's `call_service(return_response=True)` wraps results in `{"changed_states": [], "service_response": {...}}` but `parse_mcp_result` returned this as-is, so tests couldn't find `success`/`error` fields. Added `_unwrap_service_response` to extract the inner dict.

Additional fixes:
- Removed `add_timezone_metadata` from filesystem/yaml_config tools (timezone info is irrelevant for file operations, adds response nesting)
- Fixed tests using `call_tool_success` for expected-failure cases (should use `safe_call_tool` which handles `ToolError`)
- Removed dead `data.get("data", {}).get("success")` branch and unsafe `eval()` fallback in `parse_mcp_result`
- Added `tests/AGENTS.md` with e2e test infrastructure notes

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Maintenance/refactor

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)
- 22 file_operations + 18 yaml_config e2e tests now pass (previously all skipped)
- 901 unit tests pass
- Full e2e suite: 525 passed, 3 failed (pre-existing HACS issue), 11 skipped

## Checklist
- [x] I have updated documentation if needed