### PR TITLE
test(uat): give find-automations story a unique id

### DIFF
--- a/tests/uat/stories/catalog/s14_find_automations_by_entity.yaml
+++ b/tests/uat/stories/catalog/s14_find_automations_by_entity.yaml
@@ -1,4 +1,4 @@
-id: s13
+id: s14
 title: "Find automations and scripts that reference a specific entity"
 category: automation
 weight: 3


### PR DESCRIPTION
## What does this PR do?

Two UAT story catalog files shared `id: s13`, so when both ran the second story silently overwrote the first during pytest parameterization. In a recent UAT run the first `s13` ("Comprehensive dashboard operations") ran its tools but its verification block never appeared in the output, while the runner still reported both as PASS.

Rename `tests/uat/stories/catalog/s13_find_automations_by_entity.yaml` → `s14_find_automations_by_entity.yaml` and update the internal `id: s13` → `id: s14`. The dashboard story keeps `s13`.

## Type of change
- [x] 🧪 Tests only

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

`uv run pytest tests/uat/stories/ --collect-only -q` now collects 14 unique stories (`s01` through `s14`) with no id collision.

## Checklist
- [x] I have updated documentation if needed