### PR TITLE
docs: add custom component documentation and HACS install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Some tools require a companion custom component installed in Home Assistant. Sta
 |------|-------------|
 | `ha_config_set_yaml` | Safely add, replace, or remove top-level YAML keys in `configuration.yaml` and package files (automatic backup, validation, and config check) |
 | `ha_list_files` | List files in allowed directories (www/, themes/, custom_templates/) |
-| `ha_read_file` | Read configuration and log files |
+| `ha_read_file` | Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/) |
 | `ha_write_file` | Write files to allowed directories |
 | `ha_delete_file` | Delete files from allowed directories |
 

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -240,7 +240,7 @@ source ~/.zshrc
           <ul class="list-disc list-inside text-slate-300 space-y-1 ml-2">
             <li><code class="bg-slate-800 px-1 rounded">ha_config_set_yaml</code> — Safely add, replace, or remove top-level YAML keys in configuration.yaml and package files (automatic backup, validation, and config check)</li>
             <li><code class="bg-slate-800 px-1 rounded">ha_list_files</code> — List files in allowed directories (www/, themes/, custom_templates/)</li>
-            <li><code class="bg-slate-800 px-1 rounded">ha_read_file</code> — Read configuration and log files</li>
+            <li><code class="bg-slate-800 px-1 rounded">ha_read_file</code> — Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/)</li>
             <li><code class="bg-slate-800 px-1 rounded">ha_write_file</code> — Write files to allowed directories</li>
             <li><code class="bg-slate-800 px-1 rounded">ha_delete_file</code> — Delete files from allowed directories</li>
           </ul>

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -5,7 +5,7 @@ This module provides the ha_install_mcp_tools tool which installs the
 ha_mcp_tools custom component via HACS. This enables additional services
 that are not available through standard Home Assistant APIs.
 
-Feature Flag: Set HAMCP_ENABLE_MCP_TOOLS_INSTALLER=true to enable this tool.
+Feature Flag: Set HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true to enable this tool.
 """
 
 import logging
@@ -32,8 +32,7 @@ def is_custom_component_integration_enabled() -> bool:
 
 
 # Constants for ha_mcp_tools custom component
-# TODO: Switch to "homeassistant-ai/ha-mcp" after hacs.json is on default branch
-MCP_TOOLS_REPO = "julienld/ha-mcp-test-custom-component"
+MCP_TOOLS_REPO = "homeassistant-ai/ha-mcp"
 MCP_TOOLS_DOMAIN = "ha_mcp_tools"
 
 


### PR DESCRIPTION
## What does this PR do?

Adds documentation for the `ha_mcp_tools` custom component to the README and docs site FAQ. Users currently have no way to discover what the component does, why they need it, or how to install it.

**Changes:**
- **README.md**: New "Custom Component" section with tool dependency table, HACS one-click badge, and install instructions
- **site/src/pages/faq.astro**: New FAQ section covering what/why, installation (HACS badge + manual), and feature flags

Closes #864

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed