### PR TITLE
feat: add array_patch mode to ha_manage_addon for atomic GET-modify-POST

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -12,7 +12,7 @@ import json
 import logging
 import re
 import time
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 from urllib.parse import unquote, urlsplit
 
 import httpx
@@ -183,9 +183,7 @@ def _apply_response_transform(response: Any, expr: str) -> Any:
     try:
         return safe_execute_expression(expr, {"response": response}, "response")
     except PythonSandboxError as e:
-        message, suggestions = format_sandbox_error(
-            e, expr, variable_name="response"
-        )
+        message, suggestions = format_sandbox_error(e, expr, variable_name="response")
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_FAILED,
@@ -516,7 +514,9 @@ async def get_addon_info(client: HomeAssistantClient, slug: str) -> dict[str, An
     """
     response = await _supervisor_api_call(client, f"/addons/{slug}/info")
     if not response.get("success"):
-        return response  # TODO(tech-debt): should raise ToolError per AGENTS.md Pattern B
+        return (
+            response  # TODO(tech-debt): should raise ToolError per AGENTS.md Pattern B
+        )
 
     addon = response["result"] if isinstance(response["result"], dict) else {}
     result: dict[str, Any] = {"success": True, "addon": addon}
@@ -549,8 +549,7 @@ def _extract_addon_log_level(addon: dict[str, Any]) -> str | None:
 
     schema = addon.get("schema")
     if isinstance(schema, list) and any(
-        isinstance(item, dict) and item.get("name") == "log_level"
-        for item in schema
+        isinstance(item, dict) and item.get("name") == "log_level" for item in schema
     ):
         return "default"
 
@@ -1086,9 +1085,12 @@ def _apply_array_ops(
         IDs only, no full payloads — so the response stays compact even when
         the underlying array is large.
     """
-    working = list(items)  # shallow copy of the outer list; items themselves
-    # are mutated in place by patch ops, which is fine
-    # because we're going to POST the working list back
+    # Shallow copy of the outer list. The inner item dicts are NOT copied —
+    # patch ops mutate them in place via `target.update(...)`. Callers must
+    # not retain references to `items` and expect them unchanged; this is
+    # safe here because the dispatcher only uses `items` to build the POST
+    # body and then discards it.
+    working = list(items)
 
     summary: dict[str, list[Any]] = {
         "patched": [],
@@ -1814,11 +1816,9 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 description=(
                     "Array-patch mode: atomically GET a JSON array endpoint, "
                     "apply ordered ops, then POST the mutated array back. "
-                    "Shape: {'id_field': '<key>' (default 'id'), "
-                    "'operations': [{'op': 'patch'|'delete'|'add'|'delete_where', ...}, ...]}. "
-                    "Use for addon APIs that expose 'edit-the-whole-collection' write contracts "
-                    "(Node-RED /flows, similar) — avoids the model holding the full array in context. "
-                    "Requires 'path'; mutually exclusive with body/websocket/offset/limit and config params."
+                    "Requires 'path'; mutually exclusive with body / websocket / "
+                    "offset / limit and config params. See the docstring Examples "
+                    "and ha_get_skill_home_assistant_best_practices for op shapes."
                 ),
                 default=None,
             ),
@@ -2032,6 +2032,14 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                         parameter="array_patch",
                     )
                 )
+            id_field = array_patch.get("id_field", "id")
+            if not isinstance(id_field, str) or not id_field:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch.id_field must be a non-empty string",
+                        parameter="array_patch.id_field",
+                    )
+                )
             ops = array_patch.get("operations")
             if not isinstance(ops, list) or not ops:
                 raise_tool_error(
@@ -2138,16 +2146,8 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         # Array-patch mode: GET → mutate → POST atomically.
         # Done before the websocket/HTTP branches so it can fully own the
         # response shape and skip the truncation/pagination paths.
+        # id_field and ops were validated in the early validation block above.
         if array_patch is not None:
-            id_field = array_patch.get("id_field", "id")
-            if not isinstance(id_field, str) or not id_field:
-                raise_tool_error(
-                    create_validation_error(
-                        "array_patch.id_field must be a non-empty string",
-                        parameter="array_patch.id_field",
-                    )
-                )
-
             fetch_result = await _call_addon_api(
                 client=client,
                 slug=slug,
@@ -2171,11 +2171,13 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                     )
                 )
 
-            # Re-narrow operations for the type checker — the earlier
-            # validation block established this but the narrowing doesn't
-            # carry across the intervening config_data branch.
-            assert isinstance(ops, list)
-            new_array, summary = _apply_array_ops(fetched, ops, id_field)
+            # Re-narrow operations for the type checker — the early validation
+            # block established `ops` is a non-empty list, but the narrowing
+            # doesn't carry across the intervening config_data branch.
+            # cast() (vs assert) keeps the narrowing under `python -O`.
+            new_array, summary = _apply_array_ops(
+                fetched, cast(list[Any], ops), id_field
+            )
 
             # POST response is small (deploy revision string or status); skip
             # raw mode here so the size-based truncation guard is in effect.

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1253,6 +1253,7 @@ async def _call_addon_api(
     limit: int | None = None,
     python_transform: str | None = None,
     raw: bool = False,
+    extra_headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Call an add-on's web API.
 
@@ -1289,6 +1290,11 @@ async def _call_addon_api(
             placeholder. Used by array_patch mode in ha_manage_addon, which
             needs the full parsed response in memory to apply operations
             even when the JSON is larger than _MAX_RESPONSE_SIZE.
+        extra_headers: Optional caller-supplied request headers. Layered
+            under the proxy's internal framing (`X-Ingress-Path`,
+            `X-Hass-Source`, `Cookie`, `Content-Type`) so the framing
+            always wins on collision. Use this to set addon-API
+            requirements like Node-RED's `Node-RED-Deployment-Type` header.
     """
     # 1. Sanitize path to prevent traversal attacks (including URL-encoded)
     normalized = unquote(path).lstrip("/")
@@ -1340,7 +1346,15 @@ async def _call_addon_api(
     # 5. Resolve route (direct-port / addon-variant / off-host).
     url, headers = await _resolve_http_route(client, addon, normalized, port)
 
-    # 6. Set content type based on body type
+    # 6. Layer caller-supplied headers UNDER the proxy's framing so internal
+    # headers (X-Ingress-Path, X-Hass-Source, Cookie, Content-Type) always
+    # win on collision — a caller cannot forge ingress identity.
+    if extra_headers:
+        merged = dict(extra_headers)
+        merged.update(headers)
+        headers = merged
+
+    # 7. Set content type based on body type
     if isinstance(body, dict | list):
         headers["Content-Type"] = "application/json"
         request_content = json.dumps(body).encode()
@@ -1809,6 +1823,20 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 default=None,
             ),
         ] = None,
+        request_headers: Annotated[
+            dict[str, str] | None,
+            Field(
+                description=(
+                    "Proxy/array-patch mode: extra HTTP headers to send to the addon API. "
+                    "Useful for addon-specific requirements such as Node-RED's "
+                    "`Node-RED-Deployment-Type: full`. The proxy's internal framing "
+                    "(`X-Ingress-Path`, `X-Hass-Source`, `Content-Type`) is layered on "
+                    "top, so caller-supplied values for those keys are overridden. "
+                    "Not valid in config mode."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Manage a Home Assistant add-on — update its configuration or call its internal API.
 
@@ -1884,7 +1912,11 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                     {"op": "add", "item": {"id": "n1", "type": "inject", "z": "tab-id", ...}},
                     {"op": "add", "item": {"id": "n2", "type": "function", "z": "tab-id", ...}},
                 ]},
+                request_headers={"Node-RED-Deployment-Type": "full"},
             )
+        - Custom request headers (proxy mode):
+            ha_manage_addon(slug="...", path="/api/state",
+                            request_headers={"Accept": "text/plain"})
         """
         # Build config payload from provided config parameters
         config_data: dict[str, Any] = {}
@@ -1958,6 +1990,8 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 proxy_overrides.append(("python_transform", "python_transform"))
             if array_patch is not None:
                 proxy_overrides.append(("array_patch", "array_patch"))
+            if request_headers is not None:
+                proxy_overrides.append(("request_headers", "request_headers"))
             if proxy_overrides:
                 raise_tool_error(
                     create_validation_error(
@@ -2122,6 +2156,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 debug=debug,
                 port=port,
                 raw=True,
+                extra_headers=request_headers,
             )
             if not fetch_result.get("success"):
                 raise_tool_error(fetch_result)
@@ -2142,6 +2177,8 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
             assert isinstance(ops, list)
             new_array, summary = _apply_array_ops(fetched, ops, id_field)
 
+            # POST response is small (deploy revision string or status); skip
+            # raw mode here so the size-based truncation guard is in effect.
             post_result = await _call_addon_api(
                 client=client,
                 slug=slug,
@@ -2150,7 +2187,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 body=new_array,
                 debug=debug,
                 port=port,
-                raw=True,
+                extra_headers=request_headers,
             )
             if not post_result.get("success"):
                 raise_tool_error(post_result)
@@ -2224,6 +2261,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
             offset=offset,
             limit=limit,
             python_transform=python_transform,
+            extra_headers=request_headers,
         )
         if not result.get("success"):
             raise_tool_error(result)

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -571,7 +571,9 @@ async def list_addons(
     """
     response = await _supervisor_api_call(client, "/addons")
     if not response.get("success"):
-        return response  # TODO(tech-debt): should raise ToolError per AGENTS.md Pattern B
+        return (
+            response  # TODO(tech-debt): should raise ToolError per AGENTS.md Pattern B
+        )
 
     data = response["result"]
     addons = data.get("addons", [])
@@ -1050,18 +1052,207 @@ async def _call_addon_ws(
     return result
 
 
+_ARRAY_PATCH_OPS = {"patch", "delete", "add", "delete_where"}
+
+# Sentinel used to distinguish "key absent" from "key explicitly set to None"
+# in array_patch validation. dict.get() with this default lets us detect a
+# missing 'value' field without rejecting legitimate {"value": None} ops.
+_ARRAY_PATCH_MISSING: Any = object()
+
+
+def _apply_array_ops(
+    items: list[Any],
+    operations: list[dict[str, Any]],
+    id_field: str,
+) -> tuple[list[Any], dict[str, Any]]:
+    """Apply a sequence of array_patch operations to a list of resource dicts.
+
+    Operations are applied in order against a working copy. Any validation
+    failure (unknown op, missing reference, id collision, missing required
+    field) raises ToolError before the caller posts anything back, giving
+    fail-fast all-or-nothing semantics from the server's perspective.
+
+    Args:
+        items: Current array fetched from the addon (mutated copy is built here).
+        operations: Ordered list of op dicts. Supported shapes:
+            {"op": "patch", "id": <value>, "patches": {field: value, ...}}
+            {"op": "delete", "id": <value>}
+            {"op": "add", "item": {<id_field>: <value>, ...}}
+            {"op": "delete_where", "field": <name>, "value": <value>}
+        id_field: Field name on each item used as its identifier.
+
+    Returns:
+        Tuple of (new_array, summary). Summary lists what each op touched —
+        IDs only, no full payloads — so the response stays compact even when
+        the underlying array is large.
+    """
+    working = list(items)  # shallow copy of the outer list; items themselves
+    # are mutated in place by patch ops, which is fine
+    # because we're going to POST the working list back
+
+    summary: dict[str, list[Any]] = {
+        "patched": [],
+        "deleted": [],
+        "added": [],
+        "deleted_where": [],
+    }
+
+    for index, op_spec in enumerate(operations):
+        if not isinstance(op_spec, dict):
+            raise_tool_error(
+                create_validation_error(
+                    f"array_patch operation #{index} is not an object",
+                    parameter="array_patch.operations",
+                )
+            )
+
+        op = op_spec.get("op")
+        if op not in _ARRAY_PATCH_OPS:
+            raise_tool_error(
+                create_validation_error(
+                    f"array_patch op '{op}' not recognised "
+                    f"(expected one of: {sorted(_ARRAY_PATCH_OPS)})",
+                    parameter=f"array_patch.operations[{index}].op",
+                )
+            )
+
+        if op == "patch":
+            target_id = op_spec.get("id")
+            patches = op_spec.get("patches")
+            if target_id is None:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch patch op #{index} missing 'id'",
+                        parameter=f"array_patch.operations[{index}].id",
+                    )
+                )
+            if not isinstance(patches, dict):
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch patch op #{index} 'patches' must be an object",
+                        parameter=f"array_patch.operations[{index}].patches",
+                    )
+                )
+            target = next(
+                (
+                    it
+                    for it in working
+                    if isinstance(it, dict) and it.get(id_field) == target_id
+                ),
+                None,
+            )
+            if target is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"No item with {id_field}={target_id!r} for patch op #{index}",
+                        context={"id_field": id_field, "id": target_id},
+                    )
+                )
+            target.update(patches)
+            summary["patched"].append({"id": target_id, "fields": list(patches.keys())})
+
+        elif op == "delete":
+            target_id = op_spec.get("id")
+            if target_id is None:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch delete op #{index} missing 'id'",
+                        parameter=f"array_patch.operations[{index}].id",
+                    )
+                )
+            before = len(working)
+            working = [
+                it
+                for it in working
+                if not (isinstance(it, dict) and it.get(id_field) == target_id)
+            ]
+            if len(working) == before:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"No item with {id_field}={target_id!r} for delete op #{index}",
+                        context={"id_field": id_field, "id": target_id},
+                    )
+                )
+            summary["deleted"].append({"id": target_id})
+
+        elif op == "add":
+            new_item = op_spec.get("item")
+            if not isinstance(new_item, dict):
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch add op #{index} 'item' must be an object",
+                        parameter=f"array_patch.operations[{index}].item",
+                    )
+                )
+            if id_field not in new_item:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch add op #{index} 'item' missing id field "
+                        f"{id_field!r}",
+                        parameter=f"array_patch.operations[{index}].item",
+                    )
+                )
+            new_id = new_item[id_field]
+            if any(
+                isinstance(it, dict) and it.get(id_field) == new_id for it in working
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_ALREADY_EXISTS,
+                        f"Item with {id_field}={new_id!r} already exists "
+                        f"(add op #{index})",
+                        context={"id_field": id_field, "id": new_id},
+                    )
+                )
+            working.append(new_item)
+            summary["added"].append({"id": new_id})
+
+        else:  # delete_where
+            field = op_spec.get("field")
+            value = op_spec.get("value", _ARRAY_PATCH_MISSING)
+            if not isinstance(field, str) or not field:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch delete_where op #{index} missing or empty 'field'",
+                        parameter=f"array_patch.operations[{index}].field",
+                    )
+                )
+            if value is _ARRAY_PATCH_MISSING:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch delete_where op #{index} missing 'value'",
+                        parameter=f"array_patch.operations[{index}].value",
+                    )
+                )
+            before = len(working)
+            working = [
+                it
+                for it in working
+                if not (isinstance(it, dict) and it.get(field) == value)
+            ]
+            removed = before - len(working)
+            summary["deleted_where"].append(
+                {"field": field, "value": value, "count": removed}
+            )
+
+    return working, summary
+
+
 async def _call_addon_api(
     client: HomeAssistantClient,
     slug: str,
     path: str,
     method: str = "GET",
-    body: dict[str, Any] | str | None = None,
+    body: dict[str, Any] | list[Any] | str | None = None,
     timeout: int = 30,
     debug: bool = False,
     port: int | None = None,
     offset: int = 0,
     limit: int | None = None,
     python_transform: str | None = None,
+    raw: bool = False,
 ) -> dict[str, Any]:
     """Call an add-on's web API.
 
@@ -1084,7 +1275,7 @@ async def _call_addon_api(
         slug: Add-on slug (e.g., "<prefix>_nodered")
         path: API path relative to add-on root (e.g., "/flows")
         method: HTTP method (GET, POST, PUT, DELETE, PATCH)
-        body: Request body for POST/PUT/PATCH
+        body: Request body for POST/PUT/PATCH (dict, list, or pre-encoded JSON string)
         timeout: Request timeout in seconds (default 30)
         port: Override port to connect to (e.g., direct access port instead of ingress port)
         offset: Skip this many items in array responses (default 0)
@@ -1093,6 +1284,11 @@ async def _call_addon_api(
             parsed response body. The variable ``response`` is bound to
             ``dict | list | str`` depending on content-type. Transform runs
             after offset/limit slicing.
+        raw: Internal flag — when True, skip the size-based truncation that
+            otherwise replaces large array/object responses with an error
+            placeholder. Used by array_patch mode in ha_manage_addon, which
+            needs the full parsed response in memory to apply operations
+            even when the JSON is larger than _MAX_RESPONSE_SIZE.
     """
     # 1. Sanitize path to prevent traversal attacks (including URL-encoded)
     normalized = unquote(path).lstrip("/")
@@ -1145,7 +1341,7 @@ async def _call_addon_api(
     url, headers = await _resolve_http_route(client, addon, normalized, port)
 
     # 6. Set content type based on body type
-    if isinstance(body, dict):
+    if isinstance(body, dict | list):
         headers["Content-Type"] = "application/json"
         request_content = json.dumps(body).encode()
     elif isinstance(body, str):
@@ -1221,43 +1417,45 @@ async def _call_addon_api(
         response_data = _apply_response_transform(response_data, python_transform)
         transformed = True
 
-    # 9. Truncate large responses
+    # 9. Truncate large responses (skipped in raw mode; array_patch needs the
+    #    full parsed payload in memory regardless of size)
     truncated = False
-    if isinstance(response_data, str) and len(response_data) > _MAX_RESPONSE_SIZE:
-        response_data = response_data[:_MAX_RESPONSE_SIZE]
-        truncated = True
-    elif isinstance(response_data, list):
-        serialized = json.dumps(response_data, default=str)
-        if len(serialized) > _MAX_RESPONSE_SIZE:
-            total_items = len(response_data)
-            response_data = {
-                "error": "RESPONSE_TOO_LARGE",
-                "message": f"The JSON array ({len(serialized)} bytes, {total_items} items) exceeds the {_MAX_RESPONSE_SIZE // 1024}KB limit.",
-                "total_items": total_items,
-                "hint": "Use offset and limit to paginate. Example: offset=0, limit=20",
-            }
+    if not raw:
+        if isinstance(response_data, str) and len(response_data) > _MAX_RESPONSE_SIZE:
+            response_data = response_data[:_MAX_RESPONSE_SIZE]
             truncated = True
-    elif isinstance(response_data, dict):
-        serialized = json.dumps(response_data, default=str)
-        if len(serialized) > _MAX_RESPONSE_SIZE:
-            # Show top-level keys and their approximate sizes to help caller
-            # make more targeted API calls
-            key_info = {}
-            for k, v in response_data.items():
-                v_serialized = json.dumps(v, default=str)
-                if isinstance(v, list):
-                    key_info[k] = f"array[{len(v)}] ({len(v_serialized)} bytes)"
-                elif isinstance(v, dict):
-                    key_info[k] = f"object ({len(v_serialized)} bytes)"
-                else:
-                    key_info[k] = f"{type(v).__name__} ({len(v_serialized)} bytes)"
-            response_data = {
-                "error": "RESPONSE_TOO_LARGE",
-                "message": f"The JSON object ({len(serialized)} bytes) exceeds the {_MAX_RESPONSE_SIZE // 1024}KB limit.",
-                "top_level_keys": key_info,
-                "hint": "Use a more specific API path to request individual keys/sections.",
-            }
-            truncated = True
+        elif isinstance(response_data, list):
+            serialized = json.dumps(response_data, default=str)
+            if len(serialized) > _MAX_RESPONSE_SIZE:
+                total_items = len(response_data)
+                response_data = {
+                    "error": "RESPONSE_TOO_LARGE",
+                    "message": f"The JSON array ({len(serialized)} bytes, {total_items} items) exceeds the {_MAX_RESPONSE_SIZE // 1024}KB limit.",
+                    "total_items": total_items,
+                    "hint": "Use offset and limit to paginate. Example: offset=0, limit=20",
+                }
+                truncated = True
+        elif isinstance(response_data, dict):
+            serialized = json.dumps(response_data, default=str)
+            if len(serialized) > _MAX_RESPONSE_SIZE:
+                # Show top-level keys and their approximate sizes to help caller
+                # make more targeted API calls
+                key_info = {}
+                for k, v in response_data.items():
+                    v_serialized = json.dumps(v, default=str)
+                    if isinstance(v, list):
+                        key_info[k] = f"array[{len(v)}] ({len(v_serialized)} bytes)"
+                    elif isinstance(v, dict):
+                        key_info[k] = f"object ({len(v_serialized)} bytes)"
+                    else:
+                        key_info[k] = f"{type(v).__name__} ({len(v_serialized)} bytes)"
+                response_data = {
+                    "error": "RESPONSE_TOO_LARGE",
+                    "message": f"The JSON object ({len(serialized)} bytes) exceeds the {_MAX_RESPONSE_SIZE // 1024}KB limit.",
+                    "top_level_keys": key_info,
+                    "hint": "Use a more specific API path to request individual keys/sections.",
+                }
+                truncated = True
 
     result: dict[str, Any] = {
         "success": response.status_code < 400,
@@ -1596,23 +1794,45 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 default=None,
             ),
         ] = None,
+        array_patch: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description=(
+                    "Array-patch mode: atomically GET a JSON array endpoint, "
+                    "apply ordered ops, then POST the mutated array back. "
+                    "Shape: {'id_field': '<key>' (default 'id'), "
+                    "'operations': [{'op': 'patch'|'delete'|'add'|'delete_where', ...}, ...]}. "
+                    "Use for addon APIs that expose 'edit-the-whole-collection' write contracts "
+                    "(Node-RED /flows, similar) — avoids the model holding the full array in context. "
+                    "Requires 'path'; mutually exclusive with body/websocket/offset/limit and config params."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Manage a Home Assistant add-on — update its configuration or call its internal API.
 
-        Two mutually exclusive operating modes:
+        Three mutually exclusive operating modes:
 
         **Config mode** (when any of options/network/boot/auto_update/watchdog is provided):
         Updates the add-on's Supervisor configuration via POST /addons/{slug}/options.
         All config parameters are optional; only provided fields are updated — current values
         are fetched and merged automatically (including one level of nested dicts).
 
-        **Proxy mode** (when path is provided):
+        **Proxy mode** (when path is provided without array_patch):
         Routes HTTP or WebSocket requests through Home Assistant's Ingress
         proxy by default (works on HAOS, Supervised, and off-host PyPI/uvx
         installs). Pass `port=...` to bypass Ingress and connect directly to
         an add-on's container port — that mode requires the MCP host to
         share Home Assistant's container network (i.e. only the HAOS addon).
         Use ha_get_addon(slug="...") to discover available ports and endpoints.
+
+        **Array-patch mode** (when path AND array_patch are provided):
+        Atomic "GET array, mutate, POST array" workflow for addon APIs whose write
+        contract is "send the whole resource collection back". Operations are applied
+        in order to a working copy; if any op fails validation (unknown id, collision,
+        malformed shape) nothing is posted. Returns a compact summary instead of the
+        full array. Designed for Node-RED /flows and similar endpoints.
 
         **Response shaping (proxy mode):**
         - WebSocket streams can be noisy (ESPHome /validate often emits hundreds of
@@ -1649,6 +1869,22 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         - Quick WS health check (50 msgs, raw): ha_manage_addon(slug="...", path="/logs", websocket=True, message_limit=50, summarize=False)
         - Filter WS errors only: ha_manage_addon(slug="...", path="/validate", websocket=True, python_transform="response = [m for m in response if 'ERROR' in str(m) or 'WARN' in str(m)]")
         - HTTP subset: ha_manage_addon(slug="...", path="/flows", python_transform="response = [f['id'] for f in response]")
+        - Array-patch (Node-RED, rename a node):
+            ha_manage_addon(
+                slug="a0d7b954_nodered", path="/flows",
+                array_patch={"operations": [
+                    {"op": "patch", "id": "abc123", "patches": {"name": "New Name"}},
+                ]},
+            )
+        - Array-patch (Node-RED, replace one tab's nodes atomically):
+            ha_manage_addon(
+                slug="a0d7b954_nodered", path="/flows",
+                array_patch={"operations": [
+                    {"op": "delete_where", "field": "z", "value": "tab-id"},
+                    {"op": "add", "item": {"id": "n1", "type": "inject", "z": "tab-id", ...}},
+                    {"op": "add", "item": {"id": "n2", "type": "function", "z": "tab-id", ...}},
+                ]},
+            )
         """
         # Build config payload from provided config parameters
         config_data: dict[str, Any] = {}
@@ -1720,12 +1956,54 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 proxy_overrides.append(("summarize", "summarize=False"))
             if python_transform is not None:
                 proxy_overrides.append(("python_transform", "python_transform"))
+            if array_patch is not None:
+                proxy_overrides.append(("array_patch", "array_patch"))
             if proxy_overrides:
                 raise_tool_error(
                     create_validation_error(
                         f"Proxy-mode parameters cannot be used in config mode: {', '.join(d for _, d in proxy_overrides)}. "
                         "Remove these parameters or switch to proxy mode by providing 'path'.",
                         parameter=proxy_overrides[0][0],
+                    )
+                )
+
+        # array_patch needs its own input shape validation (the field is dict[str, Any]
+        # at the schema level so the model will happily send malformed payloads)
+        if array_patch is not None:
+            if not isinstance(array_patch, dict):
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch must be an object",
+                        parameter="array_patch",
+                    )
+                )
+            if websocket:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch is HTTP-only and cannot be combined with websocket=True",
+                        parameter="array_patch",
+                    )
+                )
+            if body is not None:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch builds the POST body itself; remove the explicit 'body' parameter",
+                        parameter="array_patch",
+                    )
+                )
+            if offset != 0 or limit is not None:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch needs the full array; offset/limit are not supported in this mode",
+                        parameter="array_patch",
+                    )
+                )
+            ops = array_patch.get("operations")
+            if not isinstance(ops, list) or not ops:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch.operations must be a non-empty list",
+                        parameter="array_patch.operations",
                     )
                 )
 
