### PR TITLE
Added feature flags for gated features to App config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Spend less time configuring, more time enjoying your smart home.
 | **Dashboards** | `ha_config_delete_dashboard_resource`, `ha_config_delete_dashboard`, `ha_config_get_dashboard`, `ha_config_list_dashboard_resources`, `ha_config_set_dashboard_resource`, `ha_config_set_dashboard` |
 | **Device Registry** | `ha_get_device`, `ha_remove_device`, `ha_update_device` |
 | **Entity Registry** | `ha_get_entity_exposure`, `ha_get_entity`, `ha_remove_entity`, `ha_set_entity` |
-| **Files** | `ha_delete_file`, `ha_list_files`, `ha_read_file`, `ha_write_file` |
+| **Files** | `ha_delete_file` *(beta)*, `ha_list_files` *(beta)*, `ha_read_file` *(beta)*, `ha_write_file` *(beta)* |
 | **Groups** | `ha_config_list_groups`, `ha_config_remove_group`, `ha_config_set_group` |
 | **HACS** | `ha_hacs_add_repository`, `ha_hacs_download`, `ha_hacs_repository_info`, `ha_hacs_search` |
 | **Helper Entities** | `ha_config_list_helpers`, `ha_config_remove_helper`, `ha_config_set_helper`, `ha_get_helper_schema` |
@@ -184,7 +184,7 @@ Spend less time configuring, more time enjoying your smart home.
 
 ---
 
-## 🔌 Custom Component (ha_mcp_tools)
+## 🔌 Custom Component (ha_mcp_tools) *(beta)*
 
 Some tools require a companion custom component installed in Home Assistant. Standard HA APIs do not expose file system access or YAML config editing. This component provides both.
 
@@ -193,10 +193,10 @@ Some tools require a companion custom component installed in Home Assistant. Sta
 | Tool | Description |
 |------|-------------|
 | `ha_config_set_yaml` | Safely add, replace, or remove top-level YAML keys in `configuration.yaml` and package files (automatic backup, validation, and config check) |
-| `ha_list_files` | List files in allowed directories (www/, themes/, custom_templates/) |
-| `ha_read_file` | Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/) |
-| `ha_write_file` | Write files to allowed directories |
-| `ha_delete_file` | Delete files from allowed directories |
+| `ha_list_files` *(beta)* | List files in allowed directories (www/, themes/, custom_templates/) |
+| `ha_read_file` *(beta)* | Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/) |
+| `ha_write_file` *(beta)* | Write files to allowed directories |
+| `ha_delete_file` *(beta)* | Delete files from allowed directories |
 
 All other tools work without the component. These five return an error with installation instructions if the component is missing.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Some tools require a companion custom component installed in Home Assistant. Sta
 
 | Tool | Description |
 |------|-------------|
-| `ha_config_set_yaml` | Safely add, replace, or remove top-level YAML keys in `configuration.yaml` and package files (automatic backup, validation, and config check) |
+| `ha_config_set_yaml` *(beta)* | Safely add, replace, or remove top-level YAML keys in `configuration.yaml` and package files (automatic backup, validation, and config check) |
 | `ha_list_files` *(beta)* | List files in allowed directories (www/, themes/, custom_templates/) |
 | `ha_read_file` *(beta)* | Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/) |
 | `ha_write_file` *(beta)* | Write files to allowed directories |

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -7,6 +7,11 @@ Some ha-mcp tools are gated behind feature flags and available only in the **dev
 | Tool | Toggle / env var | Description |
 |---|---|---|
 | `ha_config_set_yaml` | `enable_yaml_config_editing` (dev add-on) / `ENABLE_YAML_CONFIG_EDITING=true` (env var) | Raw YAML editing of `configuration.yaml` and packages/*.yaml for YAML-only integrations. |
+| `ha_list_files` | `enable_filesystem_tools` (dev add-on) / `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (env var) | List files in allowed directories (www/, themes/, custom_templates/). Requires `ha_mcp_tools` custom component. |
+| `ha_read_file` | `enable_filesystem_tools` (dev add-on) / `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (env var) | Read files from allowed paths. Requires `ha_mcp_tools` custom component. |
+| `ha_write_file` | `enable_filesystem_tools` (dev add-on) / `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (env var) | Write files to allowed directories. Requires `ha_mcp_tools` custom component. |
+| `ha_delete_file` | `enable_filesystem_tools` (dev add-on) / `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (env var) | Delete files from allowed directories. Requires `ha_mcp_tools` custom component. |
+| `ha_install_mcp_tools` | `enable_custom_component_integration` (dev add-on) / `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` (env var) | Installs the `ha_mcp_tools` custom component via HACS. |
 
 ## How to enable
 
@@ -53,7 +58,9 @@ This tool edits `configuration.yaml` and package files directly, bypassing Home 
 
 ### `ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`
 
-These tools provide direct file access to your Home Assistant filesystem and require both `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` and `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` to be set, as well as the `ha_mcp_tools` custom component installed and active.
+These tools provide direct file access to your Home Assistant filesystem and require `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` and the `ha_mcp_tools` custom component installed and active.
+
+`HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` is only needed if you want to allow the `ha_install_mcp_tools` installer tool; it is not required for the filesystem tools themselves.
 
 **Access is restricted but sensitive.** Only `www/`, `themes/`, and `custom_templates/` are writable. `ha_read_file` additionally allows reading config YAML files, logs, and `custom_components/`. An AI assistant with these tools enabled has meaningful read access to your HA configuration.
 

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -14,10 +14,11 @@ Some ha-mcp tools are gated behind feature flags and available only in the **dev
 
 1. Install the **Home Assistant MCP Server (Dev)** add-on. See [docs/dev-channel.md](dev-channel.md) for details.
 2. Open the add-on's **Configuration** tab.
-3. Enable the toggle (e.g., `enable_yaml_config_editing`).
-4. Restart the add-on.
+3. Enable "Show unused optional configuration options" to reveal beta toggles.
+4. Enable the desired toggle (e.g., `enable_yaml_config_editing`, `enable_filesystem_tools`).
+5. Restart the add-on.
 
-The stable add-on does not expose beta toggles.
+`enable_yaml_config_editing`, `enable_filesystem_tools`, and `enable_custom_component_integration` are only available in the dev channel add-on. The stable add-on does not expose these beta toggles.
 
 ### Option 2: Environment variable (non-add-on installs)
 
@@ -49,3 +50,13 @@ This tool edits `configuration.yaml` and package files directly, bypassing Home 
 **Recommended prerequisites:**
 - Comfort with editing `configuration.yaml` via SSH or File Editor when things go wrong
 - Understanding that dedicated tools (`ha_config_set_helper`, `ha_config_set_automation`, `ha_config_set_script`, `ha_config_set_scene`, etc.) should be preferred for anything they support
+
+### `ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`
+
+These tools provide direct file access to your Home Assistant filesystem and require both `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` and `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` to be set, as well as the `ha_mcp_tools` custom component installed and active.
+
+**Access is restricted but sensitive.** Only `www/`, `themes/`, and `custom_templates/` are writable. `ha_read_file` additionally allows reading config YAML files, logs, and `custom_components/`. An AI assistant with these tools enabled has meaningful read access to your HA configuration.
+
+**No undo.** `ha_delete_file` and `ha_write_file` (with `overwrite=True`) are irreversible. There is no recycle bin or automatic backup for file operations.
+
+**Requires the custom component.** If `ha_mcp_tools` is not installed and active, all file tools will return an error with installation instructions.

--- a/homeassistant-addon-dev/DOCS.md
+++ b/homeassistant-addon-dev/DOCS.md
@@ -14,6 +14,11 @@ The dev add-on uses the same configuration as the stable version. See the main a
 |--------|-------------|---------|
 | `backup_hint` | Backup strength preference | `normal` |
 | `secret_path` | Custom secret path (optional) | auto-generated |
+| `enable_yaml_config_editing` *(beta)* | Enables `ha_config_set_yaml` for editing `configuration.yaml` directly. Requires `ha_mcp_tools` custom component. | `false` |
+| `enable_filesystem_tools` *(beta)* | Enables file read/write tools (`ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`). Requires `ha_mcp_tools` custom component. | `false` |
+| `enable_custom_component_integration` *(beta)* | Enables `ha_install_mcp_tools` installer tool for the `ha_mcp_tools` custom component. | `false` |
+
+Beta options are hidden under "Show unused optional configuration options" in the add-on Configuration tab. See [beta.md](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md) for details.
 
 ## Updates
 

--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -21,8 +21,6 @@ options:
   enable_skills_as_tools: true
   enable_tool_search: false
   enable_yaml_config_editing: false
-  enable_filesystem_tools: false
-  enable_custom_component_integration: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?

--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -21,6 +21,8 @@ options:
   enable_skills_as_tools: true
   enable_tool_search: false
   enable_yaml_config_editing: false
+  enable_filesystem_tools: false
+  enable_custom_component_integration: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
@@ -28,5 +30,7 @@ schema:
   enable_skills_as_tools: bool?
   enable_tool_search: bool?
   enable_yaml_config_editing: bool?
+  enable_filesystem_tools: bool?
+  enable_custom_component_integration: bool?
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -39,7 +39,7 @@ configuration:
       limitations. Dedicated tools (automations, scripts, scenes, helpers,
       template sensors) should be preferred when available.
   enable_filesystem_tools:
-    name: Enable filesystem tools
+    name: Enable filesystem tools (beta)
     description: >-
       Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
       access to your Home Assistant filesystem. WARNING: This gives the MCP

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -49,10 +49,10 @@ configuration:
   enable_custom_component_integration:
     name: Enable custom component integration
     description: >-
-      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Required for the MCP
-      server to load and interact with the ha_mcp_tools custom component. Without
-      this flag enabled, the MCP server will not load the custom integration even
-      if it is installed. Also required for filesystem tools to function.
-      WARNING: This gives the MCP server sensitive direct access to your system
-      via the custom component. Only enable if you trust the AI assistant with
-      this level of access. Requires restart to take effect.
+      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Enables the
+      ha_install_mcp_tools installer tool, which can help install the
+      ha_mcp_tools custom component. This setting does not control whether the
+      MCP server loads or interacts with the custom component, and it is not
+      required for filesystem tools to function. Only enable if you want to
+      allow the AI assistant to use the installer tool. Requires restart to
+      take effect.

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -47,7 +47,7 @@ configuration:
       trust the AI assistant with file operations. Requires restart to take
       effect.
   enable_custom_component_integration:
-    name: Enable custom component integration
+    name: Enable custom component integration (beta)
     description: >-
       Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Enables the
       ha_install_mcp_tools installer tool, which can help install the

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -38,3 +38,21 @@ configuration:
       require a full HA restart to take effect. See docs/beta.md for known
       limitations. Dedicated tools (automations, scripts, scenes, helpers,
       template sensors) should be preferred when available.
+  enable_filesystem_tools:
+    name: Enable filesystem tools
+    description: >-
+      Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP
+      server sensitive direct file access to your system. Only enable if you
+      trust the AI assistant with file operations. Requires restart to take
+      effect.
+  enable_custom_component_integration:
+    name: Enable custom component integration
+    description: >-
+      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Required for the MCP
+      server to load and interact with the ha_mcp_tools custom component. Without
+      this flag enabled, the MCP server will not load the custom integration even
+      if it is installed. Also required for filesystem tools to function.
+      WARNING: This gives the MCP server sensitive direct access to your system
+      via the custom component. Only enable if you trust the AI assistant with
+      this level of access. Requires restart to take effect.

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -244,22 +244,6 @@ Replaces the full tool catalog (~85 tools, ~46K tokens) with search-based discov
 
 Requires add-on restart to take effect.
 
-### enable_filesystem_tools (Beta)
-
-**Default:** `false`
-
-Enables filesystem tools (ha_list_files, ha_read_file, ha_write_file, ha_delete_file) for managing files in the Home Assistant configuration directory.
-
-Requires add-on restart to take effect.
-
-### enable_custom_component_integration (Beta)
-
-**Default:** `false`
-
-Enables the ha_install_mcp_tools tool, which allows installing the required custom component via HACS. This component is necessary for advanced features like filesystem access.
-
-Requires add-on restart to take effect.
-
 **Example Configuration:**
 
 ```yaml

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -248,7 +248,7 @@ Requires add-on restart to take effect.
 
 **Default:** `false`
 
-Enables the `HAMCP_ENABLE_FILESYSTEM_TOOLS` feature flag.
+Enables filesystem tools (ha_list_files, ha_read_file, ha_write_file, ha_delete_file) for managing files in the Home Assistant configuration directory.
 
 Requires add-on restart to take effect.
 

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -244,7 +244,7 @@ Replaces the full tool catalog (~85 tools, ~46K tokens) with search-based discov
 
 Requires add-on restart to take effect.
 
-### enable_filesystem_tools
+### enable_filesystem_tools (Beta)
 
 **Default:** `false`
 
@@ -252,7 +252,7 @@ Enables filesystem tools (ha_list_files, ha_read_file, ha_write_file, ha_delete_
 
 Requires add-on restart to take effect.
 
-### enable_custom_component_integration
+### enable_custom_component_integration (Beta)
 
 **Default:** `false`
 
@@ -398,10 +398,10 @@ The add-on provides 85+ MCP tools for controlling Home Assistant:
 - `ha_set_entity` — Update entity properties in the entity registry.
 
 ### Files
-- `ha_delete_file` — Delete a file from allowed directories in the Home Assistant config.
-- `ha_list_files` — List files in a directory within the Home Assistant config directory.
-- `ha_read_file` — Read a file from the Home Assistant config directory.
-- `ha_write_file` — Write a file to allowed directories in the Home Assistant config.
+- `ha_delete_file` **(beta)** — Delete a file from allowed directories in the Home Assistant config.
+- `ha_list_files` **(beta)** — List files in a directory within the Home Assistant config directory.
+- `ha_read_file` **(beta)** — Read a file from the Home Assistant config directory.
+- `ha_write_file` **(beta)** — Write a file to allowed directories in the Home Assistant config.
 
 ### Groups
 - `ha_config_list_groups` — List all Home Assistant entity groups with their member entities.

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -244,6 +244,22 @@ Replaces the full tool catalog (~85 tools, ~46K tokens) with search-based discov
 
 Requires add-on restart to take effect.
 
+### enable_filesystem_tools
+
+**Default:** `false`
+
+Enables the `HAMCP_ENABLE_FILESYSTEM_TOOLS` feature flag.
+
+Requires add-on restart to take effect.
+
+### enable_custom_component_integration
+
+**Default:** `false`
+
+Enables the `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION` feature flag.
+
+Requires add-on restart to take effect.
+
 **Example Configuration:**
 
 ```yaml

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -256,7 +256,7 @@ Requires add-on restart to take effect.
 
 **Default:** `false`
 
-Enables the `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION` feature flag.
+Enables the ha_install_mcp_tools tool, which allows installing the required custom component via HACS. This component is necessary for advanced features like filesystem access.
 
 Requires add-on restart to take effect.
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -29,12 +29,16 @@ options:
   enable_skills: true
   enable_skills_as_tools: true
   enable_tool_search: false
+  enable_filesystem_tools: false
+  enable_custom_component_integration: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
   enable_skills: bool?
   enable_skills_as_tools: bool?
   enable_tool_search: bool?
+  enable_filesystem_tools: bool?
+  enable_custom_component_integration: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -21,8 +21,9 @@ host_network: true
 # Use pre-built Docker images
 image: "ghcr.io/homeassistant-ai/ha-mcp-addon-{arch}"
 # Options for user configuration
-# NOTE: enable_yaml_config_editing is intentionally NOT exposed here.
-# It is a dev-channel-only beta feature — see docs/beta.md. Do not re-mirror
+# NOTE: enable_yaml_config_editing, enable_filesystem_tools, and
+# enable_custom_component_integration are intentionally NOT exposed here.
+# They are dev-channel-only beta features — see docs/beta.md. Do not re-mirror
 # from homeassistant-addon-dev/config.yaml without reading that doc first.
 options:
   backup_hint: "normal"
@@ -35,8 +36,6 @@ schema:
   enable_skills: bool?
   enable_skills_as_tools: bool?
   enable_tool_search: bool?
-  enable_filesystem_tools: bool?
-  enable_custom_component_integration: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -29,8 +29,6 @@ options:
   enable_skills: true
   enable_skills_as_tools: true
   enable_tool_search: false
-  enable_filesystem_tools: false
-  enable_custom_component_integration: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -190,6 +190,8 @@ def main() -> int:
     enable_skills_as_tools = True  # default
     enable_tool_search = False  # default
     enable_yaml_config_editing = False  # default
+    enable_filesystem_tools = False  # default
+    enable_custom_component_integration = False  # default
     config_read_ok = True
 
     if config_file.exists():
@@ -206,6 +208,10 @@ def main() -> int:
             enable_tool_search = raw_tool_search if isinstance(raw_tool_search, bool) else False
             raw_yaml_config = config.get("enable_yaml_config_editing", False)
             enable_yaml_config_editing = raw_yaml_config if isinstance(raw_yaml_config, bool) else False
+            raw_filesystem_tools = config.get("enable_filesystem_tools", False)
+            enable_filesystem_tools = raw_filesystem_tools if isinstance(raw_filesystem_tools, bool) else False
+            raw_custom_component = config.get("enable_custom_component_integration", False)
+            enable_custom_component_integration = raw_custom_component if isinstance(raw_custom_component, bool) else False
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
             config_read_ok = False
@@ -231,6 +237,8 @@ def main() -> int:
     os.environ["ENABLE_SKILLS_AS_TOOLS"] = str(enable_skills_as_tools).lower()
     os.environ["ENABLE_TOOL_SEARCH"] = str(enable_tool_search).lower()
     os.environ["ENABLE_YAML_CONFIG_EDITING"] = str(enable_yaml_config_editing).lower()
+    os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = str(enable_filesystem_tools).lower()
+    os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = str(enable_custom_component_integration).lower()
 
     # Validate Supervisor token
     supervisor_token = os.environ.get("SUPERVISOR_TOKEN")

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -26,3 +26,20 @@ configuration:
       deferred tools or with smaller context windows. Tools are found via
       ha_search_tools and executed via categorized proxies (read/write/delete).
       Requires restart to take effect.
+  enable_filesystem_tools:
+    name: Enable filesystem tools
+    description: >-
+      Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP server sensitive direct
+      file access to your system. Only enable if you trust the AI assistant
+      with file operations. Requires restart to take effect.
+  enable_custom_component_integration:
+    name: Enable custom component integration
+    description: >-
+      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Required for the MCP
+      server to load and interact with the ha_mcp_tools custom component. Without
+      this flag enabled, the MCP server will not load the custom integration even
+      if it is installed. Also required for filesystem tools to function.
+      WARNING: This gives the MCP server sensitive direct access to your system
+      via the custom component. Only enable if you trust the AI assistant with
+      this level of access. Requires restart to take effect.

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -36,10 +36,10 @@ configuration:
   enable_custom_component_integration:
     name: Enable custom component integration
     description: >-
-      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Required for the MCP
-      server to load and interact with the ha_mcp_tools custom component. Without
-      this flag enabled, the MCP server will not load the custom integration even
-      if it is installed. Also required for filesystem tools to function.
-      WARNING: This gives the MCP server sensitive direct access to your system
-      via the custom component. Only enable if you trust the AI assistant with
-      this level of access. Requires restart to take effect.
+      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Enables registration
+      of the ha_install_mcp_tools installer tool for the ha_mcp_tools custom
+      component. This setting does not control whether other tools can interact
+      with the custom component or whether filesystem tools function. WARNING:
+      This exposes a tool that can help install the custom component. Only
+      enable if you trust the AI assistant with this level of access. Requires
+      restart to take effect.

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -26,20 +26,3 @@ configuration:
       deferred tools or with smaller context windows. Tools are found via
       ha_search_tools and executed via categorized proxies (read/write/delete).
       Requires restart to take effect.
-  enable_filesystem_tools:
-    name: Enable filesystem tools
-    description: >-
-      Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
-      access to your Home Assistant filesystem. WARNING: This gives the MCP server sensitive direct
-      file access to your system. Only enable if you trust the AI assistant
-      with file operations. Requires restart to take effect.
-  enable_custom_component_integration:
-    name: Enable custom component integration
-    description: >-
-      Sets HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true. Enables registration
-      of the ha_install_mcp_tools installer tool for the ha_mcp_tools custom
-      component. This setting does not control whether other tools can interact
-      with the custom component or whether filesystem tools function. WARNING:
-      This exposes a tool that can help install the custom component. Only
-      enable if you trust the AI assistant with this level of access. Requires
-      restart to take effect.

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -73,8 +73,7 @@ async def _is_mcp_tools_available(client: Any) -> bool:
     # This format has been stable since before HA 0.7 (the first public release).
     services = await client.get_services()
     return any(
-        isinstance(s, dict) and s.get("domain") == MCP_TOOLS_DOMAIN
-        for s in services
+        isinstance(s, dict) and s.get("domain") == MCP_TOOLS_DOMAIN for s in services
     )
 
 
@@ -86,11 +85,13 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     correctly rather than masked as COMPONENT_NOT_INSTALLED.
     """
     if not await _is_mcp_tools_available(client):
-        raise_tool_error(create_error_response(
-            ErrorCode.COMPONENT_NOT_INSTALLED,
-            f"The {MCP_TOOLS_DOMAIN} custom component is not installed. "
-            "Use ha_install_mcp_tools() to install it via HACS, then restart Home Assistant.",
-        ))
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                f"The {MCP_TOOLS_DOMAIN} custom component is not installed. "
+                "Use ha_install_mcp_tools() to install it via HACS, then restart Home Assistant.",
+            )
+        )
 
 
 class FilesystemTools:
@@ -101,7 +102,7 @@ class FilesystemTools:
 
     @tool(
         name="ha_list_files",
-        tags={"Files"},
+        tags={"Files", "beta"},
         annotations={
             "readOnlyHint": True,
             "title": "List Files",
@@ -195,7 +196,7 @@ class FilesystemTools:
 
     @tool(
         name="ha_read_file",
-        tags={"Files"},
+        tags={"Files", "beta"},
         annotations={
             "readOnlyHint": True,
             "title": "Read File",
@@ -308,7 +309,7 @@ class FilesystemTools:
 
     @tool(
         name="ha_write_file",
-        tags={"Files"},
+        tags={"Files", "beta"},
         annotations={
             "destructiveHint": True,
             "title": "Write File",
@@ -397,7 +398,9 @@ class FilesystemTools:
         try:
             # Coerce boolean parameters
             overwrite_bool = coerce_bool_param(overwrite, "overwrite", default=False)
-            create_dirs_bool = coerce_bool_param(create_dirs, "create_dirs", default=True)
+            create_dirs_bool = coerce_bool_param(
+                create_dirs, "create_dirs", default=True
+            )
 
             # Check if custom component is available
             await _assert_mcp_tools_available(self._client)
@@ -439,7 +442,7 @@ class FilesystemTools:
 
     @tool(
         name="ha_delete_file",
-        tags={"Files"},
+        tags={"Files", "beta"},
         annotations={
             "destructiveHint": True,
             "title": "Delete File",
@@ -556,9 +559,7 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     Set HAMCP_ENABLE_FILESYSTEM_TOOLS=true to enable.
     """
     if not is_filesystem_tools_enabled():
-        logger.debug(
-            f"Filesystem tools disabled (set {FEATURE_FLAG}=true to enable)"
-        )
+        logger.debug(f"Filesystem tools disabled (set {FEATURE_FLAG}=true to enable)")
         return
 
     logger.info("Filesystem tools enabled via feature flag")

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -73,7 +73,8 @@ async def _is_mcp_tools_available(client: Any) -> bool:
     # This format has been stable since before HA 0.7 (the first public release).
     services = await client.get_services()
     return any(
-        isinstance(s, dict) and s.get("domain") == MCP_TOOLS_DOMAIN for s in services
+        isinstance(s, dict) and s.get("domain") == MCP_TOOLS_DOMAIN
+        for s in services
     )
 
 
@@ -85,13 +86,11 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     correctly rather than masked as COMPONENT_NOT_INSTALLED.
     """
     if not await _is_mcp_tools_available(client):
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.COMPONENT_NOT_INSTALLED,
-                f"The {MCP_TOOLS_DOMAIN} custom component is not installed. "
-                "Use ha_install_mcp_tools() to install it via HACS, then restart Home Assistant.",
-            )
-        )
+        raise_tool_error(create_error_response(
+            ErrorCode.COMPONENT_NOT_INSTALLED,
+            f"The {MCP_TOOLS_DOMAIN} custom component is not installed. "
+            "Use ha_install_mcp_tools() to install it via HACS, then restart Home Assistant.",
+        ))
 
 
 class FilesystemTools:
@@ -398,9 +397,7 @@ class FilesystemTools:
         try:
             # Coerce boolean parameters
             overwrite_bool = coerce_bool_param(overwrite, "overwrite", default=False)
-            create_dirs_bool = coerce_bool_param(
-                create_dirs, "create_dirs", default=True
-            )
+            create_dirs_bool = coerce_bool_param(create_dirs, "create_dirs", default=True)
 
             # Check if custom component is available
             await _assert_mcp_tools_available(self._client)
@@ -559,7 +556,9 @@ def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     Set HAMCP_ENABLE_FILESYSTEM_TOOLS=true to enable.
     """
     if not is_filesystem_tools_enabled():
-        logger.debug(f"Filesystem tools disabled (set {FEATURE_FLAG}=true to enable)")
+        logger.debug(
+            f"Filesystem tools disabled (set {FEATURE_FLAG}=true to enable)"
+        )
         return
 
     logger.info("Filesystem tools enabled via feature flag")

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -163,7 +163,7 @@ class McpComponentTools:
 
     @tool(
         name="ha_install_mcp_tools",
-        tags={"Utilities"},
+        tags={"Utilities", "beta"},
         annotations={
             "destructiveHint": True,
             "title": "Install MCP Tools Component"


### PR DESCRIPTION

## What does this PR do?

This PR adds the ability to enable the feature flags `HAMCP_ENABLE_FILESYSTEM_TOOLS` and `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION` to the Dev App configuration since there is no other way to define environment variables to enable them within an HA App.

Also tagged these features as *(beta)* in the source and docs.

## Type of change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [X] 📚 Documentation
- [X] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [X] I have tested these changes with a LLM agent
- [X] All automated tests pass (`uv run pytest`)
- [X] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [X] I have updated documentation if needed
