### PR TITLE
fix: make version visible in logs and stop odd-week :stable republishes

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -79,16 +79,25 @@ jobs:
           TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
           HEAD_SHA=$(git rev-parse HEAD)
 
-          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+          # Normal release weeks: semver-release tags the release commit, then
+          # pushes follow-up housekeeping commits to master (changelog sync,
+          # addon version bump — all `[skip ci]`). HEAD != tag in that case,
+          # but the release IS current. Mirror semver-release.yml's check-changes
+          # logic: block only if there are releasable (feat/fix/perf) commits
+          # on master since the tag that would have produced a new version.
+          RELEASABLE=$(git log "$LATEST_TAG..HEAD" --oneline \
+            --grep='^feat' --grep='^fix' --grep='^perf' || true)
+
+          if [ -n "$RELEASABLE" ]; then
             if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              echo "::notice::Manual dispatch: master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA). Forcing republish of $LATEST_TAG from the tag ref."
+              echo "::notice::Manual dispatch: unreleased feat/fix/perf commits exist on master since $LATEST_TAG. Forcing republish of $LATEST_TAG from the tag ref (master HEAD $HEAD_SHA is being ignored)."
               echo "## Release Publish — forced republish" >> "$GITHUB_STEP_SUMMARY"
-              echo "Building \`$LATEST_TAG\` ($TAG_SHA); master HEAD ($HEAD_SHA) is ahead but was ignored." >> "$GITHUB_STEP_SUMMARY"
+              echo "Building \`$LATEST_TAG\` ($TAG_SHA); unreleased commits on master were ignored." >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "::notice::master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA); no new release to publish — skipping."
+              echo "::notice::Unreleased feat/fix/perf commits exist on master since $LATEST_TAG; no new release to publish — skipping."
               echo "should_publish=false" >> "$GITHUB_OUTPUT"
               echo "## Release Publish skipped" >> "$GITHUB_STEP_SUMMARY"
-              echo "master HEAD is ahead of the latest stable tag \`$LATEST_TAG\`, so there is no new release to publish." >> "$GITHUB_STEP_SUMMARY"
+              echo "master has releasable commits since the latest stable tag \`$LATEST_TAG\` but no new tag was cut, so republishing \`$LATEST_TAG\` would be misleading." >> "$GITHUB_STEP_SUMMARY"
               echo "This is expected on biweekly-gate odd weeks; the re-triggered \`workflow_run\` is being correctly ignored." >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
@@ -98,6 +107,9 @@ jobs:
           echo "Release version: $VERSION (tag $LATEST_TAG)"
           echo "## Release Publish — $VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "Building from tag \`$LATEST_TAG\` ($TAG_SHA)." >> "$GITHUB_STEP_SUMMARY"
+          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+            echo "(master HEAD is $HEAD_SHA — post-tag housekeeping commits only, no releasable changes.)" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   publish_pypi:
     name: Publish PyPI package

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,22 +21,57 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      should_publish: ${{ steps.version.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: master
           fetch-depth: 0
 
-      - name: Extract version from pyproject.toml
+      # Guard against the workflow_run trigger firing on odd-week SemVer Release
+      # runs that were correctly gated out. A SemVer Release whose biweekly-gate
+      # / check-changes / semantic-release jobs all skipped still ends with
+      # conclusion=success (skipped != failed), which would otherwise republish
+      # the existing stable version from master HEAD with whatever post-tag
+      # commits have accumulated — same :stable / :latest label, different bits.
+      # Publish only when master HEAD is at the latest stable tag's commit.
+      - name: Verify master is at the latest stable tag
         id: version
         run: |
+          set -euo pipefail
           VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Release version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "pyproject version: $VERSION"
+
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*dev*' 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::warning::No stable tag found; skipping Release Publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "release_tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Latest stable tag: $LATEST_TAG"
+
+          TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
+          HEAD_SHA=$(git rev-parse HEAD)
+          if [ "$TAG_SHA" != "$HEAD_SHA" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "::notice::master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA); no new release to publish — skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Manual dispatch is allowed to force-republish even without a new tag
+          # (emergency rebuild), but downstream jobs still check out the tag ref
+          # so the build is reproducible from the tagged source, not master HEAD.
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION (tag $LATEST_TAG)"
 
   publish_pypi:
     name: Publish PyPI package
     needs: prepare
+    if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -49,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ needs.prepare.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Install uv
@@ -67,6 +102,7 @@ jobs:
   publish_docker:
     name: Publish Docker image
     needs: prepare
+    if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: master
+          ref: ${{ needs.prepare.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -121,7 +157,7 @@ jobs:
     name: Publish MCP server manifest
     needs: [publish_pypi, publish_docker, prepare]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && needs.prepare.outputs.should_publish == 'true' }}
     permissions:
       contents: read
       id-token: write  # Required for MCP Registry OIDC authentication
@@ -137,7 +173,7 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}
         with:
-          ref: master
+          ref: ${{ needs.prepare.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Install MCP Publisher CLI

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,33 +40,64 @@ jobs:
         id: version
         run: |
           set -euo pipefail
-          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "pyproject version: $VERSION"
 
-          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*dev*' 2>/dev/null || echo "")
-          if [ -z "$LATEST_TAG" ]; then
+          # Resolve the latest stable tag. A real failure (corrupt repo, shallow
+          # clone missing tags, etc.) should fail loudly — only exit-code 128
+          # from `git describe` means "no matching tags exist in history" and is
+          # benign for a fresh repo with no stable releases yet.
+          set +e
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*dev*' 2>&1)
+          DESCRIBE_RC=$?
+          set -e
+          if [ "$DESCRIBE_RC" -eq 128 ]; then
             echo "::warning::No stable tag found; skipping Release Publish."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
             echo "release_tag=" >> "$GITHUB_OUTPUT"
+            echo "## Release Publish skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "No stable tag found in repository." >> "$GITHUB_STEP_SUMMARY"
             exit 0
+          elif [ "$DESCRIBE_RC" -ne 0 ]; then
+            echo "::error::git describe failed (rc=$DESCRIBE_RC): $LATEST_TAG"
+            exit "$DESCRIBE_RC"
           fi
           echo "release_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Latest stable tag: $LATEST_TAG"
 
+          # Read the version from pyproject.toml AT THE TAG, not master HEAD, so
+          # we publish what was tagged even if master has advanced. Prevents the
+          # "workflow_dispatch bumped pyproject ahead of tag" corner case.
+          VERSION=$(git show "$LATEST_TAG:pyproject.toml" \
+            | grep '^version = ' | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse version from $LATEST_TAG:pyproject.toml"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tagged pyproject version: $VERSION"
+
           TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
           HEAD_SHA=$(git rev-parse HEAD)
-          if [ "$TAG_SHA" != "$HEAD_SHA" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-            echo "::notice::master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA); no new release to publish — skipping."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
+
+          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "::notice::Manual dispatch: master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA). Forcing republish of $LATEST_TAG from the tag ref."
+              echo "## Release Publish — forced republish" >> "$GITHUB_STEP_SUMMARY"
+              echo "Building \`$LATEST_TAG\` ($TAG_SHA); master HEAD ($HEAD_SHA) is ahead but was ignored." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::notice::master HEAD ($HEAD_SHA) is ahead of $LATEST_TAG ($TAG_SHA); no new release to publish — skipping."
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              echo "## Release Publish skipped" >> "$GITHUB_STEP_SUMMARY"
+              echo "master HEAD is ahead of the latest stable tag \`$LATEST_TAG\`, so there is no new release to publish." >> "$GITHUB_STEP_SUMMARY"
+              echo "This is expected on biweekly-gate odd weeks; the re-triggered \`workflow_run\` is being correctly ignored." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
           fi
 
-          # Manual dispatch is allowed to force-republish even without a new tag
-          # (emergency rebuild), but downstream jobs still check out the tag ref
-          # so the build is reproducible from the tagged source, not master HEAD.
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "Release version: $VERSION (tag $LATEST_TAG)"
+          echo "## Release Publish — $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "Building from tag \`$LATEST_TAG\` ($TAG_SHA)." >> "$GITHUB_STEP_SUMMARY"
 
   publish_pypi:
     name: Publish PyPI package

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,13 @@ USER mcpuser
 # Activate virtual environment via PATH
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Propagate dev build version into the runtime so startup logs / bug reports can
+# surface e.g. '7.3.0.dev390' instead of the bare pyproject base version.
+# Stable builds leave BUILD_VERSION unset; ha_mcp._version.get_version() then
+# falls back to package metadata.
+ARG BUILD_VERSION=""
+ENV HA_MCP_BUILD_VERSION=${BUILD_VERSION}
+
 # Environment variables (can be overridden)
 ENV HOMEASSISTANT_URL="" \
     HOMEASSISTANT_TOKEN="" \

--- a/homeassistant-addon-dev/Dockerfile
+++ b/homeassistant-addon-dev/Dockerfile
@@ -43,4 +43,9 @@ LABEL \
     io.hass.type="addon" \
     io.hass.arch="${BUILD_ARCH}"
 
+# Propagate dev build version into the runtime so startup logs / bug reports can
+# surface e.g. '7.3.0.dev229' instead of the bare pyproject base version.
+# ha_mcp._version.get_version() reads HA_MCP_BUILD_VERSION first.
+ENV HA_MCP_BUILD_VERSION=${BUILD_VERSION}
+
 CMD ["python3", "/start.py"]

--- a/homeassistant-addon-dev/Dockerfile
+++ b/homeassistant-addon-dev/Dockerfile
@@ -45,7 +45,8 @@ LABEL \
 
 # Propagate dev build version into the runtime so startup logs / bug reports can
 # surface e.g. '7.3.0.dev229' instead of the bare pyproject base version.
-# ha_mcp._version.get_version() reads HA_MCP_BUILD_VERSION first.
+# Stable addon builds leave BUILD_VERSION unset; ha_mcp._version.get_version()
+# then falls back to package metadata.
 ENV HA_MCP_BUILD_VERSION=${BUILD_VERSION}
 
 CMD ["python3", "/start.py"]

--- a/src/ha_mcp/__init__.py
+++ b/src/ha_mcp/__init__.py
@@ -5,7 +5,9 @@ A Model Context Protocol server that provides complete control over Home Assista
 through REST API and WebSocket integration with 20+ enhanced tools.
 """
 
-__version__ = "7.3.0"
+from ._version import get_version
+
+__version__ = get_version()
 __author__ = "Julien"
 __license__ = "MIT"
 

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -281,6 +281,7 @@ def _setup_standard_mode() -> None:
     settings = get_settings()
     _validate_standard_credentials(settings)
     _setup_logging(settings.log_level)
+    _log_startup_version()
 
 
 def _http_run_kwargs(transport: str, port: int, path: str) -> dict:
@@ -376,6 +377,25 @@ def _setup_logging(log_level_str: str, force: bool = False) -> None:
     logging.getLogger("mcp.server.streamable_http").addFilter(
         StatelessSessionLogFilter()
     )
+
+
+def _log_startup_version() -> None:
+    """Log ha-mcp version at startup, plus a dev-channel banner when relevant.
+
+    The dev banner only fires for standalone dev installs (Docker ``:dev`` /
+    ``:latest``, or ``pip install ha-mcp-dev``). It is suppressed under the HA
+    Supervisor because add-on users already pick dev vs stable in the HAOS UI.
+    """
+    from ha_mcp._version import get_version, is_dev_version, is_running_in_addon
+
+    version = get_version()
+    logger.info(f"ha-mcp {version}")
+    if is_dev_version(version) and not is_running_in_addon():
+        logger.warning(
+            "This is the dev channel. For the stable release use the "
+            "'ghcr.io/homeassistant-ai/ha-mcp:stable' Docker tag "
+            "(or 'pip install ha-mcp' on PyPI)."
+        )
 
 
 def _get_timestamped_uvicorn_log_config() -> dict:
@@ -547,9 +567,9 @@ def main() -> None:
     """Run server via CLI using FastMCP's stdio transport."""
     # Handle --version flag early, before server creation requires config
     if "--version" in sys.argv or "-V" in sys.argv:
-        from importlib.metadata import version
+        from ha_mcp._version import get_version
 
-        print(f"ha-mcp {version('ha-mcp')}")
+        print(f"ha-mcp {get_version()}")
         sys.exit(0)
 
     # Check for smoke test flag
@@ -572,6 +592,7 @@ def main() -> None:
         sys.exit(1)
 
     _setup_logging(settings.log_level)
+    _log_startup_version()
 
     _run_entrypoint(_run_with_graceful_shutdown(), "Server")
 
@@ -747,6 +768,7 @@ def main_oauth() -> None:
     for logger_name in ["ha_mcp", "ha_mcp.auth", "ha_mcp.auth.provider"]:
         logging.getLogger(logger_name).setLevel(getattr(logging, log_level))
     logger.info(f"OAuth mode logging configured at {log_level} level")
+    _log_startup_version()
 
     port, path = _get_http_runtime(default_port=8086)
     base_url = os.getenv("MCP_BASE_URL")

--- a/src/ha_mcp/_version.py
+++ b/src/ha_mcp/_version.py
@@ -1,0 +1,45 @@
+"""Version resolution for the ha-mcp package.
+
+Kept as a standalone module (no other ``ha_mcp`` imports) so it can be used from
+``__init__.py`` and ``config.py`` without circular-import risk.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+
+
+def get_version() -> str:
+    """Return the installed ha-mcp version.
+
+    Resolution order:
+    1. ``HA_MCP_BUILD_VERSION`` env var — set by Docker/add-on builds that can't
+       rewrite ``pyproject.toml`` before install, so the dev suffix still reaches
+       the running process. Stable builds leave it unset.
+    2. ``ha-mcp`` package metadata — stable PyPI + stable Docker.
+    3. ``ha-mcp-dev`` package metadata — PyPI dev channel (renamed package).
+    """
+    if override := os.environ.get("HA_MCP_BUILD_VERSION"):
+        return override
+    for pkg_name in ("ha-mcp", "ha-mcp-dev"):
+        try:
+            return importlib.metadata.version(pkg_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "unknown"
+
+
+def is_dev_version(version: str) -> bool:
+    """Return True when the version string contains a PEP 440 ``.dev`` suffix."""
+    return ".dev" in version
+
+
+def is_running_in_addon() -> bool:
+    """Return True when running inside a Home Assistant add-on container.
+
+    The HA Supervisor injects ``SUPERVISOR_TOKEN`` into every add-on's env.
+    Checked so the standalone-Docker ``:stable`` banner isn't shown to add-on
+    users, who already see the dev/stable distinction in the HAOS add-on UI.
+    """
+    return bool(os.environ.get("SUPERVISOR_TOKEN"))

--- a/src/ha_mcp/_version.py
+++ b/src/ha_mcp/_version.py
@@ -7,7 +7,10 @@ Kept as a standalone module (no other ``ha_mcp`` imports) so it can be used from
 from __future__ import annotations
 
 import importlib.metadata
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 def get_version() -> str:
@@ -19,6 +22,11 @@ def get_version() -> str:
        the running process. Stable builds leave it unset.
     2. ``ha-mcp`` package metadata — stable PyPI + stable Docker.
     3. ``ha-mcp-dev`` package metadata — PyPI dev channel (renamed package).
+
+    If none of the above resolve, logs a warning and returns ``"unknown"``.
+    The "unknown" string is itself diagnostic in bug reports and startup logs
+    — it tells triagers the install didn't register package metadata (e.g. a
+    source checkout without ``pip install -e .``, or a broken Docker layer).
     """
     if override := os.environ.get("HA_MCP_BUILD_VERSION"):
         return override
@@ -27,6 +35,11 @@ def get_version() -> str:
             return importlib.metadata.version(pkg_name)
         except importlib.metadata.PackageNotFoundError:
             continue
+    logger.warning(
+        "ha-mcp package metadata not found and HA_MCP_BUILD_VERSION unset — "
+        "version will be reported as 'unknown'. Reinstall the package or set "
+        "HA_MCP_BUILD_VERSION if this is an intentional source-tree run."
+    )
     return "unknown"
 
 

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -2,21 +2,19 @@
 Configuration management for Home Assistant MCP Server.
 """
 
-import importlib.metadata
 import os
 
 # Load environment variables from .env file with HAMCP_ENV_FILE support
 # Use absolute path to ensure .env is found regardless of cwd
 from pathlib import Path
 
-try:
-    _PACKAGE_VERSION = importlib.metadata.version("ha-mcp")
-except importlib.metadata.PackageNotFoundError:
-    _PACKAGE_VERSION = "unknown"
-
 from dotenv import load_dotenv
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from ha_mcp._version import get_version
+
+_PACKAGE_VERSION = get_version()
 
 project_root = Path(__file__).parent.parent.parent
 

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -1,8 +1,9 @@
-"""Unit tests for ha_mcp._version."""
+"""Unit tests for ha_mcp._version and the __main__ startup log helper."""
 
 from __future__ import annotations
 
 import importlib.metadata
+import logging
 
 import pytest
 
@@ -110,3 +111,75 @@ class TestIsRunningInAddon:
         """Guard against a spurious empty-string env var masquerading as the addon."""
         monkeypatch.setenv("SUPERVISOR_TOKEN", "")
         assert is_running_in_addon() is False
+
+
+class TestLogStartupVersion:
+    """Tests for _log_startup_version() — the behavioral payload of the PR.
+
+    Covers the log emission plus the dev-banner gating logic: banner must fire
+    on standalone dev installs and must be suppressed under HA Supervisor so
+    add-on users don't get noise (they already see the channel in the HAOS UI).
+    """
+
+    def _call(self, caplog: pytest.LogCaptureFixture) -> None:
+        from ha_mcp.__main__ import _log_startup_version
+
+        # _log_startup_version uses the module-level ``logger`` in __main__.
+        with caplog.at_level(logging.INFO, logger="ha_mcp.__main__"):
+            _log_startup_version()
+
+    def test_logs_version_at_info(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        self._call(caplog)
+        info_messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.INFO
+        ]
+        assert any("ha-mcp 7.3.0" in msg for msg in info_messages), info_messages
+
+    def test_dev_version_emits_stable_banner_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0.dev42")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        self._call(caplog)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, [r.getMessage() for r in warnings]
+        msg = warnings[0].getMessage()
+        assert ":stable" in msg
+        assert "dev channel" in msg
+
+    def test_dev_banner_suppressed_under_supervisor_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The banner must NOT fire inside an HA add-on (noisy, redundant with HAOS UI)."""
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0.dev42")
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        self._call(caplog)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+        info_messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.INFO
+        ]
+        # Version line still fires — add-on users should still see what they're running.
+        assert any("7.3.0.dev42" in msg for msg in info_messages), info_messages
+
+    def test_stable_version_never_emits_banner(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Guard against an inverted is_dev_version check leaking the banner to stable users."""
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        self._call(caplog)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -52,17 +52,25 @@ class TestGetVersion:
         assert get_version() == "7.3.0.dev42"
 
     def test_returns_unknown_when_not_installed(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """When neither env var nor package metadata resolves, return 'unknown'
-        rather than raising — a missing version shouldn't crash startup."""
+        rather than raising — a missing version shouldn't crash startup — but
+        emit a WARNING so the broken install is visible in logs."""
         monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
 
         def always_missing(pkg_name: str) -> str:
             raise importlib.metadata.PackageNotFoundError(pkg_name)
 
         monkeypatch.setattr(importlib.metadata, "version", always_missing)
-        assert get_version() == "unknown"
+        with caplog.at_level(logging.WARNING, logger="ha_mcp._version"):
+            result = get_version()
+        assert result == "unknown"
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "metadata not found" in warnings[0].getMessage()
 
     def test_empty_env_var_falls_through_to_metadata(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -1,0 +1,112 @@
+"""Unit tests for ha_mcp._version."""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+from ha_mcp._version import get_version, is_dev_version, is_running_in_addon
+
+
+class TestGetVersion:
+    """Tests for the version resolution helper."""
+
+    def test_env_override_wins_over_package_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HA_MCP_BUILD_VERSION must take priority so Docker/add-on dev builds
+        can surface their dev suffix even though pyproject.toml isn't rewritten."""
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0.dev999")
+        assert get_version() == "7.3.0.dev999"
+
+    def test_falls_back_to_ha_mcp_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the env var, resolve via installed package metadata."""
+        monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
+        expected = importlib.metadata.version("ha-mcp")
+        assert get_version() == expected
+
+    def test_falls_back_to_ha_mcp_dev_when_ha_mcp_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PyPI dev channel installs register as ``ha-mcp-dev`` (renamed package).
+
+        Simulate ``ha-mcp`` not being installed so the fallback loop must try
+        ``ha-mcp-dev`` next.
+        """
+        monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
+
+        real_version = importlib.metadata.version
+
+        def fake_version(pkg_name: str) -> str:
+            if pkg_name == "ha-mcp":
+                raise importlib.metadata.PackageNotFoundError(pkg_name)
+            if pkg_name == "ha-mcp-dev":
+                return "7.3.0.dev42"
+            return real_version(pkg_name)
+
+        monkeypatch.setattr(importlib.metadata, "version", fake_version)
+        assert get_version() == "7.3.0.dev42"
+
+    def test_returns_unknown_when_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When neither env var nor package metadata resolves, return 'unknown'
+        rather than raising — a missing version shouldn't crash startup."""
+        monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
+
+        def always_missing(pkg_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError(pkg_name)
+
+        monkeypatch.setattr(importlib.metadata, "version", always_missing)
+        assert get_version() == "unknown"
+
+    def test_empty_env_var_falls_through_to_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty HA_MCP_BUILD_VERSION (stable Docker default from ARG="")
+        must not override — otherwise stable builds would report '' as version."""
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "")
+        expected = importlib.metadata.version("ha-mcp")
+        assert get_version() == expected
+
+
+class TestIsDevVersion:
+    """Tests for PEP 440 dev-suffix detection."""
+
+    @pytest.mark.parametrize(
+        "version",
+        ["7.3.0.dev390", "7.3.0.dev0", "8.0.0.dev1", "1.2.3.dev100+abc123"],
+    )
+    def test_detects_dev_suffix(self, version: str) -> None:
+        assert is_dev_version(version) is True
+
+    @pytest.mark.parametrize(
+        "version",
+        ["7.3.0", "7.3.1", "8.0.0", "1.2.3rc1", "1.2.3a1", "1.2.3b1", "unknown"],
+    )
+    def test_stable_and_pre_release_versions_are_not_dev(self, version: str) -> None:
+        assert is_dev_version(version) is False
+
+
+class TestIsRunningInAddon:
+    """Tests for HA add-on environment detection."""
+
+    def test_detects_supervisor_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-token-abc")
+        assert is_running_in_addon() is True
+
+    def test_absent_when_no_supervisor_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        assert is_running_in_addon() is False
+
+    def test_empty_supervisor_token_treated_as_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard against a spurious empty-string env var masquerading as the addon."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "")
+        assert is_running_in_addon() is False


### PR DESCRIPTION
## What does this PR do?

Closes #1041. Two separate bugs surfaced in that thread:

### 1. Version never appeared in startup logs, dev suffix didn't reach Docker/add-on installs (bondskin)

Users on `:latest` / `:dev` had no way to tell which dev build they were running. The `ha_mcp` package was hard-coded to `__version__ = "7.3.0"` in `__init__.py`, the startup log didn't emit a version line, and even `importlib.metadata.version()` returned bare `7.3.0` inside Docker containers because neither Dockerfile propagated the build-arg's dev suffix (only the PyPI dev workflow rewrites `pyproject.toml` before build).

Fixed by:

- **New `ha_mcp._version` module** — resolves the running version via `HA_MCP_BUILD_VERSION` env var → `ha-mcp` metadata → `ha-mcp-dev` metadata → `"unknown"`. Stays dependency-free so `__init__.py` and `config.py` can both import it without circular risk. Logs a WARNING when the fallback returns `"unknown"` so a broken install is visible.
- **Dockerfiles propagate the dev suffix** — main `Dockerfile` and `homeassistant-addon-dev/Dockerfile` now set `ENV HA_MCP_BUILD_VERSION=${BUILD_VERSION}` from the existing build-arg. Stable builds leave the arg empty and fall through to package metadata.
- **Startup logs the version from every entrypoint** — `main`, `main_web`, `main_sse`, `main_oauth` all emit `ha-mcp <version>` at INFO. Standalone dev installs emit an additional WARNING pointing at the `:stable` Docker tag. The banner is suppressed under the HA Supervisor (`SUPERVISOR_TOKEN`) since the HAOS UI already distinguishes channels.

### 2. `:stable` and `:latest` getting silently rebuilt every Wednesday (DavBax)

`release-publish.yml` is triggered via `workflow_run` on every SemVer Release completion, gated only on `conclusion == 'success'`. "Skipped" jobs don't fail a workflow run, so on odd weeks when the biweekly gate correctly decided not to release, SemVer Release still finished as `success` and Release Publish fired. It then read the version from `pyproject.toml` at master HEAD and rebuilt Docker from master HEAD, repushing `:stable`, `:latest`, `:<version>`, and `:<major>` — same label, different digest, containing unreleased post-tag commits.

Confirmed from workflow logs: this happened 2026-03-25 (republished 7.1.0), 2026-04-08 (republished 7.2.0), and 2026-04-22 (republished 7.3.0).

Fixed by:

- **`prepare` job now resolves the latest stable tag** via `git describe --match 'v[0-9]*' --exclude '*dev*'`, reads the pyproject version from that tag (not master HEAD), and emits `should_publish=false` whenever master HEAD's SHA isn't the tag's SHA. Only exit-code 128 from `git describe` is treated as "no tags yet"; any other failure is surfaced loudly.
- **Downstream jobs gate on `should_publish`** and check out the tag ref explicitly, so even on `workflow_dispatch` (where the SHA guard is bypassed for emergency republishes) the build is reproducible from the tagged source.
- **`GITHUB_STEP_SUMMARY` entries** distinguish "correctly skipped" from "published" on the Actions UI at a glance.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed