### PR TITLE
test(e2e): add negative-input test for ha_config_get_label with nonexistent label_id

### DIFF
--- a/tests/src/e2e/workflows/labels/test_lifecycle.py
+++ b/tests/src/e2e/workflows/labels/test_lifecycle.py
@@ -363,6 +363,18 @@ class TestLabelLifecycle:
 class TestLabelValidation:
     """Test label validation and error handling."""
 
+    async def test_get_label_nonexistent(self, mcp_client):
+        """Test ha_config_get_label returns ENTITY_NOT_FOUND for unknown label_id."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_get_label",
+            {"label_id": "nonexistent_label_e2e_xyz_404"},
+        )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "ENTITY_NOT_FOUND"
+
+
     async def test_update_nonexistent_label(self, mcp_client):
         """Test updating a label that doesn't exist."""
         logger.info("Testing update of nonexistent label...")

--- a/tests/src/e2e/workflows/labels/test_lifecycle.py
+++ b/tests/src/e2e/workflows/labels/test_lifecycle.py
@@ -373,6 +373,8 @@ class TestLabelValidation:
 
         assert result["success"] is False
         assert result["error"]["code"] == "ENTITY_NOT_FOUND"
+        assert "Label not found" in result["error"]["message"]
+        assert "available_label_ids" in result
 
 
     async def test_update_nonexistent_label(self, mcp_client):

--- a/tests/src/e2e/workflows/labels/test_lifecycle.py
+++ b/tests/src/e2e/workflows/labels/test_lifecycle.py
@@ -365,6 +365,8 @@ class TestLabelValidation:
 
     async def test_get_label_nonexistent(self, mcp_client):
         """Test ha_config_get_label returns ENTITY_NOT_FOUND for unknown label_id."""
+        logger.info("Testing get of nonexistent label (label_id=nonexistent_label_e2e_xyz_404)...")
+
         result = await safe_call_tool(
             mcp_client,
             "ha_config_get_label",
@@ -375,6 +377,7 @@ class TestLabelValidation:
         assert result["error"]["code"] == "ENTITY_NOT_FOUND"
         assert "Label not found" in result["error"]["message"]
         assert "available_label_ids" in result
+        logger.info("Nonexistent label get correctly rejected")
 
 
     async def test_update_nonexistent_label(self, mcp_client):


### PR DESCRIPTION
## What does this PR do?

Adds one hard-asserting negative-input test for `ha_config_get_label` when
called with a `label_id` that does not exist. Continues the pattern from the
[#914 discussion](https://github.com/homeassistant-ai/ha-mcp/discussions/914).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change
- [x] 🧪 Tests only

## Background

While mapping A2-archetype coverage (optional ID → list or detail), I found
that `ha_config_get_label(label_id="nonexistent")` has no hard assertion
anywhere in the suite. The existing nonexistent-label tests in
`test_lifecycle.py` cover `ha_config_set_label` (update) and
`ha_config_remove_label` (delete) — not the get path.

## Test added

**`test_get_label_nonexistent`** in `test_lifecycle.py`

| Step | Source | Evidence |
|---|---|---|
| WS call `config/label_registry/list` succeeds | `tools_labels.py:66–79` | common to all `ha_config_get_label` calls |
| `next((lbl for lbl in labels if lbl.get("label_id") == label_id), None)` → `None` | `tools_labels.py:89–91` | no label matches |
| `raise_tool_error(ENTITY_NOT_FOUND, ...)` | `tools_labels.py:102–107` | client-side filter, no WS error |

Expected: `success=False`, `error["code"] == "ENTITY_NOT_FOUND"`

## Coverage before/after

| Tool | Input | Unit-HARD before | E2E-HARD before | After this PR |
|---|---|---|---|---|
| `ha_config_get_label` | `label_id="nonexistent_label_e2e_xyz_404"` | ❌ | ❌ | ✅ HARD |

## Other A2 candidates considered

During the survey I also checked `ha_config_get_category`, `ha_get_blueprint`,
and `ha_get_integration`. None warrant a new PR here:

- **`ha_get_blueprint`** — `test_get_blueprint_not_found` (line 161) already
  uses `call_tool_failure` with a nonexistent path. Hard-covered.
- **`ha_config_get_category`** — `test_get_nonexistent_category` (line 180)
  exists but uses `safe_call_tool` + `data.get("success")` — a soft assertion.
  Same code branch, weaker assertion. An upgrade is possible but falls outside
  the scope of #914 (new branch coverage), which asks for uncovered paths, not
  assertion strengthening.
- **`ha_get_integration`** — a post-delete verification on line 175 uses
  `verify_data.get("success", False)` to confirm the entry is gone. Same
  `_get_single_entry` 404-catch path as a fresh nonexistent ID. Again a soft
  assertion on an already-exercised branch, not an uncovered path.

## File placement

`workflows/labels/test_lifecycle.py` — inserted before the existing
nonexistent-label tests, inside `TestLabelLifecycle`.

Not in `error_handling/` — per #924 review: that directory is for
cross-cutting concerns, not tool-specific input validation.

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed