### PR TITLE
fix: parallelize deep_search Tier 3 config fetches (closes #879)

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -27,15 +27,19 @@ INDIVIDUAL_CONFIG_TIMEOUT = 5.0  # Timeout for individual config fetches
 # Time budgets for fallback individual fetching (in seconds).
 # Configurable via env vars for instances with many automations/scripts.
 def _env_float(key: str, default: float) -> float:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
     try:
-        return float(os.environ.get(key, default))
+        return float(raw)
     except (ValueError, TypeError):
+        logger.warning(f"Invalid value for {key}={raw!r}, using default {default}")
         return default
 
 AUTOMATION_CONFIG_TIME_BUDGET = _env_float("HAMCP_AUTOMATION_CONFIG_TIME_BUDGET", 30.0)
 SCRIPT_CONFIG_TIME_BUDGET = _env_float("HAMCP_SCRIPT_CONFIG_TIME_BUDGET", 20.0)
 
-# Batch size for parallel individual config fetches (Tier 3 fallback)
+# Batch size for parallel individual config fetches (Attempt C fallback)
 INDIVIDUAL_FETCH_BATCH_SIZE = 10
 
 
@@ -913,7 +917,7 @@ class SmartSearchTools:
                             )
 
                 # Attempt C: Parallel individual REST calls with time budget (LAST RESORT)
-                # Fetch ALL configs in parallel batches — don't prioritize by name score.
+                # Fetch configs in parallel batches (subject to time budget) — don't prioritize by name score.
                 # Name score is only used for result ranking, not fetch order, because
                 # deep_search's purpose is to find matches INSIDE configs (conditions/actions),
                 # not just by name. Prioritizing by name would skip the configs most likely
@@ -927,6 +931,7 @@ class SmartSearchTools:
                     ]
                     total_to_fetch = len(uids_to_fetch)
                     fetched_count = 0
+                    failed_count = 0
 
                     async def _fetch_automation_config(uid: str) -> tuple[str, dict[str, Any] | None]:
                         try:
@@ -948,23 +953,24 @@ class SmartSearchTools:
                             time.perf_counter() - budget_start
                             > AUTOMATION_CONFIG_TIME_BUDGET
                         ):
-                            skipped = total_to_fetch - fetched_count
+                            skipped = total_to_fetch - fetched_count - failed_count
                             logger.warning(
                                 f"Automation config fetch budget exhausted "
                                 f"({AUTOMATION_CONFIG_TIME_BUDGET}s). "
-                                f"Fetched {fetched_count}/{total_to_fetch}, "
-                                f"skipped {skipped} automations."
+                                f"Fetched {fetched_count}/{total_to_fetch} "
+                                f"({failed_count} failed), skipped {skipped} automations."
                             )
                             break
                         batch = uids_to_fetch[i : i + INDIVIDUAL_FETCH_BATCH_SIZE]
                         batch_results = await asyncio.gather(
                             *[_fetch_automation_config(uid) for uid in batch],
-                            return_exceptions=True,
                         )
-                        for br in batch_results:
-                            if isinstance(br, tuple) and br[1] is not None:
-                                all_automation_configs[br[0]] = br[1]
+                        for uid_result, config_result in batch_results:
+                            if config_result is not None:
+                                all_automation_configs[uid_result] = config_result
                                 fetched_count += 1
+                            else:
+                                failed_count += 1
 
                 # Phase 3: Score with whatever configs we have
                 for entity_id, friendly_name, name_score, unique_id in name_scored:
@@ -1079,6 +1085,7 @@ class SmartSearchTools:
                     ]
                     total_to_fetch = len(sids_to_fetch)
                     fetched_count = 0
+                    failed_count = 0
 
                     async def _fetch_script_config(sid: str) -> tuple[str, dict[str, Any] | None]:
                         try:
@@ -1098,23 +1105,24 @@ class SmartSearchTools:
                             time.perf_counter() - budget_start
                             > SCRIPT_CONFIG_TIME_BUDGET
                         ):
