### PR TITLE
feat: add opt-in Node-RED tools module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,14 @@ LOG_LEVEL=INFO
 # top-level keys in configuration.yaml and packages/*.yaml.
 # ENABLE_YAML_CONFIG_EDITING=false
 
+# Node-RED tools: opt-in module exposing the Node-RED Admin API
+# (flows, nodes, inject, deploy). Disabled by default. When enabled,
+# all three NODERED_* settings below are required.
+# ENABLE_NODERED_TOOLS=false
+# NODERED_URL=https://your-ha-host/nodered-api
+# NODERED_USERNAME=your_nodered_user
+# NODERED_PASSWORD=your_nodered_password
+
 # Optional: MCP Server Configuration
 MCP_SERVER_NAME=ha-mcp
 # MCP_SERVER_VERSION defaults to the package version (e.g. 6.7.2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-xdist>=3.8.0",
     "requests>=2.25.0",
+    "respx>=0.21.1",
     "lefthook>=1.10.0",
     "ruamel.yaml>=0.18.0",
     "ruff>=0.12.12",

--- a/src/ha_mcp/client/nodered_client.py
+++ b/src/ha_mcp/client/nodered_client.py
@@ -1,0 +1,161 @@
+"""
+Node-RED Admin API client with HTTP Basic authentication and structured error handling.
+
+Mirrors the design of `rest_client.py` so the Node-RED tool layer can rely on the
+same exception types that ``helpers.exception_to_structured_error`` already
+classifies. The Node-RED Admin API is enabled by default on Home Assistant
+Node-RED add-on installations and is reachable through the same NGINX proxy as
+Home Assistant itself (typically at `/nodered-api/`).
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from ..config import get_global_settings
+
+logger = logging.getLogger(__name__)
+
+
+class NodeRedError(Exception):
+    """Base exception for Node-RED API errors."""
+
+
+class NodeRedConnectionError(NodeRedError):
+    """Connection error to the Node-RED Admin API."""
+
+
+class NodeRedAuthError(NodeRedError):
+    """Authentication error with the Node-RED Admin API."""
+
+
+class NodeRedAPIError(NodeRedError):
+    """API error returned by Node-RED."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        response_text: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_text = response_text
+
+
+class NodeRedClient:
+    """Authenticated HTTP client for the Node-RED Admin API."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        timeout: int | None = None,
+    ) -> None:
+        if base_url is None or username is None or password is None:
+            settings = get_global_settings()
+            self.base_url = (base_url or settings.nodered_url).rstrip("/")
+            self.username = username or settings.nodered_username
+            self.password = password or settings.nodered_password
+            self.timeout = timeout if timeout is not None else settings.timeout
+        else:
+            self.base_url = base_url.rstrip("/")
+            self.username = username
+            self.password = password
+            self.timeout = timeout if timeout is not None else 30
+
+        self.httpx_client = httpx.AsyncClient(
+            base_url=self.base_url,
+            auth=(self.username, self.password),
+            headers={"Content-Type": "application/json"},
+            timeout=httpx.Timeout(self.timeout),
+        )
+
+        logger.info("Initialised Node-RED client for %s", self.base_url)
+
+    async def __aenter__(self) -> "NodeRedClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        await self.httpx_client.aclose()
+        logger.debug("Closed Node-RED client")
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        json_body: Any = None,
+        deployment_type: str = "full",
+    ) -> Any:
+        """Issue an authenticated request and return the parsed body.
+
+        For POST/PUT calls the Node-RED `Node-RED-Deployment-Type` header is set
+        so partial deploys behave consistently with the upstream Node-RED
+        editor's default. Returns parsed JSON when the response advertises a
+        JSON content-type, otherwise returns response text.
+        """
+        path = "/" + endpoint.lstrip("/")
+        method_upper = method.upper()
+
+        headers: dict[str, str] = {}
+        if method_upper in {"POST", "PUT", "DELETE"}:
+            headers["Node-RED-Deployment-Type"] = deployment_type
+
+        try:
+            response = await self.httpx_client.request(
+                method_upper, path, json=json_body, headers=headers
+            )
+        except httpx.TimeoutException as e:
+            raise NodeRedConnectionError(
+                f"Node-RED request timeout after {self.timeout}s"
+            ) from e
+        except httpx.RequestError as e:
+            raise NodeRedConnectionError(f"Failed to connect to Node-RED: {e}") from e
+
+        if response.status_code in (401, 403):
+            raise NodeRedAuthError(
+                f"Node-RED rejected the credentials (HTTP {response.status_code})"
+            )
+
+        if response.status_code >= 400:
+            raise NodeRedAPIError(
+                f"Node-RED API error: {response.status_code} - {response.text}",
+                status_code=response.status_code,
+                response_text=response.text,
+            )
+
+        content_type = response.headers.get("content-type", "")
+        if "application/json" in content_type:
+            return response.json()
+        return response.text
+
+    async def get_flows(self) -> list[dict[str, Any]]:
+        """Return the full `/flows` array (tabs, nodes and config nodes)."""
+        result = await self._request("GET", "/flows")
+        if not isinstance(result, list):
+            raise NodeRedAPIError(
+                "Unexpected /flows response shape (expected a JSON array)"
+            )
+        return result
+
+    async def post_flows(self, flows: list[dict[str, Any]]) -> Any:
+        """Replace the entire `/flows` array. Returns the deployment revision."""
+        return await self._request("POST", "/flows", json_body=flows)
+
+    async def get_settings(self) -> dict[str, Any]:
+        """Return the Node-RED runtime `/settings` payload."""
+        result = await self._request("GET", "/settings")
+        if not isinstance(result, dict):
+            raise NodeRedAPIError(
+                "Unexpected /settings response shape (expected a JSON object)"
+            )
+        return result
+
+    async def inject(self, node_id: str) -> Any:
+        """Trigger an inject node by ID via `/inject/<id>`."""
+        return await self._request("POST", f"/inject/{node_id}")

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -112,6 +112,34 @@ class Settings(BaseSettings):
     # files. Disabled by default; only for YAML-only features with no UI/API path.
     enable_yaml_config_editing: bool = Field(False, alias="ENABLE_YAML_CONFIG_EDITING")
 
+    # Node-RED tools — opt-in module exposing Node-RED Admin API operations
+    # (flows, nodes, inject, deploy). Disabled by default. When enabled,
+    # NODERED_URL/USERNAME/PASSWORD must also be set.
+    enable_nodered_tools: bool = Field(False, alias="ENABLE_NODERED_TOOLS")
+    nodered_url: str = Field("", alias="NODERED_URL")
+    nodered_username: str = Field("", alias="NODERED_USERNAME")
+    nodered_password: str = Field("", alias="NODERED_PASSWORD")
+
+    @model_validator(mode="after")
+    def _nodered_credentials(self) -> "Settings":
+        """Require Node-RED credentials whenever the tools module is enabled."""
+        if not self.enable_nodered_tools:
+            return self
+        missing = [
+            name
+            for name, value in (
+                ("NODERED_URL", self.nodered_url),
+                ("NODERED_USERNAME", self.nodered_username),
+                ("NODERED_PASSWORD", self.nodered_password),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                "ENABLE_NODERED_TOOLS=true but missing: " + ", ".join(missing)
+            )
+        return self
+
     @model_validator(mode="after")
     def _skills_dependency(self) -> "Settings":
         """Auto-enable skills (resources) when skills-as-tools is on.

--- a/src/ha_mcp/tools/tools_nodered.py
+++ b/src/ha_mcp/tools/tools_nodered.py
@@ -1,0 +1,834 @@
+"""
+Node-RED flow management tools for the Home Assistant MCP server.
+
+These tools wrap the Node-RED Admin API (HTTP Basic auth, exposed via the
+HA Node-RED add-on's NGINX proxy by default) so AI agents can read flows,
+patch nodes, and deploy structural changes from the same MCP session that
+controls Home Assistant itself.
+
+Feature flag: set ``ENABLE_NODERED_TOOLS=true`` along with ``NODERED_URL``,
+``NODERED_USERNAME`` and ``NODERED_PASSWORD`` to load these tools. The
+module is a no-op when the flag is off.
+
+Behaviour notes preserved from the prior hand-rolled server:
+- ``ha_nodered_patch_node`` and ``ha_nodered_patch_flow`` only mutate
+  *existing* node properties — they cannot change a node's type. Use
+  ``ha_nodered_replace_flow`` for structural rewrites.
+- ``ha_nodered_replace_flow`` requires the caller to supply the full new
+  list of nodes for the tab. Disabled nodes must carry ``"d": true``
+  explicitly; there is no additive-insert mode.
+- ``ha_nodered_get_nodes`` filters by ``search_name`` (case-insensitive
+  substring on ``name``) and/or ``node_type``.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import tool
+from pydantic import Field
+
+from ..client.nodered_client import NodeRedClient
+from ..config import get_global_settings
+from ..errors import ErrorCode, create_error_response, create_resource_not_found_error
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    register_tool_methods,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cap returned matches from search-style tools so a misconfigured Node-RED
+# install (thousands of nodes) cannot blow up an MCP response payload.
+_NODE_SEARCH_LIMIT = 100
+
+
+class NodeRedTools:
+    """Node-RED Admin API tools."""
+
+    def __init__(self, client: NodeRedClient) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------
+    # Read-only tools
+    # ------------------------------------------------------------------
+
+    @tool(
+        name="ha_nodered_get_flows",
+        tags={"Node-RED"},
+        annotations={
+            "readOnlyHint": True,
+            "idempotentHint": True,
+            "title": "List Node-RED Flows",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_get_flows(self) -> dict[str, Any]:
+        """List all Node-RED flow tabs with per-tab node counts."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"operation": "nodered_get_flows"},
+                suggestions=[
+                    "Verify NODERED_URL is reachable",
+                    "Confirm NODERED_USERNAME / NODERED_PASSWORD are correct",
+                ],
+            )
+
+        tabs: list[dict[str, Any]] = []
+        nodes_per_tab: dict[str, int] = {}
+        config_node_count = 0
+
+        for node in flows:
+            node_type = node.get("type", "")
+            if node_type == "tab":
+                tab_id = node.get("id", "")
+                tabs.append(
+                    {
+                        "id": tab_id,
+                        "label": node.get("label", "Unnamed"),
+                        "disabled": node.get("disabled", False),
+                        "info": node.get("info", ""),
+                    }
+                )
+                nodes_per_tab.setdefault(tab_id, 0)
+            elif node.get("z"):
+                tab_id = node["z"]
+                nodes_per_tab[tab_id] = nodes_per_tab.get(tab_id, 0) + 1
+            else:
+                config_node_count += 1
+
+        return {
+            "success": True,
+            "data": {
+                "total_tabs": len(tabs),
+                "total_nodes": len(flows),
+                "tabs": tabs,
+                "nodes_per_tab": nodes_per_tab,
+                "config_nodes_count": config_node_count,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_get_flow",
+        tags={"Node-RED"},
+        annotations={
+            "readOnlyHint": True,
+            "idempotentHint": True,
+            "title": "Get Node-RED Flow",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_get_flow(
+        self,
+        flow_id: Annotated[
+            str,
+            Field(description="The flow/tab ID to retrieve"),
+        ],
+    ) -> dict[str, Any]:
+        """Get one Node-RED flow tab and every node it contains."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_get_flow", "flow_id": flow_id}
+            )
+
+        tab_info: dict[str, Any] | None = None
+        tab_nodes: list[dict[str, Any]] = []
+        for node in flows:
+            if node.get("id") == flow_id and node.get("type") == "tab":
+                tab_info = node
+            elif node.get("z") == flow_id:
+                tab_nodes.append(node)
+
+        if tab_info is None:
+            raise_tool_error(create_resource_not_found_error("flow", flow_id))
+
+        return {
+            "success": True,
+            "data": {
+                "id": tab_info.get("id"),
+                "label": tab_info.get("label", "Unnamed"),
+                "disabled": tab_info.get("disabled", False),
+                "info": tab_info.get("info", ""),
+                "node_count": len(tab_nodes),
+                "nodes": tab_nodes,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_get_nodes",
+        tags={"Node-RED"},
+        annotations={
+            "readOnlyHint": True,
+            "idempotentHint": True,
+            "title": "Search Node-RED Nodes",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_get_nodes(
+        self,
+        node_type: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Exact node type to match (e.g. 'inject', 'function', "
+                    "'api-call-service'). Case-sensitive."
+                ),
+                default=None,
+            ),
+        ] = None,
+        search_name: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Case-insensitive substring matched against the node's "
+                    "'name' property."
+                ),
+                default=None,
+            ),
+        ] = None,
+        flow_id: Annotated[
+            str | None,
+            Field(
+                description="Restrict the search to nodes inside this flow/tab.",
+                default=None,
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        """Search Node-RED nodes across all flows by type, name and/or flow."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(e, context={"operation": "nodered_get_nodes"})
+
+        needle = search_name.lower() if search_name else None
+        matches: list[dict[str, Any]] = []
+        for node in flows:
+            if node.get("type") == "tab":
+                continue
+            if flow_id and node.get("z") != flow_id:
+                continue
+            if node_type and node.get("type") != node_type:
+                continue
+            if needle and needle not in node.get("name", "").lower():
+                continue
+
+            matches.append(
+                {
+                    "id": node.get("id"),
+                    "type": node.get("type"),
+                    "name": node.get("name", ""),
+                    "flow_id": node.get("z", "global"),
+                    "x": node.get("x"),
+                    "y": node.get("y"),
+                    "wires": node.get("wires", []),
+                }
+            )
+
+        truncated = len(matches) > _NODE_SEARCH_LIMIT
+        return {
+            "success": True,
+            "data": {
+                "filters": {
+                    "node_type": node_type,
+                    "search_name": search_name,
+                    "flow_id": flow_id,
+                },
+                "matches": len(matches),
+                "truncated": truncated,
+                "limit": _NODE_SEARCH_LIMIT,
+                "nodes": matches[:_NODE_SEARCH_LIMIT],
+            },
+        }
+
+    @tool(
+        name="ha_nodered_get_settings",
+        tags={"Node-RED"},
+        annotations={
+            "readOnlyHint": True,
+            "idempotentHint": True,
+            "title": "Get Node-RED Runtime Settings",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_get_settings(self) -> dict[str, Any]:
+        """Get Node-RED runtime settings (version, palette categories, theme)."""
+        try:
+            settings = await self._client.get_settings()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_get_settings"}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "version": settings.get("version", ""),
+                "http_node_root": settings.get("httpNodeRoot", "/"),
+                "palette_categories": settings.get("paletteCategories", []),
+                "flow_encryption": settings.get("flowEncryptionType", ""),
+                "editor_theme": settings.get("editorTheme", {}),
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # State-changing tools
+    # ------------------------------------------------------------------
+
+    @tool(
+        name="ha_nodered_inject_node",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "title": "Trigger Node-RED Inject Node",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_inject_node(
+        self,
+        node_id: Annotated[str, Field(description="ID of the inject node to trigger")],
+    ) -> dict[str, Any]:
+        """Trigger a Node-RED inject node by ID."""
+        try:
+            await self._client.inject(node_id)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"operation": "nodered_inject_node", "node_id": node_id},
+            )
+
+        return {
+            "success": True,
+            "data": {"node_id": node_id, "message": "Inject node triggered"},
+        }
+
+    @tool(
+        name="ha_nodered_patch_node",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Patch Node-RED Node",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_patch_node(
+        self,
+        node_id: Annotated[str, Field(description="ID of the node to patch")],
+        patches: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    "Properties to overwrite on the node, e.g. "
+                    "{'func': 'return msg;', 'name': 'My Name'}. Cannot "
+                    "change the node's 'type' — use ha_nodered_replace_flow "
+                    "for structural changes."
+                )
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Patch one node's properties in place and redeploy all flows."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"operation": "nodered_patch_node", "node_id": node_id},
+            )
+
+        target: dict[str, Any] | None = None
+        for node in flows:
+            if node.get("id") == node_id:
+                target = node
+                break
+
+        if target is None:
+            raise_tool_error(create_resource_not_found_error("node", node_id))
+
+        if "type" in patches and patches["type"] != target.get("type"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Cannot change node 'type' via patch; use ha_nodered_replace_flow.",
+                    context={"node_id": node_id, "current_type": target.get("type")},
+                )
+            )
+
+        for key, value in patches.items():
+            target[key] = value
+
+        try:
+            revision = await self._client.post_flows(flows)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"operation": "nodered_patch_node", "node_id": node_id},
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": "Node patched and flows deployed",
+                "node": {
+                    "id": target.get("id"),
+                    "type": target.get("type"),
+                    "name": target.get("name", ""),
+                    "patched_fields": list(patches.keys()),
+                },
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_patch_flow",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Patch Multiple Node-RED Nodes",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_patch_flow(
+        self,
+        flow_id: Annotated[
+            str, Field(description="ID of the flow/tab containing the nodes to patch")
+        ],
+        node_patches: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description=(
+                    "List of patch specs, each shaped "
+                    "{'node_id': '...', 'patches': {field: value, ...}}. "
+                    "All target nodes must already exist in the named flow; "
+                    "node 'type' cannot be changed."
+                )
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Patch multiple nodes in one flow and redeploy all flows."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_patch_flow", "flow_id": flow_id}
+            )
+
+        flow_exists = any(
+            n.get("id") == flow_id and n.get("type") == "tab" for n in flows
+        )
+        if not flow_exists:
+            raise_tool_error(create_resource_not_found_error("flow", flow_id))
+
+        nodes_by_id = {node.get("id"): node for node in flows}
+        patched: list[dict[str, Any]] = []
+        item_errors: list[dict[str, Any]] = []
+
+        for patch_spec in node_patches:
+            node_id = patch_spec.get("node_id")
+            patches = patch_spec.get("patches", {})
+
+            if not node_id or node_id not in nodes_by_id:
+                item_errors.append(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"Node '{node_id}' not found",
+                        context={"node_id": node_id},
+                    )
+                )
+                continue
+
+            node = nodes_by_id[node_id]
+            if node.get("z") != flow_id:
+                item_errors.append(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Node '{node_id}' is not in flow '{flow_id}'",
+                        context={"node_id": node_id, "flow_id": flow_id},
+                    )
+                )
+                continue
+
+            if "type" in patches and patches["type"] != node.get("type"):
+                item_errors.append(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Cannot change 'type' on node '{node_id}'",
+                        context={"node_id": node_id},
+                    )
+                )
+                continue
+
+            for key, value in patches.items():
+                node[key] = value
+            patched.append(
+                {
+                    "id": node_id,
+                    "type": node.get("type"),
+                    "name": node.get("name", ""),
+                    "patched_fields": list(patches.keys()),
+                }
+            )
+
+        if not patched:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "No nodes were patched.",
+                    context={"flow_id": flow_id, "errors": item_errors},
+                )
+            )
+
+        try:
+            revision = await self._client.post_flows(flows)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_patch_flow", "flow_id": flow_id}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": f"Patched {len(patched)} node(s) and deployed",
+                "patched_nodes": patched,
+                "errors": item_errors or None,
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_replace_flow",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Replace Node-RED Flow Contents",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_replace_flow(
+        self,
+        flow_id: Annotated[
+            str, Field(description="ID of the flow/tab to replace contents of")
+        ],
+        new_flow_nodes: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description=(
+                    "Complete list of new node objects for this flow. "
+                    "Caller is responsible for the FULL set of nodes — there "
+                    "is no additive insert mode. Disabled nodes must carry "
+                    "'d': true explicitly. Each node's 'z' field is forced to "
+                    "match flow_id."
+                )
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Replace every node inside one flow tab; other flows are left intact."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_replace_flow", "flow_id": flow_id}
+            )
+
+        flow_tab: dict[str, Any] | None = None
+        for node in flows:
+            if node.get("id") == flow_id and node.get("type") == "tab":
+                flow_tab = node
+                break
+        if flow_tab is None:
+            raise_tool_error(create_resource_not_found_error("flow", flow_id))
+
+        kept: list[dict[str, Any]] = []
+        old_node_count = 0
+        for node in flows:
+            if node.get("z") == flow_id:
+                old_node_count += 1
+            else:
+                kept.append(node)
+
+        for node in new_flow_nodes:
+            if node.get("type") != "tab":
+                node["z"] = flow_id
+
+        kept.extend(new_flow_nodes)
+
+        try:
+            revision = await self._client.post_flows(kept)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_replace_flow", "flow_id": flow_id}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": f"Replaced flow '{flow_tab.get('label', flow_id)}'",
+                "flow_id": flow_id,
+                "flow_label": flow_tab.get("label", ""),
+                "old_node_count": old_node_count,
+                "new_node_count": len(new_flow_nodes),
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_add_flow",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "title": "Add Node-RED Flow",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_add_flow(
+        self,
+        flow_tab: Annotated[
+            dict[str, Any],
+            Field(
+                description=(
+                    "The new tab node object — must include 'id', "
+                    "'type': 'tab', and 'label'."
+                )
+            ),
+        ],
+        flow_nodes: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description=(
+                    "Nodes to place inside the new tab. Each node's 'z' "
+                    "field is forced to match flow_tab['id']."
+                )
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Create a new Node-RED flow tab with its nodes; other flows are kept."""
+        if flow_tab.get("type") != "tab":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "flow_tab must have type='tab'",
+                    context={"flow_tab": flow_tab},
+                )
+            )
+        if not flow_tab.get("id"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "flow_tab must have an 'id'",
+                    context={"flow_tab": flow_tab},
+                )
+            )
+        if not flow_tab.get("label"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "flow_tab must have a 'label'",
+                    context={"flow_tab": flow_tab},
+                )
+            )
+
+        flow_id = flow_tab["id"]
+
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_add_flow", "flow_id": flow_id}
+            )
+
+        for node in flows:
+            if node.get("id") == flow_id:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_ALREADY_EXISTS,
+                        f"A node with ID '{flow_id}' already exists. "
+                        "Use ha_nodered_replace_flow to update it.",
+                        context={"flow_id": flow_id},
+                    )
+                )
+
+        for node in flow_nodes:
+            node["z"] = flow_id
+
+        flows.append(flow_tab)
+        flows.extend(flow_nodes)
+
+        try:
+            revision = await self._client.post_flows(flows)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_add_flow", "flow_id": flow_id}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": f"Added new flow '{flow_tab.get('label')}'",
+                "flow_id": flow_id,
+                "flow_label": flow_tab.get("label"),
+                "node_count": len(flow_nodes),
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_delete_flow",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "title": "Delete Node-RED Flow",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_delete_flow(
+        self,
+        flow_id: Annotated[str, Field(description="ID of the flow/tab to delete")],
+    ) -> dict[str, Any]:
+        """Delete a Node-RED flow tab and every node inside it."""
+        try:
+            flows = await self._client.get_flows()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_delete_flow", "flow_id": flow_id}
+            )
+
+        flow_tab: dict[str, Any] | None = None
+        for node in flows:
+            if node.get("id") == flow_id and node.get("type") == "tab":
+                flow_tab = node
+                break
+        if flow_tab is None:
+            raise_tool_error(create_resource_not_found_error("flow", flow_id))
+
+        deleted_count = 0
+        kept: list[dict[str, Any]] = []
+        for node in flows:
+            if node.get("id") == flow_id or node.get("z") == flow_id:
+                deleted_count += 1
+            else:
+                kept.append(node)
+
+        try:
+            revision = await self._client.post_flows(kept)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_delete_flow", "flow_id": flow_id}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": f"Deleted flow '{flow_tab.get('label', flow_id)}'",
+                "flow_id": flow_id,
+                "flow_label": flow_tab.get("label", ""),
+                "deleted_node_count": deleted_count,
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+    @tool(
+        name="ha_nodered_update_flows",
+        tags={"Node-RED"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Replace All Node-RED Flows",
+        },
+    )
+    @log_tool_usage
+    async def ha_nodered_update_flows(
+        self,
+        flows: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description=(
+                    "Complete /flows array (tabs, nodes and config nodes). "
+                    "This REPLACES every flow. The caller must include all "
+                    "existing content they want to keep."
+                )
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """Replace the entire Node-RED `/flows` array (full deployment)."""
+        try:
+            revision = await self._client.post_flows(flows)
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e, context={"operation": "nodered_update_flows"}
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "message": "Flows deployed successfully",
+                "node_count": len(flows),
+                "revision": revision if isinstance(revision, str) else None,
+            },
+        }
+
+
+def register_nodered_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register Node-RED tools when ENABLE_NODERED_TOOLS=true.
+
+    The ``client`` argument from the registry is the Home Assistant client and
+    is intentionally ignored — Node-RED has its own credentials and HTTP
+    client lifecycle.
+    """
+    settings = get_global_settings()
+    if not settings.enable_nodered_tools:
+        logger.debug(
+            "Node-RED tools disabled (set ENABLE_NODERED_TOOLS=true to enable)"
+        )
+        return
+
+    nodered_client = NodeRedClient(
+        base_url=settings.nodered_url,
+        username=settings.nodered_username,
+        password=settings.nodered_password,
+        timeout=settings.timeout,
+    )
+    register_tool_methods(mcp, NodeRedTools(nodered_client))
+    logger.info("Node-RED tools registered (11 tools)")

--- a/src/ha_mcp/tools/tools_nodered.py
+++ b/src/ha_mcp/tools/tools_nodered.py
@@ -11,16 +11,18 @@ Feature flag: set ``ENABLE_NODERED_TOOLS=true`` along with ``NODERED_URL``,
 module is a no-op when the flag is off.
 
 Behaviour notes preserved from the prior hand-rolled server:
-- ``ha_nodered_patch_node`` and ``ha_nodered_patch_flow`` only mutate
+- ``ha_update_nodered_node`` and ``ha_update_nodered_flow_nodes`` only mutate
   *existing* node properties — they cannot change a node's type. Use
-  ``ha_nodered_replace_flow`` for structural rewrites.
-- ``ha_nodered_replace_flow`` requires the caller to supply the full new
+  ``ha_replace_nodered_flow_nodes`` for structural rewrites.
+- ``ha_replace_nodered_flow_nodes`` requires the caller to supply the full new
   list of nodes for the tab. Disabled nodes must carry ``"d": true``
   explicitly; there is no additive-insert mode.
-- ``ha_nodered_get_nodes`` filters by ``search_name`` (case-insensitive
+- ``ha_search_nodered_nodes`` filters by ``search_name`` (case-insensitive
   substring on ``name``) and/or ``node_type``.
 """
 
+import asyncio
+import atexit
 import logging
 from typing import Annotated, Any
 
@@ -44,6 +46,24 @@ logger = logging.getLogger(__name__)
 # install (thousands of nodes) cannot blow up an MCP response payload.
 _NODE_SEARCH_LIMIT = 100
 
+# Track the active client so atexit can release the underlying httpx connection
+# pool cleanly. FastMCP doesn't expose a public on_shutdown hook and upstream's
+# server.py constructs FastMCP without a custom lifespan, so atexit is the
+# least-invasive way to hook process teardown without modifying upstream files.
+_active_client: NodeRedClient | None = None
+
+
+def _close_active_client_atexit() -> None:
+    """Close the registered NodeRedClient at process exit."""
+    if _active_client is None:
+        return
+    try:
+        asyncio.run(_active_client.close())
+    except RuntimeError:
+        # Event loop already running or interpreter shutting down — httpx will
+        # release sockets on process teardown anyway. Log and move on.
+        logger.debug("NodeRedClient atexit close skipped (no usable event loop)")
+
 
 class NodeRedTools:
     """Node-RED Admin API tools."""
@@ -56,7 +76,7 @@ class NodeRedTools:
     # ------------------------------------------------------------------
 
     @tool(
-        name="ha_nodered_get_flows",
+        name="ha_list_nodered_flows",
         tags={"Node-RED"},
         annotations={
             "readOnlyHint": True,
@@ -65,7 +85,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_get_flows(self) -> dict[str, Any]:
+    async def ha_list_nodered_flows(self) -> dict[str, Any]:
         """List all Node-RED flow tabs with per-tab node counts."""
         try:
             flows = await self._client.get_flows()
@@ -116,7 +136,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_get_flow",
+        name="ha_get_nodered_flow",
         tags={"Node-RED"},
         annotations={
             "readOnlyHint": True,
@@ -125,7 +145,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_get_flow(
+    async def ha_get_nodered_flow(
         self,
         flow_id: Annotated[
             str,
@@ -166,7 +186,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_get_nodes",
+        name="ha_search_nodered_nodes",
         tags={"Node-RED"},
         annotations={
             "readOnlyHint": True,
@@ -175,7 +195,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_get_nodes(
+    async def ha_search_nodered_nodes(
         self,
         node_type: Annotated[
             str | None,
@@ -254,7 +274,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_get_settings",
+        name="ha_get_nodered_settings",
         tags={"Node-RED"},
         annotations={
             "readOnlyHint": True,
@@ -263,7 +283,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_get_settings(self) -> dict[str, Any]:
+    async def ha_get_nodered_settings(self) -> dict[str, Any]:
         """Get Node-RED runtime settings (version, palette categories, theme)."""
         try:
             settings = await self._client.get_settings()
@@ -290,7 +310,7 @@ class NodeRedTools:
     # ------------------------------------------------------------------
 
     @tool(
-        name="ha_nodered_inject_node",
+        name="ha_call_nodered_inject_node",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": False,
@@ -299,11 +319,11 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_inject_node(
+    async def ha_call_nodered_inject_node(
         self,
         node_id: Annotated[str, Field(description="ID of the inject node to trigger")],
     ) -> dict[str, Any]:
-        """Trigger a Node-RED inject node by ID."""
+        """Call a Node-RED inject node by ID to fire its configured payload."""
         try:
             await self._client.inject(node_id)
         except ToolError:
@@ -320,7 +340,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_patch_node",
+        name="ha_update_nodered_node",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": True,
@@ -329,7 +349,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_patch_node(
+    async def ha_update_nodered_node(
         self,
         node_id: Annotated[str, Field(description="ID of the node to patch")],
         patches: Annotated[
@@ -338,7 +358,7 @@ class NodeRedTools:
                 description=(
                     "Properties to overwrite on the node, e.g. "
                     "{'func': 'return msg;', 'name': 'My Name'}. Cannot "
-                    "change the node's 'type' — use ha_nodered_replace_flow "
+                    "change the node's 'type' — use ha_replace_nodered_flow_nodes "
                     "for structural changes."
                 )
             ),
@@ -368,7 +388,7 @@ class NodeRedTools:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "Cannot change node 'type' via patch; use ha_nodered_replace_flow.",
+                    "Cannot change node 'type' via patch; use ha_replace_nodered_flow_nodes.",
                     context={"node_id": node_id, "current_type": target.get("type")},
                 )
             )
@@ -401,7 +421,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_patch_flow",
+        name="ha_update_nodered_flow_nodes",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": True,
@@ -410,7 +430,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_patch_flow(
+    async def ha_update_nodered_flow_nodes(
         self,
         flow_id: Annotated[
             str, Field(description="ID of the flow/tab containing the nodes to patch")
@@ -522,7 +542,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_replace_flow",
+        name="ha_replace_nodered_flow_nodes",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": True,
@@ -531,7 +551,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_replace_flow(
+    async def ha_replace_nodered_flow_nodes(
         self,
         flow_id: Annotated[
             str, Field(description="ID of the flow/tab to replace contents of")
@@ -603,7 +623,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_add_flow",
+        name="ha_create_nodered_flow",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": False,
@@ -612,7 +632,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_add_flow(
+    async def ha_create_nodered_flow(
         self,
         flow_tab: Annotated[
             dict[str, Any],
@@ -676,7 +696,7 @@ class NodeRedTools:
                     create_error_response(
                         ErrorCode.RESOURCE_ALREADY_EXISTS,
                         f"A node with ID '{flow_id}' already exists. "
-                        "Use ha_nodered_replace_flow to update it.",
+                        "Use ha_replace_nodered_flow_nodes to update it.",
                         context={"flow_id": flow_id},
                     )
                 )
@@ -708,7 +728,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_delete_flow",
+        name="ha_delete_nodered_flow",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": True,
@@ -717,7 +737,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_delete_flow(
+    async def ha_delete_nodered_flow(
         self,
         flow_id: Annotated[str, Field(description="ID of the flow/tab to delete")],
     ) -> dict[str, Any]:
@@ -768,7 +788,7 @@ class NodeRedTools:
         }
 
     @tool(
-        name="ha_nodered_update_flows",
+        name="ha_replace_nodered_flows",
         tags={"Node-RED"},
         annotations={
             "destructiveHint": True,
@@ -777,7 +797,7 @@ class NodeRedTools:
         },
     )
     @log_tool_usage
-    async def ha_nodered_update_flows(
+    async def ha_replace_nodered_flows(
         self,
         flows: Annotated[
             list[dict[str, Any]],
@@ -830,5 +850,15 @@ def register_nodered_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         password=settings.nodered_password,
         timeout=settings.timeout,
     )
+
+    global _active_client
+    if _active_client is None:
+        _active_client = nodered_client
+        atexit.register(_close_active_client_atexit)
+    else:
+        # Re-registration (e.g. test harness): swap the tracked client so the
+        # latest one is closed at exit. Old client is the caller's responsibility.
+        _active_client = nodered_client
+
     register_tool_methods(mcp, NodeRedTools(nodered_client))
     logger.info("Node-RED tools registered (11 tools)")

--- a/tests/src/unit/test_nodered_client.py
+++ b/tests/src/unit/test_nodered_client.py
@@ -1,0 +1,119 @@
+"""Unit tests for NodeRedClient (httpx wrapper, auth + error classification).
+
+Uses respx to intercept httpx requests at the transport layer, so we exercise
+the real client code (Basic-auth header construction, JSON vs text branching,
+status-code → exception mapping) without needing a live Node-RED instance.
+"""
+
+import httpx
+import pytest
+import respx
+
+from ha_mcp.client.nodered_client import (
+    NodeRedAPIError,
+    NodeRedAuthError,
+    NodeRedClient,
+    NodeRedConnectionError,
+)
+
+BASE = "https://nodered.example.test"
+
+
+def _make_client() -> NodeRedClient:
+    return NodeRedClient(base_url=BASE, username="user", password="secret", timeout=5)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_flows_returns_parsed_json_array():
+    respx.get(f"{BASE}/flows").mock(
+        return_value=httpx.Response(
+            200,
+            json=[{"id": "tab1", "type": "tab"}],
+            headers={"content-type": "application/json"},
+        )
+    )
+    client = _make_client()
+    flows = await client.get_flows()
+    assert flows == [{"id": "tab1", "type": "tab"}]
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_post_flows_sets_deployment_header_and_basic_auth():
+    route = respx.post(f"{BASE}/flows").mock(
+        return_value=httpx.Response(
+            200, text="rev-1", headers={"content-type": "text/plain"}
+        )
+    )
+    client = _make_client()
+    revision = await client.post_flows([{"id": "tab1", "type": "tab"}])
+    assert revision == "rev-1"
+
+    sent = route.calls.last.request
+    assert sent.headers["Node-RED-Deployment-Type"] == "full"
+    # httpx stores Basic auth as a base64-encoded Authorization header
+    assert sent.headers["Authorization"].startswith("Basic ")
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_settings_rejects_non_dict_response():
+    respx.get(f"{BASE}/settings").mock(
+        return_value=httpx.Response(
+            200, json=["not", "a", "dict"], headers={"content-type": "application/json"}
+        )
+    )
+    client = _make_client()
+    with pytest.raises(NodeRedAPIError):
+        await client.get_settings()
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_401_raises_auth_error():
+    respx.get(f"{BASE}/flows").mock(return_value=httpx.Response(401, text="nope"))
+    client = _make_client()
+    with pytest.raises(NodeRedAuthError):
+        await client.get_flows()
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_500_raises_api_error_with_status_and_body():
+    respx.get(f"{BASE}/flows").mock(
+        return_value=httpx.Response(500, text="server exploded")
+    )
+    client = _make_client()
+    with pytest.raises(NodeRedAPIError) as exc:
+        await client.get_flows()
+    assert exc.value.status_code == 500
+    assert "server exploded" in (exc.value.response_text or "")
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_transport_error_raises_connection_error():
+    respx.get(f"{BASE}/flows").mock(side_effect=httpx.ConnectError("boom"))
+    client = _make_client()
+    with pytest.raises(NodeRedConnectionError):
+        await client.get_flows()
+    await client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_inject_uses_post_with_node_id_in_path():
+    route = respx.post(f"{BASE}/inject/abc123").mock(
+        return_value=httpx.Response(200, text="OK")
+    )
+    client = _make_client()
+    result = await client.inject("abc123")
+    assert result == "OK"
+    assert route.called
+    await client.close()

--- a/tests/src/unit/test_tools_nodered.py
+++ b/tests/src/unit/test_tools_nodered.py
@@ -1,0 +1,465 @@
+"""Unit tests for the Node-RED tools module (`tools_nodered.py`).
+
+These tests exercise the per-tool logic against a mocked NodeRedClient. The
+client itself is a thin httpx wrapper — its exception-classification paths
+are exercised end-to-end through ``exception_to_structured_error`` here.
+
+Live integration tests against a real Node-RED instance would belong under
+``tests/src/integration/`` and be gated behind ``NODERED_LIVE_TESTS=true``;
+they are deliberately not added in this commit.
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.client.nodered_client import (
+    NodeRedAPIError,
+    NodeRedAuthError,
+    NodeRedConnectionError,
+)
+from ha_mcp.tools.tools_nodered import NodeRedTools
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _flows_fixture() -> list[dict]:
+    """A representative /flows payload: two tabs, a few nodes, one config node."""
+    return [
+        {"id": "tab1", "type": "tab", "label": "Lights", "disabled": False},
+        {"id": "tab2", "type": "tab", "label": "Bathroom", "disabled": False},
+        {
+            "id": "n1",
+            "type": "inject",
+            "z": "tab1",
+            "name": "Morning Trigger",
+            "x": 100,
+            "y": 100,
+            "wires": [["n2"]],
+        },
+        {
+            "id": "n2",
+            "type": "function",
+            "z": "tab1",
+            "name": "Compute Brightness",
+            "x": 250,
+            "y": 100,
+            "wires": [[]],
+            "func": "return msg;",
+        },
+        {
+            "id": "n3",
+            "type": "api-call-service",
+            "z": "tab2",
+            "name": "Turn on Fan",
+            "x": 100,
+            "y": 200,
+            "wires": [[]],
+        },
+        {"id": "cfg1", "type": "server", "name": "HA Server"},  # config node, no z
+    ]
+
+
+@pytest.fixture
+def mock_client():
+    client = AsyncMock()
+    client.get_flows = AsyncMock(return_value=_flows_fixture())
+    client.post_flows = AsyncMock(return_value="rev-abc-123")
+    client.get_settings = AsyncMock(
+        return_value={
+            "version": "4.0.2",
+            "httpNodeRoot": "/",
+            "paletteCategories": ["common", "function"],
+            "flowEncryptionType": "user",
+            "editorTheme": {"projects": {"enabled": False}},
+        }
+    )
+    client.inject = AsyncMock(return_value="OK")
+    return client
+
+
+@pytest.fixture
+def tools(mock_client):
+    return NodeRedTools(mock_client)
+
+
+def _bare(method):
+    """Strip @log_tool_usage / @tool wrappers to call the underlying coroutine."""
+    fn = method
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _parse_tool_error(exc: ToolError) -> dict:
+    """Tool errors are JSON-serialised structured responses."""
+    return json.loads(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Read-only tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_flows_summarises_tabs_and_nodes(tools):
+    result = await _bare(tools.ha_nodered_get_flows)(tools)
+    assert result["success"] is True
+    data = result["data"]
+    assert data["total_tabs"] == 2
+    assert data["total_nodes"] == 6
+    assert data["nodes_per_tab"] == {"tab1": 2, "tab2": 1}
+    assert data["config_nodes_count"] == 1
+    assert {t["id"] for t in data["tabs"]} == {"tab1", "tab2"}
+
+
+@pytest.mark.asyncio
+async def test_get_flow_returns_tab_with_nodes(tools):
+    result = await _bare(tools.ha_nodered_get_flow)(tools, flow_id="tab1")
+    assert result["success"] is True
+    data = result["data"]
+    assert data["id"] == "tab1"
+    assert data["label"] == "Lights"
+    assert data["node_count"] == 2
+    assert {n["id"] for n in data["nodes"]} == {"n1", "n2"}
+
+
+@pytest.mark.asyncio
+async def test_get_flow_unknown_id_raises_resource_not_found(tools):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_get_flow)(tools, flow_id="missing")
+    err = _parse_tool_error(exc.value)
+    assert err["success"] is False
+    assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+    assert err["identifier"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_filters_by_type_and_name_substring(tools):
+    result = await _bare(tools.ha_nodered_get_nodes)(
+        tools, node_type="function", search_name="brightness"
+    )
+    assert result["success"] is True
+    data = result["data"]
+    assert data["matches"] == 1
+    assert data["nodes"][0]["id"] == "n2"
+    assert data["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_restricts_to_flow_id(tools):
+    result = await _bare(tools.ha_nodered_get_nodes)(tools, flow_id="tab2")
+    assert result["success"] is True
+    assert {n["id"] for n in result["data"]["nodes"]} == {"n3"}
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_search_is_case_insensitive(tools):
+    result = await _bare(tools.ha_nodered_get_nodes)(tools, search_name="MORNING")
+    ids = {n["id"] for n in result["data"]["nodes"]}
+    assert "n1" in ids
+
+
+@pytest.mark.asyncio
+async def test_get_settings_passes_through_runtime_info(tools):
+    result = await _bare(tools.ha_nodered_get_settings)(tools)
+    assert result["data"]["version"] == "4.0.2"
+    assert "common" in result["data"]["palette_categories"]
+
+
+# ---------------------------------------------------------------------------
+# Inject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inject_node_calls_client_and_reports_success(tools, mock_client):
+    result = await _bare(tools.ha_nodered_inject_node)(tools, node_id="n1")
+    mock_client.inject.assert_awaited_once_with("n1")
+    assert result["data"]["node_id"] == "n1"
+
+
+# ---------------------------------------------------------------------------
+# Patch node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_node_updates_fields_and_redeploys(tools, mock_client):
+    result = await _bare(tools.ha_nodered_patch_node)(
+        tools, node_id="n2", patches={"name": "Renamed", "func": "return null;"}
+    )
+    assert result["success"] is True
+    deployed = mock_client.post_flows.await_args.args[0]
+    n2 = next(n for n in deployed if n["id"] == "n2")
+    assert n2["name"] == "Renamed"
+    assert n2["func"] == "return null;"
+    assert set(result["data"]["node"]["patched_fields"]) == {"name", "func"}
+
+
+@pytest.mark.asyncio
+async def test_patch_node_missing_raises_resource_not_found(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_patch_node)(
+            tools, node_id="ghost", patches={"name": "x"}
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+    mock_client.post_flows.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_patch_node_rejects_type_change(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_patch_node)(
+            tools, node_id="n1", patches={"type": "function"}
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+    mock_client.post_flows.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Patch flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_flow_applies_multiple_patches(tools, mock_client):
+    result = await _bare(tools.ha_nodered_patch_flow)(
+        tools,
+        flow_id="tab1",
+        node_patches=[
+            {"node_id": "n1", "patches": {"name": "Trigger v2"}},
+            {"node_id": "n2", "patches": {"func": "return 42;"}},
+        ],
+    )
+    assert result["data"]["message"].startswith("Patched 2")
+    deployed = mock_client.post_flows.await_args.args[0]
+    by_id = {n["id"]: n for n in deployed}
+    assert by_id["n1"]["name"] == "Trigger v2"
+    assert by_id["n2"]["func"] == "return 42;"
+
+
+@pytest.mark.asyncio
+async def test_patch_flow_collects_item_errors_for_wrong_flow(tools, mock_client):
+    result = await _bare(tools.ha_nodered_patch_flow)(
+        tools,
+        flow_id="tab1",
+        node_patches=[
+            {"node_id": "n1", "patches": {"name": "ok"}},
+            {"node_id": "n3", "patches": {"name": "wrong tab"}},  # n3 is on tab2
+        ],
+    )
+    assert result["success"] is True
+    assert len(result["data"]["patched_nodes"]) == 1
+    assert result["data"]["errors"] is not None
+    assert (
+        result["data"]["errors"][0]["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_flow_unknown_flow_raises(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_patch_flow)(
+            tools, flow_id="missing", node_patches=[{"node_id": "n1", "patches": {}}]
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+    mock_client.post_flows.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_patch_flow_all_failures_raises(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_patch_flow)(
+            tools,
+            flow_id="tab1",
+            node_patches=[{"node_id": "ghost", "patches": {"name": "x"}}],
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "VALIDATION_FAILED"
+    mock_client.post_flows.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Replace flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_flow_swaps_nodes_and_forces_z(tools, mock_client):
+    new_nodes = [
+        {"id": "new1", "type": "inject", "name": "New Inject", "wires": []},
+        {"id": "new2", "type": "debug", "name": "Dbg", "wires": []},
+    ]
+    result = await _bare(tools.ha_nodered_replace_flow)(
+        tools, flow_id="tab1", new_flow_nodes=new_nodes
+    )
+    assert result["data"]["old_node_count"] == 2
+    assert result["data"]["new_node_count"] == 2
+
+    deployed = mock_client.post_flows.await_args.args[0]
+    deployed_ids = {n["id"] for n in deployed}
+    # Old tab1 nodes gone, new ones present, tab2 + config preserved
+    assert {"n1", "n2"}.isdisjoint(deployed_ids)
+    assert {"new1", "new2", "tab1", "tab2", "n3", "cfg1"} <= deployed_ids
+    # New nodes had z forced to flow_id
+    for node in deployed:
+        if node["id"] in {"new1", "new2"}:
+            assert node["z"] == "tab1"
+
+
+@pytest.mark.asyncio
+async def test_replace_flow_unknown_flow_raises(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_replace_flow)(
+            tools, flow_id="missing", new_flow_nodes=[]
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+    mock_client.post_flows.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Add flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_flow_appends_tab_and_nodes(tools, mock_client):
+    new_tab = {"id": "tab3", "type": "tab", "label": "Garage"}
+    new_nodes = [{"id": "g1", "type": "inject", "name": "Garage Trigger", "wires": []}]
+    result = await _bare(tools.ha_nodered_add_flow)(
+        tools, flow_tab=new_tab, flow_nodes=new_nodes
+    )
+    assert result["data"]["flow_id"] == "tab3"
+    deployed = mock_client.post_flows.await_args.args[0]
+    deployed_by_id = {n["id"]: n for n in deployed}
+    assert deployed_by_id["tab3"]["type"] == "tab"
+    assert deployed_by_id["g1"]["z"] == "tab3"
+
+
+@pytest.mark.asyncio
+async def test_add_flow_rejects_duplicate_id(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_add_flow)(
+            tools,
+            flow_tab={"id": "tab1", "type": "tab", "label": "dup"},
+            flow_nodes=[],
+        )
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "RESOURCE_ALREADY_EXISTS"
+    mock_client.post_flows.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_tab,expected_code",
+    [
+        ({"id": "x", "label": "y"}, "VALIDATION_INVALID_PARAMETER"),  # type missing
+        ({"type": "tab", "label": "y"}, "VALIDATION_MISSING_PARAMETER"),  # id
+        ({"id": "x", "type": "tab"}, "VALIDATION_MISSING_PARAMETER"),  # label
+    ],
+)
+async def test_add_flow_validates_tab_shape(tools, mock_client, bad_tab, expected_code):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_add_flow)(tools, flow_tab=bad_tab, flow_nodes=[])
+    assert _parse_tool_error(exc.value)["error"]["code"] == expected_code
+    mock_client.post_flows.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Delete flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_flow_removes_tab_and_its_nodes(tools, mock_client):
+    result = await _bare(tools.ha_nodered_delete_flow)(tools, flow_id="tab1")
+    assert result["data"]["deleted_node_count"] == 3  # tab1 + n1 + n2
+    deployed_ids = {n["id"] for n in mock_client.post_flows.await_args.args[0]}
+    assert "tab1" not in deployed_ids
+    assert "n1" not in deployed_ids
+    assert "n2" not in deployed_ids
+    assert {"tab2", "n3", "cfg1"} <= deployed_ids
+
+
+@pytest.mark.asyncio
+async def test_delete_flow_unknown_raises(tools, mock_client):
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_delete_flow)(tools, flow_id="missing")
+    err = _parse_tool_error(exc.value)
+    assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+    mock_client.post_flows.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Update flows (raw deploy)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_flows_passes_through(tools, mock_client):
+    payload = [{"id": "tabX", "type": "tab", "label": "Replacement"}]
+    result = await _bare(tools.ha_nodered_update_flows)(tools, flows=payload)
+    mock_client.post_flows.assert_awaited_once_with(payload)
+    assert result["data"]["node_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Client error mapping (verifies tool wraps client exceptions structurally)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_error_maps_to_connection_failed(tools, mock_client):
+    mock_client.get_flows.side_effect = NodeRedConnectionError(
+        "connection refused on socket"
+    )
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_get_flows)(tools)
+    code = _parse_tool_error(exc.value)["error"]["code"]
+    assert code in ("CONNECTION_FAILED", "CONNECTION_TIMEOUT")
+
+
+@pytest.mark.asyncio
+async def test_timeout_message_maps_to_timeout_operation(tools, mock_client):
+    """The client formats timeouts with the word 'timeout' so the upstream
+    message-based classifier returns TIMEOUT_OPERATION — guard against the
+    classifier being narrowed in a future upstream change."""
+    mock_client.get_flows.side_effect = NodeRedConnectionError(
+        "Node-RED request timeout after 30s"
+    )
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_get_flows)(tools)
+    assert _parse_tool_error(exc.value)["error"]["code"] == "TIMEOUT_OPERATION"
+
+
+@pytest.mark.asyncio
+async def test_auth_error_maps_to_auth_invalid_token(tools, mock_client):
+    mock_client.get_flows.side_effect = NodeRedAuthError("auth failed 401")
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_get_flows)(tools)
+    code = _parse_tool_error(exc.value)["error"]["code"]
+    assert code == "AUTH_INVALID_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_api_error_classified_by_helpers(tools, mock_client):
+    mock_client.get_flows.side_effect = NodeRedAPIError(
+        "Node-RED 500", status_code=500, response_text="boom"
+    )
+    with pytest.raises(ToolError) as exc:
+        await _bare(tools.ha_nodered_get_flows)(tools)
+    err = _parse_tool_error(exc.value)
+    # Falls through to internal-error / service-call-failed via message classifier
+    assert err["error"]["code"] in (
+        "INTERNAL_ERROR",
+        "SERVICE_CALL_FAILED",
+    )

--- a/tests/src/unit/test_tools_nodered.py
+++ b/tests/src/unit/test_tools_nodered.py
@@ -107,7 +107,7 @@ def _parse_tool_error(exc: ToolError) -> dict:
 
 @pytest.mark.asyncio
 async def test_get_flows_summarises_tabs_and_nodes(tools):
-    result = await _bare(tools.ha_nodered_get_flows)(tools)
+    result = await _bare(tools.ha_list_nodered_flows)(tools)
     assert result["success"] is True
     data = result["data"]
     assert data["total_tabs"] == 2
@@ -119,7 +119,7 @@ async def test_get_flows_summarises_tabs_and_nodes(tools):
 
 @pytest.mark.asyncio
 async def test_get_flow_returns_tab_with_nodes(tools):
-    result = await _bare(tools.ha_nodered_get_flow)(tools, flow_id="tab1")
+    result = await _bare(tools.ha_get_nodered_flow)(tools, flow_id="tab1")
     assert result["success"] is True
     data = result["data"]
     assert data["id"] == "tab1"
@@ -131,7 +131,7 @@ async def test_get_flow_returns_tab_with_nodes(tools):
 @pytest.mark.asyncio
 async def test_get_flow_unknown_id_raises_resource_not_found(tools):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_get_flow)(tools, flow_id="missing")
+        await _bare(tools.ha_get_nodered_flow)(tools, flow_id="missing")
     err = _parse_tool_error(exc.value)
     assert err["success"] is False
     assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
@@ -140,7 +140,7 @@ async def test_get_flow_unknown_id_raises_resource_not_found(tools):
 
 @pytest.mark.asyncio
 async def test_get_nodes_filters_by_type_and_name_substring(tools):
-    result = await _bare(tools.ha_nodered_get_nodes)(
+    result = await _bare(tools.ha_search_nodered_nodes)(
         tools, node_type="function", search_name="brightness"
     )
     assert result["success"] is True
@@ -152,21 +152,21 @@ async def test_get_nodes_filters_by_type_and_name_substring(tools):
 
 @pytest.mark.asyncio
 async def test_get_nodes_restricts_to_flow_id(tools):
-    result = await _bare(tools.ha_nodered_get_nodes)(tools, flow_id="tab2")
+    result = await _bare(tools.ha_search_nodered_nodes)(tools, flow_id="tab2")
     assert result["success"] is True
     assert {n["id"] for n in result["data"]["nodes"]} == {"n3"}
 
 
 @pytest.mark.asyncio
 async def test_get_nodes_search_is_case_insensitive(tools):
-    result = await _bare(tools.ha_nodered_get_nodes)(tools, search_name="MORNING")
+    result = await _bare(tools.ha_search_nodered_nodes)(tools, search_name="MORNING")
     ids = {n["id"] for n in result["data"]["nodes"]}
     assert "n1" in ids
 
 
 @pytest.mark.asyncio
 async def test_get_settings_passes_through_runtime_info(tools):
-    result = await _bare(tools.ha_nodered_get_settings)(tools)
+    result = await _bare(tools.ha_get_nodered_settings)(tools)
     assert result["data"]["version"] == "4.0.2"
     assert "common" in result["data"]["palette_categories"]
 
@@ -178,7 +178,7 @@ async def test_get_settings_passes_through_runtime_info(tools):
 
 @pytest.mark.asyncio
 async def test_inject_node_calls_client_and_reports_success(tools, mock_client):
-    result = await _bare(tools.ha_nodered_inject_node)(tools, node_id="n1")
+    result = await _bare(tools.ha_call_nodered_inject_node)(tools, node_id="n1")
     mock_client.inject.assert_awaited_once_with("n1")
     assert result["data"]["node_id"] == "n1"
 
@@ -190,7 +190,7 @@ async def test_inject_node_calls_client_and_reports_success(tools, mock_client):
 
 @pytest.mark.asyncio
 async def test_patch_node_updates_fields_and_redeploys(tools, mock_client):
-    result = await _bare(tools.ha_nodered_patch_node)(
+    result = await _bare(tools.ha_update_nodered_node)(
         tools, node_id="n2", patches={"name": "Renamed", "func": "return null;"}
     )
     assert result["success"] is True
@@ -204,7 +204,7 @@ async def test_patch_node_updates_fields_and_redeploys(tools, mock_client):
 @pytest.mark.asyncio
 async def test_patch_node_missing_raises_resource_not_found(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_patch_node)(
+        await _bare(tools.ha_update_nodered_node)(
             tools, node_id="ghost", patches={"name": "x"}
         )
     err = _parse_tool_error(exc.value)
@@ -215,7 +215,7 @@ async def test_patch_node_missing_raises_resource_not_found(tools, mock_client):
 @pytest.mark.asyncio
 async def test_patch_node_rejects_type_change(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_patch_node)(
+        await _bare(tools.ha_update_nodered_node)(
             tools, node_id="n1", patches={"type": "function"}
         )
     err = _parse_tool_error(exc.value)
@@ -230,7 +230,7 @@ async def test_patch_node_rejects_type_change(tools, mock_client):
 
 @pytest.mark.asyncio
 async def test_patch_flow_applies_multiple_patches(tools, mock_client):
-    result = await _bare(tools.ha_nodered_patch_flow)(
+    result = await _bare(tools.ha_update_nodered_flow_nodes)(
         tools,
         flow_id="tab1",
         node_patches=[
@@ -247,7 +247,7 @@ async def test_patch_flow_applies_multiple_patches(tools, mock_client):
 
 @pytest.mark.asyncio
 async def test_patch_flow_collects_item_errors_for_wrong_flow(tools, mock_client):
-    result = await _bare(tools.ha_nodered_patch_flow)(
+    result = await _bare(tools.ha_update_nodered_flow_nodes)(
         tools,
         flow_id="tab1",
         node_patches=[
@@ -266,7 +266,7 @@ async def test_patch_flow_collects_item_errors_for_wrong_flow(tools, mock_client
 @pytest.mark.asyncio
 async def test_patch_flow_unknown_flow_raises(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_patch_flow)(
+        await _bare(tools.ha_update_nodered_flow_nodes)(
             tools, flow_id="missing", node_patches=[{"node_id": "n1", "patches": {}}]
         )
     err = _parse_tool_error(exc.value)
@@ -277,7 +277,7 @@ async def test_patch_flow_unknown_flow_raises(tools, mock_client):
 @pytest.mark.asyncio
 async def test_patch_flow_all_failures_raises(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_patch_flow)(
+        await _bare(tools.ha_update_nodered_flow_nodes)(
             tools,
             flow_id="tab1",
             node_patches=[{"node_id": "ghost", "patches": {"name": "x"}}],
@@ -298,7 +298,7 @@ async def test_replace_flow_swaps_nodes_and_forces_z(tools, mock_client):
         {"id": "new1", "type": "inject", "name": "New Inject", "wires": []},
         {"id": "new2", "type": "debug", "name": "Dbg", "wires": []},
     ]
-    result = await _bare(tools.ha_nodered_replace_flow)(
+    result = await _bare(tools.ha_replace_nodered_flow_nodes)(
         tools, flow_id="tab1", new_flow_nodes=new_nodes
     )
     assert result["data"]["old_node_count"] == 2
@@ -318,7 +318,7 @@ async def test_replace_flow_swaps_nodes_and_forces_z(tools, mock_client):
 @pytest.mark.asyncio
 async def test_replace_flow_unknown_flow_raises(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_replace_flow)(
+        await _bare(tools.ha_replace_nodered_flow_nodes)(
             tools, flow_id="missing", new_flow_nodes=[]
         )
     err = _parse_tool_error(exc.value)
@@ -335,7 +335,7 @@ async def test_replace_flow_unknown_flow_raises(tools, mock_client):
 async def test_add_flow_appends_tab_and_nodes(tools, mock_client):
     new_tab = {"id": "tab3", "type": "tab", "label": "Garage"}
     new_nodes = [{"id": "g1", "type": "inject", "name": "Garage Trigger", "wires": []}]
-    result = await _bare(tools.ha_nodered_add_flow)(
+    result = await _bare(tools.ha_create_nodered_flow)(
         tools, flow_tab=new_tab, flow_nodes=new_nodes
     )
     assert result["data"]["flow_id"] == "tab3"
@@ -348,7 +348,7 @@ async def test_add_flow_appends_tab_and_nodes(tools, mock_client):
 @pytest.mark.asyncio
 async def test_add_flow_rejects_duplicate_id(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_add_flow)(
+        await _bare(tools.ha_create_nodered_flow)(
             tools,
             flow_tab={"id": "tab1", "type": "tab", "label": "dup"},
             flow_nodes=[],
@@ -369,7 +369,9 @@ async def test_add_flow_rejects_duplicate_id(tools, mock_client):
 )
 async def test_add_flow_validates_tab_shape(tools, mock_client, bad_tab, expected_code):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_add_flow)(tools, flow_tab=bad_tab, flow_nodes=[])
+        await _bare(tools.ha_create_nodered_flow)(
+            tools, flow_tab=bad_tab, flow_nodes=[]
+        )
     assert _parse_tool_error(exc.value)["error"]["code"] == expected_code
     mock_client.post_flows.assert_not_called()
 
@@ -381,7 +383,7 @@ async def test_add_flow_validates_tab_shape(tools, mock_client, bad_tab, expecte
 
 @pytest.mark.asyncio
 async def test_delete_flow_removes_tab_and_its_nodes(tools, mock_client):
-    result = await _bare(tools.ha_nodered_delete_flow)(tools, flow_id="tab1")
+    result = await _bare(tools.ha_delete_nodered_flow)(tools, flow_id="tab1")
     assert result["data"]["deleted_node_count"] == 3  # tab1 + n1 + n2
     deployed_ids = {n["id"] for n in mock_client.post_flows.await_args.args[0]}
     assert "tab1" not in deployed_ids
@@ -393,7 +395,7 @@ async def test_delete_flow_removes_tab_and_its_nodes(tools, mock_client):
 @pytest.mark.asyncio
 async def test_delete_flow_unknown_raises(tools, mock_client):
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_delete_flow)(tools, flow_id="missing")
+        await _bare(tools.ha_delete_nodered_flow)(tools, flow_id="missing")
     err = _parse_tool_error(exc.value)
     assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
     mock_client.post_flows.assert_not_called()
@@ -407,7 +409,7 @@ async def test_delete_flow_unknown_raises(tools, mock_client):
 @pytest.mark.asyncio
 async def test_update_flows_passes_through(tools, mock_client):
     payload = [{"id": "tabX", "type": "tab", "label": "Replacement"}]
-    result = await _bare(tools.ha_nodered_update_flows)(tools, flows=payload)
+    result = await _bare(tools.ha_replace_nodered_flows)(tools, flows=payload)
     mock_client.post_flows.assert_awaited_once_with(payload)
     assert result["data"]["node_count"] == 1
 
@@ -423,7 +425,7 @@ async def test_connection_error_maps_to_connection_failed(tools, mock_client):
         "connection refused on socket"
     )
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_get_flows)(tools)
+        await _bare(tools.ha_list_nodered_flows)(tools)
     code = _parse_tool_error(exc.value)["error"]["code"]
     assert code in ("CONNECTION_FAILED", "CONNECTION_TIMEOUT")
 
@@ -437,7 +439,7 @@ async def test_timeout_message_maps_to_timeout_operation(tools, mock_client):
         "Node-RED request timeout after 30s"
     )
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_get_flows)(tools)
+        await _bare(tools.ha_list_nodered_flows)(tools)
     assert _parse_tool_error(exc.value)["error"]["code"] == "TIMEOUT_OPERATION"
 
 
@@ -445,7 +447,7 @@ async def test_timeout_message_maps_to_timeout_operation(tools, mock_client):
 async def test_auth_error_maps_to_auth_invalid_token(tools, mock_client):
     mock_client.get_flows.side_effect = NodeRedAuthError("auth failed 401")
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_get_flows)(tools)
+        await _bare(tools.ha_list_nodered_flows)(tools)
     code = _parse_tool_error(exc.value)["error"]["code"]
     assert code == "AUTH_INVALID_TOKEN"
 
@@ -456,7 +458,7 @@ async def test_api_error_classified_by_helpers(tools, mock_client):
         "Node-RED 500", status_code=500, response_text="boom"
     )
     with pytest.raises(ToolError) as exc:
-        await _bare(tools.ha_nodered_get_flows)(tools)
+        await _bare(tools.ha_list_nodered_flows)(tools)
     err = _parse_tool_error(exc.value)
     # Falls through to internal-error / service-call-failed via message classifier
     assert err["error"]["code"] in (

--- a/uv.lock
+++ b/uv.lock
@@ -429,6 +429,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "requests" },
+    { name = "respx" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
     { name = "testcontainers" },
@@ -459,6 +460,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests", specifier = ">=2.25.0" },
+    { name = "respx", specifier = ">=0.21.1" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "ruff", specifier = ">=0.12.12" },
     { name = "testcontainers", specifier = ">=4.13.0" },
@@ -1169,6 +1171,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Opens as a follow-up to discussion #1013 — would welcome maintainer feedback on the approach before this is marked ready for review.

## Summary

Adds 11 tools wrapping the Node-RED Admin API. Most users run Node-RED via the HA add-on, so the API is reachable through the same NGINX proxy and reuses the HA auth boundary.

The module is **disabled by default** and gated on `ENABLE_NODERED_TOOLS=true`. When the flag is off, `register_nodered_tools()` returns immediately and the new settings are not validated, so existing deployments are completely unaffected.

## Tools (named `ha_nodered_<verb>_<noun>` per AGENTS.md convention)

| Category | Tools |
|---|---|
| Read | `ha_nodered_get_flows`, `ha_nodered_get_flow`, `ha_nodered_get_nodes`, `ha_nodered_get_settings` |
| Trigger | `ha_nodered_inject_node` |
| Write | `ha_nodered_patch_node`, `ha_nodered_patch_flow`, `ha_nodered_replace_flow`, `ha_nodered_add_flow`, `ha_nodered_delete_flow`, `ha_nodered_update_flows` |

Tagged `{"Node-RED"}` so they group cleanly in `tools.json` / DOCS.md after `sync-tool-docs.yml` runs.

## Files

**New:**
- `src/ha_mcp/client/nodered_client.py` — thin httpx Basic-auth wrapper, mirrors `rest_client.py` exception types
- `src/ha_mcp/tools/tools_nodered.py` — `NodeRedTools` class, `@tool` + `@log_tool_usage` stack, structured errors via `exception_to_structured_error` / `raise_tool_error` (no raw `ToolError(str)`)
- `tests/src/unit/test_tools_nodered.py` — 24 tests, mocked client
- `tests/src/unit/test_nodered_client.py` — 8 tests, respx-mocked httpx

**Modified (append-only — minimises rebase conflict surface):**
- `src/ha_mcp/config.py` — 4 new settings + a `model_validator` that raises if the flag is on without creds
- `.env.example` — documented Node-RED section
- `pyproject.toml` — `respx` added to dev deps for httpx mocking

No changes to `registry.py`, `server.py`, or any existing tool — auto-discovery picks up the new `tools_nodered.py` automatically.

## Behaviour notes (preserved from a prior reference implementation)

- `patch_node` / `patch_flow` only mutate **existing** properties; cannot change a node's `type` (use `replace_flow` for structural changes)
- `replace_flow` expects the FULL new node list for the tab; no additive insert mode; disabled nodes must carry `\"d\": true` explicitly
- `get_nodes` filters by case-insensitive substring on `name` and/or exact match on `type`

## Quality checks (run locally)

\`\`\`
ruff check src/ha_mcp/tools/tools_nodered.py src/ha_mcp/client/nodered_client.py src/ha_mcp/config.py tests/src/unit/test_*nodered*  → clean
ruff format ...                                                                                                                       → clean
mypy src/ha_mcp/tools/tools_nodered.py src/ha_mcp/client/nodered_client.py src/ha_mcp/config.py                                       → 0 issues
ast-grep scan ...                                                                                                                     → clean
pytest tests/src/unit/test_tools_nodered.py tests/src/unit/test_nodered_client.py                                                     → 36 passed
pytest tests/src/unit/                                                                                                                → 522 passed (3 pre-existing skills-vendor failures unrelated to this PR)
\`\`\`

## Open questions for maintainers

1. **In-scope for this project?** Node-RED is a separate API but tightly coupled to the HA ecosystem. Discussion #1013 has the long form.
2. **Opt-in pattern OK?** Disabled by default, env-flag gated, no impact when off — modeled on `enable_yaml_config_editing`. Or would you prefer this as a separate package (e.g. `ha-mcp-nodered`)?
3. **Naming preference besides `ha_nodered_*`?**
4. **E2E story:** upstream's E2E suite uses testcontainers + a Docker HA. There's no equivalent for Node-RED, so I've left live-Node-RED tests out of CI and rely on the unit tests + respx for the HTTP layer. Happy to add an opt-in live-integration suite gated behind `NODERED_LIVE_TESTS=true` if you'd like.

Marked draft — will mark ready for review once you've signaled the approach is acceptable.