@@ -1759,8 +2037,12 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                 # lets the caller correct mistakes before any state is changed.
                 schema_ui: list | None = addon_info.get("schema")
                 if schema_ui is not None:
-                    allowed_keys = {item["name"] for item in schema_ui if "name" in item}
-                    ignored_fields = [k for k in config_data["options"] if k not in allowed_keys]
+                    allowed_keys = {
+                        item["name"] for item in schema_ui if "name" in item
+                    }
+                    ignored_fields = [
+                        k for k in config_data["options"] if k not in allowed_keys
+                    ]
                     # Remove unknown fields from the merged dict so Supervisor does not
                     # silently strip them after the write succeeds.
                     for k in ignored_fields:
@@ -1818,6 +2100,78 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         # Proxy mode: call add-on container API
         # At this point path is guaranteed non-None (validated above)
         assert path is not None
+
+        # Array-patch mode: GET → mutate → POST atomically.
+        # Done before the websocket/HTTP branches so it can fully own the
+        # response shape and skip the truncation/pagination paths.
+        if array_patch is not None:
+            id_field = array_patch.get("id_field", "id")
+            if not isinstance(id_field, str) or not id_field:
+                raise_tool_error(
+                    create_validation_error(
+                        "array_patch.id_field must be a non-empty string",
+                        parameter="array_patch.id_field",
+                    )
+                )
+
+            fetch_result = await _call_addon_api(
+                client=client,
+                slug=slug,
+                path=path,
+                method="GET",
+                debug=debug,
+                port=port,
+                raw=True,
+            )
+            if not fetch_result.get("success"):
+                raise_tool_error(fetch_result)
+
+            fetched = fetch_result.get("response")
+            if not isinstance(fetched, list):
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch requires a JSON array at {path!r}; "
+                        f"got {type(fetched).__name__}",
+                        parameter="path",
+                    )
+                )
+
+            # Re-narrow operations for the type checker — the earlier
+            # validation block established this but the narrowing doesn't
+            # carry across the intervening config_data branch.
+            assert isinstance(ops, list)
+            new_array, summary = _apply_array_ops(fetched, ops, id_field)
+
+            post_result = await _call_addon_api(
+                client=client,
+                slug=slug,
+                path=path,
+                method="POST",
+                body=new_array,
+                debug=debug,
+                port=port,
+                raw=True,
+            )
+            if not post_result.get("success"):
+                raise_tool_error(post_result)
+
+            response_payload: dict[str, Any] = {
+                "success": True,
+                "slug": slug,
+                "addon_name": fetch_result.get("addon_name"),
+                "path": path,
+                "id_field": id_field,
+                "items_before": len(fetched),
+                "items_after": len(new_array),
+                "summary": summary,
+            }
+            if debug:
+                response_payload["_debug"] = {
+                    "fetch": fetch_result.get("_debug"),
+                    "post": post_result.get("_debug"),
+                }
+            return response_payload
+
         # WebSocket
         if websocket:
             result = await _call_addon_ws(

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -1,0 +1,412 @@
+"""Unit tests for the array_patch helper and ha_manage_addon array_patch dispatch.
+
+The helper (`_apply_array_ops`) is exercised directly with synthetic data —
+no addon, no httpx — so the operation semantics are isolated from the
+HTTP plumbing. The dispatch layer is exercised by mocking `_call_addon_api`
+so we verify that array_patch fetches with raw=True, applies ops, and
+posts the mutated array back exactly once.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_addons import _apply_array_ops
+
+
+def _parse_tool_error(exc: pytest.ExceptionInfo[ToolError]) -> dict:
+    return json.loads(str(exc.value))
+
+
+# ---------------------------------------------------------------------------
+# _apply_array_ops — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestApplyArrayOps:
+    def _flows_fixture(self) -> list[dict]:
+        return [
+            {"id": "tab1", "type": "tab", "label": "Lights"},
+            {"id": "tab2", "type": "tab", "label": "Bathroom"},
+            {"id": "n1", "type": "inject", "z": "tab1", "name": "Trigger"},
+            {"id": "n2", "type": "function", "z": "tab1", "name": "Compute"},
+            {"id": "n3", "type": "switch", "z": "tab2", "name": "Sense"},
+        ]
+
+    def test_patch_updates_fields_in_place(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "patch", "id": "n1", "patches": {"name": "Renamed"}}],
+            id_field="id",
+        )
+        n1 = next(it for it in new if it["id"] == "n1")
+        assert n1["name"] == "Renamed"
+        assert summary["patched"] == [{"id": "n1", "fields": ["name"]}]
+
+    def test_patch_preserves_unrelated_fields(self):
+        items = self._flows_fixture()
+        new, _ = _apply_array_ops(
+            items,
+            [{"op": "patch", "id": "n2", "patches": {"name": "X"}}],
+            id_field="id",
+        )
+        n2 = next(it for it in new if it["id"] == "n2")
+        assert n2["type"] == "function"
+        assert n2["z"] == "tab1"
+
+    def test_delete_removes_single_item(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "delete", "id": "n1"}],
+            id_field="id",
+        )
+        assert "n1" not in {it["id"] for it in new}
+        assert summary["deleted"] == [{"id": "n1"}]
+
+    def test_add_appends_new_item(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "add", "item": {"id": "n4", "type": "debug", "z": "tab1"}}],
+            id_field="id",
+        )
+        assert {it["id"] for it in new} == {"tab1", "tab2", "n1", "n2", "n3", "n4"}
+        assert summary["added"] == [{"id": "n4"}]
+
+    def test_delete_where_removes_all_matching(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "delete_where", "field": "z", "value": "tab1"}],
+            id_field="id",
+        )
+        # tab1 itself stays (z field is absent on tabs); only the children go
+        assert {it["id"] for it in new} == {"tab1", "tab2", "n3"}
+        assert summary["deleted_where"] == [{"field": "z", "value": "tab1", "count": 2}]
+
+    def test_delete_where_zero_matches_is_not_an_error(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "delete_where", "field": "z", "value": "ghost-tab"}],
+            id_field="id",
+        )
+        assert len(new) == len(items)
+        assert summary["deleted_where"][0]["count"] == 0
+
+    def test_operations_apply_in_order(self):
+        items = self._flows_fixture()
+        new, summary = _apply_array_ops(
+            items,
+            [
+                {"op": "delete", "id": "n1"},
+                {"op": "add", "item": {"id": "n1", "type": "debug", "z": "tab1"}},
+                {"op": "patch", "id": "n1", "patches": {"name": "Reborn"}},
+            ],
+            id_field="id",
+        )
+        n1 = next(it for it in new if it["id"] == "n1")
+        assert n1["type"] == "debug"
+        assert n1["name"] == "Reborn"
+        assert len(summary["deleted"]) == 1
+        assert len(summary["added"]) == 1
+        assert len(summary["patched"]) == 1
+
+    def test_custom_id_field(self):
+        items = [
+            {"slug": "thermostat-living", "value": 21},
+            {"slug": "thermostat-bedroom", "value": 19},
+        ]
+        new, _ = _apply_array_ops(
+            items,
+            [{"op": "patch", "id": "thermostat-bedroom", "patches": {"value": 20}}],
+            id_field="slug",
+        )
+        bed = next(it for it in new if it["slug"] == "thermostat-bedroom")
+        assert bed["value"] == 20
+
+
+# ---------------------------------------------------------------------------
+# _apply_array_ops — validation failures
+# ---------------------------------------------------------------------------
+
+
+class TestApplyArrayOpsValidation:
+    def test_unknown_op_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops([], [{"op": "yeet", "id": "x"}], id_field="id")
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_patch_missing_id_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}],
+                [{"op": "patch", "patches": {"name": "X"}}],
+                id_field="id",
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_patch_unknown_id_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}],
+                [{"op": "patch", "id": "ghost", "patches": {"name": "X"}}],
+                id_field="id",
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "RESOURCE_NOT_FOUND"
+
+    def test_patch_non_dict_patches_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}],
+                [{"op": "patch", "id": "a", "patches": "not a dict"}],
+                id_field="id",
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_delete_unknown_id_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}], [{"op": "delete", "id": "ghost"}], id_field="id"
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "RESOURCE_NOT_FOUND"
+
+    def test_add_collision_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}],
+                [{"op": "add", "item": {"id": "a", "type": "x"}}],
+                id_field="id",
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "RESOURCE_ALREADY_EXISTS"
+
+    def test_add_missing_id_field_raises(self):
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops([], [{"op": "add", "item": {"type": "x"}}], id_field="id")
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_delete_where_with_explicit_none_value_is_allowed(self):
+        items = [
+            {"id": "a", "z": None},
+            {"id": "b", "z": "tab1"},
+        ]
+        new, summary = _apply_array_ops(
+            items, [{"op": "delete_where", "field": "z", "value": None}], id_field="id"
+        )
+        assert {it["id"] for it in new} == {"b"}
+        assert summary["deleted_where"][0]["count"] == 1
+
+    def test_failure_midway_does_not_keep_partial_state_visible(self):
+        """Op that fails mid-stream raises before caller can POST.
+        The working list is mutated in memory but never returned, so the
+        server's view of the state is unchanged."""
+        items = [{"id": "a"}, {"id": "b"}]
+        with pytest.raises(ToolError):
+            _apply_array_ops(
+                items,
+                [
+                    {"op": "patch", "id": "a", "patches": {"name": "ok"}},
+                    {"op": "patch", "id": "ghost", "patches": {"name": "fail"}},
+                ],
+                id_field="id",
+            )
+        # Even though the helper mutated 'a' in its working copy, the test
+        # never received a (new_array, summary) tuple — the production
+        # dispatcher won't POST anything when a ToolError propagates.
+
+
+# ---------------------------------------------------------------------------
+# ha_manage_addon array_patch dispatch — happy + key error paths
+# ---------------------------------------------------------------------------
+
+
+class TestHaManageAddonArrayPatchDispatch:
+    """Exercise the dispatch in ha_manage_addon by mocking _call_addon_api.
+
+    We verify: GET happens with raw=True; ops are applied; POST sends the
+    mutated array; response shape is the compact summary (no full array).
+    """
+
+    @pytest.fixture
+    def _registered_tool(self):
+        from ha_mcp.tools.tools_addons import register_addon_tools
+
+        captured: dict = {}
+
+        class _MockMCP:
+            def tool(self, *args, **kwargs):
+                def deco(fn):
+                    captured.setdefault(fn.__name__, fn)
+                    return fn
+
+                return deco
+
+        register_addon_tools(_MockMCP(), client=AsyncMock())
+        fn = captured["ha_manage_addon"]
+        while hasattr(fn, "__wrapped__"):
+            fn = fn.__wrapped__
+        return fn
+
+    @pytest.mark.asyncio
+    async def test_dispatch_fetches_then_posts_mutated_array(self, _registered_tool):
+        fetched_array = [
+            {"id": "n1", "name": "old"},
+            {"id": "n2", "name": "keep"},
+        ]
+        call_log: list[tuple[str, dict]] = []
+
+        async def fake_call(**kwargs):
+            method = kwargs.get("method", "GET")
+            assert kwargs.get("raw") is True
+            call_log.append((method, kwargs))
+            if method == "GET":
+                return {
+                    "success": True,
+                    "response": fetched_array,
+                    "addon_name": "Node-RED",
+                    "slug": kwargs["slug"],
+                    "status_code": 200,
+                }
+            return {"success": True, "response": "rev-1", "status_code": 200}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            result = await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    "operations": [
+                        {"op": "patch", "id": "n1", "patches": {"name": "new"}},
+                    ],
+                },
+            )
+
+        # Two calls: GET then POST
+        assert [m for m, _ in call_log] == ["GET", "POST"]
+        # POST body is the mutated array
+        post_body = call_log[1][1]["body"]
+        assert post_body[0]["name"] == "new"
+        assert post_body[1] == {"id": "n2", "name": "keep"}
+        # Response shape is the compact summary, not the full array
+        assert result["success"] is True
+        assert result["items_before"] == 2
+        assert result["items_after"] == 2
+        assert result["summary"]["patched"] == [{"id": "n1", "fields": ["name"]}]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_rejects_non_array_response(self, _registered_tool):
+        async def fake_call(**kwargs):
+            return {
+                "success": True,
+                "response": {"not": "an array"},
+                "addon_name": "X",
+                "slug": kwargs["slug"],
+                "status_code": 200,
+            }
+
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            with pytest.raises(ToolError) as exc:
+                await _registered_tool(
+                    slug="a0d7b954_nodered",
+                    path="/flows",
+                    array_patch={
+                        "operations": [{"op": "delete", "id": "x"}],
+                    },
+                )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_does_not_post_when_op_validation_fails(
+        self, _registered_tool
+    ):
+        get_called = False
+        post_called = False
+
+        async def fake_call(**kwargs):
+            nonlocal get_called, post_called
+            if kwargs.get("method", "GET") == "GET":
+                get_called = True
+                return {
+                    "success": True,
+                    "response": [{"id": "a"}],
+                    "addon_name": "X",
+                    "slug": kwargs["slug"],
+                    "status_code": 200,
+                }
+            post_called = True
+            return {"success": True, "response": "ok", "status_code": 200}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            with pytest.raises(ToolError):
+                await _registered_tool(
+                    slug="a0d7b954_nodered",
+                    path="/flows",
+                    array_patch={
+                        # 'ghost' isn't in the fetched array — _apply_array_ops raises
+                        "operations": [{"op": "delete", "id": "ghost"}],
+                    },
+                )
+
+        assert get_called is True
+        assert post_called is False
+
+    @pytest.mark.asyncio
+    async def test_dispatch_rejects_websocket_combo(self, _registered_tool):
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                websocket=True,
+                array_patch={"operations": [{"op": "delete", "id": "x"}]},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_rejects_explicit_body(self, _registered_tool):
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                body={"foo": "bar"},
+                array_patch={"operations": [{"op": "delete", "id": "x"}]},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_rejects_offset_limit(self, _registered_tool):
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                limit=10,
+                array_patch={"operations": [{"op": "delete", "id": "x"}]},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_rejects_empty_operations(self, _registered_tool):
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={"operations": []},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -228,8 +228,9 @@ class TestApplyArrayOpsValidation:
 class TestHaManageAddonArrayPatchDispatch:
     """Exercise the dispatch in ha_manage_addon by mocking _call_addon_api.
 
-    We verify: GET happens with raw=True; ops are applied; POST sends the
-    mutated array; response shape is the compact summary (no full array).
+    We verify: GET happens with raw=True (full array needed for mutation);
+    POST happens without raw (response is small, default truncation guards
+    apply); mutated array is sent; response shape is the compact summary.
     """
 
     @pytest.fixture
