### PR TITLE
fix: route supervisor log through REST; fix stale ha_list_addons hints

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -13,6 +13,10 @@ from ..config import get_global_settings
 
 logger = logging.getLogger(__name__)
 
+# Home Assistant add-on slugs are lowercase alphanumerics plus ``_`` and ``-``.
+# Validated on input to prevent path traversal via Supervisor proxy endpoints.
+_ALLOWED_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_-")
+
 
 class HomeAssistantError(Exception):
     """Base exception for Home Assistant API errors."""
@@ -422,7 +426,16 @@ class HomeAssistantClient:
 
         Uses ``/hassio/addons/{slug}/logs`` which returns ``text/plain`` and
         therefore cannot be retrieved via ``_request`` (which assumes JSON).
+
+        The ``slug`` is validated against Home Assistant's add-on slug format
+        (lowercase alphanumerics plus ``_`` / ``-``) to prevent path traversal
+        into the Supervisor proxy (e.g. ``slug="../../config"``).
         """
+        if not slug or not all(c in _ALLOWED_SLUG_CHARS for c in slug):
+            raise HomeAssistantAPIError(
+                f"Invalid add-on slug: {slug!r}",
+                status_code=400,
+            )
         logger.debug("Fetching supervisor log for add-on: %s", slug)
         return await self._request_text("GET", f"/hassio/addons/{slug}/logs")
 

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -151,6 +151,55 @@ class HomeAssistantClient:
         except httpx.HTTPError as e:
             raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
 
+    async def _request_text(self, method: str, endpoint: str, **kwargs: Any) -> str:
+        """
+        Make authenticated request to Home Assistant API and return raw text.
+
+        Use this for endpoints that return non-JSON payloads (e.g. ``text/plain``
+        log endpoints). Auth and HTTP error handling mirror :meth:`_request`.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            endpoint: API endpoint (without /api prefix)
+            **kwargs: Additional arguments for httpx request
+
+        Returns:
+            Response body as raw text.
+
+        Raises:
+            HomeAssistantConnectionError: Connection failed
+            HomeAssistantAuthError: Authentication failed
+            HomeAssistantAPIError: API error
+        """
+        try:
+            response = await self.httpx_client.request(method, endpoint, **kwargs)
+
+            if response.status_code == 401:
+                raise HomeAssistantAuthError("Invalid authentication token")
+
+            if response.status_code >= 400:
+                try:
+                    error_data = response.json()
+                except Exception:
+                    error_data = {"message": response.text}
+
+                raise HomeAssistantAPIError(
+                    f"API error: {response.status_code} - {error_data.get('message', 'Unknown error')}",
+                    status_code=response.status_code,
+                    response_data=error_data,
+                )
+
+            return response.text
+
+        except httpx.ConnectError as e:
+            raise HomeAssistantConnectionError(
+                f"Failed to connect to Home Assistant: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
+        except httpx.HTTPError as e:
+            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+
     async def get_config(self) -> dict[str, Any]:
         """Get Home Assistant configuration."""
         logger.debug("Fetching Home Assistant configuration")
@@ -366,6 +415,16 @@ class HomeAssistantClient:
         logger.debug("Fetching error log")
         response = await self._request("GET", "/error_log")
         return response if isinstance(response, str) else str(response)
+
+    async def get_addon_log(self, slug: str) -> str:
+        """
+        Get Supervisor add-on log via the Core REST proxy.
+
+        Uses ``/hassio/addons/{slug}/logs`` which returns ``text/plain`` and
+        therefore cannot be retrieved via ``_request`` (which assumes JSON).
+        """
+        logger.debug("Fetching supervisor log for add-on: %s", slug)
+        return await self._request_text("GET", f"/hassio/addons/{slug}/logs")
 
     async def test_connection(self) -> tuple[bool, str | None]:
         """

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -562,16 +562,18 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             TimeoutError,
             OSError,
         ) as e:
-            suggestions = [
-                f"Verify add-on slug '{slug}' is correct",
-                "Use ha_get_addon() to find available add-on slugs",
-                "Ensure Supervisor is available (HA OS or Supervised install)",
-            ]
             if isinstance(e, HomeAssistantAPIError) and e.status_code == 404:
-                suggestions.insert(
-                    0,
+                suggestions = [
                     "Add-on not found or Supervisor API not available - requires HA OS or Supervised install",
-                )
+                    f"Verify add-on slug '{slug}' is correct",
+                    "Use ha_get_addon() to find available add-on slugs",
+                ]
+            else:
+                suggestions = [
+                    f"Verify add-on slug '{slug}' is correct",
+                    "Use ha_get_addon() to find available add-on slugs",
+                    "Ensure Supervisor is available (HA OS or Supervised install)",
+                ]
             exception_to_structured_error(
                 e,
                 context={"source": "supervisor", "slug": slug},

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -182,7 +182,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "The 'slug' parameter is required for source='supervisor'",
                     suggestions=[
                         "Provide the add-on slug, e.g. slug='core_mosquitto'",
-                        "Use ha_list_addons() to find available add-on slugs",
+                        "Use ha_get_addon() to find available add-on slugs",
                     ],
                 )
             )
@@ -519,49 +519,11 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         effective_limit = _coerce_limit(limit, default=DEFAULT_LOG_LIMIT, suggestion_example="100")
 
         try:
-            result = await client.send_websocket_message(
-                {
-                    "type": "supervisor/api",
-                    "endpoint": f"/addons/{slug}/logs",
-                    "method": "get",
-                }
-            )
-
-            if not result.get("success"):
-                error_msg = str(result.get("error", ""))
-                suggestions = [
-                    f"Verify add-on slug '{slug}' is correct",
-                    "Use ha_list_addons() to find available add-on slugs",
-                ]
-                if "not_found" in error_msg.lower() or "unknown" in error_msg.lower():
-                    suggestions.insert(
-                        0,
-                        "Supervisor API not available - requires HA OS or Supervised install",
-                    )
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result.get(
-                            "error", f"Failed to retrieve logs for add-on '{slug}'"
-                        ),
-                        context={"slug": slug},
-                        suggestions=suggestions,
-                    )
-                )
-
-            # Result may be a string (log text) or dict with result key
-            log_text = result.get("result", "")
-            if isinstance(log_text, dict):
-                if "data" in log_text:
-                    log_text = log_text["data"]
-                else:
-                    logger.warning(
-                        "Supervisor log for '%s' returned unexpected dict structure",
-                        slug,
-                    )
-                    log_text = ""
-            if not isinstance(log_text, str):
-                log_text = str(log_text)
+            # The Supervisor ``/addons/{slug}/logs`` endpoint returns ``text/plain``
+            # and must therefore be fetched over the REST proxy, not the
+            # ``supervisor/api`` WebSocket command (which forces JSON parsing in
+            # the HA Core proxy and fails with an empty error message).
+            log_text = await client.get_addon_log(slug)
 
             lines = log_text.splitlines() if log_text else []
 
@@ -600,14 +562,20 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             TimeoutError,
             OSError,
         ) as e:
+            suggestions = [
+                f"Verify add-on slug '{slug}' is correct",
+                "Use ha_get_addon() to find available add-on slugs",
+                "Ensure Supervisor is available (HA OS or Supervised install)",
+            ]
+            if isinstance(e, HomeAssistantAPIError) and e.status_code == 404:
+                suggestions.insert(
+                    0,
+                    "Add-on not found or Supervisor API not available - requires HA OS or Supervised install",
+                )
             exception_to_structured_error(
                 e,
                 context={"source": "supervisor", "slug": slug},
-                suggestions=[
-                    f"Verify add-on slug '{slug}' is correct",
-                    "Use ha_list_addons() to find available add-on slugs",
-                    "Ensure Supervisor is available (HA OS or Supervised install)",
-                ],
+                suggestions=suggestions,
             )
 
     @mcp.tool(

--- a/tests/src/unit/test_rest_client_supervisor.py
+++ b/tests/src/unit/test_rest_client_supervisor.py
@@ -1,0 +1,143 @@
+"""Unit tests for REST client Supervisor log retrieval and _request_text.
+
+These tests cover the text/plain fetch path for Supervisor add-on logs:
+the ``/addons/{slug}/logs`` endpoint returns raw text, so it cannot go
+through ``_request`` (which forces JSON parsing).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantAuthError,
+    HomeAssistantClient,
+    HomeAssistantConnectionError,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock HomeAssistantClient for testing."""
+    with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+        client = HomeAssistantClient()
+        client.base_url = "http://test.local:8123"
+        client.token = "test-token"
+        client.timeout = 30
+        client.httpx_client = MagicMock()
+        return client
+
+
+class TestRequestText:
+    """Tests for the _request_text method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_raw_text_on_200(self, mock_client):
+        """200 response body should be returned verbatim, no JSON parsing."""
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "2026-04-16 12:00:00 INFO some log line\nsecond line\n"
+        mock_client.httpx_client.request = AsyncMock(return_value=response)
+
+        result = await mock_client._request_text("GET", "/hassio/addons/foo/logs")
+
+        assert result == "2026-04-16 12:00:00 INFO some log line\nsecond line\n"
+        mock_client.httpx_client.request.assert_called_once_with(
+            "GET", "/hassio/addons/foo/logs"
+        )
+
+    @pytest.mark.asyncio
+    async def test_401_raises_auth_error(self, mock_client):
+        """401 should raise HomeAssistantAuthError with the standard message."""
+        response = MagicMock()
+        response.status_code = 401
+        mock_client.httpx_client.request = AsyncMock(return_value=response)
+
+        with pytest.raises(HomeAssistantAuthError) as exc_info:
+            await mock_client._request_text("GET", "/hassio/addons/foo/logs")
+
+        assert "Invalid authentication token" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_404_raises_api_error_with_status(self, mock_client):
+        """404 should raise HomeAssistantAPIError with status_code=404."""
+        response = MagicMock()
+        response.status_code = 404
+        response.json = MagicMock(side_effect=ValueError("not json"))
+        response.text = "404: Not Found"
+        mock_client.httpx_client.request = AsyncMock(return_value=response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client._request_text("GET", "/hassio/addons/bogus/logs")
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_500_raises_api_error(self, mock_client):
+        """5xx should raise HomeAssistantAPIError; JSON error body is used if present."""
+        response = MagicMock()
+        response.status_code = 500
+        response.json = MagicMock(return_value={"message": "internal boom"})
+        mock_client.httpx_client.request = AsyncMock(return_value=response)
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client._request_text("GET", "/hassio/addons/foo/logs")
+
+        assert exc_info.value.status_code == 500
+        assert "internal boom" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_connection_error(self, mock_client):
+        """httpx.ConnectError should be wrapped in HomeAssistantConnectionError."""
+        mock_client.httpx_client.request = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+
+        with pytest.raises(HomeAssistantConnectionError):
+            await mock_client._request_text("GET", "/hassio/addons/foo/logs")
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_connection_error(self, mock_client):
+        """httpx.TimeoutException should be wrapped in HomeAssistantConnectionError."""
+        mock_client.httpx_client.request = AsyncMock(
+            side_effect=httpx.TimeoutException("timed out")
+        )
+
+        with pytest.raises(HomeAssistantConnectionError):
+            await mock_client._request_text("GET", "/hassio/addons/foo/logs")
+
+
+class TestGetAddonLog:
+    """Tests for get_addon_log."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_log_text(self, mock_client):
+        """Happy path: get_addon_log returns the raw text from _request_text."""
+        mock_client._request_text = AsyncMock(
+            return_value="line 1\nline 2\nline 3\n"
+        )
+
+        result = await mock_client.get_addon_log("core_mosquitto")
+
+        assert result == "line 1\nline 2\nline 3\n"
+        mock_client._request_text.assert_called_once_with(
+            "GET", "/hassio/addons/core_mosquitto/logs"
+        )
+
+    @pytest.mark.asyncio
+    async def test_addon_not_found_propagates_404(self, mock_client):
+        """404 from the Supervisor proxy should propagate as HomeAssistantAPIError."""
+        mock_client._request_text = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - not found", status_code=404
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_addon_log("does_not_exist")
+
+        assert exc_info.value.status_code == 404
+        assert "404" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()

--- a/tests/src/unit/test_rest_client_supervisor.py
+++ b/tests/src/unit/test_rest_client_supervisor.py
@@ -143,12 +143,23 @@ class TestGetAddonLog:
         assert "not found" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
-    async def test_rejects_path_traversal_slug(self, mock_client):
-        """Slugs with path separators must be rejected before any HTTP call."""
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "../../config",
+            "my/addon",
+            "foo\\bar",
+            "slug with space",
+            "UPPER_case",
+            "has.dot",
+        ],
+    )
+    async def test_rejects_invalid_slug(self, mock_client, bad_slug):
+        """Slugs outside the allowed charset must be rejected before any HTTP call."""
         mock_client._request_text = AsyncMock()
 
         with pytest.raises(HomeAssistantAPIError) as exc_info:
-            await mock_client.get_addon_log("../../config")
+            await mock_client.get_addon_log(bad_slug)
 
         assert exc_info.value.status_code == 400
         assert "Invalid add-on slug" in str(exc_info.value)

--- a/tests/src/unit/test_rest_client_supervisor.py
+++ b/tests/src/unit/test_rest_client_supervisor.py
@@ -141,3 +141,43 @@ class TestGetAddonLog:
         assert exc_info.value.status_code == 404
         assert "404" in str(exc_info.value)
         assert "not found" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_slug(self, mock_client):
+        """Slugs with path separators must be rejected before any HTTP call."""
+        mock_client._request_text = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_addon_log("../../config")
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid add-on slug" in str(exc_info.value)
+        mock_client._request_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_slug(self, mock_client):
+        """Empty slug must be rejected; empty f-string would yield /hassio/addons//logs."""
+        mock_client._request_text = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_addon_log("")
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid add-on slug" in str(exc_info.value)
+        mock_client._request_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "slug",
+        ["core_mosquitto", "81f33d0f_ha_mcp_dev", "a0d7b954_ssh", "some-addon-123"],
+    )
+    async def test_accepts_realistic_slugs(self, mock_client, slug):
+        """Realistic Supervisor slugs (lowercase alnum + _ / -) must pass validation."""
+        mock_client._request_text = AsyncMock(return_value="ok\n")
+
+        result = await mock_client.get_addon_log(slug)
+
+        assert result == "ok\n"
+        mock_client._request_text.assert_called_once_with(
+            "GET", f"/hassio/addons/{slug}/logs"
+        )


### PR DESCRIPTION
## Summary

Fixes both bugs in `ha_get_logs(source="supervisor")` reported in #950:

1. **`_get_supervisor_log` always fails with empty `"Command failed: "`** because the `supervisor/api` WebSocket command forces JSON deserialization on the `text/plain` Supervisor log response, and that JSONDecodeError surfaces as an empty error string.
2. **Three stale suggestion strings** reference `ha_list_addons()`, a tool that was consolidated into `ha_get_addon()`.

## Approach

### Bug 1 - route through REST proxy

Add `_request_text(method, endpoint)` to `HomeAssistantClient`, a sibling of `_request` that returns `response.text` verbatim (auth and HTTP error handling mirror `_request`). Add `get_addon_log(slug)` which calls `_request_text("GET", f"/hassio/addons/{slug}/logs")` through the Core REST proxy.

In `tools_utility.py::_get_supervisor_log`, replace the WebSocket call + `result.get("success")` check with `await client.get_addon_log(slug)`. A 404 from the Supervisor proxy (add-on slug invalid, or Supervisor not available on Core-only installs) now surfaces the "not available / not installed" hint that was previously keyed off the WS error string; all other errors continue to flow through `exception_to_structured_error` -> `ErrorCode.SERVICE_CALL_FAILED`, same as before.

This mirrors the existing `get_error_log()` pattern for `/error_log`.

### Bug 2 - stale strings

Replace all three `"Use ha_list_addons() to find available add-on slugs"` with `"Use ha_get_addon() to find available add-on slugs"`.

## Verification

Live-tested against a running HA OS instance: