### PR TITLE
feat: add WebSocket response-shaping controls to ha_manage_addon

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -28,6 +28,7 @@ from ..errors import (
     create_timeout_error,
     create_validation_error,
 )
+from ..utils.python_sandbox import PythonSandboxError, safe_execute_expression
 from .helpers import (
     exception_to_structured_error,
     get_connected_ws_client,
@@ -40,11 +41,158 @@ logger = logging.getLogger(__name__)
 # Maximum response size to return from add-on API calls (50 KB)
 _MAX_RESPONSE_SIZE = 50 * 1024
 
-# Maximum number of WebSocket messages to collect
+# Hard safety cap on WebSocket messages collected per call. `message_limit`
+# can lower this but never raise it.
 _MAX_WS_MESSAGES = 1000
 
 # ANSI escape code pattern for stripping terminal colors from addon output
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+# Substrings that flag a WebSocket message as "signal" for the summarize pass.
+# Keep conservative: false negatives get elided, false positives just mean
+# no elision. Case-insensitive match on the JSON-stringified message.
+_SIGNAL_PATTERNS = re.compile(
+    r"(?:^|[^A-Za-z])(INFO|WARN(?:ING)?|ERROR|FATAL|FAIL(?:ED|URE)?|EXCEPTION|"
+    r"TRACEBACK|Configuration is valid|Successfully|unsuccessful|exit|"
+    r"returncode|Compiling|Linking)",
+    re.IGNORECASE,
+)
+
+# Consecutive non-signal messages needed to trigger elision. Below this,
+# the run passes through untouched.
+_SUMMARIZE_RUN_THRESHOLD = 10
+
+# Messages preserved verbatim at each end of an elided run for context.
+_SUMMARIZE_CONTEXT_KEEP = 2
+
+
+def _slice_ws_messages(
+    messages: list[Any],
+    offset: int,
+    limit: int | None,
+) -> tuple[list[Any], dict[str, Any]]:
+    """Apply offset/limit to a collected WebSocket message list.
+
+    Returns ``(sliced_messages, pagination_metadata)``. Pagination metadata
+    is always returned so the response shape is stable regardless of whether
+    offset/limit were applied.
+    """
+    total_collected = len(messages)
+    if offset < 0:
+        offset = 0
+    if offset > total_collected:
+        sliced: list[Any] = []
+    elif limit is None:
+        sliced = messages[offset:]
+    else:
+        if limit < 0:
+            limit = 0
+        sliced = messages[offset : offset + limit]
+
+    pagination: dict[str, Any] = {
+        "total_collected": total_collected,
+        "offset": offset,
+        "returned": len(sliced),
+    }
+    if limit is not None:
+        pagination["limit"] = limit
+    return sliced, pagination
+
+
+def _is_signal_message(msg: Any) -> bool:
+    """Return True if ``msg`` looks like a log line or terminal event worth keeping.
+
+    The heuristic errs toward keeping messages — false positives just mean
+    a run doesn't get elided.
+    """
+    if isinstance(msg, (dict, list)):
+        serialized = json.dumps(msg, default=str)
+    else:
+        serialized = str(msg)
+    return bool(_SIGNAL_PATTERNS.search(serialized[:2000]))
+
+
+def _summarize_ws_messages(
+    messages: list[Any],
+    *,
+    run_threshold: int = _SUMMARIZE_RUN_THRESHOLD,
+    context_keep: int = _SUMMARIZE_CONTEXT_KEEP,
+) -> tuple[list[Any], dict[str, Any]]:
+    """Collapse runs of non-signal WebSocket messages into elision markers.
+
+    Each run of ≥ ``run_threshold`` consecutive non-signal entries becomes:
+    ``context_keep`` originals, one elision dict
+    ``{"elided": N, "note": "..."}``, then ``context_keep`` originals.
+    Signal messages always pass through unchanged.
+    """
+    result: list[Any] = []
+    run_start: int | None = None
+    elided_total = 0
+
+    def flush(run_end: int) -> None:
+        nonlocal elided_total
+        assert run_start is not None
+        run_len = run_end - run_start
+        if run_len >= run_threshold:
+            result.extend(messages[run_start : run_start + context_keep])
+            elided_count = run_len - 2 * context_keep
+            result.append(
+                {
+                    "elided": elided_count,
+                    "note": (
+                        f"{elided_count} non-signal messages elided; "
+                        "pass summarize=False for full output"
+                    ),
+                }
+            )
+            result.extend(messages[run_end - context_keep : run_end])
+            elided_total += elided_count
+        else:
+            result.extend(messages[run_start:run_end])
+
+    for i, msg in enumerate(messages):
+        if _is_signal_message(msg):
+            if run_start is not None:
+                flush(i)
+                run_start = None
+            result.append(msg)
+        else:
+            if run_start is None:
+                run_start = i
+
+    if run_start is not None:
+        flush(len(messages))
+
+    return result, {
+        "original_count": len(messages),
+        "summarized_count": len(result),
+        "elided_count": elided_total,
+    }
+
+
+def _apply_response_transform(response: Any, expr: str) -> Any:
+    """Run a sandboxed ``python_transform`` expression against ``response``.
+
+    Exposes the value to the expression as ``response``. Supports both
+    in-place mutation and reassignment (``response = [...]``). Raises
+    ToolError with VALIDATION_FAILED on sandbox errors so the agent gets
+    a structured code it can react to.
+    """
+    try:
+        return safe_execute_expression(expr, {"response": response}, "response")
+    except PythonSandboxError as e:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_FAILED,
+                f"python_transform failed: {e!s}",
+                context={"expression_preview": expr[:200]},
+                suggestions=[
+                    "Operate on the `response` variable (in-place or reassign)",
+                    "Allowed: dict/list access, assignment, loops, "
+                    "comprehensions, whitelisted str/list/dict methods",
+                ],
+            )
+        )
 
 
 def _merge_options(base: dict, override: dict) -> dict:
@@ -325,6 +473,10 @@ async def _call_addon_ws(
     debug: bool = False,
     port: int | None = None,
     wait_for_close: bool = True,
+    message_limit: int | None = None,
+    message_offset: int = 0,
+    summarize: bool = True,
+    python_transform: str | None = None,
 ) -> dict[str, Any]:
     """Connect to an add-on's WebSocket API and collect messages.
 
@@ -338,6 +490,20 @@ async def _call_addon_ws(
         port: Override port (same as HTTP tool)
         wait_for_close: If True, collect messages until server closes or timeout.
             If False, return after first batch of messages (up to 2s of silence).
+        message_limit: Cap on messages collected from the wire. Bounded by the
+            hard ceiling ``_MAX_WS_MESSAGES``. None means "collect up to the
+            ceiling" (legacy behavior).
+        message_offset: Drop this many messages from the start of the collected
+            list before returning. Useful for paginating past a known-noisy
+            header when re-running the same call.
+        summarize: When True (default), collapse runs of non-signal messages
+            (typically YAML config dumps) into short elision markers. Set to
+            False to return the raw stream.
+        python_transform: Optional sandboxed Python expression that post-
+            processes the response. The variable ``response`` is bound to
+            the list of parsed messages (``list[dict | str]``); the value
+            of ``response`` after execution replaces ``messages`` in the
+            output. See ``ha_manage_addon`` docstring for details.
 
     Returns:
         Dictionary with collected messages, metadata, and status.
@@ -427,6 +593,16 @@ async def _call_addon_ws(
     close_reason = "unknown"
     start_time = time.monotonic()
 
+    # Effective collection cap: callers may lower _MAX_WS_MESSAGES via
+    # message_limit but cannot raise it. A caller's message_limit interacts
+    # with message_offset — we collect enough to satisfy `offset + limit`
+    # so requesting a later window actually returns the window.
+    if message_limit is None:
+        collection_cap = _MAX_WS_MESSAGES
+    else:
+        requested = max(0, message_offset) + max(0, message_limit)
+        collection_cap = min(_MAX_WS_MESSAGES, requested)
+
     try:
         async with websockets.connect(
             ws_url,
@@ -451,7 +627,7 @@ async def _call_addon_ws(
                     close_reason = "timeout"
                     break
 
-                if len(collected) >= _MAX_WS_MESSAGES:
+                if len(collected) >= collection_cap:
                     close_reason = "message_limit"
                     break
 
@@ -527,7 +703,9 @@ async def _call_addon_ws(
     elapsed = round(time.monotonic() - start_time, 2)
 
     # 8. Build result
-    # Try to parse each message as JSON; keep as string if not JSON
+    # Try to parse each message as JSON; keep as string if not JSON.
+    # Result shape is list[dict | str] — the heterogeneity is part of the
+    # python_transform contract (see ha_manage_addon docstring).
     parsed_messages: list[Any] = []
     for msg in collected:
         try:
@@ -535,15 +713,53 @@ async def _call_addon_ws(
         except (json.JSONDecodeError, ValueError):
             parsed_messages.append(msg)
 
+    # 8a. Apply offset/limit slicing before summarize/transform so users
+    # paginate the raw collected list, not the post-summarize output.
+    sliced_messages, pagination = _slice_ws_messages(
+        parsed_messages,
+        offset=message_offset,
+        limit=message_limit,
+    )
+
+    # 8b. Summarize (default on) — collapse bulk non-signal runs.
+    summary_meta: dict[str, Any] | None = None
+    processed_messages: list[Any] = sliced_messages
+    if summarize:
+        processed_messages, summary_meta = _summarize_ws_messages(sliced_messages)
+
+    # 8c. python_transform (optional) — user-controlled post-processing.
+    transformed = False
+    pre_transform_count = len(processed_messages)
+    if python_transform is not None:
+        processed_messages = _apply_response_transform(
+            processed_messages,
+            python_transform,
+        )
+        transformed = True
+
     result: dict[str, Any] = {
         "success": True,
-        "messages": parsed_messages,
-        "message_count": len(parsed_messages),
+        "messages": processed_messages,
+        "message_count": (
+            len(processed_messages) if isinstance(processed_messages, list) else None
+        ),
         "closed_by": close_reason,
         "duration_seconds": elapsed,
         "addon_name": addon_name,
         "slug": slug,
     }
+
+    # Pagination metadata is always present when offset/limit were used so
+    # callers have a stable shape to reason about.
+    if message_offset > 0 or message_limit is not None:
+        result["pagination"] = pagination
+
+    if summary_meta is not None and summary_meta["elided_count"] > 0:
+        result["summary"] = summary_meta
+
+    if transformed:
+        result["transformed"] = True
+        result["pre_transform_message_count"] = pre_transform_count
 
     if debug:
         result["_debug"] = {
@@ -551,6 +767,7 @@ async def _call_addon_ws(
             "request_headers": dict(headers),
             "initial_message": body,
             "total_bytes_collected": total_size,
+            "collection_cap": collection_cap,
         }
 
     # Cap the serialized result size (raw bytes undercount due to JSON + MCP overhead)
@@ -559,17 +776,20 @@ async def _call_addon_ws(
         result = {
             "success": True,
             "error": "RESPONSE_TOO_LARGE",
-            "message": f"WebSocket collected {len(parsed_messages)} messages "
-            f"({len(result_serialized)} bytes serialized) exceeding "
-            f"{_MAX_RESPONSE_SIZE // 1024}KB limit.",
-            "message_count": len(parsed_messages),
+            "message": f"WebSocket response ({len(result_serialized)} bytes "
+            f"serialized) exceeds {_MAX_RESPONSE_SIZE // 1024}KB limit.",
+            "message_count": (
+                len(processed_messages)
+                if isinstance(processed_messages, list)
+                else None
+            ),
             "closed_by": close_reason,
             "duration_seconds": elapsed,
             "addon_name": addon_name,
             "slug": slug,
             "truncated": True,
-            "hint": "Use wait_for_close=false for shorter collection, "
-            "or use the HTTP endpoint with offset/limit for paginated access.",
+            "hint": "Lower message_limit, raise message_offset, keep summarize=True, "
+            "or narrow the response with python_transform.",
         }
 
     return result
@@ -586,6 +806,7 @@ async def _call_addon_api(
     port: int | None = None,
     offset: int = 0,
     limit: int | None = None,
+    python_transform: str | None = None,
 ) -> dict[str, Any]:
     """Call an add-on's web API through Home Assistant's Ingress proxy.
 
@@ -599,6 +820,10 @@ async def _call_addon_api(
         port: Override port to connect to (e.g., direct access port instead of ingress port)
         offset: Skip this many items in array responses (default 0)
         limit: Return at most this many items from array responses
+        python_transform: Optional sandboxed Python expression applied to the
+            parsed response body. The variable ``response`` is bound to
+            ``dict | list | str`` depending on content-type. Transform runs
+            after offset/limit slicing.
 
     Returns:
         Dictionary with response data, status code, and content type.
@@ -756,6 +981,13 @@ async def _call_addon_api(
             "returned": len(response_data),
         }
 
+    # 8a. python_transform (optional) — runs after slicing, before size cap,
+    # so an agent can narrow a large response down under the limit.
+    transformed = False
+    if python_transform is not None:
+        response_data = _apply_response_transform(response_data, python_transform)
+        transformed = True
+
     # 9. Truncate large responses
     truncated = False
     if isinstance(response_data, str) and len(response_data) > _MAX_RESPONSE_SIZE:
@@ -813,6 +1045,9 @@ async def _call_addon_api(
 
     if pagination_meta:
         result["pagination"] = pagination_meta
+
+    if transformed:
+        result["transformed"] = True
 
     if truncated:
         result["truncated"] = True
@@ -1046,6 +1281,44 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 default=True,
             ),
         ] = True,
