### PR TITLE
Windows - Do not kill the terminal

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -37,7 +37,7 @@ if ($uvInstalled) {
         Write-Host "  Please install manually:" -ForegroundColor Red
         Write-Host "  winget install astral-sh.uv" -ForegroundColor Cyan
         Write-Host "  OR download from: https://docs.astral.sh/uv/" -ForegroundColor Cyan
-        exit 1
+        throw
     }
 }
 Write-Host ""

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -154,5 +154,3 @@ Write-Host "  Replace HOMEASSISTANT_TOKEN with your token"
 Write-Host "  (Generate token in HA: Profile > Security > Long-lived tokens)"
 Write-Host ""
 
-# Exit successfully
-exit 0


### PR DESCRIPTION
When following the install guide for Windows, the installation will kill the terminal by executing `exit 0`. This is poor UX, since I can't see anything it did nor read the output.

If an exit 0 is truly needed, I can modify the PR to provide a delay of a few seconds, which will allow the user to abort the script before the window is killed.