### PR TITLE
feat: add ha_manage_energy_prefs tool for Energy Dashboard CRUD

### DIFF
--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -1,0 +1,539 @@
+"""
+Energy Dashboard preference management tools for Home Assistant.
+
+This module provides a single tool to read and write Home Assistant's Energy
+Dashboard configuration through the ``energy/get_prefs`` / ``energy/save_prefs``
+WebSocket commands. The underlying API has destructive full-replace semantics
+per top-level key (``energy_sources``, ``device_consumption``,
+``device_consumption_water``) — sending a key with a partial list silently
+deletes everything else the user had configured. Optimistic locking via
+``config_hash`` prevents concurrent-modification data loss; a local shape
+check catches the most common agent-side errors; and a server-side
+``energy/validate`` call after every write surfaces residual issues
+(missing stats, wrong unit classes, etc.) in the response.
+
+Note: ``energy/validate`` in Home Assistant Core takes no payload — it
+validates the currently-persisted config. Pre-write validation of an
+unsubmitted payload is therefore not possible; this tool validates the
+post-save state instead.
+
+Note: On a fresh Home Assistant instance that has never had the Energy
+Dashboard configured, ``energy/get_prefs`` returns
+``ERR_NOT_FOUND "No prefs"`` rather than an empty default. The tool
+transparently maps that case to the documented default preferences
+structure (all three top-level keys present, empty lists) so agents
+get uniform behavior on fresh and configured instances alike.
+"""
+
+import logging
+from typing import Annotated, Any, Literal
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import tool
+from pydantic import Field
+
+from ..errors import ErrorCode, create_error_response
+from ..utils.config_hash import compute_config_hash
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    register_tool_methods,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Top-level keys in the energy prefs payload. Each is an independent
+# full-replace slot in ``energy/save_prefs``.
+_PREFS_TOP_LEVEL_KEYS = (
+    "energy_sources",
+    "device_consumption",
+    "device_consumption_water",
+)
+
+
+def _default_prefs() -> dict[str, Any]:
+    """Return the default empty prefs structure used by HA Core.
+
+    Mirrors ``EnergyManager.default_preferences()`` in
+    ``homeassistant/components/energy/data.py``. A Home Assistant instance
+    that has never had the Energy Dashboard configured returns
+    ``ERR_NOT_FOUND "No prefs"`` from ``energy/get_prefs``; this helper
+    provides the canonical empty structure so the tool can transparently
+    treat the two cases (never-configured vs. configured-but-empty) the
+    same way.
+    """
+    return {
+        "energy_sources": [],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+def _is_no_prefs_error(error_msg: str) -> bool:
+    """True if an error string from send_websocket_message indicates
+    ``ERR_NOT_FOUND "No prefs"`` from HA Core's energy/get_prefs handler.
+
+    HA Core wraps the error as ``f"Command failed: {message}"``; the
+    underlying sentinel we key on is the literal ``"No prefs"`` message
+    emitted by ``ws_get_prefs`` when ``manager.data is None``.
+    """
+    return "No prefs" in error_msg
+
+
+def _flatten_validation_errors(raw: Any) -> list[dict[str, str]]:
+    """Convert the raw ``energy/validate`` response into a flat error list.
+
+    The raw response mirrors the prefs structure: a dict with the three
+    top-level keys, each mapping to a list of per-entry error lists (empty
+    inner list = that entry is valid). This function walks that structure and
+    returns a flat list of ``{"path", "message"}`` dicts, suitable for agent
+    consumption.
+
+    A successful validation returns an empty list.
+    """
+    if not isinstance(raw, dict):
+        return []
+
+    errors: list[dict[str, str]] = []
+    for key in _PREFS_TOP_LEVEL_KEYS:
+        entries = raw.get(key, [])
+        if not isinstance(entries, list):
+            continue
+        for idx, entry_errors in enumerate(entries):
+            if not entry_errors:
+                continue
+            if isinstance(entry_errors, list):
+                errors.extend(
+                    {"path": f"{key}[{idx}]", "message": str(msg)}
+                    for msg in entry_errors
+                )
+            elif isinstance(entry_errors, dict):
+                for field, msgs in entry_errors.items():
+                    msg_list = msgs if isinstance(msgs, list) else [msgs]
+                    errors.extend(
+                        {"path": f"{key}[{idx}].{field}", "message": str(msg)}
+                        for msg in msg_list
+                    )
+    return errors
+
+
+def _shape_check(config: dict[str, Any]) -> list[dict[str, str]]:
+    """Cheap local shape check before sending to the server.
+
+    Validates that top-level keys have the expected list-of-dicts shape and
+    that required identifying fields are present. Does NOT validate semantic
+    correctness (stat IDs existing, units matching, etc.) — that's surfaced
+    by the post-save server-side ``energy/validate`` call.
+    """
+    errors: list[dict[str, str]] = []
+
+    if not isinstance(config, dict):
+        return [{"path": "config", "message": "must be a dict"}]
+
+    for key in _PREFS_TOP_LEVEL_KEYS:
+        if key not in config:
+            continue
+        value = config[key]
+        if not isinstance(value, list):
+            errors.append({"path": key, "message": "must be a list"})
+            continue
+        for idx, entry in enumerate(value):
+            if not isinstance(entry, dict):
+                errors.append({
+                    "path": f"{key}[{idx}]",
+                    "message": "entry must be a dict",
+                })
+                continue
+            if key == "energy_sources" and "type" not in entry:
+                errors.append({
+                    "path": f"{key}[{idx}]",
+                    "message": "energy_sources entries require 'type' (grid|solar|battery|gas)",
+                })
+            if key == "device_consumption" and "stat_consumption" not in entry:
+                errors.append({
+                    "path": f"{key}[{idx}]",
+                    "message": "device_consumption entries require 'stat_consumption'",
+                })
+            if key == "device_consumption_water" and "stat_consumption" not in entry:
+                errors.append({
+                    "path": f"{key}[{idx}]",
+                    "message": "device_consumption_water entries require 'stat_consumption'",
+                })
+
+    return errors
+
+
+class EnergyTools:
+    """Energy Dashboard preference management tools for Home Assistant."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @tool(
+        name="ha_manage_energy_prefs",
+        tags={"Energy"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Manage Energy Dashboard Preferences",
+        },
+    )
+    @log_tool_usage
+    async def ha_manage_energy_prefs(
+        self,
+        mode: Annotated[
+            Literal["get", "set"],
+            Field(description="Operation mode: 'get' reads the current prefs; 'set' writes a new prefs payload."),
+        ],
+        config: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    "Full prefs payload for mode='set'. Must contain the "
+                    "top-level keys you intend to replace: 'energy_sources', "
+                    "'device_consumption', 'device_consumption_water'. Any "
+                    "top-level key present in this payload REPLACES the "
+                    "existing list entirely; any omitted key is preserved. "
+                    "Call with mode='get' first, mutate the returned config, "
+                    "then pass the whole object back."
+                ),
+                default=None,
+            ),
+        ] = None,
+        config_hash: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Hash returned by the previous mode='get' call. REQUIRED "
+                    "for mode='set' unless dry_run=True. Rejected if the "
+                    "server-side config has changed since that read — re-read "
+                    "and retry."
+                ),
+                default=None,
+            ),
+        ] = None,
+        dry_run: Annotated[
+            bool,
+            Field(
+                description=(
+                    "For mode='set' only. If True, runs a local shape check "
+                    "on the proposed config AND calls the server's "
+                    "energy/validate against the CURRENT persisted state "
+                    "(Home Assistant's validate endpoint cannot validate "
+                    "an unsubmitted payload). Returns both error lists "
+                    "without writing. Default False."
+                ),
+                default=False,
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """
+        Read or write the Home Assistant Energy Dashboard preferences.
+
+        The Energy Dashboard configuration (grid/solar/battery/gas sources,
+        individual device consumption sensors, cost tariffs, water) is stored
+        in ``.storage/energy`` and not otherwise reachable via REST, services,
+        or helper flows — this tool is the only way for agents to inspect or
+        modify it.
+
+        WHEN TO USE:
+        - To inspect or modify the Energy Dashboard config programmatically.
+
+        WHEN NOT TO USE:
+        - To create the underlying statistics themselves — they must already
+          exist as HA entities before being referenced here; create them via
+          the relevant integration's config flow first.
+
+        CAVEATS:
+        - ``energy/save_prefs`` has per-key FULL-REPLACE semantics. Passing
+          ``{"device_consumption": [<one entry>]}`` deletes every other device
+          the user had configured — silently, with no error. Always call
+          mode='get' first, mutate the returned config, pass the whole object
+          back, and include the returned ``config_hash`` so the tool can
+          reject concurrent modifications.
+        - A local shape check runs before every write; malformed payloads
+          are rejected with a ``shape_errors`` list.
+        - After a successful write, the tool calls ``energy/validate`` and
+          returns any residual issues as ``post_save_validation_errors`` in
+          the response. These reflect semantic problems (missing stats, unit
+          mismatches) that shape checks can't catch; the save persists
+          regardless — correct the config and write again if needed.
+        - The underlying save endpoint is admin-only. Non-admin tokens will
+          receive an authorization error from Home Assistant.
+        """
+        if mode == "get":
+            return await self._get_prefs()
+
+        # mode == "set"
+        if config is None:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "'config' is required when mode='set'",
+                context={"mode": mode},
+                suggestions=[
+                    "Call ha_manage_energy_prefs(mode='get') first, mutate the returned config, pass it back",
+                ],
+            ))
+
+        if dry_run:
+            return await self._dry_run(config)
+
+        if config_hash is None:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "'config_hash' is required when mode='set' and dry_run=False",
+                context={"mode": mode},
+                suggestions=[
+                    "Call ha_manage_energy_prefs(mode='get') to obtain a fresh config_hash",
+                    "Or call again with dry_run=True to validate without a hash",
+                ],
+            ))
+
+        return await self._set_prefs(config, config_hash)
+
+    # ------------------------------------------------------------------
+    # Internal handlers
+    # ------------------------------------------------------------------
+
+    async def _get_prefs(self) -> dict[str, Any]:
+        """Fetch current prefs and return them with a config_hash.
+
+        On a Home Assistant instance that has never had the Energy Dashboard
+        configured, ``energy/get_prefs`` returns ``ERR_NOT_FOUND "No prefs"``
+        rather than an empty default. This method maps that case to the
+        documented default preferences structure so the tool works uniformly
+        on fresh installations.
+        """
+        try:
+            result = await self._client.send_websocket_message({
+                "type": "energy/get_prefs",
+            })
+
+            if not result.get("success"):
+                error_msg = str(result.get("error", ""))
+                if _is_no_prefs_error(error_msg):
+                    prefs = _default_prefs()
+                    return {
+                        "success": True,
+                        "mode": "get",
+                        "config": prefs,
+                        "config_hash": compute_config_hash(prefs),
+                        "note": (
+                            "Energy Dashboard has never been configured on "
+                            "this instance; returning empty default."
+                        ),
+                    }
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to get energy prefs: {result.get('error', 'Unknown error')}",
+                    context={"mode": "get"},
+                ))
+
+            prefs = result.get("result", {})
+            return {
+                "success": True,
+                "mode": "get",
+                "config": prefs,
+                "config_hash": compute_config_hash(prefs),
+            }
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting energy prefs: {e}")
+            exception_to_structured_error(e, context={"mode": "get"}, suggestions=[
+                "Check Home Assistant connection",
+                "Verify WebSocket connection is active",
+            ])
+
+    async def _dry_run(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Shape-check the proposed config and fetch current-state validate.
+
+        Returns both error lists clearly labelled so agents can distinguish
+        problems they're about to introduce (shape_errors) from pre-existing
+        issues in the persisted state (current_state_validation_errors).
+        """
+        try:
+            shape_errors = _shape_check(config)
+
+            validate_result = await self._client.send_websocket_message({
+                "type": "energy/validate",
+            })
+            if validate_result.get("success"):
+                current_state_errors = _flatten_validation_errors(
+                    validate_result.get("result", {})
+                )
+            else:
+                current_state_errors = []
+
+            return {
+                "success": len(shape_errors) == 0,
+                "mode": "set",
+                "dry_run": True,
+                "shape_errors": shape_errors,
+                "current_state_validation_errors": current_state_errors,
+                "message": (
+                    "Shape OK. Note: HA's energy/validate cannot validate an "
+                    "unsubmitted payload — current_state_validation_errors "
+                    "reflects the CURRENT persisted config, not your proposal. "
+                    "Semantic issues in the proposed config (missing stats, "
+                    "wrong units) will surface in post_save_validation_errors "
+                    "after an actual mode='set' write."
+                    if not shape_errors
+                    else f"{len(shape_errors)} shape error(s) — fix before writing."
+                ),
+            }
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in energy prefs dry_run: {e}")
+            exception_to_structured_error(
+                e,
+                context={"mode": "set", "dry_run": True},
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Verify config shape matches energy/get_prefs response",
+                ],
+            )
+
+    async def _set_prefs(
+        self,
+        config: dict[str, Any],
+        config_hash: str,
+    ) -> dict[str, Any]:
+        """Shape-check → hash-check → save → post-save validate.
+
+        Shape errors and hash mismatch fail closed. Post-save validation
+        errors are reported in the response as a non-fatal warning; the
+        save already succeeded.
+        """
+        try:
+            # 1. Shape check (fast local, fail closed)
+            shape_errors = _shape_check(config)
+            if shape_errors:
+                raise_tool_error(create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    f"Config shape invalid: {len(shape_errors)} error(s)",
+                    context={
+                        "mode": "set",
+                        "shape_errors": shape_errors,
+                    },
+                    suggestions=[
+                        "Fix the listed errors and retry",
+                        "Call with dry_run=True to re-check without writing",
+                    ],
+                ))
+
+            # 2. Fresh read for hash comparison. Map "No prefs" (never
+            # configured) to empty default so the hash-check works on
+            # fresh installations too.
+            current_result = await self._client.send_websocket_message({
+                "type": "energy/get_prefs",
+            })
+            if not current_result.get("success"):
+                error_msg = str(current_result.get("error", ""))
+                if _is_no_prefs_error(error_msg):
+                    current_prefs: dict[str, Any] = _default_prefs()
+                else:
+                    raise_tool_error(create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Failed to re-read prefs for hash check: {current_result.get('error', 'Unknown error')}",
+                        context={"mode": "set"},
+                    ))
+                    # unreachable; appeases type checkers
+                    current_prefs = {}
+            else:
+                current_prefs = current_result.get("result", {}) or {}
+
+            current_hash = compute_config_hash(current_prefs)
+
+            if current_hash != config_hash:
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Energy prefs modified since last read (conflict)",
+                    context={"mode": "set"},
+                    suggestions=[
+                        "Call ha_manage_energy_prefs(mode='get') again",
+                        "Re-apply your changes to the fresh config",
+                        "Pass the new config_hash back in",
+                    ],
+                ))
+
+            # 3. Save
+            save_payload: dict[str, Any] = {"type": "energy/save_prefs"}
+            for key in _PREFS_TOP_LEVEL_KEYS:
+                if key in config:
+                    save_payload[key] = config[key]
+
+            save_result = await self._client.send_websocket_message(save_payload)
+            if not save_result.get("success"):
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to save energy prefs: {save_result.get('error', 'Unknown error')}",
+                    context={"mode": "set"},
+                    suggestions=[
+                        "Verify the token has admin privileges (energy/save_prefs is admin-only)",
+                        "Check config shape against the energy/get_prefs response",
+                    ],
+                ))
+
+            # 4. Post-save validation against the newly-persisted state
+            post_save_errors: list[dict[str, str]] = []
+            try:
+                validate_result = await self._client.send_websocket_message({
+                    "type": "energy/validate",
+                })
+                if validate_result.get("success"):
+                    post_save_errors = _flatten_validation_errors(
+                        validate_result.get("result", {})
+                    )
+            except Exception as e:
+                # Post-save validate failure is non-fatal — the save itself
+                # succeeded. Log and continue.
+                logger.warning(f"Post-save energy/validate failed: {e}")
+
+            # 5. Compute new hash from the effective new state (current
+            # merged with the submitted keys; save_prefs does not echo it
+            # back).
+            new_prefs = {**current_prefs}
+            for key in _PREFS_TOP_LEVEL_KEYS:
+                if key in config:
+                    new_prefs[key] = config[key]
+            new_hash = compute_config_hash(new_prefs)
+
+            response: dict[str, Any] = {
+                "success": True,
+                "mode": "set",
+                "config_hash": new_hash,
+                "message": "Energy prefs updated.",
+            }
+            if post_save_errors:
+                response["post_save_validation_errors"] = post_save_errors
+                response["warning"] = (
+                    f"Save succeeded, but the persisted config has "
+                    f"{len(post_save_errors)} validation error(s). Review "
+                    "and re-write if any relate to this change."
+                )
+            return response
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"Error setting energy prefs: {e}")
+            exception_to_structured_error(
+                e,
+                context={"mode": "set"},
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Verify token has admin privileges",
+                    "Re-read prefs and retry with a fresh config_hash",
+                ],
+            )
+
+
+def register_energy_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register Home Assistant energy preference management tools."""
+    register_tool_methods(mcp, EnergyTools(client))

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -481,22 +481,22 @@ class EnergyTools:
                     "type": "energy/get_prefs",
                 }
             )
-            if not current_result.get("success"):
-                error_msg = str(current_result.get("error", ""))
-                if _is_no_prefs_error(error_msg):
-                    current_prefs: dict[str, Any] = _default_prefs()
+            if current_result.get("success"):
+                current_prefs: dict[str, Any] = current_result.get("result") or {}
+            else:
+                error = current_result.get("error") or "Unknown error"
+                if _is_no_prefs_error(str(error)):
+                    current_prefs = _default_prefs()
                 else:
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
-                            f"Failed to re-read prefs for hash check: {current_result.get('error', 'Unknown error')}",
+                            f"Failed to re-read prefs for hash check: {error}",
                             context={"mode": "set"},
                         )
                     )
                     # unreachable; appeases type checkers
                     current_prefs = {}
-            else:
-                current_prefs = current_result.get("result", {}) or {}
 
             current_hash = compute_config_hash(current_prefs)
 

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -141,26 +141,54 @@ def _shape_check(config: dict[str, Any]) -> list[dict[str, str]]:
             continue
         for idx, entry in enumerate(value):
             if not isinstance(entry, dict):
-                errors.append({
-                    "path": f"{key}[{idx}]",
-                    "message": "entry must be a dict",
-                })
+                errors.append(
+                    {
+                        "path": f"{key}[{idx}]",
+                        "message": "entry must be a dict",
+                    }
+                )
                 continue
-            if key == "energy_sources" and "type" not in entry:
-                errors.append({
-                    "path": f"{key}[{idx}]",
-                    "message": "energy_sources entries require 'type' (grid|solar|battery|gas)",
-                })
+            if key == "energy_sources":
+                valid_types = {"grid", "solar", "battery", "gas"}
+                requires_stat_from = {"solar", "battery", "gas"}
+                entry_type = entry.get("type")
+                if entry_type is None:
+                    errors.append(
+                        {
+                            "path": f"{key}[{idx}]",
+                            "message": "energy_sources entries require 'type' (grid|solar|battery|gas)",
+                        }
+                    )
+                elif entry_type not in valid_types:
+                    errors.append(
+                        {
+                            "path": f"{key}[{idx}].type",
+                            "message": f"invalid type '{entry_type}' (must be one of grid|solar|battery|gas)",
+                        }
+                    )
+                elif (
+                    entry_type in requires_stat_from and "stat_energy_from" not in entry
+                ):
+                    errors.append(
+                        {
+                            "path": f"{key}[{idx}]",
+                            "message": f"{entry_type} entries require 'stat_energy_from'",
+                        }
+                    )
             if key == "device_consumption" and "stat_consumption" not in entry:
-                errors.append({
-                    "path": f"{key}[{idx}]",
-                    "message": "device_consumption entries require 'stat_consumption'",
-                })
+                errors.append(
+                    {
+                        "path": f"{key}[{idx}]",
+                        "message": "device_consumption entries require 'stat_consumption'",
+                    }
+                )
             if key == "device_consumption_water" and "stat_consumption" not in entry:
-                errors.append({
-                    "path": f"{key}[{idx}]",
-                    "message": "device_consumption_water entries require 'stat_consumption'",
-                })
+                errors.append(
+                    {
+                        "path": f"{key}[{idx}]",
+                        "message": "device_consumption_water entries require 'stat_consumption'",
+                    }
+                )
 
     return errors
 
@@ -185,7 +213,9 @@ class EnergyTools:
         self,
         mode: Annotated[
             Literal["get", "set"],
-            Field(description="Operation mode: 'get' reads the current prefs; 'set' writes a new prefs payload."),
+            Field(
+                description="Operation mode: 'get' reads the current prefs; 'set' writes a new prefs payload."
+            ),
         ],
         config: Annotated[
             dict[str, Any] | None,
@@ -230,7 +260,7 @@ class EnergyTools:
         ] = False,
     ) -> dict[str, Any]:
         """
