### PR TITLE
test(e2e): add A2 negative-input tests for optional-id list-or-detail tools

### DIFF
--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -183,8 +183,8 @@ class TestBlueprintManagement:
             assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
                 f"Expected error code RESOURCE_NOT_FOUND, got: {result['error']}"
             )
-            assert "suggestions" in result["error"], (
-                "Error response should include suggestions"
+            assert "suggestion" in result["error"] or "suggestions" in result["error"], (
+                "Error response should include a suggestion or suggestions"
             )
             logger.info("ha_get_blueprint properly handles non-existent blueprint")
 

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -181,13 +181,9 @@ class TestBlueprintManagement:
             )
 
             assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
-                f"Expected error code RESOURCE_NOT_FOUND, got: {result.get('error')}"
+                f"Expected error code RESOURCE_NOT_FOUND, got: {result['error']}"
             )
-            error_msg = str(result.get("error", "")).lower()
-            assert "not found" in error_msg, (
-                f"Expected 'not found' in error message, got: {result.get('error')}"
-            )
-            assert "suggestions" in result.get("error", {}), (
+            assert "suggestions" in result["error"], (
                 "Error response should include suggestions"
             )
             logger.info("ha_get_blueprint properly handles non-existent blueprint")

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -183,8 +183,8 @@ class TestBlueprintManagement:
             assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
                 f"Expected error code RESOURCE_NOT_FOUND, got: {result['error']}"
             )
-            assert "suggestion" in result["error"] or "suggestions" in result["error"], (
-                "Error response should include a suggestion or suggestions"
+            assert "suggestion" in result["error"], (
+                "Error response should include a suggestion"
             )
             logger.info("ha_get_blueprint properly handles non-existent blueprint")
 

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -160,9 +160,15 @@ class TestBlueprintManagement:
 
     async def test_get_blueprint_not_found(self, mcp_client):
         """
-        Test: Get blueprint that doesn't exist
+        Test: ha_get_blueprint with a nonexistent path returns a structured
+        error with code RESOURCE_NOT_FOUND, not success=True.
 
-        Validates proper error handling when blueprint path doesn't exist.
+        Source path: tools_blueprints.py — when the requested path is absent
+        from the blueprints registry, raise_tool_error is invoked with
+        ErrorCode.RESOURCE_NOT_FOUND and the message "Blueprint not found: ...".
+
+        Hardened from suggestions-only check to explicit error-code and
+        message-substring assertions.
         """
         logger.info("Testing ha_get_blueprint with non-existent path...")
 
@@ -170,12 +176,20 @@ class TestBlueprintManagement:
             # Try to get a non-existent blueprint
             result = await mcp.call_tool_failure(
                 "ha_get_blueprint",
-                {"path": "nonexistent/blueprint_xyz.yaml", "domain": "automation"},
+                {"path": "nonexistent/blueprint_a2_e2e_xyz_404.yaml", "domain": "automation"},
                 expected_error="not found",
             )
 
-            # Verify error response includes suggestions (nested under "error")
-            assert "suggestions" in result.get("error", {}), "Error response should include suggestions"
+            assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
+                f"Expected error code RESOURCE_NOT_FOUND, got: {result.get('error')}"
+            )
+            error_msg = str(result.get("error", "")).lower()
+            assert "not found" in error_msg, (
+                f"Expected 'not found' in error message, got: {result.get('error')}"
+            )
+            assert "suggestions" in result.get("error", {}), (
+                "Error response should include suggestions"
+            )
             logger.info("ha_get_blueprint properly handles non-existent blueprint")
 
     async def test_get_blueprint_invalid_domain(self, mcp_client):

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -167,8 +167,8 @@ class TestBlueprintManagement:
         from the blueprints registry, raise_tool_error is invoked with
         ErrorCode.RESOURCE_NOT_FOUND and the message "Blueprint not found: ...".
 
-        Hardened from suggestions-only check to explicit error-code and
-        message-substring assertions.
+        Hardened from a single suggestions-presence check to explicit
+        error-code and structured suggestion-presence assertions.
         """
         logger.info("Testing ha_get_blueprint with non-existent path...")
 

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -226,11 +226,11 @@ class TestLabelCRUD:
             f"Should fail for non-existent label: {data}"
         )
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
-            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+            f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
-        error_msg = str(data.get("error", "")).lower()
+        error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
-            f"Expected 'not found' in error message, got: {data.get('error')}"
+            f"Expected 'not found' in error message, got: {data['error']}"
         )
         logger.info("Non-existent label properly returned error")
 

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -202,17 +202,35 @@ class TestLabelCRUD:
         )
 
     async def test_get_nonexistent_label(self, mcp_client):
-        """Test getting a non-existent label."""
+        """
+        Test: ha_config_get_label with a nonexistent label_id returns a
+        structured error with code ENTITY_NOT_FOUND, not success=True.
+
+        Source path: tools_labels.py — after listing labels via WebSocket,
+        the requested label_id is looked up in the result. When absent,
+        raise_tool_error is invoked with ErrorCode.ENTITY_NOT_FOUND and the
+        message "Label not found: ...".
+
+        Hardened from success-only check to explicit error-code and
+        message-substring assertions.
+        """
         logger.info("Testing get non-existent label")
 
         data = await safe_call_tool(
             mcp_client,
             "ha_config_get_label",
-            {"label_id": "nonexistent_label_xyz_12345"},
+            {"label_id": "nonexistent_label_a2_e2e_xyz_404"},
         )
 
         assert data.get("success") is False, (
             f"Should fail for non-existent label: {data}"
+        )
+        assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
+            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "not found" in error_msg, (
+            f"Expected 'not found' in error message, got: {data.get('error')}"
         )
         logger.info("Non-existent label properly returned error")
 

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -228,6 +228,9 @@ class TestLabelCRUD:
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
             f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
+        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
+            "Error response should include a suggestion or suggestions"
+        )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
             f"Expected 'not found' in error message, got: {data['error']}"

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -228,8 +228,8 @@ class TestLabelCRUD:
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
             f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
-        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
-            "Error response should include a suggestion or suggestions"
+        assert "suggestion" in data["error"], (
+            "Error response should include a suggestion"
         )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (

--- a/tests/src/e2e/workflows/integrations/test_list_integrations.py
+++ b/tests/src/e2e/workflows/integrations/test_list_integrations.py
@@ -460,6 +460,9 @@ class TestGetIntegrationNegativeInputs:
         assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
             f"Expected error code RESOURCE_NOT_FOUND, got: {data['error']}"
         )
+        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
+            "Error response should include a suggestion or suggestions"
+        )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
             f"Expected 'not found' in error message, got: {data['error']}"

--- a/tests/src/e2e/workflows/integrations/test_list_integrations.py
+++ b/tests/src/e2e/workflows/integrations/test_list_integrations.py
@@ -460,8 +460,8 @@ class TestGetIntegrationNegativeInputs:
         assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
             f"Expected error code RESOURCE_NOT_FOUND, got: {data['error']}"
         )
-        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
-            "Error response should include a suggestion or suggestions"
+        assert "suggestion" in data["error"], (
+            "Error response should include a suggestion"
         )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (

--- a/tests/src/e2e/workflows/integrations/test_list_integrations.py
+++ b/tests/src/e2e/workflows/integrations/test_list_integrations.py
@@ -12,7 +12,7 @@ import logging
 
 import pytest
 
-from ...utilities.assertions import assert_mcp_success
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -421,3 +421,46 @@ async def test_integration_discovery(mcp_client):
     logger.info(
         f"Integration discovery test passed: found {data['total_count']} integrations"
     )
+
+
+@pytest.mark.integrations
+class TestGetIntegrationNegativeInputs:
+    """
+    A2 negative-input tests for ha_get_integration's single-entry lookup mode.
+
+    Covers the nonexistent-entry_id failure path (entry_id provided, no match
+    in the config-entry registry). The existing tests in this file exercise
+    the list/query/domain-filter modes, which return empty results rather
+    than errors — that is A4-style behavior. The entry_id branch goes through
+    a distinct error path and was previously untested.
+
+    Methodology: source-verified against tools_integrations.py. When
+    _get_single_entry encounters a 404 from the underlying REST/WebSocket
+    call, raise_tool_error is invoked with ErrorCode.RESOURCE_NOT_FOUND and
+    the message "Config entry not found: ...".
+    """
+
+    async def test_get_integration_nonexistent_entry_id(self, mcp_client):
+        """
+        Test: ha_get_integration(entry_id="<nonexistent>") returns a
+        structured error with code RESOURCE_NOT_FOUND, not success=True.
+
+        Source path: tools_integrations.py — _get_single_entry catches a
+        404/not-found exception and raises RESOURCE_NOT_FOUND.
+        """
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_get_integration",
+            {"entry_id": "nonexistent_entry_a2_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent entry_id, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected error code RESOURCE_NOT_FOUND, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "not found" in error_msg, (
+            f"Expected 'not found' in error message, got: {data.get('error')}"
+        )

--- a/tests/src/e2e/workflows/integrations/test_list_integrations.py
+++ b/tests/src/e2e/workflows/integrations/test_list_integrations.py
@@ -458,9 +458,9 @@ class TestGetIntegrationNegativeInputs:
             f"Expected failure for nonexistent entry_id, got success=True: {data}"
         )
         assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
-            f"Expected error code RESOURCE_NOT_FOUND, got: {data.get('error')}"
+            f"Expected error code RESOURCE_NOT_FOUND, got: {data['error']}"
         )
-        error_msg = str(data.get("error", "")).lower()
+        error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
-            f"Expected 'not found' in error message, got: {data.get('error')}"
+            f"Expected 'not found' in error message, got: {data['error']}"
         )

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -625,3 +625,46 @@ async def test_device_entity_independence(mcp_client):
     assert restore_data.get("success"), f"Failed to restore device name: {restore_data}"
 
     logger.info("Device/entity naming independence test completed")
+
+
+@pytest.mark.registry
+class TestDeviceGetNegativeInputs:
+    """
+    A2 negative-input tests for ha_get_device's single-device lookup mode.
+
+    Covers the nonexistent-device_id failure path. Existing tests in this
+    file exercise the list mode, area/manufacturer filters, and the
+    update/remove flows, but never call ha_get_device with a device_id
+    that is absent from the device registry.
+
+    Methodology: source-verified against tools_registry.py. When the
+    requested device_id is not present in the device registry list,
+    raise_tool_error is invoked with ErrorCode.ENTITY_NOT_FOUND and the
+    message "Device not found: ...".
+    """
+
+    async def test_get_device_nonexistent_device_id(self, mcp_client):
+        """
+        Test: ha_get_device(device_id="<nonexistent>") returns a structured
+        error with code ENTITY_NOT_FOUND, not success=True.
+
+        Source path: tools_registry.py — single-device lookup branch returns
+        ENTITY_NOT_FOUND when the device_id is absent from
+        config/device_registry/list.
+        """
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_get_device",
+            {"device_id": "nonexistent_device_a2_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent device_id, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
+            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "not found" in error_msg, (
+            f"Expected 'not found' in error message, got: {data.get('error')}"
+        )

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -662,9 +662,9 @@ class TestDeviceGetNegativeInputs:
             f"Expected failure for nonexistent device_id, got success=True: {data}"
         )
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
-            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+            f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
-        error_msg = str(data.get("error", "")).lower()
+        error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
-            f"Expected 'not found' in error message, got: {data.get('error')}"
+            f"Expected 'not found' in error message, got: {data['error']}"
         )

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -664,8 +664,8 @@ class TestDeviceGetNegativeInputs:
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
             f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
-        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
-            "Error response should include a suggestion or suggestions"
+        assert "suggestion" in data["error"], (
+            "Error response should include a suggestion"
         )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -664,6 +664,9 @@ class TestDeviceGetNegativeInputs:
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
             f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
+        assert "suggestion" in data["error"] or "suggestions" in data["error"], (
+            "Error response should include a suggestion or suggestions"
+        )
         error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
             f"Expected 'not found' in error message, got: {data['error']}"

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -534,3 +534,48 @@ async def test_update_tools_discovery(mcp_client):
     )
 
     logger.info("Update tools discovery test passed")
+
+
+@pytest.mark.updates
+class TestUpdatesGetNegativeInputs:
+    """
+    A2 negative-input tests for ha_get_updates' single-entity detail mode.
+
+    Covers the nonexistent-entity_id failure path. Existing tests in this
+    file exercise listing, release-notes inclusion, and edge cases on real
+    update entities, but do not call ha_get_updates with an entity_id that
+    has no matching update.
+
+    Methodology: source-verified against tools_updates.py. _get_update_details
+    fetches the entity state via REST; a 404 from /api/states/<entity_id>
+    raises HomeAssistantAPIError("API error: 404 - Entity not found.").
+    The except-Exception branch in ha_get_updates matches "404" / "not found"
+    in the error message and raises ErrorCode.ENTITY_NOT_FOUND. Live-probed
+    against a real HA instance: GET /api/states/update.<nonexistent> returns
+    HTTP 404 with body {"message": "Entity not found."}.
+    """
+
+    async def test_get_updates_nonexistent_entity_id(self, mcp_client):
+        """
+        Test: ha_get_updates(entity_id="update.<nonexistent>") returns a
+        structured error with code ENTITY_NOT_FOUND, not success=True.
+
+        Source path: REST 404 → HomeAssistantAPIError → except-Exception
+        in ha_get_updates → ENTITY_NOT_FOUND.
+        """
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_get_updates",
+            {"entity_id": "update.nonexistent_a2_e2e_xyz_404"},
+        )
+
+        assert not data.get("success"), (
+            f"Expected failure for nonexistent update entity_id, got success=True: {data}"
+        )
+        assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
+            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+        )
+        error_msg = str(data.get("error", "")).lower()
+        assert "not found" in error_msg, (
+            f"Expected 'not found' in error message, got: {data.get('error')}"
+        )

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -563,19 +563,16 @@ class TestUpdatesGetNegativeInputs:
         Source path: REST 404 → HomeAssistantAPIError → except-Exception
         in ha_get_updates → ENTITY_NOT_FOUND.
         """
