### PR TITLE
test(e2e): add A5 negative-input tests for ha_config_set_automation and ha_config_set_helper

### DIFF
--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -1305,6 +1305,7 @@ class TestConfigHashMismatch:
         logger.info("Update without config_hash succeeded — guard correctly skipped")
 
 
+@pytest.mark.asyncio
 @pytest.mark.automation
 class TestSetAutomationNegativeInputs:
     """Negative-input tests for ha_config_set_automation pre-flight guards."""
@@ -1343,6 +1344,41 @@ class TestSetAutomationNegativeInputs:
                 "python_transform": "config['alias'] = 'Modified'",
                 "config_hash": "dummy_hash",
             },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_python_transform_requires_config_hash(
+        self, mcp_client
+    ) -> None:
+        """Rejects python_transform when config_hash is absent.
+
+        Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
+        when python_transform is set but config_hash is None.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {
+                "identifier": "automation.test",
+                "python_transform": "config['alias'] = 'Modified'",
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_requires_at_least_one_input(
+        self, mcp_client
+    ) -> None:
+        """Rejects a call that supplies neither config nor python_transform.
+
+        Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
+        when both parameters are None.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {},
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"

--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -1303,3 +1303,46 @@ class TestConfigHashMismatch:
             f"update without config_hash should succeed: {result}"
         )
         logger.info("Update without config_hash succeeded — guard correctly skipped")
+
+
+@pytest.mark.automation
+class TestSetAutomationNegativeInputs:
+    """Negative-input tests for ha_config_set_automation pre-flight guards."""
+
+    async def test_config_and_python_transform_mutually_exclusive(
+        self, mcp_client
+    ) -> None:
+        """Rejects a call that supplies both config and python_transform simultaneously.
+
+        Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
+        before any WebSocket I/O when both parameters are non-None.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {
+                "config": {"alias": "Test", "trigger": [], "action": []},
+                "python_transform": "config['alias'] = 'Modified'",
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_python_transform_requires_identifier(
+        self, mcp_client
+    ) -> None:
+        """Rejects python_transform when identifier is absent.
+
+        Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
+        before any WebSocket I/O when python_transform is set but identifier is None.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {
+                "python_transform": "config['alias'] = 'Modified'",
+                "config_hash": "dummy_hash",
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"

--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -1328,6 +1328,7 @@ class TestSetAutomationNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "both config and python_transform" in result["error"]["message"].lower()
 
     async def test_python_transform_requires_identifier(
         self, mcp_client
@@ -1347,6 +1348,7 @@ class TestSetAutomationNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "identifier is required" in result["error"]["message"].lower()
 
     async def test_python_transform_requires_config_hash(
         self, mcp_client
@@ -1366,6 +1368,7 @@ class TestSetAutomationNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "config_hash is required" in result["error"]["message"].lower()
 
     async def test_requires_at_least_one_input(
         self, mcp_client
@@ -1382,3 +1385,4 @@ class TestSetAutomationNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "either config or python_transform" in result["error"]["message"].lower()

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1510,7 +1510,7 @@ class TestTagCRUD:
         logger.info("Tag update test cleanup complete")
 
 
-@pytest.mark.helpers
+@pytest.mark.helper
 class TestSetHelperNegativeInputs:
     """Negative-input tests for ha_config_set_helper pre-flight guards."""
 

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1529,3 +1529,43 @@ class TestSetHelperNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_input_number_invalid_range(self, mcp_client) -> None:
+        """Rejects input_number when min_value > max_value.
+
+        Guard: tools_config_helpers.py — raises VALIDATION_INVALID_PARAMETER
+        when min_value is greater than max_value.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_number",
+                "name": "Invalid Range",
+                "min_value": 100,
+                "max_value": 0,
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_input_datetime_both_date_and_time_false(
+        self, mcp_client
+    ) -> None:
+        """Rejects input_datetime when both has_date and has_time are False.
+
+        Guard: tools_config_helpers.py — raises VALIDATION_INVALID_PARAMETER
+        when both fields are explicitly False.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_datetime",
+                "name": "Invalid DateTime",
+                "has_date": False,
+                "has_time": False,
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1508,3 +1508,22 @@ class TestTagCRUD:
             {"helper_type": "tag", "helper_id": tag_id},
         )
         logger.info("Tag update test cleanup complete")
+
+
+@pytest.mark.helpers
+class TestSetHelperNegativeInputs:
+    """Negative-input tests for ha_config_set_helper pre-flight guards."""
+
+    async def test_create_requires_name(self, mcp_client) -> None:
+        """Rejects a create call when name is empty.
+
+        Guard: tools_config_helpers.py — raises VALIDATION_INVALID_PARAMETER
+        before any WebSocket I/O when action is "create" and name is falsy.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_helper",
+            {"helper_type": "input_boolean", "name": ""},
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1510,6 +1510,8 @@ class TestTagCRUD:
         logger.info("Tag update test cleanup complete")
 
 
+@pytest.mark.asyncio
+@pytest.mark.config
 @pytest.mark.helper
 class TestSetHelperNegativeInputs:
     """Negative-input tests for ha_config_set_helper pre-flight guards."""

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1569,3 +1569,21 @@ class TestSetHelperNegativeInputs:
         )
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    async def test_input_select_requires_options(self, mcp_client) -> None:
+        """Rejects input_select when options is absent.
+
+        Guard: tools_config_helpers.py — raises VALIDATION_INVALID_PARAMETER
+        before any WebSocket I/O when helper_type is "input_select" and
+        options is falsy.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_select",
+                "name": "Missing Options",
+            },
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"


### PR DESCRIPTION
## What does this PR do?

Adds eight hard-asserting negative-input tests for A5 archetype tools (structured config / create), following the pattern from the [#914 discussion](https://github.com/homeassistant-ai/ha-mcp/discussions/914).

## Type of change
- [x] 🧪 Tests only

## Background

Continuing the archetype-based coverage from #914. A5 covers tools that accept structured config to create or update HA objects. Both tools have pre-flight guards that reject invalid input before any WebSocket I/O — none were hard-asserted in the E2E suite.

### `ha_config_set_automation` — four guards tested

| # | Input | Guard location | What happens |
|---|---|---|---|
| 1 | `config` + `python_transform` both non-None | `tools_config_automations.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 2 | `python_transform` without `identifier` | `tools_config_automations.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 3 | `python_transform` without `config_hash` | `tools_config_automations.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 4 | neither `config` nor `python_transform` | `tools_config_automations.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |

Tests 2–4 also pin the error message substring against the guard message in source (per review feedback) to anchor each assertion to its specific guard.

### `ha_config_set_helper` — four guards tested

| # | Input | Guard location | What happens |
|---|---|---|---|
| 5 | `name=""`, no `helper_id` (create path) | `tools_config_helpers.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 6 | `input_number` with `min >= max` | `tools_config_helpers.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 7 | `input_datetime` with both `has_date=False` and `has_time=False` | `tools_config_helpers.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |
| 8 | `input_select` without `options` | `tools_config_helpers.py` | `VALIDATION_INVALID_PARAMETER` — pre-flight, no WS call |

### Coverage before/after

| Tool | Input | Hard coverage before | After this PR |
|---|---|---|---|
| `ha_config_set_automation` | config + python_transform | ❌ (soft warning only) | ✅ HARD |
| `ha_config_set_automation` | python_transform, no identifier | ❌ | ✅ HARD |
| `ha_config_set_automation` | python_transform, no config_hash | ❌ | ✅ HARD |
| `ha_config_set_automation` | neither config nor python_transform | ❌ | ✅ HARD |
| `ha_config_set_helper` | name="" on create | ❌ | ✅ HARD |
| `ha_config_set_helper` | input_number with min >= max | ❌ | ✅ HARD |
| `ha_config_set_helper` | input_datetime with both date and time disabled | ❌ | ✅ HARD |
| `ha_config_set_helper` | input_select without options | ❌ | ✅ HARD |

### Scope

This PR covers pre-flight validation guards for two A5 archetype tools (`ha_config_set_automation` and `ha_config_set_helper`) — eight tests total, one structurally distinct path per test. Error-message substring pinning applied to the four automation tests per maintainer review. Rebased on current master.

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed