### PR TITLE
refactor(search): make ha_search_entities query optional, clarify docs

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -157,9 +157,31 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     )
     @log_tool_usage
     async def ha_search_entities(
-        query: str,
-        domain_filter: str | None = None,
-        area_filter: str | None = None,
+        query: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    "Entity name to search for (fuzzy or exact match). "
+                    "Omit (or leave empty) to list entities — in that mode, "
+                    "`domain_filter` or `area_filter` must be set."
+                ),
+            ),
+        ] = None,
+        domain_filter: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description="Limit to a single domain (e.g. 'light', 'sensor', 'calendar').",
+            ),
+        ] = None,
+        area_filter: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description="Limit to entities in a specific area (area ID or name).",
+            ),
+        ] = None,
         limit: int = 10,
         offset: Annotated[
             int | str,
@@ -181,26 +203,18 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = True,
     ) -> dict[str, Any]:
-        """PRIMARY tool for finding entities (lights, sensors, switches, etc.) by name, area, or domain. Use this first when looking up any entity ID.
+        """Find or list entities (lights, sensors, switches, etc.) by name, domain, or area.
 
-        For searching *inside* automation/script/helper configurations, use ha_deep_search instead.
+        When NOT to use: for searching inside automation, script, helper, or dashboard
+        *configurations* (e.g. which automations call a service or reference an entity),
+        use `ha_deep_search`.
 
-        **Listing Entities by Domain:**
-        Use domain_filter with an empty query to list all entities of a specific type:
-        - ha_search_entities(query="", domain_filter="calendar") - List all calendars
-        - ha_search_entities(query="", domain_filter="todo") - List all todo lists
-        - ha_search_entities(query="", domain_filter="scene") - List all scenes
-        - ha_search_entities(query="", domain_filter="zone") - List all zones (as entities)
-
-        **BEST PRACTICE:** Before performing searches, call ha_get_overview() first to understand:
-        - Smart home size and scale (total entities, domains, areas)
-        - Language used in entity naming (French/English/mixed)
-        - Available areas/rooms and their entity distribution
-
-        Choose overview detail level based on task:
-        - 'minimal': Quick orientation (10 entities per domain sample) - RECOMMENDED for searches
-        - 'standard': Complete picture (all entities, friendly names only) - for comprehensive tasks
-        - 'full': Maximum detail (includes states, device types, services) - for deep analysis"""
+        To enumerate all entities of a domain, omit `query` and pass `domain_filter` — for
+        example, `ha_search_entities(domain_filter="calendar")` lists all calendars. At
+        least one of `query`, `domain_filter`, or `area_filter` must be set.
+        """
+        # Normalize omitted/None query to empty string so downstream logic is unchanged
+        query = query or ""
         # Coerce boolean parameter that may come as string from XML-style calls
         group_by_domain_bool = (
             coerce_bool_param(group_by_domain, "group_by_domain", default=False)

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -215,6 +215,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         """
         # Normalize omitted/None query to empty string so downstream logic is unchanged
         query = query or ""
+        if not query.strip() and not domain_filter and not area_filter:
+            raise_tool_error(
+                create_validation_error(
+                    "At least one of 'query', 'domain_filter', or 'area_filter' must be set.",
+                    parameter="query",
+                )
+            )
         # Coerce boolean parameter that may come as string from XML-style calls
         group_by_domain_bool = (
             coerce_bool_param(group_by_domain, "group_by_domain", default=False)

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -163,8 +163,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 default=None,
                 description=(
                     "Entity name to search for (fuzzy or exact match). "
-                    "Omit (or leave empty) to list entities — in that mode, "
-                    "`domain_filter` or `area_filter` must be set."
+                    "Omit to list entities; `domain_filter` or `area_filter` "
+                    "must be set in that mode."
                 ),
             ),
         ] = None,
@@ -209,7 +209,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         *configurations* (e.g. which automations call a service or reference an entity),
         use `ha_deep_search`.
 
-        To enumerate all entities of a domain, omit `query` and pass `domain_filter` — for
+        To enumerate all entities of a domain, omit `query` and pass `domain_filter`. For
         example, `ha_search_entities(domain_filter="calendar")` lists all calendars. At
         least one of `query`, `domain_filter`, or `area_filter` must be set.
         """

--- a/tests/src/e2e/performance/test_performance_baselines.py
+++ b/tests/src/e2e/performance/test_performance_baselines.py
@@ -151,7 +151,7 @@ async def test_search_entities_domain_filter_performance(mcp_client, perf_metric
     results = await run_performance_iterations(
         mcp_client,
         tool_name="ha_search_entities",
-        params={"query": "", "domain_filter": "light", "limit": 50},
+        params={"domain_filter": "light", "limit": 50},
         iterations=5,
         warmup=1,
     )
@@ -368,7 +368,7 @@ async def test_performance_report_generation(mcp_client):
         ("ha_get_overview", {"detail_level": "full"}),
         ("ha_get_overview", {"detail_level": "minimal"}),
         ("ha_search_entities", {"query": "light", "limit": 10}),
-        ("ha_search_entities", {"query": "", "domain_filter": "sensor", "limit": 20}),
+        ("ha_search_entities", {"domain_filter": "sensor", "limit": 20}),
         ("ha_deep_search", {"query": "light", "limit": 5}),
         ("ha_get_state", {"entity_id": "sun.sun"}),
     ]

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -127,7 +127,7 @@ async def test_search_entities_group_by_domain(mcp_client):
 
     result = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "light", "group_by_domain": True, "limit": 50},
+        {"domain_filter": "light", "group_by_domain": True, "limit": 50},
     )
     raw_data = assert_mcp_success(result, "Group by domain")
     # Tool returns {"data": {...}, "metadata": {...}} structure via add_timezone_metadata
@@ -151,7 +151,7 @@ async def test_search_entities_nonexistent_domain(mcp_client):
 
     result = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "nonexistent_domain_xyz", "limit": 10},
+        {"domain_filter": "nonexistent_domain_xyz", "limit": 10},
     )
     raw_data = assert_mcp_success(result, "Nonexistent domain")
     # Tool returns {"data": {...}, "metadata": {...}} structure via add_timezone_metadata
@@ -172,7 +172,7 @@ async def test_search_entities_limit_respected(mcp_client):
     # First, get all lights to see how many exist
     result_all = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "light", "limit": 1000},
+        {"domain_filter": "light", "limit": 1000},
     )
     raw_data_all = assert_mcp_success(result_all, "Get all lights")
     # Tool returns {"data": {...}, "metadata": {...}} structure via add_timezone_metadata
@@ -185,7 +185,7 @@ async def test_search_entities_limit_respected(mcp_client):
     # Now test with a small limit
     result_limited = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "light", "limit": 2},
+        {"domain_filter": "light", "limit": 2},
     )
     raw_data_limited = assert_mcp_success(result_limited, "Limited lights")
     data_limited = raw_data_limited.get("data", raw_data_limited)
@@ -218,7 +218,7 @@ async def test_search_entities_multiple_domains(mcp_client):
     for domain in domains_to_test:
         result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": domain, "limit": 100},
+            {"domain_filter": domain, "limit": 100},
         )
         raw_data = parse_mcp_result(result)
         # Tool returns {"data": {...}, "metadata": {...}} structure via add_timezone_metadata
@@ -415,7 +415,7 @@ async def test_search_entities_offset_pagination(mcp_client):
     # Get first page
     result1 = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "light", "limit": 2, "offset": 0},
+        {"domain_filter": "light", "limit": 2, "offset": 0},
     )
     raw_data1 = assert_mcp_success(result1, "First page")
     data1 = raw_data1.get("data", raw_data1)
@@ -427,7 +427,7 @@ async def test_search_entities_offset_pagination(mcp_client):
     # Get second page
     result2 = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "light", "limit": 2, "offset": 2},
+        {"domain_filter": "light", "limit": 2, "offset": 2},
     )
     raw_data2 = assert_mcp_success(result2, "Second page")
     data2 = raw_data2.get("data", raw_data2)

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -94,11 +94,26 @@ async def test_search_entities_whitespace_query_with_domain_filter(mcp_client):
 
 
 @pytest.mark.asyncio
-async def test_search_entities_all_filters_empty_rejected(mcp_client):
-    """Calling with no query and no filters returns a validation error."""
-    logger.info("Testing validation: all filter params empty/omitted")
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"query": ""},
+        {"query": "   "},
+        {"query": None},
+        {"query": "", "domain_filter": None, "area_filter": None},
+    ],
+    ids=["all-omitted", "empty-query", "whitespace-query", "null-query", "all-none"],
+)
+async def test_search_entities_all_filters_empty_rejected(mcp_client, params):
+    """Calling with no usable query and no filters returns a validation error.
 
-    data = await safe_call_tool(mcp_client, "ha_search_entities", {})
+    Locks down the equivalence of empty / whitespace / None / omitted forms
+    through the ``query = query or ""`` + ``.strip()`` normalization.
+    """
+    logger.info(f"Testing validation: {params}")
+
+    data = await safe_call_tool(mcp_client, "ha_search_entities", params)
     inner = data.get("data", data)
 
     assert inner.get("success") is False, f"Should fail validation: {inner}"
@@ -107,7 +122,30 @@ async def test_search_entities_all_filters_empty_rejected(mcp_client):
         f"Should be VALIDATION_FAILED: {inner}"
     )
 
-    logger.info("Validation correctly rejects empty-filters call")
+
+@pytest.mark.asyncio
+async def test_search_entities_area_filter_only(mcp_client):
+    """area_filter alone (no query, no domain_filter) returns entities in that area.
+
+    Smoke test for the standalone form legitimized by the new docstring.
+    Accepts zero matches (demo env may lack areas) as long as search_type
+    is 'area_only' and success=True.
+    """
+    logger.info("Testing area_filter alone")
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": "kitchen", "limit": 10},
+    )
+    raw_data = assert_mcp_success(result, "area_filter alone")
+    data = raw_data.get("data", raw_data)
+
+    assert data.get("success") is True
+    assert data.get("search_type") == "area_only", (
+        f"Expected search_type 'area_only', got '{data.get('search_type')}'"
+    )
+
+    logger.info(f"area_filter='kitchen' returned {data.get('total_matches', 0)} matches")
 
 
 @pytest.mark.asyncio

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -94,6 +94,23 @@ async def test_search_entities_whitespace_query_with_domain_filter(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_search_entities_all_filters_empty_rejected(mcp_client):
+    """Calling with no query and no filters returns a validation error."""
+    logger.info("Testing validation: all filter params empty/omitted")
+
+    data = await safe_call_tool(mcp_client, "ha_search_entities", {})
+    inner = data.get("data", data)
+
+    assert inner.get("success") is False, f"Should fail validation: {inner}"
+    error = inner.get("error", {})
+    assert isinstance(error, dict) and error.get("code") == "VALIDATION_FAILED", (
+        f"Should be VALIDATION_FAILED: {inner}"
+    )
+
+    logger.info("Validation correctly rejects empty-filters call")
+
+
+@pytest.mark.asyncio
 async def test_search_entities_domain_filter_with_query(mcp_client):
     """Test domain_filter combined with a non-empty query."""
     logger.info("Testing domain_filter with query")

--- a/tests/src/e2e/utilities/cleanup.py
+++ b/tests/src/e2e/utilities/cleanup.py
@@ -227,7 +227,7 @@ async def cleanup_test_entities_by_name(
             # Search for entities in this domain
             search_result = await mcp_client.call_tool(
                 "ha_search_entities",
-                {"query": "", "domain_filter": domain, "limit": 50},
+                {"domain_filter": domain, "limit": 50},
             )
 
             search_data = parse_mcp_result(search_result)

--- a/tests/src/e2e/workflows/automation/test_helpers.py
+++ b/tests/src/e2e/workflows/automation/test_helpers.py
@@ -981,7 +981,7 @@ async def test_helper_search_and_discovery(mcp_client):
     for domain in helper_domains:
         logger.info(f"🔍 Searching for {domain} helpers...")
         search_result = await mcp_client.call_tool(
-            "ha_search_entities", {"query": "", "domain_filter": domain, "limit": 10}
+            "ha_search_entities", {"domain_filter": domain, "limit": 10}
         )
 
         search_data = parse_mcp_result(search_result)

--- a/tests/src/e2e/workflows/core/test_bulk.py
+++ b/tests/src/e2e/workflows/core/test_bulk.py
@@ -150,7 +150,7 @@ class TestBulkControl:
         # Search for multiple lights
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "light", "limit": 5},
+            {"domain_filter": "light", "limit": 5},
         )
         search_data = parse_mcp_result(search_result)
 
@@ -268,7 +268,7 @@ class TestBulkControl:
         # Search for light and switch entities
         light_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "light", "limit": 2},
+            {"domain_filter": "light", "limit": 2},
         )
         light_data = parse_mcp_result(light_result)
         if "data" in light_data:
@@ -278,7 +278,7 @@ class TestBulkControl:
 
         switch_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "switch", "limit": 2},
+            {"domain_filter": "switch", "limit": 2},
         )
         switch_data = parse_mcp_result(switch_result)
         if "data" in switch_data:
@@ -339,7 +339,7 @@ class TestBulkControl:
         # Search for lights
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "light", "limit": 3},
+            {"domain_filter": "light", "limit": 3},
         )
         search_data = parse_mcp_result(search_result)
 
@@ -374,7 +374,7 @@ class TestBulkControl:
         # Search for lights
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "light", "limit": 3},
+            {"domain_filter": "light", "limit": 3},
         )
         search_data = parse_mcp_result(search_result)
 

--- a/tests/src/e2e/workflows/core/test_get_states.py
+++ b/tests/src/e2e/workflows/core/test_get_states.py
@@ -26,7 +26,7 @@ class TestGetStates:
         # Find a sensor entity to pair with sun.sun
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "sensor", "limit": 1},
+            {"domain_filter": "sensor", "limit": 1},
         )
         search_data = parse_mcp_result(search_result)
 

--- a/tests/src/e2e/workflows/core/test_history.py
+++ b/tests/src/e2e/workflows/core/test_history.py
@@ -116,7 +116,7 @@ class TestGetHistory:
         # Search for a sensor to add to the query
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "sensor", "limit": 2},
+            {"domain_filter": "sensor", "limit": 2},
         )
         search_data = parse_mcp_result(search_result)
 
@@ -373,7 +373,7 @@ class TestGetHistoryStatisticsSource:
             # Fallback: try any sensor
             search_result = await mcp_client.call_tool(
                 "ha_search_entities",
-                {"query": "", "domain_filter": "sensor", "limit": 5},
+                {"domain_filter": "sensor", "limit": 5},
             )
             search_data = parse_mcp_result(search_result)
             if "data" in search_data:
@@ -426,7 +426,7 @@ class TestGetHistoryStatisticsSource:
         # Find a sensor
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "sensor", "limit": 1},
+            {"domain_filter": "sensor", "limit": 1},
         )
         search_data = parse_mcp_result(search_result)
         if "data" in search_data:
@@ -469,7 +469,7 @@ class TestGetHistoryStatisticsSource:
         # Find a sensor
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "sensor", "limit": 1},
+            {"domain_filter": "sensor", "limit": 1},
         )
         search_data = parse_mcp_result(search_result)
         if "data" in search_data:

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -284,7 +284,7 @@ class TestCallService:
         # Search for a scene
         search_result = await mcp_client.call_tool(
             "ha_search_entities",
-            {"query": "", "domain_filter": "scene", "limit": 5},
+            {"domain_filter": "scene", "limit": 5},
         )
         search_data = parse_mcp_result(search_result)
 

