### PR TITLE
fix(history): add "year" to valid statistics periods

### DIFF
--- a/site/src/data/tools.json
+++ b/site/src/data/tools.json
@@ -1626,7 +1626,7 @@
           "default": null
         },
         "period": {
-          "type": "Annotated[str, Field(description='Aggregation period: \"5minute\", \"hour\", \"day\", \"week\", \"month\". Default: \"day\". Ignored when source=\"history\"', default='day')]",
+          "type": "Annotated[str, Field(description='Aggregation period: \"5minute\", \"hour\", \"day\", \"week\", \"month\", \"year\". Default: \"day\". Ignored when source=\"history\"', default='day')]",
           "default": "day"
         },
         "statistic_types": {

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -186,7 +186,7 @@ class HistoryTools:
         period: Annotated[
             str,
             Field(
-                description='Aggregation period: "5minute", "hour", "day", "week", "month". Default: "day". Ignored when source="history"',
+                description='Aggregation period: "5minute", "hour", "day", "week", "month", "year". Default: "day". Ignored when source="history"',
                 default="day",
             ),
         ] = "day",
@@ -481,7 +481,7 @@ async def _fetch_statistics(
 ) -> dict[str, Any]:
     """Execute the recorder/statistics_during_period WebSocket call."""
     # Validate period
-    valid_periods = ["5minute", "hour", "day", "week", "month"]
+    valid_periods = ["5minute", "hour", "day", "week", "month", "year"]
     if period not in valid_periods:
         raise_tool_error(create_error_response(
             ErrorCode.VALIDATION_INVALID_PARAMETER,

--- a/tests/src/e2e/workflows/core/test_history.py
+++ b/tests/src/e2e/workflows/core/test_history.py
@@ -439,7 +439,7 @@ class TestGetHistoryStatisticsSource:
 
         test_sensor = sensors[0].get("entity_id")
 
-        periods = ["5minute", "hour", "day", "week", "month"]
+        periods = ["5minute", "hour", "day", "week", "month", "year"]
 
         for period in periods:
             result = await mcp_client.call_tool(


### PR DESCRIPTION
## What

Adds `"year"` to the valid statistics periods in `_fetch_statistics`.

HA's `recorder/statistics_during_period` WebSocket API explicitly accepts `"year"` as a valid period (verified in `homeassistant/core` — `homeassistant/components/recorder/websocket_api.py`):

```python
vol.Required("period"): vol.Any("5minute", "hour", "day", "week", "month", "year")
```

The tool validator was missing it — an oversight from the original implementation that was carried over unchanged into #911. Passing `period="year"` currently raises `VALIDATION_INVALID_PARAMETER` even though HA would accept it.

Also fixes `test_get_statistics_different_periods` in the E2E suite (added in #945), which mirrored the incomplete `valid_periods` list.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [x] `test_get_statistics_different_periods` updated to include `"year"`
- [x] Existing `test_get_statistics_invalid_period` continues to reject non-listed values
- [x] All automated tests pass

## Checklist

- [x] I have updated documentation if needed (`tools.json` period description updated)