### PR TITLE
test(e2e): enable HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION for HACS tests

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,7 +6,7 @@
 - HA's `call_service(return_response=True)` wraps results in `{"changed_states": [], "service_response": {...}}` — tools unwrap this with `result.get("service_response", result)` before returning
 - `hass.async_add_executor_job` only passes positional args — use `lambda:` wrappers for calls needing kwargs (e.g., `mkdir(parents=True, exist_ok=True)`)
 - HA Docker image uses `annotatedyaml` (PyYAML wrapper), NOT `ruamel.yaml` — custom components needing ruamel must declare it in `manifest.json` requirements
-- Feature flags (`ENABLE_YAML_CONFIG_EDITING`, `HAMCP_ENABLE_FILESYSTEM_TOOLS`) are set in `ha_container_with_fresh_config` fixture
+- Feature flags (`ENABLE_YAML_CONFIG_EDITING`, `HAMCP_ENABLE_FILESYSTEM_TOOLS`, `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION`) are set in `ha_container_with_fresh_config` fixture
 
 ## Test Patterns
 

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -300,6 +300,7 @@ def ha_container_with_fresh_config():
         # Enable feature flags for e2e tests
         os.environ["ENABLE_YAML_CONFIG_EDITING"] = "true"
         os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = "true"
+        os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = "true"
 
         # Reset cached settings so WebSocket client picks up the dynamic URL
         import ha_mcp.config


### PR DESCRIPTION
## What does this PR do?

The feature flag `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION` is declared in `tests/.env.test` but that file only loads in CI (via `HAMCP_ENV_FILE: "tests/.env.test"` in `e2e-tests.yml`). Local runs without that env var miss the flag, so `ha_install_mcp_tools` is not registered and the HACS `TestMcpToolsInstallation` class fails with `Unknown tool: 'ha_install_mcp_tools'`.

Setting the flag in `conftest.py` matches the existing pattern for `ENABLE_YAML_CONFIG_EDITING` and `HAMCP_ENABLE_FILESYSTEM_TOOLS`, so HACS tests pass locally without extra shell setup (CI behaviour is unchanged since the flag was already set there).

Also updated `tests/CLAUDE.md` (symlink to `tests/AGENTS.md`) to list the third flag alongside the existing two.

### Verification

Ran `pytest src/e2e/workflows/hacs/test_hacs.py::TestMcpToolsInstallation` on a fresh worktree off `origin/master` with the change applied. 3/3 tests pass in 88.75s. Without the change they fail with `Unknown tool: 'ha_install_mcp_tools'`.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`)
- [x] Code follows style guidelines (\`uv run ruff check\`)

## Checklist
- [x] I have updated documentation if needed