### PR TITLE
chore(addon): publish hotfix version 7.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 <!-- version list -->
 
 
+## v7.4.1 (2026-05-02)
+
+### Fixed
+
+- **addon**: Propagate `BUILD_VERSION` to runtime so the production add-on
+  reports the correct version in startup logs instead of the stale value
+  from `pyproject.toml` at build time
+  ([#1090](https://github.com/homeassistant-ai/ha-mcp/pull/1090)).
+- **ci**: Unbreak `hotfix-release.yml` semantic-release run; the previous
+  detached-HEAD checkout silently no-op'd every hotfix merge
+  ([#1091](https://github.com/homeassistant-ai/ha-mcp/pull/1091)).
+
+
 ## v7.4.0 (2026-04-29)
 
 ### Added

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -3,6 +3,19 @@
 <!-- version list -->
 
 
+## v7.4.1 (2026-05-02)
+
+### Fixed
+
+- **addon**: Propagate `BUILD_VERSION` to runtime so the production add-on
+  reports the correct version in startup logs instead of the stale value
+  from `pyproject.toml` at build time
+  ([#1090](https://github.com/homeassistant-ai/ha-mcp/pull/1090)).
+- **ci**: Unbreak `hotfix-release.yml` semantic-release run; the previous
+  detached-HEAD checkout silently no-op'd every hotfix merge
+  ([#1091](https://github.com/homeassistant-ai/ha-mcp/pull/1091)).
+
+
 ## v7.4.0 (2026-04-29)
 
 ### Added

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Home Assistant MCP Server"
 description: "AI assistant integration for Home Assistant via Model Context Protocol (MCP)"
-version: "7.4.0"
+version: "7.4.1"
 slug: "ha_mcp"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 arch:


### PR DESCRIPTION
## What does this PR do?

Manual recovery commit for the v7.4.1 hotfix release.

`hotfix-release.yml` silently no-op'd on the merge of #1090 due to a detached-HEAD bug
(fixed in #1091, but the fix only takes effect on future hotfix merges). The
v7.4.1 git tag has already been created at `f4bf177b` (the merge commit of #1090),
the `stable` tag has been moved to `v7.4.1`, and the production addon Docker
images for `7.4.1` have been built and pushed via a manual `addon-publish.yml`
workflow_dispatch.

This PR provides the changelog and config bumps that `_update-addon-config.yml`
would normally have committed automatically:
- `homeassistant-addon/config.yaml`: `7.4.0` → `7.4.1`
- `CHANGELOG.md`: add v7.4.1 entry
- `homeassistant-addon/CHANGELOG.md`: synced from root

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed