### PR TITLE
docs: document webhook proxy addon in README, setup site, and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ No token or credential setup needed — the add-on connects to Home Assistant au
 
 </details>
 
+<details>
+<summary><b>🌐 Remote Access (Nabu Casa / Webhook Proxy)</b></summary>
+
+Already have **Nabu Casa** or another reverse proxy pointing at your Home Assistant? The Webhook Proxy add-on routes MCP traffic through your existing setup — no separate tunnel or port forwarding needed.
+
+1. Install the **MCP Server add-on** (see above) and the **Webhook Proxy** add-on from the same store
+2. Start the webhook proxy and **restart Home Assistant** when prompted
+3. Copy the webhook URL from the add-on logs:
+   ```
+   MCP Server URL (remote): https://xxxxx.ui.nabu.casa/api/webhook/mcp_xxxxxxxx
+   ```
+4. Configure your AI client with that URL
+
+For other remote access methods (Cloudflare Tunnel, custom reverse proxy), see the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/).
+
+[Webhook proxy documentation →](homeassistant-addon-webhook-proxy/DOCS.md)
+
+</details>
+
 ### 🧙 Setup Wizard for 15+ clients
 
 **Claude Code, Gemini CLI, ChatGPT, Open WebUI, VSCode, Cursor, and more.**

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Already have **Nabu Casa** or another reverse proxy pointing at your Home Assist
 
 For other remote access methods (Cloudflare Tunnel, custom reverse proxy), see the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/).
 
-[Webhook proxy documentation →](homeassistant-addon-webhook-proxy/DOCS.md)
+[Webhook proxy documentation →](https://github.com/homeassistant-ai/ha-mcp/blob/master/homeassistant-addon-webhook-proxy/DOCS.md)
 
 </details>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -206,7 +206,7 @@ source ~/.zshrc
 4. If "Home Assistant" is not listed, check your config file syntax
 5. Try asking Claude: "Can you list your available tools?"
 
-### Can't connect remotely? Try the Webhook Proxy add-on
+### Can't connect remotely? Try the Webhook Proxy add-on {#webhook-proxy}
 
 If you're having trouble setting up remote access — TLS errors, Cloudflare configuration issues, or port forwarding problems — the **Webhook Proxy add-on** may be a simpler alternative.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -206,6 +206,19 @@ source ~/.zshrc
 4. If "Home Assistant" is not listed, check your config file syntax
 5. Try asking Claude: "Can you list your available tools?"
 
+### Can't connect remotely? Try the Webhook Proxy add-on
+
+If you're having trouble setting up remote access — TLS errors, Cloudflare configuration issues, or port forwarding problems — the **Webhook Proxy add-on** may be a simpler alternative.
+
+Instead of requiring a dedicated tunnel to port 9583, the Webhook Proxy routes MCP traffic through Home Assistant's main port (8123) via a webhook. If you already have **Nabu Casa** or any reverse proxy pointing at your HA instance, this can be the easiest remote setup.
+
+1. Install the **MCP Server add-on** and the **Webhook Proxy add-on** from the add-on store
+2. Start the webhook proxy and restart Home Assistant when prompted
+3. Copy the webhook URL from the add-on logs
+4. Use that URL in your MCP client configuration
+
+See [#784](https://github.com/homeassistant-ai/ha-mcp/issues/784) for an example where this resolved a TLS connection issue.
+
 ### Server works but responses are slow
 
 1. **First request is slow** - `uvx` downloads packages on first run

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -102,13 +102,31 @@ Replace the URL with the one from your add-on logs.
 
 ### <details><summary><b>🌐 Web Clients (Claude.ai, ChatGPT, etc.)</b></summary>
 
-For secure remote access without port forwarding, use the **Cloudflared add-on**:
+For secure remote access, you have two options:
 
-#### Install Cloudflared Add-on
+#### Option A: Webhook Proxy Add-on (Simplest — if you have Nabu Casa or an existing reverse proxy)
+
+The **Webhook Proxy** add-on routes MCP traffic through your existing Home Assistant reverse proxy — no separate tunnel needed.
+
+1. Install the **"Webhook Proxy for HA MCP"** add-on from the add-on store
+2. Start it and **restart Home Assistant** when prompted
+3. Copy the URL from the webhook proxy add-on logs:
+   ```
+   MCP Server URL (remote): https://xxxxx.ui.nabu.casa/api/webhook/mcp_xxxxxxxx
+   ```
+4. Use that URL in your MCP client
+
+Works with Nabu Casa, Cloudflare, DuckDNS, nginx, or any other reverse proxy pointing at HA.
+
+#### Option B: Cloudflared Add-on (No existing reverse proxy needed)
+
+Use the **Cloudflared add-on** for a dedicated tunnel:
+
+##### Install Cloudflared Add-on
 
 [![Add Cloudflared Repository](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fbrenner-tobias%2Faddon-cloudflared)
 
-#### Configure Cloudflared
+##### Configure Cloudflared
 
 **Note:** The Cloudflared add-on requires a Cloudflare account and uses named tunnels. You'll need to authenticate via the browser flow when first setting up the tunnel.
 
@@ -127,7 +145,7 @@ additional_hosts:
     service: http://localhost:9583
 ```
 
-#### Authenticate and Get Your Public URL
+##### Authenticate and Get Your Public URL
 
 When you first start Cloudflared:
 
@@ -143,7 +161,7 @@ When you first start Cloudflared:
    - Named tunnel: `https://ha-mcp-<random>.cfargotunnel.com`
    - Custom domain: `https://ha-mcp.yourdomain.com` (if DNS configured)
 
-#### Use Your MCP Server
+##### Use Your MCP Server
 
 Combine the Cloudflare tunnel URL with your secret path:
 ```
@@ -158,7 +176,7 @@ https://ha-mcp-<random>.cfargotunnel.com/private_zctpwlX7ZkIAr7oqdfLPxw
 
 **Note on Quick Tunnels:** True Quick Tunnel mode (temporary `*.trycloudflare.com` URLs without account) requires running `cloudflared tunnel --url http://localhost:9583` directly via CLI or Docker, which is not supported by this add-on. The Home Assistant Cloudflared add-on uses named tunnels that require a Cloudflare account for authentication and management.
 
-#### ⚠️ Disable "Block AI Training Bots"
+##### ⚠️ Disable "Block AI Training Bots"
 
 > **This is the most common connection issue for Cloudflare users.** If your LLM client can't connect but visiting the URL in your browser works, this setting is almost certainly the cause.
 
@@ -251,7 +269,7 @@ The add-on uses Home Assistant Supervisor's built-in authentication. No tokens o
 ### Network Exposure
 
 - **Local network only by default** - The add-on listens on port 9583
-- **Remote access** - Use the Cloudflared add-on for secure HTTPS tunnels
+- **Remote access** - Use the [Webhook Proxy add-on](../homeassistant-addon-webhook-proxy/DOCS.md) (easiest with Nabu Casa) or the Cloudflared add-on for secure HTTPS tunnels
 - **Never expose** port 9583 directly to the internet without proper security measures
 
 ---

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -108,13 +108,14 @@ For secure remote access, you have two options:
 
 The **Webhook Proxy** add-on routes MCP traffic through your existing Home Assistant reverse proxy — no separate tunnel needed.
 
-1. Install the **"Webhook Proxy for HA MCP"** add-on from the add-on store
-2. Start it and **restart Home Assistant** when prompted
-3. Copy the URL from the webhook proxy add-on logs:
+1. Install the **MCP Server add-on** first (if not already installed — see the Installation section above)
+2. Install the **"Webhook Proxy for HA MCP"** add-on from the add-on store
+3. Start it and **restart Home Assistant** when prompted
+4. Copy the URL from the webhook proxy add-on logs:
    ```
    MCP Server URL (remote): https://xxxxx.ui.nabu.casa/api/webhook/mcp_xxxxxxxx
    ```
-4. Use that URL in your MCP client
+5. Use that URL in your MCP client
 
 Works with Nabu Casa, Cloudflare, DuckDNS, nginx, or any other reverse proxy pointing at HA.
 

--- a/site/src/content/connections/remote.md
+++ b/site/src/content/connections/remote.md
@@ -59,10 +59,15 @@ ha-mcp is exposed to the internet via a secure HTTPS tunnel or reverse proxy.
    - Free tier available
    - Works behind CGNAT
 
-2. **Caddy Reverse Proxy**
+2. **Webhook Proxy Add-on** (Easiest if you have Nabu Casa)
+   - Uses your existing HA reverse proxy (Nabu Casa, Cloudflare, DuckDNS, nginx)
+   - No separate tunnel to port 9583 needed
+   - Proxies MCP traffic through HA's main port 8123
+
+3. **Caddy Reverse Proxy**
    - Automatic HTTPS via Let's Encrypt
    - Requires public IP or dynamic DNS
 
-3. **Nginx + Let's Encrypt**
+4. **Nginx + Let's Encrypt**
    - Traditional setup
    - Full control over configuration

--- a/site/src/content/deployment/webhook-proxy.md
+++ b/site/src/content/deployment/webhook-proxy.md
@@ -53,6 +53,6 @@ AI Client → HTTPS → Your Reverse Proxy → HA (port 8123) → Webhook → MC
 |---|---|---|
 | **Setup** | Install add-on, restart HA | Install Cloudflared, configure tunnel |
 | **Requires** | Existing reverse proxy / Nabu Casa (paid) | Cloudflare account (free) |
-| **Extra hop** | Yes (HA → webhook → MCP) | No (direct to port 9583) |
+| **Routing** | Through HA web server (port 8123) | Direct to MCP port (9583) |
 | **Port** | Uses HA's port 8123 | Dedicated port 9583 |
 | **Best for** | Already have Nabu Casa / reverse proxy | No existing proxy, or want direct connection |

--- a/site/src/content/deployment/webhook-proxy.md
+++ b/site/src/content/deployment/webhook-proxy.md
@@ -52,7 +52,7 @@ AI Client → HTTPS → Your Reverse Proxy → HA (port 8123) → Webhook → MC
 | | Webhook Proxy | Cloudflare Tunnel |
 |---|---|---|
 | **Setup** | Install add-on, restart HA | Install Cloudflared, configure tunnel |
-| **Requires** | Existing reverse proxy / Nabu Casa | Cloudflare account (free) |
+| **Requires** | Existing reverse proxy / Nabu Casa (paid) | Cloudflare account (free) |
 | **Extra hop** | Yes (HA → webhook → MCP) | No (direct to port 9583) |
 | **Port** | Uses HA's port 8123 | Dedicated port 9583 |
 | **Best for** | Already have Nabu Casa / reverse proxy | No existing proxy, or want direct connection |

--- a/site/src/content/deployment/webhook-proxy.md
+++ b/site/src/content/deployment/webhook-proxy.md
@@ -1,0 +1,58 @@
+---
+name: Webhook Proxy Add-on
+description: Remote access via existing reverse proxy (Nabu Casa, Cloudflare, etc.)
+icon: webhook
+forConnections: ['remote']
+order: 5
+---
+
+## Overview
+
+The Webhook Proxy add-on enables remote access to ha-mcp through any reverse proxy that already points at your Home Assistant instance — Nabu Casa, Cloudflare, DuckDNS, nginx, or any other. Instead of requiring a dedicated tunnel to port 9583, it proxies MCP traffic through HA's main port (8123) via a webhook.
+
+**Best for users who already have Nabu Casa or another reverse proxy pointing at Home Assistant.**
+
+## How It Works
+
+```
+AI Client → HTTPS → Your Reverse Proxy → HA (port 8123) → Webhook → MCP Server Add-on
+```
+
+1. The add-on installs a lightweight integration that registers a webhook endpoint
+2. Incoming MCP requests hit `/api/webhook/<id>` on your existing HA URL
+3. The webhook proxies requests to the MCP Server add-on running locally
+
+## Prerequisites
+
+- **Home Assistant MCP Server** add-on must be installed and running
+- **Nabu Casa** subscription with remote UI enabled, **or** a working reverse proxy pointing at your HA instance
+
+## Installation
+
+1. **Install the MCP Server add-on first** (if not already installed)
+
+2. **Install the Webhook Proxy add-on** from the same add-on store
+
+3. **Start the add-on** — on first run it installs the integration and asks you to restart HA
+
+4. **Restart Home Assistant** (Settings > System > Restart)
+
+5. **Copy the remote URL** from the add-on logs:
+   ```
+   MCP Server URL (remote): https://xxxxx.ui.nabu.casa/api/webhook/mcp_xxxxxxxx
+   ```
+
+## Configuration
+
+- **Nabu Casa users**: Leave all settings blank — everything is auto-detected
+- **Other reverse proxies**: Set `remote_url` to your external HA URL (e.g., `https://ha.example.com`)
+
+## Comparison with Cloudflare Tunnel
+
+| | Webhook Proxy | Cloudflare Tunnel |
+|---|---|---|
+| **Setup** | Install add-on, restart HA | Install Cloudflared, configure tunnel |
+| **Requires** | Existing reverse proxy / Nabu Casa | Cloudflare account (free) |
+| **Extra hop** | Yes (HA → webhook → MCP) | No (direct to port 9583) |
+| **Port** | Uses HA's port 8123 | Dedicated port 9583 |
+| **Best for** | Already have Nabu Casa / reverse proxy | No existing proxy, or want direct connection |

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -259,7 +259,7 @@ source ~/.zshrc
             <li>Copy the webhook URL from the add-on logs</li>
             <li>Use that URL in your MCP client configuration</li>
           </ol>
-          <p class="text-slate-400 text-sm">See <a href="https://github.com/homeassistant-ai/ha-mcp/issues/784" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#784</a> for an example where this resolved a TLS connection issue. The webhook proxy was added in v7.0.0 (<a href="https://github.com/homeassistant-ai/ha-mcp/pull/554" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#554</a>).</p>
+          <p class="text-slate-400 text-sm">See <a href="https://github.com/homeassistant-ai/ha-mcp/issues/784" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#784</a> for an example where this resolved a TLS connection issue.</p>
         </div>
 
         <div class="faq-item">

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -28,6 +28,7 @@ const withBase = (path: string) => {
         <li><a href="#demo" class="text-blue-400 hover:underline">Try Without Your Own Home Assistant</a></li>
         <li><a href="#troubleshooting" class="text-blue-400 hover:underline">Troubleshooting</a></li>
         <li class="ml-4"><a href="#macos-connection" class="text-blue-400 hover:underline">macOS Connection Issues</a></li>
+        <li class="ml-4"><a href="#webhook-proxy" class="text-blue-400 hover:underline">Webhook Proxy Alternative</a></li>
         <li><a href="#custom-component" class="text-blue-400 hover:underline">Custom Component (ha_mcp_tools)</a></li>
         <li><a href="#configuration" class="text-blue-400 hover:underline">Configuration Options</a></li>
         <li><a href="#feedback" class="text-blue-400 hover:underline">Feedback & Help</a></li>
@@ -246,6 +247,19 @@ source ~/.zshrc
             <li>If "Home Assistant" is not listed, check your config file syntax</li>
             <li>Try asking Claude: "Can you list your available tools?"</li>
           </ol>
+        </div>
+
+        <div class="faq-item" id="webhook-proxy">
+          <h3 class="text-lg font-medium text-white mb-2">Can't connect remotely? Try the Webhook Proxy add-on</h3>
+          <p class="text-slate-300 mb-3">If you're having trouble setting up remote access — TLS errors, Cloudflare configuration issues, or port forwarding problems — the <strong>Webhook Proxy add-on</strong> may be a simpler alternative.</p>
+          <p class="text-slate-300 mb-3">Instead of requiring a dedicated tunnel to port 9583, the Webhook Proxy routes MCP traffic through Home Assistant's main port (8123) via a webhook. If you already have <strong>Nabu Casa</strong> or any reverse proxy pointing at your HA instance, this can be the easiest remote setup.</p>
+          <ol class="text-slate-300 space-y-2 list-decimal list-inside mb-3">
+            <li>Install the <strong>MCP Server add-on</strong> and the <strong>Webhook Proxy add-on</strong> from the add-on store</li>
+            <li>Start the webhook proxy and restart Home Assistant when prompted</li>
+            <li>Copy the webhook URL from the add-on logs</li>
+            <li>Use that URL in your MCP client configuration</li>
+          </ol>
+          <p class="text-slate-400 text-sm">See <a href="https://github.com/homeassistant-ai/ha-mcp/issues/784" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#784</a> for an example where this resolved a TLS connection issue. The webhook proxy was added in v7.0.0 (<a href="https://github.com/homeassistant-ai/ha-mcp/pull/554" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#554</a>).</p>
         </div>
 
         <div class="faq-item">

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -382,7 +382,7 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
           <span class="selected-badge" id="selected-server-setup"></span>
         </h2>
         <p class="text-slate-400 text-sm mb-4">Expose your MCP server securely to the internet</p>
-        <div class="grid md:grid-cols-2 gap-4" id="proxy-grid">
+        <div class="grid md:grid-cols-3 gap-4" id="proxy-grid">
           <button data-proxy="cloudflared" class="option-card-large">
             <div class="flex items-center gap-2 mb-2">
               <span class="text-2xl">☁️</span>
@@ -390,6 +390,14 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
             </div>
             <h3 class="font-semibold text-white">Cloudflare Tunnel</h3>
             <p class="text-sm text-slate-400">Free, no port forwarding needed</p>
+          </button>
+          <button data-proxy="webhook-proxy" class="option-card-large">
+            <div class="flex items-center gap-2 mb-2">
+              <span class="text-2xl">🏠</span>
+              <span class="complexity-badge" data-complexity="quick">⚡ Quick</span>
+            </div>
+            <h3 class="font-semibold text-white">Nabu Casa / Webhook Proxy</h3>
+            <p class="text-sm text-slate-400">Uses existing HA reverse proxy</p>
           </button>
           <button data-proxy="custom" class="option-card-large">
             <div class="flex items-center gap-2 mb-2">
@@ -772,7 +780,7 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
     }
     if (state.proxy || (state.serverSetup && !isRemote)) {
       const finalText = state.proxy ?
-        (state.proxy === 'cloudflared' ? 'Cloudflare Tunnel' : 'Custom Proxy') :
+        (state.proxy === 'cloudflared' ? 'Cloudflare Tunnel' : state.proxy === 'webhook-proxy' ? 'Webhook Proxy' : 'Custom Proxy') :
         serverSetupOptions[state.serverSetup]?.label;
       document.getElementById('selected-final').textContent = finalText || '';
     }
@@ -1009,7 +1017,7 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
     if (state.connection) badges.push(`<span class="px-3 py-1 rounded-full bg-green-900/50 text-green-300">${state.connection.name}</span>`);
     if (state.platform && isLocal) badges.push(`<span class="px-3 py-1 rounded-full bg-purple-900/50 text-purple-300">${state.platform.name}</span>`);
     if (setupInfo && !isLocal) badges.push(`<span class="px-3 py-1 rounded-full bg-orange-900/50 text-orange-300">${setupInfo.label}</span>`);
-    if (state.proxy) badges.push(`<span class="px-3 py-1 rounded-full bg-cyan-900/50 text-cyan-300">${state.proxy === 'cloudflared' ? 'Cloudflare Tunnel' : 'Custom Proxy'}</span>`);
+    if (state.proxy) badges.push(`<span class="px-3 py-1 rounded-full bg-cyan-900/50 text-cyan-300">${state.proxy === 'cloudflared' ? 'Cloudflare Tunnel' : state.proxy === 'webhook-proxy' ? 'Webhook Proxy' : 'Custom Proxy'}</span>`);
     summaryEl.innerHTML = badges.join('');
 
     // Build instructions
@@ -1070,8 +1078,8 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
     // Deployment instructions (for network/remote)
     if (derivedDeployment && !isLocal) {
       let deployInstr = '';
-      // For remote connections, add secret path for security
-      const secretPathNote = isRemote ? `
+      // For remote connections, add secret path for security (not needed for webhook-proxy — handled automatically)
+      const secretPathNote = (isRemote && state.proxy !== 'webhook-proxy') ? `
           <div class="bg-red-900/30 border border-red-700/50 rounded-lg p-3 mt-3">
             <p class="text-red-300 text-sm font-medium">🔒 Security Warning</p>
             <p class="text-red-200/80 text-xs mt-1">When exposing to the internet, <strong>always use a secret path</strong> to prevent unauthorized access. Keep this path private!</p>
@@ -1171,6 +1179,32 @@ cloudflared tunnel run ha-mcp</code></pre>
               <li>Select <strong>"do not block (allow crawlers)"</strong></li>
             </ol>
             <p class="text-amber-200/80 text-xs mt-2"><a href="https://homeassistant-ai.github.io/ha-mcp/images/cloudflare-ai-crawlers-setting.jpg" target="_blank" class="text-blue-400 hover:underline">Screenshot of the setting</a></p>
+          </div>
+        </div>`;
+      } else if (state.proxy === 'webhook-proxy') {
+        proxyInstr = `<div class="instruction-block">
+          <h4 class="instruction-title">🏠 Webhook Proxy Add-on</h4>
+          <p class="text-slate-300 mb-3">The Webhook Proxy add-on routes MCP traffic through your existing Home Assistant reverse proxy (Nabu Casa, Cloudflare, DuckDNS, nginx, etc.) — no separate tunnel to port 9583 needed.</p>
+          <ol class="text-sm text-slate-300 space-y-2 list-decimal list-inside">
+            <li><strong>Install the MCP Server add-on</strong> first (if not already installed):
+              <a href="https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fhomeassistant-ai%2Fha-mcp" target="_blank" class="inline-block mt-2 mb-2">
+                <img src="https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg" alt="Add Repository" />
+              </a>
+            </li>
+            <li><strong>Install the "Webhook Proxy for HA MCP"</strong> add-on from the same store</li>
+            <li><strong>Start the add-on</strong> — it will ask you to restart Home Assistant</li>
+            <li><strong>Restart Home Assistant</strong> (Settings &gt; System &gt; Restart)</li>
+            <li><strong>Copy the remote URL</strong> from the webhook proxy add-on logs:
+              <pre class="code-block mt-2"><code>MCP Server URL (remote): https://xxxxx.ui.nabu.casa/api/webhook/mcp_xxxxxxxx</code></pre>
+            </li>
+          </ol>
+          <div class="bg-blue-900/20 border border-blue-700/50 rounded-lg p-3 mt-4">
+            <p class="text-blue-300 text-sm font-medium">💡 When to use this method</p>
+            <p class="text-blue-200/80 text-xs mt-1">If you already have <strong>Nabu Casa</strong> or another reverse proxy pointing at your Home Assistant instance, the Webhook Proxy is the simplest remote setup — no Cloudflare account, no tunnel configuration, no extra ports.</p>
+          </div>
+          <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 mt-3">
+            <p class="text-slate-300 text-sm font-medium">Non-Nabu Casa users</p>
+            <p class="text-slate-400 text-xs mt-1">If you use a custom reverse proxy (Cloudflare, DuckDNS, nginx, etc.), set <code class="bg-slate-800 px-1 rounded">remote_url</code> in the webhook proxy add-on configuration to your external HA URL (e.g., <code class="bg-slate-800 px-1 rounded">https://ha.example.com</code>).</p>
           </div>
         </div>`;
       } else if (state.proxy === 'custom') {
@@ -1560,11 +1594,14 @@ mcpServers:
       }
       hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_TOKEN}}</code> → Your long-lived access token</li>`);
     }
-    if (isRemote && (derivedDeployment === 'uvx' || derivedDeployment === 'docker')) {
+    if (isRemote && (derivedDeployment === 'uvx' || derivedDeployment === 'docker') && state.proxy !== 'webhook-proxy') {
       hints.push(`<li><code class="bg-red-900/30 px-1 rounded text-red-300">{{RANDOM_STRING}}</code> → A random secret string (e.g., <code>abc123xyz</code>) - <strong class="text-red-400">keep this private!</strong></li>`);
     }
     if (!isStdio) {
-      hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{MCP_SERVER_URL}}</code> → Your MCP server URL (from deployment step above)</li>`);
+      const urlHint = state.proxy === 'webhook-proxy'
+        ? 'Your webhook proxy URL (from the webhook proxy add-on logs)'
+        : 'Your MCP server URL (from deployment step above)';
+      hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{MCP_SERVER_URL}}</code> → ${urlHint}</li>`);
     }
     hintsEl.innerHTML = hints.join('');
 

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1086,10 +1086,11 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
           </div>` : '';
 
       if (derivedDeployment === 'uvx') {
-        const serverPath = isRemote ? '/private_{{RANDOM_STRING}}' : '/mcp';
+        const useSecretPath = isRemote && state.proxy !== 'webhook-proxy';
+        const serverPath = useSecretPath ? '/private_{{RANDOM_STRING}}' : '/mcp';
         const portNote = `<p class="text-xs text-slate-500 mt-2">Optional: Set <code>MCP_PORT</code> to change the default port (8086).</p>`;
         if (platformId === 'windows') {
-          const secretPathEnv = isRemote ? `$env:MCP_SECRET_PATH="/private_{{RANDOM_STRING}}"  # Keep this secret!\n` : '';
+          const secretPathEnv = useSecretPath ? `$env:MCP_SECRET_PATH="/private_{{RANDOM_STRING}}"  # Keep this secret!\n` : '';
           deployInstr = `<div class="instruction-block">
           <h4 class="instruction-title">🐍 Start HTTP Server (uvx) - PowerShell</h4>
           <pre class="code-block"><code>$env:HOMEASSISTANT_URL="{{HOMEASSISTANT_URL}}"
@@ -1098,7 +1099,7 @@ ${secretPathEnv}uvx --from ha-mcp@latest ha-mcp-web</code></pre>
           <p class="text-sm text-slate-400 mt-2">Server will be at: <code>http://YOUR_IP:8086${serverPath}</code></p>${portNote}${secretPathNote}
         </div>`;
         } else {
-          const secretPathEnv = isRemote ? `export MCP_SECRET_PATH=/private_{{RANDOM_STRING}}  # Keep this secret!\n` : '';
+          const secretPathEnv = useSecretPath ? `export MCP_SECRET_PATH=/private_{{RANDOM_STRING}}  # Keep this secret!\n` : '';
           deployInstr = `<div class="instruction-block">
           <h4 class="instruction-title">🐍 Start HTTP Server (uvx)</h4>
           <pre class="code-block"><code>export HOMEASSISTANT_URL={{HOMEASSISTANT_URL}}
@@ -1108,8 +1109,9 @@ ${secretPathEnv}uvx --from ha-mcp@latest ha-mcp-web</code></pre>
         </div>`;
         }
       } else if (derivedDeployment === 'docker') {
-        const secretPathEnv = isRemote ? `  -e MCP_SECRET_PATH=/private_{{RANDOM_STRING}} \\\n` : '';
-        const serverPath = isRemote ? '/private_{{RANDOM_STRING}}' : '/mcp';
+        const useSecretPath = isRemote && state.proxy !== 'webhook-proxy';
+        const secretPathEnv = useSecretPath ? `  -e MCP_SECRET_PATH=/private_{{RANDOM_STRING}} \\\n` : '';
+        const serverPath = useSecretPath ? '/private_{{RANDOM_STRING}}' : '/mcp';
         const dockerPortNote = `<p class="text-xs text-slate-500 mt-2">Optional: Change <code>-p 8086:8086</code> to use a different port (e.g., <code>-p 9000:8086</code>).</p>`;
         deployInstr = `<div class="instruction-block">
           <h4 class="instruction-title">🐳 Start Docker Container</h4>


### PR DESCRIPTION
## What does this PR do?

Documents the webhook proxy addon across the project's documentation, making it discoverable for users who need remote access. The webhook proxy routes MCP traffic through HA's existing reverse proxy (Nabu Casa, Cloudflare, DuckDNS, nginx, etc.) instead of requiring a dedicated tunnel to port 9583.

**Changes:**
- **Setup wizard**: New "Nabu Casa / Webhook Proxy" button in the HTTPS proxy step, with full setup instructions and contextual hints
- **README**: New "Remote Access (Nabu Casa / Webhook Proxy)" collapsible section in Get Started
- **Main addon DOCS.md**: Webhook proxy as Option A for web clients (before Cloudflared), heading hierarchy fix for Option B
- **FAQ (site + standalone)**: Troubleshooting entry for TLS/connection issues pointing to webhook proxy (references #784)
- **Content collection**: New `webhook-proxy.md` deployment file with comparison table
- **remote.md**: Webhook proxy listed in deployment options

Closes #823

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)