--- a/tests/src/e2e/workflows/core/test_state.py
+++ b/tests/src/e2e/workflows/core/test_state.py
@@ -121,7 +121,7 @@ async def test_get_state_sensor_with_numeric_value(mcp_client):
     # Search for a sensor to test
     search_result = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "sensor", "limit": 5},
+        {"domain_filter": "sensor", "limit": 5},
     )
 
     search_data = parse_mcp_result(search_result)
@@ -167,7 +167,7 @@ async def test_get_state_automation_entity(mcp_client):
     # Search for an automation
     search_result = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "automation", "limit": 5},
+        {"domain_filter": "automation", "limit": 5},
     )
 
     search_data = parse_mcp_result(search_result)
@@ -218,7 +218,7 @@ async def test_get_state_binary_sensor(mcp_client):
     # Search for a binary sensor
     search_result = await mcp_client.call_tool(
         "ha_search_entities",
-        {"query": "", "domain_filter": "binary_sensor", "limit": 5},
+        {"domain_filter": "binary_sensor", "limit": 5},
     )
 
     search_data = parse_mcp_result(search_result)


### PR DESCRIPTION
## What does this PR do?

Resolves the discoverability problem raised in discussion #994: a contributor couldn't tell from the schema or the top of the docstring that `ha_search_entities` supports domain/area-only listing (no search term required).

Three changes to `ha_search_entities` (`src/ha_mcp/tools/tools_search.py`):

1. **Schema.** `query: str` → `query: str | None = None`. The listing mode is now expressible in the schema, not as a magic empty-string sentinel. Added `Field` descriptions to `query`, `domain_filter`, `area_filter`. A `query = query or ""` normalization line at the top keeps all prior callers (including ~30 tests that passed `""`) working unchanged.
2. **Docstring rewrite.** Per `AGENTS.md` guidance ("starts with an action verb", "one sentence describing what the tool does", no "motivational prose"): dropped `PRIMARY tool for…` / `Use this first when…`, collapsed four near-identical listing examples into one, and removed a leaked `ha_get_overview` detail-level block that belonged on the other tool's docstring.
3. **Test sweep.** Updated ~20 incidental `{"query": "", "domain_filter": "X", …}` call sites across 9 test files to the canonical `{"domain_filter": "X", …}` form. Explicitly preserved two regression tests that exist to exercise the BC paths: `test_search_entities_empty_query_with_domain_filter` (issue #158 regression) and `test_search_entities_whitespace_query_with_domain_filter`.

### Routing validation

Ran five BAT scenarios across three variants:

| # | Scenario | Baseline 1st tool | Revised (docstring) 1st tool | Final (docstring + schema) 1st tool |
|---|----------|-------------------|------------------------------|-------------------------------------|
| 1 | List calendars | `ha_search_entities(query="", domain_filter="calendar")` | same | `ha_search_entities(domain_filter="calendar")` ⭐ |
| 2 | Count lights | `ha_search_entities(query="", domain_filter="light", limit=100)` | same | `ha_search_entities(domain_filter="light")` ⭐ |
| 3 | bed_light state | `ha_get_state` (direct) | same | same |
| 4 | Deep entity-ref | `ha_deep_search` | same | same |
| 5 | Deep behavior | `ha_deep_search` | same | same |

Routing preserved in all 5 scenarios. In the combined run the model actually uses the canonical form (drops the `query` key), confirming the schema change is visible to clients, not just cosmetic.

### Behavior change for degenerate calls

The validation added in commit 9f6103d changes one observable behavior:

- **Before:** `ha_search_entities("")` with no filters fell through `_exact_match_search` where `"" in entity_id.lower()` was always True, returning up to 10 arbitrary entities from the full inventory.
- **After:** The same call returns a `VALIDATION_FAILED` error with message "At least one of 'query', 'domain_filter', or 'area_filter' must be set."

Not a breaking change per `AGENTS.md`'s definition (the old output was degenerate; no well-formed caller can depend on 10 randomly-ordered entities), but worth calling out. All meaningful usage patterns (non-empty query, or any filter set) are unchanged and continue to work via the `query = query or ""` normalization.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
