### PR TITLE
Installer (Windows) - remove unused variable

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -65,22 +65,6 @@ $HaMcpConfig = @{
     }
 }
 
-# The properly formatted JSON config
-$JsonConfig = @"
-{
-  "mcpServers": {
-    "Home Assistant": {
-      "command": "uvx",
-      "args": ["--python", "3.13", "--refresh", "ha-mcp@latest"],
-      "env": {
-        "HOMEASSISTANT_URL": "$DemoUrl",
-        "HOMEASSISTANT_TOKEN": "$DemoToken"
-      }
-    }
-  }
-}
-"@
-
 # Check if config file exists
 if (Test-Path $ConfigFile) {
     # Backup existing config

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -55,15 +55,21 @@ if (-not (Test-Path $ConfigDir)) {
     New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
 }
 
-# The MCP server config
-$HaMcpConfig = @{
-    command = "uvx"
-    args = @("--python", "3.13", "--refresh", "ha-mcp@latest")
-    env = @{
-        HOMEASSISTANT_URL = $DemoUrl
-        HOMEASSISTANT_TOKEN = $DemoToken
+# The properly formatted JSON config
+$JsonConfig = @"
+{
+  "mcpServers": {
+    "Home Assistant": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "--refresh", "ha-mcp@latest"],
+      "env": {
+        "HOMEASSISTANT_URL": "$DemoUrl",
+        "HOMEASSISTANT_TOKEN": "$DemoToken"
+      }
     }
+  }
 }
+"@
 
 # Check if config file exists
 if (Test-Path $ConfigFile) {


### PR DESCRIPTION
The variable `$HaMcpConfig` was defined but never used.