### PR TITLE
feat: expose allowlist_external_dirs in ha_get_overview full system_info

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -666,6 +666,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "safe_mode": config.get("safe_mode", False),
                         "internal_url": config.get("internal_url"),
                         "external_url": config.get("external_url"),
+                        "allowlist_external_dirs": config.get(
+                            "allowlist_external_dirs", []
+                        ),
                     }
                 )
             result["system_info"] = system_info

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -666,8 +666,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "safe_mode": config.get("safe_mode", False),
                         "internal_url": config.get("internal_url"),
                         "external_url": config.get("external_url"),
+                        # No default: distinguish HA-not-exposing-the-key (None)
+                        # from empty-allowlist ([]) — security-relevant for agents.
                         "allowlist_external_dirs": config.get(
-                            "allowlist_external_dirs", []
+                            "allowlist_external_dirs"
                         ),
                     }
                 )

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -299,10 +299,16 @@ class TestSystemTools:
             "location_name",
             "time_zone",
             "components_loaded",
+            "allowlist_external_dirs",
         ]
 
         for field in expected_fields:
             assert field in system_info, f"Missing expected field in system_info: {field}"
+
+        # allowlist_external_dirs is always a list (possibly empty)
+        assert isinstance(system_info["allowlist_external_dirs"], list), (
+            "allowlist_external_dirs should be a list"
+        )
 
         # Log key information
         logger.info(f"Home Assistant version: {system_info.get('version')}")

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -310,7 +310,7 @@ class TestSystemTools:
             "allowlist_external_dirs should be a list"
         )
 
-        # Negative guard: field must not leak at lower detail levels
+        # Negative guard: full-only fields must not leak at lower detail levels
         minimal_result = await mcp_client.call_tool(
             "ha_get_overview", {"detail_level": "minimal"}
         )
@@ -318,8 +318,22 @@ class TestSystemTools:
         assert minimal_data.get("success") is True, (
             f"Minimal overview failed: {minimal_data.get('error')}"
         )
-        assert "allowlist_external_dirs" not in minimal_data.get("system_info", {}), (
-            "allowlist_external_dirs should only appear at detail_level='full'"
+        full_only_fields = {
+            "country",
+            "currency",
+            "unit_system",
+            "latitude",
+            "longitude",
+            "elevation",
+            "components_loaded",
+            "safe_mode",
+            "internal_url",
+            "external_url",
+            "allowlist_external_dirs",
+        }
+        leaked = full_only_fields & minimal_data.get("system_info", {}).keys()
+        assert not leaked, (
+            f"full-only fields leaked at detail_level='minimal': {leaked}"
         )
 
         # Log key information

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -310,6 +310,18 @@ class TestSystemTools:
             "allowlist_external_dirs should be a list"
         )
 
+        # Negative guard: field must not leak at lower detail levels
+        minimal_result = await mcp_client.call_tool(
+            "ha_get_overview", {"detail_level": "minimal"}
+        )
+        minimal_data = parse_mcp_result(minimal_result)
+        assert minimal_data.get("success") is True, (
+            f"Minimal overview failed: {minimal_data.get('error')}"
+        )
+        assert "allowlist_external_dirs" not in minimal_data.get("system_info", {}), (
+            "allowlist_external_dirs should only appear at detail_level='full'"
+        )
+
         # Log key information
         logger.info(f"Home Assistant version: {system_info.get('version')}")
         logger.info(f"Location: {system_info.get('location_name')}")

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -305,35 +305,10 @@ class TestSystemTools:
         for field in expected_fields:
             assert field in system_info, f"Missing expected field in system_info: {field}"
 
-        # allowlist_external_dirs is always a list (possibly empty)
-        assert isinstance(system_info["allowlist_external_dirs"], list), (
-            "allowlist_external_dirs should be a list"
-        )
-
-        # Negative guard: full-only fields must not leak at lower detail levels
-        minimal_result = await mcp_client.call_tool(
-            "ha_get_overview", {"detail_level": "minimal"}
-        )
-        minimal_data = parse_mcp_result(minimal_result)
-        assert minimal_data.get("success") is True, (
-            f"Minimal overview failed: {minimal_data.get('error')}"
-        )
-        full_only_fields = {
-            "country",
-            "currency",
-            "unit_system",
-            "latitude",
-            "longitude",
-            "elevation",
-            "components_loaded",
-            "safe_mode",
-            "internal_url",
-            "external_url",
-            "allowlist_external_dirs",
-        }
-        leaked = full_only_fields & minimal_data.get("system_info", {}).keys()
-        assert not leaked, (
-            f"full-only fields leaked at detail_level='minimal': {leaked}"
+        # allowlist_external_dirs is list (HA exposed it) or None (HA omitted the key)
+        allowlist = system_info["allowlist_external_dirs"]
+        assert allowlist is None or isinstance(allowlist, list), (
+            "allowlist_external_dirs should be a list or None"
         )
 
         # Log key information
@@ -357,6 +332,44 @@ class TestSystemTools:
         logger.info(f"Repair count: {data['repair_count']}")
 
         logger.info("Get system overview test completed successfully")
+
+    @pytest.mark.asyncio
+    async def test_overview_minimal_excludes_full_only_fields(self, mcp_client):
+        """
+        Test: full-only system_info fields must not leak at lower detail levels.
+
+        Guards against accidental hoisting of fields out of the
+        `if detail_level == "full":` branch in tools_search.py.
+        """
+        logger.info("Testing minimal overview excludes full-only system_info fields")
+
+        result = await mcp_client.call_tool(
+            "ha_get_overview", {"detail_level": "minimal"}
+        )
+        data = parse_mcp_result(result)
+        assert data.get("success") is True, (
+            f"Minimal overview failed: {data.get('error')}"
+        )
+
+        full_only_fields = {
+            "country",
+            "currency",
+            "unit_system",
+            "latitude",
+            "longitude",
+            "elevation",
+            "components_loaded",
+            "safe_mode",
+            "internal_url",
+            "external_url",
+            "allowlist_external_dirs",
+        }
+        leaked = full_only_fields & data.get("system_info", {}).keys()
+        assert not leaked, (
+            f"full-only fields leaked at detail_level='minimal': {leaked}"
+        )
+
+        logger.info("Minimal overview leak guard completed successfully")
 
     @pytest.mark.asyncio
     async def test_get_system_health(self, mcp_client):

--- a/tests/src/unit/test_overview_system_info.py
+++ b/tests/src/unit/test_overview_system_info.py
@@ -1,0 +1,96 @@
+"""Unit tests for ha_get_overview system_info builder."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ha_mcp.tools.tools_search import register_search_tools
+
+
+class TestHaGetOverviewSystemInfo:
+    """Test system_info field assembly in ha_get_overview at detail_level='full'."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        """Create a mock MCP server that captures registered tool functions."""
+        mcp = MagicMock()
+        self.registered_tools = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock Home Assistant client with default-empty config."""
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(return_value={})
+        client.send_websocket_message = AsyncMock(return_value={"success": False})
+        return client
+
+    @pytest.fixture
+    def mock_smart_tools(self):
+        """Create a mock smart_tools that returns a minimal success result."""
+        smart = MagicMock()
+        smart.get_system_overview = AsyncMock(return_value={"success": True})
+        return smart
+
+    @pytest.fixture
+    def overview_tool(self, mock_mcp, mock_client, mock_smart_tools):
+        """Register search tools and return the ha_get_overview function."""
+        register_search_tools(mock_mcp, mock_client, smart_tools=mock_smart_tools)
+        return self.registered_tools["ha_get_overview"]
+
+    @pytest.mark.asyncio
+    async def test_allowlist_external_dirs_missing_key_yields_none(
+        self, mock_client, overview_tool
+    ):
+        """When HA config omits the key entirely, the field is None — not [].
+
+        Distinguishes 'HA didn't expose the key' from 'HA reported an empty
+        allowlist' for security-sensitive agent reasoning. Locks in the contract
+        so a future refactor cannot silently switch the default back to [].
+        """
+        mock_client.get_config = AsyncMock(return_value={})
+
+        result = await overview_tool(detail_level="full")
+
+        system_info = result["system_info"]
+        assert "allowlist_external_dirs" in system_info
+        assert system_info["allowlist_external_dirs"] is None
+
+    @pytest.mark.asyncio
+    async def test_allowlist_external_dirs_passes_through_list_value(
+        self, mock_client, overview_tool
+    ):
+        """When HA config exposes the key, the list value passes through unchanged."""
+        mock_client.get_config = AsyncMock(
+            return_value={"allowlist_external_dirs": ["/media", "/share"]}
+        )
+
+        result = await overview_tool(detail_level="full")
+
+        assert result["system_info"]["allowlist_external_dirs"] == [
+            "/media",
+            "/share",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_allowlist_external_dirs_omitted_at_minimal_detail_level(
+        self, mock_client, overview_tool
+    ):
+        """The field must not appear in system_info when detail_level != 'full'."""
+        mock_client.get_config = AsyncMock(
+            return_value={"allowlist_external_dirs": ["/media"]}
+        )
+
+        result = await overview_tool(detail_level="minimal")
+
+        assert "allowlist_external_dirs" not in result["system_info"]


### PR DESCRIPTION
## What does this PR do?

Adds `allowlist_external_dirs` to the `system_info` block returned by
`ha_get_overview(detail_level="full")`.

Home Assistant permits file operations only under an explicit list of
filesystem paths (e.g. for `media_source`, `notify.file`, image uploads).
Agents reasoning about file I/O need visibility into this list to know
whether a proposed path will be reachable — otherwise a service call
fails after the decision has already been made.

The field name matches Home Assistant core (`allowlist_*`), not the
legacy `whitelist_*` alias.

Follow-up to discussion #997.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed