### PR TITLE
test(e2e): add negative-input tests for A7 destructive tools

### DIFF
--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -1424,6 +1424,9 @@ class TestAutomationDestructiveNegativeInputs:
         assert not data.get("success"), (
             f"Expected failure for nonexistent automation, got success=True: {data}"
         )
+        assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected error code RESOURCE_NOT_FOUND, got: {data.get('error')}"
+        )
         error_msg = str(data.get("error", "")).lower()
         assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (
             f"Expected 'not found'/'does not exist'/'404' in error, got: {data.get('error')}"
@@ -1477,6 +1480,9 @@ class TestAutomationDestructiveNegativeInputs:
         assert not second_delete.get("success"), (
             f"Second delete of {entity_id} returned success=True — "
             f"expected structured error: {second_delete}"
+        )
+        assert second_delete["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected error code RESOURCE_NOT_FOUND on second delete, got: {second_delete.get('error')}"
         )
         error_msg = str(second_delete.get("error", "")).lower()
         assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (

--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -1386,3 +1386,100 @@ class TestSetAutomationNegativeInputs:
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "either config or python_transform" in result["error"]["message"].lower()
+
+
+@pytest.mark.automation
+class TestAutomationDestructiveNegativeInputs:
+    """
+    A7 negative-input tests for ha_config_remove_automation.
+
+    Covers two structurally distinct failure paths not exercised by the
+    existing CRUD lifecycle tests:
+    - Removing a nonexistent automation (direct 404 path on the remove tool itself)
+    - Double-delete: second remove after successful deletion (same 404 path,
+      separate test because it validates idempotency behaviour)
+
+    Methodology: source-verified against tools_config_automations.py lines 854-876.
+    Both inputs reach create_resource_not_found_error → raise_tool_error (ToolError).
+    The existing lifecycle tests verify deletion via ha_config_get_automation, not
+    by calling ha_config_remove_automation on a nonexistent identifier directly.
+    """
+
+    async def test_remove_automation_nonexistent(self, mcp_client):
+        """
+        Test: ha_config_remove_automation with a nonexistent identifier returns a
+        structured error, not success=True.
+
+        Source path: Exception with "404"/"not found" in str →
+        create_resource_not_found_error → raise_tool_error.
+        """
+        logger.info("Testing ha_config_remove_automation with nonexistent identifier...")
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": "automation.nonexistent_a7_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent automation, got success=True: {data}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (
+            f"Expected 'not found'/'does not exist'/'404' in error, got: {data.get('error')}"
+        )
+        logger.info("\u2705 Nonexistent automation removal correctly returned structured error")
+
+    async def test_remove_automation_double_delete(
+        self, mcp_client, test_data_factory, cleanup_tracker
+    ):
+        """
+        Test: Second ha_config_remove_automation call on an already-deleted automation
+        returns a structured error, not success=True (idempotency failure behaviour).
+
+        Source path: first delete succeeds; second delete hits the same 404 branch
+        (create_resource_not_found_error → raise_tool_error) as the nonexistent test.
+        Tests a distinct scenario: the identifier was valid moments ago, so any
+        caching or stale-state issue would cause a silent false success here.
+        """
+        automation_name = "A7 Double Delete E2E Test"
+        config = test_data_factory.automation_config(
+            automation_name,
+            trigger=[{"platform": "time", "at": "06:00:00"}],
+            action=[{"service": "light.turn_on", "target": {"entity_id": "light.bed_light"}}],
+        )
+
+        logger.info("Creating automation for double-delete test...")
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_automation",
+            {"config": config},
+        )
+        create_data = assert_mcp_success(create_result, "automation creation for double-delete")
+        entity_id = create_data.get("entity_id")
+        assert entity_id, f"No entity_id returned: {create_data}"
+        cleanup_tracker.track("automation", entity_id)
+        logger.info(f"Created automation: {entity_id}")
+
+        # First delete — must succeed
+        first_delete = await mcp_client.call_tool(
+            "ha_config_remove_automation",
+            {"identifier": entity_id, "wait": True},
+        )
+        assert_mcp_success(first_delete, "first automation deletion")
+        logger.info("First delete succeeded")
+
+        # Second delete — must return a structured error, not success=True
+        second_delete = await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": entity_id},
+        )
+        assert not second_delete.get("success"), (
+            f"Second delete of {entity_id} returned success=True — "
+            f"expected structured error: {second_delete}"
+        )
+        error_msg = str(second_delete.get("error", "")).lower()
+        assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (
+            f"Expected not-found error on second delete, got: {second_delete.get('error')}"
+        )
+        logger.info("\u2705 Double-delete correctly returned structured error on second call")

--- a/tests/src/e2e/workflows/integrations/test_integration_management.py
+++ b/tests/src/e2e/workflows/integrations/test_integration_management.py
@@ -188,3 +188,26 @@ class TestIntegrationManagement:
         )
         # Should fail - either through validation or API error
         assert not data.get("success", False)
+
+    async def test_delete_config_entry_nonexistent_confirmed(self, mcp_client):
+        """
+        Test: ha_delete_config_entry with a nonexistent entry_id and confirm=True
+        returns a structured error, not success=True.
+
+        Source path: confirm_bool=True bypasses the guard; delete_config_entry()
+        reaches the HA REST API with an unknown entry_id → Exception →
+        exception_to_structured_error(raise_error=True) → ToolError.
+
+        Existing tests cover confirm=False (guard path) and a valid entry_id
+        (CRUD cycle). This test covers the third structurally distinct path:
+        confirmed deletion of an entry that does not exist.
+        """
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_delete_config_entry",
+            {"entry_id": "nonexistent_entry_a7_e2e_xyz", "confirm": True},
+        )
+        assert not data.get("success", False), (
+            f"Expected failure for nonexistent entry_id with confirm=True, "
+            f"got success=True: {data}"
+        )

--- a/tests/src/e2e/workflows/integrations/test_integration_management.py
+++ b/tests/src/e2e/workflows/integrations/test_integration_management.py
@@ -211,3 +211,7 @@ class TestIntegrationManagement:
             f"Expected failure for nonexistent entry_id with confirm=True, "
             f"got success=True: {data}"
         )
+        # Verify a structured error is returned (not a silent pass-through)
+        assert data.get("error") is not None, (
+            f"Expected error details in failure response, got: {data}"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds negative-input E2E tests for two A7 (destructive) tools, covering three structurally distinct failure paths not exercised by the existing CRUD lifecycle tests.

**`ha_config_remove_automation`** — two new tests in a new `TestAutomationDestructiveNegativeInputs` class:

| Test | Input | Source path |
|---|---|---|
| `test_remove_automation_nonexistent` | nonexistent identifier | `create_resource_not_found_error` → `raise_tool_error` (line 854–876) |
| `test_remove_automation_double_delete` | second remove after successful delete | same 404 branch — validates idempotency failure behaviour |

The existing CRUD lifecycle test verifies deletion via `ha_config_get_automation` after a successful delete. Neither test calls `ha_config_remove_automation` on an identifier that is already absent.

**`ha_delete_config_entry`** — one new method in the existing `TestIntegrationManagement` class:

| Test | Input | Source path |
|---|---|---|
| `test_delete_config_entry_nonexistent_confirmed` | `confirm=True`, nonexistent `entry_id` | `exception_to_structured_error(raise_error=True)` → ToolError (line 476–478) |

Existing tests cover `confirm=False` (guard) and a valid `entry_id` (CRUD cycle). The `confirm=True` + nonexistent path was unexercised.

**Survey of remaining A7 tools** (not addressed in this PR, documented for follow-up): `ha_config_remove_script`, `ha_config_remove_area`, `ha_config_remove_floor`, `ha_config_remove_label`, `ha_config_remove_category`, `ha_config_delete_dashboard`, `ha_config_remove_calendar_event`, `ha_remove_device` — none have a direct nonexistent-remove test. `ha_config_remove_helper` and `ha_remove_zone` are already covered.

Related: #914

## Type of change
- [x] 🧪 Tests only

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
