### PR TITLE
feat: include addon container logs in bug reports

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -35,6 +35,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
 )
+from .util_helpers import ANSI_ESCAPE_RE
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +45,6 @@ _MAX_RESPONSE_SIZE = 50 * 1024
 # Hard safety cap on WebSocket messages collected per call. `message_limit`
 # can lower this but never raise it.
 _MAX_WS_MESSAGES = 1000
-
-# ANSI escape code pattern for stripping terminal colors from addon output
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 # Substrings that flag a WebSocket message as "signal" for the summarize pass.
 # Keep conservative: false negatives get elided, false positives just mean
@@ -661,7 +659,7 @@ async def _call_addon_ws(
                     continue
 
                 # Strip ANSI escape codes
-                clean = _ANSI_ESCAPE_RE.sub("", message)
+                clean = ANSI_ESCAPE_RE.sub("", message)
                 collected.append(clean)
                 total_size += len(clean)
 

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -8,11 +8,13 @@ on how to create effective bug reports.
 import logging
 import os
 import platform
+import re
 import sys
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import quote_plus
 
+import httpx
 from pydantic import Field
 
 from ha_mcp import __version__
@@ -29,6 +31,12 @@ logger = logging.getLogger(__name__)
 # GitHub issue template URLs
 RUNTIME_BUG_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
 AGENT_BEHAVIOR_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
+
+# ANSI escape code pattern (terminal colors in container logs)
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+# Max characters to include from addon container logs
+_ADDON_LOG_MAX_CHARS = 3000
 
 
 def _detect_installation_method() -> str:
@@ -79,6 +87,60 @@ def _detect_platform() -> dict[str, str]:
         "architecture": platform.machine(),
         "python_version": platform.python_version(),
     }
+
+
+def _sanitize_log_text(text: str) -> str:
+    """Strip common secrets from log text before including in reports."""
+    # JWT tokens (header.payload.signature)
+    text = re.sub(
+        r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+        "[REDACTED_JWT]",
+        text,
+    )
+    # Bearer tokens
+    text = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", text, flags=re.IGNORECASE)
+    # Long hex strings (API keys, tokens) - 32+ contiguous hex chars
+    text = re.sub(
+        r"(?<![a-fA-F0-9])[a-fA-F0-9]{32,}(?![a-fA-F0-9])",
+        "[REDACTED_HEX]",
+        text,
+    )
+    # IPv4 addresses
+    text = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "[IP]", text)
+    return text
+
+
+async def _fetch_addon_logs() -> str:
+    """Fetch ha-mcp addon container logs via the Supervisor REST API.
+
+    Only works when running as a Home Assistant add-on (SUPERVISOR_TOKEN set).
+    Uses /addons/self/logs which resolves to the calling addon's own logs.
+
+    Returns sanitized log text (last _ADDON_LOG_MAX_CHARS chars), or empty
+    string on failure.
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN", "")
+    if not token:
+        return ""
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as http_client:
+            resp = await http_client.get(
+                "http://supervisor/addons/self/logs",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code == 200:
+                raw = resp.text
+                # Strip ANSI escape codes (terminal colors)
+                raw = _ANSI_ESCAPE_RE.sub("", raw)
+                # Take the tail (most recent logs)
+                if len(raw) > _ADDON_LOG_MAX_CHARS:
+                    raw = raw[-_ADDON_LOG_MAX_CHARS:]
+                return _sanitize_log_text(raw)
+    except Exception as e:
+        logger.warning(f"Failed to fetch addon logs: {e}")
+
+    return ""
 
 
 def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
@@ -184,6 +246,11 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         # Get startup logs (first minute of server operation)
         startup_logs = get_startup_logs()
 
+        # Fetch addon container logs when running as HA add-on
+        addon_logs = ""
+        if install_method == "addon":
+            addon_logs = await _fetch_addon_logs()
+
         # Format logs for inclusion (sanitized summary)
         log_summary = _format_logs_for_report(recent_logs)
         startup_log_summary = _format_startup_logs(startup_logs)
@@ -221,11 +288,19 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 log_summary,
             ])
 
+        if addon_logs:
+            report_lines.extend([
+                "",
+                "=== Add-on Container Logs ===",
+                addon_logs,
+            ])
+
         formatted_report = "\n".join(report_lines)
 
         # Generate BOTH templates
         runtime_bug_template = _generate_runtime_bug_template(
-            diagnostic_info, log_summary, startup_log_summary, recent_logs, startup_logs
+            diagnostic_info, log_summary, startup_log_summary, recent_logs, startup_logs,
+            addon_logs=addon_logs,
         )
 
         agent_behavior_template = _generate_agent_behavior_template(
@@ -250,6 +325,7 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             "diagnostic_info": diagnostic_info,
             "recent_logs": recent_logs,
             "startup_logs": startup_logs,
+            "addon_logs": addon_logs,
             "log_count": len(recent_logs),
             "startup_log_count": len(startup_logs),
             "formatted_report": formatted_report,
@@ -447,6 +523,8 @@ def _generate_runtime_bug_template(
     startup_log_summary: str,
     recent_logs: list[dict[str, Any]],
     startup_logs: list[dict[str, Any]],
+    *,
+    addon_logs: str = "",
 ) -> str:
     """
     Generate a runtime bug report template matching runtime_bug.md format.
@@ -473,6 +551,24 @@ def _generate_runtime_bug_template(
 
 ```
 {startup_log_summary}
+```
+
+</details>
+"""
+
+    # Show addon container logs section only when available (addon installs only)
+    addon_section = ""
+    if addon_logs:
+        addon_section = f"""
+---
+
+## 📦 Add-on Container Logs
+
+<details>
+<summary>Click to expand ha-mcp add-on logs</summary>
+
+```
+{addon_logs}
 ```
 
 </details>
@@ -539,7 +635,7 @@ def _generate_runtime_bug_template(
 ```
 
 </details>
-{startup_section}
+{startup_section}{addon_section}
 ---
 
 ## 💡 Additional Context

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -137,7 +137,7 @@ async def _fetch_addon_logs() -> str:
                 if len(raw) > _ADDON_LOG_MAX_CHARS:
                     raw = raw[-_ADDON_LOG_MAX_CHARS:]
                 return _sanitize_log_text(raw)
-    except Exception as e:
+    except httpx.RequestError as e:
         logger.warning(f"Failed to fetch addon logs: {e}")
 
     return ""

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -25,6 +25,7 @@ from ..utils.usage_logger import (
     get_startup_logs,
 )
 from .helpers import log_tool_usage
+from .util_helpers import ANSI_ESCAPE_RE
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +33,24 @@ logger = logging.getLogger(__name__)
 RUNTIME_BUG_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
 AGENT_BEHAVIOR_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
 
-# ANSI escape code pattern (terminal colors in container logs)
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
-
-# Max characters to include from addon container logs
+# Max characters to include from addon container logs.
+# 3000 chars ≈ 750 LLM tokens — keeps the tool response well below context budgets
+# while still capturing enough recent output to diagnose most issues.
 _ADDON_LOG_MAX_CHARS = 3000
+
+# IPv4 sanitization: only redact addresses with strong network context so that
+# four-segment version strings (e.g. "ha-mcp version 1.2.3.4") are preserved.
+_IPV4_OCTET = r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)"
+_IPV4 = rf"(?:{_IPV4_OCTET}\.){{3}}{_IPV4_OCTET}"
+# IP followed by :port or /CIDR — always a network address, never a version.
+_IPV4_WITH_PORT_OR_CIDR_RE = re.compile(rf"\b{_IPV4}(?::\d+|/\d{{1,2}})\b(?!\.\d)")
+# IP preceded by a network keyword (from, to, host=, addr=, etc.).
+_IPV4_AFTER_KEYWORD_RE = re.compile(
+    rf"\b((?:from|to|host|hostname|addr|address|ip|src|dst|server|client|peer|via)\b\s*[=:]?\s*){_IPV4}\b(?!\.\d)",
+    re.IGNORECASE,
+)
+# IP appearing inside a URL (`scheme://1.2.3.4...`).
+_IPV4_IN_URL_RE = re.compile(rf"(://){_IPV4}\b(?!\.\d)")
 
 
 def _detect_installation_method() -> str:
@@ -90,23 +104,54 @@ def _detect_platform() -> dict[str, str]:
 
 
 def _sanitize_log_text(text: str) -> str:
-    """Strip common secrets from log text before including in reports."""
+    """Best-effort secret scrubber for log text.
+
+    Defense-in-depth, not exhaustive — bug reports still pass through human
+    review (see ``_generate_anonymization_guide``). Rules cover the most common
+    leak shapes seen in HA add-on logs:
+    JWTs, bearer tokens, long hex tokens, ``key=value`` style credentials,
+    URL userinfo, and IPv4 addresses with network context.
+    """
     # JWT tokens (header.payload.signature)
     text = re.sub(
         r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
         "[REDACTED_JWT]",
         text,
     )
-    # Bearer tokens
-    text = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", text, flags=re.IGNORECASE)
+    # Bearer tokens — preserve original casing of "Bearer"/"bearer"
+    text = re.sub(
+        r"\b([Bb]earer)\s+\S+",
+        lambda m: f"{m.group(1)} [REDACTED]",
+        text,
+    )
+    # Generic key=value credentials (api_key, token, secret, password, etc.).
+    # Negative lookbehind for a letter so OPENAI_API_KEY=... still matches
+    # (underscore is a word-char, so \b doesn't fire there).
+    # "authorization" is intentionally omitted — the Bearer rule above already
+    # handles "Authorization: Bearer ..." and overlapping rules double-tap.
+    text = re.sub(
+        r"(?<![A-Za-z])(api[_-]?key|access[_-]?key|secret[_-]?key|token|secret|password|passwd)\b(\s*[:=]\s*)\S+",
+        r"\1\2[REDACTED]",
+        text,
+        flags=re.IGNORECASE,
+    )
+    # URL userinfo: scheme://user:password@host -> scheme://user:[REDACTED]@host
+    text = re.sub(
+        r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^:/?#\s@]+):([^@/\s]+)@",
+        r"\1\2:[REDACTED]@",
+        text,
+    )
     # Long hex strings (API keys, tokens) - 32+ contiguous hex chars
     text = re.sub(
         r"(?<![a-fA-F0-9])[a-fA-F0-9]{32,}(?![a-fA-F0-9])",
         "[REDACTED_HEX]",
         text,
     )
-    # IPv4 addresses
-    text = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "[IP]", text)
+    # IPv4 addresses — only when there's strong network context, so that
+    # four-segment version strings (e.g. "version 1.2.3.4") survive intact.
+    text = _IPV4_WITH_PORT_OR_CIDR_RE.sub("[IP]", text)
+    text = _IPV4_IN_URL_RE.sub(r"\1[IP]", text)
+    text = _IPV4_AFTER_KEYWORD_RE.sub(r"\1[IP]", text)
     return text
 
 
@@ -114,11 +159,20 @@ async def _fetch_addon_logs() -> str:
     """Fetch ha-mcp addon container logs via the Supervisor REST API.
 
     Only works when running as a Home Assistant add-on (SUPERVISOR_TOKEN set).
-    Uses /addons/self/logs which resolves to the calling addon's own logs.
+    Uses /addons/self/logs which resolves to the calling addon's own logs via
+    the Supervisor's per-addon token binding — no slug interpolation needed.
 
-    Returns sanitized log text (last _ADDON_LOG_MAX_CHARS chars), or empty
-    string on failure.
+    Direct httpx against ``http://supervisor`` is the documented add-on access
+    pattern: it uses the Supervisor token directly (no extra HA hop) and
+    preserves the ``self`` shortcut, which the WebSocket ``supervisor/api``
+    proxy used by other tools may not.
+
+    Returns sanitized log text (last _ADDON_LOG_MAX_CHARS chars, with a
+    truncation marker prepended when truncation occurs), or empty string on
+    failure.
     """
+    # Redundant with the caller's `install_method == "addon"` gate, but kept
+    # as a defensive guard for any direct callers added later.
     token = os.environ.get("SUPERVISOR_TOKEN", "")
     if not token:
         return ""
@@ -129,14 +183,24 @@ async def _fetch_addon_logs() -> str:
                 "http://supervisor/addons/self/logs",
                 headers={"Authorization": f"Bearer {token}"},
             )