-        Read or write the Home Assistant Energy Dashboard preferences.
+        Manage the Home Assistant Energy Dashboard preferences.
 
         The Energy Dashboard configuration (grid/solar/battery/gas sources,
         individual device consumption sensors, cost tariffs, water) is stored
@@ -268,28 +298,32 @@ class EnergyTools:
 
         # mode == "set"
         if config is None:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "'config' is required when mode='set'",
-                context={"mode": mode},
-                suggestions=[
-                    "Call ha_manage_energy_prefs(mode='get') first, mutate the returned config, pass it back",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'config' is required when mode='set'",
+                    context={"mode": mode},
+                    suggestions=[
+                        "Call ha_manage_energy_prefs(mode='get') first, mutate the returned config, pass it back",
+                    ],
+                )
+            )
 
         if dry_run:
             return await self._dry_run(config)
 
         if config_hash is None:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "'config_hash' is required when mode='set' and dry_run=False",
-                context={"mode": mode},
-                suggestions=[
-                    "Call ha_manage_energy_prefs(mode='get') to obtain a fresh config_hash",
-                    "Or call again with dry_run=True to validate without a hash",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'config_hash' is required when mode='set' and dry_run=False",
+                    context={"mode": mode},
+                    suggestions=[
+                        "Call ha_manage_energy_prefs(mode='get') to obtain a fresh config_hash",
+                        "Or call again with dry_run=True to validate without a hash",
+                    ],
+                )
+            )
 
         return await self._set_prefs(config, config_hash)
 
@@ -307,9 +341,11 @@ class EnergyTools:
         on fresh installations.
         """
         try:
-            result = await self._client.send_websocket_message({
-                "type": "energy/get_prefs",
-            })
+            result = await self._client.send_websocket_message(
+                {
+                    "type": "energy/get_prefs",
+                }
+            )
 
             if not result.get("success"):
                 error_msg = str(result.get("error", ""))
@@ -325,11 +361,13 @@ class EnergyTools:
                             "this instance; returning empty default."
                         ),
                     }
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Failed to get energy prefs: {result.get('error', 'Unknown error')}",
-                    context={"mode": "get"},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Failed to get energy prefs: {result.get('error', 'Unknown error')}",
+                        context={"mode": "get"},
+                    )
+                )
 
             prefs = result.get("result", {})
             return {
@@ -343,10 +381,14 @@ class EnergyTools:
             raise
         except Exception as e:
             logger.error(f"Error getting energy prefs: {e}")
-            exception_to_structured_error(e, context={"mode": "get"}, suggestions=[
-                "Check Home Assistant connection",
-                "Verify WebSocket connection is active",
-            ])
+            exception_to_structured_error(
+                e,
+                context={"mode": "get"},
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Verify WebSocket connection is active",
+                ],
+            )
 
     async def _dry_run(self, config: dict[str, Any]) -> dict[str, Any]:
         """Shape-check the proposed config and fetch current-state validate.
@@ -358,9 +400,11 @@ class EnergyTools:
         try:
             shape_errors = _shape_check(config)
 
-            validate_result = await self._client.send_websocket_message({
-                "type": "energy/validate",
-            })
+            validate_result = await self._client.send_websocket_message(
+                {
+                    "type": "energy/validate",
+                }
+            )
             if validate_result.get("success"):
                 current_state_errors = _flatten_validation_errors(
                     validate_result.get("result", {})
@@ -414,35 +458,41 @@ class EnergyTools:
             # 1. Shape check (fast local, fail closed)
             shape_errors = _shape_check(config)
             if shape_errors:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_FAILED,
-                    f"Config shape invalid: {len(shape_errors)} error(s)",
-                    context={
-                        "mode": "set",
-                        "shape_errors": shape_errors,
-                    },
-                    suggestions=[
-                        "Fix the listed errors and retry",
-                        "Call with dry_run=True to re-check without writing",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_FAILED,
+                        f"Config shape invalid: {len(shape_errors)} error(s)",
+                        context={
+                            "mode": "set",
+                            "shape_errors": shape_errors,
+                        },
+                        suggestions=[
+                            "Fix the listed errors and retry",
+                            "Call with dry_run=True to re-check without writing",
+                        ],
+                    )
+                )
 
             # 2. Fresh read for hash comparison. Map "No prefs" (never
             # configured) to empty default so the hash-check works on
             # fresh installations too.
-            current_result = await self._client.send_websocket_message({
-                "type": "energy/get_prefs",
-            })
+            current_result = await self._client.send_websocket_message(
+                {
+                    "type": "energy/get_prefs",
+                }
+            )
             if not current_result.get("success"):
                 error_msg = str(current_result.get("error", ""))
                 if _is_no_prefs_error(error_msg):
                     current_prefs: dict[str, Any] = _default_prefs()
                 else:
-                    raise_tool_error(create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        f"Failed to re-read prefs for hash check: {current_result.get('error', 'Unknown error')}",
-                        context={"mode": "set"},
-                    ))
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            f"Failed to re-read prefs for hash check: {current_result.get('error', 'Unknown error')}",
+                            context={"mode": "set"},
+                        )
+                    )
                     # unreachable; appeases type checkers
                     current_prefs = {}
             else:
@@ -451,16 +501,18 @@ class EnergyTools:
             current_hash = compute_config_hash(current_prefs)
 
             if current_hash != config_hash:
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    "Energy prefs modified since last read (conflict)",
-                    context={"mode": "set"},
-                    suggestions=[
-                        "Call ha_manage_energy_prefs(mode='get') again",
-                        "Re-apply your changes to the fresh config",
-                        "Pass the new config_hash back in",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_LOCKED,
+                        "Energy prefs modified since last read (conflict)",
+                        context={"mode": "set"},
+                        suggestions=[
+                            "Call ha_manage_energy_prefs(mode='get') again",
+                            "Re-apply your changes to the fresh config",
+                            "Pass the new config_hash back in",
+                        ],
+                    )
+                )
 
             # 3. Save
             save_payload: dict[str, Any] = {"type": "energy/save_prefs"}
@@ -470,22 +522,26 @@ class EnergyTools:
 
             save_result = await self._client.send_websocket_message(save_payload)
             if not save_result.get("success"):
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Failed to save energy prefs: {save_result.get('error', 'Unknown error')}",
-                    context={"mode": "set"},
-                    suggestions=[
-                        "Verify the token has admin privileges (energy/save_prefs is admin-only)",
-                        "Check config shape against the energy/get_prefs response",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Failed to save energy prefs: {save_result.get('error', 'Unknown error')}",
+                        context={"mode": "set"},
+                        suggestions=[
+                            "Verify the token has admin privileges (energy/save_prefs is admin-only)",
+                            "Check config shape against the energy/get_prefs response",
+                        ],
+                    )
+                )
 
             # 4. Post-save validation against the newly-persisted state
             post_save_errors: list[dict[str, str]] = []
             try:
-                validate_result = await self._client.send_websocket_message({
-                    "type": "energy/validate",
-                })
+                validate_result = await self._client.send_websocket_message(
+                    {
+                        "type": "energy/validate",
+                    }
+                )
                 if validate_result.get("success"):
                     post_save_errors = _flatten_validation_errors(
                         validate_result.get("result", {})

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -79,7 +79,7 @@ def _is_no_prefs_error(error_msg: str) -> bool:
     underlying sentinel we key on is the literal ``"No prefs"`` message
     emitted by ``ws_get_prefs`` when ``manager.data is None``.
     """
-    return "No prefs" in error_msg
+    return error_msg.endswith("No prefs")
 
 
 def _flatten_validation_errors(raw: Any) -> list[dict[str, str]]:
@@ -369,7 +369,7 @@ class EnergyTools:
                     )
                 )
 
-            prefs = result.get("result", {})
+            prefs = result.get("result") or _default_prefs()
             return {
                 "success": True,
                 "mode": "get",
@@ -405,14 +405,23 @@ class EnergyTools:
                     "type": "energy/validate",
                 }
             )
+            validate_warning: str | None = None
             if validate_result.get("success"):
                 current_state_errors = _flatten_validation_errors(
                     validate_result.get("result", {})
                 )
             else:
+                validate_error = validate_result.get("error") or "unknown error"
+                logger.warning(
+                    f"energy/validate (current state) failed: {validate_error}"
+                )
                 current_state_errors = []
+                validate_warning = (
+                    f"energy/validate failed: {validate_error} — "
+                    "current-state validation skipped"
+                )
 
-            return {
+            response: dict[str, Any] = {
                 "success": len(shape_errors) == 0,
                 "mode": "set",
                 "dry_run": True,
@@ -429,6 +438,10 @@ class EnergyTools:
                     else f"{len(shape_errors)} shape error(s) — fix before writing."
                 ),
             }
+            if validate_warning is not None:
+                response["partial"] = True
+                response["warning"] = validate_warning
+            return response
 
         except ToolError:
             raise
@@ -482,7 +495,9 @@ class EnergyTools:
                 }
             )
             if current_result.get("success"):
-                current_prefs: dict[str, Any] = current_result.get("result") or {}
+                current_prefs: dict[str, Any] = (
+                    current_result.get("result") or _default_prefs()
+                )
             else:
                 error = current_result.get("error") or "Unknown error"
                 if _is_no_prefs_error(str(error)):
@@ -536,6 +551,7 @@ class EnergyTools:
 
             # 4. Post-save validation against the newly-persisted state
             post_save_errors: list[dict[str, str]] = []
+            post_save_validate_error: str | None = None
             try:
                 validate_result = await self._client.send_websocket_message(
                     {
@@ -546,10 +562,18 @@ class EnergyTools:
                     post_save_errors = _flatten_validation_errors(
                         validate_result.get("result", {})
                     )
+                else:
+                    post_save_validate_error = (
+                        validate_result.get("error") or "unknown error"
+                    )
+                    logger.warning(
+                        f"energy/validate (post-save) failed: {post_save_validate_error}"
+                    )
             except Exception as e:
                 # Post-save validate failure is non-fatal — the save itself
                 # succeeded. Log and continue.
                 logger.warning(f"Post-save energy/validate failed: {e}")
+                post_save_validate_error = str(e)
 
             # 5. Compute new hash from the effective new state (current
             # merged with the submitted keys; save_prefs does not echo it
@@ -572,6 +596,13 @@ class EnergyTools:
                     f"Save succeeded, but the persisted config has "
                     f"{len(post_save_errors)} validation error(s). Review "
                     "and re-write if any relate to this change."
+                )
+            elif post_save_validate_error is not None:
+                response["partial"] = True
+                response["warning"] = (
+                    f"Save succeeded, but post-save energy/validate "
+                    f"failed: {post_save_validate_error}. The persisted "
+                    "config has not been re-validated."
                 )
             return response
 

--- a/tests/src/e2e/tools/test_tools_energy.py
+++ b/tests/src/e2e/tools/test_tools_energy.py
@@ -1,0 +1,91 @@
+"""
+E2E smoke tests for ha_manage_energy_prefs.
+
+Scope: read-only mode="get" against the freshly-initialised test container.
+The container starts with no ``.storage/energy`` file, so HA returns the
+empty default — confirming tool registration, WebSocket connectivity, and
+response shape without mutating state.
+
+Write paths (mode="set", including dry_run) are covered by the unit tests
+under tests/src/unit/test_tools_energy.py. They are deliberately not
+exercised here to avoid coupling CI runs to container-persisted energy
+prefs state.
+"""
+
+import logging
+
+import pytest
+
+from ..utilities.assertions import assert_mcp_success
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_energy_prefs_get_returns_expected_shape(mcp_client):
+    """mode='get' returns the three top-level keys and a config_hash.
+
+    A fresh HA install has no ``.storage/energy``; the endpoint still
+    succeeds and returns empty lists for the top-level keys. The tool
+    must echo that structure and compute a deterministic hash.
+    """
+    result = await mcp_client.call_tool(
+        "ha_manage_energy_prefs",
+        {"mode": "get"},
+    )
+    raw = assert_mcp_success(result, "energy prefs get")
+    data = raw.get("data", raw)
+
+    assert data.get("success") is True
+    assert data.get("mode") == "get"
+    assert "config" in data
+    assert "config_hash" in data
+
+    config = data["config"]
+    assert isinstance(config, dict)
+    # All three top-level keys must be present in the response, even on a
+    # fresh install.
+    for key in ("energy_sources", "device_consumption", "device_consumption_water"):
+        assert key in config, (
+            f"top-level key '{key}' missing from energy prefs response — "
+            f"got keys: {sorted(config.keys())}"
+        )
+        assert isinstance(config[key], list), (
+            f"top-level key '{key}' must be a list, got {type(config[key]).__name__}"
+        )
+
+    # Hash must be a non-empty hex string.
+    config_hash = data["config_hash"]
+    assert isinstance(config_hash, str) and len(config_hash) > 0
+    # compute_config_hash truncates SHA256 to 16 hex chars.
+    assert len(config_hash) == 16
+    int(config_hash, 16)  # raises if not hex
+
+    logger.info(
+        "energy prefs get returned %d sources, %d devices, %d water devices; hash=%s",
+        len(config["energy_sources"]),
+        len(config["device_consumption"]),
+        len(config["device_consumption_water"]),
+        config_hash,
+    )
+
+
+@pytest.mark.asyncio
+async def test_energy_prefs_get_hash_is_deterministic(mcp_client):
+    """Repeated mode='get' on an unchanged state returns the same hash."""
+    first = await mcp_client.call_tool(
+        "ha_manage_energy_prefs",
+        {"mode": "get"},
+    )
+    second = await mcp_client.call_tool(
+        "ha_manage_energy_prefs",
+        {"mode": "get"},
+    )
+
+    first_data = assert_mcp_success(first, "first get").get("data", {})
+    second_data = assert_mcp_success(second, "second get").get("data", {})
+
+    assert first_data.get("config_hash") == second_data.get("config_hash"), (
+        "config_hash must be deterministic across repeated reads of an "
+        "unchanged state"
+    )

--- a/tests/src/e2e/tools/test_tools_energy.py
+++ b/tests/src/e2e/tools/test_tools_energy.py
@@ -1,15 +1,11 @@
 """
 E2E smoke tests for ha_manage_energy_prefs.
 
-Scope: read-only mode="get" against the freshly-initialised test container.
-The container starts with no ``.storage/energy`` file, so HA returns the
-empty default — confirming tool registration, WebSocket connectivity, and
-response shape without mutating state.
-
-Write paths (mode="set", including dry_run) are covered by the unit tests
-under tests/src/unit/test_tools_energy.py. They are deliberately not
-exercised here to avoid coupling CI runs to container-persisted energy
-prefs state.
+Scope: mode="get" and a minimal mode="set" roundtrip against the
+freshly-initialised test container. Shape-validation and dry_run logic
+remain in the unit tests under tests/src/unit/test_tools_energy.py;
+the E2E suite exercises the real WebSocket plumbing to catch command
+renames (energy/get_prefs, energy/save_prefs) that mocks cannot.
 """
 
 import logging
@@ -86,6 +82,41 @@ async def test_energy_prefs_get_hash_is_deterministic(mcp_client):
     second_data = assert_mcp_success(second, "second get").get("data", {})
 
     assert first_data.get("config_hash") == second_data.get("config_hash"), (
-        "config_hash must be deterministic across repeated reads of an "
-        "unchanged state"
+        "config_hash must be deterministic across repeated reads of an unchanged state"
+    )
+
+
+@pytest.mark.asyncio
+async def test_energy_prefs_set_roundtrip(mcp_client):
+    """mode='set' with minimal payload, re-read, assert hash symmetry.
+
+    Covers the bits unit tests cannot: that ``energy/save_prefs`` is
+    still the right WebSocket command name and accepts the payload
+    shape this tool sends. A rename on the HA side would make the
+    unit tests pass (mocks still match the old name) while the real
+    call 404s in CI.
+    """
+    # 1. Fresh get
+    get_before = await mcp_client.call_tool("ha_manage_energy_prefs", {"mode": "get"})
+    assert_mcp_success(get_before)
+    hash_before = get_before.data["config_hash"]
+
+    # 2. Minimal set — empty device_consumption
+    set_result = await mcp_client.call_tool(
+        "ha_manage_energy_prefs",
+        {
+            "mode": "set",
+            "config": {"device_consumption": []},
+            "config_hash": hash_before,
+        },
+    )
+    assert_mcp_success(set_result)
+    hash_after_set = set_result.data["config_hash"]
+
+    # 3. Re-read, confirm hash matches the one returned by set
+    get_after = await mcp_client.call_tool("ha_manage_energy_prefs", {"mode": "get"})
+    assert_mcp_success(get_after)
+    assert get_after.data["config_hash"] == hash_after_set, (
+        "Hash from mode='set' return should match hash from subsequent "
+        "mode='get' — they compute over the same effective state."
     )

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -1,0 +1,486 @@
+"""Unit tests for EnergyTools — covers all three modes plus error paths.
+
+End-to-end tests would require a live Home Assistant with an Energy Dashboard
+configured and an admin token; mocking ``send_websocket_message`` keeps these
+hermetic while still exercising every branch of the state machine.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_energy import (
+    EnergyTools,
+    _flatten_validation_errors,
+    _shape_check,
+)
+from ha_mcp.utils.config_hash import compute_config_hash
+
+# -----------------------------------------------------------------------------
+# Fixtures / helpers
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tools():
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock()
+    return EnergyTools(client)
+
+
+def _sample_prefs() -> dict:
+    return {
+        "energy_sources": [
+            {
+                "type": "grid",
+                "stat_energy_from": "sensor.grid_import",
+                "stat_energy_to": None,
+                "stat_cost": None,
+                "entity_energy_price": None,
+                "number_energy_price": None,
+                "cost_adjustment_day": 0,
+                "entity_energy_price_export": None,
+                "number_energy_price_export": None,
+                "stat_compensation": None,
+            }
+        ],
+        "device_consumption": [
+            {"stat_consumption": "sensor.fridge_energy"},
+        ],
+        "device_consumption_water": [],
+    }
+
+
+def _empty_validate_result() -> dict:
+    return {
+        "energy_sources": [[]],
+        "device_consumption": [[]],
+        "device_consumption_water": [],
+    }
+
+
+# -----------------------------------------------------------------------------
+# _flatten_validation_errors
+# -----------------------------------------------------------------------------
+
+
+class TestFlattenValidationErrors:
+    def test_all_empty_returns_empty_list(self):
+        assert _flatten_validation_errors(_empty_validate_result()) == []
+
+    def test_non_dict_input_returns_empty(self):
+        assert _flatten_validation_errors(None) == []
+        assert _flatten_validation_errors("string") == []
+        assert _flatten_validation_errors([]) == []
+
+    def test_list_of_strings_per_entry(self):
+        raw = {
+            "energy_sources": [["stat not found"], []],
+            "device_consumption": [],
+            "device_consumption_water": [],
+        }
+        errors = _flatten_validation_errors(raw)
+        assert errors == [
+            {"path": "energy_sources[0]", "message": "stat not found"}
+        ]
+
+    def test_dict_per_entry_with_field_paths(self):
+        raw = {
+            "energy_sources": [],
+            "device_consumption": [
+                {"stat_consumption": ["unit mismatch", "stat missing"]}
+            ],
+            "device_consumption_water": [],
+        }
+        errors = _flatten_validation_errors(raw)
+        assert {"path": "device_consumption[0].stat_consumption", "message": "unit mismatch"} in errors
+        assert {"path": "device_consumption[0].stat_consumption", "message": "stat missing"} in errors
+        assert len(errors) == 2
+
+
+# -----------------------------------------------------------------------------
+# _shape_check
+# -----------------------------------------------------------------------------
+
+
+class TestShapeCheck:
+    def test_valid_config(self):
+        assert _shape_check(_sample_prefs()) == []
+
+    def test_non_dict_config(self):
+        errors = _shape_check([])  # type: ignore[arg-type]
+        assert errors == [{"path": "config", "message": "must be a dict"}]
+
+    def test_top_level_not_a_list(self):
+        errors = _shape_check({"device_consumption": "not a list"})
+        assert {"path": "device_consumption", "message": "must be a list"} in errors
+
+    def test_energy_source_missing_type(self):
+        errors = _shape_check({
+            "energy_sources": [{"stat_energy_from": "sensor.x"}],
+        })
+        assert any("type" in e["message"] for e in errors)
+
+    def test_device_consumption_missing_stat_consumption(self):
+        errors = _shape_check({
+            "device_consumption": [{"name": "anonymous"}],
+        })
+        assert any("stat_consumption" in e["message"] for e in errors)
+
+    def test_entry_not_a_dict(self):
+        errors = _shape_check({"device_consumption": ["not a dict"]})
+        assert any("must be a dict" in e["message"] for e in errors)
+
+    def test_unknown_top_level_keys_ignored(self):
+        # Unknown keys are harmless at shape-check level — they'll simply not
+        # be forwarded to save_prefs by the tool.
+        assert _shape_check({"something_else": 42}) == []
+
+
+# -----------------------------------------------------------------------------
+# ha_manage_energy_prefs — mode="get"
+# -----------------------------------------------------------------------------
+
+
+class TestGetPrefs:
+    async def test_happy_path_returns_config_and_hash(self, tools):
+        prefs = _sample_prefs()
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": prefs,
+        }
+
+        result = await tools.ha_manage_energy_prefs(mode="get")
+
+        assert result["success"] is True
+        assert result["mode"] == "get"
+        assert result["config"] == prefs
+        assert result["config_hash"] == compute_config_hash(prefs)
+
+    async def test_ws_failure_raises_tool_error(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": False,
+            "error": "something broke",
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(mode="get")
+
+        err = json.loads(str(exc_info.value))
+        assert err["success"] is False
+        assert "SERVICE_CALL_FAILED" in json.dumps(err)
+
+    async def test_no_prefs_error_returns_empty_default(self, tools):
+        """Fresh HA without a configured Energy Dashboard returns
+        ERR_NOT_FOUND 'No prefs' — the tool must map that to an empty
+        default so the get/set workflow works uniformly."""
+        tools._client.send_websocket_message.return_value = {
+            "success": False,
+            "error": "Command failed: No prefs",
+        }
+
+        result = await tools.ha_manage_energy_prefs(mode="get")
+
+        assert result["success"] is True
+        assert result["mode"] == "get"
+        assert result["config"] == {
+            "energy_sources": [],
+            "device_consumption": [],
+            "device_consumption_water": [],
+        }
+        assert result["config_hash"] == compute_config_hash(result["config"])
+        assert "note" in result
+        assert "never been configured" in result["note"]
+
+
+# -----------------------------------------------------------------------------
+# ha_manage_energy_prefs — mode="set" parameter validation
+# -----------------------------------------------------------------------------
+
+
+class TestSetParameterValidation:
+    async def test_missing_config_raises(self, tools):
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(mode="set")
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_MISSING_PARAMETER" in json.dumps(err)
+        assert "config" in json.dumps(err).lower()
+
+    async def test_missing_hash_without_dry_run_raises(self, tools):
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=_sample_prefs(),
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_MISSING_PARAMETER" in json.dumps(err)
+        assert "config_hash" in json.dumps(err).lower()
+
+    async def test_missing_hash_with_dry_run_ok(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": _empty_validate_result(),
+        }
+        # dry_run=True skips the hash requirement
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config=_sample_prefs(),
+            dry_run=True,
+        )
+        assert result["success"] is True
+        assert result["dry_run"] is True
+
+
+# -----------------------------------------------------------------------------
+# ha_manage_energy_prefs — mode="set" dry_run
+# -----------------------------------------------------------------------------
+
+
+class TestDryRun:
+    async def test_valid_config_success(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": _empty_validate_result(),
+        }
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=_sample_prefs(), dry_run=True,
+        )
+        assert result["success"] is True
+        assert result["shape_errors"] == []
+        assert result["current_state_validation_errors"] == []
+
+    async def test_shape_errors_surfaced(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": _empty_validate_result(),
+        }
+        bad_config = {"energy_sources": [{"stat_energy_from": "sensor.x"}]}
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=bad_config, dry_run=True,
+        )
+        assert result["success"] is False
+        assert len(result["shape_errors"]) > 0
+        assert any("type" in e["message"] for e in result["shape_errors"])
+
+    async def test_current_state_errors_surfaced_separately(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {
+                "energy_sources": [["stat missing"]],
+                "device_consumption": [],
+                "device_consumption_water": [],
+            },
+        }
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=_sample_prefs(), dry_run=True,
+        )
+        assert result["success"] is True  # shape is fine
+        assert result["shape_errors"] == []
+        assert len(result["current_state_validation_errors"]) == 1
+
+
+# -----------------------------------------------------------------------------
+# ha_manage_energy_prefs — mode="set" write path
+# -----------------------------------------------------------------------------
+
+
+class TestSetPrefs:
+    async def test_shape_error_rejected_before_read(self, tools):
+        bad_config = {"device_consumption": [{"name": "no-stat"}]}
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set", config=bad_config, config_hash="abc",
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        # No WS call should have happened
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_hash_mismatch_rejects_and_does_not_save(self, tools):
+        current_prefs = _sample_prefs()
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+        stale_hash = "deadbeefcafefade"
+        assert stale_hash != compute_config_hash(current_prefs)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set", config=current_prefs, config_hash=stale_hash,
+            )
+        err = json.loads(str(exc_info.value))
+        assert "modified since last read" in json.dumps(err).lower()
+        # Only ONE WS call (the fresh read); no save
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_happy_path_writes_and_validates(self, tools):
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+        new_config = {**current_prefs, "device_consumption": [
+            {"stat_consumption": "sensor.fridge_energy"},
+            {"stat_consumption": "sensor.tv_energy"},
+        ]}
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},         # 1. fresh read
+            {"success": True, "result": None},                   # 2. save_prefs
+            {"success": True, "result": _empty_validate_result()},  # 3. post-save validate
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=new_config, config_hash=hash_,
+        )
+        assert result["success"] is True
+        assert result["mode"] == "set"
+        assert "config_hash" in result
+        assert "post_save_validation_errors" not in result  # none reported
+        assert tools._client.send_websocket_message.call_count == 3
+
+    async def test_save_fails_raises(self, tools):
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": False, "error": "unauthorized"},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set", config=current_prefs, config_hash=hash_,
+            )
+        err = json.loads(str(exc_info.value))
+        assert "SERVICE_CALL_FAILED" in json.dumps(err)
+
+    async def test_post_save_validation_errors_surfaced_as_warning(self, tools):
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": {
+                "energy_sources": [["stat not found"]],
+                "device_consumption": [],
+                "device_consumption_water": [],
+            }},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=current_prefs, config_hash=hash_,
+        )
+        assert result["success"] is True  # save succeeded
+        assert "post_save_validation_errors" in result
+        assert len(result["post_save_validation_errors"]) == 1
+        assert "warning" in result
+
+    async def test_post_save_validation_failure_non_fatal(self, tools):
+        """If the post-save validate itself fails, the save still succeeded."""
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            Exception("validate blew up"),
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=current_prefs, config_hash=hash_,
+        )
+        assert result["success"] is True
+        assert "post_save_validation_errors" not in result
+
+    async def test_save_payload_contains_only_submitted_keys(self, tools):
+        """Full-replace only affects keys explicitly in the submitted payload."""
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+        # Agent only wants to touch device_consumption
+        partial_config = {"device_consumption": [{"stat_consumption": "sensor.new"}]}
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        # Hash must be fresh of the current prefs, not the partial config —
+        # that's the agent's responsibility. For this test we use the right hash.
+        await tools.ha_manage_energy_prefs(
+            mode="set", config=partial_config, config_hash=hash_,
+        )
+        save_call = tools._client.send_websocket_message.call_args_list[1]
+        save_payload = save_call.args[0]
+        assert save_payload["type"] == "energy/save_prefs"
+        assert "device_consumption" in save_payload
+        # energy_sources and device_consumption_water must NOT be in the save
+        # payload — their absence preserves the existing server state.
+        assert "energy_sources" not in save_payload
+        assert "device_consumption_water" not in save_payload
+
+    async def test_set_on_fresh_install_with_default_hash_succeeds(self, tools):
+        """On a fresh HA install, get_prefs yields 'No prefs'. An agent that
+        holds the hash of the empty default (e.g. from a prior mode='get'
+        call that already normalised the No-prefs case) must be able to
+        save through."""
+        empty_default = {
+            "energy_sources": [],
+            "device_consumption": [],
+            "device_consumption_water": [],
+        }
+        default_hash = compute_config_hash(empty_default)
+        new_config = {
+            "device_consumption": [{"stat_consumption": "sensor.first_device"}],
+        }
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": False, "error": "Command failed: No prefs"},  # 1. get
+            {"success": True, "result": None},                         # 2. save
+            {"success": True, "result": _empty_validate_result()},     # 3. post-save validate
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set", config=new_config, config_hash=default_hash,
+        )
+        assert result["success"] is True
+        assert "config_hash" in result
+
+    async def test_set_on_fresh_install_with_wrong_hash_rejects(self, tools):
+        """Even on a fresh install, the hash check protects the write path —
+        a stale hash against the default-empty baseline still fails."""
+        tools._client.send_websocket_message.side_effect = [
+            {"success": False, "error": "Command failed: No prefs"},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config={"device_consumption": [{"stat_consumption": "sensor.x"}]},
+                config_hash="deadbeefcafefade",
+            )
+        err = json.loads(str(exc_info.value))
+        assert "modified since last read" in json.dumps(err).lower()
+        assert tools._client.send_websocket_message.call_count == 1
+
+
+# -----------------------------------------------------------------------------
+# Tool wiring
+# -----------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register_function_exists_and_has_expected_signature(self):
+        import inspect
+
+        from ha_mcp.tools.tools_energy import register_energy_tools
+        sig = inspect.signature(register_energy_tools)
+        params = list(sig.parameters.keys())
+        assert params[0] == "mcp"
+        assert params[1] == "client"
+        # kwargs-accepting for registry compatibility
+        assert any(
+            p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in sig.parameters.values()
+        )

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -369,6 +369,31 @@ class TestDryRun:
         assert result["shape_errors"] == []
         assert len(result["current_state_validation_errors"]) == 1
 
