### PR TITLE
docs: fix and clarify PR thread-resolution workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,24 +134,27 @@ gh issue list --state open --json number,title,labels --jq '.[] | select(.labels
 gh pr view <PR> --json comments --jq '.comments[] | {author: .author.login, created: .createdAt}'
 
 # Check inline review comments (specific to code lines)
-gh api repos/homeassistant-ai/ha-mcp/pulls/<PR>/comments --jq '.[] | {path: .path, line: .line, author: .author.login, created_at: .created_at}'
+gh api repos/homeassistant-ai/ha-mcp/pulls/<PR>/comments --jq '.[] | {id: .id, path: .path, line: .line, author: .user.login, created_at: .created_at}'
+
+# Get review-thread IDs (needed to resolve threads). Match by comment databaseId:
+gh api graphql -f query='{ repository(owner:"homeassistant-ai", name:"ha-mcp") { pullRequest(number:<PR>) { reviewThreads(first:50) { nodes { id isResolved comments(first:1) { nodes { databaseId } } } } } } }'
 
 # Check for unresolved review threads
 gh pr view <PR> --json reviews --jq '.reviews[] | select(.state == "COMMENTED") | .body'
 ```
 
 **Resolve threads:**
-After addressing a comment, **ALWAYS post a comment explaining the resolution, then mark the thread as resolved**:
+After addressing a comment, **ALWAYS post an inline reply on the specific thread explaining the resolution, then mark the thread as resolved**:
 
 ```bash
-# 1. FIRST: Post comment explaining what was done
-gh pr review <PR> --comment --body "✅ Fixed in [commit]. [Explanation]"
+# 1. FIRST: Post inline reply on the thread (not a general PR comment)
+gh api repos/homeassistant-ai/ha-mcp/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="Fixed in [commit]. [Explanation]"
 # OR for dismissed suggestions:
-gh pr review <PR> --comment --body "📝 Not addressing because [reason]."
+gh api repos/homeassistant-ai/ha-mcp/pulls/<PR>/comments/<COMMENT_ID>/replies -f body="Not addressing because [reason]."
 
 # 2. THEN: Resolve the thread
 gh api graphql -f query='mutation($threadId: ID!) {
-  resolveReviewThread(input: {pullRequestReviewThreadId: $threadId}) {
+  resolveReviewThread(input: {threadId: $threadId}) {
     thread { id isResolved }
   }
 }' -f threadId=<thread_id>


### PR DESCRIPTION
## What does this PR do?

Fixes and clarifies the PR Review Comments section in `AGENTS.md` after discovering three issues while resolving a Gemini Code Assist thread on PR #1004:

1. **`resolveReviewThread` input field fix.** The mutation example used `pullRequestReviewThreadId`, but the input object takes `threadId`. GitHub rejects the old field with `missingRequiredInputObjectAttribute` and `argumentNotAccepted`.

2. **Inline reply workflow.** The previous example used `gh pr review --comment`, which posts a general PR comment. For responding to a specific review thread, `gh api repos/.../pulls/{pr}/comments/{id}/replies` posts the reply inline on the thread, which is what "post a comment explaining the resolution" intends.

3. **Thread ID lookup.** Resolving a thread requires the thread node ID (`PRRT_...`), which is not exposed in the REST comment payload. Added a GraphQL query that returns thread IDs alongside the `databaseId` of their first comment, so you can match back to a REST comment you already have.

Also: fixed `.author.login` → `.user.login` in the inline-comment check (REST uses `user`, GraphQL uses `author`), and exposed the `id` field so the reply URL segment is readable from the listing.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`)
- [x] Code follows style guidelines (\`uv run ruff check\`)

Doc-only change; no runtime impact. Every command shown was verified against PR #1004's review threads during this session.

## Checklist
- [x] I have updated documentation if needed