-        data = await safe_call_tool(
-            mcp_client,
-            "ha_get_updates",
-            {"entity_id": "update.nonexistent_a2_e2e_xyz_404"},
-        )
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_failure(
+                "ha_get_updates",
+                {"entity_id": "update.nonexistent_a2_e2e_xyz_404"},
+                expected_error="not found",
+            )
 
-        assert not data.get("success"), (
-            f"Expected failure for nonexistent update entity_id, got success=True: {data}"
-        )
-        assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
-            f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
-        )
-        error_msg = data["error"]["message"].lower()
-        assert "not found" in error_msg, (
-            f"Expected 'not found' in error message, got: {data['error']}"
-        )
+            assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
+                f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
+            )
+            assert "suggestion" in data["error"] or "suggestions" in data["error"], (
+                "Error response should include a suggestion or suggestions"
+            )

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -573,6 +573,6 @@ class TestUpdatesGetNegativeInputs:
             assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
                 f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
             )
-            assert "suggestion" in data["error"] or "suggestions" in data["error"], (
-                "Error response should include a suggestion or suggestions"
+            assert "suggestion" in data["error"], (
+                "Error response should include a suggestion"
             )

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -573,9 +573,9 @@ class TestUpdatesGetNegativeInputs:
             f"Expected failure for nonexistent update entity_id, got success=True: {data}"
         )
         assert data["error"]["code"] == "ENTITY_NOT_FOUND", (
-            f"Expected error code ENTITY_NOT_FOUND, got: {data.get('error')}"
+            f"Expected error code ENTITY_NOT_FOUND, got: {data['error']}"
         )
-        error_msg = str(data.get("error", "")).lower()
+        error_msg = data["error"]["message"].lower()
         assert "not found" in error_msg, (
-            f"Expected 'not found' in error message, got: {data.get('error')}"
+            f"Expected 'not found' in error message, got: {data['error']}"
         )


### PR DESCRIPTION
## What does this PR do?

Adds A2 (optional ID → list-or-detail) negative-input tests from #914. Two existing soft tests are hardened with explicit error-code assertions; three new test classes cover tools that had no negative-input coverage on the single-ID lookup branch.

| Tool | Action | Expected error code |
|---|---|---|
| `ha_get_blueprint` | hardened existing soft test | `RESOURCE_NOT_FOUND` |
| `ha_config_get_label` | hardened existing soft test | `ENTITY_NOT_FOUND` |
| `ha_get_integration` | new `TestGetIntegrationNegativeInputs` (`entry_id` path) | `RESOURCE_NOT_FOUND` |
| `ha_get_device` | new `TestDeviceGetNegativeInputs` (`device_id` path) | `ENTITY_NOT_FOUND` |
| `ha_get_updates` | new `TestUpdatesGetNegativeInputs` (`entity_id` path) | `ENTITY_NOT_FOUND` |

Follows the test pattern established in #1047. References #914.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest` — 5 new/hardened tests pass locally in 13.27s against fresh HA testcontainer (HA 2026.4.1))
- [x] Code follows style guidelines (`uv run ruff check` — all checks passed)

## Checklist
- [x] I have updated documentation if needed (N/A — test-only PR)