### PR TITLE
fix(site): resolve client order collisions, anchor OpenCode shape

### DIFF
--- a/site/src/content/clients/antigravity.md
+++ b/site/src/content/clients/antigravity.md
@@ -6,7 +6,7 @@ transports: ['stdio']
 configFormat: json
 configLocation: mcp_config.json (in Antigravity UI)
 accuracy: 3
-order: 15
+order: 19
 ---
 
 ## Configuration

--- a/site/src/content/clients/chatgpt.md
+++ b/site/src/content/clients/chatgpt.md
@@ -5,7 +5,7 @@ logo: /logos/openai.svg
 transports: ['sse', 'streamable-http']
 configFormat: ui
 accuracy: 4
-order: 7
+order: 9
 beta: true
 ---
 

--- a/site/src/content/clients/claude-ai.md
+++ b/site/src/content/clients/claude-ai.md
@@ -5,7 +5,7 @@ logo: /logos/claude.svg
 transports: ['sse', 'streamable-http']
 configFormat: ui
 accuracy: 4
-order: 8
+order: 10
 httpNote: Requires HTTPS - Remote deployment required
 ---
 

--- a/site/src/content/clients/cline.md
+++ b/site/src/content/clients/cline.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'streamable-http']
 configFormat: json
 configLocation: VS Code Settings → Cline → MCP Servers
 accuracy: 4
-order: 6
+order: 7
 ---
 
 ## Configuration

--- a/site/src/content/clients/codex.md
+++ b/site/src/content/clients/codex.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'streamable-http']
 configFormat: cli
 configLocation: ~/.codex/config.toml
 accuracy: 4
-order: 13
+order: 16
 ---
 
 ## Configuration

--- a/site/src/content/clients/continue.md
+++ b/site/src/content/clients/continue.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'sse', 'streamable-http']
 configFormat: yaml
 configLocation: .continue/mcpServers/
 accuracy: 4
-order: 11
+order: 14
 ---
 
 ## Configuration

--- a/site/src/content/clients/copilot-cli.md
+++ b/site/src/content/clients/copilot-cli.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'sse', 'streamable-http']
 configFormat: ui
 configLocation: ~/.copilot/mcp-config.json
 accuracy: 5
-order: 6
+order: 8
 ---
 
 ## Configuration

--- a/site/src/content/clients/gemini-cli.md
+++ b/site/src/content/clients/gemini-cli.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'sse', 'streamable-http']
 configFormat: cli
 configLocation: ~/.gemini/settings.json
 accuracy: 4
-order: 8
+order: 11
 ---
 
 ## Configuration

--- a/site/src/content/clients/jetbrains.md
+++ b/site/src/content/clients/jetbrains.md
@@ -6,7 +6,7 @@ transports: ['stdio']
 configFormat: json
 configLocation: Settings → Tools → AI Assistant → MCP Servers
 accuracy: 4
-order: 9
+order: 12
 httpNote: stdio only - use mcp-remote for HTTP servers
 ---
 

--- a/site/src/content/clients/open-webui.md
+++ b/site/src/content/clients/open-webui.md
@@ -5,7 +5,7 @@ logo: /logos/open-webui.svg
 transports: ['streamable-http']
 configFormat: ui
 accuracy: 4
-order: 14
+order: 17
 httpNote: Requires Streamable HTTP - local or remote server
 ---
 

--- a/site/src/content/clients/opencode.md
+++ b/site/src/content/clients/opencode.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'streamable-http']
 configFormat: json
 configLocation: ~/.config/opencode/opencode.json (global) or opencode.json (project)
 accuracy: 5
-order: 14
+order: 18
 ---
 
 ## Configuration
@@ -22,6 +22,11 @@ OpenCode supports MCP servers through the `mcp` key in its JSON (or JSONC) confi
 OpenCode merges configs from all locations (project overrides global). See [config precedence](https://opencode.ai/docs/config/#precedence-order).
 
 ### stdio Configuration (Local)
+
+<!-- The uvx-stdio shape below (type, command, enabled, environment) is mirrored in: -->
+<!--   - site/src/pages/setup.astro (wizard `isOpenCode` branch) -->
+<!--   - site/src/data/clients.ts (legacy mirror entry) -->
+<!-- Keep all three aligned when editing. -->
 
 ```json
 {

--- a/site/src/content/clients/raycast.md
+++ b/site/src/content/clients/raycast.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'sse', 'streamable-http']
 configFormat: json
 configLocation: Manage MCP Servers → Show Config File in Finder
 accuracy: 4
-order: 12
+order: 15
 httpNote: HTTP transport is experimental (requires v1.100.0+)
 ---
 

--- a/site/src/content/clients/windsurf.md
+++ b/site/src/content/clients/windsurf.md
@@ -6,7 +6,7 @@ transports: ['stdio', 'sse', 'streamable-http']
 configFormat: json
 configLocation: ~/.codeium/windsurf/mcp_config.json
 accuracy: 4
-order: 5
+order: 6
 ---
 
 ## Configuration

--- a/site/src/content/clients/zed.md
+++ b/site/src/content/clients/zed.md
@@ -6,7 +6,7 @@ transports: ['stdio']
 configFormat: json
 configLocation: ~/.config/zed/settings.json
 accuracy: 4
-order: 10
+order: 13
 httpNote: stdio only - limited HTTP support
 ---
 

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -394,6 +394,8 @@ HOMEASSISTANT_TOKEN = "your_long_lived_token"`,
     configFormat: 'json',
     configLocation: '~/.config/opencode/opencode.json (global) or opencode.json (project)',
     description: 'AI coding agent by Anomaly with native MCP support over stdio and streamable HTTP.',
+    // uvx-stdio shape (type, command, enabled, environment) is mirrored in
+    // site/src/content/clients/opencode.md and site/src/pages/setup.astro — keep all three aligned.
     config: `{
   "$schema": "https://opencode.ai/config.json",
   "mcp": {

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1289,6 +1289,10 @@ cloudflared tunnel run ha-mcp</code></pre>
           }, null, 2);
         } else if (isOpenCode) {
           // OpenCode-specific stdio shape: type:"local", single command array, "environment" not "env"
+          // The uvx-stdio shape (type, command, enabled, environment) is mirrored in
+          // site/src/content/clients/opencode.md and site/src/data/clients.ts — keep all three aligned.
+          // The Docker branch below intentionally omits the top-level `environment` key (env vars are
+          // inlined as `-e KEY=VAL` in the command array), so the asymmetry is deliberate.
           const opencodeStdio = isDocker
             ? {
                 type: "local",


### PR DESCRIPTION
## What does this PR do?

Implements both follow-up cleanups from the PR #1080 review (`https://github.com/homeassistant-ai/ha-mcp/pull/1080#pullrequestreview-4213401158`).

**1. Client display-order collisions (`site/src/content/clients/*.md`).** Four pairs shared the same `order:` value, so display order fell back to alphabetical tiebreak. Renumbered to a lossless 1–19 sequence so every client has a unique, explicit value. The new sequence preserves today's display order 1:1 — alphabetical tiebreak is codified as the canonical ordering. Concrete delta on the four pairs:

| Client | Old | New |
|---|---|---|
| `windsurf.md` | 5 | 6 |
| `cline.md` | 6 | 7 |
| `copilot-cli.md` | 6 | 8 |
| `claude-ai.md` | 8 | 10 |
| `gemini-cli.md` | 8 | 11 |
| `open-webui.md` | 14 | 17 |
| `opencode.md` | 14 | 18 |

(Plus mechanical bumps to subsequent files to absorb the shifts: `chatgpt 7→9`, `jetbrains 9→12`, `zed 10→13`, `continue 11→14`, `raycast 12→15`, `codex 13→16`, `antigravity 15→19`.)

**2. OpenCode `uvx-stdio` shape — cross-reference anchors.** The shape lives in three places that already agree (`type, command, enabled, environment`); per the review this was flagged as a tracking item, not a fix. Added pointer comments at all three sites so a future contributor who edits one place sees the other two:

- `site/src/content/clients/opencode.md` — HTML comment above the JSON example
- `site/src/pages/setup.astro` — extended the existing inline comment in the `isOpenCode` branch (also documents the deliberate Docker-branch asymmetry: env vars inlined as `-e KEY=VAL` in the command array, top-level `environment` omitted)
- `site/src/data/clients.ts` — comment above the legacy mirror entry's `config` template string

The third review point (`accuracy` field not consumed in `setup.astro`) is intentionally not addressed — the reviewer scoped it explicitly to `setup.astro` and characterised it as a content-collection display value, which matches reality (the field is required by the Zod schema in `site/src/content.config.ts`).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

The three checkboxes above are not applicable to this PR — the change is site-content frontmatter and three pointer comments. No Python tool code is touched, so `pytest`/`ruff` are irrelevant; required E2E and Docker checks will run on the PR regardless.

Site-specific verification performed locally:
- `npm run build` → clean, 7 pages built (frontmatter schema accepts the renumbered `order:` values)
- Manual reasoning on display order: alphabetical-tiebreak resolution preserves the existing wizard ordering 1:1, so this is a behaviour-neutral codification
- Cross-reference comments are HTML/JS comments only — zero runtime or rendered output impact

## Checklist
- [x] I have updated documentation if needed

Closes #1092