### PR TITLE
test(e2e): close A7 negative-input gaps for remove_area/remove_floor + harden remove_category

### DIFF
--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -887,3 +887,74 @@ async def test_home_topology_schema(mcp_client):
         f"{topo_data['unassigned_count']} unassigned, "
         f"{topo_data['orphaned_count']} orphaned"
     )
+
+
+@pytest.mark.asyncio
+class TestAreaFloorDestructiveNegativeInputs:
+    """
+    A7 negative-input tests for ha_config_remove_area and ha_config_remove_floor.
+
+    Covers the nonexistent-identifier failure path, which is not exercised by
+    the existing lifecycle tests (which only call remove on identifiers they
+    just created).
+
+    Methodology: source-verified against tools_areas.py. Both tools call the
+    respective registry delete WebSocket (config/area_registry/delete,
+    config/floor_registry/delete). When the registry returns a failure result,
+    raise_tool_error is invoked with ErrorCode.SERVICE_CALL_FAILED. Live-probed
+    response shape against a fresh HA testcontainer before test authoring.
+    """
+
+    async def test_remove_area_nonexistent(self, mcp_client):
+        """
+        Test: ha_config_remove_area with a nonexistent area_id returns a
+        structured error, not success=True.
+
+        Source path: WebSocket result.success=False →
+        raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete area: ...").
+        """
+        from ...utilities.assertions import safe_call_tool
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_area",
+            {"area_id": "nonexistent_area_a7_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent area, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "SERVICE_CALL_FAILED", (
+            f"Expected error code SERVICE_CALL_FAILED, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "doesn't exist" in error_msg or "not found" in error_msg, (
+            f"Expected 'doesn't exist'/'not found' in error message, got: {data.get('error')}"
+        )
+
+    async def test_remove_floor_nonexistent(self, mcp_client):
+        """
+        Test: ha_config_remove_floor with a nonexistent floor_id returns a
+        structured error, not success=True.
+
+        Source path: WebSocket result.success=False →
+        raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete floor: ...").
+        """
+        from ...utilities.assertions import safe_call_tool
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_floor",
+            {"floor_id": "nonexistent_floor_a7_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent floor, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "SERVICE_CALL_FAILED", (
+            f"Expected error code SERVICE_CALL_FAILED, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "doesn't exist" in error_msg or "not found" in error_msg, (
+            f"Expected 'doesn't exist'/'not found' in error message, got: {data.get('error')}"
+        )

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pytest
 
-from ...utilities.assertions import parse_mcp_result
+from ...utilities.assertions import parse_mcp_result, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -889,6 +889,8 @@ async def test_home_topology_schema(mcp_client):
     )
 
 
+@pytest.mark.area
+@pytest.mark.floor
 @pytest.mark.asyncio
 class TestAreaFloorDestructiveNegativeInputs:
     """
@@ -913,8 +915,6 @@ class TestAreaFloorDestructiveNegativeInputs:
         Source path: WebSocket result.success=False →
         raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete area: ...").
         """
-        from ...utilities.assertions import safe_call_tool
-
         data = await safe_call_tool(
             mcp_client,
             "ha_config_remove_area",
@@ -940,8 +940,6 @@ class TestAreaFloorDestructiveNegativeInputs:
         Source path: WebSocket result.success=False →
         raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete floor: ...").
         """
-        from ...utilities.assertions import safe_call_tool
-
         data = await safe_call_tool(
             mcp_client,
             "ha_config_remove_floor",

--- a/tests/src/e2e/workflows/categories/test_category_crud.py
+++ b/tests/src/e2e/workflows/categories/test_category_crud.py
@@ -191,7 +191,14 @@ class TestCategoryCRUD:
         logger.info("Non-existent category properly returned error")
 
     async def test_delete_nonexistent_category(self, mcp_client):
-        """Test deleting a non-existent category."""
+        """
+        Test deleting a non-existent category returns a structured error,
+        not success=True.
+
+        Source path: WebSocket result.success=False →
+        raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete category: ...").
+        Hardened from if/else-log pattern to explicit assertions.
+        """
         logger.info("Testing delete non-existent category")
 
         data = await safe_call_tool(
@@ -200,11 +207,16 @@ class TestCategoryCRUD:
             {"scope": "automation", "category_id": "nonexistent_category_xyz_12345"},
         )
 
-        # Should return error or handle gracefully
-        if data.get("success"):
-            logger.info("Delete returned success (idempotent)")
-        else:
-            logger.info("Non-existent category delete properly returned error")
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent category, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "SERVICE_CALL_FAILED", (
+            f"Expected error code SERVICE_CALL_FAILED, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "doesn't exist" in error_msg or "not found" in error_msg, (
+            f"Expected 'doesn't exist'/'not found' in error message, got: {data.get('error')}"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Closes the remaining A7 (destructive-tool) negative-input test gaps from #914:

- **New test** `test_remove_area_nonexistent` in `TestAreaFloorDestructiveNegativeInputs` (new class in `areas/test_lifecycle.py`) — verifies `ha_config_remove_area` with a nonexistent `area_id` returns a structured error, not `success=True`.
- **New test** `test_remove_floor_nonexistent` in the same class — same shape for `ha_config_remove_floor`.
- **Hardened** existing `test_delete_nonexistent_category` in `categories/test_category_crud.py` — replaced if/else-log pattern with explicit assertions on error code + message substring.

All three tools share the same WebSocket registry-delete path: `raise_tool_error(SERVICE_CALL_FAILED, "Failed to delete <X>: Command failed: <X> ID doesn't exist")`. Response shape source-verified against a fresh HA testcontainer before test authoring. Note: these use `SERVICE_CALL_FAILED`, not `RESOURCE_NOT_FOUND` (which is reserved for automation/script/zone via their respective 404 branches).

Follow-up of #987.

**Scope note — what's not included and why.** The original A7 survey on #914 listed seven candidates. On source-read before implementation, four dropped out:

- `ha_config_remove_script` — already hard-covered in `scripts/test_lifecycle.py` (`call_tool_failure(..., expected_error="not found")`).
- `ha_remove_zone` — covered in `zones/test_lifecycle.py` (`call_tool_failure` on nonexistent zone_id).
- `ha_config_remove_helper` — has a dual-success path via `method="already_deleted"` that legitimately returns `success=True`. A hard `assert not success` would break that fallback. Needs a design decision on idempotent-success vs. error semantics — outside test-only scope.
- `ha_config_remove_calendar_event` — the existing soft test legitimately accounts for shared-calendar state (a fake UID could theoretically collide with a real event). Hardening would need either a factory-created deletable event or scope expansion beyond this PR.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest` — 3 new/hardened tests pass locally in 12.36s against fresh HA testcontainer)
- [x] Code follows style guidelines (`uv run ruff check` — all checks passed)

## Checklist
- [x] I have updated documentation if needed (N/A — test-only PR)