### PR TITLE
feat(site): add gemini-cli setup notes + compose hardening to wizard (#1027)

### DIFF
--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -117,8 +117,7 @@ If you have the [Home Assistant MCP integration](https://www.home-assistant.io/i
     "home-assistant": {
       "httpUrl": "http://192.168.1.10:8123/api/mcp",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiI...",
-        "Accept": "application/json"
+        "Authorization": "Bearer eyJhbGciOiJIUzI1NiI..."
       }
     }
   }

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -49,7 +49,7 @@ Gemini CLI uses `url` key for SSE transport:
 }
 ```
 
-> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode (the default for `ha-mcp-web`; for SSE use the separate `ha-mcp-sse` entry point on port 8087) — switch to `httpUrl` (next section).
+> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode — switch to `httpUrl` (next section). For Home Assistant: `ha-mcp-web` defaults to Streamable HTTP; for SSE use the separate `ha-mcp-sse` entry point (default port 8087).
 
 ### Streamable HTTP Configuration (Network/Remote)
 
@@ -163,7 +163,7 @@ HOMEASSISTANT_URL=http://homeassistant.local:8123
 HOMEASSISTANT_TOKEN=<your-long-lived-access-token>
 ```
 
-For production hardening (read-only filesystem via `read_only`, dropped privileges via `cap_drop`, resource limits via `deploy.resources.limits`), see Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/).
+For production hardening (read-only filesystem via `read_only`, dropped Linux capabilities via `cap_drop`, resource limits via `deploy.resources.limits`), see Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/).
 
 ## Management Commands
 

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -105,7 +105,7 @@ gemini mcp add --transport sse home-assistant {{MCP_SERVER_URL}}
 
 ## Setup Examples
 
-Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace IPs and tokens with your own. These JSON snippets are equivalent to using `gemini mcp add` (shown above) — pick whichever flow you prefer.
+Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace hosts and tokens with your own. These JSON snippets are equivalent to using `gemini mcp add` (shown above) — pick whichever flow you prefer.
 
 ### Home Assistant built-in MCP integration (no `ha-mcp` container)
 
@@ -126,7 +126,7 @@ If you have the [Home Assistant MCP integration](https://www.home-assistant.io/i
 
 ### Self-hosted `ha-mcp` Docker container
 
-If `ha-mcp` runs in its own container on the same host as Home Assistant (replace the IP with your own):
+If `ha-mcp` runs in its own container on the same host as Home Assistant (replace the host with your own):
 
 ```json
 {

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -49,8 +49,6 @@ Gemini CLI uses `url` key for SSE transport:
 }
 ```
 
-> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode — switch to `httpUrl` (see the Streamable HTTP Configuration section below). For Home Assistant: `ha-mcp-web` defaults to Streamable HTTP; for SSE use the separate `ha-mcp-sse` entry point (default port 8087).
-
 ### Streamable HTTP Configuration (Network/Remote)
 
 Gemini CLI uses `httpUrl` key for HTTP streaming transport:
@@ -102,88 +100,6 @@ gemini mcp add --transport http home-assistant {{MCP_SERVER_URL}}
 ```bash
 gemini mcp add --transport sse home-assistant {{MCP_SERVER_URL}}
 ```
-
-## Setup Examples
-
-Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace hosts and tokens with your own. These JSON snippets are equivalent to using `gemini mcp add` (shown above) — pick whichever flow you prefer.
-
-### Home Assistant built-in MCP integration (no `ha-mcp` container)
-
-If you have the [Home Assistant MCP integration](https://www.home-assistant.io/integrations/mcp_server/) enabled, point Gemini CLI directly at Home Assistant's `/api/mcp` endpoint with a long-lived access token:
-
-```json
-{
-  "mcpServers": {
-    "home-assistant": {
-      "httpUrl": "http://homeassistant.local:8123/api/mcp",
-      "headers": {
-        "Authorization": "Bearer <your-long-lived-access-token>"
-      }
-    }
-  }
-}
-```
-
-HA core also serves the legacy SSE endpoint at `/mcp_server/sse` on the same host and port. Use that path with the `url` key (not `httpUrl`) if you prefer SSE over Streamable HTTP.
-
-### Self-hosted `ha-mcp` Docker container
-
-If `ha-mcp` runs in its own container on the same host as Home Assistant (replace the host with your own):
-
-```json
-{
-  "mcpServers": {
-    "ha-mcp": {
-      "httpUrl": "http://homeassistant.local:8086/mcp"
-    }
-  }
-}
-```
-
-A `GET` against `http://<host>:8086/mcp` returns `405 Method Not Allowed` by design — that is the `register_browser_landing` handler in `__main__.py` confirming the server is running, not a fault. MCP clients use `POST`, so this only shows up if a curl probe or a browser hits the URL directly.
-
-#### Sample `docker-compose.yml` for `ha-mcp`
-
-Minimum-viable compose for a `ha-mcp-web` deployment paired with an `.env` file. The endpoint produced (`http://<host>:8086/mcp`) works with any HTTP-capable MCP client, not just Gemini CLI. Layer in the production hardening below before exposing this on a real network.
-
-```yaml
-services:
-  ha-mcp:
-    container_name: ha-mcp
-    image: ghcr.io/homeassistant-ai/ha-mcp:latest
-    command: ha-mcp-web
-    ports:
-      - "8086:8086"
-    environment:
-      - HOMEASSISTANT_URL=${HOMEASSISTANT_URL}
-      - HOMEASSISTANT_TOKEN=${HOMEASSISTANT_TOKEN}
-    restart: unless-stopped
-```
-
-Companion `.env`:
-
-```bash
-HOMEASSISTANT_URL=http://homeassistant.local:8123
-HOMEASSISTANT_TOKEN=<your-long-lived-access-token>
-```
-
-For a production-grade deployment, layer the following onto the `ha-mcp` service block above:
-
-```yaml
-    read_only: true
-    tmpfs:
-      - /tmp
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges:true
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-```
-
-`read_only: true` pairs with `tmpfs: /tmp` because the Python runtime writes temporary files there; `cap_drop: [ALL]` drops every Linux kernel capability the container would otherwise inherit; `security_opt: no-new-privileges:true` blocks privilege escalation via setuid binaries. See Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/) for the full schema.
 
 ## Management Commands
 

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -49,6 +49,8 @@ Gemini CLI uses `url` key for SSE transport:
 }
 ```
 
+> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode (POST-only, the default for `ha-mcp-web`) — switch to `httpUrl` (next section).
+
 ### Streamable HTTP Configuration (Network/Remote)
 
 Gemini CLI uses `httpUrl` key for HTTP streaming transport:
@@ -100,6 +102,69 @@ gemini mcp add --transport http home-assistant {{MCP_SERVER_URL}}
 ```bash
 gemini mcp add --transport sse home-assistant {{MCP_SERVER_URL}}
 ```
+
+## Setup Examples
+
+Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace IPs and tokens with your own.
+
+### Home Assistant built-in MCP integration (no `ha-mcp` container)
+
+If you have the [Home Assistant MCP integration](https://www.home-assistant.io/integrations/mcp_server/) enabled, point Gemini CLI directly at Home Assistant's `/api/mcp` endpoint with a long-lived access token:
+
+```json
+{
+  "mcpServers": {
+    "home-assistant": {
+      "httpUrl": "http://192.168.1.10:8123/api/mcp",
+      "headers": {
+        "Authorization": "Bearer eyJhbGciOiJIUzI1NiI...",
+        "Accept": "application/json"
+      }
+    }
+  }
+}
+```
+
+### Self-hosted `ha-mcp` Docker container
+
+If `ha-mcp` runs in its own container alongside Home Assistant:
+
+```json
+{
+  "mcpServers": {
+    "ha-mcp": {
+      "httpUrl": "http://192.168.1.20:8086/mcp"
+    }
+  }
+}
+```
+
+### Sample `docker-compose.yml` for `ha-mcp`
+
+Minimal compose for a `ha-mcp-web` deployment paired with an `.env` file. The endpoint produced (`http://<host>:8086/mcp`) works with any HTTP-capable MCP client, not just Gemini CLI.
+
+```yaml
+services:
+  ha-mcp:
+    container_name: ha-mcp
+    image: ghcr.io/homeassistant-ai/ha-mcp:latest
+    command: ha-mcp-web
+    ports:
+      - "8086:8086"
+    environment:
+      - HOMEASSISTANT_URL=${HOMEASSISTANT_URL}
+      - HOMEASSISTANT_TOKEN=${HOMEASSISTANT_TOKEN}
+    restart: unless-stopped
+```
+
+Companion `.env`:
+
+```bash
+HOMEASSISTANT_URL=http://192.168.1.10:8123
+HOMEASSISTANT_TOKEN=eyJhbGciOiJIUzI1NiI...
+```
+
+For production hardening (read-only filesystem, dropped privileges, resource limits), see Docker Compose's [security reference](https://docs.docker.com/compose/compose-file/05-services/#security_opt).
 
 ## Management Commands
 

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -126,19 +126,19 @@ If you have the [Home Assistant MCP integration](https://www.home-assistant.io/i
 
 ### Self-hosted `ha-mcp` Docker container
 
-If `ha-mcp` runs in its own container alongside Home Assistant:
+If `ha-mcp` runs in its own container on the same host as Home Assistant (replace the IP with your own):
 
 ```json
 {
   "mcpServers": {
     "ha-mcp": {
-      "httpUrl": "http://192.168.1.20:8086/mcp"
+      "httpUrl": "http://192.168.1.10:8086/mcp"
     }
   }
 }
 ```
 
-### Sample `docker-compose.yml` for `ha-mcp`
+#### Sample `docker-compose.yml` for `ha-mcp`
 
 Minimal compose for a `ha-mcp-web` deployment paired with an `.env` file. The endpoint produced (`http://<host>:8086/mcp`) works with any HTTP-capable MCP client, not just Gemini CLI.
 

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -49,7 +49,7 @@ Gemini CLI uses `url` key for SSE transport:
 }
 ```
 
-> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode — switch to `httpUrl` (next section). For Home Assistant: `ha-mcp-web` defaults to Streamable HTTP; for SSE use the separate `ha-mcp-sse` entry point (default port 8087).
+> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode — switch to `httpUrl` (see the Streamable HTTP Configuration section below). For Home Assistant: `ha-mcp-web` defaults to Streamable HTTP; for SSE use the separate `ha-mcp-sse` entry point (default port 8087).
 
 ### Streamable HTTP Configuration (Network/Remote)
 
@@ -124,6 +124,8 @@ If you have the [Home Assistant MCP integration](https://www.home-assistant.io/i
 }
 ```
 
+HA core also serves the legacy SSE endpoint at `/mcp_server/sse` on the same host and port. Use that path with the `url` key (not `httpUrl`) if you prefer SSE over Streamable HTTP.
+
 ### Self-hosted `ha-mcp` Docker container
 
 If `ha-mcp` runs in its own container on the same host as Home Assistant (replace the host with your own):
@@ -138,9 +140,11 @@ If `ha-mcp` runs in its own container on the same host as Home Assistant (replac
 }
 ```
 
+A `GET` against `http://<host>:8086/mcp` returns `405 Method Not Allowed` by design — that is the `register_browser_landing` handler in `__main__.py` confirming the server is running, not a fault. MCP clients use `POST`, so this only shows up if a curl probe or a browser hits the URL directly.
+
 #### Sample `docker-compose.yml` for `ha-mcp`
 
-Minimal compose for a `ha-mcp-web` deployment paired with an `.env` file. The endpoint produced (`http://<host>:8086/mcp`) works with any HTTP-capable MCP client, not just Gemini CLI.
+Minimum-viable compose for a `ha-mcp-web` deployment paired with an `.env` file. The endpoint produced (`http://<host>:8086/mcp`) works with any HTTP-capable MCP client, not just Gemini CLI. Layer in the production hardening below before exposing this on a real network.
 
 ```yaml
 services:
@@ -163,7 +167,23 @@ HOMEASSISTANT_URL=http://homeassistant.local:8123
 HOMEASSISTANT_TOKEN=<your-long-lived-access-token>
 ```
 