-            if resp.status_code == 200:
-                raw = resp.text
-                # Strip ANSI escape codes (terminal colors)
-                raw = _ANSI_ESCAPE_RE.sub("", raw)
-                # Take the tail (most recent logs)
-                if len(raw) > _ADDON_LOG_MAX_CHARS:
-                    raw = raw[-_ADDON_LOG_MAX_CHARS:]
-                return _sanitize_log_text(raw)
+            if resp.status_code != 200:
+                logger.info(
+                    "Addon log fetch returned HTTP %s", resp.status_code
+                )
+                return ""
+
+            # Strip ANSI escape codes first, then sanitize, then truncate.
+            # Sanitizing before truncating prevents secrets that straddle the
+            # truncation boundary from leaking through.
+            cleaned = ANSI_ESCAPE_RE.sub("", resp.text)
+            sanitized = _sanitize_log_text(cleaned)
+            if len(sanitized) > _ADDON_LOG_MAX_CHARS:
+                marker = (
+                    f"[...truncated, showing last {_ADDON_LOG_MAX_CHARS} of "
+                    f"{len(sanitized)} chars...]\n"
+                )
+                return marker + sanitized[-_ADDON_LOG_MAX_CHARS:]
+            return sanitized
     except httpx.RequestError as e:
         logger.warning(f"Failed to fetch addon logs: {e}")
 
@@ -202,7 +266,12 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - "That was inefficient"
 
         **OUTPUT:**
-        Returns both templates. Choose the appropriate one based on context.
+        Returns both templates plus diagnostic data. Key fields:
+        - `runtime_bug_template`, `agent_behavior_template` — pick based on context
+        - `recent_logs`, `startup_logs` — captured ha-mcp tool/server log entries
+        - `addon_logs` — addon container stdout/stderr (HA add-on installs only;
+          empty string otherwise)
+        - `suggested_title`, `duplicate_check_urls`, `anonymization_guide`
         """
         # Detect installation method and platform
         install_method = _detect_installation_method()
@@ -367,7 +436,8 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 f"      - Runtime bugs: {RUNTIME_BUG_URL}\n"
                 f"      - Agent behavior: {AGENT_BEHAVIOR_URL}\n"
                 "   d. Ask them to fill in the description sections\n"
-                "   e. Remind them to review for any remaining personal information before submitting\n\n"
+                "   e. For HA add-on installs, the runtime bug template includes a collapsible '📦 Add-on Container Logs' section auto-filled from addon_logs — keep it as-is\n"
+                "   f. Remind them to review for any remaining personal information before submitting\n\n"
                 "CRITICAL: Always ANONYMIZE the report BEFORE presenting it in markdown code blocks!"
             ),
         }
@@ -388,8 +458,8 @@ def _format_logs_for_report(logs: list[dict[str, Any]]) -> str:
 
         line = f"  {timestamp} | {tool_name} | {success} | {exec_time:.0f}ms"
         if error:
-            # Truncate error to avoid leaking sensitive info
-            error_short = str(error)[:100]
+            # Sanitize before truncating so secrets straddling the cut survive redaction.
+            error_short = _sanitize_log_text(str(error))[:100]
             line += f" | Error: {error_short}"
         lines.append(line)
 
@@ -408,7 +478,8 @@ def _format_startup_logs(logs: list[dict[str, Any]]) -> str:
         logger_name = log.get("logger", "")
         message = log.get("message", "")
 
-        # Truncate long messages
+        # Sanitize before truncating so secrets straddling the cut survive redaction.
+        message = _sanitize_log_text(message)
         if len(message) > 200:
             message = message[:200] + "..."
 

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -118,11 +118,14 @@ def _sanitize_log_text(text: str) -> str:
         "[REDACTED_JWT]",
         text,
     )
-    # Bearer tokens — preserve original casing of "Bearer"/"bearer"
+    # Bearer tokens — match any casing (BEARER, Bearer, bearer, BeArEr, …)
+    # via re.IGNORECASE, but preserve the original casing in the output by
+    # echoing m.group(1) back through the lambda.
     text = re.sub(
-        r"\b([Bb]earer)\s+\S+",
+        r"\b(bearer)\s+\S+",
         lambda m: f"{m.group(1)} [REDACTED]",
         text,
+        flags=re.IGNORECASE,
     )
     # Generic key=value credentials (api_key, token, secret, password, etc.).
     # Negative lookbehind for a letter so OPENAI_API_KEY=... still matches

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -7,6 +7,7 @@ This module provides common helper functions used across multiple tool registrat
 import asyncio
 import json
 import logging
+import re
 import time
 from typing import Any, overload
 
@@ -17,6 +18,9 @@ from ..client.rest_client import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Strips ANSI terminal escape codes from container/log output.
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 
 def coerce_bool_param(

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -2,10 +2,15 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from ha_mcp import __version__
-from ha_mcp.tools.tools_bug_report import register_bug_report_tools
+from ha_mcp.tools.tools_bug_report import (
+    _fetch_addon_logs,
+    _sanitize_log_text,
+    register_bug_report_tools,
+)
 
 
 class TestBugReportTool:
@@ -441,3 +446,159 @@ class TestBugReportTool:
         assert "markdown code block" in instructions.lower()
         assert "```markdown" in instructions
         assert "PROMINENTLY display the submission URL" in instructions
+
+    @pytest.mark.asyncio
+    async def test_bug_report_addon_logs_included_for_addon(
+        self, registered_tools, mock_client
+    ):
+        """Test that addon logs are fetched and included when running as addon."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        ha_report_issue = registered_tools._tools["ha_report_issue"]
+        actual_func = ha_report_issue
+        while hasattr(actual_func, "__wrapped__"):
+            actual_func = actual_func.__wrapped__
+
+        fake_logs = "2024-12-01 10:00:00 ERROR ha_mcp.server: Something broke\n"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_bug_report._detect_installation_method",
+                return_value="addon",
+            ),
+            patch(
+                "ha_mcp.tools.tools_bug_report._fetch_addon_logs",
+                return_value=fake_logs,
+            ),
+        ):
+            result = await actual_func()
+
+        assert result["addon_logs"] == fake_logs
+        assert "Add-on Container Logs" in result["formatted_report"]
+        assert "Add-on Container Logs" in result["runtime_bug_template"]
+
+    @pytest.mark.asyncio
+    async def test_bug_report_no_addon_logs_for_non_addon(
+        self, registered_tools, mock_client
+    ):
+        """Test that addon logs are NOT fetched for non-addon installs."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        ha_report_issue = registered_tools._tools["ha_report_issue"]
+        actual_func = ha_report_issue
+        while hasattr(actual_func, "__wrapped__"):
+            actual_func = actual_func.__wrapped__
+
+        with patch(
+            "ha_mcp.tools.tools_bug_report._detect_installation_method",
+            return_value="docker",
+        ):
+            result = await actual_func()
+
+        assert result["addon_logs"] == ""
+        assert "Add-on Container Logs" not in result["formatted_report"]
+        assert "Add-on Container Logs" not in result["runtime_bug_template"]
+
+
+class TestSanitizeLogText:
+    """Tests for _sanitize_log_text."""
+
+    def test_redacts_jwt_tokens(self):
+        text = "auth: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+        result = _sanitize_log_text(text)
+        assert "eyJ" not in result
+        assert "[REDACTED_JWT]" in result
+
+    def test_redacts_bearer_tokens(self):
+        text = "Authorization: Bearer abc123secrettoken"
+        result = _sanitize_log_text(text)
+        assert "abc123" not in result
+        assert "Bearer [REDACTED]" in result
+
+    def test_redacts_long_hex_strings(self):
+        text = f"token: {'a1b2c3d4' * 5}"  # 40-char hex string
+        result = _sanitize_log_text(text)
+        assert "a1b2c3d4" not in result
+        assert "[REDACTED_HEX]" in result
+
+    def test_redacts_ipv4_addresses(self):
+        text = "Connected to 192.168.1.100:8123"
+        result = _sanitize_log_text(text)
+        assert "192.168.1.100" not in result
+        assert "[IP]" in result
+
+    def test_preserves_normal_text(self):
+        text = "2024-12-01 10:00:00 ERROR ha_mcp.server: Entity not found"
+        result = _sanitize_log_text(text)
+        assert result == text
+
+
+class TestFetchAddonLogs:
+    """Tests for _fetch_addon_logs."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_supervisor_token(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = await _fetch_addon_logs()
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_sanitizes_logs(self):
+        fake_response = httpx.Response(
+            200,
+            text="INFO ha_mcp: connected to 192.168.1.50\n\x1b[31mERROR\x1b[0m: fail",
+        )
+
+        with (
+            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
+            patch("httpx.AsyncClient.get", return_value=fake_response),
+        ):
+            result = await _fetch_addon_logs()
+
+        # ANSI codes stripped
+        assert "\x1b[" not in result
+        # IPs sanitized
+        assert "192.168.1.50" not in result
+        assert "[IP]" in result
+        # Content preserved
+        assert "ha_mcp" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_logs(self):
+        long_log = "x" * 5000
+        fake_response = httpx.Response(200, text=long_log)
+
+        with (
+            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
+            patch("httpx.AsyncClient.get", return_value=fake_response),
+        ):
+            result = await _fetch_addon_logs()
+
+        assert len(result) <= 3000
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self):
+        fake_response = httpx.Response(403, text="Forbidden")
+
+        with (
+            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
+            patch("httpx.AsyncClient.get", return_value=fake_response),
+        ):
+            result = await _fetch_addon_logs()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_network_error(self):
+        with (
+            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
+            patch(
+                "httpx.AsyncClient.get",
+                side_effect=httpx.ConnectError("Connection refused"),
+            ),
+        ):
+            result = await _fetch_addon_logs()
+
+        assert result == ""

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -518,15 +518,75 @@ class TestSanitizeLogText:
         assert "Bearer [REDACTED]" in result
 
     def test_redacts_long_hex_strings(self):
-        text = f"token: {'a1b2c3d4' * 5}"  # 40-char hex string
+        # Bare hex (no leading "token:" — that path is exercised by the
+        # key=value rule below) gets the dedicated hex marker.
+        text = f"raw: {'a1b2c3d4' * 5}"  # 40-char hex string
         result = _sanitize_log_text(text)
         assert "a1b2c3d4" not in result
         assert "[REDACTED_HEX]" in result
 
-    def test_redacts_ipv4_addresses(self):
+    def test_redacts_ipv4_with_port(self):
         text = "Connected to 192.168.1.100:8123"
         result = _sanitize_log_text(text)
         assert "192.168.1.100" not in result
+        assert "[IP]" in result
+
+    def test_redacts_ipv4_in_url(self):
+        text = "fetched https://192.168.1.1/api/states"
+        result = _sanitize_log_text(text)
+        assert "192.168.1.1" not in result
+        assert "[IP]" in result
+
+    def test_redacts_ipv4_after_keyword(self):
+        text = "host=10.0.0.5 connecting"
+        result = _sanitize_log_text(text)
+        assert "10.0.0.5" not in result
+        assert "[IP]" in result
+
+    def test_preserves_four_segment_version_strings(self):
+        # Regression: bare four-segment values without network context (e.g.
+        # version banners) were being mangled by the IPv4 rule.
+        text = "ha-mcp version 1.2.3.4 starting"
+        result = _sanitize_log_text(text)
+        assert result == text
+
+    def test_redacts_key_value_credentials(self):
+        cases = [
+            ("OPENAI_API_KEY=sk-proj-AbCdEf1234567890qwerty", "sk-proj-AbCdEf"),
+            ("token=ghp_AbCdEf1234567890qwerty1234567890qwer", "ghp_AbCdEf"),
+            ("password=hunter2-S3cret!", "hunter2"),
+            ("api_key: somekey1234", "somekey1234"),
+        ]
+        for text, secret in cases:
+            result = _sanitize_log_text(text)
+            assert secret not in result, f"{secret!r} leaked in {result!r}"
+            assert "[REDACTED]" in result
+
+    def test_redacts_url_userinfo(self):
+        cases = [
+            ("https://admin:supersecret@homeassistant.local/api", "supersecret"),
+            ("mqtt://user:pass@broker.local:1883", "user:pass"),
+        ]
+        for text, secret in cases:
+            result = _sanitize_log_text(text)
+            assert secret not in result, f"{secret!r} leaked in {result!r}"
+            assert "[REDACTED]" in result
+
+    def test_bearer_preserves_casing(self):
+        # Capital and lowercase variants both get redacted; original casing kept.
+        upper = _sanitize_log_text("Authorization: Bearer abc123token")
+        lower = _sanitize_log_text("auth: bearer abc123token")
+        assert "abc123" not in upper and "abc123" not in lower
+        assert "Bearer [REDACTED]" in upper
+        assert "bearer [REDACTED]" in lower
+
+    def test_handles_multiple_secrets_in_one_line(self):
+        text = "token=abc123 connected to 192.168.1.5 with bearer xyz789"
+        result = _sanitize_log_text(text)
+        assert "abc123" not in result
+        assert "xyz789" not in result
+        assert "192.168.1.5" not in result
+        assert "[REDACTED]" in result
         assert "[IP]" in result
 
     def test_preserves_normal_text(self):
@@ -538,23 +598,32 @@ class TestSanitizeLogText:
 class TestFetchAddonLogs:
     """Tests for _fetch_addon_logs."""
 
+    @pytest.fixture
+    def _no_supervisor_token(self, monkeypatch):
+        """Remove SUPERVISOR_TOKEN without clobbering the rest of os.environ."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+
     @pytest.mark.asyncio
-    async def test_returns_empty_without_supervisor_token(self):
-        with patch.dict("os.environ", {}, clear=True):
-            result = await _fetch_addon_logs()
+    async def test_returns_empty_without_supervisor_token(self, _no_supervisor_token):
+        result = await _fetch_addon_logs()
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_fetches_and_sanitizes_logs(self):
+    async def test_returns_empty_when_supervisor_token_is_empty(self, monkeypatch):
+        # Empty-string token is treated the same as missing.
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "")
+        result = await _fetch_addon_logs()
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_sanitizes_logs(self, monkeypatch):
         fake_response = httpx.Response(
             200,
             text="INFO ha_mcp: connected to 192.168.1.50\n\x1b[31mERROR\x1b[0m: fail",
         )
 
-        with (
-            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
-            patch("httpx.AsyncClient.get", return_value=fake_response),
-        ):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        with patch("httpx.AsyncClient.get", return_value=fake_response):
             result = await _fetch_addon_logs()
 
         # ANSI codes stripped
@@ -566,38 +635,79 @@ class TestFetchAddonLogs:
         assert "ha_mcp" in result
 
     @pytest.mark.asyncio
-    async def test_truncates_long_logs(self):
+    async def test_truncates_long_logs_with_marker(self, monkeypatch):
+        # Use a long, sanitizer-clean payload so character math is exact.
         long_log = "x" * 5000
         fake_response = httpx.Response(200, text=long_log)
 
-        with (
-            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
-            patch("httpx.AsyncClient.get", return_value=fake_response),
-        ):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        with patch("httpx.AsyncClient.get", return_value=fake_response):
             result = await _fetch_addon_logs()
 
-        assert len(result) <= 3000
+        # Marker prepended, then last 3000 chars of the sanitized payload.
+        assert result.startswith("[...truncated, showing last 3000 of 5000 chars...]\n")
+        assert result.endswith("x" * 3000)
+        assert "x" * 3001 not in result  # exactly 3000 chars after marker
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_http_error(self):
+    async def test_short_logs_not_marked_or_truncated(self, monkeypatch):
+        # Logs shorter than the cap should be returned verbatim, no marker.
+        short_log = "INFO ha_mcp: started cleanly\n"
+        fake_response = httpx.Response(200, text=short_log)
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        with patch("httpx.AsyncClient.get", return_value=fake_response):
+            result = await _fetch_addon_logs()
+
+        assert result == short_log
+        assert "truncated" not in result
+
+    @pytest.mark.asyncio
+    async def test_jwt_split_at_truncation_boundary_is_redacted(self, monkeypatch):
+        # G1 regression: a JWT positioned so the truncation cut would slice
+        # into it must still be fully redacted because sanitization runs
+        # before truncation.
+        jwt = (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+            "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+        # Pad with sanitizer-clean filler so the JWT sits well before the cut,
+        # but the total length still exceeds _ADDON_LOG_MAX_CHARS (3000).
+        padding = "x" * 5000
+        fake_response = httpx.Response(200, text=f"{jwt}\n{padding}")
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        with patch("httpx.AsyncClient.get", return_value=fake_response):
+            result = await _fetch_addon_logs()
+
+        # Even though truncation kept only the tail, the JWT was redacted
+        # in the pre-truncation pass, so no fragment of it leaks through.
+        assert "eyJhbG" not in result
+        assert "SflKx" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error_with_log(self, monkeypatch, caplog):
         fake_response = httpx.Response(403, text="Forbidden")
 
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
         with (
-            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
             patch("httpx.AsyncClient.get", return_value=fake_response),
+            caplog.at_level("INFO", logger="ha_mcp.tools.tools_bug_report"),
         ):
             result = await _fetch_addon_logs()
 
         assert result == ""
+        # G6: status code is logged so users can distinguish 4xx/5xx from
+        # "Supervisor unreachable" / "not running as add-on".
+        assert any("403" in rec.getMessage() for rec in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_network_error(self):
-        with (
-            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "test-token"}),
-            patch(
-                "httpx.AsyncClient.get",
-                side_effect=httpx.ConnectError("Connection refused"),
-            ),
+    async def test_returns_empty_on_network_error(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        with patch(
+            "httpx.AsyncClient.get",
+            side_effect=httpx.ConnectError("Connection refused"),
         ):
             result = await _fetch_addon_logs()
 

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -664,27 +664,42 @@ class TestFetchAddonLogs:
 
     @pytest.mark.asyncio
     async def test_jwt_split_at_truncation_boundary_is_redacted(self, monkeypatch):
-        # G1 regression: a JWT positioned so the truncation cut would slice
-        # into it must still be fully redacted because sanitization runs
-        # before truncation.
+        # G1 regression: position the JWT so the truncation cut slices THROUGH
+        # it — the eyJ prefix falls in the dropped region, the signature falls
+        # in the kept region. Under the old truncate-then-sanitize order, the
+        # surviving JWT tail (no eyJ prefix) would not match the JWT regex and
+        # the signature characters would leak. Under the fixed sanitize-then-
+        # truncate order, the entire JWT is replaced with [REDACTED_JWT]
+        # before the cut, so nothing from the JWT survives.
+        from ha_mcp.tools.tools_bug_report import _ADDON_LOG_MAX_CHARS
+
         jwt = (
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
             "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
             "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
         )
-        # Pad with sanitizer-clean filler so the JWT sits well before the cut,
-        # but the total length still exceeds _ADDON_LOG_MAX_CHARS (3000).
-        padding = "x" * 5000
-        fake_response = httpx.Response(200, text=f"{jwt}\n{padding}")
+        # Place the JWT so cut_point lands 50 chars inside it (well past `eyJ`,
+        # well before `SflKx`).
+        prefix_len = 100
+        jwt_chars_to_drop = 50
+        total_len = prefix_len + jwt_chars_to_drop + _ADDON_LOG_MAX_CHARS
+        suffix_len = total_len - prefix_len - len(jwt)
+        assert suffix_len > 0, "suffix_len math is off"
+        # Sanity-check the placement: the buggy order really would leak SflKx.
+        assert "SflKx" in jwt[jwt_chars_to_drop:]
+        text = "x" * prefix_len + jwt + "x" * suffix_len
+        fake_response = httpx.Response(200, text=text)
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
         with patch("httpx.AsyncClient.get", return_value=fake_response):
             result = await _fetch_addon_logs()
 
-        # Even though truncation kept only the tail, the JWT was redacted
-        # in the pre-truncation pass, so no fragment of it leaks through.
-        assert "eyJhbG" not in result
+        # Pre-fix code (truncate-then-sanitize) would leave SflKx in the tail.
         assert "SflKx" not in result
+        # Confirm the marker survived the cut (positive proof sanitization
+        # actually ran before truncation, not just that SflKx happened to be
+        # truncated away).
+        assert "[REDACTED_JWT]" in result
 
     @pytest.mark.asyncio
     async def test_returns_empty_on_http_error_with_log(self, monkeypatch, caplog):

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -8,6 +8,8 @@ import pytest
 from ha_mcp import __version__
 from ha_mcp.tools.tools_bug_report import (
     _fetch_addon_logs,
+    _format_logs_for_report,
+    _format_startup_logs,
     _sanitize_log_text,
     register_bug_report_tools,
 )
@@ -573,12 +575,18 @@ class TestSanitizeLogText:
             assert "[REDACTED]" in result
 
     def test_bearer_preserves_casing(self):
-        # Capital and lowercase variants both get redacted; original casing kept.
-        upper = _sanitize_log_text("Authorization: Bearer abc123token")
-        lower = _sanitize_log_text("auth: bearer abc123token")
-        assert "abc123" not in upper and "abc123" not in lower
-        assert "Bearer [REDACTED]" in upper
-        assert "bearer [REDACTED]" in lower
+        # All casings get redacted via re.IGNORECASE; the lambda echoes
+        # m.group(1) so the original casing is preserved in the output.
+        cases = [
+            ("Authorization: Bearer abc123token", "Bearer [REDACTED]"),
+            ("auth: bearer abc123token", "bearer [REDACTED]"),
+            ("HDR: BEARER abc123token", "BEARER [REDACTED]"),
+            ("hdr: BeArEr abc123token", "BeArEr [REDACTED]"),
+        ]
+        for text, expected in cases:
+            result = _sanitize_log_text(text)
+            assert "abc123" not in result, f"abc123 leaked in {result!r}"
+            assert expected in result, f"missing {expected!r} in {result!r}"
 
     def test_handles_multiple_secrets_in_one_line(self):
         text = "token=abc123 connected to 192.168.1.5 with bearer xyz789"
@@ -727,3 +735,69 @@ class TestFetchAddonLogs:
             result = await _fetch_addon_logs()
 
         assert result == ""
+
+
+# Shared JWT fixture for the format-helper boundary tests below. 108 chars.
+_JWT_SAMPLE = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+    "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+)
+
+
+class TestFormatLogsForReportSanitization:
+    """Boy-scout-2 regression: sanitize-before-truncate for error_message."""
+
+    def test_jwt_split_at_100char_error_truncation_is_redacted(self):
+        # _format_logs_for_report truncates each error_message to the first
+        # 100 chars after sanitization. Position the JWT so the cut would
+        # land mid-JWT under the buggy truncate-then-sanitize order; the
+        # surviving JWT prefix wouldn't match the JWT regex (no signature)
+        # and would leak `eyJhbG…` into the report.
+        prefix_len = 50
+        # Cut at offset 100 = prefix_len (50) + jwt_chars_to_drop (50).
+        # JWT (108 chars) extends past the cut into the truncated region.
+        error = "x" * prefix_len + _JWT_SAMPLE + "x" * 200
+        logs = [
+            {
+                "timestamp": "2024-12-01T10:00:00",
+                "tool_name": "ha_test",
+                "success": False,
+                "execution_time_ms": 50,
+                "error_message": error,
+            }
+        ]
+
+        formatted = _format_logs_for_report(logs)
+
+        # No JWT fragment leaks (the buggy order would leave eyJhbG... in the
+        # truncated tail because the regex requires the full 3-part JWT shape).
+        assert "eyJhbG" not in formatted
+        # Positive proof: sanitization ran first, so the marker survives the
+        # 100-char cut.
+        assert "[REDACTED_JWT]" in formatted
+
+
+class TestFormatStartupLogsSanitization:
+    """Boy-scout-2 regression: sanitize-before-truncate for startup messages."""
+
+    def test_jwt_split_at_200char_message_truncation_is_redacted(self):
+        # _format_startup_logs truncates message to 200 chars after sanitize.
+        # Same shape as the _format_logs_for_report test, but with the JWT
+        # placed across the 200-char boundary.
+        prefix_len = 150
+        # Cut at offset 200 = prefix_len (150) + jwt_chars_to_drop (50).
+        message = "x" * prefix_len + _JWT_SAMPLE + "x" * 200
+        logs = [
+            {
+                "elapsed_seconds": 1.23,
+                "level": "INFO",
+                "logger": "ha_mcp.startup",
+                "message": message,
+            }
+        ]
+
+        formatted = _format_startup_logs(logs)
+
+        assert "eyJhbG" not in formatted
+        assert "[REDACTED_JWT]" in formatted


### PR DESCRIPTION
## What does this PR do?

When `ha_report_issue` runs on an **HA add-on install**, it now automatically includes the addon's own container logs in the bug report template. This addresses the recurring problem of bug reports missing addon logs, which forces maintainers to ask reporters to manually copy-paste them.

**How it works:**
- Fetches addon container logs via `GET http://supervisor/addons/self/logs` using the existing `SUPERVISOR_TOKEN`
- Strips ANSI terminal escape codes
- Truncates to the last 3000 chars (most recent output)
- Sanitizes secrets before inclusion (JWT tokens, Bearer auth, long hex strings, IPv4 addresses)
- Includes them in a collapsible `<details>` section — same pattern as startup logs
- Adds `addon_logs` to the return dict so agents can reference them

**Zero impact on non-addon installs** — the section only appears when running as an HA add-on and logs are available.

**Why addon logs specifically (not HA system/error logs):** The addon container logs are ha-mcp's own stdout/stderr — they're always directly relevant to ha-mcp bug reports, the same way startup logs and tool call history already are. This avoids the noise concern raised in #858 about bundling general HA logs that rarely correlate with MCP issues.

Closes #840

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

**12 new unit tests added:**
- `TestSanitizeLogText` (5 tests): JWT, Bearer, hex string, IPv4, and normal text preservation
- `TestFetchAddonLogs` (5 tests): no token, success + sanitization, truncation, HTTP error, network error
- `TestBugReportTool` (2 tests): addon logs included for addon installs, excluded for non-addon installs

## Checklist
- [x] I have updated documentation if needed