### PR TITLE
feat(dashboards): unify identifier handling in ha_config_*_dashboard tools (#981)

### DIFF
--- a/site/src/data/tools.json
+++ b/site/src/data/tools.json
@@ -563,15 +563,15 @@
   {
     "name": "ha_config_delete_dashboard",
     "title": "Delete Dashboard",
-    "description": "Delete a storage-mode dashboard completely.\n\nWARNING: This permanently deletes the dashboard and all its configuration.\nCannot be undone. Does not work on YAML-mode dashboards.\n\nAccepts either the internal dashboard ID or the URL path.\nThe tool resolves url_path to internal ID automatically.\n\nEXAMPLES:\n- Delete dashboard: ha_config_delete_dashboard(\"mobile-dashboard\")\n\nNote: The default dashboard cannot be deleted via this method.",
+    "description": "Delete a storage-mode dashboard completely.\n\nWARNING: This permanently deletes the dashboard and all its configuration.\nCannot be undone. Does not work on YAML-mode dashboards.\n\nAccepts either the URL path or the internal dashboard ID. HA internal IDs\nmay differ from url_path (e.g. hyphens → underscores); the tool resolves\neither form to the actual registry ID before deletion.\n\nEXAMPLES:\n- Delete dashboard: ha_config_delete_dashboard(\"mobile-dashboard\")\n\nNote: The default dashboard cannot be deleted via this method.",
     "inputSchema": {
       "properties": {
-        "dashboard_id": {
-          "type": "Annotated[str, Field(description=\"Dashboard ID or URL path to delete (e.g., 'my-dashboard' or 'my_dashboard')\")]"
+        "url_path": {
+          "type": "Annotated[str, Field(description=\"Dashboard URL path or internal ID to delete (e.g., 'my-dashboard' or 'my_dashboard'). Both forms are accepted.\")]"
         }
       },
       "required": [
-        "dashboard_id"
+        "url_path"
       ]
     },
     "annotations": {

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -781,6 +781,15 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             if url_path == "default":
                 url_path = "lovelace"
 
+            # Pre-resolve internal dashboard ID to url_path form before the
+            # hyphen check below, so callers may pass either form. Only fires
+            # when the identifier looks like an internal id (no hyphen, not
+            # the built-in "lovelace") and matches a known dashboard.
+            if "-" not in url_path and url_path != "lovelace":
+                resolved = await _resolve_dashboard(client, url_path)
+                if resolved is not None and resolved["url_path"]:
+                    url_path = resolved["url_path"]
+
             # Validate url_path contains hyphen for new dashboards
             # The built-in "lovelace" dashboard is exempt since it already exists
             if "-" not in url_path and url_path != "lovelace":
@@ -837,6 +846,24 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     get_data["url_path"] = url_path
 
                 response = await client.send_websocket_message(get_data)
+
+                # Lazy resolver fallback: same gate as ha_config_get_dashboard.
+                # If the pre-resolver above didn't fire (e.g. caller passed an
+                # identifier that contains a hyphen but isn't a real url_path),
+                # HA may still reject it — resolve and retry once.
+                if isinstance(response, dict) and not response.get("success", True):
+                    err = response.get("error", {})
+                    err_msg = (
+                        err.get("message", str(err))
+                        if isinstance(err, dict)
+                        else str(err)
+                    )
+                    if url_path and _should_lazy_resolve(err_msg):
+                        resolved = await _resolve_dashboard(client, url_path)
+                        if resolved is not None and resolved["url_path"]:
+                            url_path = resolved["url_path"]
+                            get_data["url_path"] = url_path
+                            response = await client.send_websocket_message(get_data)
 
                 if isinstance(response, dict) and not response.get("success", True):
                     error_msg = response.get("error", {})

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -913,14 +913,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
                 response = await client.send_websocket_message(get_data)
 
-                # Lazy resolver fallback: same gate as ha_config_get_dashboard.
-                # If the pre-resolver above didn't fire (e.g. caller passed an
-                # identifier that contains a hyphen but isn't a real url_path),
-                # HA may still reject it — resolve and retry once.
-                url_path, response = await _lazy_resolve_and_retry(
-                    client, url_path, get_data, response
-                )
-
                 if isinstance(response, dict) and not response.get("success", True):
                     error_msg = response.get("error", {})
                     if isinstance(error_msg, dict):

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -250,6 +250,14 @@ def _card_matches(
 # Substring in WS error message that signals the dashboard identifier was not
 # accepted by lovelace/config (e.g., caller passed an internal id where url_path
 # is expected). Used to gate the lazy resolver fallback in get/set tools.
+#
+# Source: homeassistant/components/lovelace/websocket.py, _handle_errors —
+# emits f"Unknown config specified: {url_path}" paired with structured
+# error.code "config_not_found". The websocket client currently surfaces only
+# the message string, so substring matching is the only signal available at
+# the tool layer. If HA reformats this string, the lazy fallback regresses
+# silently to never firing — re-verify with major HA upgrades.
+# Last verified: HA 2026.4.4.
 _LAZY_RESOLVE_TRIGGER = "Unknown config specified"
 
 

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -25,7 +25,6 @@ from .util_helpers import parse_json_param
 logger = logging.getLogger(__name__)
 
 
-
 async def _verify_config_unchanged(
     client: Any,
     url_path: str,
@@ -265,9 +264,7 @@ def _should_lazy_resolve(error_msg: str) -> bool:
     return _LAZY_RESOLVE_TRIGGER in error_msg
 
 
-async def _resolve_dashboard(
-    client: Any, identifier: str
-) -> dict[str, str] | None:
+async def _resolve_dashboard(client: Any, identifier: str) -> dict[str, str] | None:
     """Resolve a dashboard identifier (url_path or internal id) to both forms.
 
     Calls ``lovelace/dashboards/list`` and returns
@@ -284,9 +281,7 @@ async def _resolve_dashboard(
       cheap heuristic ("no hyphen, not 'lovelace'") rather than an error
       from HA.
     """
-    result = await client.send_websocket_message(
-        {"type": "lovelace/dashboards/list"}
-    )
+    result = await client.send_websocket_message({"type": "lovelace/dashboards/list"})
     if isinstance(result, dict) and "result" in result:
         dashboards = result["result"]
     elif isinstance(result, list):
@@ -413,8 +408,8 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "Get Dashboard"
-        }
+            "title": "Get Dashboard",
+        },
     )
     @log_tool_usage
     async def ha_config_get_dashboard(
@@ -434,7 +429,10 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             ),
         ] = False,
         force_reload: Annotated[
-            bool, Field(description="Force reload from storage (bypass cache). Not applicable in search mode (search always uses force=True for fresh results).")
+            bool,
+            Field(
+                description="Force reload from storage (bypass cache). Not applicable in search mode (search always uses force=True for fresh results)."
+            ),
         ] = False,
         entity_id: Annotated[
             str | None,
@@ -505,7 +503,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
         Note: YAML-mode dashboards (defined in configuration.yaml) are not included in list.
         """
-        search_mode = entity_id is not None or card_type is not None or heading is not None
+        search_mode = (
+            entity_id is not None or card_type is not None or heading is not None
+        )
         try:
             # List mode
             if list_only:
@@ -740,10 +740,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
     @mcp.tool(
         tags={"Dashboards"},
-        annotations={
-            "destructiveHint": True,
-            "title": "Create or Update Dashboard"
-        }
+        annotations={"destructiveHint": True, "title": "Create or Update Dashboard"},
     )
     @log_tool_usage
     async def ha_config_set_dashboard(
@@ -1383,10 +1380,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
     @mcp.tool(
         tags={"Dashboards"},
-        annotations={
-            "destructiveHint": True,
-            "title": "Delete Dashboard"
-        }
+        annotations={"destructiveHint": True, "title": "Delete Dashboard"},
     )
     @log_tool_usage
     async def ha_config_delete_dashboard(
@@ -1416,14 +1410,16 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         try:
             resolved = await _resolve_dashboard(client, url_path)
             if resolved is None:
-                raise_tool_error(create_resource_not_found_error(
-                    "Dashboard",
-                    url_path,
-                    details=(
-                        f"No dashboard found with URL path or internal ID '{url_path}'. "
-                        "Use ha_config_get_dashboard(list_only=True) to see available dashboards."
-                    ),
-                ))
+                raise_tool_error(
+                    create_resource_not_found_error(
+                        "Dashboard",
+                        url_path,
+                        details=(
+                            f"No dashboard found with URL path or internal ID '{url_path}'. "
+                            "Use ha_config_get_dashboard(list_only=True) to see available dashboards."
+                        ),
+                    )
+                )
             resolved_id = resolved["id"]
 
             response = await client.send_websocket_message(
@@ -1501,4 +1497,3 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
     # - ha_config_set_dashboard_resource: Create/update resources (inline code or URL)
     # - ha_config_delete_dashboard_resource: Delete resources
     # =========================================================================
-

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -493,7 +493,22 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
             response = await client.send_websocket_message(data)
 
-            # Check if request failed
+            # Lazy resolver fallback: if HA rejects the identifier as unknown,
+            # try resolving it via lovelace/dashboards/list and retry once.
+            # This pays the round-trip only when the caller passed an internal
+            # dashboard id (or another non-url_path form) that HA does not accept.
+            if isinstance(response, dict) and not response.get("success", True):
+                err = response.get("error", {})
+                err_msg = (
+                    err.get("message", str(err)) if isinstance(err, dict) else str(err)
+                )
+                if url_path and _should_lazy_resolve(err_msg):
+                    resolved = await _resolve_dashboard(client, url_path)
+                    if resolved is not None and resolved["url_path"]:
+                        data["url_path"] = resolved["url_path"]
+                        response = await client.send_websocket_message(data)
+
+            # Check if request failed (after potential retry)
             if isinstance(response, dict) and not response.get("success", True):
                 error_msg = response.get("error", {})
                 if isinstance(error_msg, dict):

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -323,6 +323,10 @@ async def _lazy_resolve_and_retry(
     No-op when the response is not a failure, when url_path is empty,
     or when the resolver finds no match — the original response is
     returned unchanged in those cases.
+
+    The caller's `ws_data` dict is never mutated: when a retry is needed,
+    a shallow copy is made and the canonical `url_path` written into the
+    copy before the retry call.
     """
     if not (isinstance(response, dict) and not response.get("success", True)):
         return url_path, response
@@ -339,8 +343,9 @@ async def _lazy_resolve_and_retry(
         return url_path, response
 
     url_path = resolved["url_path"]
-    ws_data["url_path"] = url_path
-    response = await client.send_websocket_message(ws_data)
+    retry_data = dict(ws_data)
+    retry_data["url_path"] = url_path
+    response = await client.send_websocket_message(retry_data)
     return url_path, response
 
 

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -675,7 +675,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # Calculate config size for progressive disclosure hint
             config_size = len(json.dumps(config)) if isinstance(config, dict) else 0
 
-            result: dict[str, Any] = {
+            get_result: dict[str, Any] = {
                 "success": True,
                 "action": "get",
                 "url_path": url_path,
@@ -688,18 +688,18 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # resolved_id field). Caller can use this to detect that their
             # input was an internal id rather than a url_path.
             if original_url_path is not None and original_url_path != url_path:
-                result["resolved_from"] = original_url_path
+                get_result["resolved_from"] = original_url_path
 
             # Add hint for large configs (progressive disclosure) - 10KB ≈ 2-3k tokens
             if config_size >= 10000:
-                result["hint"] = (
+                get_result["hint"] = (
                     f"Large config ({config_size:,} bytes). For edits, use "
                     "ha_config_get_dashboard(entity_id=...) to find card positions, "
                     "then ha_config_set_dashboard(python_transform=...) "
                     "instead of full config replacement."
                 )
 
-            return result
+            return get_result
         except ToolError:
             raise
         except Exception as e:

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1313,7 +1313,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                         "Use ha_config_get_dashboard(list_only=True) to see available dashboards."
                     ),
                 ))
-            assert resolved is not None  # narrow type for mypy after raise_tool_error
             resolved_id = resolved["id"]
 
             response = await client.send_websocket_message(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -247,6 +247,43 @@ def _card_matches(
     return True
 
 
+# Substring in WS error message that signals the dashboard identifier was not
+# accepted by lovelace/config (e.g., caller passed an internal id where url_path
+# is expected). Used to gate the lazy resolver fallback in get/set tools.
+_LAZY_RESOLVE_TRIGGER = "Unknown config specified"
+
+
+def _should_lazy_resolve(error_msg: str) -> bool:
+    """Return True if a WS error message indicates the identifier needs resolving."""
+    return _LAZY_RESOLVE_TRIGGER in error_msg
+
+
+async def _resolve_dashboard(
+    client: Any, identifier: str
+) -> dict[str, str] | None:
+    """Resolve a dashboard identifier (url_path or internal id) to both forms.
+
+    Calls lovelace/dashboards/list once and returns {"url_path": ..., "id": ...}
+    if the identifier matches either field, otherwise None. Used as a lazy
+    fallback when a direct lovelace/config call has failed with the
+    _LAZY_RESOLVE_TRIGGER error — pays the round-trip only when needed.
+    """
+    result = await client.send_websocket_message(
+        {"type": "lovelace/dashboards/list"}
+    )
+    if isinstance(result, dict) and "result" in result:
+        dashboards = result["result"]
+    elif isinstance(result, list):
+        dashboards = result
+    else:
+        return None
+
+    for d in dashboards:
+        if d.get("id") == identifier or d.get("url_path") == identifier:
+            return {"url_path": d.get("url_path", ""), "id": d.get("id", "")}
+    return None
+
+
 def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register Home Assistant dashboard configuration tools."""
 
@@ -1157,10 +1194,11 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
     )
     @log_tool_usage
     async def ha_config_delete_dashboard(
-        dashboard_id: Annotated[
+        url_path: Annotated[
             str,
             Field(
-                description="Dashboard ID or URL path to delete (e.g., 'my-dashboard' or 'my_dashboard')"
+                description="Dashboard URL path or internal ID to delete "
+                "(e.g., 'my-dashboard' or 'my_dashboard'). Both forms are accepted."
             ),
         ],
     ) -> dict[str, Any]:
@@ -1170,8 +1208,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         WARNING: This permanently deletes the dashboard and all its configuration.
         Cannot be undone. Does not work on YAML-mode dashboards.
 
-        Accepts either the internal dashboard ID or the URL path.
-        The tool resolves url_path to internal ID automatically.
+        Accepts either the URL path or the internal dashboard ID. HA internal IDs
+        may differ from url_path (e.g. hyphens → underscores); the tool resolves
+        either form to the actual registry ID before deletion.
 
         EXAMPLES:
         - Delete dashboard: ha_config_delete_dashboard("mobile-dashboard")
@@ -1179,37 +1218,18 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         Note: The default dashboard cannot be deleted via this method.
         """
         try:
-            # Fetch dashboard list to resolve the provided identifier.
-            # HA internal IDs may differ from url_path (e.g. hyphens → underscores),
-            # so we accept either and resolve to the actual registry ID.
-            list_result = await client.send_websocket_message(
-                {"type": "lovelace/dashboards/list"}
-            )
-            if isinstance(list_result, dict) and "result" in list_result:
-                dashboards = list_result["result"]
-            elif isinstance(list_result, list):
-                dashboards = list_result
-            else:
-                dashboards = []
-
-            resolved_id = None
-            for d in dashboards:
-                if d.get("id") == dashboard_id:
-                    resolved_id = d["id"]
-                    break
-                if d.get("url_path") == dashboard_id:
-                    resolved_id = d["id"]
-                    break
-
-            if resolved_id is None:
+            resolved = await _resolve_dashboard(client, url_path)
+            if resolved is None:
                 raise_tool_error(create_resource_not_found_error(
                     "Dashboard",
-                    dashboard_id,
+                    url_path,
                     details=(
-                        f"No dashboard found with ID or URL path '{dashboard_id}'. "
+                        f"No dashboard found with URL path or internal ID '{url_path}'. "
                         "Use ha_config_get_dashboard(list_only=True) to see available dashboards."
                     ),
                 ))
+            assert resolved is not None  # narrow type for mypy after raise_tool_error
+            resolved_id = resolved["id"]
 
             response = await client.send_websocket_message(
                 {"type": "lovelace/dashboards/delete", "dashboard_id": resolved_id}
@@ -1233,7 +1253,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     return {
                         "success": True,
                         "action": "delete",
-                        "dashboard_id": dashboard_id,
+                        "url_path": url_path,
                         "message": "Dashboard already deleted or does not exist",
                     }
 
@@ -1248,7 +1268,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                             "Use ha_config_get_dashboard(list_only=True) to see available dashboards",
                             "Cannot delete YAML-mode or default dashboard",
                         ],
-                        context={"action": "delete", "dashboard_id": dashboard_id},
+                        context={"action": "delete", "url_path": url_path},
                     )
                 )
 
@@ -1256,10 +1276,10 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             result: dict[str, Any] = {
                 "success": True,
                 "action": "delete",
-                "dashboard_id": dashboard_id,
+                "url_path": url_path,
                 "message": "Dashboard deleted successfully",
             }
-            if resolved_id != dashboard_id:
+            if resolved_id != url_path:
                 result["resolved_id"] = resolved_id
             return result
         except ToolError:
@@ -1268,7 +1288,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             logger.error(f"Error deleting dashboard: {e}")
             exception_to_structured_error(
                 e,
-                context={"action": "delete", "dashboard_id": dashboard_id},
+                context={"action": "delete", "url_path": url_path},
                 suggestions=[
                     "Verify dashboard exists and is storage-mode",
                     "Check that you have admin permissions",

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -7,7 +7,7 @@ This module provides tools for managing dashboard metadata and content.
 import json
 import logging
 import re
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, cast, overload
 
 from fastmcp.exceptions import ToolError
 from pydantic import Field
@@ -284,6 +284,66 @@ async def _resolve_dashboard(
     return None
 
 
+@overload
+async def _lazy_resolve_and_retry(
+    client: Any,
+    url_path: str,
+    ws_data: dict[str, Any],
+    response: Any,
+) -> tuple[str, Any]: ...
+
+
+@overload
+async def _lazy_resolve_and_retry(
+    client: Any,
+    url_path: None,
+    ws_data: dict[str, Any],
+    response: Any,
+) -> tuple[None, Any]: ...
+
+
+async def _lazy_resolve_and_retry(
+    client: Any,
+    url_path: str | None,
+    ws_data: dict[str, Any],
+    response: Any,
+) -> tuple[str | None, Any]:
+    """Trigger-gated lazy resolve + single retry of a lovelace/config call.
+
+    If `response` indicates HA rejected the identifier with the
+    _LAZY_RESOLVE_TRIGGER substring, resolves `url_path` via
+    lovelace/dashboards/list and retries the WS call with the canonical
+    url_path. Returns the (possibly updated) url_path and the
+    (possibly retried) response so the caller can chain naturally:
+
+        url_path, response = await _lazy_resolve_and_retry(
+            client, url_path, ws_data, response
+        )
+
+    No-op when the response is not a failure, when url_path is empty,
+    or when the resolver finds no match — the original response is
+    returned unchanged in those cases.
+    """
+    if not (isinstance(response, dict) and not response.get("success", True)):
+        return url_path, response
+    if not url_path:
+        return url_path, response
+
+    err = response.get("error", {})
+    err_msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
+    if not _should_lazy_resolve(err_msg):
+        return url_path, response
+
+    resolved = await _resolve_dashboard(client, url_path)
+    if resolved is None or not resolved["url_path"]:
+        return url_path, response
+
+    url_path = resolved["url_path"]
+    ws_data["url_path"] = url_path
+    response = await client.send_websocket_message(ws_data)
+    return url_path, response
+
+
 def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register Home Assistant dashboard configuration tools."""
 
@@ -494,19 +554,12 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             response = await client.send_websocket_message(data)
 
             # Lazy resolver fallback: if HA rejects the identifier as unknown,
-            # try resolving it via lovelace/dashboards/list and retry once.
-            # This pays the round-trip only when the caller passed an internal
-            # dashboard id (or another non-url_path form) that HA does not accept.
-            if isinstance(response, dict) and not response.get("success", True):
-                err = response.get("error", {})
-                err_msg = (
-                    err.get("message", str(err)) if isinstance(err, dict) else str(err)
-                )
-                if url_path and _should_lazy_resolve(err_msg):
-                    resolved = await _resolve_dashboard(client, url_path)
-                    if resolved is not None and resolved["url_path"]:
-                        data["url_path"] = resolved["url_path"]
-                        response = await client.send_websocket_message(data)
+            # resolve it via lovelace/dashboards/list and retry once. The
+            # round-trip is only paid when the caller passed an internal
+            # dashboard id (or another non-url_path form) HA does not accept.
+            url_path, response = await _lazy_resolve_and_retry(
+                client, url_path, data, response
+            )
 
             # Check if request failed (after potential retry)
             if isinstance(response, dict) and not response.get("success", True):
@@ -851,19 +904,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 # If the pre-resolver above didn't fire (e.g. caller passed an
                 # identifier that contains a hyphen but isn't a real url_path),
                 # HA may still reject it — resolve and retry once.
-                if isinstance(response, dict) and not response.get("success", True):
-                    err = response.get("error", {})
-                    err_msg = (
-                        err.get("message", str(err))
-                        if isinstance(err, dict)
-                        else str(err)
-                    )
-                    if url_path and _should_lazy_resolve(err_msg):
-                        resolved = await _resolve_dashboard(client, url_path)
-                        if resolved is not None and resolved["url_path"]:
-                            url_path = resolved["url_path"]
-                            get_data["url_path"] = url_path
-                            response = await client.send_websocket_message(get_data)
+                url_path, response = await _lazy_resolve_and_retry(
+                    client, url_path, get_data, response
+                )
 
                 if isinstance(response, dict) and not response.get("success", True):
                     error_msg = response.get("error", {})

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -257,7 +257,6 @@ def _card_matches(
 # the message string, so substring matching is the only signal available at
 # the tool layer. If HA reformats this string, the lazy fallback regresses
 # silently to never firing — re-verify with major HA upgrades.
-# Last verified: HA 2026.4.4.
 _LAZY_RESOLVE_TRIGGER = "Unknown config specified"
 
 
@@ -271,10 +270,19 @@ async def _resolve_dashboard(
 ) -> dict[str, str] | None:
     """Resolve a dashboard identifier (url_path or internal id) to both forms.
 
-    Calls lovelace/dashboards/list once and returns {"url_path": ..., "id": ...}
-    if the identifier matches either field, otherwise None. Used as a lazy
-    fallback when a direct lovelace/config call has failed with the
-    _LAZY_RESOLVE_TRIGGER error — pays the round-trip only when needed.
+    Calls ``lovelace/dashboards/list`` and returns
+    ``{"url_path": ..., "id": ...}`` when the identifier matches either field
+    on a registry entry that has both fields populated; otherwise returns
+    ``None``. Always pays the round-trip when called.
+
+    Two call sites:
+    - **Lazy fallback** (``_lazy_resolve_and_retry``): only invoked after
+      ``lovelace/config`` rejected the identifier with
+      ``_LAZY_RESOLVE_TRIGGER`` — the round-trip is gated by the caller.
+    - **Eager pre-resolve** (``ha_config_set_dashboard``): invoked before
+      hyphen validation so callers may pass either form; gated on a
+      cheap heuristic ("no hyphen, not 'lovelace'") rather than an error
+      from HA.
     """
     result = await client.send_websocket_message(
         {"type": "lovelace/dashboards/list"}
@@ -284,11 +292,28 @@ async def _resolve_dashboard(
     elif isinstance(result, list):
         dashboards = result
     else:
+        # Neither dict-with-result nor list — either HA returned an error
+        # envelope (unknown shape) or the response format changed.
+        # Surface a warning so the next response-shape change isn't a
+        # silent "always no match" regression.
+        logger.warning(
+            "lovelace/dashboards/list returned an unexpected shape (type=%s); "
+            "treating as no-match",
+            type(result).__name__,
+        )
         return None
 
     for d in dashboards:
         if d.get("id") == identifier or d.get("url_path") == identifier:
-            return {"url_path": d.get("url_path", ""), "id": d.get("id", "")}
+            url_path = d.get("url_path") or ""
+            entry_id = d.get("id") or ""
+            if not url_path or not entry_id:
+                # Malformed registry entry — neither form is safe to
+                # forward. Skip rather than return empty strings that
+                # would be silently used by callers (e.g.
+                # ``delete_dashboard`` would forward ``resolved_id=""``).
+                continue
+            return {"url_path": url_path, "id": entry_id}
     return None
 
 
@@ -328,9 +353,17 @@ async def _lazy_resolve_and_retry(
             client, url_path, ws_data, response
         )
 
-    No-op when the response is not a failure, when url_path is empty,
-    or when the resolver finds no match — the original response is
-    returned unchanged in those cases.
+    No-op when:
+    - the response is not a failure (success=True or non-dict),
+    - ``url_path`` is empty,
+    - the error message does not contain ``_LAZY_RESOLVE_TRIGGER``
+      (the substring miss),
+    - the resolver finds no match,
+    - or the resolver itself raises (logged at WARNING).
+
+    In every no-op case the original ``response`` is returned unchanged
+    so the caller's existing error-handling path runs against the real
+    HA error rather than a synthetic "resolver failed" one.
 
     The caller's `ws_data` dict is never mutated: when a retry is needed,
     a shallow copy is made and the canonical `url_path` written into the
@@ -346,7 +379,22 @@ async def _lazy_resolve_and_retry(
     if not _should_lazy_resolve(err_msg):
         return url_path, response
 
-    resolved = await _resolve_dashboard(client, url_path)
+    try:
+        resolved = await _resolve_dashboard(client, url_path)
+    except Exception as resolver_exc:
+        # Resolver itself raised (timeout, network blip, etc.). Don't let
+        # this exception escape and replace the original HA error with
+        # one about the resolver — fall through with the original
+        # response so the caller surfaces the actual "Unknown config
+        # specified" error.
+        logger.warning(
+            "Lazy resolver failed for url_path=%r: %s; "
+            "falling through to original error",
+            url_path,
+            resolver_exc,
+        )
+        return url_path, response
+
     if resolved is None or not resolved["url_path"]:
         return url_path, response
 
@@ -481,10 +529,30 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # Search mode — find cards, badges, or header cards
             if search_mode:
                 get_data: dict[str, Any] = {"type": "lovelace/config", "force": True}
-                if url_path and url_path != "default":
-                    get_data["url_path"] = url_path
+                effective_url_path: str | None = (
+                    url_path if url_path and url_path != "default" else None
+                )
+                if effective_url_path is not None:
+                    get_data["url_path"] = effective_url_path
 
                 response = await client.send_websocket_message(get_data)
+
+                # Lazy resolver fallback: same gate as get-mode. If the
+                # caller passed an internal id where url_path is expected,
+                # HA rejects with the trigger substring; resolve and retry
+                # once. (set_dashboard handles this via an eager pre-resolver
+                # before the hyphen check, so it has no equivalent fallback
+                # here.)
+                search_resolved_from: str | None = None
+                if effective_url_path is not None:
+                    new_url_path, response = await _lazy_resolve_and_retry(
+                        client, effective_url_path, get_data, response
+                    )
+                    if new_url_path != effective_url_path:
+                        # Surface the original caller-passed identifier so
+                        # the caller can see their input was canonicalized.
+                        search_resolved_from = url_path
+                        url_path = new_url_path
 
                 if isinstance(response, dict) and not response.get("success", True):
                     error_msg = response.get("error", {})
@@ -538,7 +606,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
                 config_hash: str | None = compute_config_hash(config)
 
-                return {
+                search_result: dict[str, Any] = {
                     "success": True,
                     "action": "find_card",
                     "url_path": url_path,
@@ -557,6 +625,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                         else "No matches found. Try broader search criteria."
                     ),
                 }
+                if search_resolved_from is not None:
+                    search_result["resolved_from"] = search_resolved_from
+                return search_result
 
             # Get mode - build WebSocket message
             data: dict[str, Any] = {"type": "lovelace/config", "force": force_reload}
@@ -570,6 +641,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # resolve it via lovelace/dashboards/list and retry once. The
             # round-trip is only paid when the caller passed an internal
             # dashboard id (or another non-url_path form) HA does not accept.
+            original_url_path = url_path
             url_path, response = await _lazy_resolve_and_retry(
                 client, url_path, data, response
             )
@@ -603,7 +675,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # Calculate config size for progressive disclosure hint
             config_size = len(json.dumps(config)) if isinstance(config, dict) else 0
 
-            result = {
+            result: dict[str, Any] = {
                 "success": True,
                 "action": "get",
                 "url_path": url_path,
@@ -611,6 +683,12 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 "config_hash": config_hash,
                 "config_size_bytes": config_size,
             }
+            # Surface the original caller-passed identifier when the lazy
+            # resolver canonicalised it (parity with delete_dashboard's
+            # resolved_id field). Caller can use this to detect that their
+            # input was an internal id rather than a url_path.
+            if original_url_path is not None and original_url_path != url_path:
+                result["resolved_from"] = original_url_path
 
             # Add hint for large configs (progressive disclosure) - 10KB ≈ 2-3k tokens
             if config_size >= 10000:
@@ -851,10 +929,29 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             # hyphen check below, so callers may pass either form. Only fires
             # when the identifier looks like an internal id (no hyphen, not
             # the built-in "lovelace") and matches a known dashboard.
+            #
+            # Caveat: if a caller passes a hyphenless identifier intending
+            # to *create* a new dashboard, but it happens to match an
+            # existing dashboard's id, the rewrite silently re-targets the
+            # operation onto that existing dashboard. Pre-PR they'd have
+            # hit the hyphen-validation error and known their input was
+            # invalid; now the create-vs-update distinction depends on
+            # whether the registry happens to contain a matching id.
+            # We log the rewrite and surface the original identifier as
+            # ``resolved_from`` on the success response so callers can
+            # detect this redirect.
+            pre_resolved_from: str | None = None
             if "-" not in url_path and url_path != "lovelace":
                 resolved = await _resolve_dashboard(client, url_path)
                 if resolved is not None and resolved["url_path"]:
+                    original_url_path = url_path
                     url_path = resolved["url_path"]
+                    pre_resolved_from = original_url_path
+                    logger.info(
+                        "ha_config_set_dashboard pre-resolver mapped %r -> %r",
+                        original_url_path,
+                        url_path,
+                    )
 
             # Validate url_path contains hyphen for new dashboards
             # The built-in "lovelace" dashboard is exempt since it already exists
@@ -1024,7 +1121,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 # Compute new hash for potential chaining
                 new_config_hash = compute_config_hash(transformed_config)
 
-                return {
+                transform_result: dict[str, Any] = {
                     "success": True,
                     "action": "python_transform",
                     "url_path": url_path,
@@ -1032,6 +1129,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     "python_expression": python_transform,
                     "message": f"Dashboard {url_path} updated via Python transform",
                 }
+                if pre_resolved_from is not None:
+                    transform_result["resolved_from"] = pre_resolved_from
+                return transform_result
 
             # Check if dashboard exists
             result = await client.send_websocket_message(
@@ -1257,6 +1357,12 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
             if hint:
                 result_dict["hint"] = hint
+            if pre_resolved_from is not None:
+                # Caller passed an internal id; pre-resolver mapped it to
+                # the canonical url_path. Surface the original so a caller
+                # who *intended* to create a new dashboard can detect that
+                # an existing dashboard was updated instead.
+                result_dict["resolved_from"] = pre_resolved_from
 
             return result_dict
 

--- a/tests/src/e2e/tools/test_deep_search_exact_match.py
+++ b/tests/src/e2e/tools/test_deep_search_exact_match.py
@@ -191,7 +191,7 @@ async def test_deep_search_dashboard_type(mcp_client):
     finally:
         await mcp_client.call_tool(
             "ha_config_delete_dashboard",
-            {"dashboard_id": "deep-search-test-dash"},
+            {"url_path": "deep-search-test-dash"},
         )
         logger.info("Cleaned up test dashboard")
 

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -151,7 +151,7 @@ class TestDashboardLifecycle:
         # 6. Delete dashboard
         logger.info("Deleting test dashboard...")
         delete_data = await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"dashboard_id": dashboard_id}
+            "ha_config_delete_dashboard", {"url_path": dashboard_id}
         )
         assert delete_data["success"] is True
 
@@ -195,7 +195,7 @@ class TestDashboardLifecycle:
 
         # Cleanup
         await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"dashboard_id": dashboard_id}
+            "ha_config_delete_dashboard", {"url_path": dashboard_id}
         )
 
         logger.info("Strategy-based dashboard test completed successfully")
@@ -268,7 +268,7 @@ class TestDashboardLifecycle:
 
         # Cleanup
         await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"dashboard_id": dashboard_id}
+            "ha_config_delete_dashboard", {"url_path": dashboard_id}
         )
 
         logger.info("Partial metadata update test completed successfully")
@@ -298,7 +298,7 @@ class TestDashboardLifecycle:
 
         # Cleanup
         await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"dashboard_id": dashboard_id}
+            "ha_config_delete_dashboard", {"url_path": dashboard_id}
         )
 
         logger.info("Dashboard without config test completed successfully")
@@ -326,7 +326,7 @@ class TestDashboardLifecycle:
 
         # Cleanup
         await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"dashboard_id": dashboard_id}
+            "ha_config_delete_dashboard", {"url_path": dashboard_id}
         )
 
         logger.info("Metadata update via set_dashboard test completed successfully")
@@ -358,7 +358,7 @@ class TestDashboardErrorHandling:
         with pytest.raises(ToolError) as exc_info:
             await mcp_client.call_tool(
                 "ha_config_delete_dashboard",
-                {"dashboard_id": "nonexistent-dashboard-67890"},
+                {"url_path": "nonexistent-dashboard-67890"},
             )
 
         data = json.loads(str(exc_info.value))
@@ -366,6 +366,146 @@ class TestDashboardErrorHandling:
         assert data["error"]["code"] == "RESOURCE_NOT_FOUND"
 
         logger.info("Delete nonexistent dashboard test completed successfully")
+
+
+class TestDashboardIdentifierResolution:
+    """E2E tests for #981 — get/set/delete accept both url_path and internal id."""
+
+    async def test_delete_via_url_path(self, mcp_client):
+        """Delete accepts the url_path form (was the new canonical param name)."""
+        mcp = MCPAssertions(mcp_client)
+
+        await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {"url_path": "test-981-delete-by-url", "title": "Delete by url_path"},
+        )
+
+        delete_data = await mcp.call_tool_success(
+            "ha_config_delete_dashboard", {"url_path": "test-981-delete-by-url"}
+        )
+        assert delete_data["success"] is True
+        assert delete_data["url_path"] == "test-981-delete-by-url"
+
+        list_after = await mcp.call_tool_success(
+            "ha_config_get_dashboard", {"list_only": True}
+        )
+        assert not any(
+            d.get("url_path") == "test-981-delete-by-url"
+            for d in list_after.get("dashboards", [])
+        )
+
+    async def test_get_via_internal_id_lazy_resolves(self, mcp_client):
+        """Get with the internal dashboard id triggers the lazy resolver."""
+        mcp = MCPAssertions(mcp_client)
+
+        # Create dashboard so the resolver finds something to map.
+        # url_path with hyphen → HA sanitises it to underscore for the internal id.
+        create_data = await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": "test-981-get-by-id",
+                "title": "Get by id",
+                "config": {"views": [{"cards": [{"type": "markdown", "content": "hi"}]}]},
+            },
+        )
+        internal_id = create_data["dashboard_id"]
+        assert internal_id != "test-981-get-by-id"  # resolver must do real work
+
+        try:
+            # Pass the internal id where url_path is expected — lazy fallback
+            # in get Mode 3 resolves it and retries with the canonical url_path.
+            get_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"url_path": internal_id}
+            )
+            assert get_data["success"] is True
+            assert get_data["config"]["views"][0]["cards"][0]["content"] == "hi"
+        finally:
+            await mcp.call_tool_success(
+                "ha_config_delete_dashboard", {"url_path": "test-981-get-by-id"}
+            )
+
+    async def test_set_via_internal_id_pre_resolves(self, mcp_client):
+        """Set with the internal id (no hyphen) gets pre-resolved before validation."""
+        mcp = MCPAssertions(mcp_client)
+
+        create_data = await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": "test-981-set-by-id",
+                "title": "Set by id",
+                "config": {"views": [{"cards": [{"type": "markdown", "content": "v1"}]}]},
+            },
+        )
+        internal_id = create_data["dashboard_id"]
+        assert internal_id != "test-981-set-by-id"
+        assert "-" not in internal_id  # pre-resolver must run before hyphen check
+
+        try:
+            # Update via internal id — pre-resolver replaces it with url_path
+            # so the hyphen validation passes.
+            update_data = await mcp.call_tool_success(
+                "ha_config_set_dashboard",
+                {
+                    "url_path": internal_id,
+                    "config": {
+                        "views": [{"cards": [{"type": "markdown", "content": "v2"}]}]
+                    },
+                },
+            )
+            assert update_data["success"] is True
+            assert update_data["config_updated"] is True
+
+            # Verify the canonical url_path now holds v2
+            get_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"url_path": "test-981-set-by-id"}
+            )
+            assert get_data["config"]["views"][0]["cards"][0]["content"] == "v2"
+        finally:
+            await mcp.call_tool_success(
+                "ha_config_delete_dashboard", {"url_path": "test-981-set-by-id"}
+            )
+
+    async def test_mixed_identifier_optimistic_locking(self, mcp_client):
+        """config_hash from get(url_path) matches set(internal_id) — same content."""
+        mcp = MCPAssertions(mcp_client)
+
+        create_data = await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": "test-981-mixed-hash",
+                "title": "Mixed identifier hash",
+                "config": {"views": [{"cards": [{"type": "markdown", "content": "x"}]}]},
+            },
+        )
+        internal_id = create_data["dashboard_id"]
+
+        try:
+            # Read via url_path
+            get_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"url_path": "test-981-mixed-hash"}
+            )
+            config_hash = get_data["config_hash"]
+            assert config_hash
+
+            # Apply python_transform via the internal id — lazy fallback in
+            # the python_transform path resolves it. Hash from the url_path
+            # read must still validate because the underlying config is the same.
+            transform_data = await mcp.call_tool_success(
+                "ha_config_set_dashboard",
+                {
+                    "url_path": internal_id,
+                    "config_hash": config_hash,
+                    "python_transform": (
+                        "config['views'][0]['cards'][0]['content'] = 'transformed'"
+                    ),
+                },
+            )
+            assert transform_data["success"] is True
+            assert transform_data["action"] == "python_transform"
+        finally:
+            await mcp.call_tool_success(
+                "ha_config_delete_dashboard", {"url_path": "test-981-mixed-hash"}
+            )
 
 
 class TestFindCard:
@@ -430,7 +570,7 @@ class TestFindCard:
         finally:
             await mcp.call_tool_success(
                 "ha_config_delete_dashboard",
-                {"dashboard_id": "test-find-entity"},
+                {"url_path": "test-find-entity"},
             )
 
     async def test_find_card_by_type(self, mcp_client):
@@ -477,6 +617,6 @@ class TestFindCard:
         finally:
             await mcp.call_tool_success(
                 "ha_config_delete_dashboard",
-                {"dashboard_id": "test-find-type"},
+                {"url_path": "test-find-type"},
             )
 

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -487,9 +487,11 @@ class TestDashboardIdentifierResolution:
             config_hash = get_data["config_hash"]
             assert config_hash
 
-            # Apply python_transform via the internal id — lazy fallback in
-            # the python_transform path resolves it. Hash from the url_path
-            # read must still validate because the underlying config is the same.
+            # Apply python_transform via the internal id — the set-tool's
+            # pre-resolver maps the internal id to the canonical url_path
+            # before the python_transform branch runs. The hash from the
+            # url_path read must still validate because the underlying
+            # config is the same.
             transform_data = await mcp.call_tool_success(
                 "ha_config_set_dashboard",
                 {

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -437,8 +437,11 @@ class TestDashboardIdentifierResolution:
             },
         )
         internal_id = create_data["dashboard_id"]
-        assert internal_id != "test-981-set-by-id"
-        assert "-" not in internal_id  # pre-resolver must run before hyphen check
+        # Literal compare on the canonical id form — survives an HA-side
+        # change of the slugify separator with a clearer failure message
+        # than ``"-" not in internal_id``. The pre-resolver must run before
+        # the hyphen-check on this id (it has no hyphen by construction).
+        assert internal_id == "test_981_set_by_id"
 
         try:
             # Update via internal id — pre-resolver replaces it with url_path
@@ -504,6 +507,22 @@ class TestDashboardIdentifierResolution:
             )
             assert transform_data["success"] is True
             assert transform_data["action"] == "python_transform"
+
+            # Re-read and assert the transform actually wrote new content —
+            # without this, a regression that turns the python_transform
+            # branch into a no-op save (success-but-untouched) would still
+            # pass. Mirrors the v1→v2 verification pattern in
+            # test_set_via_internal_id_pre_resolves above.
+            verify_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"url_path": "test-981-mixed-hash"}
+            )
+            assert (
+                verify_data["config"]["views"][0]["cards"][0]["content"]
+                == "transformed"
+            ), (
+                "python_transform reported success but the persisted config "
+                "did not change — likely no-op save regression"
+            )
         finally:
             await mcp.call_tool_success(
                 "ha_config_delete_dashboard", {"url_path": "test-981-mixed-hash"}

--- a/tests/src/unit/test_tools_config_dashboards.py
+++ b/tests/src/unit/test_tools_config_dashboards.py
@@ -12,7 +12,6 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from ha_mcp.tools.tools_config_dashboards import (
     _LAZY_RESOLVE_TRIGGER,
     _lazy_resolve_and_retry,

--- a/tests/src/unit/test_tools_config_dashboards.py
+++ b/tests/src/unit/test_tools_config_dashboards.py
@@ -12,13 +12,13 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from ha_mcp.tools.tools_config_dashboards import (
     _LAZY_RESOLVE_TRIGGER,
     _lazy_resolve_and_retry,
     _resolve_dashboard,
     _should_lazy_resolve,
 )
-
 
 # -----------------------------------------------------------------------------
 # Fixtures / helpers
@@ -133,9 +133,9 @@ class TestResolveDashboard:
         ):
             result = await _resolve_dashboard(fake_client, "anything")
         assert result is None
-        assert any(
-            "unexpected shape" in rec.message for rec in caplog.records
-        ), f"expected an 'unexpected shape' warning; got {caplog.records}"
+        assert any("unexpected shape" in rec.message for rec in caplog.records), (
+            f"expected an 'unexpected shape' warning; got {caplog.records}"
+        )
 
     async def test_missing_url_path_in_match_returns_none(self, fake_client):
         # Malformed registry entry where the matching dashboard is
@@ -246,9 +246,9 @@ class TestLazyResolveAndRetry:
         # Caller's ws_data dict must NOT be mutated — the retry uses a
         # shallow copy. Verify both the contract and that the retry call
         # carried the canonical url_path.
-        assert (
-            ws_data["url_path"] == "my_dash"
-        ), "_lazy_resolve_and_retry mutated the caller's ws_data dict"
+        assert ws_data["url_path"] == "my_dash", (
+            "_lazy_resolve_and_retry mutated the caller's ws_data dict"
+        )
         retry_call = fake_client.send_websocket_message.call_args_list[1]
         assert retry_call.args[0]["url_path"] == "my-dash"
         assert retry_call.args[0]["type"] == "lovelace/config"

--- a/tests/src/unit/test_tools_config_dashboards.py
+++ b/tests/src/unit/test_tools_config_dashboards.py
@@ -1,0 +1,255 @@
+"""Unit tests for the dashboard-resolver helpers in tools_config_dashboards.
+
+The helpers under test (`_should_lazy_resolve`, `_resolve_dashboard`,
+`_lazy_resolve_and_retry`) hold the substring-trigger contract and the
+two-call-site resolver glue that the rest of the dual-accept identifier
+design rests on. End-to-end tests would only catch a regression here on
+the right HA-version axis; these unit tests pin the contract independent
+of HA wording stability.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ha_mcp.tools.tools_config_dashboards import (
+    _LAZY_RESOLVE_TRIGGER,
+    _lazy_resolve_and_retry,
+    _resolve_dashboard,
+    _should_lazy_resolve,
+)
+
+
+# -----------------------------------------------------------------------------
+# Fixtures / helpers
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_client():
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock()
+    return client
+
+
+def _trigger_response(missing_id: str = "anything") -> dict:
+    """Build the WS error envelope HA emits when ``lovelace/config`` is
+    called with an identifier it does not recognise. Includes the literal
+    trigger substring."""
+    return {
+        "success": False,
+        "error": {
+            "message": f"{_LAZY_RESOLVE_TRIGGER}: {missing_id}",
+            "code": "config_not_found",
+        },
+    }
+
+
+def _success_response(payload: dict | None = None) -> dict:
+    return {"success": True, "result": payload or {"views": []}}
+
+
+# -----------------------------------------------------------------------------
+# _should_lazy_resolve — substring contract
+# -----------------------------------------------------------------------------
+
+
+class TestShouldLazyResolve:
+    """The substring trigger is the only signal available at the tool
+    layer. Pin the contract so an HA-side wording change is caught here
+    rather than degrading to "lazy fallback never fires" silently."""
+
+    def test_exact_trigger_message(self):
+        assert _should_lazy_resolve(_LAZY_RESOLVE_TRIGGER) is True
+
+    def test_trigger_with_identifier_suffix(self):
+        # The HA emit form is f"Unknown config specified: {url_path}".
+        assert _should_lazy_resolve("Unknown config specified: my_dashboard") is True
+
+    def test_trigger_embedded_in_longer_message(self):
+        assert (
+            _should_lazy_resolve("Command failed: Unknown config specified: foo")
+            is True
+        )
+
+    def test_unrelated_message_does_not_match(self):
+        assert _should_lazy_resolve("Some other error") is False
+        assert _should_lazy_resolve("") is False
+
+    def test_legitimate_empty_dashboard_message_does_not_match(self):
+        # HA emits "No config found." for genuinely empty (un-initialised)
+        # dashboards — must NOT trigger a lazy retry, otherwise the
+        # caller's empty-state path is hidden.
+        assert _should_lazy_resolve("No config found.") is False
+
+
+# -----------------------------------------------------------------------------
+# _resolve_dashboard — registry lookup
+# -----------------------------------------------------------------------------
+
+
+class TestResolveDashboard:
+    async def test_match_by_url_path(self, fake_client):
+        fake_client.send_websocket_message.return_value = {
+            "result": [
+                {"url_path": "my-dash", "id": "my_dash"},
+                {"url_path": "other", "id": "other_id"},
+            ]
+        }
+        result = await _resolve_dashboard(fake_client, "my-dash")
+        assert result == {"url_path": "my-dash", "id": "my_dash"}
+
+    async def test_match_by_internal_id(self, fake_client):
+        fake_client.send_websocket_message.return_value = {
+            "result": [{"url_path": "my-dash", "id": "my_dash"}]
+        }
+        result = await _resolve_dashboard(fake_client, "my_dash")
+        assert result == {"url_path": "my-dash", "id": "my_dash"}
+
+    async def test_response_as_bare_list(self, fake_client):
+        # Older HA versions / different response shapes return the list
+        # directly rather than wrapped in {"result": ...}.
+        fake_client.send_websocket_message.return_value = [
+            {"url_path": "my-dash", "id": "my_dash"}
+        ]
+        result = await _resolve_dashboard(fake_client, "my_dash")
+        assert result == {"url_path": "my-dash", "id": "my_dash"}
+
+    async def test_no_match_returns_none(self, fake_client):
+        fake_client.send_websocket_message.return_value = {
+            "result": [{"url_path": "my-dash", "id": "my_dash"}]
+        }
+        assert await _resolve_dashboard(fake_client, "nonexistent") is None
+
+    async def test_malformed_shape_logs_warning_and_returns_none(
+        self, fake_client, caplog
+    ):
+        # Neither dict-with-result nor list — could be a future HA shape
+        # change or an error envelope. Must surface as a logger.warning,
+        # not silently degrade to "always no match".
+        fake_client.send_websocket_message.return_value = "unexpected string"
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.tools_config_dashboards"
+        ):
+            result = await _resolve_dashboard(fake_client, "anything")
+        assert result is None
+        assert any(
+            "unexpected shape" in rec.message for rec in caplog.records
+        ), f"expected an 'unexpected shape' warning; got {caplog.records}"
+
+    async def test_missing_url_path_in_match_returns_none(self, fake_client):
+        # Malformed registry entry where the matching dashboard is
+        # missing one of the required fields. Must skip / return None
+        # rather than forwarding empty strings to delete_dashboard.
+        fake_client.send_websocket_message.return_value = {
+            "result": [{"id": "my_dash"}]  # url_path missing entirely
+        }
+        assert await _resolve_dashboard(fake_client, "my_dash") is None
+
+    async def test_empty_id_in_match_returns_none(self, fake_client):
+        fake_client.send_websocket_message.return_value = {
+            "result": [{"url_path": "my-dash", "id": ""}]
+        }
+        assert await _resolve_dashboard(fake_client, "my-dash") is None
+
+
+# -----------------------------------------------------------------------------
+# _lazy_resolve_and_retry — composition + no-op axes
+# -----------------------------------------------------------------------------
+
+
+class TestLazyResolveAndRetry:
+    async def test_success_response_short_circuits(self, fake_client):
+        ws_data = {"type": "lovelace/config", "url_path": "anything"}
+        response = _success_response()
+        new_url, new_response = await _lazy_resolve_and_retry(
+            fake_client, "anything", ws_data, response
+        )
+        assert (new_url, new_response) == ("anything", response)
+        # No WS call — short-circuit must not pay the round-trip.
+        fake_client.send_websocket_message.assert_not_called()
+
+    async def test_empty_url_path_short_circuits(self, fake_client):
+        # Default-dashboard path: caller passes None for url_path.
+        ws_data = {"type": "lovelace/config"}
+        response = _trigger_response()
+        new_url, new_response = await _lazy_resolve_and_retry(
+            fake_client, None, ws_data, response
+        )
+        assert new_url is None
+        assert new_response is response
+        fake_client.send_websocket_message.assert_not_called()
+
+    async def test_non_trigger_failure_short_circuits(self, fake_client):
+        # Failure response, but with a different error message. Must NOT
+        # invoke the resolver — that would surface a synthetic resolver
+        # error instead of the real HA error to the caller.
+        ws_data = {"type": "lovelace/config", "url_path": "x"}
+        response = {
+            "success": False,
+            "error": {"message": "permission denied"},
+        }
+        new_url, new_response = await _lazy_resolve_and_retry(
+            fake_client, "x", ws_data, response
+        )
+        assert (new_url, new_response) == ("x", response)
+        fake_client.send_websocket_message.assert_not_called()
+
+    async def test_resolver_no_match_returns_original_response(self, fake_client):
+        # Trigger fired, resolver runs, but the registry has no match —
+        # original failure response wins so the caller's existing error
+        # path runs against the real HA error.
+        fake_client.send_websocket_message.side_effect = [
+            {"result": []},  # resolver: empty list, no match
+        ]
+        ws_data = {"type": "lovelace/config", "url_path": "ghost"}
+        original = _trigger_response("ghost")
+        new_url, new_response = await _lazy_resolve_and_retry(
+            fake_client, "ghost", ws_data, original
+        )
+        assert new_url == "ghost"
+        assert new_response is original
+
+    async def test_resolver_exception_falls_through(self, fake_client, caplog):
+        # Resolver raises (timeout, network blip). Must NOT escape; must
+        # log at WARNING and fall through to the original response so
+        # the caller's existing error path surfaces the real HA error.
+        fake_client.send_websocket_message.side_effect = ConnectionError("ws gone")
+        ws_data = {"type": "lovelace/config", "url_path": "x"}
+        original = _trigger_response("x")
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.tools_config_dashboards"
+        ):
+            new_url, new_response = await _lazy_resolve_and_retry(
+                fake_client, "x", ws_data, original
+            )
+        assert (new_url, new_response) == ("x", original)
+        assert any("Lazy resolver failed" in rec.message for rec in caplog.records)
+
+    async def test_happy_path_resolves_and_retries(self, fake_client):
+        # Trigger fires, resolver finds the canonical url_path, retry
+        # succeeds with new url_path on the WS data dict.
+        fake_client.send_websocket_message.side_effect = [
+            {  # resolver
+                "result": [{"url_path": "my-dash", "id": "my_dash"}]
+            },
+            _success_response({"views": [{"cards": []}]}),  # retry
+        ]
+        ws_data = {"type": "lovelace/config", "url_path": "my_dash", "force": True}
+        original = _trigger_response("my_dash")
+        new_url, new_response = await _lazy_resolve_and_retry(
+            fake_client, "my_dash", ws_data, original
+        )
+        assert new_url == "my-dash"
+        assert new_response["success"] is True
+
+        # Caller's ws_data dict must NOT be mutated — the retry uses a
+        # shallow copy. Verify both the contract and that the retry call
+        # carried the canonical url_path.
+        assert (
+            ws_data["url_path"] == "my_dash"
+        ), "_lazy_resolve_and_retry mutated the caller's ws_data dict"
+        retry_call = fake_client.send_websocket_message.call_args_list[1]
+        assert retry_call.args[0]["url_path"] == "my-dash"
+        assert retry_call.args[0]["type"] == "lovelace/config"


### PR DESCRIPTION
## What does this PR do?

Implements path 2 (lazy resolver) from #981, per maintainer [#issuecomment-4321843366](https://github.com/homeassistant-ai/ha-mcp/issues/981#issuecomment-4321843366). All three `ha_config_*_dashboard` tools now accept either the URL path or the internal dashboard ID. The `lovelace/dashboards/list` round-trip is only paid on the fallback path.

- `ha_config_delete_dashboard`: param renamed `dashboard_id` → `url_path`; resolver factored into a module-scope helper `_resolve_dashboard`.
- `ha_config_get_dashboard`: on `Unknown config specified` WS error, resolves and retries once. Happy path stays one round-trip. Both get-mode and search-mode (`entity_id`/`card_type`/`heading`) go through the same fallback. Surfaces `resolved_from` on the response when the lazy fallback fired so callers can detect their input was canonicalised.
- `ha_config_set_dashboard`: pre-resolves the identifier before the existing hyphen validation, so callers may pass either form. The pre-resolver is gated on a cheap heuristic (no hyphen, not `"lovelace"`). When it rewrites the identifier, the success response includes `resolved_from` and a `logger.info` line records the mapping — a caller who *intended* to create a new dashboard but happened to collide with an existing internal id can detect that an update happened instead.

The lazy trigger keys on the substring `Unknown config specified` — chosen over a generic `success: false` check, because HA emits `No config found.` for an empty-but-existing dashboard, which must NOT retry. Verified live on HA 2026.3.

**Migration:** callers passing `dashboard_id=...` to `ha_config_delete_dashboard` need to pass `url_path=...`. Either form (URL path or internal ID) is accepted for the value.

Regression coverage in `TestDashboardIdentifierResolution` exercises delete-via-url_path, get-via-internal-id (lazy fallback), set-via-internal-id (pre-resolver), and mixed-identifier optimistic locking with `python_transform`. Unit coverage in `tests/src/unit/test_tools_config_dashboards.py` pins the substring-trigger contract, the resolver's malformed-shape and missing-field paths, and the no-op axes of `_lazy_resolve_and_retry` (success short-circuit, empty url_path, non-trigger failures, resolver-no-match, resolver-raises).

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist

- [x] I have updated documentation if needed

Closes #981.
