### PR TITLE
feat: per-top-level-key config_hash for ha_manage_energy_prefs (#1049)

### DIFF
--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -47,8 +47,14 @@ logger = logging.getLogger(__name__)
 
 
 # Top-level keys in the energy prefs payload. Each is an independent
-# full-replace slot in ``energy/save_prefs``.
-_PREFS_TOP_LEVEL_KEYS = (
+# full-replace slot in ``energy/save_prefs``. ``_PrefsKey`` is the
+# corresponding ``Literal`` alias so MCP-wire callers (Pydantic-validated)
+# get typo-rejection at the boundary; runtime guards in `_set_prefs` cover
+# the unit-test path that bypasses Pydantic.
+_PrefsKey = Literal[
+    "energy_sources", "device_consumption", "device_consumption_water"
+]
+_PREFS_TOP_LEVEL_KEYS: tuple[_PrefsKey, ...] = (
     "energy_sources",
     "device_consumption",
     "device_consumption_water",
@@ -73,7 +79,7 @@ def _default_prefs() -> dict[str, Any]:
     }
 
 
-def _compute_per_key_hashes(prefs: dict[str, Any]) -> dict[str, str]:
+def _compute_per_key_hashes(prefs: dict[str, Any]) -> dict[_PrefsKey, str]:
     """Per-top-level-key hashes for partial-update optimistic locking.
 
     Each top-level key is wrapped in its own single-key dict before hashing,
@@ -259,25 +265,15 @@ class EnergyTools:
             ),
         ] = None,
         config_hash: Annotated[
-            str | dict[str, str] | None,
+            str | dict[_PrefsKey, str] | None,
             Field(
                 description=(
-                    "Hash returned by the previous mode='get' call. REQUIRED "
-                    "for mode='set' unless dry_run=True. Rejected if the "
-                    "server-side config has changed since that read — re-read "
-                    "and retry. Two forms accepted: pass the full-blob "
-                    "config_hash (str) to lock against the entire prefs object, "
-                    "or pass the config_hash_per_key dict from a mode='get' "
-                    "response (dict[str, str], keyed by 'energy_sources' / "
-                    "'device_consumption' / 'device_consumption_water') to "
-                    "lock only the top-level keys you are submitting in "
-                    "'config'. The per-key form is fail-closed: every "
-                    "top-level key submitted in 'config' must have a matching "
-                    "entry in the dict, and vice versa. Unknown keys (outside "
-                    "the canonical top-level set) are silently dropped on "
-                    "both sides, mirroring the existing local-shape-check "
-                    "behaviour. Ignored by convenience modes (they read "
-                    "fresh internally)."
+                    "Hash from a previous mode='get' call. REQUIRED for "
+                    "mode='set' unless dry_run=True. Two forms: str (full-"
+                    "blob lock) or dict (per-key lock, taken from the "
+                    "config_hash_per_key field of mode='get'). See the tool "
+                    "docstring for fail-closed semantics. Ignored by "
+                    "convenience modes."
                 ),
                 default=None,
             ),
@@ -403,15 +399,22 @@ class EnergyTools:
           requires a fresh ``config_hash`` for optimistic locking; convenience
           modes hide this entirely.
         - ``config_hash`` accepts both a single ``str`` (full-blob lock) and
-          a ``dict[str, str]`` keyed by top-level keys (per-key lock, taken
-          from the ``config_hash_per_key`` field of the mode='get' response).
-          The per-key form lets an agent submit only the top-level key it
-          wants to change — set-equality between ``config`` keys and dict
-          keys is enforced, so a per-key submission still fully replaces
-          that key's value as the save endpoint requires. Mismatch on any
-          locked key returns ``RESOURCE_LOCKED`` with the offending keys
-          in the response's top-level ``mismatched_keys`` (context fields
-          are flattened to the response root by ``create_error_response``).
+          a ``dict[_PrefsKey, str]`` keyed by top-level keys (per-key lock,
+          taken from the ``config_hash_per_key`` field of the mode='get'
+          response). The per-key form lets an agent submit only the top-
+          level key it wants to change — set-equality between ``config``
+          keys and dict keys is enforced, and any key outside the canonical
+          set (typo, etc.) on either side is rejected with
+          ``VALIDATION_FAILED`` rather than silently dropped (so an empty
+          submission cannot succeed as a no-op). A per-key submission
+          still fully replaces that key's value as the save endpoint
+          requires. Mismatch on any locked key returns ``RESOURCE_LOCKED``
+          with the offending keys in the response's top-level
+          ``mismatched_keys`` (``create_error_response`` flattens the
+          ``context`` dict onto the response root).
+        - ``dry_run=True`` skips the hash check entirely for both forms;
+          the per-key form is therefore silently accepted on dry runs even
+          if its keys would mismatch the current state.
         - A local shape check runs before every write; malformed payloads
           are rejected with a ``shape_errors`` list.
         - After a successful write, the tool calls ``energy/validate`` and
@@ -635,13 +638,12 @@ class EnergyTools:
 
         ``config_hash`` accepts two forms. A ``str`` locks against the
         full prefs blob (the original optimistic-locking contract). A
-        ``dict[str, str]`` keyed by top-level keys locks each submitted
-        key individually — set-equality is enforced between the
-        ``config``-present top-level keys and the dict's top-level keys
-        (unknown keys silently dropped on both sides). Per-key mismatch
-        surfaces every offending key in the response's top-level
-        ``mismatched_keys`` (``create_error_response`` flattens the
-        ``context`` dict onto the response root).
+        ``dict[_PrefsKey, str]`` keyed by top-level keys locks each
+        submitted key individually — set-equality between ``config`` and
+        dict keys is enforced, and unknown keys on either side are
+        rejected (``VALIDATION_FAILED``) so an empty submission cannot
+        coincide as a no-op success. See the tool docstring for the full
+        agent-facing contract.
 
         ``current_prefs`` is an optional caller-supplied snapshot. When
         provided, the internal re-read is skipped — the convenience-mode
@@ -699,16 +701,49 @@ class EnergyTools:
 
             if isinstance(config_hash, dict):
                 # Per-key form: validate (and hence allow saving) only the
-                # top-level keys whose hashes were supplied. Set-equality is
-                # fail-closed; unknown keys (outside the canonical top-level
-                # set) are silently dropped on both sides — mirrors the
-                # permissive-drop semantics of _shape_check / the save loop.
-                submitted_keys = {
-                    k for k in config if k in _PREFS_TOP_LEVEL_KEYS
-                }
-                hashed_keys = {
-                    k for k in config_hash if k in _PREFS_TOP_LEVEL_KEYS
-                }
+                # top-level keys whose hashes were supplied. Fail-closed on
+                # unknown keys (no silent-drop) so a typo in both 'config'
+                # and 'config_hash' cannot coincide as an empty no-op
+                # success at the save endpoint.
+                _valid = set(_PREFS_TOP_LEVEL_KEYS)
+                invalid_config_keys = sorted(set(config) - _valid)
+                invalid_hash_keys = sorted(set(config_hash) - _valid)
+                if invalid_config_keys or invalid_hash_keys:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_FAILED,
+                            "Unknown top-level key(s) in 'config' or "
+                            "'config_hash' (per-key form)",
+                            context={
+                                "mode": "set",
+                                "invalid_config_keys": invalid_config_keys,
+                                "invalid_hash_keys": invalid_hash_keys,
+                                "valid_keys": list(_PREFS_TOP_LEVEL_KEYS),
+                            },
+                            suggestions=[
+                                "Use only 'energy_sources', "
+                                "'device_consumption', or "
+                                "'device_consumption_water'",
+                            ],
+                        )
+                    )
+
+                submitted_keys = set(config)
+                hashed_keys = set(config_hash)
+                if not submitted_keys:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_FAILED,
+                            "'config' must include at least one top-level "
+                            "key when using per-key config_hash",
+                            context={"mode": "set"},
+                            suggestions=[
+                                "Include the top-level key(s) you want to "
+                                "save in 'config' alongside their per-key "
+                                "hashes in 'config_hash'",
+                            ],
+                        )
+                    )
                 if submitted_keys != hashed_keys:
                     raise_tool_error(
                         create_error_response(

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -28,7 +28,7 @@ get uniform behavior on fresh and configured instances alike.
 import json
 import logging
 from collections.abc import Callable
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -626,7 +626,7 @@ class EnergyTools:
     async def _set_prefs(
         self,
         config: dict[str, Any],
-        config_hash: str | dict[str, str],
+        config_hash: str | dict[_PrefsKey, str],
         *,
         current_prefs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -770,10 +770,15 @@ class EnergyTools:
                         )
                     )
 
+                # ``submitted_keys`` was validated against
+                # ``_PREFS_TOP_LEVEL_KEYS`` above, so each ``key`` is in
+                # fact a ``_PrefsKey``. Mypy can't narrow ``str`` from
+                # ``sorted(set[str])`` automatically, hence the explicit
+                # ``cast`` at the dict subscript.
                 mismatched_keys = [
                     key
                     for key in sorted(submitted_keys)
-                    if config_hash[key]
+                    if config_hash[cast(_PrefsKey, key)]
                     != compute_config_hash({key: current_prefs.get(key, [])})
                 ]
                 if mismatched_keys:

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -410,7 +410,8 @@ class EnergyTools:
           keys is enforced, so a per-key submission still fully replaces
           that key's value as the save endpoint requires. Mismatch on any
           locked key returns ``RESOURCE_LOCKED`` with the offending keys
-          in ``context.mismatched_keys``.
+          in the response's top-level ``mismatched_keys`` (context fields
+          are flattened to the response root by ``create_error_response``).
         - A local shape check runs before every write; malformed payloads
           are rejected with a ``shape_errors`` list.
         - After a successful write, the tool calls ``energy/validate`` and
@@ -638,7 +639,9 @@ class EnergyTools:
         key individually — set-equality is enforced between the
         ``config``-present top-level keys and the dict's top-level keys
         (unknown keys silently dropped on both sides). Per-key mismatch
-        surfaces every offending key in ``context.mismatched_keys``.
+        surfaces every offending key in the response's top-level
+        ``mismatched_keys`` (``create_error_response`` flattens the
+        ``context`` dict onto the response root).
 
         ``current_prefs`` is an optional caller-supplied snapshot. When
         provided, the internal re-read is skipped — the convenience-mode

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -73,6 +73,22 @@ def _default_prefs() -> dict[str, Any]:
     }
 
 
+def _compute_per_key_hashes(prefs: dict[str, Any]) -> dict[str, str]:
+    """Per-top-level-key hashes for partial-update optimistic locking.
+
+    Each top-level key is wrapped in its own single-key dict before hashing,
+    so the per-key hash captures both the key name and its value — an agent
+    cannot accidentally use, say, an ``energy_sources`` hash to authorise a
+    ``device_consumption`` write. ``prefs.get(key, [])`` mirrors the
+    "missing top-level key = empty list" semantics codified by
+    ``_default_prefs``.
+    """
+    return {
+        key: compute_config_hash({key: prefs.get(key, [])})
+        for key in _PREFS_TOP_LEVEL_KEYS
+    }
+
+
 def _is_no_prefs_error(error_msg: str) -> bool:
     """True if an error string from send_websocket_message indicates
     ``ERR_NOT_FOUND "No prefs"`` from HA Core's energy/get_prefs handler.
@@ -243,14 +259,25 @@ class EnergyTools:
             ),
         ] = None,
         config_hash: Annotated[
-            str | None,
+            str | dict[str, str] | None,
             Field(
                 description=(
                     "Hash returned by the previous mode='get' call. REQUIRED "
                     "for mode='set' unless dry_run=True. Rejected if the "
                     "server-side config has changed since that read — re-read "
-                    "and retry. Ignored by convenience modes (they read fresh "
-                    "internally)."
+                    "and retry. Two forms accepted: pass the full-blob "
+                    "config_hash (str) to lock against the entire prefs object, "
+                    "or pass the config_hash_per_key dict from a mode='get' "
+                    "response (dict[str, str], keyed by 'energy_sources' / "
+                    "'device_consumption' / 'device_consumption_water') to "
+                    "lock only the top-level keys you are submitting in "
+                    "'config'. The per-key form is fail-closed: every "
+                    "top-level key submitted in 'config' must have a matching "
+                    "entry in the dict, and vice versa. Unknown keys (outside "
+                    "the canonical top-level set) are silently dropped on "
+                    "both sides, mirroring the existing local-shape-check "
+                    "behaviour. Ignored by convenience modes (they read "
+                    "fresh internally)."
                 ),
                 default=None,
             ),
@@ -375,6 +402,15 @@ class EnergyTools:
           the user had configured — silently, with no error. mode='set'
           requires a fresh ``config_hash`` for optimistic locking; convenience
           modes hide this entirely.
+        - ``config_hash`` accepts both a single ``str`` (full-blob lock) and
+          a ``dict[str, str]`` keyed by top-level keys (per-key lock, taken
+          from the ``config_hash_per_key`` field of the mode='get' response).
+          The per-key form lets an agent submit only the top-level key it
+          wants to change — set-equality between ``config`` keys and dict
+          keys is enforced, so a per-key submission still fully replaces
+          that key's value as the save endpoint requires. Mismatch on any
+          locked key returns ``RESOURCE_LOCKED`` with the offending keys
+          in ``context.mismatched_keys``.
         - A local shape check runs before every write; malformed payloads
           are rejected with a ``shape_errors`` list.
         - After a successful write, the tool calls ``energy/validate`` and
@@ -481,6 +517,7 @@ class EnergyTools:
                         "mode": "get",
                         "config": prefs,
                         "config_hash": compute_config_hash(prefs),
+                        "config_hash_per_key": _compute_per_key_hashes(prefs),
                         "note": (
                             "Energy Dashboard has never been configured on "
                             "this instance; returning empty default."
@@ -500,6 +537,7 @@ class EnergyTools:
                 "mode": "get",
                 "config": prefs,
                 "config_hash": compute_config_hash(prefs),
+                "config_hash_per_key": _compute_per_key_hashes(prefs),
             }
 
         except ToolError:
@@ -584,7 +622,7 @@ class EnergyTools:
     async def _set_prefs(
         self,
         config: dict[str, Any],
-        config_hash: str,
+        config_hash: str | dict[str, str],
         *,
         current_prefs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -594,12 +632,20 @@ class EnergyTools:
         errors are reported in the response as a non-fatal warning; the
         save already succeeded.
 
+        ``config_hash`` accepts two forms. A ``str`` locks against the
+        full prefs blob (the original optimistic-locking contract). A
+        ``dict[str, str]`` keyed by top-level keys locks each submitted
+        key individually — set-equality is enforced between the
+        ``config``-present top-level keys and the dict's top-level keys
+        (unknown keys silently dropped on both sides). Per-key mismatch
+        surfaces every offending key in ``context.mismatched_keys``.
+
         ``current_prefs`` is an optional caller-supplied snapshot. When
         provided, the internal re-read is skipped — the convenience-mode
         path uses this to avoid a second ``energy/get_prefs`` round trip
         per attempt (the snapshot was already fetched by ``_mutate_atomic``).
-        The hash check still runs against the provided snapshot as a
-        defensive guard.
+        Convenience modes always pass a ``str`` hash; the dict form is
+        only reachable via direct mode='set' callers.
         """
         try:
             # 1. Shape check (fast local, fail closed)
@@ -648,21 +694,83 @@ class EnergyTools:
                         # unreachable; appeases type checkers
                         current_prefs = {}
 
-            current_hash = compute_config_hash(current_prefs)
-
-            if current_hash != config_hash:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.RESOURCE_LOCKED,
-                        "Energy prefs modified since last read (conflict)",
-                        context={"mode": "set"},
-                        suggestions=[
-                            "Call ha_manage_energy_prefs(mode='get') again",
-                            "Re-apply your changes to the fresh config",
-                            "Pass the new config_hash back in",
-                        ],
+            if isinstance(config_hash, dict):
+                # Per-key form: validate (and hence allow saving) only the
+                # top-level keys whose hashes were supplied. Set-equality is
+                # fail-closed; unknown keys (outside the canonical top-level
+                # set) are silently dropped on both sides — mirrors the
+                # permissive-drop semantics of _shape_check / the save loop.
+                submitted_keys = {
+                    k for k in config if k in _PREFS_TOP_LEVEL_KEYS
+                }
+                hashed_keys = {
+                    k for k in config_hash if k in _PREFS_TOP_LEVEL_KEYS
+                }
+                if submitted_keys != hashed_keys:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_FAILED,
+                            "Per-key config_hash keys must match the "
+                            "top-level keys submitted in 'config'",
+                            context={
+                                "mode": "set",
+                                "submitted_keys": sorted(submitted_keys),
+                                "hashed_keys": sorted(hashed_keys),
+                                "missing_in_hash": sorted(
+                                    submitted_keys - hashed_keys
+                                ),
+                                "extra_in_hash": sorted(
+                                    hashed_keys - submitted_keys
+                                ),
+                            },
+                            suggestions=[
+                                "Pass exactly one config_hash_per_key entry "
+                                "per top-level key in 'config'",
+                                "Use the str form of config_hash to lock "
+                                "the full prefs blob instead",
+                            ],
+                        )
                     )
-                )
+
+                mismatched_keys = [
+                    key
+                    for key in sorted(submitted_keys)
+                    if config_hash[key]
+                    != compute_config_hash({key: current_prefs.get(key, [])})
+                ]
+                if mismatched_keys:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.RESOURCE_LOCKED,
+                            "Energy prefs modified since last read on "
+                            f"top-level key(s): {', '.join(mismatched_keys)}"
+                            " (conflict)",
+                            context={
+                                "mode": "set",
+                                "mismatched_keys": mismatched_keys,
+                            },
+                            suggestions=[
+                                "Call ha_manage_energy_prefs(mode='get') again",
+                                "Re-apply your changes to the fresh config",
+                                "Pass the new config_hash_per_key back in",
+                            ],
+                        )
+                    )
+            else:
+                current_hash = compute_config_hash(current_prefs)
+                if current_hash != config_hash:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.RESOURCE_LOCKED,
+                            "Energy prefs modified since last read (conflict)",
+                            context={"mode": "set"},
+                            suggestions=[
+                                "Call ha_manage_energy_prefs(mode='get') again",
+                                "Re-apply your changes to the fresh config",
+                                "Pass the new config_hash back in",
+                            ],
+                        )
+                    )
 
             # 3. Save
             save_payload: dict[str, Any] = {"type": "energy/save_prefs"}
@@ -723,6 +831,7 @@ class EnergyTools:
                 "success": True,
                 "mode": "set",
                 "config_hash": new_hash,
+                "config_hash_per_key": _compute_per_key_hashes(new_prefs),
                 "message": "Energy prefs updated.",
             }
             if post_save_errors:

--- a/tests/src/e2e/tools/test_tools_energy.py
+++ b/tests/src/e2e/tools/test_tools_energy.py
@@ -313,3 +313,75 @@ async def test_energy_add_source_non_grid_roundtrip(mcp_client, source_type):
         ), f"Added {source_type} source should appear; got sources={sources}"
     finally:
         await _cleanup_test_source(mcp_client, stat)
+
+
+@pytest.mark.asyncio
+async def test_energy_prefs_per_key_config_hash_roundtrip(mcp_client):
+    """Issue #1049: ``mode='get'`` exposes ``config_hash_per_key``, and
+    ``mode='set'`` accepts a per-top-level-key dict-form ``config_hash``
+    over the wire (Pydantic union in the tool schema). One round-trip
+    proves the new shape transports cleanly.
+
+    Mutates only ``device_consumption``; cleans up afterwards by
+    restoring the original list under a fresh per-key hash.
+    """
+    initial = await mcp_client.call_tool("ha_manage_energy_prefs", {"mode": "get"})
+    assert_mcp_success(initial)
+    initial_data = initial.data
+    assert "config_hash_per_key" in initial_data, (
+        "mode='get' must surface config_hash_per_key alongside config_hash"
+    )
+    per_key = initial_data["config_hash_per_key"]
+    for key in ("energy_sources", "device_consumption", "device_consumption_water"):
+        assert key in per_key, f"per-key hash for '{key}' missing"
+        assert isinstance(per_key[key], str) and len(per_key[key]) == 16
+
+    original_dc = list(initial_data["config"]["device_consumption"])
+    test_stat = "sensor.e2e_per_key_hash_test"
+    new_dc = original_dc + [{"stat_consumption": test_stat}]
+
+    try:
+        write = await mcp_client.call_tool(
+            "ha_manage_energy_prefs",
+            {
+                "mode": "set",
+                "config": {"device_consumption": new_dc},
+                "config_hash": {
+                    "device_consumption": per_key["device_consumption"],
+                },
+            },
+        )
+        assert_mcp_success(write)
+        assert "config_hash_per_key" in write.data, (
+            "set response must surface fresh config_hash_per_key for "
+            "chained writes without an intermediate get"
+        )
+
+        verify = await mcp_client.call_tool(
+            "ha_manage_energy_prefs", {"mode": "get"}
+        )
+        assert_mcp_success(verify)
+        verify_dc = verify.data["config"]["device_consumption"]
+        assert any(
+            d.get("stat_consumption") == test_stat for d in verify_dc
+        ), f"Per-key set must persist; got device_consumption={verify_dc}"
+    finally:
+        # Restore original device_consumption under a fresh per-key hash.
+        cleanup_initial = await mcp_client.call_tool(
+            "ha_manage_energy_prefs", {"mode": "get"}
+        )
+        if cleanup_initial.data.get("success"):
+            cleanup_per_key = cleanup_initial.data.get("config_hash_per_key", {})
+            if "device_consumption" in cleanup_per_key:
+                await mcp_client.call_tool(
+                    "ha_manage_energy_prefs",
+                    {
+                        "mode": "set",
+                        "config": {"device_consumption": original_dc},
+                        "config_hash": {
+                            "device_consumption": cleanup_per_key[
+                                "device_consumption"
+                            ],
+                        },
+                    },
+                )

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -12,7 +12,9 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_energy import (
+    _PREFS_TOP_LEVEL_KEYS,
     EnergyTools,
+    _compute_per_key_hashes,
     _flatten_validation_errors,
     _shape_check,
 )
@@ -201,6 +203,46 @@ class TestGetPrefs:
         assert result["config_hash"] == compute_config_hash(result["config"])
         assert "note" in result
         assert "never been configured" in result["note"]
+
+    async def test_response_includes_per_key_hashes(self, tools):
+        """Per-key hashes for partial-update optimistic locking. Every
+        canonical top-level key is present (even when its value is the
+        empty list, mirroring _default_prefs)."""
+        prefs = _sample_prefs()
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": prefs,
+        }
+
+        result = await tools.ha_manage_energy_prefs(mode="get")
+
+        assert "config_hash_per_key" in result
+        assert set(result["config_hash_per_key"]) == set(_PREFS_TOP_LEVEL_KEYS)
+        # Each per-key hash is the full-blob hash of {key: prefs[key]} —
+        # this disambiguates {energy_sources: []} from {device_consumption: []}
+        # so an empty-list hash for one key never authorises a write to another.
+        for key in _PREFS_TOP_LEVEL_KEYS:
+            assert result["config_hash_per_key"][key] == compute_config_hash(
+                {key: prefs[key]}
+            )
+
+    async def test_no_prefs_response_includes_per_key_hashes(self, tools):
+        """Even on a fresh-install (No prefs) response, per-key hashes are
+        populated against the empty default — so an agent can immediately
+        chain a per-key set without a second round-trip."""
+        tools._client.send_websocket_message.return_value = {
+            "success": False,
+            "error": "Command failed: No prefs",
+        }
+
+        result = await tools.ha_manage_energy_prefs(mode="get")
+
+        assert "config_hash_per_key" in result
+        assert set(result["config_hash_per_key"]) == set(_PREFS_TOP_LEVEL_KEYS)
+        for key in _PREFS_TOP_LEVEL_KEYS:
+            assert result["config_hash_per_key"][key] == compute_config_hash(
+                {key: []}
+            )
 
 
 # -----------------------------------------------------------------------------
@@ -641,6 +683,233 @@ class TestSetPrefs:
         err = json.loads(str(exc_info.value))
         assert "modified since last read" in json.dumps(err).lower()
         assert tools._client.send_websocket_message.call_count == 1
+
+
+# -----------------------------------------------------------------------------
+# ha_manage_energy_prefs — mode="set" with per-top-level-key config_hash
+# -----------------------------------------------------------------------------
+
+
+class TestSetPrefsPerKeyHash:
+    """Per-key form of ``config_hash`` (issue #1049).
+
+    The dict form locks each submitted top-level key independently, so an
+    agent that only mutates ``device_consumption`` is not rejected when an
+    unrelated key (``energy_sources``) was concurrently changed by another
+    client. Set-equality between submitted ``config`` keys and dict keys
+    is fail-closed; unknown keys (outside the canonical top-level set)
+    are silently dropped on both sides, mirroring existing _shape_check
+    semantics.
+    """
+
+    async def test_happy_path_partial_save_with_per_key_hash(self, tools):
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        # Agent mutates only device_consumption.
+        new_dc = [
+            {"stat_consumption": "sensor.fridge_energy"},
+            {"stat_consumption": "sensor.tv_energy"},
+        ]
+        partial_config = {"device_consumption": new_dc}
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config=partial_config,
+            config_hash={"device_consumption": per_key["device_consumption"]},
+        )
+        assert result["success"] is True
+        assert result["mode"] == "set"
+        # Save payload only carries the submitted top-level key.
+        save_payload = tools._client.send_websocket_message.call_args_list[
+            1
+        ].args[0]
+        assert save_payload["type"] == "energy/save_prefs"
+        assert save_payload["device_consumption"] == new_dc
+        assert "energy_sources" not in save_payload
+        assert "device_consumption_water" not in save_payload
+
+    async def test_per_key_mismatch_lists_offending_keys(self, tools):
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        # Pretend the agent's view of device_consumption is stale; the
+        # other two keys' hashes are still fresh.
+        stale_dc_hash = "deadbeefcafefade"
+        assert stale_dc_hash != per_key["device_consumption"]
+
+        # Submit two keys, only one is stale.
+        config = {
+            "device_consumption": [{"stat_consumption": "sensor.new"}],
+            "energy_sources": current_prefs["energy_sources"],
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config,
+                config_hash={
+                    "device_consumption": stale_dc_hash,
+                    "energy_sources": per_key["energy_sources"],
+                },
+            )
+        err = json.loads(str(exc_info.value))
+        assert "RESOURCE_LOCKED" in json.dumps(err)
+        # Only the stale key surfaces in mismatched_keys.
+        assert err["context"]["mismatched_keys"] == ["device_consumption"]
+        # No save WS call.
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_missing_hash_for_submitted_key_raises_validation(self, tools):
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        # Submit two keys, hash only one — fail closed.
+        config = {
+            "device_consumption": [{"stat_consumption": "sensor.x"}],
+            "energy_sources": current_prefs["energy_sources"],
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config,
+                config_hash={
+                    "device_consumption": per_key["device_consumption"],
+                },
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        assert err["context"]["missing_in_hash"] == ["energy_sources"]
+        assert err["context"]["extra_in_hash"] == []
+        # Hash check is the gate — no save happened.
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_extra_hash_key_not_in_config_raises_validation(self, tools):
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        # Submit only device_consumption but supply hashes for two keys.
+        config = {"device_consumption": [{"stat_consumption": "sensor.x"}]}
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config,
+                config_hash={
+                    "device_consumption": per_key["device_consumption"],
+                    "energy_sources": per_key["energy_sources"],
+                },
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        assert err["context"]["extra_in_hash"] == ["energy_sources"]
+        assert err["context"]["missing_in_hash"] == []
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_unknown_top_level_keys_silently_dropped(self, tools):
+        """Unknown top-level keys (outside the canonical set) on either
+        side are silently dropped before set-equality, matching the
+        permissive-drop semantics of _shape_check and the save loop.
+        """
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        config = {
+            "device_consumption": [{"stat_consumption": "sensor.fridge_energy"}],
+            "garbage_key": "ignored",
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config=config,
+            config_hash={
+                "device_consumption": per_key["device_consumption"],
+                "another_garbage_key": "also_ignored",
+            },
+        )
+        assert result["success"] is True
+        save_payload = tools._client.send_websocket_message.call_args_list[
+            1
+        ].args[0]
+        # Garbage keys never reach the save payload either.
+        assert "garbage_key" not in save_payload
+        assert "another_garbage_key" not in save_payload
+
+    async def test_response_includes_fresh_per_key_hashes_after_write(
+        self, tools
+    ):
+        """After a per-key write, the response carries an updated
+        config_hash_per_key reflecting the new merged state. An agent can
+        chain another per-key write without an intermediate mode='get'.
+        """
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        new_dc = [{"stat_consumption": "sensor.new"}]
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"device_consumption": new_dc},
+            config_hash={"device_consumption": per_key["device_consumption"]},
+        )
+        assert "config_hash_per_key" in result
+        # device_consumption hash reflects the new value; the other two
+        # keys retain their prior hashes (full-replace only on submitted
+        # keys).
+        expected_after = {
+            "energy_sources": current_prefs["energy_sources"],
+            "device_consumption": new_dc,
+            "device_consumption_water": current_prefs[
+                "device_consumption_water"
+            ],
+        }
+        assert result["config_hash_per_key"] == _compute_per_key_hashes(
+            expected_after
+        )
+        # Backward-compat: full-blob config_hash is also still emitted.
+        assert result["config_hash"] == compute_config_hash(expected_after)
+
+    async def test_str_hash_path_unchanged(self, tools):
+        """Backward compatibility: passing a str config_hash exercises the
+        full-blob path exactly as before (unchanged contract).
+        """
+        current_prefs = _sample_prefs()
+        full_hash = compute_config_hash(current_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config=current_prefs,
+            config_hash=full_hash,
+        )
+        assert result["success"] is True
+        assert result["mode"] == "set"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -763,7 +763,7 @@ class TestSetPrefsPerKeyHash:
         err = json.loads(str(exc_info.value))
         assert "RESOURCE_LOCKED" in json.dumps(err)
         # Only the stale key surfaces in mismatched_keys.
-        assert err["context"]["mismatched_keys"] == ["device_consumption"]
+        assert err["mismatched_keys"] == ["device_consumption"]
         # No save WS call.
         assert tools._client.send_websocket_message.call_count == 1
 
@@ -789,8 +789,8 @@ class TestSetPrefsPerKeyHash:
             )
         err = json.loads(str(exc_info.value))
         assert "VALIDATION_FAILED" in json.dumps(err)
-        assert err["context"]["missing_in_hash"] == ["energy_sources"]
-        assert err["context"]["extra_in_hash"] == []
+        assert err["missing_in_hash"] == ["energy_sources"]
+        assert err["extra_in_hash"] == []
         # Hash check is the gate — no save happened.
         assert tools._client.send_websocket_message.call_count == 1
 
@@ -814,8 +814,8 @@ class TestSetPrefsPerKeyHash:
             )
         err = json.loads(str(exc_info.value))
         assert "VALIDATION_FAILED" in json.dumps(err)
-        assert err["context"]["extra_in_hash"] == ["energy_sources"]
-        assert err["context"]["missing_in_hash"] == []
+        assert err["extra_in_hash"] == ["energy_sources"]
+        assert err["missing_in_hash"] == []
         assert tools._client.send_websocket_message.call_count == 1
 
     async def test_unknown_top_level_keys_silently_dropped(self, tools):

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -6,6 +6,7 @@ hermetic while still exercising every branch of the state machine.
 """
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -767,6 +768,41 @@ class TestSetPrefsPerKeyHash:
         # No save WS call.
         assert tools._client.send_websocket_message.call_count == 1
 
+    async def test_per_key_mismatch_lists_all_offending_keys_sorted(self, tools):
+        """Two stale keys must both appear in mismatched_keys, sorted —
+        regression guard against `next(...)` / single-element shortcuts
+        on the comprehension at the dict-branch's mismatch loop.
+        """
+        current_prefs = _sample_prefs()
+        per_key = _compute_per_key_hashes(current_prefs)
+        # Both device_consumption and energy_sources are stale; only
+        # device_consumption_water hash is fresh (and not submitted).
+        config = {
+            "device_consumption": [{"stat_consumption": "sensor.fridge_energy"}],
+            "energy_sources": current_prefs["energy_sources"],
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config,
+                config_hash={
+                    "device_consumption": "stale1deadbeefcafe",
+                    "energy_sources": "stale2deadbeefcafe",
+                },
+            )
+        err = json.loads(str(exc_info.value))
+        assert "RESOURCE_LOCKED" in json.dumps(err)
+        # Both stale keys surface, in lexicographic sorted order.
+        assert err["mismatched_keys"] == [
+            "device_consumption",
+            "energy_sources",
+        ]
+        assert tools._client.send_websocket_message.call_count == 1
+
     async def test_missing_hash_for_submitted_key_raises_validation(self, tools):
         current_prefs = _sample_prefs()
         per_key = _compute_per_key_hashes(current_prefs)
@@ -818,10 +854,11 @@ class TestSetPrefsPerKeyHash:
         assert err["missing_in_hash"] == []
         assert tools._client.send_websocket_message.call_count == 1
 
-    async def test_unknown_top_level_keys_silently_dropped(self, tools):
+    async def test_unknown_top_level_keys_rejected(self, tools):
         """Unknown top-level keys (outside the canonical set) on either
-        side are silently dropped before set-equality, matching the
-        permissive-drop semantics of _shape_check and the save loop.
+        side are rejected with VALIDATION_FAILED. Closes the silent-no-op
+        trap where typo'd keys on both sides would coincide as ∅ == ∅
+        and slip through as a save with an empty payload.
         """
         current_prefs = _sample_prefs()
         per_key = _compute_per_key_hashes(current_prefs)
@@ -831,25 +868,69 @@ class TestSetPrefsPerKeyHash:
         }
         tools._client.send_websocket_message.side_effect = [
             {"success": True, "result": current_prefs},
-            {"success": True, "result": None},
-            {"success": True, "result": _empty_validate_result()},
         ]
 
-        result = await tools.ha_manage_energy_prefs(
-            mode="set",
-            config=config,
-            config_hash={
-                "device_consumption": per_key["device_consumption"],
-                "another_garbage_key": "also_ignored",
-            },
-        )
-        assert result["success"] is True
-        save_payload = tools._client.send_websocket_message.call_args_list[
-            1
-        ].args[0]
-        # Garbage keys never reach the save payload either.
-        assert "garbage_key" not in save_payload
-        assert "another_garbage_key" not in save_payload
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config,
+                config_hash={
+                    "device_consumption": per_key["device_consumption"],
+                    "another_garbage_key": "also_ignored",
+                },
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        assert err["invalid_config_keys"] == ["garbage_key"]
+        assert err["invalid_hash_keys"] == ["another_garbage_key"]
+        # Hash mismatch is the gate — no save WS call.
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_all_typoed_keys_does_not_silently_succeed(self, tools):
+        """Belt-and-braces: even if EVERY submitted key is a typo (so the
+        old silent-drop logic would have left submitted_keys=∅ and
+        coincided with hashed_keys=∅), the unknown-key guard rejects
+        before set-equality runs. No no-op save reaches HA.
+        """
+        current_prefs = _sample_prefs()
+        config_only_typos = {"devic_consumption": [{"stat_consumption": "x"}]}
+        hash_only_typos = {"devic_consumption": "deadbeefcafefade"}
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=config_only_typos,
+                config_hash=hash_only_typos,
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        assert err["invalid_config_keys"] == ["devic_consumption"]
+        assert err["invalid_hash_keys"] == ["devic_consumption"]
+        # No save attempted.
+        assert tools._client.send_websocket_message.call_count == 1
+
+    async def test_empty_config_with_dict_hash_rejected(self, tools):
+        """Empty 'config' under dict-form hash is rejected — even with
+        valid (empty) hashed_keys the agent's intent is unclear, and the
+        save endpoint would no-op silently.
+        """
+        current_prefs = _sample_prefs()
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+        ]
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config={},
+                config_hash={},
+            )
+        err = json.loads(str(exc_info.value))
+        assert "VALIDATION_FAILED" in json.dumps(err)
+        assert "at least one top-level key" in json.dumps(err)
+        assert tools._client.send_websocket_message.call_count == 1
 
     async def test_response_includes_fresh_per_key_hashes_after_write(
         self, tools
@@ -910,6 +991,121 @@ class TestSetPrefsPerKeyHash:
         )
         assert result["success"] is True
         assert result["mode"] == "set"
+
+    async def test_dry_run_with_dict_form_skips_hash_check(self, tools):
+        """``dry_run=True`` short-circuits before the hash branch entirely,
+        so a dict-form ``config_hash`` (even one with stale or invalid
+        entries) is silently accepted on dry runs. Documented in the
+        tool docstring; pinned here so a future refactor cannot quietly
+        start enforcing the dict shape under dry_run.
+        """
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": _empty_validate_result(),
+        }
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config=_sample_prefs(),
+            # All three fields stale — would be RESOURCE_LOCKED under
+            # a real-run, but dry_run skips the check.
+            config_hash={
+                "energy_sources": "deadbeefcafefade",
+                "device_consumption": "deadbeefcafefade",
+                "device_consumption_water": "deadbeefcafefade",
+            },
+            dry_run=True,
+        )
+        assert result["success"] is True
+        assert result["dry_run"] is True
+
+
+# -----------------------------------------------------------------------------
+# Convenience-mode contract — never reaches dict-form hash branch (issue #1049)
+# -----------------------------------------------------------------------------
+
+
+class TestConvenienceModesPassStrHash:
+    """``_mutate_atomic`` reads ``current["config_hash"]`` (always a ``str``
+    from ``_get_prefs``) and forwards it to ``_set_prefs``. The dict-form
+    code path is therefore unreachable from convenience modes. Pinning
+    that contract guards against a future refactor that forwards
+    ``config_hash_per_key`` instead — which would expose dict-branch
+    semantics to a code path that pre-validates differently.
+    """
+
+    async def test_add_device_forwards_str_hash_to_set_prefs(self, tools, monkeypatch):
+        from ha_mcp.tools.tools_energy import EnergyTools
+
+        original_set_prefs = EnergyTools._set_prefs
+        captured: dict[str, Any] = {}
+
+        async def spy_set_prefs(self, config, config_hash, **kwargs):
+            captured["config_hash_type"] = type(config_hash).__name__
+            return await original_set_prefs(self, config, config_hash, **kwargs)
+
+        monkeypatch.setattr(EnergyTools, "_set_prefs", spy_set_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": _sample_prefs()},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+        await tools.ha_manage_energy_prefs(
+            mode="add_device", stat_consumption="sensor.tv_energy"
+        )
+        assert captured["config_hash_type"] == "str"
+
+    async def test_remove_device_forwards_str_hash_to_set_prefs(
+        self, tools, monkeypatch
+    ):
+        from ha_mcp.tools.tools_energy import EnergyTools
+
+        original_set_prefs = EnergyTools._set_prefs
+        captured: dict[str, Any] = {}
+
+        async def spy_set_prefs(self, config, config_hash, **kwargs):
+            captured["config_hash_type"] = type(config_hash).__name__
+            return await original_set_prefs(self, config, config_hash, **kwargs)
+
+        monkeypatch.setattr(EnergyTools, "_set_prefs", spy_set_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": _sample_prefs()},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+        await tools.ha_manage_energy_prefs(
+            mode="remove_device", stat_consumption="sensor.fridge_energy"
+        )
+        assert captured["config_hash_type"] == "str"
+
+    async def test_add_source_forwards_str_hash_to_set_prefs(
+        self, tools, monkeypatch
+    ):
+        from ha_mcp.tools.tools_energy import EnergyTools
+
+        original_set_prefs = EnergyTools._set_prefs
+        captured: dict[str, Any] = {}
+
+        async def spy_set_prefs(self, config, config_hash, **kwargs):
+            captured["config_hash_type"] = type(config_hash).__name__
+            return await original_set_prefs(self, config, config_hash, **kwargs)
+
+        monkeypatch.setattr(EnergyTools, "_set_prefs", spy_set_prefs)
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": _sample_prefs()},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+        await tools.ha_manage_energy_prefs(
+            mode="add_source",
+            source={
+                "type": "solar",
+                "stat_energy_from": "sensor.solar_in",
+            },
+        )
+        assert captured["config_hash_type"] == "str"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Closes #1049 by widening `ha_manage_energy_prefs`'s `config_hash` parameter to accept `str | dict[str, str]`. The dict form locks each submitted top-level key independently — agents can push a partial update (e.g. only `device_consumption`) without re-sending the full prefs blob, and without false-positive `RESOURCE_LOCKED` when an unrelated top-level key was concurrently changed.

- `mode='get'` response gains `config_hash_per_key: dict[str, str]` alongside the existing full-blob `config_hash`. Helper `_compute_per_key_hashes` wraps each top-level value in a single-key dict before hashing, so each hash is bound to its key.
- Dict-form validation is fail-closed: set-equality between `config` keys and `config_hash` keys (intersected with the canonical `_PREFS_TOP_LEVEL_KEYS`); unknown keys are silently dropped on both sides (mirrors the existing `_shape_check` / save-loop semantics). Per-key mismatch surfaces every offending key in the response's top-level `mismatched_keys` (`create_error_response` flattens `context` onto the response root).
- The `str` form is the original full-blob contract — unchanged. Convenience modes still pass `str` through `_mutate_atomic`; the dict path is only reachable from direct `mode='set'` callers.
- Pydantic `Annotated[str | dict[str, str] | None, Field(...)]` matches the existing precedent at `tools_config_dashboards.py:756`.

Touches the same module as the open #1086 (decouple `add_source` shape check) but no line overlap; either can land first.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — full unit suite locally: 1467 passed, 1 skipped (`test_numpy_version_constraint` — numpy is a transitive optional dependency, not resolved in this venv), 36.72s
- [x] Code follows style guidelines (`uv run ruff check`) — repo-pinned ruff 0.15.12 clean on changed files

Tests added:

- Unit: `config_hash_per_key` on `get` (configured + No-prefs default), happy-path partial save with per-key hash, mismatch surfaces `mismatched_keys`, set-equality fail-closed (missing key, extra key), unknown-top-level-key drop, response carries fresh per-key hashes after write, str backward-compat.

## Checklist
- [x] I have updated documentation if needed — tool docstring CAVEATS gains a per-key bullet; `_set_prefs` docstring documents both forms.
