### PR TITLE
fix(site): allow text selection in Tool Explorer tool names

### DIFF
--- a/site/src/pages/tools.astro
+++ b/site/src/pages/tools.astro
@@ -181,7 +181,7 @@ function getBadgeInfo(annotations: Record<string, any>) {
                 data-tool-size={totalChars}
                 data-original-desc={tool.description}
               >
-                <button class="tool-header w-full text-left px-4 py-3 flex items-start gap-3">
+                <button class="tool-header select-text w-full text-left px-4 py-3 flex items-start gap-3">
                   <svg class="tool-chevron w-4 h-4 mt-1 text-slate-500 transition-transform shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                   </svg>
@@ -522,6 +522,7 @@ function getBadgeInfo(annotations: Record<string, any>) {
 
   document.querySelectorAll('.tool-header').forEach(header => {
     header.addEventListener('click', () => {
+      if (window.getSelection()?.type === 'Range') return;
       const card = header.closest('.tool-card')!;
       const details = card.querySelector('.tool-details')!;
       const chevron = card.querySelector('.tool-chevron')!;


### PR DESCRIPTION
## What does this PR do?

Tool names in the Tool Explorer could not be selected and copied because they were rendered inside a `<button>` element, which has `user-select: none` by default in browsers.

- Add `select-text` Tailwind class to the button to override `user-select: none`
- Guard the click handler to skip the expand/collapse toggle when the user is selecting text (`Selection.type === 'Range'`)

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed