### PR TITLE
fix(addons): route addon API calls through HA Core ingress proxy

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -13,7 +13,7 @@ import logging
 import re
 import time
 from typing import Annotated, Any
-from urllib.parse import unquote
+from urllib.parse import unquote, urlsplit
 
 import httpx
 import websockets
@@ -674,11 +674,15 @@ async def _call_addon_ws(
                 )
             )
         session = await _create_ingress_session(client)
-        ws_scheme = "wss" if client.base_url.startswith("https") else "ws"
-        ws_host = client.base_url.split("://", 1)[1]
-        ws_url = f"{ws_scheme}://{ws_host}{ingress_entry}/{normalized}"
+        # urlsplit handles trailing slashes and reverse-proxied path
+        # prefixes that bare string slicing would mangle.
+        parsed = urlsplit(client.base_url)
+        ws_scheme = "wss" if parsed.scheme == "https" else "ws"
+        ws_path_prefix = parsed.path.rstrip("/")
+        ws_url = f"{ws_scheme}://{parsed.netloc}{ws_path_prefix}{ingress_entry}/{normalized}"
+        # Cookie-only matches the HA frontend. A bearer here would be
+        # forwarded to the add-on upstream — needless LLAT leak.
         headers["Cookie"] = f"ingress_session={session}"
-        headers["Authorization"] = f"Bearer {client.token}"
 
     # 7. Connect and exchange messages
     collected: list[str] = []
@@ -759,14 +763,25 @@ async def _call_addon_ws(
                 total_size += len(clean)
 
     except websockets.exceptions.InvalidHandshake as e:
+        suggestions = [
+            "Check that the add-on supports WebSocket on this path",
+            f"Use ha_get_addon(slug='{slug}') to inspect available endpoints",
+        ]
+        # 401/403 means auth was rejected, not a path-shape problem.
+        if isinstance(e, websockets.exceptions.InvalidStatus):
+            status = e.response.status_code
+            if status in (401, 403):
+                suggestions = [
+                    "The ingress session may have expired or your HA token "
+                    "may lack the required scope. Verify the token has admin "
+                    "rights and try again.",
+                    f"Status {status} from the WebSocket handshake.",
+                ]
         raise_tool_error(
             create_error_response(
                 ErrorCode.SERVICE_CALL_FAILED,
                 f"WebSocket handshake failed with '{addon_name}': {e!s}",
-                suggestions=[
-                    "Check that the add-on supports WebSocket on this path",
-                    f"Use ha_get_addon(slug='{slug}') to inspect available endpoints",
-                ],
+                suggestions=suggestions,
                 context={"slug": slug, "path": path},
             )
         )
@@ -1024,9 +1039,10 @@ async def _call_addon_api(
                 )
             )
         session = await _create_ingress_session(client)
-        url = f"{client.base_url}{ingress_entry}/{normalized}"
+        url = f"{client.base_url.rstrip('/')}{ingress_entry}/{normalized}"
+        # Cookie-only matches the HA frontend. A bearer here would be
+        # forwarded to the add-on upstream — needless LLAT leak.
         headers["Cookie"] = f"ingress_session={session}"
-        headers["Authorization"] = f"Bearer {client.token}"
 
     # 6. Set content type based on body type
     if isinstance(body, dict):

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -20,6 +20,7 @@ import websockets
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
+from .._version import is_running_in_addon
 from ..client.rest_client import HomeAssistantClient
 from ..errors import (
     ErrorCode,
@@ -290,9 +291,10 @@ def _addon_connection_failure_suggestions(
 ) -> list[str]:
     """Suggestions for connect/timeout failures against an add-on.
 
-    Direct-port mode hits the addon's container IP, which off-host installs
-    can't route to — the actionable hint is to drop `port`. Ingress mode
-    hits HA Core, so failures usually mean HA Core is unreachable.
+    Three modes — direct-port hits a container IP, the addon-variant ingress
+    route hits a sibling container's ingress port, the off-host ingress route
+    hits HA Core. Each mode fails for different reasons, so suggest different
+    next steps.
     """
     if port:
         return [
@@ -300,6 +302,14 @@ def _addon_connection_failure_suggestions(
             "Direct-port access requires the MCP host to share Home "
             "Assistant's container network. On PyPI/uvx installs, drop "
             "the 'port' parameter to route through Ingress instead.",
+        ]
+    if is_running_in_addon():
+        return [
+            "The target add-on container may not be reachable from this "
+            "MCP add-on. Check that the target add-on is running.",
+            "If the failure persists, the addon Docker network may be "
+            "unhealthy — try restarting the target add-on, then this "
+            "MCP add-on.",
         ]
     return [
         f"Verify Home Assistant is reachable at {client.base_url}",
@@ -334,6 +344,157 @@ async def _create_ingress_session(client: HomeAssistantClient) -> str:
             )
         )
     return session
+
+
+async def _resolve_http_route(
+    client: HomeAssistantClient,
+    addon: dict[str, Any],
+    normalized_path: str,
+    port: int | None,
+) -> tuple[str, dict[str, str]]:
+    """Pick the HTTP route shape based on `port` and install variant.
+
+    Three branches:
+    - `port` set → direct container port (`http://<ip>:<port>/...`), no
+      auth headers. Only reachable when the MCP host shares HA's container
+      network.
+    - Running as the HA add-on (`is_running_in_addon()` true) → direct
+      `<addon_ip>:<addon_ingress_port>` with `X-Ingress-Path` and
+      `X-Hass-Source: core.ingress` headers. This is the path the addon
+      variant always took on master; routing through HA Core's
+      `/api/hassio_ingress/...` proxy regresses here because
+      `client.base_url` is `http://supervisor/core` (a Supervisor proxy
+      mount that demands `Authorization: Bearer $SUPERVISOR_TOKEN`).
+    - Off-host → HA Core ingress proxy at
+      `<base_url>/api/hassio_ingress/<token>/<path>` with `Cookie:
+      ingress_session=<token>`. Mints a fresh session per call.
+    """
+    addon_name = addon.get("name", "")
+    headers: dict[str, str] = {}
+
+    if port:
+        addon_ip = addon.get("ip_address", "")
+        if not addon_ip:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"Add-on '{addon_name}' is missing ip_address",
+                    context={"slug": addon.get("slug"), "ip_address": addon_ip},
+                )
+            )
+        return f"http://{addon_ip}:{port}/{normalized_path}", headers
+
+    ingress_entry = addon.get("ingress_entry")
+    if not ingress_entry:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.INTERNAL_ERROR,
+                f"Add-on '{addon_name}' is missing ingress_entry",
+                context={"slug": addon.get("slug")},
+            )
+        )
+
+    if is_running_in_addon():
+        addon_ip = addon.get("ip_address", "")
+        ingress_port = addon.get("ingress_port")
+        if not addon_ip or not ingress_port:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"Add-on '{addon_name}' is missing network info "
+                    "(ip_address or ingress_port)",
+                    context={
+                        "slug": addon.get("slug"),
+                        "ip_address": addon_ip,
+                        "ingress_port": ingress_port,
+                    },
+                )
+            )
+        # Sibling addon containers share the hassio bridge, so we hit the
+        # ingress port directly. The X-Ingress-Path / X-Hass-Source headers
+        # are what the addon's nginx trusts as authenticated ingress source.
+        headers["X-Ingress-Path"] = ingress_entry
+        headers["X-Hass-Source"] = "core.ingress"
+        return (
+            f"http://{addon_ip}:{ingress_port}/{normalized_path}",
+            headers,
+        )
+
+    session = await _create_ingress_session(client)
+    base = client.base_url.rstrip("/")
+    headers["Cookie"] = f"ingress_session={session}"
+    return f"{base}{ingress_entry}/{normalized_path}", headers
+
+
+async def _resolve_ws_route(
+    client: HomeAssistantClient,
+    addon: dict[str, Any],
+    normalized_path: str,
+    port: int | None,
+) -> tuple[str, dict[str, str]]:
+    """Pick the WebSocket route shape. Mirrors `_resolve_http_route`.
+
+    The addon-variant and direct-port branches always speak `ws://` because
+    they hit the container directly. The off-host branch echoes
+    `client.base_url`'s scheme (so HTTPS-fronted HA gets `wss://`).
+    """
+    addon_name = addon.get("name", "")
+    headers: dict[str, str] = {}
+
+    if port:
+        addon_ip = addon.get("ip_address", "")
+        if not addon_ip:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"Add-on '{addon_name}' is missing ip_address",
+                    context={"slug": addon.get("slug")},
+                )
+            )
+        return f"ws://{addon_ip}:{port}/{normalized_path}", headers
+
+    ingress_entry = addon.get("ingress_entry")
+    if not ingress_entry:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.INTERNAL_ERROR,
+                f"Add-on '{addon_name}' is missing ingress_entry",
+                context={"slug": addon.get("slug")},
+            )
+        )
+
+    if is_running_in_addon():
+        addon_ip = addon.get("ip_address", "")
+        ingress_port = addon.get("ingress_port")
+        if not addon_ip or not ingress_port:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"Add-on '{addon_name}' is missing network info "
+                    "(ip_address or ingress_port)",
+                    context={
+                        "slug": addon.get("slug"),
+                        "ip_address": addon_ip,
+                        "ingress_port": ingress_port,
+                    },
+                )
+            )
+        headers["X-Ingress-Path"] = ingress_entry
+        headers["X-Hass-Source"] = "core.ingress"
+        return (
+            f"ws://{addon_ip}:{ingress_port}/{normalized_path}",
+            headers,
+        )
+
+    session = await _create_ingress_session(client)
+    parsed = urlsplit(client.base_url)
+    ws_scheme = "wss" if parsed.scheme == "https" else "ws"
+    ws_path_prefix = parsed.path.rstrip("/")
+    headers["Cookie"] = f"ingress_session={session}"
+    return (
+        f"{ws_scheme}://{parsed.netloc}{ws_path_prefix}{ingress_entry}/{normalized_path}",
+        headers,
+    )
 
 
 async def get_addon_info(client: HomeAssistantClient, slug: str) -> dict[str, Any]:
@@ -567,10 +728,10 @@ async def _call_addon_ws(
 ) -> dict[str, Any]:
     """Connect to an add-on's WebSocket API and collect messages.
 
-    Routing mirrors the HTTP variant: ingress mode tunnels the WS through HA
-    Core's `/api/hassio_ingress` proxy (works off-host); direct-port mode
-    (`port` set) connects straight to the container and requires the MCP
-    host to share HA's Docker network.
+    Routing mirrors the HTTP variant (see `_resolve_ws_route`): off-host
+    ingress tunnels through HA Core's `/api/hassio_ingress` proxy; the
+    HA-add-on variant hits the container's ingress port directly;
+    direct-port mode (`port` set) connects to the container's mapped port.
 
     Args:
         client: Home Assistant REST client
@@ -646,43 +807,8 @@ async def _call_addon_ws(
             )
         )
 
-    # 5. Build WebSocket URL.
-    # Ingress mode tunnels the WS through HA Core's `/api/hassio_ingress`
-    # proxy (which supports WS upgrade) so it works on off-host installs.
-    # Direct-port mode connects straight to the add-on container.
-    headers: dict[str, str] = {}
-    addon_ip = addon.get("ip_address", "")
-
-    if port:
-        if not addon_ip:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing ip_address",
-                    context={"slug": slug},
-                )
-            )
-        ws_url = f"ws://{addon_ip}:{port}/{normalized}"
-    else:
-        ingress_entry = addon.get("ingress_entry")
-        if not ingress_entry:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing ingress_entry",
-                    context={"slug": slug},
-                )
-            )
-        session = await _create_ingress_session(client)
-        # urlsplit handles trailing slashes and reverse-proxied path
-        # prefixes that bare string slicing would mangle.
-        parsed = urlsplit(client.base_url)
-        ws_scheme = "wss" if parsed.scheme == "https" else "ws"
-        ws_path_prefix = parsed.path.rstrip("/")
-        ws_url = f"{ws_scheme}://{parsed.netloc}{ws_path_prefix}{ingress_entry}/{normalized}"
-        # Cookie-only matches the HA frontend. A bearer here would be
-        # forwarded to the add-on upstream — needless LLAT leak.
-        headers["Cookie"] = f"ingress_session={session}"
+    # 5. Resolve route (direct-port / addon-variant / off-host).
+    ws_url, headers = await _resolve_ws_route(client, addon, normalized, port)
 
     # 7. Connect and exchange messages
     collected: list[str] = []
@@ -934,16 +1060,19 @@ async def _call_addon_api(
 ) -> dict[str, Any]:
     """Call an add-on's web API.
 
-    Two routing modes:
+    Routing is picked per install variant (see `_resolve_http_route`):
 
-    - **Ingress (default)**: tunnels through HA Core's
-      `/api/hassio_ingress/<token>/...` proxy. Mints a fresh Supervisor
-      ingress session per call via the WS `supervisor/api` proxy. Works on
-      HAOS, Supervised, and off-host PyPI/uvx installs.
+    - **Ingress (default), off-host**: tunnels through HA Core's
+      `/api/hassio_ingress/<token>/...` proxy with a per-call Supervisor
+      session cookie. The path that makes off-host (PyPI/uvx) installs work.
+    - **Ingress (default), HA add-on**: hits the addon container's
+      ingress port directly with the `core.ingress` source headers. Avoids
+      the Supervisor `/core` proxy hop that would otherwise demand
+      `Authorization: Bearer $SUPERVISOR_TOKEN` on top of the cookie.
     - **Direct port** (when `port` is set): connects to
       `http://<addon_ip>:<port>/...` for add-ons that expose mapped ports
       (e.g. Node-RED on 1880). Only works when the MCP host shares HA's
-      Docker network — i.e. running as the HAOS add-on.
+      Docker network.
 
     Args:
         client: Home Assistant REST client
@@ -1007,40 +1136,8 @@ async def _call_addon_api(
             )
         )
 
-    # 5. Build URL.
-    # Ingress mode (default) routes through HA Core's `/api/hassio_ingress`
-    # proxy so this works equally on HAOS addons and off-host PyPI/uvx
-    # installs. Direct-port mode connects straight to the add-on's container
-    # IP — this only works when the MCP host shares the hassio Docker
-    # bridge (i.e. the HAOS addon).
-    headers: dict[str, str] = {}
-    addon_ip = addon.get("ip_address", "")
-
-    if port:
-        if not addon_ip:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing ip_address",
-                    context={"slug": slug, "ip_address": addon_ip},
-                )
-            )
-        url = f"http://{addon_ip}:{port}/{normalized}"
-    else:
-        ingress_entry = addon.get("ingress_entry")
-        if not ingress_entry:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing ingress_entry",
-                    context={"slug": slug},
-                )
-            )
-        session = await _create_ingress_session(client)
-        url = f"{client.base_url.rstrip('/')}{ingress_entry}/{normalized}"
-        # Cookie-only matches the HA frontend. A bearer here would be
-        # forwarded to the add-on upstream — needless LLAT leak.
-        headers["Cookie"] = f"ingress_session={session}"
+    # 5. Resolve route (direct-port / addon-variant / off-host).
+    url, headers = await _resolve_http_route(client, addon, normalized, port)
 
     # 6. Set content type based on body type
     if isinstance(body, dict):

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1285,16 +1285,21 @@ async def _call_addon_api(
 
     if response.status_code >= 400:
         result["error"] = f"Add-on API returned HTTP {response.status_code}"
-        # On 403/401, include addon config so the LLM can spot relevant settings
-        # (e.g., "leave_front_door_open", auth toggles, port mappings)
-        if response.status_code in (401, 403):
-            addon_options = addon.get("options")
-            addon_ports = addon.get("network") or addon.get("ports")
-            addon_host_network = addon.get("host_network")
+        # 401 = auth credential problem (token/scope/session); IP-restriction
+        # hint and addon_config attachment would misdirect.
+        # 403 = forbidden (likely Nginx ACL); addon_config helps the LLM spot
+        # relevant toggles like leave_front_door_open and port mappings.
+        if response.status_code == 401:
+            result["suggestion"] = (
+                "Authentication failed. The ingress session may have expired, "
+                "or your HA token may lack the required scope. Verify the "
+                "token has admin rights and try again."
+            )
+        elif response.status_code == 403:
             result["addon_config"] = {
-                "options": addon_options,
-                "ports": addon_ports,
-                "host_network": addon_host_network,
+                "options": addon.get("options"),
+                "ports": addon.get("network") or addon.get("ports"),
+                "host_network": addon.get("host_network"),
                 "ingress_port": addon.get("ingress_port"),
             }
             result["suggestion"] = (

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -798,8 +798,6 @@ async def _call_addon_ws(
             )
         )
     except TimeoutError:
-        # Off-host TCP timeouts to addon container IPs are common on PyPI
-        # installs; surface the same drop-`port` hint the OSError path uses.
         raise_tool_error(
             create_error_response(
                 ErrorCode.TIMEOUT_OPERATION,
@@ -1063,10 +1061,6 @@ async def _call_addon_api(
                 content=request_content,
             )
     except httpx.TimeoutException:
-        # Off-host installs hitting an addon's container IP often see a
-        # silent TCP drop (timeout) rather than ICMP unreachable
-        # (ConnectError) — depends on the upstream router. Either way,
-        # the actionable hint is the same.
         raise_tool_error(
             create_error_response(
                 ErrorCode.TIMEOUT_OPERATION,

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -286,6 +286,35 @@ async def _supervisor_api_call(
                 pass
 
 
+async def _create_ingress_session(client: HomeAssistantClient) -> str:
+    """Create a Supervisor ingress session and return its token.
+
+    Sessions are minted via the WS `supervisor/api` proxy (which HA Core
+    authenticates on our behalf), so this works the same on HAOS, Supervised,
+    and PyPI/uvx hosts. The returned token is set as the `ingress_session`
+    cookie on requests to HA Core's `/api/hassio_ingress/<addon_token>/...`
+    endpoint, which Supervisor validates before proxying to the add-on
+    container. Sessions are valid for ~15 minutes; we mint a fresh one per
+    call to avoid managing lifetime.
+    """
+    response = await _supervisor_api_call(
+        client, "/ingress/session", method="POST", data={}
+    )
+    if not response.get("success"):
+        raise_tool_error(response)
+
+    session = response.get("result", {}).get("session")
+    if not isinstance(session, str) or not session:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Supervisor returned no ingress session token",
+                details=str(response),
+            )
+        )
+    return session
+
+
 async def get_addon_info(client: HomeAssistantClient, slug: str) -> dict[str, Any]:
     """Get detailed info for a specific add-on.
 
@@ -517,6 +546,11 @@ async def _call_addon_ws(
 ) -> dict[str, Any]:
     """Connect to an add-on's WebSocket API and collect messages.
 
+    Routing mirrors the HTTP variant: ingress mode tunnels the WS through HA
+    Core's `/api/hassio_ingress` proxy (works off-host); direct-port mode
+    (`port` set) connects straight to the container and requires the MCP
+    host to share HA's Docker network.
+
     Args:
         client: Home Assistant REST client
         slug: Add-on slug (e.g., "5c53de3b_esphome")
@@ -591,8 +625,13 @@ async def _call_addon_ws(
             )
         )
 
-    # 5. Build WebSocket URL
+    # 5. Build WebSocket URL.
+    # Ingress mode tunnels the WS through HA Core's `/api/hassio_ingress`
+    # proxy (which supports WS upgrade) so it works on off-host installs.
+    # Direct-port mode connects straight to the add-on container.
+    headers: dict[str, str] = {}
     addon_ip = addon.get("ip_address", "")
+
     if port:
         if not addon_ip:
             raise_tool_error(
@@ -602,27 +641,23 @@ async def _call_addon_ws(
                     context={"slug": slug},
                 )
             )
-        target_port = port
+        ws_url = f"ws://{addon_ip}:{port}/{normalized}"
     else:
-        ingress_port = addon.get("ingress_port")
-        if not addon_ip or not ingress_port:
+        ingress_entry = addon.get("ingress_entry")
+        if not ingress_entry:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing network info",
+                    f"Add-on '{addon_name}' is missing ingress_entry",
                     context={"slug": slug},
                 )
             )
-        target_port = ingress_port
-
-    ws_url = f"ws://{addon_ip}:{target_port}/{normalized}"
-
-    # 6. Build connection headers
-    headers: dict[str, str] = {}
-    if not port:
-        ingress_entry = addon.get("ingress_entry", "")
-        headers["X-Ingress-Path"] = ingress_entry
-        headers["X-Hass-Source"] = "core.ingress"
+        session = await _create_ingress_session(client)
+        ws_scheme = "wss" if client.base_url.startswith("https") else "ws"
+        ws_host = client.base_url.split("://", 1)[1]
+        ws_url = f"{ws_scheme}://{ws_host}{ingress_entry}/{normalized}"
+        headers["Cookie"] = f"ingress_session={session}"
+        headers["Authorization"] = f"Bearer {client.token}"
 
     # 7. Connect and exchange messages
     collected: list[str] = []
@@ -736,11 +771,20 @@ async def _call_addon_ws(
             )
         )
     except OSError as e:
+        suggestions = ["Check that the add-on is running"]
+        if port:
+            suggestions.append(
+                "Direct-port access requires the MCP host to share Home "
+                "Assistant's container network. On PyPI/uvx installs, drop "
+                "the 'port' parameter to route through Ingress instead."
+            )
         raise_tool_error(
-            create_connection_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
                 f"Failed to connect to add-on '{addon_name}' WebSocket: {e!s}",
-                details="Check that the add-on is running and the port is correct",
-                context={"slug": slug},
+                details=f"url={ws_url}",
+                context={"slug": slug, "direct_port": bool(port)},
+                suggestions=suggestions,
             )
         )
 
@@ -852,7 +896,18 @@ async def _call_addon_api(
     limit: int | None = None,
     python_transform: str | None = None,
 ) -> dict[str, Any]:
-    """Call an add-on's web API through Home Assistant's Ingress proxy.
+    """Call an add-on's web API.
+
+    Two routing modes:
+
+    - **Ingress (default)**: tunnels through HA Core's
+      `/api/hassio_ingress/<token>/...` proxy. Mints a fresh Supervisor
+      ingress session per call via the WS `supervisor/api` proxy. Works on
+      HAOS, Supervised, and off-host PyPI/uvx installs.
+    - **Direct port** (when `port` is set): connects to
+      `http://<addon_ip>:<port>/...` for add-ons that expose mapped ports
+      (e.g. Node-RED on 1880). Only works when the MCP host shares HA's
+      Docker network — i.e. running as the HAOS add-on.
 
     Args:
         client: Home Assistant REST client
@@ -868,9 +923,6 @@ async def _call_addon_api(
             parsed response body. The variable ``response`` is bound to
             ``dict | list | str`` depending on content-type. Transform runs
             after offset/limit slicing.
-
-    Returns:
-        Dictionary with response data, status code, and content type.
     """
     # 1. Sanitize path to prevent traversal attacks (including URL-encoded)
     normalized = unquote(path).lstrip("/")
@@ -919,13 +971,16 @@ async def _call_addon_api(
             )
         )
 
-    # 5. Build URL to the add-on container
+    # 5. Build URL.
+    # Ingress mode (default) routes through HA Core's `/api/hassio_ingress`
+    # proxy so this works equally on HAOS addons and off-host PyPI/uvx
+    # installs. Direct-port mode connects straight to the add-on's container
+    # IP — this only works when the MCP host shares the hassio Docker
+    # bridge (i.e. the HAOS addon).
+    headers: dict[str, str] = {}
     addon_ip = addon.get("ip_address", "")
 
     if port:
-        # Direct port access: connect to the add-on's mapped network port
-        # (e.g., 1880 for Node-RED, 6052 for ESPHome) instead of the ingress port.
-        # Requires 'leave_front_door_open' or equivalent setting on the add-on.
         if not addon_ip:
             raise_tool_error(
                 create_error_response(
@@ -934,37 +989,23 @@ async def _call_addon_api(
                     context={"slug": slug, "ip_address": addon_ip},
                 )
             )
-        target_port = port
+        url = f"http://{addon_ip}:{port}/{normalized}"
     else:
-        # Default: use the ingress port for direct container communication
-        ingress_port = addon.get("ingress_port")
-        if not addon_ip or not ingress_port:
+        ingress_entry = addon.get("ingress_entry")
+        if not ingress_entry:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.INTERNAL_ERROR,
-                    f"Add-on '{addon_name}' is missing network info (ip_address or ingress_port)",
-                    context={
-                        "slug": slug,
-                        "ip_address": addon_ip,
-                        "ingress_port": ingress_port,
-                    },
+                    f"Add-on '{addon_name}' is missing ingress_entry",
+                    context={"slug": slug},
                 )
             )
-        target_port = ingress_port
+        session = await _create_ingress_session(client)
+        url = f"{client.base_url}{ingress_entry}/{normalized}"
+        headers["Cookie"] = f"ingress_session={session}"
+        headers["Authorization"] = f"Bearer {client.token}"
 
-    url = f"http://{addon_ip}:{target_port}/{normalized}"
-
-    # 6. Make HTTP request directly to the add-on container
-    # Include Ingress headers so the add-on's web server (e.g., Nginx) recognizes
-    # this as an authenticated Ingress request and bypasses its own auth layer.
-    # When using a direct port, skip Ingress headers (not needed/recognized).
-    ingress_entry = addon.get("ingress_entry", "")
-    headers: dict[str, str] = {}
-    if not port:
-        headers["X-Ingress-Path"] = ingress_entry
-        headers["X-Hass-Source"] = "core.ingress"
-
-    # Set content type based on body type
+    # 6. Set content type based on body type
     if isinstance(body, dict):
         headers["Content-Type"] = "application/json"
         request_content = json.dumps(body).encode()
@@ -992,11 +1033,23 @@ async def _call_addon_api(
             )
         )
     except httpx.ConnectError as e:
+        # Direct-port mode is the only path that touches the addon's
+        # container IP directly; off-host installs (PyPI/uvx) have no route
+        # to that bridge, so surface the limitation in the suggestions.
+        suggestions = ["Check that the add-on is running"]
+        if port:
+            suggestions.append(
+                "Direct-port access requires the MCP host to share Home "
+                "Assistant's container network. On PyPI/uvx installs, drop "
+                "the 'port' parameter to route through Ingress instead."
+            )
         raise_tool_error(
-            create_connection_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
                 f"Failed to connect to add-on '{addon_name}': {e!s}",
-                details="Check that the add-on is running and Home Assistant Ingress is working",
-                context={"slug": slug},
+                details=f"url={url}",
+                context={"slug": slug, "direct_port": bool(port)},
+                suggestions=suggestions,
             )
         )
 
@@ -1411,7 +1464,11 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         are fetched and merged automatically (including one level of nested dicts).
 
         **Proxy mode** (when path is provided):
-        Sends requests directly to the add-on container's own web API via HTTP or WebSocket.
+        Routes HTTP or WebSocket requests through Home Assistant's Ingress
+        proxy by default (works on HAOS, Supervised, and off-host PyPI/uvx
+        installs). Pass `port=...` to bypass Ingress and connect directly to
+        an add-on's container port — that mode requires the MCP host to
+        share Home Assistant's container network (i.e. only the HAOS addon).
         Use ha_get_addon(slug="...") to discover available ports and endpoints.
 
         **Response shaping (proxy mode):**

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -25,7 +25,6 @@ from ..errors import (
     ErrorCode,
     create_connection_error,
     create_error_response,
-    create_timeout_error,
     create_validation_error,
 )
 from ..utils.python_sandbox import PythonSandboxError, safe_execute_expression
@@ -284,6 +283,28 @@ async def _supervisor_api_call(
                 await ws_client.disconnect()
             except Exception:
                 pass
+
+
+def _addon_connection_failure_suggestions(
+    client: HomeAssistantClient, port: int | None
+) -> list[str]:
+    """Suggestions for connect/timeout failures against an add-on.
+
+    Direct-port mode hits the addon's container IP, which off-host installs
+    can't route to — the actionable hint is to drop `port`. Ingress mode
+    hits HA Core, so failures usually mean HA Core is unreachable.
+    """
+    if port:
+        return [
+            "Check that the add-on is running",
+            "Direct-port access requires the MCP host to share Home "
+            "Assistant's container network. On PyPI/uvx installs, drop "
+            "the 'port' parameter to route through Ingress instead.",
+        ]
+    return [
+        f"Verify Home Assistant is reachable at {client.base_url}",
+        "Check network connectivity from the MCP host to HA Core",
+    ]
 
 
 async def _create_ingress_session(client: HomeAssistantClient) -> str:
@@ -762,29 +783,31 @@ async def _call_addon_ws(
             )
         )
     except TimeoutError:
+        # Off-host TCP timeouts to addon container IPs are common on PyPI
+        # installs; surface the same drop-`port` hint the OSError path uses.
         raise_tool_error(
-            create_timeout_error(
-                f"WebSocket connection to '{addon_name}'",
-                timeout,
+            create_error_response(
+                ErrorCode.TIMEOUT_OPERATION,
+                f"Operation 'WebSocket connection to {addon_name!r}' timed out after {timeout}s",
                 details=f"path={path}",
-                context={"slug": slug, "path": path},
+                context={
+                    "slug": slug,
+                    "path": path,
+                    "operation": f"WebSocket connection to '{addon_name}'",
+                    "timeout_seconds": timeout,
+                    "direct_port": bool(port),
+                },
+                suggestions=_addon_connection_failure_suggestions(client, port),
             )
         )
     except OSError as e:
-        suggestions = ["Check that the add-on is running"]
-        if port:
-            suggestions.append(
-                "Direct-port access requires the MCP host to share Home "
-                "Assistant's container network. On PyPI/uvx installs, drop "
-                "the 'port' parameter to route through Ingress instead."
-            )
         raise_tool_error(
             create_error_response(
                 ErrorCode.CONNECTION_FAILED,
                 f"Failed to connect to add-on '{addon_name}' WebSocket: {e!s}",
                 details=f"url={ws_url}",
                 context={"slug": slug, "direct_port": bool(port)},
-                suggestions=suggestions,
+                suggestions=_addon_connection_failure_suggestions(client, port),
             )
         )
 
@@ -1024,32 +1047,33 @@ async def _call_addon_api(
                 content=request_content,
             )
     except httpx.TimeoutException:
+        # Off-host installs hitting an addon's container IP often see a
+        # silent TCP drop (timeout) rather than ICMP unreachable
+        # (ConnectError) — depends on the upstream router. Either way,
+        # the actionable hint is the same.
         raise_tool_error(
-            create_timeout_error(
-                f"add-on API call to '{addon_name}'",
-                timeout,
+            create_error_response(
+                ErrorCode.TIMEOUT_OPERATION,
+                f"Operation 'add-on API call to {addon_name!r}' timed out after {timeout}s",
                 details=f"path={path}, method={method}",
-                context={"slug": slug, "path": path},
+                context={
+                    "slug": slug,
+                    "path": path,
+                    "operation": f"add-on API call to '{addon_name}'",
+                    "timeout_seconds": timeout,
+                    "direct_port": bool(port),
+                },
+                suggestions=_addon_connection_failure_suggestions(client, port),
             )
         )
     except httpx.ConnectError as e:
-        # Direct-port mode is the only path that touches the addon's
-        # container IP directly; off-host installs (PyPI/uvx) have no route
-        # to that bridge, so surface the limitation in the suggestions.
-        suggestions = ["Check that the add-on is running"]
-        if port:
-            suggestions.append(
-                "Direct-port access requires the MCP host to share Home "
-                "Assistant's container network. On PyPI/uvx installs, drop "
-                "the 'port' parameter to route through Ingress instead."
-            )
         raise_tool_error(
             create_error_response(
                 ErrorCode.CONNECTION_FAILED,
                 f"Failed to connect to add-on '{addon_name}': {e!s}",
                 details=f"url={url}",
                 context={"slug": slug, "direct_port": bool(port)},
-                suggestions=suggestions,
+                suggestions=_addon_connection_failure_suggestions(client, port),
             )
         )
 

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -370,6 +370,8 @@ class TestCallAddonApiErrors:
         # itself when it proxies upstream, and adding our own would conflict.
         assert "X-Ingress-Path" not in headers
         assert "X-Hass-Source" not in headers
+        # Bearer would be forwarded to the add-on upstream — leak vector.
+        assert "Authorization" not in headers
         # Ingress session was minted exactly once
         mock_ingress_session.assert_awaited_once()
 
@@ -872,6 +874,84 @@ class TestCallAddonWsErrors:
         assert "not running" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status,must_mention",
+        [
+            (401, ("token", "scope", "session")),
+            (403, ("token", "scope", "session")),
+        ],
+    )
+    async def test_ws_handshake_4xx_auth_hints_at_token(
+        self, mock_ingress_session, status, must_mention
+    ):
+        """401/403 from the WS handshake should suggest token/scope, not path."""
+        from websockets.datastructures import Headers
+        from websockets.http11 import Response
+
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            response = Response(status, "Unauthorized", Headers())
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=websockets.exceptions.InvalidStatus(response),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/compile")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        joined = " ".join(suggestions).lower()
+        assert any(k in joined for k in must_mention), suggestions
+        # Path-shape hint should NOT be the primary suggestion for an auth failure.
+        assert not any("supports WebSocket on this path" in s for s in suggestions), (
+            suggestions
+        )
+
+    @pytest.mark.asyncio
+    async def test_ws_handshake_404_keeps_path_hint(self, mock_ingress_session):
+        """404 from the WS handshake should still surface the path-shape hint."""
+        from websockets.datastructures import Headers
+        from websockets.http11 import Response
+
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            response = Response(404, "Not Found", Headers())
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=websockets.exceptions.InvalidStatus(response),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/compile")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any("path" in s.lower() or "endpoints" in s.lower() for s in suggestions), (
+            suggestions
+        )
+
+    @pytest.mark.asyncio
     async def test_ws_handshake_failure(self, mock_ingress_session):
         """Should raise ToolError when WebSocket handshake fails."""
         client = _make_mock_client()
@@ -936,6 +1016,7 @@ class TestCallAddonWsErrors:
         )
         headers = captured["kwargs"]["additional_headers"]
         assert headers["Cookie"] == f"ingress_session={_INGRESS_SESSION_TOKEN}"
+        assert "Authorization" not in headers
 
     @pytest.mark.asyncio
     async def test_ws_direct_port_skips_ingress_session(self, mock_ingress_session):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -452,6 +452,77 @@ class TestCallAddonApiErrors:
         assert any("ingress" in s.lower() for s in suggestions), suggestions
 
     @pytest.mark.asyncio
+    async def test_http_direct_port_timeout_hints_at_ingress(
+        self, mock_ingress_session
+    ):
+        """Timeouts in direct-port mode should also suggest dropping `port`.
+
+        On real off-host installs, packets to the addon's container IP often
+        get silently dropped by the upstream router instead of refused —
+        which surfaces as TimeoutException, not ConnectError. The same
+        actionable hint must apply.
+        """
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = httpx.TimeoutException(
+                "Connection timed out"
+            )
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(
+                    client, "test_addon", "/flows", port=1880, timeout=5
+                )
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any("ingress" in s.lower() for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
+    async def test_http_ingress_timeout_hints_at_ha_core(self, mock_ingress_session):
+        """Timeouts in ingress mode should point at HA Core, not the add-on."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = httpx.TimeoutException("timed out")
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(client, "test_addon", "/api/test", timeout=5)
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any(client.base_url in s for s in suggestions), suggestions
+        assert not any("'port' parameter" in s for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
     async def test_http_ingress_connection_error_hints_at_ha_core(
         self, mock_ingress_session
     ):
@@ -1010,6 +1081,63 @@ class TestCallAddonWsErrors:
         result = _parse_tool_error(exc_info)
         suggestions = result["error"].get("suggestions", [])
         assert any("ingress" in s.lower() for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
+    async def test_ws_direct_port_timeout_hints_at_ingress(self, mock_ingress_session):
+        """TimeoutError in direct-port WS mode should suggest dropping `port`."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=TimeoutError(),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(
+                    client, "test_addon", "/validate", port=6052, timeout=5
+                )
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any("ingress" in s.lower() for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
+    async def test_ws_ingress_timeout_hints_at_ha_core(self, mock_ingress_session):
+        """TimeoutError in ingress WS mode should point at HA Core."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=TimeoutError(),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/validate", timeout=5)
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any(client.base_url in s for s in suggestions), suggestions
+        assert not any("'port' parameter" in s for s in suggestions), suggestions
 
     @pytest.mark.asyncio
     async def test_ws_ingress_connection_error_hints_at_ha_core(

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -1987,7 +1987,7 @@ class TestCallAddonWsNewParams:
     """Integration tests for message_limit/offset/summarize/python_transform in _call_addon_ws."""
 
     @pytest.mark.asyncio
-    async def test_message_limit_caps_collection(self):
+    async def test_message_limit_caps_collection(self, mock_ingress_session):
         """message_limit lowers the collection cap so we stop early."""
         client = _make_mock_client()
 
@@ -2025,7 +2025,9 @@ class TestCallAddonWsNewParams:
         assert result["pagination"]["limit"] == 5
 
     @pytest.mark.asyncio
-    async def test_safety_ceiling_distinct_from_message_limit(self):
+    async def test_safety_ceiling_distinct_from_message_limit(
+        self, mock_ingress_session
+    ):
         """Hitting the global ceiling without a caller-set message_limit
         reports closed_by="safety_ceiling", not "message_limit"."""
         client = _make_mock_client()
@@ -2064,7 +2066,7 @@ class TestCallAddonWsNewParams:
         assert result["message_count"] == 5
 
     @pytest.mark.asyncio
-    async def test_message_offset_skips_head(self):
+    async def test_message_offset_skips_head(self, mock_ingress_session):
         """message_offset drops the first N messages from the returned list."""
         client = _make_mock_client()
 
@@ -2103,7 +2105,7 @@ class TestCallAddonWsNewParams:
         assert result["pagination"]["total_collected"] == 4
 
     @pytest.mark.asyncio
-    async def test_summarize_elides_yaml_dump(self):
+    async def test_summarize_elides_yaml_dump(self, mock_ingress_session):
         """The summarize pass collapses a long non-signal run from the WS stream."""
         client = _make_mock_client()
 
@@ -2144,7 +2146,7 @@ class TestCallAddonWsNewParams:
         )
 
     @pytest.mark.asyncio
-    async def test_summarize_false_returns_raw_stream(self):
+    async def test_summarize_false_returns_raw_stream(self, mock_ingress_session):
         """With summarize=False, no elision happens."""
         client = _make_mock_client()
 
@@ -2175,7 +2177,7 @@ class TestCallAddonWsNewParams:
         assert "summary" not in result
 
     @pytest.mark.asyncio
-    async def test_python_transform_filters_messages(self):
+    async def test_python_transform_filters_messages(self, mock_ingress_session):
         """python_transform post-processes the message list after summarize."""
         client = _make_mock_client()
 
@@ -2216,7 +2218,7 @@ class TestCallAddonWsNewParams:
         assert result["messages"][0]["level"] == "ERROR"
 
     @pytest.mark.asyncio
-    async def test_python_transform_invalid_raises(self):
+    async def test_python_transform_invalid_raises(self, mock_ingress_session):
         """Invalid python_transform surfaces VALIDATION_FAILED as ToolError."""
         client = _make_mock_client()
 
@@ -2255,7 +2257,7 @@ class TestCallAddonApiPythonTransform:
     """Tests for python_transform in HTTP mode (_call_addon_api)."""
 
     @pytest.mark.asyncio
-    async def test_transform_applies_to_json_array(self):
+    async def test_transform_applies_to_json_array(self, mock_ingress_session):
         """Transform reshapes a JSON array response before return."""
         client = _make_mock_client()
         with (
@@ -2290,7 +2292,7 @@ class TestCallAddonApiPythonTransform:
         assert result["response"] == [1, 2]
 
     @pytest.mark.asyncio
-    async def test_transform_applies_to_dict_body(self):
+    async def test_transform_applies_to_dict_body(self, mock_ingress_session):
         """Transform on dict content-type."""
         client = _make_mock_client()
         with (
@@ -2322,7 +2324,7 @@ class TestCallAddonApiPythonTransform:
         assert result["response"] == {"status": "ok"}
 
     @pytest.mark.asyncio
-    async def test_transform_invalid_raises(self):
+    async def test_transform_invalid_raises(self, mock_ingress_session):
         """HTTP mode: invalid transform raises ToolError."""
         client = _make_mock_client()
         with (

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -752,6 +752,99 @@ class TestCallAddonApiErrors:
         # The off-host hint about HA Core reachability must NOT appear here.
         assert not any(client.base_url in s for s in suggestions), suggestions
 
+    @pytest.mark.asyncio
+    async def test_http_401_response_hints_at_auth(self, mock_ingress_session):
+        """A 401 from the add-on points at auth/token/session, NOT at IP
+        restriction. addon_config is dropped because it's a credential
+        problem, not a misconfigured add-on."""
+        client = _make_mock_client()
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 401
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert result["status_code"] == 401
+        suggestion = result["suggestion"].lower()
+        # Auth-flavored hint expected.
+        assert any(token in suggestion for token in ("auth", "token", "scope", "session")), (
+            result["suggestion"]
+        )
+        # IP-restriction hint must NOT fire on 401 — it would misdirect.
+        assert "nginx" not in suggestion, result["suggestion"]
+        assert "ip restriction" not in suggestion, result["suggestion"]
+        # addon_config is irrelevant for a credential problem.
+        assert "addon_config" not in result, result
+
+    @pytest.mark.asyncio
+    async def test_http_403_response_hints_at_ip_restriction(
+        self, mock_ingress_session
+    ):
+        """A 403 keeps the existing 'Nginx IP restriction' hint and
+        addon_config attachment — the LLM uses addon_config to spot
+        leave_front_door_open / port toggles."""
+        client = _make_mock_client()
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 403
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert result["status_code"] == 403
+        suggestion = result["suggestion"].lower()
+        # Existing IP-restriction wording preserved on 403.
+        assert "nginx" in suggestion or "ip restriction" in suggestion, (
+            result["suggestion"]
+        )
+        # addon_config attached so the LLM can spot relevant settings.
+        assert "addon_config" in result, result
+        for key in ("options", "ports", "host_network", "ingress_port"):
+            assert key in result["addon_config"], result["addon_config"]
+
 
 class TestCreateIngressSession:
     """Tests for _create_ingress_session error and success paths.

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -451,6 +451,203 @@ class TestCallAddonApiErrors:
         suggestions = result["error"].get("suggestions", [])
         assert any("ingress" in s.lower() for s in suggestions), suggestions
 
+    @pytest.mark.asyncio
+    async def test_http_ingress_connection_error_hints_at_ha_core(
+        self, mock_ingress_session
+    ):
+        """ConnectError in ingress mode should point at HA Core, not the add-on.
+
+        The actual failure on off-host installs is HA Core unreachable from
+        the MCP host — the old generic "Check that the add-on is running"
+        hint sent users on a wild-goose chase.
+        """
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = httpx.ConnectError(
+                "Connection refused"
+            )
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(client, "test_addon", "/api/test")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        # Suggestion should reference the configured HA URL so the user
+        # knows where to verify reachability.
+        assert any(client.base_url in s for s in suggestions), suggestions
+        # Direct-port-only hint must not surface in ingress-mode failures.
+        assert not any("'port' parameter" in s for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
+    async def test_http_base_url_with_trailing_slash(self, mock_ingress_session):
+        """Trailing slash on base_url must not produce a doubled slash in the request URL."""
+        client = _make_mock_client()
+        client.base_url = "http://localhost:8123/"
+
+        captured: dict[str, object] = {}
+
+        async def fake_request(*, method, url, headers, content):
+            captured["url"] = url
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 200
+            response.json.return_value = {"ok": True}
+            response.text = '{"ok": true}'
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert captured["url"] == (
+            "http://localhost:8123/api/hassio_ingress/abc123/api/test"
+        )
+
+
+class TestCreateIngressSession:
+    """Tests for _create_ingress_session error and success paths.
+
+    The fixture mocks this helper away in most other tests, so its own
+    error handling needs direct coverage.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_session_token_on_success(self):
+        """Happy path: returns the session string from Supervisor's response."""
+        from ha_mcp.tools.tools_addons import _create_ingress_session
+
+        client = _make_mock_client()
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            new_callable=AsyncMock,
+            return_value={"success": True, "result": {"session": "abc-token-123"}},
+        ):
+            session = await _create_ingress_session(client)
+
+        assert session == "abc-token-123"
+
+    @pytest.mark.asyncio
+    async def test_supervisor_error_response_propagates(self):
+        """When _supervisor_api_call returns success=False, the error is raised."""
+        from ha_mcp.tools.tools_addons import _create_ingress_session
+
+        client = _make_mock_client()
+        error_response = {
+            "success": False,
+            "error": {
+                "code": "CONNECTION_FAILED",
+                "message": "WS connection failed",
+            },
+        }
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._supervisor_api_call",
+                new_callable=AsyncMock,
+                return_value=error_response,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _create_ingress_session(client)
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert result["error"]["code"] == "CONNECTION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_result_missing_session_field(self):
+        """Supervisor returns success but no `session` field — raise."""
+        from ha_mcp.tools.tools_addons import _create_ingress_session
+
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._supervisor_api_call",
+                new_callable=AsyncMock,
+                return_value={"success": True, "result": {}},
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _create_ingress_session(client)
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "ingress session" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_session_token_rejected(self):
+        """Empty session string is rejected (not silently treated as valid)."""
+        from ha_mcp.tools.tools_addons import _create_ingress_session
+
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._supervisor_api_call",
+                new_callable=AsyncMock,
+                return_value={"success": True, "result": {"session": ""}},
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _create_ingress_session(client)
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "ingress session" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_non_string_session_token_rejected(self):
+        """A non-string `session` value is rejected."""
+        from ha_mcp.tools.tools_addons import _create_ingress_session
+
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons._supervisor_api_call",
+                new_callable=AsyncMock,
+                return_value={"success": True, "result": {"session": 12345}},
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _create_ingress_session(client)
+
+        result = _parse_tool_error(exc_info)
+        assert result["success"] is False
+        assert "ingress session" in result["error"]["message"].lower()
+
 
 # Standard mock return for a running addon with Ingress support (for WS tests)
 _RUNNING_ADDON_INFO_WS = {
@@ -678,6 +875,7 @@ class TestCallAddonWsErrors:
 
         def capture_connect(url, **kwargs):
             captured["url"] = url
+            captured["headers"] = dict(kwargs.get("additional_headers", {}))
             cm = MagicMock()
             mock_ws = AsyncMock()
             mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
@@ -704,7 +902,149 @@ class TestCallAddonWsErrors:
 
         assert result["success"] is True
         assert captured["url"] == "ws://172.30.33.99:6052/validate"
+        # Direct-port mode must NOT carry the ingress session cookie — that
+        # cookie only authenticates against HA Core's hassio_ingress proxy.
+        assert "Cookie" not in captured["headers"]
         mock_ingress_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ws_https_base_url_uses_wss_scheme(self, mock_ingress_session):
+        """When client.base_url is https, ingress WS targets wss://."""
+        client = _make_mock_client()
+        client.base_url = "https://homeassistant.example.com:8123"
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            result = await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert result["success"] is True
+        assert captured["url"] == (
+            "wss://homeassistant.example.com:8123/api/hassio_ingress/abc123/validate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ws_base_url_with_trailing_slash(self, mock_ingress_session):
+        """Trailing slash on base_url must not produce a doubled slash in the WS URL."""
+        client = _make_mock_client()
+        client.base_url = "http://localhost:8123/"
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert captured["url"] == (
+            "ws://localhost:8123/api/hassio_ingress/abc123/validate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ws_direct_port_offhost_error_hints_at_ingress(
+        self, mock_ingress_session
+    ):
+        """OSError in direct-port WS mode should suggest dropping `port` for off-host hosts."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=OSError("No route to host"),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(
+                    client, "test_addon", "/validate", port=6052
+                )
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any("ingress" in s.lower() for s in suggestions), suggestions
+
+    @pytest.mark.asyncio
+    async def test_ws_ingress_connection_error_hints_at_ha_core(
+        self, mock_ingress_session
+    ):
+        """OSError in ingress WS mode should point at HA Core, not the add-on.
+
+        The actual failure on off-host installs is HA Core unreachable from
+        the MCP host — the old generic "Check that the add-on is running"
+        hint sent users on a wild-goose chase.
+        """
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=OSError("Connection refused"),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/validate")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any(client.base_url in s for s in suggestions), suggestions
+        assert not any("'port' parameter" in s for s in suggestions), suggestions
 
     @pytest.mark.asyncio
     async def test_ws_connection_closed_during_send(self, mock_ingress_session):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -50,6 +50,19 @@ def _parse_tool_error(exc_info: pytest.ExceptionInfo[ToolError]) -> dict:
     return json.loads(str(exc_info.value))
 
 
+@pytest.fixture(autouse=True)
+def _default_offhost_env(monkeypatch):
+    """Pin tests to the off-host install variant by default.
+
+    `is_running_in_addon()` reads `SUPERVISOR_TOKEN` from the environment.
+    Without explicit pinning, a test inheriting that env var from the host
+    shell would silently flip into the HA-add-on branch and assert the wrong
+    route. Tests exercising the addon variant must `monkeypatch.setenv`
+    inside their body to override this default.
+    """
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+
+
 @pytest.fixture
 def mock_ingress_session():
     """Patch _create_ingress_session to return a fixed token without WS calls."""
@@ -605,6 +618,139 @@ class TestCallAddonApiErrors:
         assert captured["url"] == (
             "http://localhost:8123/api/hassio_ingress/abc123/api/test"
         )
+
+    @pytest.mark.asyncio
+    async def test_http_addon_variant_uses_direct_ingress_port(
+        self, monkeypatch, mock_ingress_session
+    ):
+        """When running as the HA add-on, ingress mode hits the addon's container
+        directly with `core.ingress` source headers — no HA Core proxy hop, no
+        session cookie. This is the path that worked on master pre-PR."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        # Inside the addon variant, base_url points at Supervisor's proxy mount.
+        client.base_url = "http://supervisor/core"
+
+        captured: dict[str, object] = {}
+
+        async def fake_request(*, method, url, headers, content):
+            captured["url"] = url
+            captured["headers"] = dict(headers)
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 200
+            response.json.return_value = {"ok": True}
+            response.text = '{"ok": true}'
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert result["success"] is True
+        # URL is the addon container's ingress port — NOT the HA Core proxy.
+        assert captured["url"] == "http://172.30.33.99:5000/api/test"
+        headers = captured["headers"]
+        # Source-trust headers, the way master routed pre-PR.
+        assert headers["X-Ingress-Path"] == "/api/hassio_ingress/abc123"
+        assert headers["X-Hass-Source"] == "core.ingress"
+        # No HA-Core-side auth — not going through Core.
+        assert "Cookie" not in headers
+        assert "Authorization" not in headers
+        # No ingress session minted on the addon variant.
+        mock_ingress_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_addon_variant_missing_ingress_port_errors(
+        self, monkeypatch
+    ):
+        """Addon variant requires both ip_address and ingress_port."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "http://supervisor/core"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "started",
+                        "ingress_entry": "/api/hassio_ingress/abc123",
+                        "ip_address": "172.30.33.99",
+                        "ingress_port": None,
+                    },
+                },
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _call_addon_api(client, "test_addon", "/api/test")
+
+        result = _parse_tool_error(exc_info)
+        assert result["error"]["code"] == "INTERNAL_ERROR"
+        assert "ingress_port" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_http_addon_variant_connect_error_hints_at_addon_network(
+        self, monkeypatch, mock_ingress_session
+    ):
+        """ConnectError on addon variant should suggest restarting the target
+        add-on, not 'verify HA reachable' (HA is fine — sibling network is the
+        problem)."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "http://supervisor/core"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = httpx.ConnectError(
+                "No route to host"
+            )
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(client, "test_addon", "/api/test")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        # Addon-variant suggestion should be about the target add-on / addon
+        # network — not about HA Core reachability.
+        assert any(
+            "restart" in s.lower() or "addon network" in s.lower() for s in suggestions
+        ), suggestions
+        # The off-host hint about HA Core reachability must NOT appear here.
+        assert not any(client.base_url in s for s in suggestions), suggestions
 
 
 class TestCreateIngressSession:
@@ -1475,6 +1621,160 @@ class TestCallAddonWsErrors:
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
         assert "ip_address" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_ws_addon_variant_uses_direct_ingress_port(
+        self, monkeypatch, mock_ingress_session
+    ):
+        """When running as the HA add-on, ingress WS hits the addon container's
+        ingress port directly with `core.ingress` source headers — no HA Core
+        proxy hop, no session cookie."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "http://supervisor/core"
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = dict(kwargs.get("additional_headers", {}))
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            result = await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert result["success"] is True
+        # WS to the addon container's ingress port — never to HA Core.
+        assert captured["url"] == "ws://172.30.33.99:5000/validate"
+        headers = captured["headers"]
+        assert headers["X-Ingress-Path"] == "/api/hassio_ingress/abc123"
+        assert headers["X-Hass-Source"] == "core.ingress"
+        assert "Cookie" not in headers
+        assert "Authorization" not in headers
+        mock_ingress_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ws_addon_variant_wss_not_used_for_https_base_url(
+        self, monkeypatch, mock_ingress_session
+    ):
+        """Even when client.base_url is HTTPS, the addon-variant route hits the
+        container's bridge IP — always plain `ws://`. The base_url scheme is
+        irrelevant here because we never go through HA Core."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "https://homeassistant.example.com:8123"
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert captured["url"].startswith("ws://"), captured["url"]
+        assert not captured["url"].startswith("wss://"), captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_ws_addon_variant_missing_ingress_port_errors(
+        self, monkeypatch
+    ):
+        """Addon variant requires both ip_address and ingress_port for WS."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "http://supervisor/core"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value={
+                    "success": True,
+                    "addon": {
+                        "name": "Test Addon",
+                        "slug": "test_addon",
+                        "ingress": True,
+                        "state": "started",
+                        "ingress_entry": "/api/hassio_ingress/abc123",
+                        "ip_address": "172.30.33.99",
+                        "ingress_port": None,
+                    },
+                },
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _call_addon_ws(client, "test_addon", "/validate")
+
+        result = _parse_tool_error(exc_info)
+        assert result["error"]["code"] == "INTERNAL_ERROR"
+        assert "ingress_port" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_ws_addon_variant_connect_error_hints_at_addon_network(
+        self, monkeypatch, mock_ingress_session
+    ):
+        """OSError on addon-variant WS should suggest restarting the target
+        add-on, not 'verify HA reachable'."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "supervisor-test-token")
+        client = _make_mock_client()
+        client.base_url = "http://supervisor/core"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.side_effect = OSError("No route to host")
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/validate")
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any(
+            "restart" in s.lower() or "addon network" in s.lower() for s in suggestions
+        ), suggestions
+        assert not any(client.base_url in s for s in suggestions), suggestions
 
 
 class TestSliceWsMessages:

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -34,6 +34,8 @@ _RUNNING_ADDON_INFO = {
     },
 }
 
+_INGRESS_SESSION_TOKEN = "test-ingress-session"
+
 
 def _make_mock_client() -> MagicMock:
     """Create a mock HomeAssistantClient."""
@@ -46,6 +48,17 @@ def _make_mock_client() -> MagicMock:
 def _parse_tool_error(exc_info: pytest.ExceptionInfo[ToolError]) -> dict:
     """Parse the JSON payload from a ToolError."""
     return json.loads(str(exc_info.value))
+
+
+@pytest.fixture
+def mock_ingress_session():
+    """Patch _create_ingress_session to return a fixed token without WS calls."""
+    with patch(
+        "ha_mcp.tools.tools_addons._create_ingress_session",
+        new_callable=AsyncMock,
+        return_value=_INGRESS_SESSION_TOKEN,
+    ) as m:
+        yield m
 
 
 class TestCallAddonApiErrors:
@@ -215,8 +228,8 @@ class TestCallAddonApiErrors:
         )
 
     @pytest.mark.asyncio
-    async def test_addon_missing_network_info(self):
-        """Should raise ToolError when add-on is missing ip_address or ingress_port."""
+    async def test_direct_port_missing_ip_address(self):
+        """Direct-port mode requires the addon's container ip_address."""
         client = _make_mock_client()
 
         with (
@@ -228,26 +241,22 @@ class TestCallAddonApiErrors:
                     "addon": {
                         "name": "Test Addon",
                         "slug": "test_addon",
-                        "ingress": True,
+                        "ingress": False,
                         "state": "started",
                         "ip_address": "",
-                        "ingress_port": None,
                     },
                 },
             ),
             pytest.raises(ToolError) as exc_info,
         ):
-            await _call_addon_api(client, "test_addon", "/api/test")
+            await _call_addon_api(client, "test_addon", "/flows", port=1880)
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert (
-            "network info" in result["error"]["message"].lower()
-            or "ip_address" in str(result).lower()
-        )
+        assert "ip_address" in str(result).lower()
 
     @pytest.mark.asyncio
-    async def test_http_timeout(self):
+    async def test_http_timeout(self, mock_ingress_session):
         """Should raise ToolError when add-on API doesn't respond."""
         client = _make_mock_client()
 
@@ -279,7 +288,7 @@ class TestCallAddonApiErrors:
         )
 
     @pytest.mark.asyncio
-    async def test_http_connection_error(self):
+    async def test_http_connection_error(self, mock_ingress_session):
         """Should raise ToolError when can't reach add-on."""
         client = _make_mock_client()
 
@@ -311,6 +320,136 @@ class TestCallAddonApiErrors:
             "connect" in result["error"]["message"].lower()
             or "connection" in str(result).lower()
         )
+
+    @pytest.mark.asyncio
+    async def test_http_ingress_routes_through_ha_core(self, mock_ingress_session):
+        """Ingress mode targets HA Core's /api/hassio_ingress proxy with a session cookie."""
+        client = _make_mock_client()
+
+        captured: dict[str, object] = {}
+
+        async def fake_request(*, method, url, headers, content):
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = dict(headers)
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 200
+            response.json.return_value = {"ok": True}
+            response.text = '{"ok": true}'
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert result["success"] is True
+        # URL is HA Core's ingress proxy, NOT the addon container IP
+        assert captured["url"] == (
+            "http://localhost:8123/api/hassio_ingress/abc123/api/test"
+        )
+        # Session cookie attached
+        headers = captured["headers"]
+        assert headers["Cookie"] == f"ingress_session={_INGRESS_SESSION_TOKEN}"
+        # Direct-container Ingress headers MUST NOT be set — HA Core adds them
+        # itself when it proxies upstream, and adding our own would conflict.
+        assert "X-Ingress-Path" not in headers
+        assert "X-Hass-Source" not in headers
+        # Ingress session was minted exactly once
+        mock_ingress_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_http_direct_port_skips_ingress_session(self, mock_ingress_session):
+        """Direct-port mode connects to container IP and does not mint an ingress session."""
+        client = _make_mock_client()
+
+        captured: dict[str, object] = {}
+
+        async def fake_request(*, method, url, headers, content):
+            captured["url"] = url
+            captured["headers"] = dict(headers)
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 200
+            response.json.return_value = {"ok": True}
+            response.text = '{"ok": true}'
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(
+                client, "test_addon", "/flows", port=1880
+            )
+
+        assert result["success"] is True
+        assert captured["url"] == "http://172.30.33.99:1880/flows"
+        assert "Cookie" not in captured["headers"]
+        mock_ingress_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_direct_port_offhost_error_hints_at_ingress(
+        self, mock_ingress_session
+    ):
+        """ConnectError in direct-port mode should suggest dropping `port` for off-host hosts."""
+        client = _make_mock_client()
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = httpx.ConnectError(
+                "No route to host"
+            )
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(
+                    client, "test_addon", "/flows", port=1880
+                )
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        assert any("ingress" in s.lower() for s in suggestions), suggestions
 
 
 # Standard mock return for a running addon with Ingress support (for WS tests)
@@ -465,7 +604,7 @@ class TestCallAddonWsErrors:
         assert "not running" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
-    async def test_ws_handshake_failure(self):
+    async def test_ws_handshake_failure(self, mock_ingress_session):
         """Should raise ToolError when WebSocket handshake fails."""
         client = _make_mock_client()
 
@@ -492,7 +631,83 @@ class TestCallAddonWsErrors:
         assert "handshake" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
-    async def test_ws_connection_closed_during_send(self):
+    async def test_ws_ingress_routes_through_ha_core(self, mock_ingress_session):
+        """Ingress WS mode targets HA Core's /api/hassio_ingress proxy with a session cookie."""
+        client = _make_mock_client()
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            result = await _call_addon_ws(client, "test_addon", "/validate")
+
+        assert result["success"] is True
+        assert captured["url"] == (
+            "ws://localhost:8123/api/hassio_ingress/abc123/validate"
+        )
+        headers = captured["kwargs"]["additional_headers"]
+        assert headers["Cookie"] == f"ingress_session={_INGRESS_SESSION_TOKEN}"
+
+    @pytest.mark.asyncio
+    async def test_ws_direct_port_skips_ingress_session(self, mock_ingress_session):
+        """Direct-port WS mode hits the container IP and does not mint a session."""
+        client = _make_mock_client()
+
+        captured: dict[str, object] = {}
+
+        def capture_connect(url, **kwargs):
+            captured["url"] = url
+            cm = MagicMock()
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = websockets.exceptions.ConnectionClosed(
+                None, None
+            )
+            cm.__aenter__ = AsyncMock(return_value=mock_ws)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+                side_effect=capture_connect,
+            ),
+        ):
+            result = await _call_addon_ws(
+                client, "test_addon", "/validate", port=6052
+            )
+
+        assert result["success"] is True
+        assert captured["url"] == "ws://172.30.33.99:6052/validate"
+        mock_ingress_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ws_connection_closed_during_send(self, mock_ingress_session):
         """Should raise ToolError when connection closes during send."""
         client = _make_mock_client()
 
