### PR TITLE
test(e2e): add negative-input test for ha_get_zone with nonexistent zone_id

### DIFF
--- a/tests/src/e2e/workflows/zones/test_lifecycle.py
+++ b/tests/src/e2e/workflows/zones/test_lifecycle.py
@@ -451,6 +451,17 @@ class TestZoneLifecycle:
             logger.info("All zone deletions verified")
 
 
+    async def test_get_zone_nonexistent(self, mcp_client):
+        """Test ha_get_zone returns ENTITY_NOT_FOUND for unknown zone_id."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_failure(
+                "ha_get_zone",
+                {"zone_id": "nonexistent_zone_e2e_xyz_404"},
+            )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ENTITY_NOT_FOUND"
+
 async def test_zone_search_discovery(mcp_client):
     """
     Test: Zone search and discovery capabilities

--- a/tests/src/e2e/workflows/zones/test_lifecycle.py
+++ b/tests/src/e2e/workflows/zones/test_lifecycle.py
@@ -457,9 +457,9 @@ class TestZoneLifecycle:
             result = await mcp.call_tool_failure(
                 "ha_get_zone",
                 {"zone_id": "nonexistent_zone_e2e_xyz_404"},
+                expected_error="Zone not found",
             )
 
-        assert result["success"] is False
         assert result["error"]["code"] == "ENTITY_NOT_FOUND"
 
 async def test_zone_search_discovery(mcp_client):

--- a/tests/src/e2e/workflows/zones/test_lifecycle.py
+++ b/tests/src/e2e/workflows/zones/test_lifecycle.py
@@ -451,7 +451,7 @@ class TestZoneLifecycle:
             logger.info("All zone deletions verified")
 
 
-    async def test_get_zone_nonexistent(self, mcp_client):
+    async def test_zone_get_nonexistent(self, mcp_client):
         """Test ha_get_zone returns ENTITY_NOT_FOUND for unknown zone_id."""
         async with MCPAssertions(mcp_client) as mcp:
             result = await mcp.call_tool_failure(


### PR DESCRIPTION
## What does this PR do?

Adds one hard-asserting negative-input test for `ha_get_zone` when called
with a `zone_id` that does not exist. Continues the pattern from the
[#914 discussion](https://github.com/homeassistant-ai/ha-mcp/discussions/914).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change
- [x] 🧪 Tests only

## Background

A2-archetype tools (`ha_get_zone` and similar optional-ID tools) have solid
happy-path coverage but no hard-asserting tests for the not-found path.
`ha_get_zone(zone_id="nonexistent")` hits a distinct client-side branch that
no existing test covers with a hard assertion.

## Test added

**`test_get_zone_nonexistent`** in `test_lifecycle.py`

| Step | Source | Evidence |
|---|---|---|
| WS call `zone/list` succeeds | `tools_zones.py:68–81` | common to all `ha_get_zone` calls |
| `next((z for z in zones if z.get("id") == zone_id), None)` → `None` | `tools_zones.py:91` | no zone matches |
| `raise_tool_error(ENTITY_NOT_FOUND, ...)` | `tools_zones.py:95–100` | no WS error — client-side filter |

Expected: `success=False`, `error["code"] == "ENTITY_NOT_FOUND"`

## Coverage before/after

| Tool | Input | Unit-HARD before | E2E-HARD before | After this PR |
|---|---|---|---|---|
| `ha_get_zone` | `zone_id="nonexistent_zone_e2e_xyz_404"` | ❌ | ❌ | ✅ HARD |

## File placement

`workflows/zones/test_lifecycle.py` — appended to `TestZoneLifecycle` alongside
the existing happy-path and validation tests.

Not in `error_handling/` — per #924 review: that directory is for cross-cutting
concerns, not tool-specific input validation.

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed