### PR TITLE
perf(internal): inline-mode openai agent for BAT runner

### DIFF
--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -18,6 +18,7 @@ import argparse
 import asyncio
 import json
 import sys
+import traceback
 from pathlib import Path
 
 import openai
@@ -368,7 +369,7 @@ async def _main_async(args: argparse.Namespace) -> None:
         log(f"ERROR: Model warmup failed (BadRequestError): {e}")
         sys.exit(1)
     except Exception as e:
-        log(f"ERROR ({type(e).__name__}): {e}")
+        log(f"ERROR ({type(e).__name__}): {e}\n{traceback.format_exc()}")
         sys.exit(1)
 
     log(f"MCP config: {args.mcp_config}")
@@ -379,7 +380,7 @@ async def _main_async(args: argparse.Namespace) -> None:
         finally:
             await client.close()
     except Exception as e:
-        log(f"ERROR ({type(e).__name__}): {e}")
+        log(f"ERROR ({type(e).__name__}): {e}\n{traceback.format_exc()}")
         sys.exit(1)
 
     json.dump(result, sys.stdout, indent=2)

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -374,7 +374,10 @@ async def _main_async(args: argparse.Namespace) -> None:
     log(f"MCP config: {args.mcp_config}")
 
     try:
-        result = await run_agent(client, model, args)
+        try:
+            result = await run_agent(client, model, args)
+        finally:
+            await client.close()
     except Exception as e:
         log(f"ERROR ({type(e).__name__}): {e}")
         sys.exit(1)

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -109,8 +109,15 @@ async def tool_call_loop(
     tools: list[dict],
     mcp_client,
     max_tokens: int = DEFAULT_MAX_TOKENS,
+    tool_trace_sink: list[str] | None = None,
 ) -> dict:
-    """Run the LLM tool-call loop until a final text response or iteration limit."""
+    """Run the LLM tool-call loop until a final text response or iteration limit.
+
+    If ``tool_trace_sink`` is provided, every tool invocation (including
+    malformed-arguments and call failures) is appended as a stripped copy
+    of the corresponding ``[tool]`` stderr line, so callers on the inline
+    (non-subprocess) path can collect the trace without parsing stderr.
+    """
     num_turns = 0
     total_calls = 0
     total_success = 0
@@ -187,10 +194,13 @@ async def tool_call_loop(
             try:
                 tool_args = json.loads(tc.function.arguments)
             except json.JSONDecodeError as e:
-                log(
+                malformed_line = (
                     f"  [tool] {tool_name}: malformed arguments: "
                     f"{tc.function.arguments!r}"
                 )
+                log(malformed_line)
+                if tool_trace_sink is not None:
+                    tool_trace_sink.append(malformed_line.strip())
                 total_fail += 1
                 messages.append(
                     {
@@ -201,7 +211,10 @@ async def tool_call_loop(
                 )
                 continue
 
-            log(f"  [tool] {tool_name}({tool_args})")
+            call_line = f"  [tool] {tool_name}({tool_args})"
+            log(call_line)
+            if tool_trace_sink is not None:
+                tool_trace_sink.append(call_line.strip())
 
             try:
                 result = await mcp_client.call_tool(tool_name, tool_args)
@@ -210,7 +223,10 @@ async def tool_call_loop(
             except Exception as e:
                 result_text = f"Error: {str(e)}"
                 total_fail += 1
-                log(f"  [tool] {tool_name} failed: {e}")
+                fail_line = f"  [tool] {tool_name} failed: {e}"
+                log(fail_line)
+                if tool_trace_sink is not None:
+                    tool_trace_sink.append(fail_line.strip())
 
             messages.append(
                 {
@@ -220,9 +236,12 @@ async def tool_call_loop(
                 }
             )
 
-    # Max iterations reached
+    # Max iterations reached without a final message. Flag it so callers can
+    # surface it as a test failure — otherwise a model stuck in a tool-call
+    # loop looks identical to a clean run.
     return {
         "result": "Max tool-call iterations reached",
+        "hit_iteration_limit": True,
         "num_turns": num_turns,
         "tool_stats": {
             "totalCalls": total_calls,
@@ -249,50 +268,110 @@ async def run_agent(
 
     # fastmcp.Client accepts a config dict (same format as Claude's --mcp-config)
     async with Client(config) as mcp_client:
-        mcp_tools = await mcp_client.list_tools()
-        if args.max_tools is not None:
-            mcp_tools = mcp_tools[: args.max_tools]
-        openai_tools = [mcp_tool_to_openai(t) for t in mcp_tools]
+        return await run_scenario_inline(
+            client,
+            mcp_client,
+            model,
+            args.prompt,
+            max_tokens=args.max_tokens,
+            no_think=args.no_think,
+            max_tools=args.max_tools,
+        )
+
+
+async def fetch_openai_tools(mcp_client, max_tools: int | None = None) -> list[dict]:
+    """Fetch the MCP tool catalog and convert it to OpenAI function-calling format.
+
+    Safe to call once per MCP client and reuse the result across multiple
+    scenarios — the catalog doesn't change mid-session.
+    """
+    mcp_tools = await mcp_client.list_tools()
+    if max_tools is not None:
+        mcp_tools = mcp_tools[:max_tools]
+    return [mcp_tool_to_openai(t) for t in mcp_tools]
+
+
+async def run_scenario_inline(
+    openai_client: openai.OpenAI,
+    mcp_client,
+    model: str,
+    prompt: str,
+    *,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    no_think: bool = False,
+    max_tools: int | None = None,
+    tool_trace_sink: list[str] | None = None,
+    openai_tools: list[dict] | None = None,
+) -> dict:
+    """Run one scenario against an already-connected MCP client.
+
+    Returns the dict from ``tool_call_loop`` with a ``model`` key added.
+    If ``openai_tools`` is supplied, ``max_tools`` is ignored — the caller
+    is responsible for any truncation.
+    """
+    if openai_tools is None:
+        openai_tools = await fetch_openai_tools(mcp_client, max_tools=max_tools)
         log(f"Loaded {len(openai_tools)} MCP tools")
 
-        prompt = ("/no_think\n\n" + args.prompt) if args.no_think else args.prompt
-        messages = [{"role": "user", "content": prompt}]
-        result = await tool_call_loop(client, model, messages, openai_tools, mcp_client, max_tokens=args.max_tokens)
-        result["model"] = model
-        return result
+    agent_prompt = ("/no_think\n\n" + prompt) if no_think else prompt
+    messages = [{"role": "user", "content": agent_prompt}]
+    result = await tool_call_loop(
+        openai_client,
+        model,
+        messages,
+        openai_tools,
+        mcp_client,
+        max_tokens=max_tokens,
+        tool_trace_sink=tool_trace_sink,
+    )
+    result["model"] = model
+    return result
+
+
+def create_and_warm_openai_client(
+    base_url: str,
+    api_key: str = DEFAULT_API_KEY,
+    timeout: int = DEFAULT_TIMEOUT,
+    model: str | None = None,
+) -> tuple[openai.OpenAI, str]:
+    """Construct an OpenAI client, resolve the model, and warm it up once.
+
+    Returns ``(client, model)``. Issues a 1-token completion to force
+    backends like LM Studio and Ollama to load the model into VRAM
+    before the first real request (otherwise that request can stall
+    30-120s while the model is copied in). Raises on failure.
+    """
+    client = openai.OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+    resolved_model = model or detect_model(client)
+    log(f"Using model: {resolved_model}")
+    log("Warming up model (may take a minute if not loaded)...")
+    client.chat.completions.create(
+        model=resolved_model,
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=1,
+    )
+    log("Model ready")
+    return client, resolved_model
 
 
 def main() -> None:
     args = parse_args()
 
     try:
-        client = openai.OpenAI(
+        client, model = create_and_warm_openai_client(
             base_url=args.base_url,
             api_key=args.api_key,
             timeout=args.timeout,
+            model=args.model,
         )
-        model = args.model or detect_model(client)
+    except openai.BadRequestError as e:
+        log(f"ERROR: Model warmup failed (BadRequestError): {e}")
+        sys.exit(1)
     except Exception as e:
-        log(f"ERROR: Failed to connect to API at {args.base_url}: {e}")
+        log(f"ERROR ({type(e).__name__}): {e}")
         sys.exit(1)
 
-    log(f"Using model: {model}")
     log(f"MCP config: {args.mcp_config}")
-
-    # Warm up: load the model into memory before starting the MCP server.
-    # Ollama loads models lazily — without this, the first chat request hangs
-    # silently for 30-120s while the model is copied into VRAM.
-    try:
-        log("Warming up model (may take a minute if not loaded)...")
-        client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": "hi"}],
-            max_tokens=1,
-        )
-        log("Model ready")
-    except Exception as e:
-        log(f"ERROR: Model warmup failed ({type(e).__name__}): {e}")
-        sys.exit(1)
 
     try:
         result = asyncio.run(run_agent(client, model, args))
@@ -302,6 +381,9 @@ def main() -> None:
 
     json.dump(result, sys.stdout, indent=2)
     print()
+    if result.get("hit_iteration_limit"):
+        log("ERROR: hit max tool-call iterations without a final response")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -21,6 +21,8 @@ import sys
 from pathlib import Path
 
 import openai
+from fastmcp import Client as MCPClient
+from mcp.types import Tool as MCPTool
 
 DEFAULT_API_KEY = "no-key"
 DEFAULT_TIMEOUT = 120
@@ -32,7 +34,7 @@ def log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
-def mcp_tool_to_openai(tool) -> dict:
+def mcp_tool_to_openai(tool: MCPTool) -> dict:
     """Convert an MCP tool definition to OpenAI function-calling format."""
     parameters = tool.inputSchema or {"type": "object", "properties": {}}
     return {
@@ -45,9 +47,9 @@ def mcp_tool_to_openai(tool) -> dict:
     }
 
 
-def detect_model(client: openai.OpenAI) -> str:
+async def detect_model(client: openai.AsyncOpenAI) -> str:
     """Query /v1/models and return the first available model ID."""
-    models = client.models.list()
+    models = await client.models.list()
     if not models.data:
         raise RuntimeError("No models available at the API endpoint")
     model_id = models.data[0].id
@@ -103,11 +105,11 @@ def extract_tool_result_text(result) -> str:
 
 
 async def tool_call_loop(
-    client: openai.OpenAI,
+    client: openai.AsyncOpenAI,
     model: str,
     messages: list[dict],
     tools: list[dict],
-    mcp_client,
+    mcp_client: MCPClient,
     max_tokens: int = DEFAULT_MAX_TOKENS,
     tool_trace_sink: list[str] | None = None,
 ) -> dict:
@@ -131,7 +133,7 @@ async def tool_call_loop(
         if tools:
             kwargs["tools"] = tools
 
-        response = client.chat.completions.create(**kwargs)
+        response = await client.chat.completions.create(**kwargs)
         num_turns += 1
 
         # Accumulate running token totals; also capture first-turn prompt size as
@@ -256,18 +258,16 @@ async def tool_call_loop(
 
 
 async def run_agent(
-    client: openai.OpenAI, model: str, args: argparse.Namespace
+    client: openai.AsyncOpenAI, model: str, args: argparse.Namespace
 ) -> dict:
     """Connect to MCP server and run the tool-call loop."""
-    from fastmcp import Client
-
     # Read MCP config — same format as Claude's --mcp-config
     config = json.loads(Path(args.mcp_config).read_text())  # noqa: ASYNC240
 
     log("Starting MCP server...")
 
     # fastmcp.Client accepts a config dict (same format as Claude's --mcp-config)
-    async with Client(config) as mcp_client:
+    async with MCPClient(config) as mcp_client:
         return await run_scenario_inline(
             client,
             mcp_client,
@@ -279,7 +279,9 @@ async def run_agent(
         )
 
 
-async def fetch_openai_tools(mcp_client, max_tools: int | None = None) -> list[dict]:
+async def fetch_openai_tools(
+    mcp_client: MCPClient, max_tools: int | None = None
+) -> list[dict]:
     """Fetch the MCP tool catalog and convert it to OpenAI function-calling format.
 
     Safe to call once per MCP client and reuse the result across multiple
@@ -292,8 +294,8 @@ async def fetch_openai_tools(mcp_client, max_tools: int | None = None) -> list[d
 
 
 async def run_scenario_inline(
-    openai_client: openai.OpenAI,
-    mcp_client,
+    openai_client: openai.AsyncOpenAI,
+    mcp_client: MCPClient,
     model: str,
     prompt: str,
     *,
@@ -328,12 +330,12 @@ async def run_scenario_inline(
     return result
 
 
-def create_and_warm_openai_client(
+async def create_and_warm_openai_client(
     base_url: str,
     api_key: str = DEFAULT_API_KEY,
     timeout: int = DEFAULT_TIMEOUT,
     model: str | None = None,
-) -> tuple[openai.OpenAI, str]:
+) -> tuple[openai.AsyncOpenAI, str]:
     """Construct an OpenAI client, resolve the model, and warm it up once.
 
     Returns ``(client, model)``. Issues a 1-token completion to force
@@ -341,11 +343,11 @@ def create_and_warm_openai_client(
     before the first real request (otherwise that request can stall
     30-120s while the model is copied in). Raises on failure.
     """
-    client = openai.OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
-    resolved_model = model or detect_model(client)
+    client = openai.AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+    resolved_model = model or await detect_model(client)
     log(f"Using model: {resolved_model}")
     log("Warming up model (may take a minute if not loaded)...")
-    client.chat.completions.create(
+    await client.chat.completions.create(
         model=resolved_model,
         messages=[{"role": "user", "content": "hi"}],
         max_tokens=1,
@@ -354,11 +356,9 @@ def create_and_warm_openai_client(
     return client, resolved_model
 
 
-def main() -> None:
-    args = parse_args()
-
+async def _main_async(args: argparse.Namespace) -> None:
     try:
-        client, model = create_and_warm_openai_client(
+        client, model = await create_and_warm_openai_client(
             base_url=args.base_url,
             api_key=args.api_key,
             timeout=args.timeout,
@@ -374,7 +374,7 @@ def main() -> None:
     log(f"MCP config: {args.mcp_config}")
 
     try:
-        result = asyncio.run(run_agent(client, model, args))
+        result = await run_agent(client, model, args)
     except Exception as e:
         log(f"ERROR ({type(e).__name__}): {e}")
         sys.exit(1)
@@ -384,6 +384,11 @@ def main() -> None:
     if result.get("hit_iteration_limit"):
         log("ERROR: hit max tool-call iterations without a final response")
         sys.exit(1)
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(_main_async(args))
 
 
 if __name__ == "__main__":

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -25,6 +25,7 @@ import shutil
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from testcontainers.core.container import DockerContainer
@@ -139,16 +140,49 @@ def _build_mcp_env(
     return env
 
 
-def write_stdio_mcp_config(
+def parse_mcp_env(
+    raw_mcp_env: list[str] | None,
+    base_url: str | None = None,
+    on_default_applied: Callable[[str], None] | None = None,
+) -> dict[str, str]:
+    """Parse ``KEY=VALUE`` pairs into a dict, with the local-model default.
+
+    A bare ``KEY`` (no ``=``) maps to an empty string — useful for
+    boolean-presence flags. When ``base_url`` is set (targeting a local
+    OpenAI-compatible endpoint), ``ENABLE_TOOL_SEARCH=true`` is injected
+    unless the caller already set it. Local models typically can't prefill
+    the full tool catalog, so tool search is the default for that path.
+    Override with an explicit ``ENABLE_TOOL_SEARCH=...`` pair.
+
+    If ``on_default_applied`` is provided, it is called with a human-readable
+    message each time a default is injected.
+    """
+    pairs = raw_mcp_env or []
+    env = {k: v for pair in pairs for k, _, v in [pair.partition("=")]}
+    if base_url and "ENABLE_TOOL_SEARCH" not in env:
+        env["ENABLE_TOOL_SEARCH"] = "true"
+        if on_default_applied:
+            on_default_applied(
+                "Defaulting ENABLE_TOOL_SEARCH=true for local model (--base-url set)"
+            )
+    return env
+
+
+def build_stdio_mcp_config(
     ha_url: str,
     ha_token: str,
     branch: str | None,
     extra_env: dict[str, str] | None = None,
-) -> Path:
-    """Write a temporary Claude MCP config JSON file."""
+) -> dict:
+    """Build the stdio MCP config dict (format shared with Claude's --mcp-config).
+
+    The dict can be passed directly to ``fastmcp.Client(config)`` for in-process
+    use, or serialized to a file via ``write_stdio_mcp_config`` for CLI agents
+    that expect a file path.
+    """
     cmd = mcp_server_command(branch)
     env = _build_mcp_env(ha_url, ha_token, extra_env)
-    config = {
+    return {
         "mcpServers": {
             "home-assistant": {
                 "command": cmd[0],
@@ -157,6 +191,16 @@ def write_stdio_mcp_config(
             }
         }
     }
+
+
+def write_stdio_mcp_config(
+    ha_url: str,
+    ha_token: str,
+    branch: str | None,
+    extra_env: dict[str, str] | None = None,
+) -> Path:
+    """Write the stdio MCP config to a temporary JSON file, return its path."""
+    config = build_stdio_mcp_config(ha_url, ha_token, branch, extra_env)
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="claude_mcp_", delete=False
     ) as f:
@@ -618,13 +662,10 @@ async def run(args: argparse.Namespace) -> dict:
         log(f"MCP source: {mcp_source}" + (f" ({args.branch})" if args.branch else ""))
         log(f"Agents: {', '.join(active_agents)}")
 
-        # Parse --mcp-env pairs into a dict.  The format is KEY=VALUE, but bare
-        # KEY (no =) is also valid and intentionally sets the variable to an empty
-        # string — useful for boolean-presence flags like ENABLE_TOOL_SEARCH=.
-        raw_mcp_env = getattr(args, "mcp_env", None) or []
-        extra_env: dict[str, str] | None = (
-            {k: v for pair in raw_mcp_env for k, _, v in [pair.partition("=")]}
-            if raw_mcp_env else None
+        extra_env = parse_mcp_env(
+            getattr(args, "mcp_env", None),
+            base_url=getattr(args, "base_url", None),
+            on_default_applied=log,
         )
 
         # Run agents sequentially to avoid resource contention

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -22,9 +22,12 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 
@@ -129,6 +132,38 @@ def mcp_server_command(branch: str | None) -> list[str]:
             "ha-mcp",
         ]
     return ["uv", "run", "--project", str(REPO_ROOT), "ha-mcp"]
+
+
+def _preflight_check_docker(timeout: float = 5.0) -> str | None:
+    """Return an error string if the Docker daemon is unreachable, else None."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return "'docker' CLI not found on PATH (install Docker or pass --ha-url)"
+    except subprocess.TimeoutExpired:
+        return f"Docker daemon did not respond within {timeout:.0f}s"
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout).strip().splitlines()
+        hint = stderr[-1] if stderr else f"exit {result.returncode}"
+        return f"Docker daemon is not reachable: {hint}"
+    return None
+
+
+def _preflight_check_base_url(base_url: str, timeout: float = 5.0) -> str | None:
+    """Return an error string if the OpenAI endpoint is unreachable, else None."""
+    url = f"{base_url.rstrip('/')}/models"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout):
+            return None
+    except urllib.error.URLError as e:
+        return f"OpenAI endpoint {base_url} is not reachable: {e.reason}"
+    except Exception as e:
+        return f"OpenAI endpoint {base_url} is not reachable ({type(e).__name__}): {e}"
 
 
 def _build_mcp_env(
@@ -644,6 +679,17 @@ async def run(args: argparse.Namespace) -> dict:
             "--base-url is required when using the openai agent. "
             "Example: --base-url http://localhost:1234/v1"
         )
+
+    # Preflight: fail fast if Docker or the OpenAI endpoint is unreachable,
+    # rather than stalling inside container startup / model warmup.
+    if not args.ha_url:
+        err = _preflight_check_docker()
+        if err:
+            raise RuntimeError(err)
+    if "openai" in active_agents and getattr(args, "base_url", None):
+        err = _preflight_check_base_url(args.base_url)
+        if err:
+            raise RuntimeError(err)
 
     # Start HA (container or external)
     ha_url = args.ha_url

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -154,10 +154,18 @@ def preflight_check_docker(timeout: float = 5.0) -> str | None:
 
 
 def preflight_check_base_url(base_url: str, timeout: float = 5.0) -> str | None:
-    """Return an error string if the OpenAI endpoint is unreachable, else None."""
+    """Return an error string if the OpenAI endpoint is unreachable or broken, else None.
+
+    Catches both connection-level failures (ConnectionError, Timeout) and
+    HTTP error responses (4xx/5xx from ``raise_for_status``) — the latter
+    covers "up but wrong" cases like hitting the wrong port, a bad
+    auth token, or an upstream error, which would otherwise only surface
+    as an opaque warmup stall.
+    """
     url = f"{base_url.rstrip('/')}/models"
     try:
-        requests.get(url, timeout=timeout)
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
     except requests.RequestException as e:
         return f"OpenAI endpoint {base_url} is not reachable ({type(e).__name__}): {e}"
     return None

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -26,11 +26,10 @@ import subprocess
 import sys
 import tempfile
 import time
-import urllib.error
-import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 
+import requests
 from testcontainers.core.container import DockerContainer
 
 # Resolve paths relative to repo root
@@ -134,7 +133,7 @@ def mcp_server_command(branch: str | None) -> list[str]:
     return ["uv", "run", "--project", str(REPO_ROOT), "ha-mcp"]
 
 
-def _preflight_check_docker(timeout: float = 5.0) -> str | None:
+def preflight_check_docker(timeout: float = 5.0) -> str | None:
     """Return an error string if the Docker daemon is unreachable, else None."""
     try:
         result = subprocess.run(
@@ -154,16 +153,14 @@ def _preflight_check_docker(timeout: float = 5.0) -> str | None:
     return None
 
 
-def _preflight_check_base_url(base_url: str, timeout: float = 5.0) -> str | None:
+def preflight_check_base_url(base_url: str, timeout: float = 5.0) -> str | None:
     """Return an error string if the OpenAI endpoint is unreachable, else None."""
     url = f"{base_url.rstrip('/')}/models"
     try:
-        with urllib.request.urlopen(url, timeout=timeout):
-            return None
-    except urllib.error.URLError as e:
-        return f"OpenAI endpoint {base_url} is not reachable: {e.reason}"
-    except Exception as e:
+        requests.get(url, timeout=timeout)
+    except requests.RequestException as e:
         return f"OpenAI endpoint {base_url} is not reachable ({type(e).__name__}): {e}"
+    return None
 
 
 def _build_mcp_env(
@@ -683,11 +680,11 @@ async def run(args: argparse.Namespace) -> dict:
     # Preflight: fail fast if Docker or the OpenAI endpoint is unreachable,
     # rather than stalling inside container startup / model warmup.
     if not args.ha_url:
-        err = _preflight_check_docker()
+        err = preflight_check_docker()
         if err:
             raise RuntimeError(err)
     if "openai" in active_agents and getattr(args, "base_url", None):
-        err = _preflight_check_base_url(args.base_url)
+        err = preflight_check_base_url(args.base_url)
         if err:
             raise RuntimeError(err)
 

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -44,8 +44,13 @@ import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    import openai
+    from fastmcp import Client as MCPClient
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 CATALOG_DIR = SCRIPT_DIR / "catalog"
@@ -390,8 +395,8 @@ def _run_test_prompt(
 async def _run_test_prompt_inline(
     prompt: str,
     agent_name: str,
-    openai_client,
-    mcp_client,
+    openai_client: openai.AsyncOpenAI,
+    mcp_client: MCPClient,
     model: str,
     openai_tools: list[dict],
     *,
@@ -695,10 +700,26 @@ async def run_stories(
     agent_list = [a.strip() for a in args.agents.split(",")]
     using_external_ha = bool(args.ha_url)
 
+    from uat.run_uat import (
+        _preflight_check_base_url,
+        _preflight_check_docker,
+        build_stdio_mcp_config,
+        parse_mcp_env,
+    )
+
+    if not using_external_ha:
+        err = _preflight_check_docker()
+        if err:
+            log(f"FATAL: {err}")
+            return 2
+    if args.base_url and "openai" in agent_list:
+        err = _preflight_check_base_url(args.base_url)
+        if err:
+            log(f"FATAL: {err}")
+            return 2
+
     all_results: list[tuple[str, str, dict, int, dict | None, str | None]] = []
     # Each entry: (agent, story_id, story, exit_code, summary, session_file)
-
-    from uat.run_uat import build_stdio_mcp_config, parse_mcp_env
 
     mcp_env_dict = parse_mcp_env(
         getattr(args, "mcp_env", None),
@@ -725,9 +746,9 @@ async def run_stories(
         # MCP server spawn and model warmup. Other agents take the subprocess
         # path via _run_test_prompt.
         use_inline = agent in INLINE_AGENTS
-        inline_mcp_client = None
-        openai_client = None
-        resolved_model = None
+        inline_mcp_client: MCPClient | None = None
+        openai_client: openai.AsyncOpenAI | None = None
+        resolved_model: str | None = None
         openai_tools: list[dict] = []
 
         async with contextlib.AsyncExitStack() as agent_stack:
@@ -745,7 +766,7 @@ async def run_stories(
                     ha_url, ha_token, args.branch, mcp_env_dict or None
                 )
                 try:
-                    openai_client, resolved_model = create_and_warm_openai_client(
+                    openai_client, resolved_model = await create_and_warm_openai_client(
                         base_url=args.base_url,
                         api_key=args.api_key,
                         model=args.model,
@@ -808,7 +829,13 @@ async def run_stories(
 
                 log(f"[{agent}/{sid}] Running test prompt...")
                 run_start = time.time()
+                summary: dict | None
                 if use_inline:
+                    assert (
+                        openai_client is not None
+                        and inline_mcp_client is not None
+                        and resolved_model is not None
+                    ), "inline setup invariant: clients/model are populated when use_inline is True"
                     rc, summary = await _run_test_prompt_inline(
                         story["prompt"],
                         agent_name=agent,

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -701,19 +701,19 @@ async def run_stories(
     using_external_ha = bool(args.ha_url)
 
     from uat.run_uat import (
-        _preflight_check_base_url,
-        _preflight_check_docker,
         build_stdio_mcp_config,
         parse_mcp_env,
+        preflight_check_base_url,
+        preflight_check_docker,
     )
 
     if not using_external_ha:
-        err = _preflight_check_docker()
+        err = preflight_check_docker()
         if err:
             log(f"FATAL: {err}")
             return 2
     if args.base_url and "openai" in agent_list:
-        err = _preflight_check_base_url(args.base_url)
+        err = preflight_check_base_url(args.base_url)
         if err:
             log(f"FATAL: {err}")
             return 2
@@ -771,6 +771,7 @@ async def run_stories(
                         api_key=args.api_key,
                         model=args.model,
                     )
+                    agent_stack.push_async_callback(openai_client.close)
                 except Exception as e:
                     error_msg = f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
                     log(f"[{agent}] {error_msg}")

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 import logging
 import subprocess
@@ -52,6 +53,10 @@ REPO_ROOT = SCRIPT_DIR.parent.parent.parent
 TESTS_DIR = REPO_ROOT / "tests"
 RUN_UAT = SCRIPT_DIR.parent / "run_uat.py"
 DEFAULT_RESULTS_FILE = REPO_ROOT / "local" / "uat-results.jsonl"
+
+# Agents that can run in-process with a persistent MCP+OpenAI client across
+# stories. Claude and Gemini are external CLIs and take the subprocess path.
+INLINE_AGENTS: frozenset[str] = frozenset({"openai"})
 
 # Add paths for imports
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -382,6 +387,160 @@ def _run_test_prompt(
     return result.returncode, summary
 
 
+async def _run_test_prompt_inline(
+    prompt: str,
+    agent_name: str,
+    openai_client,
+    mcp_client,
+    model: str,
+    openai_tools: list[dict],
+    *,
+    no_think: bool = False,
+    max_tokens: int | None = None,
+) -> tuple[int, dict]:
+    """Run the test prompt via the openai_agent library directly.
+
+    Reuses a persistent ``mcp_client``, ``openai_client``, and pre-fetched
+    ``openai_tools`` across stories, so no subprocess spawn, MCP server
+    restart, model warmup, or ``list_tools`` round trip happens per
+    story. Returns ``(exit_code, summary)`` matching the shape of
+    ``_run_test_prompt`` so the surrounding story-loop code is agnostic
+    to how the test was executed. A failure always produces a summary
+    (never ``None``) so the caller can append a row to the results file.
+    """
+    import traceback
+
+    from uat.openai_agent import DEFAULT_MAX_TOKENS, run_scenario_inline
+
+    tool_trace: list[str] = []
+    start = time.time()
+    try:
+        result = await run_scenario_inline(
+            openai_client,
+            mcp_client,
+            model,
+            prompt.strip(),
+            max_tokens=max_tokens or DEFAULT_MAX_TOKENS,
+            no_think=no_think,
+            tool_trace_sink=tool_trace,
+            openai_tools=openai_tools,
+        )
+    except Exception as e:
+        log(f"  [{agent_name}] inline run failed ({type(e).__name__}): {e}")
+        tb = traceback.format_exc()
+        log(tb)
+        duration_ms = int((time.time() - start) * 1000)
+        return 1, _inline_failure_summary(
+            agent_name,
+            error_msg=f"{type(e).__name__}: {e}",
+            traceback_text=tb,
+            duration_ms=duration_ms,
+            tool_trace=tool_trace,
+        )
+
+    duration_ms = int((time.time() - start) * 1000)
+    exit_code = 1 if result.get("hit_iteration_limit") else 0
+
+    # Match the summary shape produced by run_uat.make_summary.
+    test_phase = {
+        "completed": True,
+        "duration_ms": duration_ms,
+        "exit_code": exit_code,
+        "output": result.get("result", ""),
+        "num_turns": result.get("num_turns"),
+        "tool_stats": result.get("tool_stats"),
+        "tokens_input": result.get("tokens_input"),
+        "tokens_output": result.get("tokens_output"),
+        "tool_trace": tool_trace,
+        "cost_usd": result.get("cost_usd", 0),
+    }
+    if result.get("hit_iteration_limit"):
+        test_phase["error"] = "hit_iteration_limit"
+    tool_stats = result.get("tool_stats") or {}
+    aggregate = {
+        "total_duration_ms": duration_ms,
+        "total_turns": result.get("num_turns"),
+        "total_tool_calls": tool_stats.get("totalCalls"),
+        "total_tool_success": tool_stats.get("totalSuccess"),
+        "total_tool_fail": tool_stats.get("totalFail"),
+        "tokens_first_input": result.get("tokens_first_input"),
+    }
+    summary = {
+        "agents": {
+            agent_name: {
+                "available": True,
+                "all_passed": exit_code == 0,
+                "test": test_phase,
+                "aggregate": aggregate,
+            }
+        }
+    }
+    return exit_code, summary
+
+
+def _inline_failure_summary(
+    agent_name: str,
+    *,
+    error_msg: str,
+    traceback_text: str | None = None,
+    duration_ms: int = 0,
+    tool_trace: list[str] | None = None,
+) -> dict:
+    """Build a summary dict for a failed inline run (matches make_summary shape)."""
+    test_phase: dict = {
+        "completed": False,
+        "duration_ms": duration_ms,
+        "exit_code": 1,
+        "output": traceback_text or error_msg,
+        "error": error_msg,
+        "tool_trace": tool_trace or [],
+    }
+    return {
+        "agents": {
+            agent_name: {
+                "available": True,
+                "all_passed": False,
+                "test": test_phase,
+                "aggregate": {"total_duration_ms": duration_ms},
+            }
+        }
+    }
+
+
+def _record_setup_failure(
+    filtered: list,
+    agent: str,
+    error_msg: str,
+    *,
+    all_results: list,
+    results_file,
+    sha: str,
+    describe: str,
+    branch: str | None,
+) -> None:
+    """Write a failure row per story and record it in all_results.
+
+    Called when per-agent setup (OpenAI client, MCP server) fails before
+    any story runs — otherwise every filtered story is silently dropped
+    from both the JSONL log and the process exit code.
+    """
+    for _path, story in filtered:
+        summary = _inline_failure_summary(agent, error_msg=error_msg)
+        all_results.append((agent, story["id"], story, 1, summary, None))
+        append_result(
+            results_file,
+            story,
+            agent,
+            sha,
+            describe,
+            branch,
+            summary,
+            None,
+            exit_code=1,
+            verify_results=None,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Git info
 # ---------------------------------------------------------------------------
@@ -539,12 +698,20 @@ async def run_stories(
     all_results: list[tuple[str, str, dict, int, dict | None, str | None]] = []
     # Each entry: (agent, story_id, story, exit_code, summary, session_file)
 
+    from uat.run_uat import build_stdio_mcp_config, parse_mcp_env
+
+    mcp_env_dict = parse_mcp_env(
+        getattr(args, "mcp_env", None),
+        base_url=args.base_url,
+        on_default_applied=log,
+    )
+    effective_mcp_env: list[str] = [f"{k}={v}" for k, v in mcp_env_dict.items()]
+
     for agent in agent_list:
         log(f"\n{'#' * 60}")
         log(f"Agent: {agent}")
         log(f"{'#' * 60}")
 
-        # Start a fresh container for this agent (or use external HA)
         ha = None
         ha_url = args.ha_url
         ha_token = args.ha_token
@@ -553,7 +720,79 @@ async def run_stories(
             ha_url = ha["url"]
             ha_token = ha["token"]
 
-        try:
+        # Inline agents (see INLINE_AGENTS) hold one MCP server + one OpenAI
+        # client across all stories for this agent, skipping the per-story
+        # MCP server spawn and model warmup. Other agents take the subprocess
+        # path via _run_test_prompt.
+        use_inline = agent in INLINE_AGENTS
+        inline_mcp_client = None
+        openai_client = None
+        resolved_model = None
+        openai_tools: list[dict] = []
+
+        async with contextlib.AsyncExitStack() as agent_stack:
+            if ha and not args.keep_container:
+                agent_stack.callback(_stop_container, ha)
+
+            if use_inline:
+                from fastmcp import Client as _MCPClient
+                from uat.openai_agent import (
+                    create_and_warm_openai_client,
+                    fetch_openai_tools,
+                )
+
+                config = build_stdio_mcp_config(
+                    ha_url, ha_token, args.branch, mcp_env_dict or None
+                )
+                try:
+                    openai_client, resolved_model = create_and_warm_openai_client(
+                        base_url=args.base_url,
+                        api_key=args.api_key,
+                        model=args.model,
+                    )
+                except Exception as e:
+                    error_msg = f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
+                    log(f"[{agent}] {error_msg}")
+                    _record_setup_failure(
+                        filtered,
+                        agent,
+                        error_msg,
+                        all_results=all_results,
+                        results_file=args.results_file,
+                        sha=sha,
+                        describe=describe,
+                        branch=args.branch,
+                    )
+                    continue
+                try:
+                    inline_mcp_client = await agent_stack.enter_async_context(
+                        _MCPClient(config)
+                    )
+                    openai_tools = await fetch_openai_tools(
+                        inline_mcp_client, max_tools=args.max_tools
+                    )
+                    log(f"[{agent}] MCP server ready ({len(openai_tools)} tools)")
+                except Exception as e:
+                    error_msg = f"Failed to start MCP server: {type(e).__name__}: {e}"
+                    log(f"[{agent}] {error_msg}")
+                    _record_setup_failure(
+                        filtered,
+                        agent,
+                        error_msg,
+                        all_results=all_results,
+                        results_file=args.results_file,
+                        sha=sha,
+                        describe=describe,
+                        branch=args.branch,
+                    )
+                    continue
+
+            if ha and args.keep_container:
+                log(f"\n[{agent}] Container kept alive: {ha['url']}")
+                log(f"[{agent}] Token: {ha['token']}")
+                log(f"[{agent}] Config dir: {ha['config_dir']}")
+                log(f"[{agent}] Stop manually: docker stop <container>")
+
             for _path, story in filtered:
                 sid = story["id"]
                 log(f"\n{'=' * 60}")
@@ -561,34 +800,42 @@ async def run_stories(
                 log(f"{'=' * 60}")
 
                 setup_steps = story.get("setup") or []
-
-                # Setup via FastMCP in-memory
                 if setup_steps:
                     log(
                         f"[{agent}/{sid}] Setup ({len(setup_steps)} steps via FastMCP)..."
                     )
                     await _run_mcp_steps(ha_url, ha_token, setup_steps, "setup")
 
-                # Test via agent CLI
                 log(f"[{agent}/{sid}] Running test prompt...")
                 run_start = time.time()
-                rc, summary = _run_test_prompt(
-                    story["prompt"],
-                    agent,
-                    ha_url,
-                    ha_token,
-                    args.branch,
-                    args.extra_args or None,
-                    model=args.model,
-                    base_url=args.base_url,
-                    api_key=args.api_key,
-                    max_tools=args.max_tools,
-                    no_think=args.no_think,
-                    max_tokens=getattr(args, "max_tokens", None),
-                    mcp_env=getattr(args, "mcp_env", None),
-                )
+                if use_inline:
+                    rc, summary = await _run_test_prompt_inline(
+                        story["prompt"],
+                        agent_name=agent,
+                        openai_client=openai_client,
+                        mcp_client=inline_mcp_client,
+                        model=resolved_model,
+                        openai_tools=openai_tools,
+                        no_think=args.no_think,
+                        max_tokens=getattr(args, "max_tokens", None),
+                    )
+                else:
+                    rc, summary = _run_test_prompt(
+                        story["prompt"],
+                        agent,
+                        ha_url,
+                        ha_token,
+                        args.branch,
+                        args.extra_args or None,
+                        model=args.model,
+                        base_url=args.base_url,
+                        api_key=args.api_key,
+                        max_tools=args.max_tools,
+                        no_think=args.no_think,
+                        max_tokens=getattr(args, "max_tokens", None),
+                        mcp_env=effective_mcp_env or None,
+                    )
 
-                # Detect session file created during this run
                 session_file = None
                 test_phase = (
                     (summary or {}).get("agents", {}).get(agent, {}).get("test", {})
@@ -599,7 +846,6 @@ async def run_stories(
                 if not session_file:
                     session_file = _find_latest_session_file(agent, after=run_start)
 
-                # Verify HA state if story has ha_checks
                 verify_results = None
                 ha_checks = (story.get("verify") or {}).get("ha_checks")
                 if ha_checks:
@@ -624,7 +870,6 @@ async def run_stories(
 
                 all_results.append((agent, sid, story, rc, summary, session_file))
 
-                # Append JSONL result (write even without summary if ha_checks ran)
                 if summary or verify_results is not None:
                     append_result(
                         args.results_file,
@@ -641,16 +886,6 @@ async def run_stories(
 
                 if session_file:
                     log(f"[{agent}/{sid}] Session file: {session_file}")
-
-        finally:
-            if ha:
-                if args.keep_container:
-                    log(f"\n[{agent}] Container kept alive: {ha['url']}")
-                    log(f"[{agent}] Token: {ha['token']}")
-                    log(f"[{agent}] Config dir: {ha['config_dir']}")
-                    log(f"[{agent}] Stop manually: docker stop <container>")
-                else:
-                    _stop_container(ha)
 
     # Summary
     log(f"\n{'=' * 60}")
@@ -737,7 +972,11 @@ def main() -> None:
         "--mcp-env",
         action="append",
         metavar="KEY=VALUE",
-        help="Extra env var for the MCP server (repeatable, e.g. --mcp-env ENABLE_TOOL_SEARCH=true)",
+        help=(
+            "Extra env var for the MCP server (repeatable). "
+            "ENABLE_TOOL_SEARCH defaults to true when --base-url is set "
+            "(local model); override with --mcp-env ENABLE_TOOL_SEARCH=false."
+        ),
     )
     parser.add_argument("extra_args", nargs="*", help="Extra args passed to run_uat.py")
     args = parser.parse_args()


### PR DESCRIPTION
## What does this PR do?

Add an inline execution path for the BAT openai agent: one `fastmcp.Client` plus one `openai.AsyncOpenAI` per agent run, shared across all stories, instead of spawning a subprocess and warming the model per story. Cuts wall-clock for a full openai BAT run by roughly 15-20%. Claude and Gemini still take the subprocess path; the inline path is gated by an `INLINE_AGENTS` frozenset so adding another inline-capable agent later is a one-line edit.

Also in scope:
- Switch `openai_agent.py` from `openai.OpenAI` to `openai.AsyncOpenAI` so chat completions, `models.list`, and the warmup call no longer block the event loop. Addresses Gemini Code Assist high-priority review. Concrete type hints added: `mcp_client: fastmcp.Client`, `openai_client: openai.AsyncOpenAI`, `tool: mcp.types.Tool`.
- Fail-fast preflight for Docker and the `--base-url` endpoint so outages exit in ~1s with a clear `FATAL:` line rather than stalling inside container startup or model warmup.
- Surface the max-iteration cap (`hit_iteration_limit`) as a non-zero exit in both subprocess and inline modes. Previously a model stuck in a tool-call loop was reported as a clean pass.
- Per-agent setup failures (OpenAI auth, MCP server crash) write a stub failure row per filtered story instead of dropping them from the JSONL log and the process exit code.
- Inline failures always produce a summary with the traceback attached.
- `parse_mcp_env` and `build_stdio_mcp_config` extracted from `run_uat.py` so `run_story.py` can share them.

Validated against LM Studio + qwen3.5-9b: 13/14 openai BAT stories pass. The one failure is s07 hitting `hit_iteration_limit` on HA backend 500 errors during `ha_config_set_automation`, unrelated to the async conversion and correctly surfaced by the new error handling.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed