### PR TITLE
feat(site): add OpenCode support to setup wizard

### DIFF
--- a/site/public/logos/opencode.svg
+++ b/site/public/logos/opencode.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <rect width="512" height="512" fill="#131010"/>
+  <path d="M320 224V352H192V224H320Z" fill="#5A5858"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"/>
+</svg>

--- a/site/src/content/clients/opencode.md
+++ b/site/src/content/clients/opencode.md
@@ -1,0 +1,111 @@
+---
+name: OpenCode
+company: Anomaly
+logo: /logos/opencode.svg
+transports: ['stdio', 'streamable-http']
+configFormat: json
+configLocation: ~/.config/opencode/opencode.json (global) or opencode.json (project)
+accuracy: 5
+order: 14
+---
+
+## Configuration
+
+OpenCode supports MCP servers through the `mcp` key in its JSON (or JSONC) configuration. Both stdio (`type: "local"`) and HTTP streaming (`type: "remote"`) are first-class — no proxy shim is required.
+
+### Config File Locations
+
+- **Global:** `~/.config/opencode/opencode.json`
+- **Project:** `opencode.json` (or `opencode.jsonc`) in the project root — overrides global
+- **Custom path:** `OPENCODE_CONFIG=/path/to/file.json`
+
+OpenCode merges configs from all locations (project overrides global). See [config precedence](https://opencode.ai/docs/config/#precedence-order).
+
+### stdio Configuration (Local)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "home-assistant": {
+      "type": "local",
+      "command": ["uvx", "ha-mcp@latest"],
+      "enabled": true,
+      "environment": {
+        "HOMEASSISTANT_URL": "{{HOMEASSISTANT_URL}}",
+        "HOMEASSISTANT_TOKEN": "{{HOMEASSISTANT_TOKEN}}"
+      }
+    }
+  }
+}
+```
+
+> **Note:** OpenCode's `command` is a single array containing both the executable and its arguments (no separate `args` field), and the env block is named `environment` (not `env`).
+
+### Streamable HTTP Configuration (Network/Remote)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "home-assistant": {
+      "type": "remote",
+      "url": "{{MCP_SERVER_URL}}",
+      "enabled": true
+    }
+  }
+}
+```
+
+### With Custom Headers (e.g., Bearer Auth)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "home-assistant": {
+      "type": "remote",
+      "url": "{{MCP_SERVER_URL}}",
+      "headers": {
+        "Authorization": "Bearer {env:HA_MCP_TOKEN}"
+      },
+      "oauth": false
+    }
+  }
+}
+```
+
+OpenCode supports `{env:VAR}` substitution inside the config — handy for keeping secrets out of the file.
+
+### OAuth (Automatic)
+
+If your MCP server speaks OAuth, OpenCode handles Dynamic Client Registration automatically. No extra config is needed; OpenCode prompts on first use, or you can trigger it manually:
+
+```bash
+opencode mcp auth home-assistant
+```
+
+## Management Commands
+
+```bash
+# List configured servers and their auth status
+opencode mcp list
+
+# Trigger or refresh authentication
+opencode mcp auth home-assistant
+
+# Remove stored credentials
+opencode mcp logout home-assistant
+
+# Diagnose connection / OAuth issues
+opencode mcp debug home-assistant
+```
+
+## Notes
+
+- Config key is `mcp` (not `mcpServers`).
+- Local servers use `type: "local"` with a single `command` array; `args` is not used.
+- Environment variables go under `environment` (not `env`).
+- Remote servers use `type: "remote"` with `url`; both stdio and streamable HTTP are supported natively, so no `mcp-proxy` is required for HTTP setups.
+- Tools from this server are namespaced as `home-assistant_*`. To restrict a server to specific agents, disable the namespace globally and re-enable it per agent — see [MCP per-agent docs](https://opencode.ai/docs/mcp-servers/#per-agent).
+- Each MCP server adds to the prompt context. With ha-mcp's 92+ tools this is non-trivial; consider gating it to a dedicated agent if you primarily use OpenCode for non-HA work.

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -385,6 +385,38 @@ HOMEASSISTANT_TOKEN = "your_long_lived_token"`,
     ]
   },
   {
+    id: 'opencode',
+    name: 'OpenCode',
+    company: 'Anomaly',
+    logo: '/ha-mcp/logos/opencode.svg',
+    accuracy: 5,
+    platforms: ['macOS', 'Windows', 'Linux'],
+    configFormat: 'json',
+    configLocation: '~/.config/opencode/opencode.json (global) or opencode.json (project)',
+    description: 'AI coding agent by Anomaly with native MCP support over stdio and streamable HTTP.',
+    config: `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "home-assistant": {
+      "type": "local",
+      "command": ["uvx", "ha-mcp@latest"],
+      "enabled": true,
+      "environment": {
+        "HOMEASSISTANT_URL": "http://homeassistant.local:8123",
+        "HOMEASSISTANT_TOKEN": "your_long_lived_token"
+      }
+    }
+  }
+}`,
+    notes: [
+      'Uses "mcp" key (not "mcpServers")',
+      'Local server: type:"local", single command array, "environment" not "env"',
+      'Remote server: type:"remote" with url — no mcp-proxy required',
+      'Manage with opencode mcp list / auth / logout / debug'
+    ],
+    docsUrl: 'https://opencode.ai/docs/mcp-servers/'
+  },
+  {
     id: 'jetbrains',
     name: 'JetBrains IDEs',
     company: 'JetBrains',

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1269,6 +1269,29 @@ cloudflared tunnel run ha-mcp</code></pre>
       // VS Code uses different structure: mcp.servers instead of mcpServers
       const isVSCode = state.client.id === 'vscode';
       const isZed = state.client.id === 'zed';
+      const isOpenCode = state.client.id === 'opencode';
+
+      // OpenCode-specific stdio shape: type:"local", single command array, "environment" not "env"
+      const opencodeStdio = isDocker
+        ? {
+            type: "local",
+            command: [
+              "docker", "run", "--rm", "-i",
+              "-e", "HOMEASSISTANT_URL={{HOMEASSISTANT_URL}}",
+              "-e", "HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}}",
+              "ghcr.io/homeassistant-ai/ha-mcp:latest"
+            ],
+            enabled: true
+          }
+        : {
+            type: "local",
+            command: ["uvx", "ha-mcp@latest"],
+            enabled: true,
+            environment: {
+              HOMEASSISTANT_URL: "{{HOMEASSISTANT_URL}}",
+              HOMEASSISTANT_TOKEN: "{{HOMEASSISTANT_TOKEN}}"
+            }
+          };
 
       if (isStdio) {
         if (isVSCode) {
@@ -1284,6 +1307,13 @@ cloudflared tunnel run ha-mcp</code></pre>
           config = JSON.stringify({
             context_servers: {
               "home-assistant": stdioConfig
+            }
+          }, null, 2);
+        } else if (isOpenCode) {
+          config = JSON.stringify({
+            "$schema": "https://opencode.ai/config.json",
+            mcp: {
+              "home-assistant": opencodeStdio
             }
           }, null, 2);
         } else {
@@ -1358,6 +1388,18 @@ cloudflared tunnel run ha-mcp</code></pre>
             context_servers: {
               "home-assistant": {
                 url: mcpUrl
+              }
+            }
+          }, null, 2);
+        } else if (isOpenCode) {
+          // OpenCode: type:"remote" under mcp key
+          config = JSON.stringify({
+            "$schema": "https://opencode.ai/config.json",
+            mcp: {
+              "home-assistant": {
+                type: "remote",
+                url: mcpUrl,
+                enabled: true
               }
             }
           }, null, 2);


### PR DESCRIPTION
## Summary
Add [OpenCode](https://opencode.ai) (by Anomaly) as a client option in the setup wizard. OpenCode is an AI coding agent with native MCP support over both stdio and streamable HTTP — no `mcp-proxy` shim is required for HTTP setups.

## Changes
- ✅ Add `opencode.md` client definition with JSON config format
- ✅ Support stdio and streamable-http transports (no SSE)
- ✅ Add new `opencode.svg` logo (square mark from opencode.ai)
- ✅ Wizard config generation for OpenCode's distinct schema:
  - top-level `mcp` key (not `mcpServers`)
  - local servers use `type: "local"` with a single `command` array (no separate `args`)
  - environment variables under `environment` (not `env`)
  - remote servers use `type: "remote"` with `url`
- ✅ Mirror entry in legacy `data/clients.ts` for consistency

## Testing
- [x] `npm run build` clean (7 pages, 1.67s)
- [x] `npx astro check` introduces zero new errors (6 pre-existing errors unchanged)
- [x] OpenCode tile appears in client grid with correct transports/logo
- [x] Generated configs validated for stdio (uvx + Docker) and remote HTTP modes — all parse cleanly and conform to the OpenCode `config.json` schema
- [x] Existing client paths unaffected (Cursor/Claude Desktop tested for regressions)

## Screenshots
N/A — see live wizard at `/ha-mcp/setup` after merge.

## Notes
Mirrors the pattern from #387 (Codex CLI) and #909 (Copilot CLI) — wizard entry only, no dedicated guided walkthrough page (those are reserved for Claude Desktop today).