### PR TITLE
fix(history): normalize statistic_types in query_params echo

### DIFF
--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -695,7 +695,7 @@ async def _fetch_statistics(
         },
         "statistic_types": all_stat_types,
         "query_params": {
-            "statistic_types": statistic_types,
+            "statistic_types": stat_types_list,
             "limit": effective_limit,
             "offset": effective_offset,
         },

--- a/tests/src/unit/test_history_pagination.py
+++ b/tests/src/unit/test_history_pagination.py
@@ -315,6 +315,52 @@ class TestStatisticsPagination:
         assert qp["limit"] == 10
         assert qp["offset"] == 5
 
+    @pytest.mark.asyncio
+    async def test_statistics_query_params_string_comma_normalized(self, history_tool):
+        """query_params.statistic_types reflects the normalized list when caller passes a comma-separated string.
+
+        Regression test for #990: prior to the fix, query_params echoed the raw caller input,
+        so a caller passing "mean,max" (string) would see the string in query_params while the
+        top-level statistic_types key contained the parsed list. Both must now be a list.
+        """
+        rows = _make_stat_rows(5)
+        with self._patch_ws(rows), patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d: d,
+        ):
+            result = await history_tool(
+                entity_ids="sensor.energy",
+                source="statistics",
+                start_time="30d",
+                statistic_types="mean,max",
+            )
+
+        qp = result["query_params"]
+        assert qp["statistic_types"] == ["mean", "max"]
+        assert result["statistic_types"] == ["mean", "max"]
+
+    @pytest.mark.asyncio
+    async def test_statistics_query_params_string_bracketed_normalized(self, history_tool):
+        """query_params.statistic_types reflects the normalized list when caller passes a bracketed string.
+
+        Regression test for #990: covers the parse_string_list_param branch (e.g. '["mean","max"]').
+        """
+        rows = _make_stat_rows(5)
+        with self._patch_ws(rows), patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d: d,
+        ):
+            result = await history_tool(
+                entity_ids="sensor.energy",
+                source="statistics",
+                start_time="30d",
+                statistic_types='["mean","max"]',
+            )
+
+        qp = result["query_params"]
+        assert qp["statistic_types"] == ["mean", "max"]
+        assert result["statistic_types"] == ["mean", "max"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: Option 1 — multi-entity offset guard


### PR DESCRIPTION
## What does this PR do?

Fixes #990. `query_params.statistic_types` now reflects the normalized list rather than the raw caller input, eliminating the type-inconsistency within the `_fetch_statistics` response.

**Root cause:** `_fetch_statistics` parses `statistic_types` (str | list[str] | None) into `stat_types_list` (list[str] | None) at L593–603, then uses `stat_types_list` for the HA command params and derives the top-level `statistic_types` key from it (`all_stat_types`). The `query_params` block, however, echoed the raw caller-provided `statistic_types` — so a caller passing `"mean,max"` saw the string in `query_params` while the top-level key had `["mean", "max"]`.

**Fix:** Single-line change in `query_params` to use `stat_types_list`.

**Observation origin:** #976 review by @kingpanther13; Option 1 (normalize-on-input) confirmed in #990 maintainer comment.

**Contract note:** This narrows `query_params.statistic_types` from „raw as received" to „normalized list | None". Callers relying on the previous string-echo behavior would see a list instead — considered a bug-fix per #990, not a breaking change.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

Two new regression tests in `TestStatisticsPagination` (unit), covering both string input paths of the normalizer — matching the `test_history_pagination.py` established pattern (dispatch via `HistoryTools.ha_get_history`, not `_fetch_statistics` directly):

| Test | Input | Asserts |
|---|---|---|
| `test_statistics_query_params_string_comma_normalized` | `"mean,max"` | `qp["statistic_types"] == ["mean", "max"]` and top-level match |
| `test_statistics_query_params_string_bracketed_normalized` | `'["mean","max"]'` | same — covers `parse_string_list_param` branch |

Existing `test_statistics_query_params_default` / `test_statistics_query_params_roundtrip` remain unaffected (list path).

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — relies on CI; no local `uv` env in this session
- [ ] Code follows style guidelines (`uv run ruff check`) — relies on CI

## Checklist
- [x] I have updated documentation if needed *(no docstring or tool-signature change — `scripts/extract_tools.py` not run)*

Fixes #990