-For production hardening (read-only filesystem via `read_only`, dropped Linux capabilities via `cap_drop`, resource limits via `deploy.resources.limits`), see Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/).
+For a production-grade deployment, layer the following onto the `ha-mcp` service block above:
+
+```yaml
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+```
+
+`read_only: true` pairs with `tmpfs: /tmp` because the Python runtime writes temporary files there; `cap_drop: [ALL]` drops every Linux kernel capability the container would otherwise inherit; `security_opt: no-new-privileges:true` blocks privilege escalation via setuid binaries. See Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/) for the full schema.
 
 ## Management Commands
 

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -49,7 +49,7 @@ Gemini CLI uses `url` key for SSE transport:
 }
 ```
 
-> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode (POST-only, the default for `ha-mcp-web`) — switch to `httpUrl` (next section).
+> **Note:** Use `url` only when the server actually serves SSE. If your client logs show `405 Method Not Allowed` on `GET /mcp`, the server is running in Streamable HTTP mode (the default for `ha-mcp-web`; for SSE use the separate `ha-mcp-sse` entry point on port 8087) — switch to `httpUrl` (next section).
 
 ### Streamable HTTP Configuration (Network/Remote)
 
@@ -105,7 +105,7 @@ gemini mcp add --transport sse home-assistant {{MCP_SERVER_URL}}
 
 ## Setup Examples
 
-Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace IPs and tokens with your own.
+Concrete `~/.gemini/settings.json` snippets for the two most common deployments. Replace IPs and tokens with your own. These JSON snippets are equivalent to using `gemini mcp add` (shown above) — pick whichever flow you prefer.
 
 ### Home Assistant built-in MCP integration (no `ha-mcp` container)
 
@@ -115,9 +115,9 @@ If you have the [Home Assistant MCP integration](https://www.home-assistant.io/i
 {
   "mcpServers": {
     "home-assistant": {
-      "httpUrl": "http://192.168.1.10:8123/api/mcp",
+      "httpUrl": "http://homeassistant.local:8123/api/mcp",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiI..."
+        "Authorization": "Bearer <your-long-lived-access-token>"
       }
     }
   }
@@ -132,7 +132,7 @@ If `ha-mcp` runs in its own container on the same host as Home Assistant (replac
 {
   "mcpServers": {
     "ha-mcp": {
-      "httpUrl": "http://192.168.1.10:8086/mcp"
+      "httpUrl": "http://homeassistant.local:8086/mcp"
     }
   }
 }
@@ -159,11 +159,11 @@ services:
 Companion `.env`:
 
 ```bash
-HOMEASSISTANT_URL=http://192.168.1.10:8123
-HOMEASSISTANT_TOKEN=eyJhbGciOiJIUzI1NiI...
+HOMEASSISTANT_URL=http://homeassistant.local:8123
+HOMEASSISTANT_TOKEN=<your-long-lived-access-token>
 ```
 
-For production hardening (read-only filesystem, dropped privileges, resource limits), see Docker Compose's [security reference](https://docs.docker.com/compose/compose-file/05-services/#security_opt).
+For production hardening (read-only filesystem via `read_only`, dropped privileges via `cap_drop`, resource limits via `deploy.resources.limits`), see Docker Compose's [services reference](https://docs.docker.com/reference/compose-file/services/).
 
 ## Management Commands
 

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1109,10 +1109,41 @@ ${secretPathEnv}uvx --from ha-mcp@latest ha-mcp-web</code></pre>
         const secretPathEnv = useSecretPath ? `  -e MCP_SECRET_PATH=/private_{{RANDOM_STRING}} \\\n` : '';
         const serverPath = useSecretPath ? '/private_{{RANDOM_STRING}}' : '/mcp';
         const dockerPortNote = `<p class="text-xs text-slate-500 mt-2">Optional: Change <code>-p 8086:8086</code> to use a different port (e.g., <code>-p 9000:8086</code>).</p>`;
+        const composeSecretPathLine = useSecretPath
+          ? `\n      - MCP_SECRET_PATH=/private_{{RANDOM_STRING}}`
+          : '';
         deployInstr = `<div class="instruction-block">
           <h4 class="instruction-title">Start Docker Container</h4>
           <pre class="code-block"><code>docker run -d --name ha-mcp -p 8086:8086 -e HOMEASSISTANT_URL={{HOMEASSISTANT_URL}} -e HOMEASSISTANT_TOKEN={{HOMEASSISTANT_TOKEN}}${secretPathEnv ? ' ' + secretPathEnv.trim() : ''} ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web</code></pre>
           <p class="text-sm text-slate-400 mt-2">Server will be at: <code>http://YOUR_IP:8086${serverPath}</code></p>${dockerPortNote}${secretPathNote}
+          <details class="mt-3">
+            <summary class="cursor-pointer text-sm text-slate-300 font-medium hover:text-slate-100">Production hardening (docker compose)</summary>
+            <p class="text-slate-300 text-sm mt-3 mb-2">A minimum-viable compose paired with an <code>.env</code> file:</p>
+            <pre class="code-block"><code>services:
+  ha-mcp:
+    container_name: ha-mcp
+    image: ghcr.io/homeassistant-ai/ha-mcp:latest
+    command: ha-mcp-web
+    ports:
+      - "8086:8086"
+    environment:
+      - HOMEASSISTANT_URL=\${HOMEASSISTANT_URL}
+      - HOMEASSISTANT_TOKEN=\${HOMEASSISTANT_TOKEN}${composeSecretPathLine}
+    restart: unless-stopped</code></pre>
+            <p class="text-slate-300 text-sm mt-3 mb-2">Layer these hardening directives onto the service block before exposing on a real network:</p>
+            <pre class="code-block"><code>    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 256M</code></pre>
+            <p class="text-slate-400 text-xs mt-2"><code>read_only: true</code> pairs with <code>tmpfs: /tmp</code> because the Python runtime writes temporary files there; <code>cap_drop: [ALL]</code> drops every Linux kernel capability the container would otherwise inherit; <code>no-new-privileges:true</code> blocks privilege escalation via setuid binaries. See Docker Compose's <a href="https://docs.docker.com/reference/compose-file/services/" target="_blank" class="text-blue-400 hover:underline">services reference</a> for the full schema.</p>
+          </details>
         </div>`;
       } else if (derivedDeployment === 'ha-addon') {
         deployInstr = `<div class="instruction-block">
@@ -1235,6 +1266,20 @@ cloudflared tunnel run ha-mcp</code></pre>
         <pre class="code-block"><code># mcp-proxy is run automatically via uvx in the config below</code></pre>
       </div>`;
       instructions.push(mcpProxyInstr);
+    }
+
+    // Client-specific notes for HTTP-based connections.
+    // Gemini CLI: 405-on-GET caveat (a recurring confusion source — see #1027)
+    // and the Home Assistant built-in MCP integration as an alternative to
+    // running a separate ha-mcp container.
+    if (state.client?.id === 'gemini-cli' && !isLocal) {
+      instructions.push(`<div class="instruction-block border-blue-700/50 bg-blue-900/10">
+        <h4 class="instruction-title text-blue-300">Gemini CLI Notes</h4>
+        <p class="text-slate-300 text-sm mb-2"><strong>If client logs show <code>405 Method Not Allowed</code> on <code>GET /mcp</code>:</strong> the server is running in Streamable HTTP mode — switch from <code>url</code> to <code>httpUrl</code> in <code>~/.gemini/settings.json</code>. The config below already uses <code>httpUrl</code>.</p>
+        <p class="text-slate-300 text-sm mb-2 mt-3">Entry points: <code>ha-mcp-web</code> (default) serves Streamable HTTP at <code>/mcp</code> on port 8086. The separate <code>ha-mcp-sse</code> entry point serves legacy SSE on port 8087 — pair that with the <code>url</code> key (not <code>httpUrl</code>) if you need SSE specifically.</p>
+        <p class="text-slate-300 text-sm mb-2 mt-3"><strong>A direct browser/curl probe of <code>http://&lt;host&gt;:8086/mcp</code> also returns 405 by design</strong> — that is the <code>register_browser_landing</code> handler in <code>src/ha_mcp/__main__.py</code> confirming the server is up, not a fault. MCP clients use <code>POST</code>; this only shows up if a curl probe or browser hits the URL directly.</p>
+        <p class="text-slate-300 text-sm mt-3"><strong>Alternative: HA built-in MCP integration.</strong> If you have the <a href="https://www.home-assistant.io/integrations/mcp_server/" target="_blank" class="text-blue-400 hover:underline">Home Assistant MCP integration</a> enabled, you can skip <code>ha-mcp</code> entirely and point Gemini CLI at HA's <code>/api/mcp</code> endpoint with a long-lived access token in a <code>Bearer</code> header. HA core also serves the legacy SSE endpoint at <code>/mcp_server/sse</code> on the same host/port — same 405-on-GET caveat applies there.</p>
+      </div>`);
     }
 
     // Generate client config


### PR DESCRIPTION
## What does this PR do?

Per @kingpanther13's stepback comment, the original markdown additions in `clients/gemini-cli.md` were dead content (the `clients/*.md` body is never rendered on the deployed site — `setup.astro` consumes only the frontmatter via `getCollection`). The PR is rescoped to land the same content in `setup.astro`'s wizard instruction-builder, where it actually reaches end users hitting #1027-style confusion.

- Reverted `site/src/content/clients/gemini-cli.md` to upstream/master (drops the −84 lines added in the earlier commits).
- Added a **Gemini CLI Notes** advisory block to `setup.astro` that fires when `state.client.id === 'gemini-cli'` and the connection is not local (HTTP transports). Covers symptom→fix for the 405 error, entry points (`ha-mcp-web` / `ha-mcp-sse` and their default ports), the 405-by-design behaviour of `register_browser_landing` in `src/ha_mcp/__main__.py`, and the HA built-in MCP integration as an alternative to running a separate `ha-mcp` container.
- Added a **Production hardening (docker compose)** `<details>` block to the existing Docker network/remote deployment instructions — generic, applies to any client choosing the Docker self-hosted path. Inlines a minimum-viable compose paired with `.env` plus the hardening directives (`read_only: true`, `tmpfs: /tmp`, `cap_drop: [ALL]`, `security_opt: no-new-privileges:true`, `deploy.resources.limits.memory`) and a brief rationale.

The five items from @kingpanther13's earlier review (405 split, "next section" cross-reference, `/mcp_server/sse` for HA built-in, self-hosted 405-by-design with `register_browser_landing` + module path, compose hardening) all land in the wizard rather than the markdown body.

`npm run build` from `site/` succeeds clean, and the rendered `dist/setup/index.html` contains the new strings (`Gemini CLI Notes`, `Production hardening`, `register_browser_landing`, `src/ha_mcp/__main__.py`, `405`).

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)
- [x] `npm run build` from `site/` clean; new advisory + compose-hardening text present in `dist/setup/index.html`.

## Checklist

- [x] I have updated documentation if needed

Refs #1027. The dead-doc problem affects all 18 `clients/*.md` plus the `platforms/`, `connections/`, and `deployment/` collections (per @kingpanther13's analysis); that broader cleanup is being tracked separately and is out of scope here.