+        message_limit: Annotated[
+            int | None,
+            Field(
+                description="Proxy mode only. WebSocket: cap on messages collected from the wire, "
+                "bounded by an internal safety ceiling. None = collect up to the ceiling. "
+                "Lower to save tokens on noisy streams (e.g., message_limit=50 for a quick health check).",
+                default=None,
+            ),
+        ] = None,
+        message_offset: Annotated[
+            int,
+            Field(
+                description="Proxy mode only. WebSocket: drop this many messages from the start of the "
+                "collected list before returning. Useful for paginating past known-noisy headers. Default: 0.",
+                default=0,
+            ),
+        ] = 0,
+        summarize: Annotated[
+            bool,
+            Field(
+                description="Proxy mode only. WebSocket: when True (default), collapse runs of "
+                "non-signal messages (typically YAML config dumps) into short elision markers. "
+                "Set to False to return the raw stream.",
+                default=True,
+            ),
+        ] = True,
+        python_transform: Annotated[
+            str | None,
+            Field(
+                description="Proxy mode only. Sandboxed Python expression that post-processes the response. "
+                "Variable `response` is exposed — a list[dict | str] for WebSocket (parsed JSON or raw text), "
+                "or dict/list/str for HTTP (parsed body). Supports in-place mutation "
+                "(response.append(...)) or reassignment (response = [...]). "
+                "Example: response = [m for m in response if 'ERROR' in str(m)]. "
+                "Post-processing only — does not provide optimistic-locking write semantics.",
+                default=None,
+            ),
+        ] = None,
         options: Annotated[
             dict[str, Any] | None,
             Field(
@@ -1095,6 +1368,23 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         Sends requests directly to the add-on container's own web API via HTTP or WebSocket.
         Use ha_get_addon(slug="...") to discover available ports and endpoints.
 
+        **Response shaping (proxy mode):**
+        - WebSocket streams can be noisy (ESPHome /validate often emits hundreds of
+          config-dump lines). By default, `summarize=True` collapses long runs of
+          non-signal messages into short elision markers; INFO/WARNING/ERROR/exit
+          lines always pass through. Pagination via `message_offset` / `message_limit`
+          works on the raw collected list before summarize runs.
+        - `python_transform` applies a sandboxed Python expression as a final
+          post-processing step in both HTTP and WebSocket modes. The variable
+          `response` is bound to:
+            * WebSocket: `list[dict | str]` — parsed JSON messages are dicts,
+              undecodable frames stay as ANSI-stripped strings. Elision markers
+              appear as `{"elided": N, "note": "..."}` dicts when summarize ran.
+            * HTTP: `dict | list | str` — whichever the content-type produced.
+          Transforms may mutate in place (response.append(...), del response[k])
+          or reassign (response = [...]). This is post-processing only — it does
+          NOT provide optimistic-locking or write-back semantics.
+
         **WARNING:** Setting boot="auto"/"manual" will fail for add-ons whose Supervisor
         metadata locks the boot mode. The Supervisor returns an error in this case.
 
@@ -1110,6 +1400,9 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         - Call HTTP API: ha_manage_addon(slug="...", path="/api/events")
         - Direct port: ha_manage_addon(slug="...", path="/flows", port=1880)
         - WebSocket: ha_manage_addon(slug="...", path="/validate", port=6052, websocket=True, body={"type": "spawn", "configuration": "device.yaml"})
+        - Quick WS health check (50 msgs, raw): ha_manage_addon(slug="...", path="/logs", websocket=True, message_limit=50, summarize=False)
+        - Filter WS errors only: ha_manage_addon(slug="...", path="/validate", websocket=True, python_transform="response = [m for m in response if 'ERROR' in str(m) or 'WARN' in str(m)]")
+        - HTTP subset: ha_manage_addon(slug="...", path="/flows", python_transform="response = [f['id'] for f in response]")
         """
         # Build config payload from provided config parameters
         config_data: dict[str, Any] = {}
@@ -1169,6 +1462,18 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 proxy_overrides.append(("websocket", "websocket=True"))
             if not wait_for_close:
                 proxy_overrides.append(("wait_for_close", "wait_for_close=False"))
+            if message_limit is not None:
+                proxy_overrides.append(
+                    ("message_limit", f"message_limit={message_limit}")
+                )
+            if message_offset != 0:
+                proxy_overrides.append(
+                    ("message_offset", f"message_offset={message_offset}")
+                )
+            if not summarize:
+                proxy_overrides.append(("summarize", "summarize=False"))
+            if python_transform is not None:
+                proxy_overrides.append(("python_transform", "python_transform"))
             if proxy_overrides:
                 raise_tool_error(
                     create_validation_error(
@@ -1278,6 +1583,10 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 debug=debug,
                 port=port,
                 wait_for_close=wait_for_close,
+                message_limit=message_limit,
+                message_offset=message_offset,
+                summarize=summarize,
+                python_transform=python_transform,
             )
             if not result.get("success"):
                 raise_tool_error(result)
@@ -1293,6 +1602,17 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 )
             )
 
+        # HTTP mode does not use WebSocket-specific params. Reject explicit
+        # use so misroutes surface immediately rather than silently ignoring.
+        if message_limit is not None or message_offset != 0 or not summarize:
+            raise_tool_error(
+                create_validation_error(
+                    "message_limit / message_offset / summarize apply only to "
+                    "WebSocket mode. Set websocket=True or remove them.",
+                    parameter="message_limit",
+                )
+            )
+
         result = await _call_addon_api(
             client=client,
             slug=slug,
@@ -1303,6 +1623,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
             port=port,
             offset=offset,
             limit=limit,
+            python_transform=python_transform,
         )
         if not result.get("success"):
             raise_tool_error(result)

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -628,7 +628,14 @@ async def _call_addon_ws(
                     break
 
                 if len(collected) >= collection_cap:
-                    close_reason = "message_limit"
+                    # Distinguish caller-set cap from the global safety ceiling
+                    # so an agent reading the response can tell "I capped this"
+                    # from "ha-mcp's hard ceiling kicked in".
+                    close_reason = (
+                        "message_limit"
+                        if message_limit is not None
+                        else "safety_ceiling"
+                    )
                     break
 
                 if total_size >= _MAX_RESPONSE_SIZE:

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -131,6 +131,38 @@ BLOCKED_FUNCTIONS = {
 }
 
 
+# Minimal set of builtins exposed to sandboxed expressions. All entries are
+# pure (no side effects, no I/O, no imports) and commonly needed by data
+# transforms — type checks, length, numeric/string coercion, simple
+# collection helpers. Expanding this list is fine if another pure builtin
+# is genuinely needed; adding anything that touches the filesystem, network,
+# or interpreter state is not.
+_SAFE_BUILTINS: dict[str, Any] = {
+    "isinstance": isinstance,
+    "len": len,
+    "range": range,
+    "enumerate": enumerate,
+    "zip": zip,
+    "sorted": sorted,
+    "reversed": reversed,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "abs": abs,
+    "any": any,
+    "all": all,
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+    "tuple": tuple,
+    "set": set,
+    "round": round,
+}
+
+
 def validate_expression(expr: str) -> tuple[bool, str]:
     """
     Validate Python expression is safe to execute.
@@ -208,16 +240,80 @@ def _validate_call_node(node: ast.Call) -> str | None:
     return None
 
 
-def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
+def safe_execute_expression(
+    expr: str,
+    variables: dict[str, Any],
+    result_key: str,
+) -> Any:
     """
-    Execute validated Python expression in restricted environment.
+    Execute a validated Python expression in a restricted environment.
+
+    The expression runs with ``variables`` available as locals. After
+    execution, the value bound to ``result_key`` is returned. This supports
+    both in-place mutation (``response.append(...)``) and reassignment
+    (``response = [...]``) — in the reassignment case the returned object
+    is the new one, not the original reference.
 
     Args:
         expr: Python expression to execute
-        config: Dashboard configuration dict (will be modified in-place)
+        variables: Mapping of variable names to values exposed to the expression
+        result_key: Name of the variable in ``variables`` whose post-execution
+            value should be returned
 
     Returns:
-        Modified config dict
+        The value of ``result_key`` in the local namespace after execution
+
+    Raises:
+        PythonSandboxError: If expression validation fails or execution errors
+
+    Examples:
+        >>> safe_execute_expression(
+        ...     "response = [m for m in response if m.get('level') == 'ERROR']",
+        ...     {"response": [{"level": "INFO"}, {"level": "ERROR"}]},
+        ...     "response",
+        ... )
+        [{'level': 'ERROR'}]
+    """
+    valid, error = validate_expression(expr)
+    if not valid:
+        raise PythonSandboxError(f"Expression validation failed: {error}")
+
+    if result_key not in variables:
+        raise PythonSandboxError(
+            f"result_key {result_key!r} not found in variables",
+        )
+
+    safe_globals: dict[str, Any] = {
+        "__builtins__": _SAFE_BUILTINS,
+        "__name__": "__main__",
+        "__doc__": None,
+    }
+    safe_locals: dict[str, Any] = dict(variables)
+
+    try:
+        exec(expr, safe_globals, safe_locals)
+    except Exception as e:
+        raise PythonSandboxError(f"Execution error: {type(e).__name__}: {e}") from e
+
+    return safe_locals[result_key]
+
+
+def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Execute validated Python expression against a ``config`` dict.
+
+    Thin wrapper around :func:`safe_execute_expression` that exposes the
+    input as the variable ``config`` (used by dashboard/automation/script
+    transforms).
+
+    Args:
+        expr: Python expression to execute
+        config: Configuration dict (may be modified in-place)
+
+    Returns:
+        The value bound to ``config`` after execution — typically the same
+        dict mutated in place, but also supports expressions that reassign
+        ``config`` to a new object.
 
     Raises:
         PythonSandboxError: If expression validation fails or execution errors
@@ -227,29 +323,7 @@ def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
         >>> safe_execute("config['views'][0]['cards'][0]['icon'] = 'new'", config)
         {'views': [{'cards': [{'icon': 'new'}]}]}
     """
-    # Validate expression
-    valid, error = validate_expression(expr)
-    if not valid:
-        raise PythonSandboxError(f"Expression validation failed: {error}")
-
-    # Execute in restricted environment
-    # No builtins to prevent access to dangerous functions
-    safe_globals: dict[str, Any] = {
-        "__builtins__": {},
-        "__name__": "__main__",
-        "__doc__": None,
-    }
-
-    safe_locals: dict[str, Any] = {
-        "config": config,
-    }
-
-    try:
-        exec(expr, safe_globals, safe_locals)
-    except Exception as e:
-        raise PythonSandboxError(f"Execution error: {type(e).__name__}: {e}") from e
-
-    return config
+    return safe_execute_expression(expr, {"config": config}, "config")
 
 
 def get_security_documentation() -> str:
@@ -270,12 +344,15 @@ PYTHON TRANSFORM SECURITY:
 - Loops: for, while, if/else
 - Comprehensions: [x for x in ...]
 - String methods: startswith, endswith, lower, upper, split, join
+- Safe builtins: isinstance, len, range, enumerate, zip, sorted, reversed,
+  min, max, sum, abs, any, all, round, str, int, float, bool, list, dict,
+  tuple, set
 
 ❌ FORBIDDEN:
 - Imports: import, from, __import__
 - File operations: open, read, write
 - Dunder access: __class__, __bases__, __subclasses__
-- Dangerous builtins: eval, exec, compile
+- Dangerous builtins: eval, exec, compile, getattr, setattr, delattr, hasattr
 - Function definitions: def, class
 - Exception handling: try/except (use validation instead)
 """.strip()

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -7,7 +7,7 @@ callers are already authenticated MCP users with full HA access.
 """
 
 import ast
-from typing import Any
+from typing import Any, cast
 
 
 class PythonSandboxError(Exception):
@@ -323,7 +323,13 @@ def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
         >>> safe_execute("config['views'][0]['cards'][0]['icon'] = 'new'", config)
         {'views': [{'cards': [{'icon': 'new'}]}]}
     """
-    return safe_execute_expression(expr, {"config": config}, "config")
+    # safe_execute_expression returns Any (generic over result_key); at this
+    # call site the result is always the dict bound to `config`, so narrow
+    # for mypy and existing callers that depend on the dict interface.
+    return cast(
+        dict[str, Any],
+        safe_execute_expression(expr, {"config": config}, "config"),
+    )
 
 
 def get_security_documentation() -> str:

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -5,6 +5,7 @@ import pytest
 from ha_mcp.utils.python_sandbox import (
     PythonSandboxError,
     safe_execute,
+    safe_execute_expression,
     validate_expression,
 )
 
@@ -205,3 +206,107 @@ for card in config['views'][0]['cards']:
         expr = "config['nonexistent']['key'] = 'value'"
         with pytest.raises(PythonSandboxError, match="Execution error"):
             safe_execute(expr, config)
+
+
+class TestSafeExecuteExpression:
+    """Tests for the generalized safe_execute_expression."""
+
+    def test_custom_variable_name(self):
+        """Supports arbitrary variable names, not just 'config'."""
+        expr = "response = [x for x in response if x > 1]"
+        result = safe_execute_expression(expr, {"response": [1, 2, 3]}, "response")
+        assert result == [2, 3]
+
+    def test_reassignment_returns_new_object(self):
+        """Reassignment inside the expression is reflected in the return value.
+
+        The old safe_execute semantics returned the original reference, which
+        silently dropped reassigned values. safe_execute_expression returns
+        the post-execution binding, so `response = [...]` works.
+        """
+        expr = "response = {'filtered': True}"
+        result = safe_execute_expression(expr, {"response": {}}, "response")
+        assert result == {"filtered": True}
+
+    def test_in_place_mutation(self):
+        """In-place mutations on mutable values are returned as expected."""
+        original = [1, 2, 3]
+        expr = "response.append(4)"
+        result = safe_execute_expression(expr, {"response": original}, "response")
+        assert result == [1, 2, 3, 4]
+        assert original == [1, 2, 3, 4]  # same reference, mutated
+
+    def test_missing_result_key_raises(self):
+        """If result_key is not in variables, raise PythonSandboxError up front."""
+        with pytest.raises(PythonSandboxError, match="result_key"):
+            safe_execute_expression(
+                "response = 1", {"other": 1}, "response"
+            )
+
+    def test_validation_failure_raises(self):
+        """Invalid expressions raise with 'validation failed' prefix."""
+        with pytest.raises(PythonSandboxError, match="validation failed"):
+            safe_execute_expression("import os", {"response": None}, "response")
+
+    def test_execution_error_raises(self):
+        """Runtime errors in the expression raise with 'Execution error' prefix."""
+        with pytest.raises(PythonSandboxError, match="Execution error"):
+            safe_execute_expression(
+                "response['missing']['key'] = 1",
+                {"response": {}},
+                "response",
+            )
+
+    def test_mixed_shape_list_with_isinstance(self):
+        """Transforms handle heterogeneous list[dict | str] using isinstance.
+
+        The WebSocket message list is intentionally heterogeneous (parsed JSON
+        dicts interleaved with raw ANSI-stripped strings). Agents need
+        isinstance/str to reason about the shape — both are in the minimal
+        safe-builtins set.
+        """
+        messages = [
+            {"level": "INFO", "text": "Starting"},
+            "raw text line",
+            {"level": "ERROR", "text": "Boom"},
+            "another raw line",
+        ]
+        expr = (
+            "response = [m for m in response "
+            "if isinstance(m, dict) and m.get('level') == 'ERROR']"
+        )
+        result = safe_execute_expression(
+            expr, {"response": messages}, "response"
+        )
+        assert result == [{"level": "ERROR", "text": "Boom"}]
+
+    def test_str_coercion_available(self):
+        """str() is in the safe builtins for text-content matching."""
+        messages = [{"level": "ERROR"}, "plain string", 42]
+        expr = "response = [m for m in response if 'ERROR' in str(m)]"
+        result = safe_execute_expression(
+            expr, {"response": messages}, "response"
+        )
+        assert result == [{"level": "ERROR"}]
+
+    def test_builtins_do_not_include_open(self):
+        """Dangerous builtins like open remain blocked at AST validation."""
+        with pytest.raises(PythonSandboxError, match="validation failed"):
+            safe_execute_expression(
+                "open('/etc/passwd')", {"response": None}, "response"
+            )
+
+    def test_builtins_do_not_include_getattr(self):
+        """getattr remains blocked at AST validation."""
+        with pytest.raises(PythonSandboxError, match="validation failed"):
+            safe_execute_expression(
+                "getattr(response, '__class__')",
+                {"response": []},
+                "response",
+            )
+
+    def test_safe_execute_wrapper_still_works(self):
+        """safe_execute should remain backward-compatible with existing callers."""
+        config = {"views": [{"icon": "old"}]}
+        result = safe_execute("config['views'][0]['icon'] = 'new'", config)
+        assert result["views"][0]["icon"] == "new"

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -8,7 +8,15 @@ import pytest
 import websockets.exceptions
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.tools_addons import _call_addon_api, _call_addon_ws, list_addons
+from ha_mcp.tools.tools_addons import (
+    _apply_response_transform,
+    _call_addon_api,
+    _call_addon_ws,
+    _is_signal_message,
+    _slice_ws_messages,
+    _summarize_ws_messages,
+    list_addons,
+)
 
 # Standard mock return for a running addon with Ingress support
 _RUNNING_ADDON_INFO = {
@@ -707,6 +715,545 @@ class TestCallAddonWsErrors:
         )
 
 
+class TestSliceWsMessages:
+    """Tests for the _slice_ws_messages helper (pure function)."""
+
+    def test_no_offset_no_limit_returns_all(self):
+        """Without offset/limit, all collected messages pass through."""
+        messages = [1, 2, 3, 4, 5]
+        sliced, meta = _slice_ws_messages(messages, offset=0, limit=None)
+        assert sliced == messages
+        assert meta == {"total_collected": 5, "offset": 0, "returned": 5}
+
+    def test_limit_truncates(self):
+        """Limit caps the returned count."""
+        sliced, meta = _slice_ws_messages([1, 2, 3, 4, 5], offset=0, limit=3)
+        assert sliced == [1, 2, 3]
+        assert meta["returned"] == 3
+        assert meta["limit"] == 3
+
+    def test_offset_skips_head(self):
+        """Offset drops the first N messages."""
+        sliced, _ = _slice_ws_messages([1, 2, 3, 4, 5], offset=2, limit=None)
+        assert sliced == [3, 4, 5]
+
+    def test_offset_plus_limit(self):
+        """Offset + limit selects a window."""
+        sliced, meta = _slice_ws_messages([1, 2, 3, 4, 5], offset=1, limit=2)
+        assert sliced == [2, 3]
+        assert meta["offset"] == 1
+        assert meta["limit"] == 2
+        assert meta["returned"] == 2
+
+    def test_offset_beyond_total_returns_empty(self):
+        """Offset past the end yields an empty slice but stable metadata."""
+        sliced, meta = _slice_ws_messages([1, 2, 3], offset=10, limit=None)
+        assert sliced == []
+        assert meta["total_collected"] == 3
+        assert meta["returned"] == 0
+
+    def test_negative_offset_clamped_to_zero(self):
+        """Negative offset is clamped — no reverse slicing."""
+        sliced, _ = _slice_ws_messages([1, 2, 3], offset=-5, limit=None)
+        assert sliced == [1, 2, 3]
+
+    def test_negative_limit_clamped_to_zero(self):
+        """Negative limit is clamped to zero (empty return)."""
+        sliced, _ = _slice_ws_messages([1, 2, 3], offset=0, limit=-1)
+        assert sliced == []
+
+
+class TestIsSignalMessage:
+    """Tests for the _is_signal_message heuristic."""
+
+    def test_info_log_is_signal(self):
+        assert _is_signal_message("INFO Reading configuration")
+
+    def test_warning_log_is_signal(self):
+        assert _is_signal_message("WARNING Something looks off")
+        assert _is_signal_message("WARN deprecated setting")
+
+    def test_error_log_is_signal(self):
+        assert _is_signal_message("ERROR Compile failed")
+        assert _is_signal_message({"level": "ERROR", "msg": "boom"})
+
+    def test_exit_event_is_signal(self):
+        assert _is_signal_message({"event": "exit", "code": 0})
+        assert _is_signal_message({"returncode": 1})
+
+    def test_config_valid_is_signal(self):
+        assert _is_signal_message("Configuration is valid!")
+
+    def test_yaml_dump_line_is_not_signal(self):
+        """Plain YAML-shaped lines are non-signal (expected to be elided)."""
+        assert not _is_signal_message("  - platform: gpio")
+        assert not _is_signal_message("sensor:")
+        assert not _is_signal_message("    pin: GPIO0")
+
+
+class TestSummarizeWsMessages:
+    """Tests for the _summarize_ws_messages heuristic."""
+
+    def test_short_non_signal_run_passes_through(self):
+        """A run shorter than the threshold is not elided."""
+        messages = ["  key1: val", "  key2: val", "  key3: val"]
+        result, meta = _summarize_ws_messages(messages, run_threshold=10)
+        assert result == messages
+        assert meta["elided_count"] == 0
+
+    def test_long_non_signal_run_is_elided(self):
+        """A run ≥ threshold is collapsed with context kept at each end."""
+        messages = [f"  line_{i}: value" for i in range(50)]
+        result, meta = _summarize_ws_messages(
+            messages, run_threshold=10, context_keep=2
+        )
+        # 2 head + 1 elision marker + 2 tail = 5 entries
+        assert len(result) == 5
+        assert result[0] == "  line_0: value"
+        assert result[1] == "  line_1: value"
+        assert isinstance(result[2], dict)
+        assert result[2]["elided"] == 46
+        assert "summarize=False" in result[2]["note"]
+        assert result[3] == "  line_48: value"
+        assert result[4] == "  line_49: value"
+        assert meta["original_count"] == 50
+        assert meta["elided_count"] == 46
+
+    def test_signal_messages_split_runs(self):
+        """Signal messages break non-signal runs so each run is checked separately."""
+        messages = (
+            [f"  k{i}: v" for i in range(5)]
+            + ["INFO something happened"]
+            + [f"  k{i}: v" for i in range(5)]
+        )
+        result, meta = _summarize_ws_messages(messages, run_threshold=10)
+        # Neither 5-long run is ≥ threshold → nothing elided
+        assert result == messages
+        assert meta["elided_count"] == 0
+
+    def test_mixed_with_esphome_validate_shape(self):
+        """Simulates a realistic ESPHome /validate stream: header signals, big
+        YAML dump, trailing success signal."""
+        messages = (
+            ["INFO Reading configuration motion1.yaml..."]
+            + [f"    key_{i}: val_{i}" for i in range(100)]
+            + [
+                "INFO Configuration is valid!",
+                {"event": "exit", "code": 0},
+            ]
+        )
+        result, meta = _summarize_ws_messages(messages, run_threshold=10)
+        # 1 header INFO + (2 context + 1 elided + 2 context) + 2 trailing signals
+        assert len(result) == 8
+        assert "Reading configuration" in str(result[0])
+        assert result[1] == "    key_0: val_0"
+        assert isinstance(result[3], dict)
+        assert result[3]["elided"] == 96
+        assert "Configuration is valid" in str(result[6])
+        assert result[7] == {"event": "exit", "code": 0}
+        assert meta["elided_count"] == 96
+
+    def test_heterogeneous_dict_and_string_list(self):
+        """Transforms and summarize both accept list[dict | str] (explicit shape contract)."""
+        messages: list = [
+            {"level": "INFO", "text": "hi"},
+            "plain string 1",
+            "plain string 2",
+            {"event": "exit"},
+        ]
+        result, meta = _summarize_ws_messages(messages, run_threshold=10)
+        # Short run, no elision
+        assert result == messages
+        assert meta["original_count"] == 4
+
+
+class TestApplyResponseTransform:
+    """Tests for _apply_response_transform wrapper."""
+
+    def test_filter_list(self):
+        """A reassigning expression narrows a list."""
+        messages = [{"level": "INFO"}, {"level": "ERROR"}, {"level": "INFO"}]
+        result = _apply_response_transform(
+            messages,
+            "response = [m for m in response if m.get('level') == 'ERROR']",
+        )
+        assert result == [{"level": "ERROR"}]
+
+    def test_in_place_mutation(self):
+        """An in-place mutation is reflected in the return value."""
+        messages = [1, 2, 3]
+        result = _apply_response_transform(messages, "response.append(4)")
+        assert result == [1, 2, 3, 4]
+
+    def test_heterogeneous_shape(self):
+        """Mixed dict/string messages (WS shape) can be transformed."""
+        messages = [
+            {"level": "INFO", "msg": "start"},
+            "raw text",
+            {"level": "ERROR", "msg": "boom"},
+            "another raw",
+        ]
+        # Filter by stringified form — works uniformly on dicts and strings.
+        result = _apply_response_transform(
+            messages,
+            "response = [m for m in response if 'ERROR' in str(m) or 'raw' in str(m)]",
+        )
+        assert len(result) == 3
+        assert "raw text" in result
+        assert {"level": "ERROR", "msg": "boom"} in result
+
+    def test_invalid_expression_raises_tool_error(self):
+        """Forbidden operations raise ToolError with VALIDATION_FAILED."""
+        with pytest.raises(ToolError) as exc_info:
+            _apply_response_transform([1, 2, 3], "import os")
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "python_transform failed" in result["error"]["message"]
+
+    def test_runtime_error_raises_tool_error(self):
+        """Runtime execution errors surface as ToolError with preview."""
+        with pytest.raises(ToolError) as exc_info:
+            _apply_response_transform(
+                {}, "response['missing']['key'] = 1"
+            )
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "python_transform failed" in result["error"]["message"]
+
+
+class TestCallAddonWsNewParams:
+    """Integration tests for message_limit/offset/summarize/python_transform in _call_addon_ws."""
+
+    @pytest.mark.asyncio
+    async def test_message_limit_caps_collection(self):
+        """message_limit lowers the collection cap so we stop early."""
+        client = _make_mock_client()
+
+        # Produce many messages, then a close
+        messages_to_send = [f"msg {i}" for i in range(100)]
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = messages_to_send + [
+                websockets.exceptions.ConnectionClosed(None, None)
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(
+                client,
+                "test_addon",
+                "/compile",
+                message_limit=5,
+                summarize=False,
+            )
+
+        assert result["success"] is True
+        assert result["closed_by"] == "message_limit"
+        assert result["message_count"] == 5
+        assert result["pagination"]["total_collected"] == 5
+        assert result["pagination"]["limit"] == 5
+
+    @pytest.mark.asyncio
+    async def test_message_offset_skips_head(self):
+        """message_offset drops the first N messages from the returned list."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = [
+                "msg 0",
+                "msg 1",
+                "msg 2",
+                "msg 3",
+                websockets.exceptions.ConnectionClosed(None, None),
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(
+                client,
+                "test_addon",
+                "/logs",
+                message_offset=2,
+                summarize=False,
+            )
+
+        assert result["success"] is True
+        assert result["messages"] == ["msg 2", "msg 3"]
+        assert result["pagination"]["offset"] == 2
+        assert result["pagination"]["total_collected"] == 4
+
+    @pytest.mark.asyncio
+    async def test_summarize_elides_yaml_dump(self):
+        """The summarize pass collapses a long non-signal run from the WS stream."""
+        client = _make_mock_client()
+
+        # 30 plain YAML-ish lines with one surrounding INFO on each end
+        yaml_lines = [f"  key_{i}: value" for i in range(30)]
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = (
+                ["INFO Reading configuration..."]
+                + yaml_lines
+                + [
+                    "INFO Configuration is valid!",
+                    websockets.exceptions.ConnectionClosed(None, None),
+                ]
+            )
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert result["success"] is True
+        # 1 header + 2 context + 1 elision + 2 context + 1 footer = 7
+        assert result["message_count"] == 7
+        assert "summary" in result
+        assert result["summary"]["elided_count"] == 26
+        # Verify the elision marker is present
+        assert any(
+            isinstance(m, dict) and m.get("elided") == 26 for m in result["messages"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_summarize_false_returns_raw_stream(self):
+        """With summarize=False, no elision happens."""
+        client = _make_mock_client()
+
+        yaml_lines = [f"  key_{i}: value" for i in range(30)]
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = yaml_lines + [
+                websockets.exceptions.ConnectionClosed(None, None)
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(
+                client, "test_addon", "/validate", summarize=False
+            )
+
+        assert result["success"] is True
+        assert result["message_count"] == 30
+        assert "summary" not in result
+
+    @pytest.mark.asyncio
+    async def test_python_transform_filters_messages(self):
+        """python_transform post-processes the message list after summarize."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = [
+                '{"level": "INFO", "msg": "start"}',
+                '{"level": "ERROR", "msg": "boom"}',
+                '{"level": "INFO", "msg": "done"}',
+                websockets.exceptions.ConnectionClosed(None, None),
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(
+                client,
+                "test_addon",
+                "/validate",
+                summarize=False,
+                python_transform=(
+                    "response = [m for m in response if 'ERROR' in str(m)]"
+                ),
+            )
+
+        assert result["success"] is True
+        assert result["transformed"] is True
+        assert result["pre_transform_message_count"] == 3
+        assert result["message_count"] == 1
+        assert result["messages"][0]["level"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_python_transform_invalid_raises(self):
+        """Invalid python_transform surfaces VALIDATION_FAILED as ToolError."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = [
+                "msg",
+                websockets.exceptions.ConnectionClosed(None, None),
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(
+                    client,
+                    "test_addon",
+                    "/logs",
+                    python_transform="import os",
+                )
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "python_transform failed" in result["error"]["message"]
+
+
+class TestCallAddonApiPythonTransform:
+    """Tests for python_transform in HTTP mode (_call_addon_api)."""
+
+    @pytest.mark.asyncio
+    async def test_transform_applies_to_json_array(self):
+        """Transform reshapes a JSON array response before return."""
+        client = _make_mock_client()
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch("ha_mcp.tools.tools_addons.httpx.AsyncClient") as mock_httpx,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = [
+                {"id": 1, "name": "alice"},
+                {"id": 2, "name": "bob"},
+            ]
+            mock_client_ctx = AsyncMock()
+            mock_client_ctx.request = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_ctx)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(
+                client,
+                "test_addon",
+                "/users",
+                python_transform="response = [u['id'] for u in response]",
+            )
+
+        assert result["success"] is True
+        assert result["transformed"] is True
+        assert result["response"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_transform_applies_to_dict_body(self):
+        """Transform on dict content-type."""
+        client = _make_mock_client()
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch("ha_mcp.tools.tools_addons.httpx.AsyncClient") as mock_httpx,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"status": "ok", "details": "..." * 100}
+            mock_client_ctx = AsyncMock()
+            mock_client_ctx.request = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_ctx)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(
+                client,
+                "test_addon",
+                "/status",
+                python_transform="del response['details']",
+            )
+
+        assert result["success"] is True
+        assert result["transformed"] is True
+        assert result["response"] == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_transform_invalid_raises(self):
+        """HTTP mode: invalid transform raises ToolError."""
+        client = _make_mock_client()
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch("ha_mcp.tools.tools_addons.httpx.AsyncClient") as mock_httpx,
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"content-type": "application/json"}
+            mock_response.json.return_value = {"x": 1}
+            mock_client_ctx = AsyncMock()
+            mock_client_ctx.request = AsyncMock(return_value=mock_response)
+            mock_httpx.return_value.__aenter__ = AsyncMock(return_value=mock_client_ctx)
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(
+                    client,
+                    "test_addon",
+                    "/x",
+                    python_transform="open('/etc/passwd')",
+                )
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "python_transform failed" in result["error"]["message"]
+
+
 # Mock Supervisor API responses for list_addons tests
 _ADDONS_LIST_RESPONSE = {
     "success": True,
@@ -1251,3 +1798,84 @@ class TestManageAddon:
         error = _parse_tool_error(exc_info)
         assert error["error"]["code"] == "VALIDATION_FAILED"
         assert "method" in error["error"]["message"] or "INVALID" in error["error"]["message"]
+
+    # --- New WS response-control params (issue #992) ---
+
+    @pytest.mark.asyncio
+    async def test_ws_params_forwarded_to_call_addon_ws(self, manage_addon_tool):
+        """message_limit/offset/summarize/python_transform reach _call_addon_ws."""
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_ws",
+            return_value={"success": True, "messages": []},
+        ) as mock_ws:
+            await manage_addon_tool(
+                slug="test_addon",
+                path="/validate",
+                websocket=True,
+                message_limit=25,
+                message_offset=5,
+                summarize=False,
+                python_transform="response = response[:1]",
+            )
+
+        call_kwargs = mock_ws.call_args[1]
+        assert call_kwargs["message_limit"] == 25
+        assert call_kwargs["message_offset"] == 5
+        assert call_kwargs["summarize"] is False
+        assert call_kwargs["python_transform"] == "response = response[:1]"
+
+    @pytest.mark.asyncio
+    async def test_http_python_transform_forwarded(self, manage_addon_tool):
+        """python_transform reaches _call_addon_api in HTTP mode."""
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            return_value={"success": True, "response": []},
+        ) as mock_api:
+            await manage_addon_tool(
+                slug="test_addon",
+                path="/flows",
+                python_transform="response = [f['id'] for f in response]",
+            )
+        assert (
+            mock_api.call_args[1]["python_transform"]
+            == "response = [f['id'] for f in response]"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ws_only_params_rejected_in_http_mode(self, manage_addon_tool):
+        """HTTP mode rejects message_limit/offset/summarize."""
+        with pytest.raises(ToolError) as exc_info:
+            await manage_addon_tool(
+                slug="test_addon",
+                path="/flows",
+                message_limit=10,
+            )
+        error = _parse_tool_error(exc_info)
+        assert error["error"]["code"] == "VALIDATION_FAILED"
+        assert "WebSocket" in error["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_ws_params_rejected_in_config_mode(self, manage_addon_tool):
+        """Config mode rejects the new WS-only params."""
+        with pytest.raises(ToolError) as exc_info:
+            await manage_addon_tool(
+                slug="test_addon",
+                auto_update=False,
+                message_limit=10,
+            )
+        error = _parse_tool_error(exc_info)
+        assert error["error"]["code"] == "VALIDATION_FAILED"
+        assert "message_limit" in error["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_python_transform_rejected_in_config_mode(self, manage_addon_tool):
+        """Config mode rejects python_transform."""
+        with pytest.raises(ToolError) as exc_info:
+            await manage_addon_tool(
+                slug="test_addon",
+                auto_update=False,
+                python_transform="response = []",
+            )
+        error = _parse_tool_error(exc_info)
+        assert error["error"]["code"] == "VALIDATION_FAILED"
+        assert "python_transform" in error["error"]["message"]

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -963,6 +963,45 @@ class TestCallAddonWsNewParams:
         assert result["pagination"]["limit"] == 5
 
     @pytest.mark.asyncio
+    async def test_safety_ceiling_distinct_from_message_limit(self):
+        """Hitting the global ceiling without a caller-set message_limit
+        reports closed_by="safety_ceiling", not "message_limit"."""
+        client = _make_mock_client()
+
+        messages_to_send = [f"msg {i}" for i in range(10)]
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._MAX_WS_MESSAGES",
+                5,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = messages_to_send + [
+                websockets.exceptions.ConnectionClosed(None, None)
+            ]
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(
+                client,
+                "test_addon",
+                "/compile",
+                summarize=False,
+            )
+
+        assert result["success"] is True
+        assert result["closed_by"] == "safety_ceiling"
+        assert result["message_count"] == 5
+
+    @pytest.mark.asyncio
     async def test_message_offset_skips_head(self):
         """message_offset drops the first N messages from the returned list."""
         client = _make_mock_client()


### PR DESCRIPTION
## What does this PR do?

Closes #992. Adds four opt-in parameters to the proxy mode of `ha_manage_addon` so agents can control WebSocket response size and shape instead of always getting the full firehose up to hardcoded caps:

- **`message_limit`** (WS) — cap messages collected from the wire, bounded by the existing safety ceiling. Lower to save tokens on noisy streams.
- **`message_offset`** (WS) — drop the first N messages before returning (pagination past known-noisy headers).
- **`summarize`** (WS, default `True`) — collapse runs of non-signal messages (typically YAML config dumps) into `{"elided": N, ...}` markers. INFO/WARNING/ERROR/exit lines always pass through. `summarize=False` returns the raw stream.
- **`python_transform`** (HTTP + WS) — sandboxed Python expression that post-processes the response. Variable `response` is exposed; supports in-place mutation or reassignment.

The example in the issue — ESPHome `/validate` returning 850 messages / ~15K tokens for what's really just "exit code 0, configuration valid" — now defaults to an elided summary and can be narrowed further with `python_transform` when even that is too much.

### How `python_transform` is wired

Generalized `safe_execute` in `python_sandbox.py` into `safe_execute_expression(expr, variables, result_key)`. The existing `safe_execute(expr, config)` is a thin wrapper for backwards compatibility — dashboard/automation/script call sites keep working unchanged. Sandbox now exposes a minimal set of **pure** builtins (`isinstance`, `len`, `str`, `range`, `enumerate`, `sorted`, `min`, `max`, `any`, `all`, type-coercion, …) so shape-aware transforms on heterogeneous `list[dict | str]` payloads are actually expressible. Dangerous names (`open`, `eval`, `getattr`, imports, dunders) remain blocked at AST validation.

### What this PR does NOT do

- No optimistic-locking / write-back semantics on `python_transform`. This is post-processing only. Following the lesson from #980, any future ESPHome-YAML-write workflow must add its own canonicalization step before hashing — do not reuse this code path for that.
- No changes to the HTTP `offset`/`limit` behavior.
- No regeneration of `tools.json` / `README.md` / `homeassistant-addon/DOCS.md` — those are auto-regenerated on master merge by `sync-tool-docs.yml`.

## Type of change
- [x] ✨ New feature

## Testing
- [x] All automated tests pass (`uv run pytest`) — CI only; local Termux can't install deps
- [x] Code follows style guidelines (`uv run ruff check`) — ran locally, clean

**Test coverage added (unit, in `tests/src/unit/`):**
- `TestSliceWsMessages` — slice helper, including offset/limit edges (negative, beyond-total)
- `TestIsSignalMessage` / `TestSummarizeWsMessages` — signal heuristic and elision behavior, incl. realistic ESPHome `/validate` message shape
- `TestApplyResponseTransform` — transform on lists, dicts, **heterogeneous** `list[dict | str]` (explicit shape-contract coverage per #980)
- `TestCallAddonWsNewParams` — integration through `_call_addon_ws` for each new param
- `TestCallAddonApiPythonTransform` — transform on HTTP responses (array, dict, invalid expression)
- Additions to `TestManageAddon` — the new params are forwarded; HTTP mode rejects WS-only params; config mode rejects all four
- `TestSafeExecuteExpression` — custom var name, reassignment semantics, backwards-compat of `safe_execute` wrapper, expanded builtins (`isinstance`, `str`) work, blocked builtins (`open`, `getattr`) stay blocked

## Checklist
- [x] I have updated documentation if needed — docstring of `ha_manage_addon` spells out response-shape contract for both modes, noise-vs-signal heuristic, and the post-processing-only scope. Tool-facing `get_security_documentation()` updated to reflect new safe builtins.