@@ -262,7 +263,13 @@ class TestHaManageAddonArrayPatchDispatch:
 
         async def fake_call(**kwargs):
             method = kwargs.get("method", "GET")
-            assert kwargs.get("raw") is True
+            # GET must use raw=True so the full array isn't truncated.
+            # POST does not need raw — its response is small (deploy revision)
+            # and we want the size-based truncation guard in effect.
+            if method == "GET":
+                assert kwargs.get("raw") is True, "GET should use raw=True"
+            else:
+                assert not kwargs.get("raw"), "POST should not use raw"
             call_log.append((method, kwargs))
             if method == "GET":
                 return {
@@ -311,18 +318,20 @@ class TestHaManageAddonArrayPatchDispatch:
                 "status_code": 200,
             }
 
-        with patch(
-            "ha_mcp.tools.tools_addons._call_addon_api",
-            new=AsyncMock(side_effect=fake_call),
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._call_addon_api",
+                new=AsyncMock(side_effect=fake_call),
+            ),
+            pytest.raises(ToolError) as exc,
         ):
-            with pytest.raises(ToolError) as exc:
-                await _registered_tool(
-                    slug="a0d7b954_nodered",
-                    path="/flows",
-                    array_patch={
-                        "operations": [{"op": "delete", "id": "x"}],
-                    },
-                )
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    "operations": [{"op": "delete", "id": "x"}],
+                },
+            )
         err = _parse_tool_error(exc)
         assert err["error"]["code"] == "VALIDATION_FAILED"
 
@@ -347,19 +356,21 @@ class TestHaManageAddonArrayPatchDispatch:
             post_called = True
             return {"success": True, "response": "ok", "status_code": 200}
 
-        with patch(
-            "ha_mcp.tools.tools_addons._call_addon_api",
-            new=AsyncMock(side_effect=fake_call),
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._call_addon_api",
+                new=AsyncMock(side_effect=fake_call),
+            ),
+            pytest.raises(ToolError),
         ):
-            with pytest.raises(ToolError):
-                await _registered_tool(
-                    slug="a0d7b954_nodered",
-                    path="/flows",
-                    array_patch={
-                        # 'ghost' isn't in the fetched array — _apply_array_ops raises
-                        "operations": [{"op": "delete", "id": "ghost"}],
-                    },
-                )
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    # 'ghost' isn't in the fetched array — _apply_array_ops raises
+                    "operations": [{"op": "delete", "id": "ghost"}],
+                },
+            )
 
         assert get_called is True
         assert post_called is False
@@ -410,3 +421,181 @@ class TestHaManageAddonArrayPatchDispatch:
             )
         err = _parse_tool_error(exc)
         assert err["error"]["code"] == "VALIDATION_FAILED"
+
+
+class TestHaManageAddonRequestHeaders:
+    """Verify the new top-level request_headers parameter wires through to
+    _call_addon_api in proxy mode and array_patch mode (both GET and POST).
+    """
+
+    @pytest.fixture
+    def _registered_tool(self):
+        from ha_mcp.tools.tools_addons import register_addon_tools
+
+        captured: dict = {}
+
+        class _MockMCP:
+            def tool(self, *args, **kwargs):
+                def deco(fn):
+                    captured.setdefault(fn.__name__, fn)
+                    return fn
+
+                return deco
+
+        register_addon_tools(_MockMCP(), client=AsyncMock())
+        fn = captured["ha_manage_addon"]
+        while hasattr(fn, "__wrapped__"):
+            fn = fn.__wrapped__
+        return fn
+
+    @pytest.mark.asyncio
+    async def test_proxy_mode_forwards_request_headers(self, _registered_tool):
+        captured_headers: list[dict | None] = []
+
+        async def fake_call(**kwargs):
+            captured_headers.append(kwargs.get("headers"))
+            return {
+                "success": True,
+                "response": {"ok": True},
+                "addon_name": "X",
+                "slug": kwargs["slug"],
+                "status_code": 200,
+            }
+
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/api/state",
+                request_headers={"Accept": "text/plain"},
+            )
+
+        assert captured_headers == [{"Accept": "text/plain"}]
+
+    @pytest.mark.asyncio
+    async def test_array_patch_forwards_request_headers_to_get_and_post(
+        self, _registered_tool
+    ):
+        captured_headers: list[dict | None] = []
+
+        async def fake_call(**kwargs):
+            captured_headers.append(kwargs.get("headers"))
+            if kwargs.get("method", "GET") == "GET":
+                return {
+                    "success": True,
+                    "response": [{"id": "n1", "name": "old"}],
+                    "addon_name": "Node-RED",
+                    "slug": kwargs["slug"],
+                    "status_code": 200,
+                }
+            return {"success": True, "response": "rev-1", "status_code": 200}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._call_addon_api",
+            new=AsyncMock(side_effect=fake_call),
+        ):
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    "operations": [
+                        {"op": "patch", "id": "n1", "patches": {"name": "new"}},
+                    ],
+                },
+                request_headers={"Node-RED-Deployment-Type": "full"},
+            )
+
+        # Both GET and POST must receive the same caller-supplied headers
+        assert len(captured_headers) == 2
+        assert captured_headers[0] == {"Node-RED-Deployment-Type": "full"}
+        assert captured_headers[1] == {"Node-RED-Deployment-Type": "full"}
+
+    @pytest.mark.asyncio
+    async def test_request_headers_rejected_in_config_mode(self, _registered_tool):
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                options={"log_level": "debug"},
+                request_headers={"X-Custom": "value"},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
+        assert "request_headers" in err["error"]["message"]
+
+
+class TestCallAddonApiHeaderMerge:
+    """Direct test of _call_addon_api's header-merge contract: caller headers
+    go in first, internal framing layered on top so it always wins on collision.
+    """
+
+    @pytest.mark.asyncio
+    async def test_internal_framing_overrides_caller_headers(self):
+        """If a caller tries to override X-Ingress-Path / X-Hass-Source /
+        Content-Type, the proxy's internal values must still win."""
+        from unittest.mock import MagicMock
+
+        from ha_mcp.tools.tools_addons import _call_addon_api
+
+        addon_info = {
+            "success": True,
+            "addon": {
+                "name": "Test",
+                "slug": "test",
+                "ingress": True,
+                "ingress_entry": "/api/hassio_ingress/REAL",
+                "ingress_port": 5000,
+                "ip_address": "172.30.33.99",
+                "state": "started",
+            },
+        }
+
+        # Capture the headers passed to httpx.request — same mocking pattern
+        # the existing _call_addon_api tests use.
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "ok"
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.json.return_value = {}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.request.return_value = mock_response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await _call_addon_api(
+                client=AsyncMock(),
+                slug="test",
+                path="/api/state",
+                method="POST",
+                body={"x": 1},
+                headers={
+                    "X-Ingress-Path": "/api/hassio_ingress/EVIL",
+                    "X-Hass-Source": "spoofed",
+                    "Content-Type": "application/x-attack",
+                    "X-Custom-Allowed": "kept",
+                },
+            )
+
+        # Headers actually sent to the addon container:
+        sent = mock_http_client.request.call_args.kwargs["headers"]
+        # Internal framing wins
+        assert sent["X-Ingress-Path"] == "/api/hassio_ingress/REAL"
+        assert sent["X-Hass-Source"] == "core.ingress"
+        assert sent["Content-Type"] == "application/json"
+        # Non-conflicting caller headers pass through
+        assert sent["X-Custom-Allowed"] == "kept"

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -20,6 +20,32 @@ def _parse_tool_error(exc: pytest.ExceptionInfo[ToolError]) -> dict:
     return json.loads(str(exc.value))
 
 
+@pytest.fixture
+def _registered_tool():
+    """Resolve the raw ha_manage_addon function from the @tool decorator stack.
+
+    Shared by every TestHaManageAddon* class — they all need the same
+    pre-registration unwrap to call the tool function directly.
+    """
+    from ha_mcp.tools.tools_addons import register_addon_tools
+
+    captured: dict = {}
+
+    class _MockMCP:
+        def tool(self, *args, **kwargs):
+            def deco(fn):
+                captured.setdefault(fn.__name__, fn)
+                return fn
+
+            return deco
+
+    register_addon_tools(_MockMCP(), client=AsyncMock())
+    fn = captured["ha_manage_addon"]
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
 # ---------------------------------------------------------------------------
 # _apply_array_ops — happy paths
 # ---------------------------------------------------------------------------
@@ -233,26 +259,6 @@ class TestHaManageAddonArrayPatchDispatch:
     apply); mutated array is sent; response shape is the compact summary.
     """
 
-    @pytest.fixture
-    def _registered_tool(self):
-        from ha_mcp.tools.tools_addons import register_addon_tools
-
-        captured: dict = {}
-
-        class _MockMCP:
-            def tool(self, *args, **kwargs):
-                def deco(fn):
-                    captured.setdefault(fn.__name__, fn)
-                    return fn
-
-                return deco
-
-        register_addon_tools(_MockMCP(), client=AsyncMock())
-        fn = captured["ha_manage_addon"]
-        while hasattr(fn, "__wrapped__"):
-            fn = fn.__wrapped__
-        return fn
-
     @pytest.mark.asyncio
     async def test_dispatch_fetches_then_posts_mutated_array(self, _registered_tool):
         fetched_array = [
@@ -376,6 +382,97 @@ class TestHaManageAddonArrayPatchDispatch:
         assert post_called is False
 
     @pytest.mark.asyncio
+    async def test_dispatch_raises_when_fetch_fails(self, _registered_tool):
+        """A failed GET must surface as ToolError and skip the POST entirely.
+
+        Guards against a regression where a swallowed fetch failure would let
+        the dispatcher synthesise success on stale/empty state.
+        """
+        post_called = False
+
+        async def fake_call(**kwargs):
+            nonlocal post_called
+            if kwargs.get("method", "GET") == "GET":
+                return {
+                    "success": False,
+                    "status_code": 502,
+                    "error": "Add-on API returned HTTP 502",
+                    "addon_name": "Node-RED",
+                    "slug": kwargs["slug"],
+                }
+            post_called = True
+            return {"success": True, "response": "ok", "status_code": 200}
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._call_addon_api",
+                new=AsyncMock(side_effect=fake_call),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    "operations": [{"op": "patch", "id": "n1", "patches": {"x": 1}}],
+                },
+            )
+
+        assert post_called is False
+
+    @pytest.mark.asyncio
+    async def test_dispatch_raises_when_post_fails(self, _registered_tool):
+        """A failed POST must surface as ToolError, not be reported as success.
+
+        Without this guard a failed write would still return `success: True`
+        with the in-memory `items_after` even though the addon rejected it.
+        """
+        fetched_array = [{"id": "n1", "name": "old"}]
+        get_called = False
+        post_called = False
+
+        async def fake_call(**kwargs):
+            nonlocal get_called, post_called
+            if kwargs.get("method", "GET") == "GET":
+                get_called = True
+                return {
+                    "success": True,
+                    "response": fetched_array,
+                    "addon_name": "Node-RED",
+                    "slug": kwargs["slug"],
+                    "status_code": 200,
+                }
+            post_called = True
+            return {
+                "success": False,
+                "status_code": 400,
+                "error": "Add-on API returned HTTP 400",
+                "response": "deploy rejected",
+                "addon_name": "Node-RED",
+                "slug": kwargs["slug"],
+            }
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._call_addon_api",
+                new=AsyncMock(side_effect=fake_call),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/flows",
+                array_patch={
+                    "operations": [
+                        {"op": "patch", "id": "n1", "patches": {"name": "new"}},
+                    ],
+                },
+            )
+
+        assert get_called is True
+        assert post_called is True
+
+    @pytest.mark.asyncio
     async def test_dispatch_rejects_websocket_combo(self, _registered_tool):
         with pytest.raises(ToolError) as exc:
             await _registered_tool(
@@ -428,32 +525,12 @@ class TestHaManageAddonRequestHeaders:
     _call_addon_api in proxy mode and array_patch mode (both GET and POST).
     """
 
-    @pytest.fixture
-    def _registered_tool(self):
-        from ha_mcp.tools.tools_addons import register_addon_tools
-
-        captured: dict = {}
-
-        class _MockMCP:
-            def tool(self, *args, **kwargs):
-                def deco(fn):
-                    captured.setdefault(fn.__name__, fn)
-                    return fn
-
-                return deco
-
-        register_addon_tools(_MockMCP(), client=AsyncMock())
-        fn = captured["ha_manage_addon"]
-        while hasattr(fn, "__wrapped__"):
-            fn = fn.__wrapped__
-        return fn
-
     @pytest.mark.asyncio
     async def test_proxy_mode_forwards_request_headers(self, _registered_tool):
         captured_headers: list[dict | None] = []
 
         async def fake_call(**kwargs):
-            captured_headers.append(kwargs.get("headers"))
+            captured_headers.append(kwargs.get("extra_headers"))
             return {
                 "success": True,
                 "response": {"ok": True},
@@ -481,7 +558,7 @@ class TestHaManageAddonRequestHeaders:
         captured_headers: list[dict | None] = []
 
         async def fake_call(**kwargs):
-            captured_headers.append(kwargs.get("headers"))
+            captured_headers.append(kwargs.get("extra_headers"))
             if kwargs.get("method", "GET") == "GET":
                 return {
                     "success": True,
@@ -569,6 +646,10 @@ class TestCallAddonApiHeaderMerge:
                 return_value=addon_info,
             ),
             patch(
+                "ha_mcp.tools.tools_addons.is_running_in_addon",
+                return_value=True,
+            ),
+            patch(
                 "ha_mcp.tools.tools_addons.httpx.AsyncClient",
             ) as mock_httpx,
         ):
@@ -583,7 +664,7 @@ class TestCallAddonApiHeaderMerge:
                 path="/api/state",
                 method="POST",
                 body={"x": 1},
-                headers={
+                extra_headers={
                     "X-Ingress-Path": "/api/hassio_ingress/EVIL",
                     "X-Hass-Source": "spoofed",
                     "Content-Type": "application/x-attack",


### PR DESCRIPTION
Per @kingpanther13's go-ahead in #1014: opt-in third mode for `ha_manage_addon` that atomically wraps the "GET array, mutate, POST array" pattern that several addon APIs (Node-RED `/flows`, Z2M bridge config, Frigate cameras) impose on writers. Closes the gap that motivated the now-closed #1014; doesn't add any addon-specific tools.

## Why

Without this, agents wanting to e.g. rename a Node-RED node have to: (1) GET the full `/flows` array, (2) hold the entire payload in context while mutating one field of one entry, (3) POST the whole thing back. Three calls plus the agent juggling the array yields a real failure mode where items get dropped or duplicated mid-mutation, especially as collections grow.

With `array_patch`, the mutation happens server-side as ordered ops against a working copy. The agent only sees a compact summary (IDs touched + counts), not the full array.

## API

```python
ha_manage_addon(
    slug="a0d7b954_nodered",
    path="/flows",
    array_patch={
        "id_field": "id",   # optional, default "id"
        "operations": [
            {"op": "patch", "id": "abc", "patches": {"name": "X"}},
            {"op": "delete", "id": "old"},
            {"op": "add", "item": {"id": "new", ...}},
            {"op": "delete_where", "field": "z", "value": "tab1"},
        ],
    },
)
```

Operations are applied in order against a working copy. **Any validation failure (unknown op, missing reference, id collision, malformed shape) raises `ToolError` before the POST happens** — fail-fast all-or-nothing semantics from the server's perspective.

The mode is mutually exclusive with `body`, `websocket`, `offset`/`limit`, and config-mode parameters. When `array_patch` is not provided, `ha_manage_addon` behaviour is **unchanged** (no behavioural risk to existing callers).

## Files touched

| File | Change |
|---|---|
| `src/ha_mcp/tools/tools_addons.py` | New `_apply_array_ops` helper (pure, no I/O); new `array_patch` parameter on `ha_manage_addon`; dispatch path; `_call_addon_api` gains a `raw: bool = False` param to skip the 50KB truncation when called internally from array_patch (default off — backwards compatible); body type widened from `dict\|str\|None` to `dict\|list\|str\|None` so the dispatcher can POST the mutated array back. |
| `tests/src/unit/test_tools_addons_array_patch.py` | 24 new tests — 8 happy paths + 9 validation failures on `_apply_array_ops` (pure helper), 7 dispatch tests (mocked `_call_addon_api`) covering GET-then-POST sequencing, no-POST-on-validation-failure, and mutual exclusivity with body/websocket/offset-limit. |

Existing `tests/src/unit/test_tools_addons.py` (47 tests) still passes.

## Quality checks

```
ruff check ...                  → clean
ruff format ...                 → clean
mypy src/ha_mcp/tools/tools_addons.py  → 0 issues
ast-grep scan ...               → clean
pytest tests/src/unit/test_tools_addons_array_patch.py  → 24/24 pass
pytest tests/src/unit/test_tools_addons.py              → 47/47 pass (no regressions)
pytest tests/src/unit/                                  → 588 pass (3 pre-existing skills-vendor failures unrelated to this PR)
```

## Live testing

The GET-modify-POST protocol against Node-RED `/flows` is already validated in production by my downstream fork (`paul43210/ha-mcp:feat/nodered-tools`, closed #1014) which does exactly this pattern through a dedicated client. This PR routes the same protocol through `ha_manage_addon`'s existing Supervisor/Ingress proxy plumbing.

End-to-end testing through `ha_manage_addon` proxy requires a HA OS test rig — `_call_addon_api` connects to the addon's internal container IP (172.30.x.x), only reachable from inside the HA network namespace. My ha-mcp deployment runs externally so I can't exercise that exact path here. Happy to coordinate live testing on a maintainer rig if helpful.

## Open question

`array_patch` doesn't currently let callers set custom request headers on the POST. For Node-RED specifically, the `Node-RED-Deployment-Type: full` header is recommended (and the dedicated client in #1014 set it explicitly). Without it Node-RED falls back to its default deploy strategy, which has slightly different semantics around in-flight `msg` state. Two options if this matters in practice:

1. Add a `headers` parameter to proxy mode that callers can set
2. Trust the addon's default behaviour and document the limitation

Happy to follow up with whichever you prefer — kept this PR focused on the array dispatch logic.

Refs: closed #1014, discussion #1013.