### PR TITLE
fix: route supervisor add-on log fetches through HA Core REST proxy

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -367,6 +367,52 @@ class HomeAssistantClient:
         response = await self._request("GET", "/error_log")
         return response if isinstance(response, str) else str(response)
 
+    async def get_addon_logs(self, slug: str) -> str:
+        """Fetch an add-on's container logs via HA Core's Supervisor REST proxy.
+
+        Uses `/api/hassio/addons/{slug}/logs`, which HA Core proxies to
+        Supervisor and returns as `text/plain`. This avoids the
+        `supervisor/api` websocket path that tries to JSON-decode the text
+        body and always fails (see #950).
+
+        Raises:
+            HomeAssistantAuthError: 401 from HA Core.
+            HomeAssistantAPIError: Non-2xx response (e.g. 404 unknown slug,
+                400 addon not installed). `status_code` is set so callers
+                can map to specific suggestions.
+            HomeAssistantConnectionError: Network, timeout, or transport error.
+        """
+        logger.debug(f"Fetching addon logs for slug={slug}")
+        endpoint = f"/hassio/addons/{slug}/logs"
+        try:
+            response = await self.httpx_client.request(
+                "GET",
+                endpoint,
+                headers={"Accept": "text/plain"},
+            )
+
+            if response.status_code == 401:
+                raise HomeAssistantAuthError("Invalid authentication token")
+
+            if response.status_code >= 400:
+                body = response.text[:500] if response.text else ""
+                raise HomeAssistantAPIError(
+                    f"Addon log request failed: {response.status_code} - {body}",
+                    status_code=response.status_code,
+                    response_data={"message": body},
+                )
+
+            return response.text
+
+        except httpx.ConnectError as e:
+            raise HomeAssistantConnectionError(
+                f"Failed to connect to Home Assistant: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
+        except httpx.HTTPError as e:
+            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+
     async def test_connection(self) -> tuple[bool, str | None]:
         """
         Test connection to Home Assistant.

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -97,9 +97,53 @@ class HomeAssistantClient:
         await self.httpx_client.aclose()
         logger.debug("Closed Home Assistant client")
 
+    async def _raw_request(
+        self, method: str, endpoint: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Authenticated request that returns the raw httpx.Response.
+
+        Handles auth, HTTP 4xx/5xx, and transport errors in one place.
+        Callers parse the body themselves (JSON via `_request`, text via
+        `get_addon_logs`, etc.).
+
+        Raises:
+            HomeAssistantAuthError: 401 response.
+            HomeAssistantAPIError: Non-2xx response (with status_code and
+                response_data set from JSON body when possible).
+            HomeAssistantConnectionError: Network, timeout, or transport error.
+        """
+        try:
+            response = await self.httpx_client.request(method, endpoint, **kwargs)
+
+            if response.status_code == 401:
+                raise HomeAssistantAuthError("Invalid authentication token")
+
+            if response.status_code >= 400:
+                try:
+                    error_data = response.json()
+                except Exception:
+                    error_data = {"message": response.text}
+
+                raise HomeAssistantAPIError(
+                    f"API error: {response.status_code} - {error_data.get('message', 'Unknown error')}",
+                    status_code=response.status_code,
+                    response_data=error_data,
+                )
+
+            return response
+
+        except httpx.ConnectError as e:
+            raise HomeAssistantConnectionError(
+                f"Failed to connect to Home Assistant: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
+        except httpx.HTTPError as e:
+            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+
     async def _request(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """
-        Make authenticated request to Home Assistant API.
+        Make authenticated request to Home Assistant API and parse JSON body.
 
         Args:
             method: HTTP method (GET, POST, etc.)
@@ -114,42 +158,13 @@ class HomeAssistantClient:
             HomeAssistantAuthError: Authentication failed
             HomeAssistantAPIError: API error
         """
+        response = await self._raw_request(method, endpoint, **kwargs)
         try:
-            response = await self.httpx_client.request(method, endpoint, **kwargs)
-
-            # Handle authentication errors
-            if response.status_code == 401:
-                raise HomeAssistantAuthError("Invalid authentication token")
-
-            # Handle other HTTP errors
-            if response.status_code >= 400:
-                try:
-                    error_data = response.json()
-                except Exception:
-                    error_data = {"message": response.text}
-
-                raise HomeAssistantAPIError(
-                    f"API error: {response.status_code} - {error_data.get('message', 'Unknown error')}",
-                    status_code=response.status_code,
-                    response_data=error_data,
-                )
-
-            # Parse JSON response
-            try:
-                result: dict[str, Any] = response.json()
-                return result
-            except json.JSONDecodeError:
-                # Some endpoints return empty responses
-                return {}
-
-        except httpx.ConnectError as e:
-            raise HomeAssistantConnectionError(
-                f"Failed to connect to Home Assistant: {e}"
-            ) from e
-        except httpx.TimeoutException as e:
-            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
-        except httpx.HTTPError as e:
-            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+            result: dict[str, Any] = response.json()
+            return result
+        except json.JSONDecodeError:
+            # Some endpoints return empty responses
+            return {}
 
     async def get_config(self) -> dict[str, Any]:
         """Get Home Assistant configuration."""
@@ -383,35 +398,12 @@ class HomeAssistantClient:
             HomeAssistantConnectionError: Network, timeout, or transport error.
         """
         logger.debug(f"Fetching addon logs for slug={slug}")
-        endpoint = f"/hassio/addons/{slug}/logs"
-        try:
-            response = await self.httpx_client.request(
-                "GET",
-                endpoint,
-                headers={"Accept": "text/plain"},
-            )
-
-            if response.status_code == 401:
-                raise HomeAssistantAuthError("Invalid authentication token")
-
-            if response.status_code >= 400:
-                body = response.text[:500] if response.text else ""
-                raise HomeAssistantAPIError(
-                    f"Addon log request failed: {response.status_code} - {body}",
-                    status_code=response.status_code,
-                    response_data={"message": body},
-                )
-
-            return response.text
-
-        except httpx.ConnectError as e:
-            raise HomeAssistantConnectionError(
-                f"Failed to connect to Home Assistant: {e}"
-            ) from e
-        except httpx.TimeoutException as e:
-            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
-        except httpx.HTTPError as e:
-            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+        response = await self._raw_request(
+            "GET",
+            f"/hassio/addons/{slug}/logs",
+            headers={"Accept": "text/plain"},
+        )
+        return response.text
 
     async def test_connection(self) -> tuple[bool, str | None]:
         """

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -124,8 +124,12 @@ class HomeAssistantClient:
                 except Exception:
                     error_data = {"message": response.text}
 
+                message = error_data.get("message")
+                if not message or not message.strip():
+                    message = response.reason_phrase or "<empty body>"
+
                 raise HomeAssistantAPIError(
-                    f"API error: {response.status_code} - {error_data.get('message', 'Unknown error')}",
+                    f"API error: {response.status_code} - {message}",
                     status_code=response.status_code,
                     response_data=error_data,
                 )

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -559,14 +559,16 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         except ToolError:
             raise
         except HomeAssistantAPIError as e:
-            # 400/404 usually mean unknown slug or addon not installed
             status = getattr(e, "status_code", None)
-            is_not_found = status in (400, 404)
-            first_suggestion = (
-                f"Add-on '{slug}' not found or not installed"
-                if is_not_found
-                else f"Verify add-on slug '{slug}' is correct"
-            )
+            if status == 404:
+                first_suggestion = f"Add-on '{slug}' not found or not installed"
+            elif status == 400:
+                first_suggestion = (
+                    f"Supervisor rejected the request for '{slug}' — verify slug "
+                    "format or that the add-on is installed and running"
+                )
+            else:
+                first_suggestion = f"Verify add-on slug '{slug}' is correct"
             exception_to_structured_error(
                 e,
                 context={"source": "supervisor", "slug": slug},
@@ -586,6 +588,8 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 context={"source": "supervisor", "slug": slug},
                 suggestions=[
                     "Check Home Assistant connection",
+                    f"Verify add-on slug '{slug}' is correct",
+                    "Use ha_get_addon() to list installed add-on slugs",
                     "Ensure Supervisor is available (HA OS or Supervised install)",
                 ],
             )

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -559,23 +559,19 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         except ToolError:
             raise
         except HomeAssistantAPIError as e:
+            # 400/404 usually mean unknown slug or addon not installed
             status = getattr(e, "status_code", None)
-            # 404/400 usually mean unknown slug or addon not installed
-            if status in (400, 404):
-                exception_to_structured_error(
-                    e,
-                    context={"source": "supervisor", "slug": slug},
-                    suggestions=[
-                        f"Add-on '{slug}' not found or not installed",
-                        "Use ha_get_addon() to list installed add-on slugs",
-                        "Ensure Supervisor is available (HA OS or Supervised install)",
-                    ],
-                )
+            is_not_found = status in (400, 404)
+            first_suggestion = (
+                f"Add-on '{slug}' not found or not installed"
+                if is_not_found
+                else f"Verify add-on slug '{slug}' is correct"
+            )
             exception_to_structured_error(
                 e,
                 context={"source": "supervisor", "slug": slug},
                 suggestions=[
-                    f"Verify add-on slug '{slug}' is correct",
+                    first_suggestion,
                     "Use ha_get_addon() to list installed add-on slugs",
                     "Ensure Supervisor is available (HA OS or Supervised install)",
                 ],

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -182,7 +182,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "The 'slug' parameter is required for source='supervisor'",
                     suggestions=[
                         "Provide the add-on slug, e.g. slug='core_mosquitto'",
-                        "Use ha_list_addons() to find available add-on slugs",
+                        "Use ha_get_addon() to list installed add-on slugs",
                     ],
                 )
             )
@@ -515,53 +515,17 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         limit: int | str | None = None,
         search: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch add-on container logs via the Supervisor API."""
+        """Fetch add-on container logs via HA Core's Supervisor REST proxy.
+
+        Routes through `/api/hassio/addons/{slug}/logs` (returned as
+        text/plain) instead of the `supervisor/api` websocket path, which
+        always fails because HA Core's proxy tries to JSON-decode the
+        text body. See #950.
+        """
         effective_limit = _coerce_limit(limit, default=DEFAULT_LOG_LIMIT, suggestion_example="100")
 
         try:
-            result = await client.send_websocket_message(
-                {
-                    "type": "supervisor/api",
-                    "endpoint": f"/addons/{slug}/logs",
-                    "method": "get",
-                }
-            )
-
-            if not result.get("success"):
-                error_msg = str(result.get("error", ""))
-                suggestions = [
-                    f"Verify add-on slug '{slug}' is correct",
-                    "Use ha_list_addons() to find available add-on slugs",
-                ]
-                if "not_found" in error_msg.lower() or "unknown" in error_msg.lower():
-                    suggestions.insert(
-                        0,
-                        "Supervisor API not available - requires HA OS or Supervised install",
-                    )
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result.get(
-                            "error", f"Failed to retrieve logs for add-on '{slug}'"
-                        ),
-                        context={"slug": slug},
-                        suggestions=suggestions,
-                    )
-                )
-
-            # Result may be a string (log text) or dict with result key
-            log_text = result.get("result", "")
-            if isinstance(log_text, dict):
-                if "data" in log_text:
-                    log_text = log_text["data"]
-                else:
-                    logger.warning(
-                        "Supervisor log for '%s' returned unexpected dict structure",
-                        slug,
-                    )
-                    log_text = ""
-            if not isinstance(log_text, str):
-                log_text = str(log_text)
+            log_text = await client.get_addon_logs(slug)
 
             lines = log_text.splitlines() if log_text else []
 
@@ -594,9 +558,30 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         except ToolError:
             raise
+        except HomeAssistantAPIError as e:
+            status = getattr(e, "status_code", None)
+            # 404/400 usually mean unknown slug or addon not installed
+            if status in (400, 404):
+                exception_to_structured_error(
+                    e,
+                    context={"source": "supervisor", "slug": slug},
+                    suggestions=[
+                        f"Add-on '{slug}' not found or not installed",
+                        "Use ha_get_addon() to list installed add-on slugs",
+                        "Ensure Supervisor is available (HA OS or Supervised install)",
+                    ],
+                )
+            exception_to_structured_error(
+                e,
+                context={"source": "supervisor", "slug": slug},
+                suggestions=[
+                    f"Verify add-on slug '{slug}' is correct",
+                    "Use ha_get_addon() to list installed add-on slugs",
+                    "Ensure Supervisor is available (HA OS or Supervised install)",
+                ],
+            )
         except (
             HomeAssistantConnectionError,
-            HomeAssistantAPIError,
             TimeoutError,
             OSError,
         ) as e:
@@ -604,8 +589,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 e,
                 context={"source": "supervisor", "slug": slug},
                 suggestions=[
-                    f"Verify add-on slug '{slug}' is correct",
-                    "Use ha_list_addons() to find available add-on slugs",
+                    "Check Home Assistant connection",
                     "Ensure Supervisor is available (HA OS or Supervised install)",
                 ],
             )

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -560,13 +560,28 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             raise
         except HomeAssistantAPIError as e:
             status = getattr(e, "status_code", None)
+            if status == 400:
+                # Supervisor-side rejection — not caller validation. The default
+                # `exception_to_structured_error` path would map 400 →
+                # VALIDATION_INVALID_PARAMETER, which reads as "caller passed
+                # bad input"; a downstream proxy rejection is better modelled
+                # as SERVICE_CALL_FAILED.
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        str(e),
+                        context={"source": "supervisor", "slug": slug},
+                        suggestions=[
+                            f"Supervisor rejected the request for '{slug}' — "
+                            "verify slug format or that the add-on is installed "
+                            "and running",
+                            "Use ha_get_addon() to list installed add-on slugs",
+                            "Ensure Supervisor is available (HA OS or Supervised install)",
+                        ],
+                    )
+                )
             if status == 404:
                 first_suggestion = f"Add-on '{slug}' not found or not installed"
-            elif status == 400:
-                first_suggestion = (
-                    f"Supervisor rejected the request for '{slug}' — verify slug "
-                    "format or that the add-on is installed and running"
-                )
             else:
                 first_suggestion = f"Verify add-on slug '{slug}' is correct"
             exception_to_structured_error(

--- a/tests/src/e2e/tools/test_logbook.py
+++ b/tests/src/e2e/tools/test_logbook.py
@@ -2,6 +2,7 @@
 Tests for ha_get_logs tool - log access with multiple sources and pagination.
 """
 
+import json
 import logging
 
 import pytest
@@ -429,6 +430,44 @@ async def test_logs_supervisor_missing_slug(mcp_client):
 
     assert "slug" in str(exc_info.value).lower()
     logger.info("Supervisor without slug correctly raises ToolError")
+
+
+@pytest.mark.asyncio
+async def test_logs_supervisor_propagates_api_error_to_structured_tool_error(
+    mcp_client,
+):
+    """Supervisor-less Core still pins the full error chain end-to-end.
+
+    The testcontainer runs HA Core with no Supervisor attached, so hitting
+    `/api/hassio/addons/<anything>/logs` returns a non-2xx that must travel
+    `_raw_request → HomeAssistantAPIError → exception_to_structured_error`
+    and surface as a `ToolError` whose payload carries the slug context and
+    the `ha_get_addon()` / Supervisor suggestions. Regression guard for the
+    #950 chain (see PR #951).
+    """
+    logger.info("Testing supervisor error path is translated to structured ToolError")
+
+    with pytest.raises(ToolError) as exc_info:
+        await mcp_client.call_tool(
+            "ha_get_logs",
+            {"source": "supervisor", "slug": "nonexistent_addon_slug"},
+        )
+
+    # ToolError payload is JSON-serialized — parse to assert on structure.
+    payload = json.loads(str(exc_info.value))
+    assert payload["success"] is False
+    assert payload.get("slug") == "nonexistent_addon_slug"
+    assert payload.get("source") == "supervisor"
+
+    suggestions = payload["error"].get("suggestions") or []
+    # At minimum the error must point the caller at the add-on tool.
+    assert any("ha_get_addon" in s for s in suggestions), (
+        f"expected ha_get_addon() suggestion, got: {suggestions}"
+    )
+    assert any("Supervisor" in s for s in suggestions), (
+        f"expected Supervisor availability hint, got: {suggestions}"
+    )
+    logger.info("Supervisor error path correctly surfaces structured ToolError")
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -80,10 +80,16 @@ class TestGetAddonLogs:
 
     @pytest.mark.asyncio
     async def test_raises_api_error_on_404_with_slug_context(self, mock_client):
-        """404 (unknown slug) raises HomeAssistantAPIError with status 404 and body."""
+        """404 (unknown slug) raises HomeAssistantAPIError with status 404 and body.
+
+        The Supervisor-proxied endpoint returns `text/plain` error bodies, not
+        JSON, so `response.json()` raises and the error message falls back to
+        `response.text`. Mirror that here.
+        """
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.text = "Addon is not installed"
+        mock_response.json = MagicMock(side_effect=ValueError("not json"))
         mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
 
         with pytest.raises(HomeAssistantAPIError) as exc_info:

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -4,17 +4,23 @@ Covers:
 - `HomeAssistantClient.get_addon_logs()` — new REST-client method that fetches
   add-on container logs via HA Core's `/api/hassio/addons/{slug}/logs` proxy,
   which HA Core returns as text/plain (no JSON decode in the hot path).
-- `ha_get_logs(source="supervisor")` no longer routes through the broken
-  `supervisor/api` websocket proxy.
+- `_get_supervisor_log` (the `ha_get_logs(source="supervisor")` wrapper) —
+  response shape, tail slicing, search filter, and API-error → ToolError
+  translation with status-code-specific suggestions.
 - Stale `ha_list_addons()` suggestion strings are replaced with
   `ha_get_addon()`.
 """
 
+import json
+import re
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import (
     HomeAssistantAPIError,
@@ -22,6 +28,7 @@ from ha_mcp.client.rest_client import (
     HomeAssistantClient,
     HomeAssistantConnectionError,
 )
+from ha_mcp.tools.tools_utility import register_utility_tools
 
 
 @pytest.fixture
@@ -34,6 +41,31 @@ def mock_client():
         client.timeout = 30
         client.httpx_client = MagicMock()
         return client
+
+
+def _register_and_collect(client: Any) -> dict[str, Any]:
+    """Register utility tools on a collector mcp and return the registered tools.
+
+    The production decorator chain is ``@mcp.tool(...)`` outside ``@log_tool_usage``,
+    so the collected entry is the ``log_tool_usage``-wrapped async function.
+    """
+    collected: dict[str, Any] = {}
+
+    def _tool(**_kwargs: Any) -> Any:
+        def _wrap(fn: Any) -> Any:
+            collected[fn.__name__] = fn
+            return fn
+        return _wrap
+
+    mcp = SimpleNamespace(tool=_tool)
+    register_utility_tools(mcp, client)
+    return collected
+
+
+def _parse_tool_error(exc_info: pytest.ExceptionInfo[ToolError]) -> dict[str, Any]:
+    """Parse the JSON payload from a ToolError raised by a tool."""
+    payload: dict[str, Any] = json.loads(str(exc_info.value))
+    return payload
 
 
 class TestGetAddonLogs:
@@ -135,19 +167,226 @@ class TestGetAddonLogs:
         mock_response.json.assert_not_called()
 
 
+class TestRawRequestEmptyBodyFallback:
+    """Error message must stay actionable even when the 4xx body is empty.
+
+    If `_raw_request` just used `error_data.get("message", "Unknown error")`
+    when the proxy returned a blank body, the raised error read
+    `"API error: 4xx - "` — same silent-failure signature #950 describes,
+    one layer down.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_body_falls_back_to_reason_phrase(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 502
+        mock_response.reason_phrase = "Bad Gateway"
+        mock_response.text = ""
+        mock_response.json = MagicMock(side_effect=ValueError("empty"))
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client._raw_request("GET", "/anything")
+
+        # Message must not be the bare "API error: 502 - " with an empty tail.
+        assert "Bad Gateway" in str(exc_info.value)
+        assert not str(exc_info.value).endswith(" - ")
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_body_falls_back(self, mock_client):
+        """A whitespace-only JSON body like `{"message": "   "}` still yields an
+        actionable tail, not `"API error: 4xx -    "`."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.reason_phrase = "Internal Server Error"
+        mock_response.text = '{"message": "   "}'
+        mock_response.json = MagicMock(return_value={"message": "   "})
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client._raw_request("GET", "/anything")
+
+        assert "Internal Server Error" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_empty_body_and_no_reason_phrase_uses_placeholder(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.reason_phrase = ""
+        mock_response.text = ""
+        mock_response.json = MagicMock(side_effect=ValueError("empty"))
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client._raw_request("GET", "/anything")
+
+        assert "<empty body>" in str(exc_info.value)
+
+
+class TestGetSupervisorLogWrapper:
+    """Tests for the `_get_supervisor_log` wrapper exercised via `ha_get_logs`.
+
+    Locks down the response shape, the `[-limit:]` tail slicing, the `search`
+    filter, and the `HomeAssistantAPIError → exception_to_structured_error`
+    translation the REST-client tests don't cover.
+    """
+
+    @pytest.fixture
+    def client_with_logs(self):
+        """Client whose `get_addon_logs` is a configurable AsyncMock."""
+        client = MagicMock()
+        client.get_addon_logs = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_happy_path_response_shape(self, client_with_logs):
+        client_with_logs.get_addon_logs.return_value = "line 1\nline 2\nline 3\n"
+        tools = _register_and_collect(client_with_logs)
+
+        result = await tools["ha_get_logs"](source="supervisor", slug="core_mosquitto")
+
+        assert result["success"] is True
+        assert result["source"] == "supervisor"
+        assert result["slug"] == "core_mosquitto"
+        assert result["log"] == "line 1\nline 2\nline 3"
+        assert result["total_lines"] == 3
+        assert result["returned_lines"] == 3
+        assert "limit" in result
+        # No filters applied → key is omitted
+        assert "filters_applied" not in result
+        client_with_logs.get_addon_logs.assert_awaited_once_with("core_mosquitto")
+
+    @pytest.mark.asyncio
+    async def test_tail_slicing_returns_last_n_lines(self, client_with_logs):
+        """`lines[-effective_limit:]` — users want recent activity, not the head."""
+        client_with_logs.get_addon_logs.return_value = "\n".join(
+            f"line {i}" for i in range(1, 21)
+        ) + "\n"
+        tools = _register_and_collect(client_with_logs)
+
+        result = await tools["ha_get_logs"](
+            source="supervisor", slug="core_mosquitto", limit=5
+        )
+
+        returned = result["log"].splitlines()
+        assert returned == ["line 16", "line 17", "line 18", "line 19", "line 20"]
+        assert result["total_lines"] == 20
+        assert result["returned_lines"] == 5
+        assert result["limit"] == 5
+
+    @pytest.mark.asyncio
+    async def test_search_filter_is_case_insensitive_and_recorded(
+        self, client_with_logs
+    ):
+        client_with_logs.get_addon_logs.return_value = (
+            "INFO startup complete\n"
+            "ERROR something broke\n"
+            "DEBUG trivial\n"
+            "ERROR another failure\n"
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        result = await tools["ha_get_logs"](
+            source="supervisor", slug="core_mosquitto", search="error"
+        )
+
+        lines = result["log"].splitlines()
+        assert len(lines) == 2
+        assert all("ERROR" in ln for ln in lines)
+        assert result["total_lines"] == 2  # total after filter
+        assert result["filters_applied"] == {"search": "error"}
+
+    @pytest.mark.asyncio
+    async def test_404_raises_tool_error_with_not_found_suggestion(
+        self, client_with_logs
+    ):
+        client_with_logs.get_addon_logs.side_effect = HomeAssistantAPIError(
+            "API error: 404 - Addon is not installed",
+            status_code=404,
+            response_data={"message": "Addon is not installed"},
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools["ha_get_logs"](
+                source="supervisor", slug="nonexistent"
+            )
+
+        payload = _parse_tool_error(exc_info)
+        suggestions = payload["error"]["suggestions"]
+        assert any("not found or not installed" in s for s in suggestions)
+        assert any("ha_get_addon" in s for s in suggestions)
+        # context kwargs get spread onto the response root by create_error_response
+        assert payload.get("slug") == "nonexistent"
+        assert payload.get("source") == "supervisor"
+
+    @pytest.mark.asyncio
+    async def test_400_uses_distinct_suggestion(self, client_with_logs):
+        """400 means Supervisor rejected the request — not the same as 404."""
+        client_with_logs.get_addon_logs.side_effect = HomeAssistantAPIError(
+            "API error: 400 - bad request",
+            status_code=400,
+            response_data={"message": "bad request"},
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools["ha_get_logs"](
+                source="supervisor", slug="weird_slug"
+            )
+
+        payload = _parse_tool_error(exc_info)
+        suggestions = payload["error"]["suggestions"]
+        # 400 must NOT say "not found or not installed" — different root cause.
+        assert not any("not found or not installed" in s for s in suggestions)
+        assert any("Supervisor rejected" in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_connection_error_keeps_slug_hint(self, client_with_logs):
+        """A transient network failure on a wrong slug should still hint at slug
+        verification — the connection-error path must not drop that suggestion."""
+        client_with_logs.get_addon_logs.side_effect = HomeAssistantConnectionError(
+            "no route"
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools["ha_get_logs"](
+                source="supervisor", slug="core_mosquitto"
+            )
+
+        payload = _parse_tool_error(exc_info)
+        suggestions = payload["error"]["suggestions"]
+        assert any("Check Home Assistant connection" in s for s in suggestions)
+        assert any(
+            "Verify add-on slug 'core_mosquitto' is correct" in s for s in suggestions
+        )
+        assert any("ha_get_addon" in s for s in suggestions)
+
+
 class TestStaleToolNameReferences:
     """Regression guard for #950 bug 2: stale `ha_list_addons()` suggestions."""
 
-    def test_tools_utility_does_not_reference_removed_ha_list_addons(self):
-        """`ha_list_addons` was consolidated into `ha_get_addon` — no stale refs."""
-        source = (
+    def test_no_tool_module_references_removed_ha_list_addons(self):
+        """`ha_list_addons` was consolidated into `ha_get_addon` — no stale refs.
+
+        Scans every `src/ha_mcp/tools/**/*.py` with a word-boundary regex so
+        the guard catches regressions in any module, not just tools_utility.py,
+        and ignores substrings inside longer identifiers.
+        """
+        tools_dir = (
             Path(__file__).resolve().parents[3]
             / "src"
             / "ha_mcp"
             / "tools"
-            / "tools_utility.py"
-        ).read_text()
-        assert "ha_list_addons" not in source, (
-            "tools_utility.py still references the removed `ha_list_addons` tool. "
-            "Replace suggestions with `ha_get_addon()` — see #950."
+        )
+        pattern = re.compile(r"\bha_list_addons\b")
+        offenders = [
+            f.relative_to(tools_dir)
+            for f in tools_dir.rglob("*.py")
+            if pattern.search(f.read_text(encoding="utf-8"))
+        ]
+        assert not offenders, (
+            f"Stale `ha_list_addons` reference in: {offenders}. "
+            "Replace suggestions/docs with `ha_get_addon()` — see #950."
         )

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -321,8 +321,15 @@ class TestGetSupervisorLogWrapper:
         assert payload.get("source") == "supervisor"
 
     @pytest.mark.asyncio
-    async def test_400_uses_distinct_suggestion(self, client_with_logs):
-        """400 means Supervisor rejected the request — not the same as 404."""
+    async def test_400_uses_distinct_suggestion_and_service_error_code(
+        self, client_with_logs
+    ):
+        """400 means Supervisor rejected the request, not caller input validation.
+
+        The default `exception_to_structured_error` path would map 400 →
+        VALIDATION_INVALID_PARAMETER; for a downstream proxy rejection,
+        SERVICE_CALL_FAILED is more accurate.
+        """
         client_with_logs.get_addon_logs.side_effect = HomeAssistantAPIError(
             "API error: 400 - bad request",
             status_code=400,
@@ -340,6 +347,7 @@ class TestGetSupervisorLogWrapper:
         # 400 must NOT say "not found or not installed" — different root cause.
         assert not any("not found or not installed" in s for s in suggestions)
         assert any("Supervisor rejected" in s for s in suggestions)
+        assert payload["error"]["code"] == "SERVICE_CALL_FAILED"
 
     @pytest.mark.asyncio
     async def test_connection_error_keeps_slug_hint(self, client_with_logs):

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -1,0 +1,147 @@
+"""Unit tests for the supervisor add-on log fix (#950).
+
+Covers:
+- `HomeAssistantClient.get_addon_logs()` — new REST-client method that fetches
+  add-on container logs via HA Core's `/api/hassio/addons/{slug}/logs` proxy,
+  which HA Core returns as text/plain (no JSON decode in the hot path).
+- `ha_get_logs(source="supervisor")` no longer routes through the broken
+  `supervisor/api` websocket proxy.
+- Stale `ha_list_addons()` suggestion strings are replaced with
+  `ha_get_addon()`.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantAuthError,
+    HomeAssistantClient,
+    HomeAssistantConnectionError,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """HomeAssistantClient with stubbed internals — no real network."""
+    with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+        client = HomeAssistantClient()
+        client.base_url = "http://test.local:8123"
+        client.token = "test-token"
+        client.timeout = 30
+        client.httpx_client = MagicMock()
+        return client
+
+
+class TestGetAddonLogs:
+    """Tests for the REST-client `get_addon_logs` method (the core fix)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_text_on_200(self, mock_client):
+        """Successful 200 response returns the raw text body."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "2026-04-11 10:00:00 addon starting\nready\n"
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        result = await mock_client.get_addon_logs("core_mosquitto")
+
+        assert "addon starting" in result
+        assert "ready" in result
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_endpoint_with_text_accept(self, mock_client):
+        """Endpoint path and Accept: text/plain header must match the HA proxy contract."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        await mock_client.get_addon_logs("81f33d0f_ha_mcp_dev")
+
+        mock_client.httpx_client.request.assert_called_once()
+        args, kwargs = mock_client.httpx_client.request.call_args
+        assert args[0] == "GET"
+        assert args[1] == "/hassio/addons/81f33d0f_ha_mcp_dev/logs"
+        assert kwargs["headers"]["Accept"] == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_raises_auth_error_on_401(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "unauthorized"
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HomeAssistantAuthError):
+            await mock_client.get_addon_logs("core_mosquitto")
+
+    @pytest.mark.asyncio
+    async def test_raises_api_error_on_404_with_slug_context(self, mock_client):
+        """404 (unknown slug) raises HomeAssistantAPIError with status 404 and body."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Addon is not installed"
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_addon_logs("nonexistent_slug")
+
+        assert exc_info.value.status_code == 404
+        assert "Addon is not installed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_raises_connection_error_on_network_failure(self, mock_client):
+        mock_client.httpx_client.request = AsyncMock(
+            side_effect=httpx.ConnectError("no route")
+        )
+
+        with pytest.raises(HomeAssistantConnectionError):
+            await mock_client.get_addon_logs("core_mosquitto")
+
+    @pytest.mark.asyncio
+    async def test_raises_connection_error_on_timeout(self, mock_client):
+        mock_client.httpx_client.request = AsyncMock(
+            side_effect=httpx.TimeoutException("timeout")
+        )
+
+        with pytest.raises(HomeAssistantConnectionError):
+            await mock_client.get_addon_logs("core_mosquitto")
+
+    @pytest.mark.asyncio
+    async def test_does_not_parse_json(self, mock_client):
+        """Regression guard for #950: the fetch must not try to JSON-decode the
+        text/plain log body (that's what broke the old websocket path)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "plain log line 1\nplain log line 2\n"
+        # Make .json() raise so any stray call would fail the test.
+        mock_response.json = MagicMock(
+            side_effect=ValueError("json parse should not be called")
+        )
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        result = await mock_client.get_addon_logs("core_mosquitto")
+
+        assert "plain log line 1" in result
+        mock_response.json.assert_not_called()
+
+
+class TestStaleToolNameReferences:
+    """Regression guard for #950 bug 2: stale `ha_list_addons()` suggestions."""
+
+    def test_tools_utility_does_not_reference_removed_ha_list_addons(self):
+        """`ha_list_addons` was consolidated into `ha_get_addon` — no stale refs."""
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "ha_mcp"
+            / "tools"
+            / "tools_utility.py"
+        ).read_text()
+        assert "ha_list_addons" not in source, (
+            "tools_utility.py still references the removed `ha_list_addons` tool. "
+            "Replace suggestions with `ha_get_addon()` — see #950."
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes `ha_get_logs(source="supervisor")` which has been 100% broken for every slug on every install.

**Bug 1 — always fails.** The old code routed through HA Core's `supervisor/api` websocket proxy, which tries to JSON-decode Supervisor's `text/plain` log body and raises. ha-mcp only sees an empty error string and surfaces it as `"Command failed: "`.

**Fix:** fetch via HA Core's `/api/hassio/addons/{slug}/logs` REST endpoint, which HA Core returns as `text/plain` — no JSON hop. Works for all install types, not just addon.

Added `HomeAssistantClient.get_addon_logs(slug)` that centralizes the text fetch with proper error mapping (401 → auth, 4xx → API error with status, network → connection error).

**Bug 2 — stale suggestion text.** Three places in `tools_utility.py` still referenced `ha_list_addons()`, a tool that was removed during consolidation. Replaced with `ha_get_addon()`.

**Manually verified** against a live HA OS instance with 7 different add-ons (`core_mosquitto`, `81f33d0f_ha_mcp_dev`, `81f33d0f_ha_mcp_webhook_proxy`, `a0d7b954_nodered`, `a0d7b954_appdaemon`, `core_ssh`, `49686a9f_evcc`) — all return real logs. Unknown slugs return clean 404s with actionable suggestions.

**Independent of #934.** PR #934 (addon logs in bug reports) adds its own `_fetch_addon_logs` helper that uses `http://supervisor/addons/self/logs` directly. That path is self-only and addon-only, so the two PRs cover different use cases without overlap. When both land, a follow-up can extract a shared helper.

Closes #950

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`) — CI will run unit + e2e
- [x] Code follows style guidelines (\`uv run ruff check\`)

**New unit tests in \`tests/src/unit/test_tools_utility_supervisor_logs.py\`:**
- \`TestGetAddonLogs\` (7 tests) — 200 returns text, correct endpoint + \`Accept: text/plain\`, 401 → auth error, 404 → API error with status, connect/timeout → connection error, no JSON decoding path.
- \`TestStaleToolNameReferences\` (1 test) — source grep to prevent regression of stale \`ha_list_addons()\` references.

## Checklist
- [x] I have updated documentation if needed