### PR TITLE
fix(internal): add ast-grep rule to catch hand-built error dicts

### DIFF
--- a/rules/no-return-success-false.yml
+++ b/rules/no-return-success-false.yml
@@ -1,0 +1,25 @@
+id: no-return-success-false
+language: python
+rule:
+  kind: dictionary
+  has:
+    all:
+      - kind: pair
+      - has:
+          kind: "false"
+          stopBy: end
+      - has:
+          kind: string_content
+          regex: ^success$
+          stopBy: end
+  inside:
+    kind: return_statement
+    stopBy: end
+files:
+  - "src/ha_mcp/tools/**"
+message: |
+  Do not return hand-built `{"success": False, ...}` dicts from tool functions.
+  Returning an error dict does not set `isError=true` on the MCP response (per MCP spec).
+  Use `raise_tool_error(create_error_response(...))` instead.
+  Exception: batch item failures appended to a results list (use `.append()` instead of `return`).
+severity: error


### PR DESCRIPTION
## What does this PR do?

Adds a new ast-grep rule (`no-return-success-false`) that catches hand-built `return {"success": False, ...}` dicts in tool functions.

The existing `no-return-error-response` rule only catches returns of helper functions like `return create_error_response(...)`. Code that constructs error dicts inline and returns them (e.g. `return await add_timezone_metadata(client, {"success": False, ...})`) bypasses the check entirely. These returns don't set `isError=true` on the MCP response, so LLM agents may not recognize them as errors.

The new rule uses AST-level matching (`kind: dictionary` with `has: pair` containing `"success"` + `false`) to catch any dict with `"success": False` inside a `return_statement`, regardless of key ordering. It correctly excludes batch item appends (`.append(...)`) and dict assignments.

Currently flags 9 pre-existing violations across 4 files:
- `tools_hacs.py` (3), `device_control.py` (2), `tools_entities.py` (2), `backup.py` (2)

These will be fixed in follow-up PRs. This PR adds the rule only so that new violations are caught by the lefthook pre-commit hook.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance/refactor
- [ ] Breaking change

## Testing
- [x] Rule tested against example patterns (both positive and negative cases)
- [x] Rule tested against full `src/ha_mcp/tools/` — 9 matches, 0 false positives
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed