### PR TITLE
docs(groups): point agents from service-based groups to flow-based helper

### DIFF
--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -245,10 +245,17 @@ class GroupTools:
         ] = True,
     ) -> dict[str, Any]:
         """
-        Create or update a Home Assistant entity group.
+        Create or update a service-based Home Assistant entity group via the group.set service.
 
-        Uses the group.set service to create a new group or update an existing one.
-        Groups are useful for organizing entities and controlling them together.
+        **When NOT to use:** for typical "combine these entities into one controllable group"
+        requests, prefer `ha_config_set_helper(helper_type="group", ...)`. Config-entry-backed
+        groups are registered in the entity registry, so `ha_set_entity` can assign them to
+        areas and they are deletable via `ha_delete_config_entry`.
+
+        **When to use:** compatibility with existing groups already configured via group.set
+        or YAML, or the rare case where entity-registry membership is explicitly unwanted.
+        Groups created here are only removable via `ha_config_remove_group` — neither
+        `ha_config_remove_helper` nor `ha_delete_config_entry` will find them.
 
         **For NEW groups:** Provide object_id and entities (required).
         **For EXISTING groups:** Provide object_id and any fields to update.
@@ -333,9 +340,14 @@ class GroupTools:
         ] = True,
     ) -> dict[str, Any]:
         """
-        Remove a Home Assistant entity group.
+        Remove a service-based Home Assistant entity group via the group.remove service.
 
-        Uses the group.remove service to delete the group.
+        **When NOT to use:** for groups created through `ha_config_set_helper(helper_type="group", ...)`,
+        use `ha_delete_config_entry`. Those config-entry-backed groups are not reachable via the
+        group.remove service, and `ha_config_remove_helper` does not support helper_type="group".
+
+        **When to use:** removing groups created with `ha_config_set_group` or defined in YAML
+        via `group:` configuration. Config-entry-backed deletion tools cannot find these.
 
         EXAMPLES:
         - Remove group: ha_config_remove_group("living_room_lights")


### PR DESCRIPTION
## What does this PR do?

Adds "When NOT to use" / "When to use" guidance to `ha_config_set_group` and `ha_config_remove_group` docstrings, pointing agents at `ha_config_set_helper(helper_type="group", ...)` / `ha_delete_config_entry` for the common case. Service-based groups stay supported; the docstrings just surface the trade-offs so agents don't silently land users in state-only groups that `ha_set_entity` can't area-assign and `ha_config_remove_helper` can't touch.

Closes #1015.

## Type of change
- [x] 📚 Documentation

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Behavior verified live on HA 2026.4 (storage-mode, Nabu Casa):
- Service-based group via `group.set` → not in entity registry; `config/entity_registry/update` with `area_id` returns `not_found`.
- Flow-based group via `group` config flow → registered with `config_entry_id`; area assignment succeeds.
- `group.remove` against a flow-based group's object_id returns HTTP 200 `[]` (no-op); flow group persists.
- `ha_config_remove_helper`'s `Literal[...]` does not include `"group"` — correct flow-based deletion path is `ha_delete_config_entry`, which the docstrings now reflect.

Docstring-only change; no logic, signature, or test changes.

## Checklist
- [x] I have updated documentation if needed