@@ -526,7 +741,7 @@ class TestCallAddonWsErrors:
         assert "closed unexpectedly" in result["error"]["message"].lower()
 
     @pytest.mark.asyncio
-    async def test_ws_connection_error(self):
+    async def test_ws_connection_error(self, mock_ingress_session):
         """Should raise ToolError when can't connect to add-on WebSocket."""
         client = _make_mock_client()
 
@@ -556,7 +771,7 @@ class TestCallAddonWsErrors:
         )
 
     @pytest.mark.asyncio
-    async def test_ws_collects_messages(self):
+    async def test_ws_collects_messages(self, mock_ingress_session):
         """Should collect text messages and parse JSON ones."""
         client = _make_mock_client()
 
@@ -591,7 +806,7 @@ class TestCallAddonWsErrors:
         assert result["messages"][2] == {"event": "exit", "code": 0}
 
     @pytest.mark.asyncio
-    async def test_ws_strips_ansi_codes(self):
+    async def test_ws_strips_ansi_codes(self, mock_ingress_session):
         """Should strip ANSI escape codes from messages."""
         client = _make_mock_client()
 
@@ -619,7 +834,7 @@ class TestCallAddonWsErrors:
         assert result["messages"][0] == "SUCCESS Build complete"
 
     @pytest.mark.asyncio
-    async def test_ws_skips_binary_frames(self):
+    async def test_ws_skips_binary_frames(self, mock_ingress_session):
         """Should skip binary WebSocket frames."""
         client = _make_mock_client()
 
@@ -649,7 +864,7 @@ class TestCallAddonWsErrors:
         assert result["messages"][0] == "text message"
 
     @pytest.mark.asyncio
-    async def test_ws_wait_for_close_false_returns_early(self):
+    async def test_ws_wait_for_close_false_returns_early(self, mock_ingress_session):
         """With wait_for_close=False, should return after silence timeout."""
         client = _make_mock_client()
 
@@ -685,8 +900,8 @@ class TestCallAddonWsErrors:
         assert result["closed_by"] == "silence"
 
     @pytest.mark.asyncio
-    async def test_ws_missing_network_info(self):
-        """Should raise ToolError when add-on is missing ip_address."""
+    async def test_ws_direct_port_missing_ip_address(self):
+        """Direct-port WS mode requires the addon's container ip_address."""
         client = _make_mock_client()
 
         with (
@@ -698,23 +913,19 @@ class TestCallAddonWsErrors:
                     "addon": {
                         "name": "Test Addon",
                         "slug": "test_addon",
-                        "ingress": True,
+                        "ingress": False,
                         "state": "started",
                         "ip_address": "",
-                        "ingress_port": None,
                     },
                 },
             ),
             pytest.raises(ToolError) as exc_info,
         ):
-            await _call_addon_ws(client, "test_addon", "/compile")
+            await _call_addon_ws(client, "test_addon", "/validate", port=6052)
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert (
-            "network info" in result["error"]["message"].lower()
-            or "ip_address" in str(result).lower()
-        )
+        assert "ip_address" in str(result).lower()
 
 
 class TestSliceWsMessages:


### PR DESCRIPTION
Refs #1001 — addresses the `ha_manage_addon` (formerly `ha_call_addon_api`) symptom; see "Scope" below.

## Problem

`ha_manage_addon` proxy mode opened direct HTTP/WebSocket connections to the add-on's container IP on HA's `hassio` Docker bridge. That works when the MCP host shares HA's network namespace (the HAOS / Supervised add-on variant), but is unreachable from PyPI/uvx installs or any off-host setup sitting on a regular LAN — TCP just goes nowhere, hence the ~21 s `CONNECTION_FAILED` reported.

## Fix

Route the default (Ingress) path through HA Core's existing proxy:

1. Mint a Supervisor ingress session via the WS `supervisor/api` hop (same path `ha_get_addon` already uses, so this works equally on HAOS, Supervised, and off-host installs).
2. Send the request to `<HA_URL>/api/hassio_ingress/<addon_token>/<path>` with `Cookie: ingress_session=<session>`. HA Core proxies to the add-on container; we never touch `172.30.x.x` directly.

Both HTTP and WebSocket modes are covered. The `port=…` direct-container path is preserved unchanged (it's the only way to reach non-Ingress ports like Node-RED's 1880 or ESPHome's 6052), but its `ConnectError` now includes a suggestion to drop `port=…` so off-host callers get a useful next step instead of a silent 21 s timeout.

## Scope

Issue #1001 reports two failing tools. This PR addresses one:

- ✅ `ha_manage_addon` (proxy mode, ingress) — fixed.
- ⚠️ `ha_get_logs(source="supervisor")` — works already off-host (#950 retired the broken WS path)

## Validation

Tested from off-host PyPI/uvx (macOS) → real HAOS instance:

| Add-on | Slug | Path | Result |
|---|---|---|---|
| File Editor | `core_configurator` | `/` | ✅ 200, HTML body |
| Matter Server | `core_matter_server` | `/api/version` | ✅ 404 from add-on |
| Music Assistant | `d5369777_music_assistant` | `/api/info` | ✅ 404 from add-on |

All three round-trip cleanly through `<HA_URL>/api/hassio_ingress/<token>/...`. Pre-fix, all three would have hung ~21 s and errored out — never reaching the add-on. The 404s are proof of routing, not failure: a real HTTP response from the add-on container means the proxy chain worked.

## Test plan

- [x] Unit tests cover both modes:
  - `test_http_ingress_routes_through_ha_core` — asserts URL, cookie, no `X-Ingress-Path` header (HA Core adds those itself when proxying)
  - `test_http_direct_port_skips_ingress_session` — asserts direct-container URL + no session minted
  - `test_http_direct_port_offhost_error_hints_at_ingress` — asserts `ConnectError` suggestion mentions Ingress mode
  - WebSocket equivalents for all three
- [x] Existing addon unit tests updated to mock `_create_ingress_session`
- [x] Full E2E suite passes locally (no addon-specific E2E exists; testcontainer doesn't run Supervisor, so add-ons aren't reachable in that environment — unit tests are the appropriate coverage layer)
- [x] `ruff check` clean, `mypy` clean