### PR TITLE
fix: validate entity & service references in automation/script configs

### DIFF
--- a/src/ha_mcp/tools/reference_validator.py
+++ b/src/ha_mcp/tools/reference_validator.py
@@ -1,0 +1,275 @@
+"""Reference validator for automation and script configs.
+
+Walks a config dict and extracts every literal service and entity
+reference, then cross-checks them against the live service and entity
+registries. Produces soft warnings that flow into the existing response
+alongside ``best_practice_warnings``.
+
+Intentional limits (documented, not bugs):
+
+- **Templates** (strings containing ``{{``) are counted and skipped.
+  Jinja is not rendered here; template-safe validation would need
+  ``POST /api/template`` round-trips and is a later follow-up.
+- **Blueprint automations** (``use_blueprint`` at the root) are skipped
+  wholesale. Post-substitution config is not exposed by any HA API, so
+  the effective refs cannot be ground-truthed.
+- **``device_id`` / ``area_id`` / ``label_id``** are NOT checked yet.
+  They require separate registry fetches and are planned for a later
+  pass; see #940.
+
+Background: #940 (hallucinated ``notify.mobile_app_andrew_phone`` that
+``ha_config_set_automation`` accepted silently).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, TypedDict
+
+logger = logging.getLogger(__name__)
+
+# Keys whose value (literal string) names a Home Assistant service in
+# the form ``<domain>.<service_name>``. Both legacy (``service:``) and
+# the new-style (``action:``) keys are recognized — HA accepts either
+# inside automation/script action blocks.
+_SERVICE_KEYS: frozenset[str] = frozenset({"service", "action"})
+
+# Keys whose value (string or list of strings) names an entity. These
+# appear in triggers, conditions, ``target:`` blocks, and service
+# ``data:`` blocks — the walker is depth-agnostic so the location
+# doesn't matter.
+_ENTITY_KEYS: frozenset[str] = frozenset({"entity_id"})
+
+
+class ExtractedRef(TypedDict):
+    """One reference pulled out of the config tree."""
+
+    path: str
+    value: str
+    kind: str  # "service" | "entity"
+
+
+class WalkerResult(TypedDict):
+    """Return value of :func:`extract_refs`."""
+
+    refs: list[ExtractedRef]
+    unvalidated_templates: int
+    blueprint_skipped: bool
+
+
+class ValidationWarning(TypedDict):
+    """One warning in the tool response."""
+
+    path: str
+    value: str
+    kind: str
+    reason: str
+
+
+def extract_refs(config: Any) -> WalkerResult:
+    """Pull every literal service/entity reference out of *config*.
+
+    Pure function: no network, no mutation of the input. The caller
+    decides what to do with the extracted refs.
+
+    Blueprint configs short-circuit with an empty ref list and
+    ``blueprint_skipped=True`` — the effective post-substitution config
+    is not reachable from ha-mcp, so it cannot be validated.
+    """
+    if isinstance(config, dict) and "use_blueprint" in config:
+        return {
+            "refs": [],
+            "unvalidated_templates": 0,
+            "blueprint_skipped": True,
+        }
+
+    refs: list[ExtractedRef] = []
+    # Wrapped in a single-element list so the inner closure can mutate
+    # it without a ``nonlocal`` dance.
+    unvalidated_templates = [0]
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                sub_path = f"{path}.{key}" if path else key
+
+                if key in _SERVICE_KEYS and isinstance(value, str):
+                    if _is_template(value):
+                        unvalidated_templates[0] += 1
+                    else:
+                        refs.append(
+                            {"path": sub_path, "value": value, "kind": "service"}
+                        )
+                    continue
+
+                if key in _ENTITY_KEYS:
+                    if isinstance(value, str):
+                        if _is_template(value):
+                            unvalidated_templates[0] += 1
+                        else:
+                            refs.append(
+                                {"path": sub_path, "value": value, "kind": "entity"}
+                            )
+                        continue
+                    if isinstance(value, list):
+                        for i, item in enumerate(value):
+                            if not isinstance(item, str):
+                                continue
+                            item_path = f"{sub_path}[{i}]"
+                            if _is_template(item):
+                                unvalidated_templates[0] += 1
+                            else:
+                                refs.append(
+                                    {
+                                        "path": item_path,
+                                        "value": item,
+                                        "kind": "entity",
+                                    }
+                                )
+                        continue
+
+                # Neither a service nor an entity key: recurse so deeply
+                # nested action blocks (choose/if/parallel/repeat) still
+                # get walked.
+                _walk(value, sub_path)
+
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                _walk(item, f"{path}[{i}]")
+        # Primitives: nothing to extract.
+
+    _walk(config, "")
+    return {
+        "refs": refs,
+        "unvalidated_templates": unvalidated_templates[0],
+        "blueprint_skipped": False,
+    }
+
+
+def _is_template(value: str) -> bool:
+    """Return True if *value* looks like a Jinja template."""
+    return "{{" in value
+
+
+def build_service_index(services_payload: Any) -> dict[str, set[str]]:
+    """Turn ``/api/services`` output into a ``{domain: {services}}`` map.
+
+    HA returns a list of ``{"domain": str, "services": {name: {...}}}``
+    objects — one per domain. Any malformed entry is skipped silently.
+    """
+    index: dict[str, set[str]] = {}
+    if not isinstance(services_payload, list):
+        return index
+    for entry in services_payload:
+        if not isinstance(entry, dict):
+            continue
+        domain = entry.get("domain")
+        services = entry.get("services")
+        if not isinstance(domain, str) or not isinstance(services, dict):
+            continue
+        index[domain] = set(services.keys())
+    return index
+
+
+def build_entity_set(states_payload: Any) -> set[str]:
+    """Turn ``/api/states`` output into a set of entity_ids."""
+    entities: set[str] = set()
+    if not isinstance(states_payload, list):
+        return entities
+    for entry in states_payload:
+        if isinstance(entry, dict):
+            entity_id = entry.get("entity_id")
+            if isinstance(entity_id, str):
+                entities.add(entity_id)
+    return entities
+
+
+def check_refs(
+    refs: list[ExtractedRef],
+    service_index: dict[str, set[str]],
+    entity_set: set[str],
+) -> list[ValidationWarning]:
+    """Return one warning per ref that isn't in the registry."""
+    warnings: list[ValidationWarning] = []
+    for ref in refs:
+        value = ref["value"]
+        if ref["kind"] == "service":
+            domain, _, service_name = value.partition(".")
+            if (
+                not service_name
+                or domain not in service_index
+                or service_name not in service_index[domain]
+            ):
+                warnings.append(
+                    {
+                        "path": ref["path"],
+                        "value": value,
+                        "kind": "service",
+                        "reason": "not found in service registry",
+                    }
+                )
+        elif ref["kind"] == "entity":
+            if value not in entity_set:
+                warnings.append(
+                    {
+                        "path": ref["path"],
+                        "value": value,
+                        "kind": "entity",
+                        "reason": "not found in entity registry",
+                    }
+                )
+    return warnings
+
+
+async def validate_config_references(
+    client: Any, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Walk *config*, fetch registries, return validation metadata.
+
+    Errors from the two registry fetches are logged and swallowed so
+    validation can never break the happy path of
+    ``ha_config_set_automation`` / ``ha_config_set_script``.
+
+    Returns a dict with three keys:
+
+    - ``warnings`` - list of :class:`ValidationWarning`, empty on success
+    - ``unvalidated_templates`` - int, templated strings skipped by the
+      walker
+    - ``blueprint_skipped`` - bool, True iff the root config uses
+      ``use_blueprint``
+    """
+    walker_result = extract_refs(config)
+
+    if walker_result["blueprint_skipped"] or not walker_result["refs"]:
+        return {
+            "warnings": [],
+            "unvalidated_templates": walker_result["unvalidated_templates"],
+            "blueprint_skipped": walker_result["blueprint_skipped"],
+        }
+
+    try:
+        services_payload, states_payload = await asyncio.gather(
+            client.get_services(),
+            client.get_states(),
+        )
+    except Exception:
+        logger.exception(
+            "Reference validator: failed to fetch service/entity registries; "
+            "skipping validation for this call"
+        )
+        return {
+            "warnings": [],
+            "unvalidated_templates": walker_result["unvalidated_templates"],
+            "blueprint_skipped": False,
+        }
+
+    service_index = build_service_index(services_payload)
+    entity_set = build_entity_set(states_payload)
+    warnings = check_refs(walker_result["refs"], service_index, entity_set)
+
+    return {
+        "warnings": warnings,
+        "unvalidated_templates": walker_result["unvalidated_templates"],
+        "blueprint_skipped": False,
+    }

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -29,6 +29,7 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .reference_validator import validate_config_references
 from .util_helpers import (
     apply_entity_category,
     coerce_bool_param,
@@ -157,6 +158,32 @@ def _normalize_trigger_keys(triggers: list[dict[str, Any]]) -> list[dict[str, An
             normalized_trigger["platform"] = normalized_trigger.pop("trigger")
         normalized_triggers.append(normalized_trigger)
     return normalized_triggers
+
+
+def _merge_validation_meta(
+    result: dict[str, Any], validation_meta: dict[str, Any]
+) -> None:
+    """Attach reference-validator output to a set-tool success ``result``.
+
+    Produces a single nested ``validation`` field when there's anything
+    worth reporting — warnings, skipped templates, or a blueprint
+    short-circuit. Keeps the happy-path response unchanged.
+    """
+    warnings = validation_meta.get("warnings") or []
+    unvalidated_templates = validation_meta.get("unvalidated_templates") or 0
+    blueprint_skipped = bool(validation_meta.get("blueprint_skipped"))
+
+    if not warnings and not unvalidated_templates and not blueprint_skipped:
+        return
+
+    entry: dict[str, Any] = {}
+    if warnings:
+        entry["warnings"] = warnings
+    if unvalidated_templates:
+        entry["unvalidated_templates"] = unvalidated_templates
+    if blueprint_skipped:
+        entry["blueprint_skipped"] = True
+    result["validation"] = entry
 
 
 def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
@@ -470,6 +497,13 @@ class AutomationConfigTools:
                 config_dict, skill_prefix=_get_skill_prefix()
             )
 
+            # Cross-check literal service and entity references against
+            # the live registries. Soft warnings only — the write still
+            # happens, even when references don't resolve (#940).
+            validation_meta = await validate_config_references(
+                self._client, config_dict
+            )
+
             result = await self._client.upsert_automation_config(config_dict, identifier)
 
             # If the client could not verify the entity was registered, warn but don't hard-fail.
@@ -505,6 +539,8 @@ class AutomationConfigTools:
 
             if bp_warnings:
                 result["best_practice_warnings"] = bp_warnings
+
+            _merge_validation_meta(result, validation_meta)
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -34,6 +34,7 @@ from .util_helpers import (
     apply_entity_category,
     coerce_bool_param,
     fetch_entity_category,
+    merge_validation_meta,
     parse_json_param,
     wait_for_entity_registered,
     wait_for_entity_removed,
@@ -158,32 +159,6 @@ def _normalize_trigger_keys(triggers: list[dict[str, Any]]) -> list[dict[str, An
             normalized_trigger["platform"] = normalized_trigger.pop("trigger")
         normalized_triggers.append(normalized_trigger)
     return normalized_triggers
-
-
-def _merge_validation_meta(
-    result: dict[str, Any], validation_meta: dict[str, Any]
-) -> None:
-    """Attach reference-validator output to a set-tool success ``result``.
-
-    Produces a single nested ``validation`` field when there's anything
-    worth reporting — warnings, skipped templates, or a blueprint
-    short-circuit. Keeps the happy-path response unchanged.
-    """
-    warnings = validation_meta.get("warnings") or []
-    unvalidated_templates = validation_meta.get("unvalidated_templates") or 0
-    blueprint_skipped = bool(validation_meta.get("blueprint_skipped"))
-
-    if not warnings and not unvalidated_templates and not blueprint_skipped:
-        return
-
-    entry: dict[str, Any] = {}
-    if warnings:
-        entry["warnings"] = warnings
-    if unvalidated_templates:
-        entry["unvalidated_templates"] = unvalidated_templates
-    if blueprint_skipped:
-        entry["blueprint_skipped"] = True
-    result["validation"] = entry
 
 
 def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
@@ -540,7 +515,7 @@ class AutomationConfigTools:
             if bp_warnings:
                 result["best_practice_warnings"] = bp_warnings
 
-            _merge_validation_meta(result, validation_meta)
+            merge_validation_meta(result, validation_meta)
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -26,11 +26,11 @@ from .helpers import (
     register_tool_methods,
 )
 from .reference_validator import validate_config_references
-from .tools_config_automations import _merge_validation_meta
 from .util_helpers import (
     apply_entity_category,
     coerce_bool_param,
     fetch_entity_category,
+    merge_validation_meta,
     parse_json_param,
     wait_for_entity_registered,
     wait_for_entity_removed,
@@ -359,7 +359,7 @@ class ConfigScriptTools:
             if bp_warnings:
                 result["best_practice_warnings"] = bp_warnings
 
-            _merge_validation_meta(result, validation_meta)
+            merge_validation_meta(result, validation_meta)
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -25,6 +25,8 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .reference_validator import validate_config_references
+from .tools_config_automations import _merge_validation_meta
 from .util_helpers import (
     apply_entity_category,
     coerce_bool_param,
@@ -328,6 +330,13 @@ class ConfigScriptTools:
                 config_dict, skill_prefix=_get_skill_prefix()
             )
 
+            # Cross-check literal service and entity references against
+            # the live registries. Soft warnings only — the write still
+            # happens, even when references don't resolve (#940).
+            validation_meta = await validate_config_references(
+                self._client, config_dict
+            )
+
             result = await self._client.upsert_script_config(config_dict, script_id)
 
             # Wait for script to be queryable
@@ -349,6 +358,8 @@ class ConfigScriptTools:
 
             if bp_warnings:
                 result["best_practice_warnings"] = bp_warnings
+
+            _merge_validation_meta(result, validation_meta)
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -530,3 +530,34 @@ async def apply_entity_category(
         result_dict["category_warning"] = (
             f"{entity_type.capitalize()} saved but failed to set category: {e}"
         )
+
+
+def merge_validation_meta(
+    result: dict[str, Any], validation_meta: dict[str, Any]
+) -> None:
+    """Attach reference-validator output to a set-tool success ``result``.
+
+    Produces a single nested ``validation`` field when there's anything
+    worth reporting - warnings, skipped templates, or a blueprint
+    short-circuit. Keeps the happy-path response unchanged.
+
+    Shared between ``ha_config_set_automation`` and
+    ``ha_config_set_script``; see
+    :mod:`ha_mcp.tools.reference_validator` for the validator itself
+    and #940 for background.
+    """
+    warnings = validation_meta.get("warnings") or []
+    unvalidated_templates = validation_meta.get("unvalidated_templates") or 0
+    blueprint_skipped = bool(validation_meta.get("blueprint_skipped"))
+
+    if not warnings and not unvalidated_templates and not blueprint_skipped:
+        return
+
+    entry: dict[str, Any] = {}
+    if warnings:
+        entry["warnings"] = warnings
+    if unvalidated_templates:
+        entry["unvalidated_templates"] = unvalidated_templates
+    if blueprint_skipped:
+        entry["blueprint_skipped"] = True
+    result["validation"] = entry

--- a/tests/src/unit/test_reference_validator.py
+++ b/tests/src/unit/test_reference_validator.py
@@ -1,0 +1,481 @@
+"""Unit tests for reference_validator.
+
+Covers the extraction walker (pure, sync), the registry index builders,
+the check layer, and the end-to-end async runner with a mock client.
+Regression coverage for #940: a hallucinated
+``notify.mobile_app_andrew_phone`` must produce a warning, not a
+silent success.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.tools.reference_validator import (
+    build_entity_set,
+    build_service_index,
+    check_refs,
+    extract_refs,
+    validate_config_references,
+)
+
+# ---------------------------------------------------------------------------
+# extract_refs — pure walker
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRefs:
+    def test_empty_config(self):
+        result = extract_refs({})
+        assert result["refs"] == []
+        assert result["unvalidated_templates"] == 0
+        assert result["blueprint_skipped"] is False
+
+    def test_flat_service_call(self):
+        config = {
+            "alias": "t",
+            "trigger": [{"platform": "time", "at": "07:00:00"}],
+            "action": [
+                {"service": "light.turn_on", "target": {"entity_id": "light.kitchen"}}
+            ],
+        }
+        result = extract_refs(config)
+        kinds = sorted((r["kind"], r["value"]) for r in result["refs"])
+        assert kinds == [("entity", "light.kitchen"), ("service", "light.turn_on")]
+
+    def test_hallucinated_service_is_extracted(self):
+        """#940 reproduction: the bogus notify service must be extracted."""
+        config = {
+            "alias": "battery_alert",
+            "trigger": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.grid_status_battery_percentage",
+                    "below": 50,
+                }
+            ],
+            "action": [{"service": "notify.mobile_app_andrew_phone"}],
+        }
+        result = extract_refs(config)
+        services = [r for r in result["refs"] if r["kind"] == "service"]
+        entities = [r for r in result["refs"] if r["kind"] == "entity"]
+        assert len(services) == 1
+        assert services[0]["value"] == "notify.mobile_app_andrew_phone"
+        assert len(entities) == 1
+        assert entities[0]["value"] == "sensor.grid_status_battery_percentage"
+
+    def test_action_alias_for_service_key(self):
+        """HA accepts both `service:` and `action:` as the call key."""
+        config = {"action": [{"action": "light.turn_on"}]}
+        result = extract_refs(config)
+        assert [r["value"] for r in result["refs"]] == ["light.turn_on"]
+
+    def test_entity_id_as_list(self):
+        config = {
+            "action": [
+                {
+                    "service": "light.turn_on",
+                    "target": {"entity_id": ["light.a", "light.b", "light.c"]},
+                }
+            ]
+        }
+        result = extract_refs(config)
+        entities = sorted(r["value"] for r in result["refs"] if r["kind"] == "entity")
+        assert entities == ["light.a", "light.b", "light.c"]
+
+    def test_entity_id_in_trigger(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "binary_sensor.motion"}],
+            "action": [],
+        }
+        result = extract_refs(config)
+        assert any(
+            r["kind"] == "entity" and r["value"] == "binary_sensor.motion"
+            for r in result["refs"]
+        )
+
+    def test_nested_choose_action(self):
+        config = {
+            "action": [
+                {
+                    "choose": [
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "state",
+                                    "entity_id": "sun.sun",
+                                    "state": "above_horizon",
+                                }
+                            ],
+                            "sequence": [
+                                {
+                                    "service": "cover.open_cover",
+                                    "target": {"entity_id": "cover.garage"},
+                                }
+                            ],
+                        }
+                    ],
+                    "default": [
+                        {
+                            "service": "light.turn_off",
+                            "target": {"entity_id": "light.porch"},
+                        }
+                    ],
+                }
+            ]
+        }
+        result = extract_refs(config)
+        service_values = {r["value"] for r in result["refs"] if r["kind"] == "service"}
+        entity_values = {r["value"] for r in result["refs"] if r["kind"] == "entity"}
+        assert service_values == {"cover.open_cover", "light.turn_off"}
+        assert entity_values == {"sun.sun", "cover.garage", "light.porch"}
+
+    def test_repeat_and_parallel(self):
+        config = {
+            "action": [
+                {
+                    "repeat": {
+                        "count": 3,
+                        "sequence": [
+                            {
+                                "service": "light.toggle",
+                                "target": {"entity_id": "light.a"},
+                            }
+                        ],
+                    }
+                },
+                {
+                    "parallel": [
+                        {
+                            "service": "switch.turn_on",
+                            "target": {"entity_id": "switch.x"},
+                        },
+                        {
+                            "service": "switch.turn_on",
+                            "target": {"entity_id": "switch.y"},
+                        },
+                    ]
+                },
+            ]
+        }
+        result = extract_refs(config)
+        entities = sorted(r["value"] for r in result["refs"] if r["kind"] == "entity")
+        assert entities == ["light.a", "switch.x", "switch.y"]
+
+    def test_template_service_is_skipped_and_counted(self):
+        config = {"action": [{"service": "{{ 'light.turn_on' }}"}]}
+        result = extract_refs(config)
+        assert result["refs"] == []
+        assert result["unvalidated_templates"] == 1
+
+    def test_template_entity_is_skipped_and_counted(self):
+        config = {
+            "action": [
+                {
+                    "service": "light.turn_on",
+                    "target": {"entity_id": "{{ states('input_text.target') }}"},
+                }
+            ]
+        }
+        result = extract_refs(config)
+        services = [r for r in result["refs"] if r["kind"] == "service"]
+        assert len(services) == 1
+        entities = [r for r in result["refs"] if r["kind"] == "entity"]
+        assert entities == []
+        assert result["unvalidated_templates"] == 1
+
+    def test_template_in_entity_list_only_skips_that_entry(self):
+        config = {
+            "action": [
+                {
+                    "service": "light.turn_on",
+                    "target": {
+                        "entity_id": ["light.kitchen", "{{ var }}", "light.hallway"]
+                    },
+                }
+            ]
+        }
+        result = extract_refs(config)
+        entities = sorted(r["value"] for r in result["refs"] if r["kind"] == "entity")
+        assert entities == ["light.hallway", "light.kitchen"]
+        assert result["unvalidated_templates"] == 1
+
+    def test_blueprint_short_circuits(self):
+        config = {
+            "alias": "blueprint auto",
+            "use_blueprint": {
+                "path": "homeassistant/motion_light.yaml",
+                "input": {
+                    "motion_entity": "binary_sensor.motion",
+                    "light_target": {"entity_id": "light.hallway"},
+                },
+            },
+        }
+        result = extract_refs(config)
+        assert result["refs"] == []
+        assert result["blueprint_skipped"] is True
+        assert result["unvalidated_templates"] == 0
+
+    def test_path_tracking(self):
+        config = {
+            "action": [
+                {"service": "light.turn_on"},
+                {"service": "fan.turn_on", "target": {"entity_id": "fan.ceiling"}},
+            ]
+        }
+        result = extract_refs(config)
+        paths = {r["path"] for r in result["refs"]}
+        assert "action[0].service" in paths
+        assert "action[1].service" in paths
+        assert "action[1].target.entity_id" in paths
+
+    def test_non_string_service_values_ignored(self):
+        """A non-string service value shouldn't crash the walker."""
+        config = {"action": [{"service": 42, "data": {"entity_id": None}}]}
+        result = extract_refs(config)
+        assert result["refs"] == []
+
+
+# ---------------------------------------------------------------------------
+# build_service_index / build_entity_set
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIndices:
+    def test_build_service_index_shape(self):
+        payload = [
+            {
+                "domain": "light",
+                "services": {"turn_on": {}, "turn_off": {}, "toggle": {}},
+            },
+            {
+                "domain": "notify",
+                "services": {
+                    "persistent_notification": {},
+                    "mobile_app_real_phone": {},
+                },
+            },
+        ]
+        index = build_service_index(payload)
+        assert index["light"] == {"turn_on", "turn_off", "toggle"}
+        assert "mobile_app_real_phone" in index["notify"]
+
+    def test_build_service_index_ignores_malformed(self):
+        payload = [
+            {"domain": "light", "services": {"turn_on": {}}},
+            "garbage",
+            {"domain": None, "services": {}},
+            {"domain": "switch"},  # missing services
+        ]
+        index = build_service_index(payload)
+        assert index == {"light": {"turn_on"}}
+
+    def test_build_service_index_non_list(self):
+        assert build_service_index(None) == {}
+        assert build_service_index({}) == {}
+
+    def test_build_entity_set(self):
+        payload = [
+            {"entity_id": "light.kitchen", "state": "on"},
+            {"entity_id": "sensor.temp", "state": "21.5"},
+            {"entity_id": None},
+            "bad_entry",
+        ]
+        entities = build_entity_set(payload)
+        assert entities == {"light.kitchen", "sensor.temp"}
+
+
+# ---------------------------------------------------------------------------
+# check_refs
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRefs:
+    @pytest.fixture
+    def service_index(self) -> dict[str, set[str]]:
+        return {
+            "light": {"turn_on", "turn_off"},
+            "notify": {"persistent_notification"},
+        }
+
+    @pytest.fixture
+    def entity_set(self) -> set[str]:
+        return {"light.kitchen", "sensor.temp", "binary_sensor.motion"}
+
+    def test_valid_service_no_warning(self, service_index, entity_set):
+        refs = [
+            {"path": "action[0].service", "value": "light.turn_on", "kind": "service"}
+        ]
+        assert check_refs(refs, service_index, entity_set) == []
+
+    def test_missing_service_warned(self, service_index, entity_set):
+        refs = [
+            {
+                "path": "action[0].service",
+                "value": "notify.mobile_app_andrew_phone",
+                "kind": "service",
+            }
+        ]
+        warnings = check_refs(refs, service_index, entity_set)
+        assert len(warnings) == 1
+        assert warnings[0]["kind"] == "service"
+        assert warnings[0]["value"] == "notify.mobile_app_andrew_phone"
+        assert "not found" in warnings[0]["reason"]
+
+    def test_bogus_domain_warned(self, service_index, entity_set):
+        refs = [{"path": "p", "value": "bogus.thing", "kind": "service"}]
+        warnings = check_refs(refs, service_index, entity_set)
+        assert len(warnings) == 1
+
+    def test_service_without_dot_warned(self, service_index, entity_set):
+        refs = [{"path": "p", "value": "not_a_service", "kind": "service"}]
+        warnings = check_refs(refs, service_index, entity_set)
+        assert len(warnings) == 1
+
+    def test_valid_entity_no_warning(self, service_index, entity_set):
+        refs = [
+            {"path": "trigger[0].entity_id", "value": "light.kitchen", "kind": "entity"}
+        ]
+        assert check_refs(refs, service_index, entity_set) == []
+
+    def test_missing_entity_warned(self, service_index, entity_set):
+        refs = [
+            {"path": "trigger[0].entity_id", "value": "sensor.ghost", "kind": "entity"}
+        ]
+        warnings = check_refs(refs, service_index, entity_set)
+        assert len(warnings) == 1
+        assert warnings[0]["kind"] == "entity"
+        assert warnings[0]["value"] == "sensor.ghost"
+
+    def test_mixed_refs_partial_failure(self, service_index, entity_set):
+        refs = [
+            {"path": "action[0].service", "value": "light.turn_on", "kind": "service"},
+            {
+                "path": "action[0].target.entity_id",
+                "value": "light.ghost",
+                "kind": "entity",
+            },
+            {
+                "path": "trigger[0].entity_id",
+                "value": "binary_sensor.motion",
+                "kind": "entity",
+            },
+        ]
+        warnings = check_refs(refs, service_index, entity_set)
+        assert len(warnings) == 1
+        assert warnings[0]["value"] == "light.ghost"
+
+
+# ---------------------------------------------------------------------------
+# validate_config_references — async end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _mock_client(services_payload: Any, states_payload: Any) -> Any:
+    client = AsyncMock()
+    client.get_services = AsyncMock(return_value=services_payload)
+    client.get_states = AsyncMock(return_value=states_payload)
+    return client
+
+
+class TestValidateConfigReferences:
+    @pytest.mark.anyio
+    async def test_940_reproduction_produces_warning(self):
+        """The exact scenario from #940 must yield a service warning."""
+        config = {
+            "alias": "battery_alert",
+            "trigger": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.grid_status_battery_percentage",
+                    "below": 50,
+                }
+            ],
+            "action": [{"service": "notify.mobile_app_andrew_phone"}],
+        }
+        client = _mock_client(
+            services_payload=[
+                {"domain": "notify", "services": {"persistent_notification": {}}},
+            ],
+            states_payload=[
+                {"entity_id": "sensor.grid_status_battery_percentage", "state": "45"},
+            ],
+        )
+        result = await validate_config_references(client, config)
+        assert result["blueprint_skipped"] is False
+        assert result["unvalidated_templates"] == 0
+        warnings = result["warnings"]
+        assert len(warnings) == 1
+        assert warnings[0]["kind"] == "service"
+        assert warnings[0]["value"] == "notify.mobile_app_andrew_phone"
+
+    @pytest.mark.anyio
+    async def test_all_valid_no_warnings(self):
+        config = {
+            "action": [
+                {"service": "light.turn_on", "target": {"entity_id": "light.kitchen"}}
+            ]
+        }
+        client = _mock_client(
+            services_payload=[{"domain": "light", "services": {"turn_on": {}}}],
+            states_payload=[{"entity_id": "light.kitchen", "state": "off"}],
+        )
+        result = await validate_config_references(client, config)
+        assert result["warnings"] == []
+
+    @pytest.mark.anyio
+    async def test_blueprint_short_circuits_no_fetch(self):
+        """Blueprint configs must not even hit the registries."""
+        config = {
+            "alias": "bp",
+            "use_blueprint": {
+                "path": "homeassistant/motion_light.yaml",
+                "input": {"motion_entity": "binary_sensor.motion"},
+            },
+        }
+        client = _mock_client(services_payload=[], states_payload=[])
+        result = await validate_config_references(client, config)
+        assert result["blueprint_skipped"] is True
+        assert result["warnings"] == []
+        client.get_services.assert_not_called()
+        client.get_states.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_registry_fetch_failure_is_swallowed(self, caplog):
+        """A broken client must never break the automation write path."""
+        config = {"action": [{"service": "light.turn_on"}]}
+        client = AsyncMock()
+        client.get_services = AsyncMock(side_effect=RuntimeError("boom"))
+        client.get_states = AsyncMock(return_value=[])
+        with caplog.at_level("ERROR"):
+            result = await validate_config_references(client, config)
+        assert result["warnings"] == []
+        assert any("validator" in rec.message.lower() for rec in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_empty_config_no_fetch(self):
+        """No refs → no registry fetches, no warnings."""
+        client = _mock_client(services_payload=[], states_payload=[])
+        result = await validate_config_references(client, {"alias": "empty"})
+        assert result["warnings"] == []
+        client.get_services.assert_not_called()
+        client.get_states.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_templates_counted_not_warned(self):
+        config = {
+            "action": [
+                {"service": "{{ 'light.turn_on' }}"},
+                {"service": "light.turn_off", "target": {"entity_id": "light.real"}},
+            ]
+        }
+        client = _mock_client(
+            services_payload=[{"domain": "light", "services": {"turn_off": {}}}],
+            states_payload=[{"entity_id": "light.real", "state": "on"}],
+        )
+        result = await validate_config_references(client, config)
+        assert result["warnings"] == []
+        assert result["unvalidated_templates"] == 1

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -36,6 +36,10 @@ class TestScriptToolsValidation:
         client.get_entity_state = AsyncMock(
             return_value={"state": "off", "entity_id": "script.test_script"}
         )
+        # Reference validator (#940) calls these during set_script;
+        # provide empty-but-valid payloads so the walker runs.
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
         return client
 
     @pytest.fixture

--- a/tests/src/unit/test_wait_parameter.py
+++ b/tests/src/unit/test_wait_parameter.py
@@ -47,6 +47,9 @@ class TestAutomationWaitParameter:
                 }
             ]
         )
+        # Reference validator (#940) calls these during set_*; provide
+        # empty-but-valid payloads so the walker runs without errors.
+        client.get_services = AsyncMock(return_value=[])
         return client
 
     @pytest.fixture
@@ -215,6 +218,10 @@ class TestScriptWaitParameter:
         client.get_entity_state = AsyncMock(
             return_value={"state": "off", "entity_id": "script.test_script"}
         )
+        # Reference validator (#940) calls these during set_script;
+        # provide empty-but-valid payloads so the walker runs.
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
         return client
 
     @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Closes #940.

Completes the second half of #940: automation and script writes now
cross-check literal entity and service references against the live HA
registries before returning. Hallucinated references like
\`notify.mobile_app_andrew_phone\` — the exact symptom reported — now
surface as soft \`validation.warnings\` on the response instead of
being silently accepted.

PR #955 addressed the retrieval side (claude.ai BM25 ranking). This
PR addresses the validation side.

### Why a local walker

HA Core's own validators cannot catch hallucinated services.
\`homeassistant/helpers/script.py\` lists \`SCRIPT_ACTION_CALL_SERVICE\`
in \`STATIC_VALIDATION_ACTION_TYPES\`, and the inline comment is
explicit: *"This check ignores services that do not exist which will
raise an appropriate error in the service call below."* The WS
\`validate_config\` command and \`homeassistant.check_config\` service
go through the same blindspot, so local walking is the only option.

### Design

New module \`src/ha_mcp/tools/reference_validator.py\`:

1. **\`extract_refs(config)\`** — pure sync walker, depth-agnostic.
   Finds every literal \`service:\` / \`action:\` key and every
   \`entity_id:\` value (string or list) in the config tree. Tracks
   JSON-pointer-style paths like \`action[0].target.entity_id\` for
   precise warning locations. Skips blueprint automations wholesale
   (post-substitution config is not reachable via HA APIs). Skips
   templated fields (\`"{{\` in value) and counts them separately.
2. **\`build_service_index\` / \`build_entity_set\`** — turn the
   \`/api/services\` and \`/api/states\` payloads into fast lookup
   structures.
3. **\`check_refs(refs, service_index, entity_set)\`** — cross-check
   each extracted ref; emit one \`ValidationWarning\` per missing ref.
4. **\`validate_config_references(client, config)\`** — async
   end-to-end. One parallel \`asyncio.gather\` call for services +
   states. Registry fetch failures are logged and swallowed so the
   validator can never break the set-tool happy path.

Plumbed into \`ha_config_set_automation\` and \`ha_config_set_script\`
next to the existing \`best_practice_warnings\` flow. A shared
\`_merge_validation_meta\` helper produces a nested \`validation\`
field on success responses only when there is something to report.

### Soft warnings, never blocking

The write still happens. Users legitimately reference services from
disabled integrations (they re-enable later), and a hard block would
break those flows. The validator is informational — agents see the
warnings and self-correct.

### Intentional v1 limits (documented in the module docstring)

- **Templates** are skipped and counted, not rendered. Template-safe
  validation would need \`POST /api/template\` round-trips per
  fragment — a follow-up.
- **Blueprints** short-circuit with \`blueprint_skipped: true\`. HA
  does not expose the post-substitution config.
- **\`device_id\` / \`area_id\` / \`label_id\`** are not checked.
  These need separate registry fetches and are a planned follow-up.
- **Read-path \`validate=True\` flag** on the matching get-tools is
  not in this PR. Easy ~20-line follow-up once this shape is
  validated in the wild.

### Response shape

The new \`validation\` field is *entirely omitted* when there is
nothing to report — happy path response shape is unchanged.

\`\`\`json
{
  "success": true,
  "action": "set",
  "entity_id": "automation.foo",
  "best_practice_warnings": [],
  "validation": {
    "warnings": [
      {"path": "action[0].service",
       "value": "notify.mobile_app_andrew_phone",
       "kind": "service",
       "reason": "not found in service registry"}
    ]
  }
}
\`\`\`

### Tests

34 new unit tests in \`tests/src/unit/test_reference_validator.py\`:

- \`TestExtractRefs\` (14) — flat and nested walker coverage,
  choose/if, repeat/parallel, entity_id as string and list, template
  skipping, blueprint short-circuit, path tracking, non-string value
  safety.
- \`TestRegistryIndices\` (4) — service index shape, malformed input
  handling, entity set.
- \`TestCheckRefs\` (7) — valid/invalid services (including
  \`notify.mobile_app_andrew_phone\`), bogus domains, services
  without a dot, entities, mixed partial failure.
- \`TestValidateConfigReferences\` (6) — end-to-end with mocked
  client, including the exact #940 reproduction, fetch-failure path
  (caplog asserts swallowed error), blueprint short-circuit (asserts
  registry fetches are NOT called), template counting.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`) — CI
- [x] Code follows style guidelines (\`uv run ruff check\`)

## Checklist
- [x] Documentation updated where needed (module docstring explicitly
      calls out the v1 limits and references #940)

## Notes

This PR is based on \`upstream/master\`, **not** on #955's branch. The
two PRs address different halves of the same issue and don't touch
overlapping code. Both can merge in either order.