### PR TITLE
fix: enforce Python 3.13 in install scripts and at runtime

### DIFF
--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -73,7 +73,7 @@ mkdir -p "$CONFIG_DIR"
 # The MCP server config to add (using full path for Claude Desktop compatibility)
 HA_MCP_CONFIG='{
   "command": "'"$UVX_PATH"'",
-  "args": ["--python", "3.13", "ha-mcp@latest"],
+  "args": ["--python", "3.13", "--refresh", "ha-mcp@latest"],
   "env": {
     "HOMEASSISTANT_URL": "'"$DEMO_URL"'",
     "HOMEASSISTANT_TOKEN": "'"$DEMO_TOKEN"'"

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -58,7 +58,7 @@ if (-not (Test-Path $ConfigDir)) {
 # The MCP server config
 $HaMcpConfig = @{
     command = "uvx"
-    args = @("--python", "3.13", "ha-mcp@latest")
+    args = @("--python", "3.13", "--refresh", "ha-mcp@latest")
     env = @{
         HOMEASSISTANT_URL = $DemoUrl
         HOMEASSISTANT_TOKEN = $DemoToken

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 13):  # noqa: UP036 — uvx can bypass requires-python
         f"ERROR: ha-mcp requires Python 3.13+, but you are running Python "
         f"{sys.version_info.major}.{sys.version_info.minor}.\n"
         "If using uvx, add '--python 3.13' to your config args:\n"
-        '  "args": ["--python", "3.13", "ha-mcp@latest"]\n'
+        '  "args": ["--python", "3.13", "--refresh", "ha-mcp@latest"]\n'
         "Or install Python 3.13: brew install python@3.13 (macOS) / "
         "sudo apt install python3.13 (Linux)",
         file=sys.stderr,


### PR DESCRIPTION
## What does this PR do?

Prevents `uvx` from silently running ha-mcp on Python 3.12, which pulls an outdated version with known bugs (read-only filesystem crashes, missing fixes). Three changes:

1. **Runtime version check** (`src/ha_mcp/__main__.py`) — exits immediately with a clear error message and fix instructions if Python < 3.13. This catches cases where uvx bypasses `requires-python` and runs the package on an older interpreter.

2. **macOS install script** (`scripts/install-macos.sh`) — adds `--python 3.13` to all uvx args (generated config + pre-download command), ensuring the installer always targets the correct Python version.

3. **Windows install script** (`scripts/install-windows.ps1`) — same `--python 3.13` addition for consistency.

### Context

From [#773 comment by @kszpakowski](https://github.com/homeassistant-ai/ha-mcp/issues/773#issuecomment-4190498498): even after installing Python 3.13 and clearing cache, Codex (and likely Claude Desktop) still launched ha-mcp with Python 3.12. Adding `--python 3.13` to uvx args was the fix.

The `requires-python = ">=3.13,<3.14"` in pyproject.toml is supposed to prevent this, but `uvx` doesn't always enforce it — it picks the default `python3` which may be 3.12.

Closes #773

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The runtime check uses `noqa: UP036` because ruff's UP036 rule considers version checks "outdated" when `requires-python >= 3.13`, but that's exactly the scenario we're guarding against — uvx bypassing the constraint.

## Checklist
- [x] I have updated documentation if needed

Credit to @kszpakowski for the idea. 