+    async def test_validate_failure_surfaced_as_warning(self, tools, caplog):
+        """If energy/validate returns success=false in dry_run, the caller
+        sees partial/warning rather than a silent empty current_state_errors
+        list."""
+        import logging
+
+        tools._client.send_websocket_message.return_value = {
+            "success": False,
+            "error": "websocket timeout",
+        }
+        with caplog.at_level(logging.WARNING, logger="ha_mcp.tools.tools_energy"):
+            result = await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=_sample_prefs(),
+                dry_run=True,
+            )
+        assert result["success"] is True  # shape is fine
+        assert result["current_state_validation_errors"] == []
+        assert result["partial"] is True
+        assert "websocket timeout" in result["warning"]
+        assert any(
+            "energy/validate (current state) failed" in rec.message
+            for rec in caplog.records
+        )
+
 
 # -----------------------------------------------------------------------------
 # ha_manage_energy_prefs — mode="set" write path
@@ -486,7 +511,11 @@ class TestSetPrefs:
         assert "warning" in result
 
     async def test_post_save_validation_failure_non_fatal(self, tools):
-        """If the post-save validate itself fails, the save still succeeded."""
+        """If the post-save validate itself fails, the save still succeeded.
+
+        The exception-branch sets post_save_validate_error, which surfaces
+        as partial/warning in the response.
+        """
         current_prefs = _sample_prefs()
         hash_ = compute_config_hash(current_prefs)
 
@@ -503,6 +532,37 @@ class TestSetPrefs:
         )
         assert result["success"] is True
         assert "post_save_validation_errors" not in result
+        assert result["partial"] is True
+        assert "validate blew up" in result["warning"]
+
+    async def test_post_save_validate_failure_surfaced_as_warning(self, tools, caplog):
+        """If post-save energy/validate returns success=false, the caller sees
+        partial/warning rather than a silent empty post_save_errors list."""
+        import logging
+
+        current_prefs = _sample_prefs()
+        hash_ = compute_config_hash(current_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": False, "error": "validate endpoint missing"},
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="ha_mcp.tools.tools_energy"):
+            result = await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=current_prefs,
+                config_hash=hash_,
+            )
+        assert result["success"] is True
+        assert "post_save_validation_errors" not in result
+        assert result["partial"] is True
+        assert "validate endpoint missing" in result["warning"]
+        assert any(
+            "energy/validate (post-save) failed" in rec.message
+            for rec in caplog.records
+        )
 
     async def test_save_payload_contains_only_submitted_keys(self, tools):
         """Full-replace only affects keys explicitly in the submitted payload."""

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -82,9 +82,7 @@ class TestFlattenValidationErrors:
             "device_consumption_water": [],
         }
         errors = _flatten_validation_errors(raw)
-        assert errors == [
-            {"path": "energy_sources[0]", "message": "stat not found"}
-        ]
+        assert errors == [{"path": "energy_sources[0]", "message": "stat not found"}]
 
     def test_dict_per_entry_with_field_paths(self):
         raw = {
@@ -95,8 +93,14 @@ class TestFlattenValidationErrors:
             "device_consumption_water": [],
         }
         errors = _flatten_validation_errors(raw)
-        assert {"path": "device_consumption[0].stat_consumption", "message": "unit mismatch"} in errors
-        assert {"path": "device_consumption[0].stat_consumption", "message": "stat missing"} in errors
+        assert {
+            "path": "device_consumption[0].stat_consumption",
+            "message": "unit mismatch",
+        } in errors
+        assert {
+            "path": "device_consumption[0].stat_consumption",
+            "message": "stat missing",
+        } in errors
         assert len(errors) == 2
 
 
@@ -118,15 +122,19 @@ class TestShapeCheck:
         assert {"path": "device_consumption", "message": "must be a list"} in errors
 
     def test_energy_source_missing_type(self):
-        errors = _shape_check({
-            "energy_sources": [{"stat_energy_from": "sensor.x"}],
-        })
+        errors = _shape_check(
+            {
+                "energy_sources": [{"stat_energy_from": "sensor.x"}],
+            }
+        )
         assert any("type" in e["message"] for e in errors)
 
     def test_device_consumption_missing_stat_consumption(self):
-        errors = _shape_check({
-            "device_consumption": [{"name": "anonymous"}],
-        })
+        errors = _shape_check(
+            {
+                "device_consumption": [{"name": "anonymous"}],
+            }
+        )
         assert any("stat_consumption" in e["message"] for e in errors)
 
     def test_entry_not_a_dict(self):
@@ -245,7 +253,9 @@ class TestDryRun:
             "result": _empty_validate_result(),
         }
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=_sample_prefs(), dry_run=True,
+            mode="set",
+            config=_sample_prefs(),
+            dry_run=True,
         )
         assert result["success"] is True
         assert result["shape_errors"] == []
@@ -258,11 +268,88 @@ class TestDryRun:
         }
         bad_config = {"energy_sources": [{"stat_energy_from": "sensor.x"}]}
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=bad_config, dry_run=True,
+            mode="set",
+            config=bad_config,
+            dry_run=True,
         )
         assert result["success"] is False
         assert len(result["shape_errors"]) > 0
         assert any("type" in e["message"] for e in result["shape_errors"])
+
+    async def test_shape_errors_energy_sources_enum_and_conditional(self, tools):
+        """G1b + G1c coverage:
+        - invalid type reports as '.type' path with enum message
+        - solar/battery/gas without stat_energy_from reports required
+        - grid without stat_energy_from is valid (HA core schema: Optional)
+        """
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": _empty_validate_result(),
+        }
+
+        # Invalid type
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "wind", "stat_energy_from": "s.x"}]},
+            dry_run=True,
+        )
+        assert result["success"] is False
+        assert any(
+            e["path"].endswith(".type") and "invalid type 'wind'" in e["message"]
+            for e in result["shape_errors"]
+        )
+
+        # Solar without stat_energy_from
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "solar"}]},
+            dry_run=True,
+        )
+        assert result["success"] is False
+        assert any(
+            "solar entries require 'stat_energy_from'" in e["message"]
+            for e in result["shape_errors"]
+        )
+
+        # Battery without stat_energy_from
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "battery"}]},
+            dry_run=True,
+        )
+        assert result["success"] is False
+        assert any(
+            "battery entries require 'stat_energy_from'" in e["message"]
+            for e in result["shape_errors"]
+        )
+
+        # Gas without stat_energy_from
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "gas"}]},
+            dry_run=True,
+        )
+        assert result["success"] is False
+        assert any(
+            "gas entries require 'stat_energy_from'" in e["message"]
+            for e in result["shape_errors"]
+        )
+
+        # Grid without stat_energy_from (valid per HA core schema)
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "grid"}]},
+            dry_run=True,
+        )
+        # Grid is valid: no shape errors about stat_energy_from on grid.
+        # (Other fields may still be complained about, but stat_energy_from
+        # must NOT appear in shape_errors for type=grid.)
+        grid_stat_errors = [
+            e
+            for e in result.get("shape_errors", [])
+            if "stat_energy_from" in e["message"]
+        ]
+        assert grid_stat_errors == []
 
     async def test_current_state_errors_surfaced_separately(self, tools):
         tools._client.send_websocket_message.return_value = {
@@ -274,7 +361,9 @@ class TestDryRun:
             },
         }
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=_sample_prefs(), dry_run=True,
+            mode="set",
+            config=_sample_prefs(),
+            dry_run=True,
         )
         assert result["success"] is True  # shape is fine
         assert result["shape_errors"] == []
@@ -291,7 +380,9 @@ class TestSetPrefs:
         bad_config = {"device_consumption": [{"name": "no-stat"}]}
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_manage_energy_prefs(
-                mode="set", config=bad_config, config_hash="abc",
+                mode="set",
+                config=bad_config,
+                config_hash="abc",
             )
         err = json.loads(str(exc_info.value))
         assert "VALIDATION_FAILED" in json.dumps(err)
@@ -308,29 +399,40 @@ class TestSetPrefs:
 
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_manage_energy_prefs(
-                mode="set", config=current_prefs, config_hash=stale_hash,
+                mode="set",
+                config=current_prefs,
+                config_hash=stale_hash,
             )
         err = json.loads(str(exc_info.value))
         assert "modified since last read" in json.dumps(err).lower()
+        assert "RESOURCE_LOCKED" in json.dumps(err)
         # Only ONE WS call (the fresh read); no save
         assert tools._client.send_websocket_message.call_count == 1
 
     async def test_happy_path_writes_and_validates(self, tools):
         current_prefs = _sample_prefs()
         hash_ = compute_config_hash(current_prefs)
-        new_config = {**current_prefs, "device_consumption": [
-            {"stat_consumption": "sensor.fridge_energy"},
-            {"stat_consumption": "sensor.tv_energy"},
-        ]}
+        new_config = {
+            **current_prefs,
+            "device_consumption": [
+                {"stat_consumption": "sensor.fridge_energy"},
+                {"stat_consumption": "sensor.tv_energy"},
+            ],
+        }
 
         tools._client.send_websocket_message.side_effect = [
-            {"success": True, "result": current_prefs},         # 1. fresh read
-            {"success": True, "result": None},                   # 2. save_prefs
-            {"success": True, "result": _empty_validate_result()},  # 3. post-save validate
+            {"success": True, "result": current_prefs},  # 1. fresh read
+            {"success": True, "result": None},  # 2. save_prefs
+            {
+                "success": True,
+                "result": _empty_validate_result(),
+            },  # 3. post-save validate
         ]
 
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=new_config, config_hash=hash_,
+            mode="set",
+            config=new_config,
+            config_hash=hash_,
         )
         assert result["success"] is True
         assert result["mode"] == "set"
@@ -349,7 +451,9 @@ class TestSetPrefs:
 
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_manage_energy_prefs(
-                mode="set", config=current_prefs, config_hash=hash_,
+                mode="set",
+                config=current_prefs,
+                config_hash=hash_,
             )
         err = json.loads(str(exc_info.value))
         assert "SERVICE_CALL_FAILED" in json.dumps(err)
@@ -361,15 +465,20 @@ class TestSetPrefs:
         tools._client.send_websocket_message.side_effect = [
             {"success": True, "result": current_prefs},
             {"success": True, "result": None},
-            {"success": True, "result": {
-                "energy_sources": [["stat not found"]],
-                "device_consumption": [],
-                "device_consumption_water": [],
-            }},
+            {
+                "success": True,
+                "result": {
+                    "energy_sources": [["stat not found"]],
+                    "device_consumption": [],
+                    "device_consumption_water": [],
+                },
+            },
         ]
 
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=current_prefs, config_hash=hash_,
+            mode="set",
+            config=current_prefs,
+            config_hash=hash_,
         )
         assert result["success"] is True  # save succeeded
         assert "post_save_validation_errors" in result
@@ -388,7 +497,9 @@ class TestSetPrefs:
         ]
 
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=current_prefs, config_hash=hash_,
+            mode="set",
+            config=current_prefs,
+            config_hash=hash_,
         )
         assert result["success"] is True
         assert "post_save_validation_errors" not in result
@@ -409,7 +520,9 @@ class TestSetPrefs:
         # Hash must be fresh of the current prefs, not the partial config —
         # that's the agent's responsibility. For this test we use the right hash.
         await tools.ha_manage_energy_prefs(
-            mode="set", config=partial_config, config_hash=hash_,
+            mode="set",
+            config=partial_config,
+            config_hash=hash_,
         )
         save_call = tools._client.send_websocket_message.call_args_list[1]
         save_payload = save_call.args[0]
@@ -437,12 +550,17 @@ class TestSetPrefs:
 
         tools._client.send_websocket_message.side_effect = [
             {"success": False, "error": "Command failed: No prefs"},  # 1. get
-            {"success": True, "result": None},                         # 2. save
-            {"success": True, "result": _empty_validate_result()},     # 3. post-save validate
+            {"success": True, "result": None},  # 2. save
+            {
+                "success": True,
+                "result": _empty_validate_result(),
+            },  # 3. post-save validate
         ]
 
         result = await tools.ha_manage_energy_prefs(
-            mode="set", config=new_config, config_hash=default_hash,
+            mode="set",
+            config=new_config,
+            config_hash=default_hash,
         )
         assert result["success"] is True
         assert "config_hash" in result
@@ -475,12 +593,12 @@ class TestRegistration:
         import inspect
 
         from ha_mcp.tools.tools_energy import register_energy_tools
+
         sig = inspect.signature(register_energy_tools)
         params = list(sig.parameters.keys())
         assert params[0] == "mcp"
         assert params[1] == "client"
         # kwargs-accepting for registry compatibility
         assert any(
-            p.kind == inspect.Parameter.VAR_KEYWORD
-            for p in sig.parameters.values()
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
         )


### PR DESCRIPTION
Closes #1033.

## What

Adds `ha_manage_energy_prefs`, a single tool with `mode="get"` / `mode="set"` wrapping Home Assistant's `energy/get_prefs` and `energy/save_prefs` WebSocket commands. The Energy Dashboard configuration is otherwise unreachable via REST, services, or helper flows — agents currently cannot add a newly-paired smart plug to the Energy Dashboard programmatically.

## Design choices

**Single `manage` tool, not a `get`+`set` pair.** Read-modify-write is the only safe workflow given the API's destructive per-key full-replace semantics (sending `{"device_consumption": [<one>]}` silently deletes every other device). Mirrors the `ha_manage_addon` consolidation (#978).

**Required `config_hash` on write, no force-write escape hatch.** Primary mitigation for the full-replace footgun; also covers concurrent-editing. Follows `compute_config_hash` usage in `tools_config_dashboards.py`.

**Local shape check + post-save server-side validate.** HA Core's `energy/validate` does not accept an unsubmitted payload — it validates the currently-persisted config — so pre-write validation of the proposed payload is not possible. Post-save residual issues (missing stats, wrong unit classes) surface as `post_save_validation_errors`.

**`dry_run=True`: shape check + current-state validate.** Returns `shape_errors` (for the proposed config) and `current_state_validation_errors` (labelled as reflecting the *persisted* state, since validate can't do the proposal).

**Fresh-install handling.** On an HA instance that has never had the Energy Dashboard configured, `energy/get_prefs` returns `ERR_NOT_FOUND "No prefs"`. The tool maps that to the documented empty default so the workflow is uniform across fresh and configured instances. Caught by the E2E test against a fresh testcontainer.

## Tests

- **Unit (30 tests):** every state-machine branch — success and error paths, `config_hash` mismatch, shape errors before any WS call, post-save validate failures treated as non-fatal, fresh-install `No prefs` handling in both `get` and `set`.
- **E2E (2 tests):** read-only `mode="get"` against the freshly-initialised testcontainer — tool registration, WebSocket round-trip, response shape, hash determinism. Write paths are unit-only to avoid coupling CI to container-persisted energy state.

ruff + mypy clean.

## Deferred as follow-ups

- **Per-key hashes:** partial updates with one hash per top-level key. Architecturally cleaner but introduces a new pattern the codebase doesn't use elsewhere — separate design discussion.
- **Convenience helpers** (e.g. `add_device_to_energy_dashboard` doing read-modify-write internally): violates the tool-consolidation guideline. Primitive-tool approach is deliberate.

---

Non-maintainer contribution. Merge decision stays with the maintainers.

Coverage gap: `gas` energy sources and `device_consumption_water` entries are shape-checked but not exercised against live HA — neither is configured on my instance.
