### PR TITLE
refactor(internal): reduce C901 complexity in 5 non-tool files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,12 +134,6 @@ ignore = [
 "tests/**/*" = ["E501", "B011"]
 # C901 ignores for tools files with complex methods (see #925).
 # Remove lines as individual methods are simplified below threshold.
-"src/ha_mcp/tools/backup.py" = ["C901"]
-"src/ha_mcp/tools/best_practice_checker.py" = ["C901"]
-"src/ha_mcp/tools/device_control.py" = ["C901"]
-"src/ha_mcp/tools/helpers.py" = ["C901"]
-"src/ha_mcp/tools/registry.py" = ["C901"]
-"src/ha_mcp/tools/smart_search.py" = ["C901"]
 "src/ha_mcp/tools/tools_addons.py" = ["C901"]
 "src/ha_mcp/tools/tools_config_dashboards.py" = ["C901"]
 "src/ha_mcp/tools/tools_config_helpers.py" = ["C901"]
@@ -147,6 +141,7 @@ ignore = [
 "src/ha_mcp/tools/tools_registry.py" = ["C901"]
 "src/ha_mcp/tools/tools_search.py" = ["C901"]
 "src/ha_mcp/tools/tools_utility.py" = ["C901"]
+"src/ha_mcp/tools/smart_search.py" = ["C901"]
 "src/ha_mcp/tools/util_helpers.py" = ["C901"]
 
 [tool.pytest.ini_options]

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_BACKUP_MAX_WAIT_S = 120
+_BACKUP_POLL_INTERVAL_S = 2
+
 
 def _get_backup_hint_text() -> str:
     """
@@ -85,6 +88,80 @@ async def _get_backup_password(
     return cast(str, default_password)
 
 
+async def _poll_backup_completion(
+    ws_client: HomeAssistantWebSocketClient,
+    name: str,
+    backup_job_id: str,
+    max_wait_seconds: int,
+    poll_interval: int,
+) -> dict[str, Any]:
+    """Poll backup/info until the named backup completes, fails, or times out.
+
+    Raises ToolError on backup failure or timeout.
+    """
+    waited = 0
+
+    while waited < max_wait_seconds:
+        await asyncio.sleep(poll_interval)
+        waited += poll_interval
+
+        info_result = await ws_client.send_command("backup/info")
+        if info_result.get("success"):
+            state = info_result.get("result", {}).get("state")
+            last_event = info_result.get("result", {}).get("last_action_event", {})
+            event_state = last_event.get("state")
+
+            logger.debug(
+                f"Backup state: {state}, event_state: {event_state}, waited: {waited}s"
+            )
+
+            if state == "idle" and event_state == "completed":
+                backups = info_result.get("result", {}).get("backups", [])
+                created_backup = None
+                for backup in backups:
+                    if backup.get("name") == name:
+                        created_backup = backup
+                        break
+
+                if created_backup:
+                    logger.info(
+                        f"Backup completed successfully: {created_backup.get('backup_id')}"
+                    )
+                    return {
+                        "success": True,
+                        "backup_id": created_backup.get("backup_id"),
+                        "backup_job_id": backup_job_id,
+                        "name": name,
+                        "date": created_backup.get("date"),
+                        "size_bytes": created_backup.get("agents", {})
+                        .get("hassio.local", {})
+                        .get("size"),
+                        "status": "Backup completed successfully",
+                        "duration_seconds": waited,
+                        "note": "Backup uses your Home Assistant's default backup password",
+                    }
+                else:
+                    logger.warning(
+                        "Backup completed but not found in backup list yet, waiting..."
+                    )
+                    continue
+
+            elif event_state == "failed":
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Backup creation failed",
+                    context={"backup_job_id": backup_job_id},
+                ))
+
+    logger.warning(f"Backup did not complete within {max_wait_seconds} seconds")
+    raise_tool_error(create_error_response(
+        ErrorCode.TIMEOUT_OPERATION,
+        f"Backup creation timed out after {max_wait_seconds} seconds",
+        context={"backup_job_id": backup_job_id, "name": name},
+        suggestions=["Backup may still be in progress. Check Home Assistant backup status."],
+    ))
+
+
 async def create_backup(
     client: HomeAssistantClient, name: str | None = None
 ) -> dict[str, Any]:
@@ -140,76 +217,13 @@ async def create_backup(
         backup_job_id = result.get("result", {}).get("backup_job_id")
         logger.info(f"Backup job started: {backup_job_id}, waiting for completion...")
 
-        # Wait for backup to complete by polling backup/info
-        max_wait_seconds = 120  # 2 minutes max wait
-        poll_interval = 2  # Check every 2 seconds
-        waited = 0
-
-        while waited < max_wait_seconds:
-            await asyncio.sleep(poll_interval)
-            waited += poll_interval
-
-            # Check backup status
-            info_result = await ws_client.send_command("backup/info")
-            if info_result.get("success"):
-                state = info_result.get("result", {}).get("state")
-                last_event = info_result.get("result", {}).get("last_action_event", {})
-                event_state = last_event.get("state")
-
-                logger.debug(
-                    f"Backup state: {state}, event_state: {event_state}, waited: {waited}s"
-                )
-
-                # Check if backup is complete
-                if state == "idle" and event_state == "completed":
-                    # Find the backup that was just created
-                    backups = info_result.get("result", {}).get("backups", [])
-                    created_backup = None
-                    for backup in backups:
-                        if backup.get("name") == name:
-                            created_backup = backup
-                            break
-
-                    if created_backup:
-                        logger.info(
-                            f"Backup completed successfully: {created_backup.get('backup_id')}"
-                        )
-                        return {
-                            "success": True,
-                            "backup_id": created_backup.get("backup_id"),
-                            "backup_job_id": backup_job_id,
-                            "name": name,
-                            "date": created_backup.get("date"),
-                            "size_bytes": created_backup.get("agents", {})
-                            .get("hassio.local", {})
-                            .get("size"),
-                            "status": "Backup completed successfully",
-                            "duration_seconds": waited,
-                            "note": "Backup uses your Home Assistant's default backup password",
-                        }
-                    else:
-                        # Backup completed but not found in list yet
-                        logger.warning(
-                            "Backup completed but not found in backup list yet, waiting..."
-                        )
-                        continue
-
-                # Check if backup failed
-                elif event_state == "failed":
-                    raise_tool_error(create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        "Backup creation failed",
-                        context={"backup_job_id": backup_job_id},
-                    ))
-
-        # Timeout waiting for backup
-        logger.warning(f"Backup did not complete within {max_wait_seconds} seconds")
-        raise_tool_error(create_error_response(
-            ErrorCode.TIMEOUT_OPERATION,
-            f"Backup creation timed out after {max_wait_seconds} seconds",
-            context={"backup_job_id": backup_job_id, "name": name},
-            suggestions=["Backup may still be in progress. Check Home Assistant backup status."],
-        ))
+        return await _poll_backup_completion(
+            ws_client,
+            name,
+            backup_job_id,
+            max_wait_seconds=_BACKUP_MAX_WAIT_S,
+            poll_interval=_BACKUP_POLL_INTERVAL_S,
+        )
 
     except ToolError:
         raise
@@ -227,6 +241,43 @@ async def create_backup(
                 await ws_client.disconnect()
             except Exception:
                 pass  # Ignore errors during cleanup
+
+
+async def _create_safety_backup(
+    ws_client: HomeAssistantWebSocketClient,
+    password: str | None,
+) -> str | None:
+    """Create a pre-restore safety backup.
+
+    Returns the safety backup ID, or None when password is None (backup intentionally
+    skipped). Raises ToolError if backup creation fails.
+    """
+    if password is None:
+        return None
+
+    now = datetime.now()
+    safety_backup_name = f"PreRestore_Safety_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
+
+    safety_backup = await ws_client.send_command(
+        "backup/generate",
+        name=safety_backup_name,
+        password=password,
+        agent_ids=["hassio.local"],
+        include_homeassistant=True,
+        include_database=True,
+        include_all_addons=True,
+    )
+
+    if not safety_backup.get("success"):
+        raise_tool_error(create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            safety_backup.get("error", "Failed to create safety backup before restore"),
+            suggestions=["Cannot proceed with restore without safety backup"],
+        ))
+
+    safety_backup_id = safety_backup.get("result", {}).get("backup_job_id")
+    logger.info(f"Safety backup created: {safety_backup_id}")
+    return cast(str, safety_backup_id)
 
 
 async def restore_backup(
@@ -277,38 +328,14 @@ async def restore_backup(
 
         # Create safety backup BEFORE restoring
         logger.info("Creating safety backup before restore...")
-        now = datetime.now()
-        safety_backup_name = f"PreRestore_Safety_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
-
-        # Get backup password
         try:
             password = await _get_backup_password(ws_client)
         except ToolError:
             # Password error - log warning but continue (restore might still work)
             logger.warning("No default password - proceeding without safety backup")
             password = None
-            safety_backup_id = None
 
-        if password is not None:
-            safety_backup = await ws_client.send_command(
-                "backup/generate",
-                name=safety_backup_name,
-                password=password,
-                agent_ids=["hassio.local"],
-                include_homeassistant=True,
-                include_database=True,  # Full backup for safety
-                include_all_addons=True,
-            )
-
-            if not safety_backup.get("success"):
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    safety_backup.get("error", "Failed to create safety backup before restore"),
-                    suggestions=["Cannot proceed with restore without safety backup"],
-                ))
-
-            safety_backup_id = safety_backup.get("result", {}).get("backup_job_id")
-            logger.info(f"Safety backup created: {safety_backup_id}")
+        safety_backup_id = await _create_safety_backup(ws_client, password)
 
         # Perform restore
         restore_params = {

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -216,6 +216,27 @@ def _check_template_string(
 # ---------------------------------------------------------------------------
 
 
+def _check_choose_actions(
+    choose: Any, warnings: list[str], skill_prefix: str | None
+) -> None:
+    for option in _as_list(choose):
+        if isinstance(option, dict):
+            _check_condition_templates(
+                option.get("conditions", []), warnings, skill_prefix
+            )
+            _check_action_tree(
+                option.get("sequence", []), warnings, skill_prefix
+            )
+
+
+def _check_repeat_actions(
+    repeat: dict, warnings: list[str], skill_prefix: str | None
+) -> None:
+    _check_condition_templates(repeat.get("while", []), warnings, skill_prefix)
+    _check_condition_templates(repeat.get("until", []), warnings, skill_prefix)
+    _check_action_tree(repeat.get("sequence", []), warnings, skill_prefix)
+
+
 def _check_action_tree(
     actions: Any, warnings: list[str], skill_prefix: str | None
 ) -> None:
@@ -235,14 +256,7 @@ def _check_action_tree(
 
         # Nested conditions in choose/if/repeat
         if "choose" in action:
-            for option in _as_list(action["choose"]):
-                if isinstance(option, dict):
-                    _check_condition_templates(
-                        option.get("conditions", []), warnings, skill_prefix
-                    )
-                    _check_action_tree(
-                        option.get("sequence", []), warnings, skill_prefix
-                    )
+            _check_choose_actions(action["choose"], warnings, skill_prefix)
 
         if "if" in action:
             _check_condition_templates(action["if"], warnings, skill_prefix)
@@ -253,16 +267,7 @@ def _check_action_tree(
                 _check_action_tree(nested, warnings, skill_prefix)
 
         if "repeat" in action and isinstance(action["repeat"], dict):
-            repeat = action["repeat"]
-            _check_condition_templates(
-                repeat.get("while", []), warnings, skill_prefix
-            )
-            _check_condition_templates(
-                repeat.get("until", []), warnings, skill_prefix
-            )
-            _check_action_tree(
-                repeat.get("sequence", []), warnings, skill_prefix
-            )
+            _check_repeat_actions(action["repeat"], warnings, skill_prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +352,20 @@ def _check_mode_motion(
         )
 
 
+def _has_delay_or_wait_in_nested(action: dict) -> bool:
+    for key in ("then", "else", "default", "sequence"):
+        if key in action and _has_delay_or_wait(action[key]):
+            return True
+    if "choose" in action:
+        for opt in _as_list(action["choose"]):
+            if isinstance(opt, dict) and _has_delay_or_wait(opt.get("sequence", [])):
+                return True
+    if "repeat" in action and isinstance(action["repeat"], dict):
+        if _has_delay_or_wait(action["repeat"].get("sequence", [])):
+            return True
+    return False
+
+
 def _has_delay_or_wait(actions: Any) -> bool:
     """Recursively check if any action uses delay or wait."""
     for action in _as_list(actions):
@@ -354,18 +373,8 @@ def _has_delay_or_wait(actions: Any) -> bool:
             continue
         if any(k in action for k in ("delay", "wait_for_trigger", "wait_template")):
             return True
-        for key in ("then", "else", "default", "sequence"):
-            if key in action and _has_delay_or_wait(action[key]):
-                return True
-        if "choose" in action:
-            for opt in _as_list(action["choose"]):
-                if isinstance(opt, dict) and _has_delay_or_wait(
-                    opt.get("sequence", [])
-                ):
-                    return True
-        if "repeat" in action and isinstance(action["repeat"], dict):
-            if _has_delay_or_wait(action["repeat"].get("sequence", [])):
-                return True
+        if _has_delay_or_wait_in_nested(action):
+            return True
     return False
 
 

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -6,8 +6,9 @@ and async operation verification through WebSocket monitoring.
 """
 
 import asyncio
+import json
 import logging
-from typing import Any
+from typing import Any, ClassVar
 
 from fastmcp.exceptions import ToolError
 
@@ -78,22 +79,8 @@ class DeviceControlTools:
         await self._ensure_websocket_listener()
 
         try:
-            # Handle parameters that might be passed as JSON string
-            if parameters and isinstance(parameters, str):
-                try:
-                    import json
+            parameters = self._parse_parameters(parameters, entity_id, action)
 
-                    parameters = json.loads(parameters)
-                except json.JSONDecodeError:
-                    raise_tool_error(create_error_response(
-                        ErrorCode.VALIDATION_INVALID_JSON,
-                        f"Invalid JSON in parameters: {parameters}",
-                        suggestions=[
-                            "Parameters should be a valid JSON object",
-                            "Example: {'brightness': 102, 'color_temp_kelvin': 4000}",
-                        ],
-                        context={"entity_id": entity_id, "action": action},
-                    ))
             # Parse domain from entity ID
             if "." not in entity_id:
                 raise_tool_error(create_error_response(
@@ -110,30 +97,9 @@ class DeviceControlTools:
             handler = get_domain_handler(domain)
 
             # Validate entity exists if requested
+            current_state = None
             if validate_first:
-                try:
-                    current_state = await self.client.get_entity_state(entity_id)
-                    if not current_state:
-                        raise_tool_error(create_error_response(
-                            ErrorCode.ENTITY_NOT_FOUND,
-                            f"Entity not found: {entity_id}",
-                            suggestions=[
-                                "Use smart_entity_search to find the correct entity",
-                                "Check entity is not disabled in Home Assistant",
-                            ],
-                            context={"entity_id": entity_id, "action": action},
-                        ))
-                except ToolError:
-                    raise
-                except Exception as e:
-                    exception_to_structured_error(
-                        e,
-                        context={"entity_id": entity_id, "action": action},
-                        suggestions=[
-                            "Check Home Assistant connection",
-                            "Verify entity ID spelling",
-                        ],
-                    )
+                current_state = await self._validate_entity_exists(entity_id, action)
 
             # Validate action for domain
             valid_actions = handler.get("valid_actions", ["on", "off", "toggle"])
@@ -150,7 +116,7 @@ class DeviceControlTools:
 
             # Build service call
             service_call = self._build_service_call(
-                entity_id, domain, action, parameters, handler
+                entity_id, domain, action, parameters
             )
 
             # Predict expected state after operation
@@ -224,17 +190,65 @@ class DeviceControlTools:
                 ],
             )
 
-    def _build_service_call(
+    def _parse_parameters(
+        self,
+        parameters: dict[str, Any] | None,
+        entity_id: str,
+        action: str,
+    ) -> dict[str, Any] | None:
+        if parameters and isinstance(parameters, str):
+            try:
+                return json.loads(parameters)
+            except json.JSONDecodeError:
+                raise_tool_error(create_error_response(
+                    ErrorCode.VALIDATION_INVALID_JSON,
+                    f"Invalid JSON in parameters: {parameters}",
+                    suggestions=[
+                        "Parameters should be a valid JSON object",
+                        "Example: {'brightness': 102, 'color_temp_kelvin': 4000}",
+                    ],
+                    context={"entity_id": entity_id, "action": action},
+                ))
+        return parameters
+
+    async def _validate_entity_exists(
         self,
         entity_id: str,
+        action: str,
+    ) -> dict[str, Any]:
+        """Fetch entity state, raising ToolError if the entity does not exist."""
+        try:
+            current_state = await self.client.get_entity_state(entity_id)
+            if not current_state:
+                raise_tool_error(create_error_response(
+                    ErrorCode.ENTITY_NOT_FOUND,
+                    f"Entity not found: {entity_id}",
+                    suggestions=[
+                        "Use smart_entity_search to find the correct entity",
+                        "Check entity is not disabled in Home Assistant",
+                    ],
+                    context={"entity_id": entity_id, "action": action},
+                ))
+            return current_state
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"entity_id": entity_id, "action": action},
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Verify entity ID spelling",
+                ],
+            )
+            raise  # unreachable; keeps type checker satisfied
+
+    def _resolve_service_name(
+        self,
         domain: str,
         action: str,
         parameters: dict[str, Any] | None,
-        handler: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Build Home Assistant service call from action and parameters."""
-
-        # Basic service mapping
+    ) -> tuple[str, dict[str, Any] | None]:
         service_mapping = {
             "on": "turn_on",
             "off": "turn_off",
@@ -246,7 +260,6 @@ class DeviceControlTools:
 
         service_name = service_mapping.get(action, action)
 
-        # Domain-specific service adjustments
         if domain == "climate":
             if action in ["heat", "cool", "auto"]:
                 service_name = "set_hvac_mode"
@@ -262,77 +275,67 @@ class DeviceControlTools:
             elif action == "set":
                 service_name = "volume_set"
 
-        # Build service data
-        service_data = {"entity_id": entity_id}
+        return service_name, parameters
 
-        # Add parameters based on domain
+    _DOMAIN_PARAMS: ClassVar[dict[str, list[str]]] = {
+        "light": ["brightness", "color_temp_kelvin", "rgb_color", "effect"],
+        "climate": ["temperature", "target_temp_high", "target_temp_low", "hvac_mode"],
+        "cover": ["position", "tilt_position"],
+        "media_player": ["volume_level", "media_content_id", "media_content_type"],
+    }
+
+    @staticmethod
+    def _normalize_light_color_temp(parameters: dict[str, Any]) -> None:
+        """Convert deprecated color temp parameters to color_temp_kelvin."""
+        if "color_temp_kelvin" in parameters:
+            return
+        if "kelvin" in parameters:
+            parameters["color_temp_kelvin"] = parameters.pop("kelvin")
+        elif "color_temp" in parameters:
+            mired_val = parameters.pop("color_temp")
+            if isinstance(mired_val, (int, float)) and mired_val > 0:
+                parameters["color_temp_kelvin"] = round(1_000_000 / mired_val)
+
+    def _add_domain_params(
+        self,
+        domain: str,
+        parameters: dict[str, Any],
+        service_data: dict[str, Any],
+    ) -> None:
+        if domain == "light":
+            self._normalize_light_color_temp(parameters)
+
+        allowed = self._DOMAIN_PARAMS.get(domain, [])
+        for param in allowed:
+            if param in parameters:
+                service_data[param] = parameters[param]
+
+    def _build_service_call(
+        self,
+        entity_id: str,
+        domain: str,
+        action: str,
+        parameters: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Build Home Assistant service call from action and parameters."""
+        service_name, parameters = self._resolve_service_name(domain, action, parameters)
+
+        service_data: dict[str, Any] = {"entity_id": entity_id}
+
         if parameters:
-            if domain == "light":
-                # Backward compat: convert deprecated color temp parameters
-                if "color_temp_kelvin" not in parameters:
-                    if "kelvin" in parameters:
-                        parameters["color_temp_kelvin"] = parameters.pop("kelvin")
-                    elif "color_temp" in parameters:
-                        mired_val = parameters.pop("color_temp")
-                        if isinstance(mired_val, (int, float)) and mired_val > 0:
-                            parameters["color_temp_kelvin"] = round(
-                                1_000_000 / mired_val
-                            )
-
-                light_params = [
-                    "brightness",
-                    "color_temp_kelvin",
-                    "rgb_color",
-                    "effect",
-                ]
-                for param in light_params:
-                    if param in parameters:
-                        service_data[param] = parameters[param]
-
-            elif domain == "climate":
-                climate_params = [
-                    "temperature",
-                    "target_temp_high",
-                    "target_temp_low",
-                    "hvac_mode",
-                ]
-                for param in climate_params:
-                    if param in parameters:
-                        service_data[param] = parameters[param]
-
-            elif domain == "cover":
-                cover_params = ["position", "tilt_position"]
-                for param in cover_params:
-                    if param in parameters:
-                        service_data[param] = parameters[param]
-
-            elif domain == "media_player":
-                media_params = [
-                    "volume_level",
-                    "media_content_id",
-                    "media_content_type",
-                ]
-                for param in media_params:
-                    if param in parameters:
-                        service_data[param] = parameters[param]
+            self._add_domain_params(domain, parameters, service_data)
 
         # Remove None values
         service_data = {k: v for k, v in service_data.items() if v is not None}
 
         return {"domain": domain, "service": service_name, "data": service_data}
 
-    def _predict_expected_state(
+    def _predict_state_from_action(
         self,
-        current_state: dict[str, Any] | None,
         action: str,
-        parameters: dict[str, Any] | None,
-        domain: str,
+        current_state: dict[str, Any] | None,
     ) -> dict[str, Any] | None:
-        """Predict expected entity state after operation."""
-
-        expected = {}
-
-        # State predictions by action
+        expected: dict[str, Any] = {}
         if action == "on":
             expected["state"] = "on"
         elif action == "off":
@@ -342,28 +345,48 @@ class DeviceControlTools:
                 current = current_state.get("state", "off")
                 expected["state"] = "off" if current == "on" else "on"
             else:
-                # Can't predict toggle without current state
                 return None
         elif action == "open":
             expected["state"] = "open"
         elif action == "close":
             expected["state"] = "closed"
+        return expected
 
-        # Domain-specific attribute predictions
+    def _predict_attributes_from_params(
+        self,
+        domain: str,
+        action: str,
+        parameters: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        if domain == "light" and action in ["on", "set"]:
+            if "brightness" in parameters:
+                expected["brightness"] = parameters["brightness"]
+            if "color_temp_kelvin" in parameters:
+                expected["color_temp_kelvin"] = parameters["color_temp_kelvin"]
+
+        elif domain == "climate" and action in ["set", "heat", "cool", "auto"]:
+            if "temperature" in parameters:
+                expected["temperature"] = parameters["temperature"]
+            if "hvac_mode" in parameters:
+                expected["hvac_mode"] = parameters["hvac_mode"]
+            elif action in ["heat", "cool", "auto"]:
+                expected["hvac_mode"] = action
+
+    def _predict_expected_state(
+        self,
+        current_state: dict[str, Any] | None,
+        action: str,
+        parameters: dict[str, Any] | None,
+        domain: str,
+    ) -> dict[str, Any] | None:
+        """Predict expected entity state after operation."""
+        expected = self._predict_state_from_action(action, current_state)
+        if expected is None:
+            return None
+
         if parameters:
-            if domain == "light" and action in ["on", "set"]:
-                if "brightness" in parameters:
-                    expected["brightness"] = parameters["brightness"]
-                if "color_temp_kelvin" in parameters:
-                    expected["color_temp_kelvin"] = parameters["color_temp_kelvin"]
-
-            elif domain == "climate" and action in ["set", "heat", "cool", "auto"]:
-                if "temperature" in parameters:
-                    expected["temperature"] = parameters["temperature"]
-                if "hvac_mode" in parameters:
-                    expected["hvac_mode"] = parameters["hvac_mode"]
-                elif action in ["heat", "cool", "auto"]:
-                    expected["hvac_mode"] = action
+            self._predict_attributes_from_params(domain, action, parameters, expected)
 
         return expected if expected else None
 
@@ -475,6 +498,41 @@ class DeviceControlTools:
                 ],
             }
 
+    @staticmethod
+    def _validate_bulk_operations(
+        operations: list[dict[str, Any]],
+        skipped_operations: list[dict[str, Any]],
+    ) -> list[tuple[int, dict[str, Any], str, str]]:
+        valid: list[tuple[int, dict[str, Any], str, str]] = []
+        for i, op in enumerate(operations):
+            if not isinstance(op, dict):
+                error = f"Operation at index {i} is not a dict: {type(op).__name__}"
+                logger.warning(f"Bulk control: {error}")
+                err_response = create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER, error, context={"index": i}
+                )
+                err_response["index"] = i
+                err_response["operation"] = op
+                skipped_operations.append(err_response)
+                continue
+
+            entity_id = op.get("entity_id")
+            action = op.get("action")
+            missing = [f for f in ("entity_id", "action") if not op.get(f)]
+
+            if missing:
+                error = f"Operation at index {i} missing required fields: {', '.join(missing)}"
+                logger.warning(f"Bulk control: {error}")
+                err_response = create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER, error, context={"index": i}
+                )
+                err_response["index"] = i
+                err_response["operation"] = op
+                skipped_operations.append(err_response)
+            else:
+                valid.append((i, op, str(entity_id), str(action)))
+        return valid
+
     async def bulk_device_control(
         self, operations: list[dict[str, Any]], parallel: bool = True
     ) -> dict[str, Any]:
@@ -500,136 +558,20 @@ class DeviceControlTools:
         operation_ids: list[str] = []
         skipped_operations: list[dict[str, Any]] = []
 
-        def validate_operation(
-            op: Any, index: int
-        ) -> tuple[str | None, str | None, str | None]:
-            """Validate operation and return (entity_id, action, error) tuple."""
-            if not isinstance(op, dict):
-                error = f"Operation at index {index} is not a dict: {type(op).__name__}"
-                logger.warning(f"Bulk control: {error}")
-                return None, None, error
-
-            entity_id = op.get("entity_id")
-            action = op.get("action")
-
-            missing_fields = []
-            if not entity_id:
-                missing_fields.append("entity_id")
-            if not action:
-                missing_fields.append("action")
-
-            if missing_fields:
-                error = (
-                    f"Operation at index {index} missing required fields: "
-                    f"{', '.join(missing_fields)}"
-                )
-                logger.warning(f"Bulk control: {error}")
-                return None, None, error
-
-            return str(entity_id), str(action), None
-
         try:
-            # Validate all operations first (centralized validation)
-            valid_operations: list[tuple[int, dict[str, Any], str, str]] = []
-            for i, op in enumerate(operations):
-                entity_id, action, error = validate_operation(op, i)
-                if error:
-                    err_response = create_error_response(
-                        ErrorCode.VALIDATION_MISSING_PARAMETER,
-                        error,
-                        context={"index": i},
-                    )
-                    err_response["index"] = i
-                    err_response["operation"] = op
-                    skipped_operations.append(err_response)
-                else:
-                    # Store (index, original_op, entity_id, action) for execution
-                    valid_operations.append((i, op, entity_id, action))  # type: ignore[arg-type]
+            valid_operations = self._validate_bulk_operations(
+                operations, skipped_operations
+            )
 
             # Execute only valid operations
             if parallel:
-                # Build tasks for parallel execution
-                tasks = []
-                for _i, op, entity_id, action in valid_operations:
-                    task = self.control_device_smart(
-                        entity_id=entity_id,
-                        action=action,
-                        parameters=op.get("parameters"),
-                        timeout_seconds=op.get("timeout_seconds", 10),
-                        validate_first=op.get("validate_first", True),
-                    )
-                    tasks.append(task)
-
-                if tasks:
-                    task_results = await asyncio.gather(*tasks, return_exceptions=True)
-
-                    # Process results and extract operation IDs
-                    for result in task_results:
-                        if isinstance(result, Exception):
-                            results.append(create_error_response(
-                                ErrorCode.SERVICE_CALL_FAILED,
-                                f"Exception during execution: {result!s}",
-                            ))
-                        elif isinstance(result, dict):
-                            results.append(result)
-                            if "operation_id" in result:
-                                operation_ids.append(result["operation_id"])
-
+                await self._execute_parallel(valid_operations, results, operation_ids)
             else:
-                # Execute valid operations sequentially
-                for _i, op, entity_id, action in valid_operations:
-                    result = await self.control_device_smart(
-                        entity_id=entity_id,
-                        action=action,
-                        parameters=op.get("parameters"),
-                        timeout_seconds=op.get("timeout_seconds", 10),
-                        validate_first=op.get("validate_first", True),
-                    )
-                    results.append(result)
+                await self._execute_sequential(valid_operations, results, operation_ids)
 
-                    if "operation_id" in result:
-                        operation_ids.append(result["operation_id"])
-
-            # Count successes and failures from executed operations
-            successful = len(
-                [r for r in results if isinstance(r, dict) and r.get("command_sent")]
+            return self._build_bulk_response(
+                operations, results, operation_ids, skipped_operations, parallel
             )
-            executed_failed = len(results) - successful
-            # Total failed includes both execution failures and skipped operations
-            total_failed = executed_failed + len(skipped_operations)
-
-            response: dict[str, Any] = {
-                "total_operations": len(operations),
-                "successful_commands": successful,
-                "failed_commands": total_failed,
-                "skipped_operations": len(skipped_operations),
-                "execution_mode": "parallel" if parallel else "sequential",
-                "operation_ids": operation_ids,
-                "results": results,
-                "follow_up": (
-                    {
-                        "message": (
-                            f"Use get_bulk_operation_status() to check all "
-                            f"{len(operation_ids)} operations"
-                        ),
-                        "operation_ids": operation_ids,
-                    }
-                    if operation_ids
-                    else None
-                ),
-            }
-
-            # Include skipped operation details if any were skipped
-            if skipped_operations:
-                response["skipped_details"] = skipped_operations
-                response["suggestions"] = [
-                    "Some operations were skipped due to validation errors",
-                    "Each operation requires 'entity_id' and 'action' fields",
-                    "Check skipped_details for specific errors",
-                    "Example format: {'entity_id': 'light.living_room', 'action': 'on'}",
-                ]
-
-            return response
 
         except ToolError:
             raise
@@ -640,6 +582,123 @@ class DeviceControlTools:
                 context={"results": results},
                 suggestions=["Check operation parameters and try again"],
             )
+
+    @staticmethod
+    def _tool_error_to_dict(e: ToolError) -> dict[str, Any]:
+        """Extract structured error dict from ToolError without double-encoding."""
+        try:
+            result: dict[str, Any] = json.loads(str(e))
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(f"Could not decode ToolError as structured response: {e!r}")
+            result = create_error_response(ErrorCode.SERVICE_CALL_FAILED, str(e))
+        return result
+
+    async def _execute_parallel(
+        self,
+        valid_operations: list[tuple[int, dict[str, Any], str, str]],
+        results: list[dict[str, Any]],
+        operation_ids: list[str],
+    ) -> None:
+        tasks = []
+        for _i, op, entity_id, action in valid_operations:
+            task = self.control_device_smart(
+                entity_id=entity_id,
+                action=action,
+                parameters=op.get("parameters"),
+                timeout_seconds=op.get("timeout_seconds", 10),
+                validate_first=op.get("validate_first", True),
+            )
+            tasks.append(task)
+
+        if tasks:
+            task_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for result in task_results:
+                if isinstance(result, ToolError):
+                    results.append(self._tool_error_to_dict(result))
+                elif isinstance(result, Exception):
+                    results.append(create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Exception during execution: {result!s}",
+                    ))
+                elif isinstance(result, dict):
+                    results.append(result)
+                    if "operation_id" in result:
+                        operation_ids.append(result["operation_id"])
+
+    async def _execute_sequential(
+        self,
+        valid_operations: list[tuple[int, dict[str, Any], str, str]],
+        results: list[dict[str, Any]],
+        operation_ids: list[str],
+    ) -> None:
+        for _i, op, entity_id, action in valid_operations:
+            try:
+                result = await self.control_device_smart(
+                    entity_id=entity_id,
+                    action=action,
+                    parameters=op.get("parameters"),
+                    timeout_seconds=op.get("timeout_seconds", 10),
+                    validate_first=op.get("validate_first", True),
+                )
+                results.append(result)
+                if "operation_id" in result:
+                    operation_ids.append(result["operation_id"])
+            except ToolError as e:
+                results.append(self._tool_error_to_dict(e))
+            except Exception as e:
+                results.append(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Exception during execution: {e!s}",
+                ))
+
+    def _build_bulk_response(
+        self,
+        operations: list[dict[str, Any]],
+        results: list[dict[str, Any]],
+        operation_ids: list[str],
+        skipped_operations: list[dict[str, Any]],
+        parallel: bool,
+    ) -> dict[str, Any]:
+        successful = len(
+            [r for r in results if isinstance(r, dict) and r.get("command_sent")]
+        )
+        executed_failed = len(results) - successful
+        # Total failed includes both execution failures and skipped operations
+        total_failed = executed_failed + len(skipped_operations)
+
+        response: dict[str, Any] = {
+            "total_operations": len(operations),
+            "successful_commands": successful,
+            "failed_commands": total_failed,
+            "skipped_operations": len(skipped_operations),
+            "execution_mode": "parallel" if parallel else "sequential",
+            "operation_ids": operation_ids,
+            "results": results,
+            "follow_up": (
+                {
+                    "message": (
+                        f"Use get_bulk_operation_status() to check all "
+                        f"{len(operation_ids)} operations"
+                    ),
+                    "operation_ids": operation_ids,
+                }
+                if operation_ids
+                else None
+            ),
+        }
+
+        # Include skipped operation details if any were skipped
+        if skipped_operations:
+            response["skipped_details"] = skipped_operations
+            response["suggestions"] = [
+                "Some operations were skipped due to validation errors",
+                "Each operation requires 'entity_id' and 'action' fields",
+                "Check skipped_details for specific errors",
+                "Example format: {'entity_id': 'light.living_room', 'action': 'on'}",
+            ]
+
+        return response
 
     async def get_bulk_operation_status(
         self, operation_ids: list[str]

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -98,6 +98,115 @@ async def get_connected_ws_client(
     return ws_client, None
 
 
+
+def _classify_api_status(
+    error: HomeAssistantAPIError,
+    error_msg: str,
+    context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Classify HomeAssistantAPIError by HTTP status code."""
+    match error.status_code:
+        case 404:
+            entity_id = context.get("entity_id") if context else None
+            if entity_id:
+                result = create_entity_not_found_error(entity_id, details=error_msg)
+            else:
+                result = create_error_response(ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context)
+        case 401 | 403:
+            result = create_auth_error(error_msg, context=context)
+        case 400:
+            result = create_validation_error(error_msg, context=context)
+        case _:
+            result = create_error_response(ErrorCode.SERVICE_CALL_FAILED, error_msg, context=context)
+    return result
+
+
+def _classify_exception(
+    error: Exception,
+    error_str: str,
+    error_msg: str,
+    context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Classify exception into structured error response by type, then message."""
+    result: dict[str, Any] | None = None
+
+    # Type-based classification
+    match error:
+        case HomeAssistantConnectionError():
+            result = create_connection_error(
+                error_msg, timeout="timeout" in error_str, context=context
+            )
+        case HomeAssistantAuthError():
+            result = create_auth_error(
+                error_msg, expired="expired" in error_str, context=context
+            )
+        case HomeAssistantAPIError():
+            result = _classify_api_status(error, error_msg, context)
+        case TimeoutError():
+            operation = context.get("operation", "request") if context else "request"
+            timeout_seconds = context.get("timeout_seconds", 30) if context else 30
+            result = create_timeout_error(operation, timeout_seconds, details=error_msg, context=context)
+        case ValueError():
+            result = create_validation_error(error_msg, context=context)
+
+    if result is not None:
+        return result
+
+    # Message-based classification fallback
+    return _classify_by_message(error_str, error_msg, context)
+
+
+def _classify_by_message(
+    error_str: str,
+    error_msg: str,
+    context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Classify exception by error message patterns."""
+    result: dict[str, Any]
+    if "not found" in error_str or "404" in error_str:
+        entity_id = context.get("entity_id") if context else None
+        if entity_id:
+            result = create_entity_not_found_error(entity_id, details=error_msg)
+        else:
+            result = create_error_response(ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context)
+    elif "timeout" in error_str:
+        result = create_timeout_error("operation", 30, details=error_msg, context=context)
+    elif "connection" in error_str or "connect" in error_str:
+        result = create_connection_error(error_msg, context=context)
+    elif "auth" in error_str or "token" in error_str or "401" in error_str:
+        result = create_auth_error(error_msg, context=context)
+    else:
+        result = create_error_response(
+            ErrorCode.INTERNAL_ERROR, "An unexpected error occurred", details=error_msg, context=context
+        )
+    return result
+
+
+def _append_macos_hints(error_response: dict[str, Any]) -> None:
+    if not (
+        sys.platform == "darwin"
+        and "error" in error_response
+        and isinstance(error_response["error"], dict)
+        and error_response["error"].get("code")
+        in (ErrorCode.CONNECTION_FAILED, ErrorCode.CONNECTION_TIMEOUT)
+    ):
+        return
+    macos_hints = [
+        "macOS may block local network access for Claude Desktop subprocesses "
+        "(System Settings > Privacy & Security > Local Network)",
+        "Try an SSH tunnel: ssh -N -L 8123:localhost:8123 user@ha-server, "
+        "then use http://localhost:8123",
+        "Ensure you are using http:// (not https://) unless SSL/TLS is configured",
+    ]
+    # Handle both "suggestions" (plural, 2+ items) and "suggestion" (singular, 1 item)
+    existing = error_response["error"].get("suggestions") or []
+    if not existing:
+        single = error_response["error"].get("suggestion")
+        if single:
+            existing = [single]
+    error_response["error"]["suggestions"] = existing + macos_hints
+
+
 @overload
 def exception_to_structured_error(
     error: Exception,
@@ -149,111 +258,14 @@ def exception_to_structured_error(
     error_str = str(error).lower()
     error_msg = str(error)
 
-    error_response: dict[str, Any]
-
-    # Handle specific exception types
-    if isinstance(error, HomeAssistantConnectionError):
-        if "timeout" in error_str:
-            error_response = create_connection_error(error_msg, timeout=True, context=context)
-        else:
-            error_response = create_connection_error(error_msg, context=context)
-
-    elif isinstance(error, HomeAssistantAuthError):
-        if "expired" in error_str:
-            error_response = create_auth_error(error_msg, expired=True, context=context)
-        else:
-            error_response = create_auth_error(error_msg, context=context)
-
-    elif isinstance(error, HomeAssistantAPIError):
-        # Check for specific error patterns
-        match error.status_code:
-            case 404:
-                # Entity or resource not found
-                entity_id = context.get("entity_id") if context else None
-                if entity_id:
-                    error_response = create_entity_not_found_error(entity_id, details=error_msg)
-                else:
-                    error_response = create_error_response(
-                        ErrorCode.RESOURCE_NOT_FOUND,
-                        error_msg,
-                        context=context,
-                    )
-            case 401 | 403:
-                error_response = create_auth_error(error_msg, context=context)
-            case 400:
-                error_response = create_validation_error(error_msg, context=context)
-            case _:
-                # Generic API error
-                error_response = create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    error_msg,
-                    context=context,
-                )
-
-    elif isinstance(error, TimeoutError):
-        operation = context.get("operation", "request") if context else "request"
-        timeout_seconds = context.get("timeout_seconds", 30) if context else 30
-        error_response = create_timeout_error(operation, timeout_seconds, details=error_msg, context=context)
-
-    elif isinstance(error, ValueError):
-        error_response = create_validation_error(error_msg, context=context)
-
-    # Check for common error patterns in error message
-    elif "not found" in error_str or "404" in error_str:
-        entity_id = context.get("entity_id") if context else None
-        if entity_id:
-            error_response = create_entity_not_found_error(entity_id, details=error_msg)
-        else:
-            error_response = create_error_response(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                error_msg,
-                context=context,
-            )
-
-    elif "timeout" in error_str:
-        error_response = create_timeout_error("operation", 30, details=error_msg, context=context)
-
-    elif "connection" in error_str or "connect" in error_str:
-        error_response = create_connection_error(error_msg, context=context)
-
-    elif "auth" in error_str or "token" in error_str or "401" in error_str:
-        error_response = create_auth_error(error_msg, context=context)
-
-    else:
-        # Default to internal error -- use generic message to avoid leaking internals
-        error_response = create_error_response(
-            ErrorCode.INTERNAL_ERROR,
-            "An unexpected error occurred",
-            details=error_msg,
-            context=context,
-        )
+    error_response = _classify_exception(error, error_str, error_msg, context)
 
     if suggestions and "error" in error_response and isinstance(error_response["error"], dict):
         error_response["error"]["suggestions"] = suggestions
 
     # Append macOS-specific hints for connection failures (after all other processing
     # so hints survive regardless of whether caller provided explicit suggestions)
-    if (
-        sys.platform == "darwin"
-        and "error" in error_response
-        and isinstance(error_response["error"], dict)
-        and error_response["error"].get("code")
-        in (ErrorCode.CONNECTION_FAILED, ErrorCode.CONNECTION_TIMEOUT)
-    ):
-        macos_hints = [
-            "macOS may block local network access for Claude Desktop subprocesses "
-            "(System Settings > Privacy & Security > Local Network)",
-            "Try an SSH tunnel: ssh -N -L 8123:localhost:8123 user@ha-server, "
-            "then use http://localhost:8123",
-            "Ensure you are using http:// (not https://) unless SSL/TLS is configured",
-        ]
-        # Handle both "suggestions" (plural, 2+ items) and "suggestion" (singular, 1 item)
-        existing = error_response["error"].get("suggestions") or []
-        if not existing:
-            single = error_response["error"].get("suggestion")
-            if single:
-                existing = [single]
-        error_response["error"]["suggestions"] = existing + macos_hints
+    _append_macos_hints(error_response)
 
     if raise_error:
         raise_tool_error(error_response)

--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -132,6 +132,42 @@ class ToolsRegistry:
 
         return discovered
 
+    def _import_and_register_module(
+        self, module_name: str, kwargs: dict[str, Any], func_name: str | None = None
+    ) -> bool:
+        """Import a tools submodule and call its register function.
+
+        When ``func_name`` is given, uses it directly (explicit mode); otherwise scans
+        the module for an attribute matching the ``register_*_tools`` convention.
+        Returns True if registered, False if no register function was found.
+        Re-raises on import or registration failure (fail-fast).
+        """
+        import importlib
+
+        try:
+            module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
+
+            if func_name is not None:
+                register_func = getattr(module, func_name)
+            else:
+                register_func = None
+                for attr_name in dir(module):
+                    if attr_name.startswith("register_") and attr_name.endswith("_tools"):
+                        register_func = getattr(module, attr_name)
+                        break
+
+            if register_func:
+                register_func(self.mcp, self.client, **kwargs)
+                logger.debug(f"Registered tools from {module_name}")
+                return True
+            else:
+                logger.warning(f"Module {module_name} has no register_*_tools function")
+                return False
+
+        except Exception as e:
+            logger.error(f"Failed to register tools from {module_name}: {e}")
+            raise
+
     def register_all_tools(self) -> None:
         """Register all tools with the MCP server using lazy auto-discovery.
 
@@ -141,8 +177,6 @@ class ToolsRegistry:
         if self._modules_registered:
             logger.debug("Tools already registered, skipping")
             return
-
-        import importlib
 
         # Build kwargs with all available dependencies (lazy access)
         kwargs = {
@@ -157,44 +191,16 @@ class ToolsRegistry:
             # Skip explicit modules - handled separately
             if module_name in EXPLICIT_MODULES:
                 continue
-
-            try:
-                module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
-
-                # Find the register function (convention: register_*_tools)
-                register_func = None
-                for attr_name in dir(module):
-                    if attr_name.startswith("register_") and attr_name.endswith("_tools"):
-                        register_func = getattr(module, attr_name)
-                        break
-
-                if register_func:
-                    register_func(self.mcp, self.client, **kwargs)
-                    registered_count += 1
-                    logger.debug(f"Registered tools from {module_name}")
-                else:
-                    logger.warning(
-                        f"Module {module_name} has no register_*_tools function"
-                    )
-
-            except Exception as e:
-                logger.error(f"Failed to register tools from {module_name}: {e}")
-                raise
+            if self._import_and_register_module(module_name, kwargs):
+                registered_count += 1
 
         # Register explicit modules (those not following tools_*.py convention)
         # Only register if they were included in discovered modules (respects filtering)
         for module_name, func_name in EXPLICIT_MODULES.items():
             if module_name not in self._discovered_modules:
                 continue
-            try:
-                module = importlib.import_module(f".{module_name}", "ha_mcp.tools")
-                register_func = getattr(module, func_name)
-                register_func(self.mcp, self.client, **kwargs)
+            if self._import_and_register_module(module_name, kwargs, func_name):
                 registered_count += 1
-                logger.debug(f"Registered tools from {module_name}")
-            except Exception as e:
-                logger.error(f"Failed to register tools from {module_name}: {e}")
-                raise
 
         self._modules_registered = True
         logger.info(f"Auto-discovery registered tools from {registered_count} modules")

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -1,10 +1,12 @@
 """Unit tests for bulk_device_control validation in device_control module."""
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.errors import ErrorCode, create_error_response
 from ha_mcp.tools.device_control import DeviceControlTools
 
 
@@ -141,3 +143,63 @@ class TestBulkDeviceControlValidation:
 
         assert result["skipped_operations"] == 1
         assert result["execution_mode"] == "sequential"
+
+
+class TestBulkExecutionErrorHandling:
+    """Test error handling semantics in parallel and sequential bulk execution."""
+
+    @pytest.fixture
+    def tools_with_mock_control(self):
+        """Create DeviceControlTools with mocked control_device_smart."""
+        tools = DeviceControlTools(client=MagicMock())
+        tools._ensure_websocket_listener = AsyncMock()  # type: ignore[method-assign]
+        return tools
+
+    @pytest.mark.asyncio
+    async def test_sequential_continues_after_tool_error(self, tools_with_mock_control):
+        """Sequential execution no longer aborts on a single ToolError (fail-soft)."""
+        tools_with_mock_control.control_device_smart = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {"entity_id": "light.ok", "command_sent": True, "operation_id": "op1"},
+                ToolError(json.dumps(create_error_response(
+                    ErrorCode.ENTITY_NOT_FOUND, "Entity not found: light.missing",
+                ))),
+                {"entity_id": "light.also_ok", "command_sent": True, "operation_id": "op3"},
+            ]
+        )
+
+        operations = [
+            {"entity_id": "light.ok", "action": "on"},
+            {"entity_id": "light.missing", "action": "on"},
+            {"entity_id": "light.also_ok", "action": "on"},
+        ]
+        result = await tools_with_mock_control.bulk_device_control(operations, parallel=False)
+
+        assert result["total_operations"] == 3
+        assert result["successful_commands"] == 2
+        assert len(result["results"]) == 3
+        # Middle op's structured code survived, not flattened into a string
+        assert result["results"][1]["error"]["code"] == ErrorCode.ENTITY_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_parallel_preserves_tool_error_code(self, tools_with_mock_control):
+        """Parallel execution preserves the structured ErrorCode from a ToolError."""
+        tools_with_mock_control.control_device_smart = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {"entity_id": "light.ok", "command_sent": True, "operation_id": "op1"},
+                ToolError(json.dumps(create_error_response(
+                    ErrorCode.VALIDATION_INVALID_JSON, "Invalid JSON in parameters",
+                ))),
+            ]
+        )
+
+        operations = [
+            {"entity_id": "light.ok", "action": "on"},
+            {"entity_id": "light.bad", "action": "on", "parameters": "{not-json"},
+        ]
+        result = await tools_with_mock_control.bulk_device_control(operations, parallel=True)
+
+        assert result["total_operations"] == 2
+        assert result["successful_commands"] == 1
+        # Structured code preserved, not flattened to SERVICE_CALL_FAILED
+        assert result["results"][1]["error"]["code"] == ErrorCode.VALIDATION_INVALID_JSON


### PR DESCRIPTION
## Summary

- Extract helper functions to bring cyclomatic complexity below threshold in `backup.py`, `best_practice_checker.py`, `device_control.py`, `helpers.py`, and `registry.py`
- Remove 5 C901 ignores from `pyproject.toml` (down from 21 to 9)

## Behavior changes

While refactoring `bulk_device_control`, two behaviors were intentionally changed for consistency:

1. **Sequential bulk execution is now fail-soft** (previously fail-fast). Before: a `ToolError` from op #2 aborted the batch via the outer `except ToolError: raise` (op #3+ never ran). After: each op is wrapped in its own try/except, matching the parallel branch's `return_exceptions=True` semantics. Both execution modes now behave consistently.

2. **Structured error codes from `ToolError` are preserved in bulk results** (previously flattened). Before: `ToolError` (subclass of `Exception`) was caught by the generic branch and flattened to `f"Exception during execution: {str(e)}"`, losing the `ErrorCode` (e.g., `ENTITY_NOT_FOUND`, `VALIDATION_INVALID_JSON`) inside an opaque string. After: `_tool_error_to_dict` decodes the JSON-encoded error, preserving the structured code. Consumers pattern-matching on `error.code == "SERVICE_CALL_FAILED"` for per-op bulk failures will now see the original codes.

Tests added: `test_sequential_continues_after_tool_error` (op #2 raises, op #3 still executes), `test_parallel_preserves_tool_error_code` (asserts original `ErrorCode` survives).

## Details

**backup.py** (complexity 15, 12):
- `_poll_backup_completion`: extracted polling loop from `create_backup`
- `_create_safety_backup`: extracted safety backup creation from `restore_backup`
- Promoted polling constants to module-level (`_BACKUP_MAX_WAIT_S`, `_BACKUP_POLL_INTERVAL_S`)

**best_practice_checker.py** (complexity 11, 11):
- `_check_choose_actions`, `_check_repeat_actions`: extracted from `_check_action_tree`
- `_has_delay_or_wait_in_nested`: extracted from `_has_delay_or_wait`

**device_control.py** (complexity 13, 25, 15, 21):
- `_parse_parameters`, `_validate_entity_exists`: extracted from `control_device_smart`
- `_resolve_service_name`, `_normalize_light_color_temp`, `_add_domain_params`: extracted from `_build_service_call`
- `_predict_state_from_action`, `_predict_attributes_from_params`: extracted from `_predict_expected_state`
- `_validate_bulk_operations`, `_execute_parallel`, `_execute_sequential`, `_build_bulk_response`, `_tool_error_to_dict`: extracted from `bulk_device_control`
- `_DOMAIN_PARAMS` ClassVar replaces repeated inline parameter lists
- Removed unused `handler` parameter from `_build_service_call`

**helpers.py** (complexity 22):
- `_classify_exception`, `_classify_api_status`, `_classify_by_message`, `_append_macos_hints`: extracted from `exception_to_structured_error`

**registry.py** (complexity 11):
- `_import_and_register_module`: consolidated duplicated import-and-register logic

## Test plan

- [x] All 1045 unit tests pass (added 2 for the behavior changes above)
- [x] Ruff lint clean (including C901)
- [x] Mypy type check clean
- [x] ast-grep clean

Tracks #925