-                            skipped = total_to_fetch - fetched_count
+                            skipped = total_to_fetch - fetched_count - failed_count
                             logger.warning(
                                 f"Script config fetch budget exhausted "
                                 f"({SCRIPT_CONFIG_TIME_BUDGET}s). "
-                                f"Fetched {fetched_count}/{total_to_fetch}, "
-                                f"skipped {skipped} scripts."
+                                f"Fetched {fetched_count}/{total_to_fetch} "
+                                f"({failed_count} failed), skipped {skipped} scripts."
                             )
                             break
                         batch = sids_to_fetch[i : i + INDIVIDUAL_FETCH_BATCH_SIZE]
                         batch_results = await asyncio.gather(
                             *[_fetch_script_config(sid) for sid in batch],
-                            return_exceptions=True,
                         )
-                        for br in batch_results:
-                            if isinstance(br, tuple) and br[1] is not None:
-                                all_script_configs[br[0]] = br[1]
+                        for sid_result, config_result in batch_results:
+                            if config_result is not None:
+                                all_script_configs[sid_result] = config_result
                                 fetched_count += 1
+                            else:
+                                failed_count += 1
 
                 # Phase 3: Score scripts
                 for (

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -1,9 +1,9 @@
-"""Unit tests for parallel Tier 3 config fetching in deep_search.
+"""Unit tests for parallel Attempt C config fetching in deep_search.
 
-Validates that when bulk config fetches fail (Tier 1 & 2), Tier 3 fetches
-configs in parallel batches without name-score prioritization. This ensures
-entities referenced only inside automation conditions/actions (not in the
-automation name) are still found. Regression test for #879.
+Validates that when bulk config fetches fail (Attempts A & B), Attempt C
+fetches configs in parallel batches without name-score prioritization. This
+ensures entities referenced only inside automation/script conditions/actions
+(not in the name) are still found. Regression test for #879.
 """
 
 import asyncio
@@ -44,8 +44,8 @@ def _make_automation_entities(count: int) -> list[dict]:
     ]
 
 
-class TestTier3ParallelFetch:
-    """Test that Tier 3 fetches configs in parallel without name-score prioritization."""
+class TestAttemptCParallelFetch:
+    """Test that Attempt C fetches configs in parallel without name-score prioritization."""
 
     @pytest.fixture
     def mock_client(self):
@@ -63,7 +63,7 @@ class TestTier3ParallelFetch:
         return _make_tools(mock_client)
 
     @pytest.mark.asyncio
-    async def test_tier3_fetches_all_configs_not_just_name_matches(
+    async def test_attempt_c_fetches_all_configs_not_just_name_matches(
         self, mock_client, smart_tools
     ):
         """Configs for ALL automations should be fetched, not just name-matched ones.
@@ -155,8 +155,8 @@ class TestTier3ParallelFetch:
         )
 
     @pytest.mark.asyncio
-    async def test_tier3_respects_time_budget(self, mock_client, smart_tools):
-        """Tier 3 should stop fetching when time budget is exhausted."""
+    async def test_attempt_c_respects_time_budget(self, mock_client, smart_tools):
+        """Attempt C should stop fetching when time budget is exhausted."""
         automations = _make_automation_entities(30)
         mock_client.get_states = AsyncMock(return_value=automations)
 
@@ -165,11 +165,10 @@ class TestTier3ParallelFetch:
         async def _slow_fetch(method: str, url: str) -> dict:
             nonlocal call_count
             uid = url.split("/")[-1]
-            # First call triggers bulk fetch failure
             if url.rstrip("/") == "/config/automation/config":
                 raise Exception("Bulk unavailable")
             call_count += 1
-            await asyncio.sleep(1.5)  # Simulate slow fetches
+            await asyncio.sleep(0.01)  # Minimal sleep to yield control
             return {"id": uid, "action": []}
 
         mock_client._request = AsyncMock(side_effect=_slow_fetch)
@@ -177,21 +176,96 @@ class TestTier3ParallelFetch:
             side_effect=Exception("WebSocket unavailable")
         )
 
+        # Budget of 0.005s: batch 1 starts at t=0 (passes check), but by the
+        # time it completes (~0.01s), the budget is exceeded so batch 2 is skipped.
         with patch(
-            "ha_mcp.tools.smart_search.AUTOMATION_CONFIG_TIME_BUDGET", 2.0
+            "ha_mcp.tools.smart_search.AUTOMATION_CONFIG_TIME_BUDGET", 0.005
         ):
-            result = await smart_tools.deep_search(
+            await smart_tools.deep_search(
                 query="test",
                 search_types=["automation"],
                 limit=10,
             )
 
-        # With 2s budget and 1.5s per fetch (parallel batches of 10),
-        # batch 1 (t=0→1.5s) completes under budget, batch 2 (t=1.5→3.0s)
-        # may start but batch 3 is skipped. Expect 10-20 fetched.
-        assert call_count < 30, (
-            f"Should stop before fetching all 30, but fetched {call_count}"
+        # Batch 1 (10 items) completes because the budget check happens before
+        # launching each batch. Batch 2 at ~0.01s exceeds the 0.005s budget.
+        assert call_count == 10, (
+            f"Expected exactly one batch of 10, but fetched {call_count}"
         )
-        assert call_count >= 10, (
-            f"Should complete at least one full batch of 10, but only fetched {call_count}"
+
+
+class TestAttemptCScriptParallelFetch:
+    """Test that Attempt C works for scripts (structurally different from automations)."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        client._request = AsyncMock(side_effect=Exception("Bulk fetch unavailable"))
+        client.send_websocket_message = AsyncMock(
+            side_effect=Exception("WebSocket unavailable")
+        )
+        return client
+
+    @pytest.fixture
+    def smart_tools(self, mock_client):
+        return _make_tools(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_script_attempt_c_fetches_configs(self, mock_client, smart_tools):
+        """Script Attempt C should fetch configs and find matches inside them.
+
+        Scripts use a different tuple format (entity_id, friendly_name, script_id,
+        name_score) and client.get_script_config() instead of client._request().
+        """
+        scripts = [
+            {
+                "entity_id": "script.morning_coffee",
+                "state": "off",
+                "attributes": {"friendly_name": "Morning Coffee"},
+            },
+            {
+                "entity_id": "script.night_lockup",
+                "state": "off",
+                "attributes": {"friendly_name": "Night Lockup"},
+            },
+        ]
+        all_entities = scripts + [
+            _make_entity("lock.front_door", "Front Door Lock"),
+        ]
+        mock_client.get_states = AsyncMock(return_value=all_entities)
+
+        fetched_sids = []
+
+        async def _script_config(sid: str) -> dict:
+            fetched_sids.append(sid)
+            if sid == "night_lockup":
+                return {
+                    "config": {
+                        "sequence": [
+                            {
+                                "service": "lock.lock",
+                                "target": {"entity_id": "lock.front_door"},
+                            }
+                        ]
+                    }
+                }
+            return {"config": {"sequence": [{"service": "switch.turn_on"}]}}
+
+        mock_client.get_script_config = AsyncMock(side_effect=_script_config)
+
+        result = await smart_tools.deep_search(
+            query="front_door",
+            search_types=["script"],
+            limit=10,
+        )
+
+        # Both script configs should have been fetched
+        assert len(fetched_sids) == 2, f"Expected 2 script fetches, got {fetched_sids}"
+
+        # Night Lockup references front_door in its sequence
+        script_results = result.get("scripts", [])
+        matched_ids = [r["entity_id"] for r in script_results]
+        assert "script.night_lockup" in matched_ids, (
+            f"Should find script referencing front_door. Got: {matched_ids}"
         )


### PR DESCRIPTION
## What does this PR do?

Fixes `ha_deep_search` missing automations/scripts when bulk config fetch fails (Tier 1/2) and the Tier 3 fallback times out before fetching all configs.

**Root cause:** Tier 3 fetched configs sequentially, prioritized by name-match score. Automations whose names didn't match the query were deprioritized and skipped when the time budget expired — even if the entity was referenced inside their conditions/actions.

**Fix (3 changes):**

1. **Parallel batch fetching** — Replace sequential `for` loop with `asyncio.gather` batches of 10. This fetches 10x more configs in the same time window.

2. **Remove name-score prioritization for fetch order** — All configs are now fetched without priority ordering. Name score is still used for result ranking after configs are retrieved. Deep search's purpose is to find matches *inside* configs, so deprioritizing by name defeats the purpose.

3. **Configurable time budgets** — Budgets are now configurable via `HAMCP_AUTOMATION_CONFIG_TIME_BUDGET` (default: 30s, was 15s) and `HAMCP_SCRIPT_CONFIG_TIME_BUDGET` (default: 20s, was 10s). Higher defaults are safe since parallel fetching completes faster.

**Additional:** Logs a warning with fetch/skip counts when the budget is exhausted, so users can diagnose incomplete results.

Closes #879

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed