### PR TITLE
fix: persist auto-generated secret_path to addon options (#941)

### DIFF
--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -6,9 +6,11 @@ import os
 import re
 import secrets
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 
 def _log_with_timestamp(level: str, message: str, stream: TextIO | None = None) -> None:
@@ -97,6 +99,48 @@ def get_or_create_secret_path(data_dir: Path, custom_path: str = "") -> str:
         return new_path
 
 
+def persist_addon_options(options: dict[str, Any]) -> bool:
+    """Persist the full addon options dict back to Supervisor.
+
+    Sends the provided options as-is to `POST /addons/self/options`, which
+    performs a full replace validated against the addon's schema. Callers
+    must pass the complete options dict (including all required fields) —
+    partial dicts are rejected by the Supervisor.
+
+    Used after auto-generating the secret path so the webhook proxy can
+    read it from addon info without having to parse addon logs (#941).
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN")
+    if not token:
+        log_error("Cannot persist addon options: SUPERVISOR_TOKEN not set")
+        return False
+    payload = json.dumps({"options": options}).encode()
+    req = urllib.request.Request(
+        "http://supervisor/addons/self/options",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+        return True
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:
+            pass
+        log_error(f"Failed to persist addon options: HTTP {e.code} — {body}")
+        return False
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        log_error(f"Failed to persist addon options: {e}")
+        return False
+
+
 def main() -> int:
     """Start the Home Assistant MCP Server."""
     log_info("Starting Home Assistant MCP Server...")
@@ -104,6 +148,7 @@ def main() -> int:
     # Read configuration from Supervisor
     config_file = Path("/data/options.json")
     data_dir = Path("/data")
+    config: dict[str, Any] = {}
     backup_hint = "normal"  # default
     custom_secret_path = ""  # default
     enable_skills = True  # default
@@ -130,6 +175,18 @@ def main() -> int:
 
     # Generate or retrieve secret path
     secret_path = get_or_create_secret_path(data_dir, custom_secret_path)
+
+    # Persist secret path back to addon options so other addons (e.g. the
+    # webhook proxy) can read it via `GET /addons/{slug}/info → options`
+    # instead of scraping it from this addon's logs (#941). The webhook
+    # proxy's log-parsing fallback is fragile — the `(/private_\S+)` regex
+    # breaks on any whitespace the Supervisor log API inserts into the URL.
+    #
+    # Only write when the stored path differs from the path we just
+    # resolved. POST is a full replace validated against the addon schema,
+    # so we send the entire config dict with `secret_path` overwritten.
+    if secret_path != config.get("secret_path", ""):
+        persist_addon_options({**config, "secret_path": secret_path})
 
     log_info(f"Backup hint mode: {backup_hint}")
 

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -99,46 +99,31 @@ def get_or_create_secret_path(data_dir: Path, custom_path: str = "") -> str:
         return new_path
 
 
-def persist_addon_options(options: dict[str, Any]) -> bool:
-    """Persist the full addon options dict back to Supervisor.
+def persist_addon_options(options: dict[str, Any], supervisor_token: str) -> None:
+    """POST the full addon options dict to the Supervisor.
 
-    Sends the provided options as-is to `POST /addons/self/options`, which
-    performs a full replace validated against the addon's schema. Callers
-    must pass the complete options dict (including all required fields) —
-    partial dicts are rejected by the Supervisor.
+    The endpoint is a full-replace validated against the addon schema, so
+    callers must pass the complete options dict (not a partial patch).
 
-    Used after auto-generating the secret path so the webhook proxy can
-    read it from addon info without having to parse addon logs (#941).
+    Used after auto-generating the secret path so other addons (the
+    webhook proxy) can read it from `GET /addons/{slug}/info → options`
+    instead of scraping it from addon logs (#941).
+
+    Raises the underlying `urllib.error.HTTPError` / `URLError` / `OSError`
+    on failure — callers decide how loudly to surface the problem.
     """
-    token = os.environ.get("SUPERVISOR_TOKEN")
-    if not token:
-        log_error("Cannot persist addon options: SUPERVISOR_TOKEN not set")
-        return False
     payload = json.dumps({"options": options}).encode()
     req = urllib.request.Request(
         "http://supervisor/addons/self/options",
         data=payload,
         method="POST",
         headers={
-            "Authorization": f"Bearer {token}",
+            "Authorization": f"Bearer {supervisor_token}",
             "Content-Type": "application/json",
         },
     )
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            resp.read()
-        return True
-    except urllib.error.HTTPError as e:
-        body = ""
-        try:
-            body = e.read().decode("utf-8", errors="replace")[:200]
-        except Exception:
-            pass
-        log_error(f"Failed to persist addon options: HTTP {e.code} — {body}")
-        return False
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        log_error(f"Failed to persist addon options: {e}")
-        return False
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        resp.read()
 
 
 def main() -> int:
@@ -173,20 +158,43 @@ def main() -> int:
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
 
+    # Validate Supervisor token (needed for both ha-mcp auth below and the
+    # options-persist call right after secret path resolution)
+    supervisor_token = os.environ.get("SUPERVISOR_TOKEN")
+    if not supervisor_token:
+        log_error("SUPERVISOR_TOKEN not found! Cannot authenticate.")
+        return 1
+
     # Generate or retrieve secret path
     secret_path = get_or_create_secret_path(data_dir, custom_secret_path)
 
     # Persist secret path back to addon options so other addons (e.g. the
     # webhook proxy) can read it via `GET /addons/{slug}/info → options`
     # instead of scraping it from this addon's logs (#941). The webhook
-    # proxy's log-parsing fallback is fragile — the `(/private_\S+)` regex
-    # breaks on any whitespace the Supervisor log API inserts into the URL.
+    # proxy's log-parsing fallback uses `(/private_\S+)` which breaks on
+    # any whitespace the Supervisor log API inserts into the URL.
     #
     # Only write when the stored path differs from the path we just
-    # resolved. POST is a full replace validated against the addon schema,
-    # so we send the entire config dict with `secret_path` overwritten.
+    # resolved, so this is a one-time write per new path. The Supervisor
+    # endpoint is a full-replace validated against the addon schema, so we
+    # send the entire config dict with `secret_path` overwritten — a
+    # partial `{"secret_path": ...}` payload would fail validation (missing
+    # required fields) and persist nothing.
     if secret_path != config.get("secret_path", ""):
-        persist_addon_options({**config, "secret_path": secret_path})
+        try:
+            persist_addon_options(
+                {**config, "secret_path": secret_path}, supervisor_token
+            )
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as e:
+            detail = f"HTTP {e.code}: {e.reason}" if isinstance(e, urllib.error.HTTPError) else str(e)
+            log_error(
+                f"Failed to persist secret_path to addon options ({detail}). "
+                f"This addon will still run with secret_path={secret_path!r}, "
+                "but other addons (e.g. the webhook proxy) cannot auto-discover "
+                "it via Supervisor. Workaround: open this addon's Configuration "
+                "tab and paste the secret_path above into the 'Secret path override' "
+                "field, then save."
+            )
 
     log_info(f"Backup hint mode: {backup_hint}")
 
@@ -197,12 +205,6 @@ def main() -> int:
     os.environ["ENABLE_SKILLS_AS_TOOLS"] = str(enable_skills_as_tools).lower()
     os.environ["ENABLE_TOOL_SEARCH"] = str(enable_tool_search).lower()
     os.environ["ENABLE_YAML_CONFIG_EDITING"] = str(enable_yaml_config_editing).lower()
-
-    # Validate Supervisor token
-    supervisor_token = os.environ.get("SUPERVISOR_TOKEN")
-    if not supervisor_token:
-        log_error("SUPERVISOR_TOKEN not found! Cannot authenticate.")
-        return 1
 
     os.environ["HOMEASSISTANT_TOKEN"] = supervisor_token
 

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -126,6 +126,47 @@ def persist_addon_options(options: dict[str, Any], supervisor_token: str) -> Non
         resp.read()
 
 
+def maybe_persist_secret_path(
+    config: dict[str, Any], secret_path: str, supervisor_token: str
+) -> None:
+    """Persist `secret_path` into the addon's stored options when needed.
+
+    Only calls `persist_addon_options` when all of these hold:
+    - `config` is non-empty. If `/data/options.json` was missing or failed
+      to parse, `config` is `{}` and the addon is running off hardcoded
+      defaults. Sending a bare `{"secret_path": ...}` in that state would
+      be rejected by Supervisor's schema validation (missing required
+      `backup_hint`), producing a second misleading error line on top of
+      the "Failed to read config" we already logged.
+    - The resolved `secret_path` differs from the stored one. Otherwise
+      the write is a pure no-op and we'd just add noise on every restart.
+
+    Errors from the POST are caught and logged with an actionable recovery
+    message — the addon keeps running, but the user is told exactly which
+    value to paste into the Configuration tab if they hit it.
+    """
+    if not config:
+        return
+    if secret_path == config.get("secret_path", ""):
+        return
+    try:
+        persist_addon_options({**config, "secret_path": secret_path}, supervisor_token)
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as e:
+        detail = (
+            f"HTTP {e.code}: {e.reason}"
+            if isinstance(e, urllib.error.HTTPError)
+            else str(e)
+        )
+        log_error(
+            f"Failed to persist secret_path to addon options ({detail}). "
+            f"This addon will still run with secret_path={secret_path!r}, "
+            "but other addons (e.g. the webhook proxy) cannot auto-discover "
+            "it via Supervisor. Workaround: open this addon's Configuration "
+            "tab and paste the secret_path above into the 'Secret path override' "
+            "field, then save."
+        )
+
+
 def main() -> int:
     """Start the Home Assistant MCP Server."""
     log_info("Starting Home Assistant MCP Server...")
@@ -170,31 +211,9 @@ def main() -> int:
 
     # Persist secret path back to addon options so other addons (e.g. the
     # webhook proxy) can read it via `GET /addons/{slug}/info → options`
-    # instead of scraping it from this addon's logs (#941). The webhook
-    # proxy's log-parsing fallback uses `(/private_\S+)` which breaks on
-    # any whitespace the Supervisor log API inserts into the URL.
-    #
-    # Only write when the stored path differs from the path we just
-    # resolved, so this is a one-time write per new path. The Supervisor
-    # endpoint is a full-replace validated against the addon schema, so we
-    # send the entire config dict with `secret_path` overwritten — a
-    # partial `{"secret_path": ...}` payload would fail validation (missing
-    # required fields) and persist nothing.
-    if secret_path != config.get("secret_path", ""):
-        try:
-            persist_addon_options(
-                {**config, "secret_path": secret_path}, supervisor_token
-            )
-        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as e:
-            detail = f"HTTP {e.code}: {e.reason}" if isinstance(e, urllib.error.HTTPError) else str(e)
-            log_error(
-                f"Failed to persist secret_path to addon options ({detail}). "
-                f"This addon will still run with secret_path={secret_path!r}, "
-                "but other addons (e.g. the webhook proxy) cannot auto-discover "
-                "it via Supervisor. Workaround: open this addon's Configuration "
-                "tab and paste the secret_path above into the 'Secret path override' "
-                "field, then save."
-            )
+    # instead of scraping it from this addon's logs (#941). Details and
+    # the skip/retry rules live in maybe_persist_secret_path().
+    maybe_persist_secret_path(config, secret_path, supervisor_token)
 
     log_info(f"Backup hint mode: {backup_hint}")
 

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -93,8 +93,7 @@ class TestPersistAddonOptions:
         self.addon = _load_addon_start()
 
     def test_sends_full_options_dict_as_post(self, monkeypatch):
-        """persist_addon_options sends a POST to /addons/self/options with the full dict wrapped in {options: ...}."""
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        """Sends POST /addons/self/options with body {"options": <full dict>}."""
         captured: dict = {}
 
         class FakeResp:
@@ -121,34 +120,23 @@ class TestPersistAddonOptions:
             "enable_skills": True,
             "secret_path": "/private_abc12345",
         }
-        assert self.addon.persist_addon_options(options) is True
+        # Returns None on success — helper communicates failure via exceptions.
+        assert self.addon.persist_addon_options(options, "test-token") is None
         assert captured["url"] == "http://supervisor/addons/self/options"
         assert captured["method"] == "POST"
-        # Header keys are lowercased by urllib.request.Request.header_items()
         assert captured["headers"]["Authorization"] == "Bearer test-token"
         assert captured["headers"]["Content-type"] == "application/json"
         assert json.loads(captured["body"]) == {"options": options}
 
-    def test_missing_supervisor_token_returns_false(self, monkeypatch):
-        """Without SUPERVISOR_TOKEN the helper refuses to POST."""
-        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
-        called = False
+    def test_http_error_propagates(self, monkeypatch):
+        """Validation failures from Supervisor propagate to the caller.
 
-        def fake_urlopen(*args, **kwargs):
-            nonlocal called
-            called = True
-            raise AssertionError("urlopen should not be called without token")
-
-        monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
-        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
-        assert called is False
-
-    def test_http_error_returns_false(self, monkeypatch):
-        """Validation failures from Supervisor surface as False, not an exception."""
+        Silent suppression here would hide the exact failure this PR exists
+        to fix: the webhook proxy unable to discover the secret path. Main()
+        must see the exception so it can log an actionable recovery message.
+        """
         import io
         import urllib.error
-
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
 
         def fake_urlopen(req, timeout=None):
             raise urllib.error.HTTPError(
@@ -160,19 +148,19 @@ class TestPersistAddonOptions:
             )
 
         monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
-        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
+        with pytest.raises(urllib.error.HTTPError):
+            self.addon.persist_addon_options({"secret_path": "/private_x"}, "test-token")
 
-    def test_connection_error_returns_false(self, monkeypatch):
-        """Network failures surface as False, not an exception."""
+    def test_connection_error_propagates(self, monkeypatch):
+        """Network failures propagate to the caller — no silent swallowing."""
         import urllib.error
-
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
 
         def fake_urlopen(req, timeout=None):
             raise urllib.error.URLError("connection refused")
 
         monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
-        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
+        with pytest.raises(urllib.error.URLError):
+            self.addon.persist_addon_options({"secret_path": "/private_x"}, "test-token")
 
 
 IMAGE_TAG = "ha-mcp-addon-test"

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -84,6 +84,97 @@ class TestSecretPathValidation:
         assert self.addon._is_valid_secret_path("no-leading-slash") is False
         assert self.addon._is_valid_secret_path("") is False
 
+
+class TestPersistAddonOptions:
+    """Unit tests for persisting addon options to Supervisor (#941)."""
+
+    @pytest.fixture(autouse=True)
+    def addon(self):
+        self.addon = _load_addon_start()
+
+    def test_sends_full_options_dict_as_post(self, monkeypatch):
+        """persist_addon_options sends a POST to /addons/self/options with the full dict wrapped in {options: ...}."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+        captured: dict = {}
+
+        class FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b""
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["method"] = req.get_method()
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = req.data
+            return FakeResp()
+
+        monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
+
+        options = {
+            "backup_hint": "normal",
+            "enable_skills": True,
+            "secret_path": "/private_abc12345",
+        }
+        assert self.addon.persist_addon_options(options) is True
+        assert captured["url"] == "http://supervisor/addons/self/options"
+        assert captured["method"] == "POST"
+        # Header keys are lowercased by urllib.request.Request.header_items()
+        assert captured["headers"]["Authorization"] == "Bearer test-token"
+        assert captured["headers"]["Content-type"] == "application/json"
+        assert json.loads(captured["body"]) == {"options": options}
+
+    def test_missing_supervisor_token_returns_false(self, monkeypatch):
+        """Without SUPERVISOR_TOKEN the helper refuses to POST."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        called = False
+
+        def fake_urlopen(*args, **kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("urlopen should not be called without token")
+
+        monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
+        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
+        assert called is False
+
+    def test_http_error_returns_false(self, monkeypatch):
+        """Validation failures from Supervisor surface as False, not an exception."""
+        import io
+        import urllib.error
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                req.full_url,
+                400,
+                "Bad Request",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=io.BytesIO(b'{"result":"error","message":"invalid options"}'),
+            )
+
+        monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
+        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
+
+    def test_connection_error_returns_false(self, monkeypatch):
+        """Network failures surface as False, not an exception."""
+        import urllib.error
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(self.addon.urllib.request, "urlopen", fake_urlopen)
+        assert self.addon.persist_addon_options({"secret_path": "/private_x"}) is False
+
+
 IMAGE_TAG = "ha-mcp-addon-test"
 DOCKERFILE = "homeassistant-addon/Dockerfile"
 

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -163,6 +163,112 @@ class TestPersistAddonOptions:
             self.addon.persist_addon_options({"secret_path": "/private_x"}, "test-token")
 
 
+class TestMaybePersistSecretPath:
+    """Tests for the gate-and-recover wrapper called from main() (#941)."""
+
+    @pytest.fixture(autouse=True)
+    def addon(self):
+        self.addon = _load_addon_start()
+
+    def test_skips_when_config_is_empty(self, monkeypatch):
+        """If /data/options.json was missing/corrupt, don't try to persist.
+
+        Sending a bare `{"secret_path": ...}` without required fields would
+        trip schema validation on the Supervisor side and produce a second,
+        misleading error line on top of the "Failed to read config" we
+        already logged upstream.
+        """
+        calls: list = []
+        monkeypatch.setattr(
+            self.addon,
+            "persist_addon_options",
+            lambda *args, **kwargs: calls.append(args),
+        )
+        self.addon.maybe_persist_secret_path({}, "/private_new", "test-token")
+        assert calls == []
+
+    def test_skips_when_stored_path_matches(self, monkeypatch):
+        """No-op when Supervisor already has the right value — avoids noise on every restart."""
+        calls: list = []
+        monkeypatch.setattr(
+            self.addon,
+            "persist_addon_options",
+            lambda *args, **kwargs: calls.append(args),
+        )
+        config = {"backup_hint": "normal", "secret_path": "/private_same"}
+        self.addon.maybe_persist_secret_path(config, "/private_same", "test-token")
+        assert calls == []
+
+    def test_persists_with_full_config_merged(self, monkeypatch):
+        """When the path changes, POSTs `{**config, "secret_path": new}`."""
+        captured: list = []
+
+        def fake_persist(options, token):
+            captured.append((options, token))
+
+        monkeypatch.setattr(self.addon, "persist_addon_options", fake_persist)
+        config = {
+            "backup_hint": "normal",
+            "enable_skills": True,
+            "secret_path": "/private_old",
+        }
+        self.addon.maybe_persist_secret_path(config, "/private_new", "test-token")
+        assert captured == [
+            (
+                {
+                    "backup_hint": "normal",
+                    "enable_skills": True,
+                    "secret_path": "/private_new",
+                },
+                "test-token",
+            )
+        ]
+
+    def test_catches_http_error_and_logs_actionable_message(self, monkeypatch, capfd):
+        """HTTPError from Supervisor must not escape — the addon must keep starting — but the log line must name the path so the user can recover manually."""
+        import urllib.error
+
+        def raising_persist(options, token):
+            raise urllib.error.HTTPError(
+                "http://supervisor/addons/self/options",
+                400,
+                "Bad Request",
+                hdrs=None,  # type: ignore[arg-type]
+                fp=None,
+            )
+
+        monkeypatch.setattr(self.addon, "persist_addon_options", raising_persist)
+        # Should not raise.
+        self.addon.maybe_persist_secret_path(
+            {"backup_hint": "normal", "secret_path": "/private_old"},
+            "/private_new",
+            "test-token",
+        )
+        err = capfd.readouterr().err
+        assert "Failed to persist secret_path" in err
+        assert "HTTP 400" in err
+        assert "/private_new" in err  # user-facing recovery value
+        assert "Secret path override" in err  # points at the config field
+
+    def test_catches_network_error_and_logs(self, monkeypatch, capfd):
+        """URLError / timeout / OSError all caught the same way."""
+        import urllib.error
+
+        def raising_persist(options, token):
+            raise urllib.error.URLError("supervisor unreachable")
+
+        monkeypatch.setattr(self.addon, "persist_addon_options", raising_persist)
+        self.addon.maybe_persist_secret_path(
+            {"backup_hint": "normal", "secret_path": "/private_old"},
+            "/private_new",
+            "test-token",
+        )
+        err = capfd.readouterr().err
+        assert "Failed to persist secret_path" in err
+        assert "supervisor unreachable" in err
+        assert "/private_new" in err
+
+
 IMAGE_TAG = "ha-mcp-addon-test"
 DOCKERFILE = "homeassistant-addon/Dockerfile"
 


### PR DESCRIPTION
## What does this PR do?

After the ha-mcp addon auto-generates its HTTP secret path, it now persists it back to its own addon options via `POST /addons/self/options`. Other addons — notably the webhook proxy — can then read the path from `GET /addons/{slug}/info → options.secret_path` instead of scraping it from this addon's logs.

Closes #941.

### Why

The webhook proxy's `_discover_secret_path()` already checks addon options first and only falls through to log parsing as a fallback. The log-parsing branch uses `re.search(r"(/private_\S+)", logs)` — `\S+` stops at any whitespace, so on Supervisor configurations where the log API line-wraps the URL, the regex captures only a prefix and the webhook proxy hands the MCP client a broken URL. That's the failure mode behind #929.

Persisting the path to options makes the options-first branch always succeed for auto-generated paths, so the fragile log-parsing branch is never reached in practice. The webhook proxy's fallback stays in place for backwards compat with older ha-mcp versions — no coordinated release needed.

### How

New helper in `homeassistant-addon/start.py`:

```python
def persist_addon_options(options: dict[str, Any], supervisor_token: str) -> None:
    # POST http://supervisor/addons/self/options with {"options": options}
    # Raises urllib.error.HTTPError / URLError / OSError on failure.
```

Called from `main()` after `SUPERVISOR_TOKEN` validation (which moved a few lines up) and after `get_or_create_secret_path()` returns:

```python
if secret_path != config.get("secret_path", ""):
    try:
        persist_addon_options({**config, "secret_path": secret_path}, supervisor_token)
    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as e:
        # Log an actionable recovery message — no silent suppression.
        log_error(
            f"Failed to persist secret_path ... Workaround: paste {secret_path!r} "
            "into this addon's 'Secret path override' field and save."
        )
```

**Key design points:**

- **Idempotent write.** The POST only fires when the resolved path differs from the path currently stored in options. First boot after the fix writes once; every subsequent boot is a no-op.
- **Full replace, not partial patch.** The Supervisor endpoint is a full-replace validated against the addon schema (verified in `supervisor/api/addons.py`: `addon.options = addon.schema(body[ATTR_OPTIONS])`). A payload of only `{secret_path}` is rejected with `"Missing option 'backup_hint'"` and stored options stay untouched — safe, but useless. So we send `{**config, "secret_path": secret_path}` — the full dict already loaded from `/data/options.json`, with the new path spliced in. Every other field round-trips unchanged.
- **Loud failure, not silent.** The helper raises; `main()` catches and logs an actionable recovery message that names the exact value to paste into the Configuration tab. If persist fails, the addon still runs — but the user knows the webhook proxy may not auto-discover, and knows the exact workaround, rather than discovering it through a broken MCP connection later.
- **No addon restart triggered.** `supervisor/addons/addon.py::save_persist` just persists data; no restart. Verified empirically below.

### Empirical verification

Ran the full write path against a live Supervisor (HAOS 6.12.77, HA 2026.4.1) targeting the `81f33d0f_ha_mcp_dev` addon, using `curl` from inside an addon container with its `SUPERVISOR_TOKEN`:

| # | Request | Observed |
|---|---|---|
| 1 | GET current options | snapshot recorded |
| 2 | POST full dict unchanged | `{"result":"ok"}`, stored options identical |
| 3 | POST only `{secret_path}` (no `backup_hint`) | `{"result":"error","message":"Missing option 'backup_hint' in root"}`, stored options **unchanged** |
| 4 | POST full dict with new `secret_path` | `{"result":"ok"}`, secret_path updated, every other field preserved |
| 5 | POST full dict restoring original | `{"result":"ok"}`, state matches snapshot |

Addon stayed in `state: started` throughout, no container restart, no MCP session drop.

## Type of change
- [x] 🐛 Bug fix

## Testing

New unit tests in `tests/addon/test_addon_startup.py::TestPersistAddonOptions`:

- `test_sends_full_options_dict_as_post` — asserts request URL, method, `Authorization` / `Content-Type` headers, and exact body (`{"options": {...}}`)
- `test_http_error_propagates` — asserts `HTTPError` from Supervisor is re-raised (not swallowed)
- `test_connection_error_propagates` — asserts `URLError` is re-raised (not swallowed)

Run with `python3.13 -m pytest tests/addon/test_addon_startup.py::TestPersistAddonOptions -v`.

- [x] All automated tests pass (unit subset; full E2E requires Docker, not run locally)
- [x] `ruff check` clean on the touched files

## Related

- Closes #941
- Context: #929 (original user report of the log-wrapping failure)