### PR TITLE
fix(ci): unbreak hotfix-release semantic-release run

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -28,13 +28,21 @@ jobs:
       issues: write
 
     steps:
-    - name: Checkout hotfix branch commit
+    - name: Checkout merged hotfix on master
       uses: actions/checkout@v6
       with:
-        # Checkout the original hotfix commit, not the merge commit
-        ref: ${{ github.event.pull_request.head.sha }}
+        # Check out the merge commit so the workspace matches master's history;
+        # then attach to a local master branch below. python-semantic-release
+        # matches the active branch against [tool.semantic_release].branch
+        # in pyproject.toml — a detached HEAD checkout (e.g., of head.sha)
+        # fails silently with "Detached HEAD state cannot match any release
+        # groups; no release will be made", which is what broke PR #1090.
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Attach to master branch locally
+      run: git checkout -B master HEAD
 
     - name: Validate hotfix is based on stable
       run: |


### PR DESCRIPTION
## What does this PR do?

Fixes the `hotfix-release.yml` workflow that silently no-ops on every hotfix
merge. Discovered when PR #1090 was merged: stable was never advanced past
v7.4.0 and v7.4.1 was never built.

**Root cause:** The Checkout step used `ref: github.event.pull_request.head.sha`,
which puts git in detached HEAD state. python-semantic-release v10.5.3 then
exits with:

```
Detached HEAD state cannot match any release groups; no release will be made
```

…because it can't match the active branch against `pyproject.toml`'s
`[tool.semantic_release].branch = "master"` config. The release silently
no-ops, no tag is cut, and the downstream `build-and-release` /
`build-addon` / `update-addon-config` jobs are all skipped (their
`needs.semantic-release.outputs.released == 'true'` gate is never true).

**Latent second bug:** the PR head SHA isn't on master's history, so the
later `git push origin HEAD:master` (in the "Copy changelog to addon
directory" step) would have been non-fast-forward and rejected even if
semantic-release had worked.

**Fix:** Use `github.event.pull_request.merge_commit_sha` (the merge result
that's actually on master) and attach a local `master` branch at it. The
validation step still passes (`stable` is still an ancestor of HEAD), and
the downstream push fast-forwards as intended.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed

## Note on recovery

This PR alone won't release `v7.4.1` — the workflow that runs on its merge
will be the *current* (broken) version. To actually cut `v7.4.1` for the
fix in #1090, the `stable` tag and the addon would need to be advanced
manually (or the next biweekly stable picks up everything).

## Addendum: v7.4.1 release lineage

For anyone tracing the v7.4.1 release history, the full set of related PRs is:

- **#1090** — the actual hotfix (`fix(addon)`: propagate `BUILD_VERSION`).
  This is what `v7.4.1` is tagged at (commit `f4bf177b`).
- **#1091** — *this* PR (`fix(ci)`: unbreak `hotfix-release.yml`).
  Merged AFTER `v7.4.1` was tagged, so it is **NOT** in the `v7.4.1` release
  even though the CHANGELOG entry currently lists it. The fix only takes
  effect for hotfixes merged from this point forward.
- **#1093** — `chore(addon): publish hotfix version 7.4.1`. Bumps
  `homeassistant-addon/config.yaml` and syncs CHANGELOG so HA users see the
  new addon version in the UI. (Also not in the `v7.4.1` tag.)

The CHANGELOG.md entry for `v7.4.1` and the GitHub release notes both
attribute #1091 to `v7.4.1`; the attribution is incorrect (it was a
manual-recovery oversight) but kept as-is rather than rewritten.
