### PR TITLE
fix: apply SearchKeywordsTransform unconditionally for claude.ai BM25 retrieval

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -143,6 +143,13 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         # Register bundled skills as MCP resources
         self._register_skills()
 
+        # Enrich tool descriptions with BM25 keyword boosts. Runs
+        # unconditionally so Claude's native deferred-tool search
+        # (claude.ai) benefits even when ENABLE_TOOL_SEARCH is off.
+        # Must come before _apply_tool_search so CategorizedSearchTransform
+        # indexes the enriched descriptions.
+        self._apply_search_keyword_enrichment()
+
         # Apply tool search transform (must come after all tools and
         # ResourcesAsTools are registered so it can wrap everything)
         self._apply_tool_search()
@@ -336,8 +343,11 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
     )
 
     # Extra keywords appended to tool descriptions for BM25 ranking.
-    # Only active behind enable_tool_search — the original docstrings
-    # are unchanged; these keywords are appended by SearchKeywordsTransform.
+    # Applied unconditionally via SearchKeywordsTransform so they also
+    # improve retrieval for Claude's native deferred-tool search on
+    # claude.ai, which indexes tool names and descriptions with BM25
+    # (no semantic matching). Original tool docstrings stay unchanged;
+    # these keywords are appended by the transform at list-tools time.
     _SEARCH_KEYWORDS: ClassVar[dict[str, str]] = {
         # s02: "find entities" → ha_search_entities should outrank ha_deep_search
         "ha_search_entities": (
@@ -386,8 +396,11 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
     }
 
     # Description overrides that REPLACE the original description for BM25.
-    # Used to narrow overly broad tools so they stop matching generic queries.
-    # Only active behind enable_tool_search via SearchKeywordsTransform.
+    # Used to narrow overly broad tools so they stop matching generic queries
+    # against ha-mcp's internal BM25 search tool. Only applied when
+    # enable_tool_search=True, because they are tuned specifically for the
+    # categorized search transform and replacing the base description would
+    # unnecessarily trim context for other clients.
     _SEARCH_DESCRIPTION_OVERRIDES: ClassVar[dict[str, str]] = {
         "ha_deep_search": (
             "Search INSIDE automation, script, and helper YAML configurations. "
@@ -398,6 +411,53 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         ),
     }
 
+    def _apply_search_keyword_enrichment(self) -> None:
+        """Append BM25 keyword boosts to tool descriptions.
+
+        Applied unconditionally so Claude's native deferred-tool search
+        (claude.ai uses BM25 over tool names and descriptions) can find
+        ha-mcp tools for common natural-language queries like "create
+        automation" — the scenario in #940. The original tool docstrings
+        in ``src/ha_mcp/tools/`` are unchanged; keywords are appended at
+        list-tools time via ``SearchKeywordsTransform``.
+
+        Description overrides (``_SEARCH_DESCRIPTION_OVERRIDES``) are only
+        applied when ``enable_tool_search`` is also set, because they
+        REPLACE the original description and are tuned specifically for
+        ha-mcp's internal BM25 search tool.
+
+        Runs before ``_apply_tool_search`` so downstream transforms
+        index the enriched descriptions.
+        """
+        try:
+            from .transforms import SearchKeywordsTransform
+        except ImportError:
+            logger.warning(
+                "SearchKeywordsTransform not available; skipping description "
+                "enrichment (tool discoverability on claude.ai may be degraded)."
+            )
+            return
+
+        overrides = (
+            self._SEARCH_DESCRIPTION_OVERRIDES
+            if self.settings.enable_tool_search
+            else None
+        )
+        try:
+            self.mcp.add_transform(
+                SearchKeywordsTransform(
+                    keywords=self._SEARCH_KEYWORDS,
+                    overrides=overrides,
+                )
+            )
+            logger.info(
+                "Search keyword enrichment applied (%d boosts%s)",
+                len(self._SEARCH_KEYWORDS),
+                f", {len(overrides)} overrides" if overrides else "",
+            )
+        except Exception:
+            logger.exception("Failed to apply SearchKeywordsTransform")
+
     def _apply_tool_search(self) -> None:
         """Apply the CategorizedSearchTransform if enabled.
 
@@ -406,6 +466,10 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         remain directly visible in list_tools() for individual permission
         gating. ResourcesAsTools (list_resources/read_resource) are also
         pinned when enabled.
+
+        Note: ``_apply_search_keyword_enrichment`` already ran before this
+        method and installed ``SearchKeywordsTransform`` — the enriched
+        catalog is what the categorized transform indexes.
         """
         if not self.settings.enable_tool_search:
             return
@@ -443,18 +507,6 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             )
 
         try:
-            # Enrich tool descriptions for BM25 ranking (innermost transform).
-            # Added first so the search transform indexes enriched descriptions.
-            # Original tool docstrings are unchanged.
-            from .transforms import SearchKeywordsTransform
-
-            self.mcp.add_transform(
-                SearchKeywordsTransform(
-                    keywords=self._SEARCH_KEYWORDS,
-                    overrides=self._SEARCH_DESCRIPTION_OVERRIDES,
-                )
-            )
-
             self.mcp.add_transform(
                 CategorizedSearchTransform(
                     max_results=5,
@@ -619,7 +671,9 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
                 if not f.resolve().is_relative_to(resolved_root):
                     continue
                 rel = f.relative_to(skill_dir)
-                ref_files.append({"name": str(rel), "uri": f"skill://{skill_name}/{rel}"})
+                ref_files.append(
+                    {"name": str(rel), "uri": f"skill://{skill_name}/{rel}"}
+                )
         except OSError:
             logger.warning("Error reading skill files in %s", skill_dir)
         return ref_files

--- a/tests/src/unit/test_categorized_search.py
+++ b/tests/src/unit/test_categorized_search.py
@@ -652,3 +652,97 @@ class TestSearchKeywordsTransform:
         call_next = AsyncMock(return_value=None)
         result = await transform.get_tool("ha_nonexistent", call_next)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# HomeAssistantSmartMCPServer._apply_search_keyword_enrichment
+#
+# Regression coverage for #940: SearchKeywordsTransform must be applied
+# unconditionally so Claude's native deferred-tool search (claude.ai, BM25)
+# can locate ha-mcp tools for common natural-language queries, regardless
+# of whether ENABLE_TOOL_SEARCH is set.
+# ---------------------------------------------------------------------------
+
+
+class TestApplySearchKeywordEnrichment:
+    """Tests for the always-on keyword enrichment hook on the server class."""
+
+    def _make_server_stub(self, *, enable_tool_search: bool) -> MagicMock:
+        """Minimal stub exposing only the attributes the method touches."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = MagicMock()
+        stub._SEARCH_KEYWORDS = HomeAssistantSmartMCPServer._SEARCH_KEYWORDS
+        stub._SEARCH_DESCRIPTION_OVERRIDES = (
+            HomeAssistantSmartMCPServer._SEARCH_DESCRIPTION_OVERRIDES
+        )
+        stub.settings = MagicMock(enable_tool_search=enable_tool_search)
+        stub.mcp = MagicMock()
+        return stub
+
+    def test_applies_keywords_when_tool_search_disabled(self):
+        """Keywords go on even when ENABLE_TOOL_SEARCH is false (#940)."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_tool_search=False)
+        HomeAssistantSmartMCPServer._apply_search_keyword_enrichment(stub)
+
+        stub.mcp.add_transform.assert_called_once()
+        transform = stub.mcp.add_transform.call_args.args[0]
+        assert isinstance(transform, SearchKeywordsTransform)
+        assert transform._keywords == stub._SEARCH_KEYWORDS
+        # Overrides are gated behind enable_tool_search; flag is off so none
+        assert transform._overrides == {}
+
+    def test_applies_keywords_and_overrides_when_tool_search_enabled(self):
+        """With categorized search on, both keywords and overrides apply."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_tool_search=True)
+        HomeAssistantSmartMCPServer._apply_search_keyword_enrichment(stub)
+
+        stub.mcp.add_transform.assert_called_once()
+        transform = stub.mcp.add_transform.call_args.args[0]
+        assert isinstance(transform, SearchKeywordsTransform)
+        assert transform._keywords == stub._SEARCH_KEYWORDS
+        assert transform._overrides == stub._SEARCH_DESCRIPTION_OVERRIDES
+
+    def test_transform_failure_is_logged_not_raised(self, caplog):
+        """Enrichment failures must not break server startup."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_tool_search=False)
+        stub.mcp.add_transform.side_effect = RuntimeError("boom")
+        with caplog.at_level("ERROR"):
+            HomeAssistantSmartMCPServer._apply_search_keyword_enrichment(stub)
+        assert any(
+            "SearchKeywordsTransform" in rec.message for rec in caplog.records
+        )
+
+    @pytest.mark.anyio
+    async def test_canonical_keywords_end_to_end_for_940_tools(self):
+        """The specific tools in #940 actually get enriched descriptions."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        keywords = HomeAssistantSmartMCPServer._SEARCH_KEYWORDS
+        # These are the tools named in the #940 reproduction
+        for tool_name in (
+            "ha_config_set_automation",
+            "ha_config_set_script",
+            "ha_config_set_helper",
+            "ha_search_entities",
+        ):
+            assert tool_name in keywords, f"{tool_name} missing from _SEARCH_KEYWORDS"
+
+        transform = SearchKeywordsTransform(keywords=keywords)
+        tool = _make_tool(
+            "ha_config_set_automation",
+            destructive=True,
+            description="Create or update a Home Assistant automation.",
+        )
+        enriched = (await transform.list_tools([tool]))[0]
+        assert enriched.description.startswith(
+            "Create or update a Home Assistant automation."
+        )
+        for term in ("create", "update", "modify", "edit", "new", "save"):
+            assert term in enriched.description.lower()


### PR DESCRIPTION
## What does this PR do?

Addresses the retrieval half of #940.

Claude's native deferred-tool search — used by claude.ai when an MCP
connector has many tools — indexes tool names and descriptions with BM25
and has no semantic understanding. The reporter in #940 hit the
predictable failure mode: searching for "create home assistant
automation" did not return `ha_config_set_automation` in the top 5
results, because common tokens like "automation", "config", "set" are
IDF-suppressed across the ha-mcp catalog.

#727 already ships a BM25-tuned `_SEARCH_KEYWORDS` dict plus a
`SearchKeywordsTransform` that appends per-tool keyword boosts. It was
only active behind `ENABLE_TOOL_SEARCH=true`, which the reporter cannot
enable because it double-defers under claude.ai's own loader.

This PR splits the two concerns so the keyword boosts apply
unconditionally, while `CategorizedSearchTransform` stays opt-in.

### Change

Split `_apply_tool_search()` into two methods in `server.py`:

- **`_apply_search_keyword_enrichment()`** — runs unconditionally from
  `__init__`. Installs `SearchKeywordsTransform` with `_SEARCH_KEYWORDS`
  so every client benefits from the BM25-tuned ranking, including
  claude.ai with deferred tools.
- **`_apply_tool_search()`** — still runs only when
  `ENABLE_TOOL_SEARCH=true`. Installs `CategorizedSearchTransform`
  unchanged.

`_SEARCH_DESCRIPTION_OVERRIDES` stay gated behind `ENABLE_TOOL_SEARCH`.
They REPLACE descriptions (rather than append) and are tuned
specifically for ha-mcp's internal search tool — applying them to every
client would trim user-visible tool context with no benefit.

### Transform ordering preserved

When \`ENABLE_TOOL_SEARCH=true\`, the resulting transform stack is
identical to before:

1. \`ResourcesAsTools\` (from \`_register_skills\`)
2. \`SearchKeywordsTransform\` (now from \`_apply_search_keyword_enrichment\`)
3. \`CategorizedSearchTransform\` (from \`_apply_tool_search\`)

When \`ENABLE_TOOL_SEARCH=false\`, the stack is \`ResourcesAsTools\` +
\`SearchKeywordsTransform\`. Previously it was just \`ResourcesAsTools\`.

### Tests

Four new unit tests in \`TestApplySearchKeywordEnrichment\`:

- \`test_applies_keywords_when_tool_search_disabled\` — regression for
  the core #940 claim (keywords reach claude.ai users)
- \`test_applies_keywords_and_overrides_when_tool_search_enabled\` —
  preserves existing #727 behavior
- \`test_transform_failure_is_logged_not_raised\` — enrichment
  failures log and continue, never break server startup
- \`test_canonical_keywords_end_to_end_for_940_tools\` — asserts the
  four tools named in the issue (\`ha_config_set_automation\`,
  \`ha_config_set_script\`, \`ha_config_set_helper\`,
  \`ha_search_entities\`) are present in \`_SEARCH_KEYWORDS\` and that
  \`ha_config_set_automation\` ends up with all the target synonyms in
  its enriched description.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`) — via CI
- [x] Code follows style guidelines (\`uv run ruff check\`)

## Checklist
- [x] Documentation updated where needed (comments near
      \`_SEARCH_KEYWORDS\` and \`_SEARCH_DESCRIPTION_OVERRIDES\`
      reflect the new gating)

## Notes

- **Does not close #940.** A follow-up PR will add write-time
  validation of entity/service references in
  \`ha_config_set_automation\` / \`ha_config_set_script\`, plus a
  \`validate=True\` flag on the matching read tools. That addresses the
  second half of the issue (the hallucinated \`notify.mobile_app_andrew_phone\`
  that the server accepted silently).
- \`_SEARCH_KEYWORDS\` itself is unchanged — it was already BM25-tuned
  by #727's BAT work. This PR just delivers those existing keywords to
  the scenario in #940.