### PR TITLE
feat: combine ha_config_list_floors and ha_config_list_areas into ha_list_floors_areas

### DIFF
--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -395,14 +395,13 @@ class AreaTools:
     @log_tool_usage
     async def ha_get_home_topology(self) -> dict[str, Any]:
         """
-        Get the hierarchical floor/area structure of the home.
+        Get floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
 
-        Returns floors sorted by level (basement first, upper floors last),
-        each with its assigned areas nested underneath, plus unassigned_areas
-        for areas without a floor assignment. Pre-joins data from
-        ha_config_list_floors and ha_config_list_areas into a single
-        hierarchy, useful for location-based queries (e.g., "which rooms
-        are on the ground floor").
+        Do not use for flat listings — ha_config_list_areas and ha_config_list_floors cover those.
+
+        Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level. Pre-joins the two registries on floor_id so the agent does not need to join in context.
+
+        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads.
         """
         try:
             areas_result = await self._client.send_websocket_message(

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -411,13 +411,20 @@ class AreaTools:
                 {"type": "config/floor_registry/list"}
             )
 
-            if not (areas_result.get("success") and floors_result.get("success")):
+            # A response with success=True but no "result" key is malformed —
+            # treat it as a service call failure rather than silently returning
+            # floor_count=0, area_count=0 on a populated instance.
+            areas_ok = areas_result.get("success") and "result" in areas_result
+            floors_ok = floors_result.get("success") and "result" in floors_result
+            if not (areas_ok and floors_ok):
                 raise_tool_error(create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
                     "Failed to retrieve area or floor registry",
                     context={
                         "areas_success": areas_result.get("success"),
                         "floors_success": floors_result.get("success"),
+                        "areas_response_keys": sorted(areas_result.keys()),
+                        "floors_response_keys": sorted(floors_result.keys()),
                     },
                     suggestions=[
                         "Check Home Assistant connection",
@@ -425,8 +432,8 @@ class AreaTools:
                     ],
                 ))
 
-            areas = areas_result.get("result", [])
-            floors = floors_result.get("result", [])
+            areas = areas_result["result"]
+            floors = floors_result["result"]
 
             # Guard against area.floor_id references that do not exist in the
             # floors list (race between the two sequential reads, or manual

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -401,7 +401,7 @@ class AreaTools:
 
         Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level. Pre-joins the two registries on floor_id so the agent does not need to join in context.
 
-        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads — for example, an area whose floor_id no longer exists in the floors list will appear in unassigned_areas.
+        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads — for example, an area whose floor_id no longer exists in the floors list will appear in orphaned_areas.
         """
         try:
             areas_result = await self._client.send_websocket_message(
@@ -435,19 +435,26 @@ class AreaTools:
             areas = areas_result["result"]
             floors = floors_result["result"]
 
-            # Guard against area.floor_id references that do not exist in the
-            # floors list (race between the two sequential reads, or manual
-            # .storage inconsistency). Such areas are routed to unassigned_areas
-            # rather than silently dropped from the response.
+            # Partition areas into three disjoint sets:
+            #   - nested:    floor_id present AND points to a known floor
+            #   - orphaned:  floor_id present BUT points to a non-existent floor
+            #                (race between the two sequential reads, or manual
+            #                .storage inconsistency)
+            #   - unassigned: no floor_id at all
+            # Orphaned is surfaced as a separate key so the LLM can diagnose
+            # registry drift without introspecting individual area fields.
             valid_floor_ids = {f.get("floor_id") for f in floors if f.get("floor_id")}
             floor_map: dict[str, list[dict[str, Any]]] = {}
             unassigned_areas: list[dict[str, Any]] = []
+            orphaned_areas: list[dict[str, Any]] = []
             for area in areas:
                 fid = area.get("floor_id")
-                if fid and fid in valid_floor_ids:
+                if not fid:
+                    unassigned_areas.append(area)
+                elif fid in valid_floor_ids:
                     floor_map.setdefault(fid, []).append(area)
                 else:
-                    unassigned_areas.append(area)
+                    orphaned_areas.append(area)
 
             # Build nested hierarchy, preserving all floor-registry fields for
             # forward compatibility with future HA Core additions
@@ -464,11 +471,14 @@ class AreaTools:
                 "floor_count": len(topology),
                 "area_count": len(areas),
                 "unassigned_count": len(unassigned_areas),
+                "orphaned_count": len(orphaned_areas),
                 "floors": topology,
                 "unassigned_areas": unassigned_areas,
+                "orphaned_areas": orphaned_areas,
                 "message": (
                     f"Found {len(topology)} floor(s), {len(areas)} area(s), "
-                    f"{len(unassigned_areas)} unassigned"
+                    f"{len(unassigned_areas)} unassigned, "
+                    f"{len(orphaned_areas)} orphaned"
                 ),
             }
 

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -443,13 +443,18 @@ class AreaTools:
             #   - unassigned: no floor_id at all
             # Orphaned is surfaced as a separate key so the LLM can diagnose
             # registry drift without introspecting individual area fields.
-            valid_floor_ids = {f.get("floor_id") for f in floors if f.get("floor_id")}
+            # Use `is None` rather than falsy-check so that a floor_id of ""
+            # (valid but unusual) is treated as orphaned if it does not resolve,
+            # not as unassigned.
+            valid_floor_ids = {
+                f.get("floor_id") for f in floors if f.get("floor_id") is not None
+            }
             floor_map: dict[str, list[dict[str, Any]]] = {}
             unassigned_areas: list[dict[str, Any]] = []
             orphaned_areas: list[dict[str, Any]] = []
             for area in areas:
                 fid = area.get("floor_id")
-                if not fid:
+                if fid is None:
                     unassigned_areas.append(area)
                 elif fid in valid_floor_ids:
                     floor_map.setdefault(fid, []).append(area)

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -388,6 +388,86 @@ class AreaTools:
             ])
 
     @tool(
+        name="ha_get_home_topology",
+        tags={"Areas & Floors"},
+        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Home Topology"},
+    )
+    @log_tool_usage
+    async def ha_get_home_topology(self) -> dict[str, Any]:
+        """
+        Get the hierarchical floor/area structure of the home.
+
+        Returns floors sorted by level (basement first, upper floors last),
+        each with its assigned areas nested underneath, plus unassigned_areas
+        for areas without a floor assignment. Pre-joins data from
+        ha_config_list_floors and ha_config_list_areas into a single
+        hierarchy, useful for location-based queries (e.g., "which rooms
+        are on the ground floor").
+        """
+        try:
+            areas_result = await self._client.send_websocket_message(
+                {"type": "config/area_registry/list"}
+            )
+            floors_result = await self._client.send_websocket_message(
+                {"type": "config/floor_registry/list"}
+            )
+
+            if not (areas_result.get("success") and floors_result.get("success")):
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Failed to retrieve area or floor registry",
+                    context={
+                        "areas_success": areas_result.get("success"),
+                        "floors_success": floors_result.get("success"),
+                    },
+                ))
+
+            areas = areas_result.get("result", [])
+            floors = floors_result.get("result", [])
+
+            # Group areas by floor_id; collect areas without floor assignment
+            floor_map: dict[str, list[dict[str, Any]]] = {}
+            unassigned_areas: list[dict[str, Any]] = []
+            for area in areas:
+                fid = area.get("floor_id")
+                if fid:
+                    floor_map.setdefault(fid, []).append(area)
+                else:
+                    unassigned_areas.append(area)
+
+            # Build nested hierarchy, preserving all floor-registry fields for
+            # forward compatibility with future HA Core additions
+            topology = [
+                {**floor, "areas": floor_map.get(floor.get("floor_id"), [])}
+                for floor in floors
+            ]
+
+            # Sort by level ascending; None treated as 0 (Python sort fails on None/int mix)
+            topology.sort(key=lambda f: f.get("level") or 0)
+
+            return {
+                "success": True,
+                "floor_count": len(topology),
+                "area_count": len(areas),
+                "unassigned_count": len(unassigned_areas),
+                "floors": topology,
+                "unassigned_areas": unassigned_areas,
+                "message": (
+                    f"Found {len(topology)} floor(s), {len(areas)} area(s), "
+                    f"{len(unassigned_areas)} unassigned"
+                ),
+            }
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting home topology: {e}")
+            exception_to_structured_error(e, context={"operation": "get_home_topology"}, suggestions=[
+                "Check Home Assistant connection",
+                "Verify WebSocket connection is active",
+            ])
+
+    @tool(
         name="ha_config_set_floor",
         tags={"Areas & Floors"},
         annotations={"destructiveHint": True, "title": "Create or Update Floor"},

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -399,9 +399,9 @@ class AreaTools:
 
         Do not use for flat listings — ha_config_list_areas and ha_config_list_floors cover those.
 
-        Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level. Pre-joins the two registries on floor_id so the agent does not need to join in context.
+        Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level.
 
-        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads — for example, an area whose floor_id no longer exists in the floors list will appear in orphaned_areas.
+        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas; areas whose floor_id points to a non-existent floor appear in orphaned_areas — a topology snapshot may diverge from individual list calls if the registries change between reads.
         """
         try:
             areas_result = await self._client.send_websocket_message(

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -388,14 +388,14 @@ class AreaTools:
             ])
 
     @tool(
-        name="ha_get_home_topology",
+        name="ha_list_floors_areas",
         tags={"Areas & Floors"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Home Topology"},
+        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "List Floors and Areas"},
     )
     @log_tool_usage
-    async def ha_get_home_topology(self) -> dict[str, Any]:
+    async def ha_list_floors_areas(self) -> dict[str, Any]:
         """
-        Get floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
+        List floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
 
         Do not use for flat listings — ha_config_list_areas and ha_config_list_floors cover those.
 
@@ -468,8 +468,8 @@ class AreaTools:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error getting home topology: {e}")
-            exception_to_structured_error(e, context={"operation": "get_home_topology"}, suggestions=[
+            logger.error(f"Error listing floors and areas: {e}")
+            exception_to_structured_error(e, context={"operation": "list_floors_areas"}, suggestions=[
                 "Check Home Assistant connection",
                 "Verify WebSocket connection is active",
             ])

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -401,7 +401,7 @@ class AreaTools:
 
         Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level. Pre-joins the two registries on floor_id so the agent does not need to join in context.
 
-        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads.
+        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas instead of under any floor. The two registries are read sequentially; a topology snapshot may diverge from individual list calls if the registries change between reads — for example, an area whose floor_id no longer exists in the floors list will appear in unassigned_areas.
         """
         try:
             areas_result = await self._client.send_websocket_message(
@@ -419,17 +419,25 @@ class AreaTools:
                         "areas_success": areas_result.get("success"),
                         "floors_success": floors_result.get("success"),
                     },
+                    suggestions=[
+                        "Check Home Assistant connection",
+                        "Verify WebSocket connection is active",
+                    ],
                 ))
 
             areas = areas_result.get("result", [])
             floors = floors_result.get("result", [])
 
-            # Group areas by floor_id; collect areas without floor assignment
+            # Guard against area.floor_id references that do not exist in the
+            # floors list (race between the two sequential reads, or manual
+            # .storage inconsistency). Such areas are routed to unassigned_areas
+            # rather than silently dropped from the response.
+            valid_floor_ids = {f.get("floor_id") for f in floors if f.get("floor_id")}
             floor_map: dict[str, list[dict[str, Any]]] = {}
             unassigned_areas: list[dict[str, Any]] = []
             for area in areas:
                 fid = area.get("floor_id")
-                if fid:
+                if fid and fid in valid_floor_ids:
                     floor_map.setdefault(fid, []).append(area)
                 else:
                     unassigned_areas.append(area)

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -403,13 +403,19 @@ class AreaTools:
 
         Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas; areas whose floor_id points to a non-existent floor appear in orphaned_areas — a topology snapshot may diverge from individual list calls if the registries change between reads.
         """
+        progress: dict[str, Any] = {
+            "operation": "list_floors_areas",
+            "phase": "start",
+        }
         try:
             areas_result = await self._client.send_websocket_message(
                 {"type": "config/area_registry/list"}
             )
+            progress["phase"] = "areas_fetched"
             floors_result = await self._client.send_websocket_message(
                 {"type": "config/floor_registry/list"}
             )
+            progress["phase"] = "floors_fetched"
 
             # A response with success=True but no "result" key is malformed —
             # treat it as a service call failure rather than silently returning
@@ -460,6 +466,7 @@ class AreaTools:
                     floor_map.setdefault(fid, []).append(area)
                 else:
                     orphaned_areas.append(area)
+            progress["phase"] = "partitioned"
 
             # Build nested hierarchy, preserving all floor-registry fields for
             # forward compatibility with future HA Core additions
@@ -468,8 +475,24 @@ class AreaTools:
                 for floor in floors
             ]
 
-            # Sort by level ascending; None treated as 0 (Python sort fails on None/int mix)
-            topology.sort(key=lambda f: f.get("level") or 0)
+            # Sort by level ascending; coerce defensively so a malformed
+            # string `level` cannot raise TypeError mid-sort and get
+            # flattened by the broad `except Exception` below.
+            def _floor_sort_key(floor: dict[str, Any]) -> int:
+                raw = floor.get("level")
+                if raw is None:
+                    return 0
+                try:
+                    return int(raw)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        f"Floor {floor.get('floor_id')!r} has non-numeric "
+                        f"level {raw!r}; treating as 0 for sort"
+                    )
+                    return 0
+
+            topology.sort(key=_floor_sort_key)
+            progress["phase"] = "sorted"
 
             return {
                 "success": True,
@@ -490,11 +513,18 @@ class AreaTools:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error listing floors and areas: {e}")
-            exception_to_structured_error(e, context={"operation": "list_floors_areas"}, suggestions=[
-                "Check Home Assistant connection",
-                "Verify WebSocket connection is active",
-            ])
+            logger.error(
+                f"Error listing floors and areas in phase {progress['phase']!r}: {e} "
+                f"(progress={progress})"
+            )
+            exception_to_structured_error(
+                e,
+                context=progress,
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Verify WebSocket connection is active",
+                ],
+            )
 
     @tool(
         name="ha_config_set_floor",

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -517,6 +517,93 @@ class TestAreaFloorIntegration:
         await mcp_client.call_tool("ha_config_remove_floor", {"floor_id": floor_id})
         logger.info("Cleanup completed")
 
+    async def test_home_topology_with_assignment(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create floor -> Create area on floor -> ha_get_home_topology ->
+              Verify area appears nested under floor, not in unassigned_areas.
+        """
+        floor_name = generate_unique_name("test_topo_floor")
+        area_name = generate_unique_name("test_topo_area")
+        logger.info(f"Testing topology with assignment: {floor_name} -> {area_name}")
+
+        floor_result = await mcp_client.call_tool(
+            "ha_config_set_floor", {"name": floor_name, "level": 2}
+        )
+        floor_data = parse_mcp_result(floor_result)
+        assert floor_data.get("success"), f"Failed to create floor: {floor_data}"
+        floor_id = floor_data.get("floor_id")
+        cleanup_tracker.track("floor", floor_id)
+
+        area_result = await mcp_client.call_tool(
+            "ha_config_set_area",
+            {"name": area_name, "floor_id": floor_id, "icon": "mdi:sofa"},
+        )
+        area_data = parse_mcp_result(area_result)
+        assert area_data.get("success"), f"Failed to create area: {area_data}"
+        area_id = area_data.get("area_id")
+        cleanup_tracker.track("area", area_id)
+
+        topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+        topo_data = parse_mcp_result(topo_result)
+
+        assert topo_data.get("success"), f"Topology call failed: {topo_data}"
+        assert "floors" in topo_data and "unassigned_areas" in topo_data
+
+        target_floor = next(
+            (f for f in topo_data["floors"] if f.get("floor_id") == floor_id), None
+        )
+        assert target_floor is not None, f"Created floor not in topology: {floor_id}"
+        assert "areas" in target_floor, "Floor entry missing 'areas' key"
+
+        nested_area_ids = [a.get("area_id") for a in target_floor["areas"]]
+        assert area_id in nested_area_ids, (
+            f"Area {area_id} not nested under floor {floor_id}: {nested_area_ids}"
+        )
+
+        unassigned_ids = [a.get("area_id") for a in topo_data["unassigned_areas"]]
+        assert area_id not in unassigned_ids, (
+            f"Assigned area leaked into unassigned_areas: {area_id}"
+        )
+        logger.info(f"Topology verified: {area_id} nested under {floor_id}")
+
+        await mcp_client.call_tool("ha_config_remove_area", {"area_id": area_id})
+        await mcp_client.call_tool("ha_config_remove_floor", {"floor_id": floor_id})
+
+    async def test_home_topology_unassigned_area(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create area without floor_id -> ha_get_home_topology ->
+              Verify area appears in unassigned_areas, not nested under any floor.
+        """
+        area_name = generate_unique_name("test_topo_unassigned")
+        logger.info(f"Testing topology with unassigned area: {area_name}")
+
+        area_result = await mcp_client.call_tool(
+            "ha_config_set_area", {"name": area_name, "icon": "mdi:garage"}
+        )
+        area_data = parse_mcp_result(area_result)
+        assert area_data.get("success"), f"Failed to create area: {area_data}"
+        area_id = area_data.get("area_id")
+        cleanup_tracker.track("area", area_id)
+
+        topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+        topo_data = parse_mcp_result(topo_result)
+
+        assert topo_data.get("success"), f"Topology call failed: {topo_data}"
+
+        unassigned_ids = [a.get("area_id") for a in topo_data["unassigned_areas"]]
+        assert area_id in unassigned_ids, (
+            f"Unassigned area {area_id} not in unassigned_areas: {unassigned_ids}"
+        )
+
+        for floor in topo_data["floors"]:
+            floor_area_ids = [a.get("area_id") for a in floor.get("areas", [])]
+            assert area_id not in floor_area_ids, (
+                f"Unassigned area leaked into floor {floor.get('floor_id')}: {area_id}"
+            )
+        logger.info(f"Verified {area_id} is in unassigned_areas only")
+
+        await mcp_client.call_tool("ha_config_remove_area", {"area_id": area_id})
+
     @pytest.mark.slow
     async def test_multiple_areas_on_floor(self, mcp_client, cleanup_tracker):
         """
@@ -641,3 +728,43 @@ async def test_floor_list_empty_or_populated(mcp_client):
     )
 
     logger.info(f"Found {list_data['count']} existing floor(s)")
+
+
+@pytest.mark.area
+@pytest.mark.floor
+async def test_home_topology_schema(mcp_client):
+    """
+    Test: ha_get_home_topology returns a well-formed response on any HA instance
+    (populated or empty). Validates schema only, not content.
+    """
+    logger.info("Testing ha_get_home_topology schema")
+
+    topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+    topo_data = parse_mcp_result(topo_result)
+
+    assert topo_data.get("success"), f"Topology call failed: {topo_data}"
+    assert "floor_count" in topo_data, f"Missing floor_count: {topo_data}"
+    assert "area_count" in topo_data, f"Missing area_count: {topo_data}"
+    assert "unassigned_count" in topo_data, f"Missing unassigned_count: {topo_data}"
+    assert "floors" in topo_data, f"Missing floors: {topo_data}"
+    assert "unassigned_areas" in topo_data, f"Missing unassigned_areas: {topo_data}"
+    assert isinstance(topo_data["floors"], list), (
+        f"floors should be list: {type(topo_data['floors'])}"
+    )
+    assert isinstance(topo_data["unassigned_areas"], list), (
+        f"unassigned_areas should be list: {type(topo_data['unassigned_areas'])}"
+    )
+    assert isinstance(topo_data["floor_count"], int)
+    assert isinstance(topo_data["area_count"], int)
+    assert isinstance(topo_data["unassigned_count"], int)
+    # Each floor entry must carry its floor-registry fields plus the areas list
+    for floor in topo_data["floors"]:
+        assert "floor_id" in floor, f"Floor entry missing floor_id: {floor}"
+        assert "areas" in floor, f"Floor entry missing areas key: {floor}"
+        assert isinstance(floor["areas"], list)
+
+    logger.info(
+        f"Schema ok: {topo_data['floor_count']} floor(s), "
+        f"{topo_data['area_count']} area(s), "
+        f"{topo_data['unassigned_count']} unassigned"
+    )

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -519,7 +519,7 @@ class TestAreaFloorIntegration:
 
     async def test_home_topology_with_assignment(self, mcp_client, cleanup_tracker):
         """
-        Test: Create floor -> Create area on floor -> ha_get_home_topology ->
+        Test: Create floor -> Create area on floor -> ha_list_floors_areas ->
               Verify area appears nested under floor, not in unassigned_areas.
         """
         floor_name = generate_unique_name("test_topo_floor")
@@ -543,7 +543,7 @@ class TestAreaFloorIntegration:
         area_id = area_data.get("area_id")
         cleanup_tracker.track("area", area_id)
 
-        topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+        topo_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         topo_data = parse_mcp_result(topo_result)
 
         assert topo_data.get("success"), f"Topology call failed: {topo_data}"
@@ -571,7 +571,7 @@ class TestAreaFloorIntegration:
 
     async def test_home_topology_unassigned_area(self, mcp_client, cleanup_tracker):
         """
-        Test: Create area without floor_id -> ha_get_home_topology ->
+        Test: Create area without floor_id -> ha_list_floors_areas ->
               Verify area appears in unassigned_areas, not nested under any floor.
         """
         area_name = generate_unique_name("test_topo_unassigned")
@@ -585,7 +585,7 @@ class TestAreaFloorIntegration:
         area_id = area_data.get("area_id")
         cleanup_tracker.track("area", area_id)
 
-        topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+        topo_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         topo_data = parse_mcp_result(topo_result)
 
         assert topo_data.get("success"), f"Topology call failed: {topo_data}"
@@ -734,12 +734,12 @@ async def test_floor_list_empty_or_populated(mcp_client):
 @pytest.mark.floor
 async def test_home_topology_schema(mcp_client):
     """
-    Test: ha_get_home_topology returns a well-formed response on any HA instance
+    Test: ha_list_floors_areas returns a well-formed response on any HA instance
     (populated or empty). Validates schema only, not content.
     """
-    logger.info("Testing ha_get_home_topology schema")
+    logger.info("Testing ha_list_floors_areas schema")
 
-    topo_result = await mcp_client.call_tool("ha_get_home_topology", {})
+    topo_result = await mcp_client.call_tool("ha_list_floors_areas", {})
     topo_data = parse_mcp_result(topo_result)
 
     assert topo_data.get("success"), f"Topology call failed: {topo_data}"

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -12,6 +12,7 @@ This test suite validates:
 
 import logging
 import uuid
+from typing import Any
 
 import pytest
 
@@ -603,6 +604,117 @@ class TestAreaFloorIntegration:
         logger.info(f"Verified {area_id} is in unassigned_areas only")
 
         await mcp_client.call_tool("ha_config_remove_area", {"area_id": area_id})
+
+    async def test_home_topology_empty_floor(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create floor with no areas -> ha_list_floors_areas ->
+              Verify floor appears in floors with "areas": [], not filtered out
+              and not crashing a downstream iterator.
+        """
+        floor_name = generate_unique_name("test_topo_empty")
+        logger.info(f"Testing topology with empty floor: {floor_name}")
+
+        floor_result = await mcp_client.call_tool(
+            "ha_config_set_floor",
+            {"name": floor_name, "level": 3, "icon": "mdi:home-floor-3"},
+        )
+        floor_data = parse_mcp_result(floor_result)
+        assert floor_data.get("success"), f"Failed to create floor: {floor_data}"
+        floor_id = floor_data.get("floor_id")
+        cleanup_tracker.track("floor", floor_id)
+
+        topo_result = await mcp_client.call_tool("ha_list_floors_areas", {})
+        topo_data = parse_mcp_result(topo_result)
+
+        assert topo_data.get("success"), f"Topology call failed: {topo_data}"
+
+        floor_ids = [f.get("floor_id") for f in topo_data["floors"]]
+        assert floor_id in floor_ids, (
+            f"Empty floor {floor_id} not found in floors list: {floor_ids}"
+        )
+
+        empty_floor = next(
+            (f for f in topo_data["floors"] if f.get("floor_id") == floor_id),
+            None,
+        )
+        assert empty_floor is not None, f"Empty floor entry missing: {floor_id}"
+        assert "areas" in empty_floor, (
+            f"Empty floor has no 'areas' key — downstream iterators would crash: {empty_floor}"
+        )
+        assert empty_floor["areas"] == [], (
+            f"Empty floor 'areas' should be [], got: {empty_floor['areas']}"
+        )
+
+        # Downstream-iterator smoke: must not raise
+        for _area in empty_floor["areas"]:
+            pass
+
+        logger.info(f"Verified empty floor {floor_id} has areas=[]")
+
+        await mcp_client.call_tool("ha_config_remove_floor", {"floor_id": floor_id})
+
+    async def test_home_topology_sort_order(self, mcp_client, cleanup_tracker):
+        """
+        Test: Create floors with level=[-1, 0, None, 2] -> ha_list_floors_areas ->
+              Verify sort order: -1 first, 2 last, 0 and None adjacent
+              (both map to sort key 0 via `level or 0`; stable sort preserves
+              insertion order within the tie).
+        """
+        prefix = generate_unique_name("test_topo_sort")
+        logger.info(f"Testing topology sort order with levels [-1, 0, None, 2]: {prefix}")
+
+        levels = [-1, 0, None, 2]
+        floor_ids_by_level: dict[str, Any] = {}
+        for lvl in levels:
+            payload: dict[str, Any] = {"name": f"{prefix}_lvl_{lvl}"}
+            if lvl is not None:
+                payload["level"] = lvl
+            floor_result = await mcp_client.call_tool("ha_config_set_floor", payload)
+            floor_data = parse_mcp_result(floor_result)
+            assert floor_data.get("success"), (
+                f"Failed to create floor level={lvl}: {floor_data}"
+            )
+            fid = floor_data.get("floor_id")
+            cleanup_tracker.track("floor", fid)
+            floor_ids_by_level[str(lvl)] = fid
+
+        topo_result = await mcp_client.call_tool("ha_list_floors_areas", {})
+        topo_data = parse_mcp_result(topo_result)
+        assert topo_data.get("success"), f"Topology call failed: {topo_data}"
+
+        # Extract only our floors in the order returned by the tool
+        our_ids = set(floor_ids_by_level.values())
+        returned_order = [
+            f for f in topo_data["floors"] if f.get("floor_id") in our_ids
+        ]
+        assert len(returned_order) == 4, (
+            f"Expected 4 floors, got {len(returned_order)}: {returned_order}"
+        )
+
+        # Sort key in the implementation is `level or 0`, so:
+        #   -1 -> -1, 0 -> 0, None -> 0, 2 -> 2
+        # Position 0 must be level=-1, position 3 must be level=2.
+        # Positions 1 and 2 are the 0/None tie — either order is valid.
+        assert returned_order[0].get("floor_id") == floor_ids_by_level["-1"], (
+            f"First floor should be level=-1, got: {returned_order[0]}"
+        )
+        assert returned_order[3].get("floor_id") == floor_ids_by_level["2"], (
+            f"Last floor should be level=2, got: {returned_order[3]}"
+        )
+
+        middle_ids = {returned_order[1].get("floor_id"), returned_order[2].get("floor_id")}
+        expected_middle = {floor_ids_by_level["0"], floor_ids_by_level["None"]}
+        assert middle_ids == expected_middle, (
+            f"Middle positions should contain level=0 and level=None floors, "
+            f"got: {middle_ids} vs expected {expected_middle}"
+        )
+
+        logger.info(
+            "Verified sort order: -1 first, 2 last, 0/None tied in middle"
+        )
+
+        for fid in floor_ids_by_level.values():
+            await mcp_client.call_tool("ha_config_remove_floor", {"floor_id": fid})
 
     @pytest.mark.slow
     async def test_multiple_areas_on_floor(self, mcp_client, cleanup_tracker):

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -869,6 +869,12 @@ async def test_home_topology_schema(mcp_client):
     assert isinstance(topo_data["floor_count"], int)
     assert isinstance(topo_data["area_count"], int)
     assert isinstance(topo_data["unassigned_count"], int)
+    assert "orphaned_count" in topo_data, f"Missing orphaned_count: {topo_data}"
+    assert "orphaned_areas" in topo_data, f"Missing orphaned_areas: {topo_data}"
+    assert isinstance(topo_data["orphaned_areas"], list), (
+        f"orphaned_areas should be list: {type(topo_data['orphaned_areas'])}"
+    )
+    assert isinstance(topo_data["orphaned_count"], int)
     # Each floor entry must carry its floor-registry fields plus the areas list
     for floor in topo_data["floors"]:
         assert "floor_id" in floor, f"Floor entry missing floor_id: {floor}"
@@ -878,5 +884,6 @@ async def test_home_topology_schema(mcp_client):
     logger.info(
         f"Schema ok: {topo_data['floor_count']} floor(s), "
         f"{topo_data['area_count']} area(s), "
-        f"{topo_data['unassigned_count']} unassigned"
+        f"{topo_data['unassigned_count']} unassigned, "
+        f"{topo_data['orphaned_count']} orphaned"
     )

--- a/tests/src/unit/test_tools_areas.py
+++ b/tests/src/unit/test_tools_areas.py
@@ -1,0 +1,81 @@
+"""Unit tests for AreaTools — orphaned partition branch + malformed-WS-response guard.
+
+Both paths are untriggerable from E2E: the orphaned branch needs .storage drift
+between the two sequential WS reads, and the SERVICE_CALL_FAILED guard needs a
+malformed WS response with success=True but no "result" key. Mocking the client
+covers both cheaply.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_areas import AreaTools
+
+
+class TestHomeTopologyPartition:
+    """Covers the orphaned partition branch that E2E cannot reach."""
+
+    @pytest.fixture
+    def tools(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return AreaTools(client)
+
+    async def test_orphaned_area_partition(self, tools):
+        """An area whose floor_id points to a non-existent floor lands in orphaned_areas."""
+        tools._client.send_websocket_message.side_effect = [
+            # areas: one nested, one orphaned, one unassigned
+            {
+                "success": True,
+                "result": [
+                    {"area_id": "kitchen", "floor_id": "ground"},
+                    {"area_id": "ghost", "floor_id": "deleted_floor_id"},
+                    {"area_id": "loose", "floor_id": None},
+                ],
+            },
+            # floors: only "ground" exists — "deleted_floor_id" is not present
+            {
+                "success": True,
+                "result": [
+                    {"floor_id": "ground", "name": "Ground", "level": 0},
+                ],
+            },
+        ]
+
+        result = await tools.ha_list_floors_areas()
+
+        assert result["success"] is True
+        assert result["orphaned_count"] == 1
+        assert result["unassigned_count"] == 1
+        assert [a["area_id"] for a in result["orphaned_areas"]] == ["ghost"]
+        assert [a["area_id"] for a in result["unassigned_areas"]] == ["loose"]
+
+        ground = next(f for f in result["floors"] if f["floor_id"] == "ground")
+        assert [a["area_id"] for a in ground["areas"]] == ["kitchen"]
+
+
+class TestHomeTopologyMalformedResponseGuard:
+    """Covers the SERVICE_CALL_FAILED guard for malformed WS responses."""
+
+    @pytest.fixture
+    def tools(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return AreaTools(client)
+
+    async def test_malformed_ws_response_triggers_guard(self, tools):
+        """success=True without a "result" key must raise SERVICE_CALL_FAILED, not silently return empty counts."""
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True},  # malformed — no "result" key
+            {"success": True, "result": []},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_list_floors_areas()
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["success"] is False
+        assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"


### PR DESCRIPTION
## What does this PR do?

Adds `ha_get_home_topology`, a read-only tool that combines `config/area_registry/list` and `config/floor_registry/list` into one nested hierarchy: floors sorted by level ascending, each with its assigned areas nested underneath, plus `unassigned_areas` for areas without a floor.

Collapses the two-call in-context join (by `floor_id`) into one server-side call, reducing agent reasoning for location-based queries such as *"which rooms are on the ground floor"*. The existing `ha_config_list_areas` and `ha_config_list_floors` are unchanged — this PR is purely additive (86 → 87 tools).

Rationale (per AGENTS.md §Tool Consolidation): this is a "frequently chained operations → consolidate" case where tool-side logic adds value by combining multiple API calls. Follows the `ha_get_overview` precedent for joined read-only tools (sequential `await`, fail-fast on registry error; both registries are essential here, unlike the optional subparts in `ha_get_overview`).

Closes #902.

### Response shape

​`json
{
  "success": true,
  "floor_count": 2,
  "area_count": 3,
  "unassigned_count": 1,
  "floors": [
    {"floor_id": "basement", "name": "Basement", "level": -1, "icon": null,
     "aliases": [], "areas": [{"area_id": "storage", ...}]},
    {"floor_id": "ground", "name": "Ground Floor", "level": 0, "icon": "mdi:home-floor-0",
     "aliases": [], "areas": [{"area_id": "kitchen", ...}, {"area_id": "living_room", ...}]}
  ],
  "unassigned_areas": [{"area_id": "garage", ...}]
}
​`

Floor entries pass through all registry fields via dict-spread (`{**floor, "areas": [...]}`) for forward compatibility with future HA Core additions. Areas are nested as full dicts so the LLM never needs to re-query. `level` may be `None` (HA Core: `FloorEntry.level: int | None`); sort key uses `x.get("level") or 0` so `None` floors land next to level-0 instead of raising `TypeError`.

## Type of change
- [x] ✨ New feature

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Three E2E tests added in `tests/src/e2e/workflows/areas/test_lifecycle.py`:
- `test_home_topology_schema` — standalone schema check (works on any HA instance)
- `test_home_topology_with_assignment` — create floor + area-on-floor, verify area nested under floor and not in `unassigned_areas`
- `test_home_topology_unassigned_area` — create area without `floor_id`, verify area in `unassigned_areas` and not leaked into any floor's `areas` list

## Checklist
- [x] I have updated documentation if needed

`scripts/extract_tools.py` not included in this PR; `.github/workflows/sync-tool-docs.yml` regenerates `tools.json` / `README.md` / `DOCS.md` automatically after merge to master. Can push a follow-up commit if preferred.