### PR TITLE
docs(tools): fix misleading domain.service example in ha_call_service

### DIFF
--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -205,40 +205,35 @@ class ServiceTools:
         wait: bool | str = True,
     ) -> dict[str, Any]:
         """
-        Execute Home Assistant services to control entities and trigger automations.
+        Execute a Home Assistant service (e.g. turn a light on, set a climate setpoint).
 
-        This is the universal tool for controlling all Home Assistant entities. Services follow
-        the pattern domain.service (e.g., light.turn_on, climate.set_temperature).
+        HA services are written as `domain.service` in docs (e.g. `light.turn_on`), but
+        this tool takes them as TWO SEPARATE PARAMETERS. Split on the dot:
+          light.turn_on  →  domain="light", service="turn_on"
+          climate.set_temperature  →  domain="climate", service="set_temperature"
 
-        **Basic Usage:**
-        ```python
-        # Turn on a light
-        ha_call_service("light", "turn_on", entity_id="light.living_room")
+        WRONG: ha_call_service(service="light.turn_on", entity_id="light.bed_light")
+        RIGHT: ha_call_service(domain="light", service="turn_on", entity_id="light.bed_light")
 
-        # Set temperature with parameters
-        ha_call_service("climate", "set_temperature",
-                      entity_id="climate.thermostat", data={"temperature": 22})
+        Examples:
+          ha_call_service(domain="light", service="turn_on", entity_id="light.living_room")
+          ha_call_service(domain="climate", service="set_temperature",
+                          entity_id="climate.thermostat", data={"temperature": 22})
+          ha_call_service(domain="automation", service="trigger",
+                          entity_id="automation.morning_routine")
+          ha_call_service(domain="homeassistant", service="toggle",
+                          entity_id="switch.porch_light")  # universal
 
-        # Trigger automation
-        ha_call_service("automation", "trigger", entity_id="automation.morning_routine")
+        Params:
+          domain (str): service domain ONLY, no dot (e.g. "light", "climate").
+          service (str): service name ONLY, no dot (e.g. "turn_on", "set_temperature").
+          entity_id (str, opt): target entity. Omit to target the whole domain.
+          data (dict, opt): service-specific parameters.
+          return_response (bool): True for services that return data.
+          wait (bool): wait for state change (default True). False for fire-and-forget
+            or bulk operations.
 
-        # Universal controls work with any entity
-        ha_call_service("homeassistant", "toggle", entity_id="switch.porch_light")
-        ```
-
-        **Parameters:**
-        - **domain**: Service domain (light, climate, automation, etc.)
-        - **service**: Service name (turn_on, set_temperature, trigger, etc.)
-        - **entity_id**: Optional target entity. For some services (e.g., light.turn_off), omitting this targets all entities in the domain
-        - **data**: Optional dict of service-specific parameters
-        - **return_response**: Set to True for services that return data
-        - **wait**: Wait for the entity state to change after the service call (default: True).
-          Only applies to state-changing services on a single entity. Set to False for
-          fire-and-forget calls, bulk operations, or services without observable state changes.
-
-        **For detailed service documentation, use ha_get_skill_home_assistant_best_practices.**
-
-        Common patterns: Use ha_get_state() to check current values before making changes.
+        For detailed per-service parameters: ha_get_skill_home_assistant_best_practices.
         Use ha_search_entities() to find correct entity IDs.
         """
         try:

--- a/src/ha_mcp/transforms/categorized_search.py
+++ b/src/ha_mcp/transforms/categorized_search.py
@@ -99,9 +99,11 @@ class SearchKeywordsTransform(Transform):
 
 # Proxy description suffix (shared across all proxies)
 _PROXY_PARAMS_SUFFIX = (
-    "Params: name (str) = tool name, arguments (dict) = tool parameters. "
-    "These are separate top-level params, not nested.\n"
-    "IMPORTANT: Call this tool SEQUENTIALLY, not in parallel with other proxy calls."
+    "Params (separate top-level, NOT nested):\n"
+    "  name (str): tool name from search results (starts with 'ha_'). "
+    "NOT a Home Assistant service like 'light.turn_on' or an entity_id.\n"
+    "  arguments (dict): the tool's own parameters.\n"
+    "IMPORTANT: Call sequentially, not in parallel."
 )
 
 
@@ -109,20 +111,25 @@ def _build_proxy_descriptions(search_tool_name: str) -> dict[str, str]:
     """Build proxy descriptions that reference the configured search tool name."""
     return {
         "read": (
-            f"Execute a read-only tool discovered via {search_tool_name}. "
-            f"Safe — does not modify any data or state.\n"
+            f"Execute a read-only tool you already discovered via {search_tool_name}. "
+            f"Safe — does not modify data.\n"
+            f"Example: ha_call_read_tool(name='ha_get_state', "
+            f"arguments={{'entity_id': 'light.bed_light'}})\n"
             f"{_PROXY_PARAMS_SUFFIX}"
         ),
         "write": (
-            f"Execute a write tool discovered via {search_tool_name}. "
-            f"Creates or updates data. Use for any tool that modifies "
-            f"state but does not delete/remove resources.\n"
+            f"Execute a write tool you already discovered via {search_tool_name}. "
+            f"Creates or updates state (not delete/remove).\n"
+            f"Example: ha_call_write_tool(name='ha_call_service', "
+            f"arguments={{'domain': 'light', 'service': 'turn_on', "
+            f"'entity_id': 'light.bed_light'}})\n"
             f"{_PROXY_PARAMS_SUFFIX}"
         ),
         "delete": (
-            f"Execute a delete/remove tool discovered via {search_tool_name}. "
-            f"Permanently removes data. Use for tools that delete or "
-            f"remove resources (areas, automations, devices, etc.).\n"
+            f"Execute a delete/remove tool you already discovered via {search_tool_name}. "
+            f"Permanently removes resources (areas, automations, devices, etc.).\n"
+            f"Example: ha_call_delete_tool(name='ha_config_remove_area', "
+            f"arguments={{'area_id': 'living_room'}})\n"
             f"{_PROXY_PARAMS_SUFFIX}"
         ),
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a misleading sentence in `ha_call_service`'s docstring and adds concrete examples to the categorized search-proxy descriptions.

### `ha_call_service` (`src/ha_mcp/tools/tools_service.py`)

Before, the docstring said:

> *"Services follow the pattern `domain.service` (e.g., `light.turn_on`, `climate.set_temperature`)."*

The tool takes `domain` and `service` as two separate parameters. Read literally, the old sentence tells the reader to pass `service="light.turn_on"` — which the tool rejects with a validation error. Small local models emitted exactly that shape consistently.

Replaced with explicit "TWO SEPARATE PARAMETERS" framing, a `WRONG/RIGHT` contrast, and examples in named-arg form that match the MCP tool-call shape:

```
WRONG: ha_call_service(service="light.turn_on", entity_id="light.bed_light")
RIGHT: ha_call_service(domain="light", service="turn_on", entity_id="light.bed_light")
```

### Categorized proxy descriptions (`src/ha_mcp/transforms/categorized_search.py`)

Added a concrete worked example per proxy and a "NOT a Home Assistant service like `light.turn_on`" anti-pattern line. Helps clients that route through the proxy understand `name` means a tool name, not a service name.

No runtime behaviour change — docstring/description text only.

## Scope note

This started as a broader investigation into small-model tool-calling reliability. BAT measurement at n=5 on `qwen3.5-9b` showed no statistically significant effect for the broader set of candidate changes, so those commits were dropped. What's left is the one change that's defensible without measurement: the `ha_call_service` docstring contained a factual inaccuracy, and it's now removed. Local investigation notes are in `docs/plans/2026-04-18-tool-search-small-models.md` (not included in this PR).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] All automated tests pass (`uv run pytest`) — pre-commit hooks ran the unit suite on this commit
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (`ha_call_service` docstring, categorized proxy descriptions)