### PR TITLE
fix(search): validate limit and offset parameters in ha_deep_search

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -746,7 +746,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ),
             ),
         ] = None,
-        limit: int = 5,
+        limit: Annotated[
+            int | str,
+            Field(
+                default=5,
+                description="Maximum total results to return (default: 5)",
+            ),
+        ] = 5,
         offset: Annotated[
             int | str,
             Field(

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -747,7 +747,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = None,
         limit: int = 5,
-        offset: int = 0,
+        offset: Annotated[
+            int | str,
+            Field(
+                default=0,
+                description="Number of results to skip for pagination (default: 0)",
+            ),
+        ] = 0,
         include_config: Annotated[
             bool | str,
             Field(
@@ -802,6 +808,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         )
         exact_match_bool = coerce_bool_param(exact_match, "exact_match", default=True)
         try:
+            limit = coerce_int_param(limit, "limit", default=5, min_value=1)
+            offset = coerce_int_param(offset, "offset", default=0, min_value=0)
             result = await smart_tools.deep_search(
                 query,
                 parsed_search_types,

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -358,3 +358,29 @@ async def test_deep_search_no_results(mcp_client):
     assert len(helpers) == 0, f"Should have no helper matches, but found: {helpers}"
 
     logger.info("✅ Correctly returned empty results for non-matching query")
+
+
+@pytest.mark.parametrize(
+    "limit,description",
+    [
+        pytest.param(-1, "negative limit"),
+        pytest.param(0, "zero limit"),
+    ],
+)
+async def test_deep_search_invalid_limit_returns_error(mcp_client, limit, description):
+    """Test that ha_deep_search rejects invalid limit values.
+
+    A negative or zero limit caused silent data corruption before the fix:
+    limit=-1 dropped the last result (tagged_results[0:-1]), limit=0 returned
+    an empty result with has_more=True, enabling an infinite pagination loop.
+    """
+    result = await safe_call_tool(
+        mcp_client,
+        "ha_deep_search",
+        {"query": "light", "limit": limit},
+    )
+    assert result["success"] is False, f"Expected failure for {description}, got success=True"
+    assert result["error"]["code"] == "VALIDATION_FAILED", (
+        f"Expected VALIDATION_FAILED for {description}, "
+        f"got {result.get('error', {}).get('code')}"
+    )

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -362,23 +362,25 @@ async def test_deep_search_no_results(mcp_client):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "limit,description",
+    "params,description",
     [
-        pytest.param(-1, "negative limit"),
-        pytest.param(0, "zero limit"),
+        pytest.param({"limit": -1}, "negative limit", id="limit_negative"),
+        pytest.param({"limit": 0}, "zero limit", id="limit_zero"),
+        pytest.param({"offset": -1}, "negative offset", id="offset_negative"),
     ],
 )
-async def test_deep_search_invalid_limit_returns_error(mcp_client, limit, description):
-    """Test that ha_deep_search rejects invalid limit values.
+async def test_deep_search_invalid_params_returns_error(mcp_client, params, description):
+    """Test that ha_deep_search rejects invalid limit and offset values.
 
-    A negative or zero limit caused silent data corruption before the fix:
+    Before the fix, invalid values caused silent data corruption:
     limit=-1 dropped the last result (tagged_results[0:-1]), limit=0 returned
-    an empty result with has_more=True, enabling an infinite pagination loop.
+    an empty result with has_more=True enabling an infinite pagination loop,
+    offset=-1 produced has_more=True with next_offset=4 (incorrect pagination state).
     """
     result = await safe_call_tool(
         mcp_client,
         "ha_deep_search",
-        {"query": "light", "limit": limit},
+        {"query": "light", **params},
     )
     assert result["success"] is False, f"Expected failure for {description}, got success=True"
     assert result["error"]["code"] == "VALIDATION_FAILED", (

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -360,6 +360,7 @@ async def test_deep_search_no_results(mcp_client):
     logger.info("✅ Correctly returned empty results for non-matching query")
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "limit,description",
     [

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from ..utilities.assertions import assert_mcp_success
+from ..utilities.assertions import assert_mcp_success, safe_call_tool
 from ..utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-corruption bug in `ha_deep_search` where negative or zero `limit` values produced incorrect results without error, and adds two E2E tests to prevent regression. Follows the pattern established in #946 (`ha_search_entities`).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Bug

`limit: int = 5` in `ha_deep_search` had no lower-bound guard. The value was passed directly to `smart_tools.deep_search()`, which uses it in a Python slice:

```python
paginated = tagged_results[offset : offset + limit]
```

| Input | Slice | Result | Expected |
|---|---|---|---|
| `limit=-1` | `results[0:-1]` | drops last result, `success=True` | `success=False` |
| `limit=0` | `results[0:0]` | empty result, `has_more=True`, `next_offset=0` | `success=False` |

`offset` had the same issue (no coercion for string inputs from MCP clients).

Live-verified on HA 2026.4.1 before the fix.

## Fix

Adds `coerce_int_param` calls inside the `try` block, consistent with `ha_search_entities` after #946:

```python
limit = coerce_int_param(limit, "limit", default=5, min_value=1)
offset = coerce_int_param(offset, "offset", default=0, min_value=0)
```

`offset` also gets `Annotated[int | str, Field(...)]` in the signature — consistent with `ha_search_entities`.

## Tests

Two parametrized E2E tests appended to `tests/src/e2e/tools/test_deep_search.py`:

- `limit=-1` → `success=False`, `error.code == "VALIDATION_FAILED"`
- `limit=0` → `success=False`, `error.code == "VALIDATION_FAILED"`

## Related

Follows up on #946 (`ha_search_entities` limit fix). Same root cause, same pattern.