### PR TITLE
refactor: validate only new entries on convenience-mode writes (#1086)

### DIFF
--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -143,13 +143,28 @@ def _flatten_validation_errors(raw: Any) -> list[dict[str, str]]:
     return errors
 
 
-def _shape_check(config: dict[str, Any]) -> list[dict[str, str]]:
+def _shape_check(
+    config: dict[str, Any],
+    validate_only: dict[str, set[int]] | None = None,
+) -> list[dict[str, str]]:
     """Cheap local shape check before sending to the server.
 
     Validates that top-level keys have the expected list-of-dicts shape and
     that required identifying fields are present. Does NOT validate semantic
     correctness (stat IDs existing, units matching, etc.) — that's surfaced
     by the post-save server-side ``energy/validate`` call.
+
+    ``validate_only`` scopes the per-entry check. ``None`` (default) validates
+    every entry under every present top-level key — the original contract.
+    A dict scopes the check to the listed keys and, within each, only the
+    listed indices: top-level keys absent from the dict are skipped entirely,
+    indices outside each key's set are skipped per-entry. The "must be a
+    list" structural check still fires for any present-and-listed key with a
+    non-list value, so ``validate_only`` cannot be used to bypass structural
+    sanity. An empty dict skips the entire per-entry pass (used by
+    convenience-mode write paths whose mutator did not append any new
+    entries — e.g. remove operations). See issue #1086 for the asymmetric
+    over-validation problem this addresses.
     """
     errors: list[dict[str, str]] = []
 
@@ -159,11 +174,18 @@ def _shape_check(config: dict[str, Any]) -> list[dict[str, str]]:
     for key in _PREFS_TOP_LEVEL_KEYS:
         if key not in config:
             continue
+        if validate_only is not None and key not in validate_only:
+            continue
         value = config[key]
         if not isinstance(value, list):
             errors.append({"path": key, "message": "must be a list"})
             continue
+        allowed_indices: set[int] | None = (
+            validate_only[key] if validate_only is not None else None
+        )
         for idx, entry in enumerate(value):
+            if allowed_indices is not None and idx not in allowed_indices:
+                continue
             if not isinstance(entry, dict):
                 errors.append(
                     {
@@ -629,6 +651,7 @@ class EnergyTools:
         config_hash: str | dict[_PrefsKey, str],
         *,
         current_prefs: dict[str, Any] | None = None,
+        validate_only: dict[str, set[int]] | None = None,
     ) -> dict[str, Any]:
         """Shape-check → hash-check → save → post-save validate.
 
@@ -649,12 +672,23 @@ class EnergyTools:
         provided, the internal re-read is skipped — the convenience-mode
         path uses this to avoid a second ``energy/get_prefs`` round trip
         per attempt (the snapshot was already fetched by ``_mutate_atomic``).
+<<<<<<< HEAD
         Convenience modes always pass a ``str`` hash; the dict form is
         only reachable via direct mode='set' callers.
+=======
+        The hash check still runs against the provided snapshot as a
+        defensive guard.
+
+        ``validate_only`` is forwarded to ``_shape_check`` and lets a caller
+        scope the per-entry check to specific top-level keys / indices.
+        Convenience-mode writes pass the appended tail indices so
+        pre-existing (HA-validated) entries are not re-validated against the
+        local schema — see issue #1086.
+>>>>>>> 0825a15 (refactor: validate only new entries on convenience-mode writes (#1086))
         """
         try:
             # 1. Shape check (fast local, fail closed)
-            shape_errors = _shape_check(config)
+            shape_errors = _shape_check(config, validate_only=validate_only)
             if shape_errors:
                 raise_tool_error(
                     create_error_response(
@@ -1206,8 +1240,17 @@ class EnergyTools:
 
                 # Backstop shape-check, mirroring the real-run path through
                 # ``_set_prefs`` — keeps dry_run/real-run shape-equivalent
-                # if the entry-construction logic ever changes.
-                shape_errors = _shape_check({target_key: new_list})
+                # if the entry-construction logic ever changes. ``validate_only``
+                # scopes it to the appended tail (per issue #1086): for add_*
+                # this is the new entry, for remove_* this is an empty set so
+                # nothing is re-validated.
+                appended_indices = set(
+                    range(len(existing_list), len(new_list))
+                )
+                shape_errors = _shape_check(
+                    {target_key: new_list},
+                    validate_only={target_key: appended_indices},
+                )
                 if shape_errors:
                     raise_tool_error(
                         create_error_response(
@@ -1241,11 +1284,21 @@ class EnergyTools:
                 new_list = mutator(existing_list)
 
                 partial_config = {target_key: new_list}
+                # Per issue #1086: validate only the appended tail entries,
+                # so a pre-existing (HA-validated) entry that would now fail
+                # a tightened ``_shape_check`` cannot block an unrelated
+                # add. For remove_* this set is empty — nothing new to
+                # re-validate. Assumes append-only/remove-only mutator
+                # semantics; revisit if an in-place mutator is added.
+                appended_indices = set(
+                    range(len(existing_list), len(new_list))
+                )
                 try:
                     set_result = await self._set_prefs(
                         partial_config,
                         current_hash,
                         current_prefs=current_config,
+                        validate_only={target_key: appended_indices},
                     )
                 except ToolError as exc:
                     # _set_prefs raises ToolError(RESOURCE_LOCKED) on hash mismatch.

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -147,7 +147,7 @@ def _shape_check(
     config: dict[str, Any],
     validate_only: dict[str, set[int]] | None = None,
 ) -> list[dict[str, str]]:
-    """Perform a cheap local shape check before sending to the server.
+    """Validate config shape locally before sending to the server.
 
     Validates that top-level keys have the expected list-of-dicts shape and
     that required identifying fields are present. Does NOT validate semantic
@@ -1208,7 +1208,7 @@ class EnergyTools:
         dry_run: bool,
         preview_payload: dict[str, Any],
     ) -> dict[str, Any]:
-        """Run the read-modify-write loop for convenience modes.
+        """Run convenience-mode read-modify-write with dry-run backstop and hash-conflict retry.
 
         Atomicity is with respect to the *entire* prefs snapshot, not just
         ``target_key``: ``_set_prefs`` validates the full ``config_hash``, so
@@ -1241,7 +1241,11 @@ class EnergyTools:
                 # if the entry-construction logic ever changes. ``validate_only``
                 # scopes it to the appended tail (per issue #1086): for add_*
                 # this is the new entry, for remove_* this is an empty set so
-                # nothing is re-validated.
+                # nothing is re-validated. The heuristic assumes append-only /
+                # shrink-only mutators (current set: _add_*, _remove_*). An
+                # in-place mutator (where len(new) == len(existing) but content
+                # changed) would yield an empty appended_indices and skip the
+                # per-entry pass entirely — revisit before adding such a mutator.
                 appended_indices = set(
                     range(len(existing_list), len(new_list))
                 )
@@ -1286,8 +1290,12 @@ class EnergyTools:
                 # so a pre-existing (HA-validated) entry that would now fail
                 # a tightened ``_shape_check`` cannot block an unrelated
                 # add. For remove_* this set is empty — nothing new to
-                # re-validate. Assumes append-only/remove-only mutator
-                # semantics; revisit if an in-place mutator is added.
+                # re-validate. The heuristic assumes append-only / shrink-
+                # only mutators (current set: _add_*, _remove_*). An
+                # in-place mutator (where len(new) == len(existing) but
+                # content changed) would yield an empty appended_indices
+                # and skip the per-entry pass entirely — revisit before
+                # adding such a mutator.
                 appended_indices = set(
                     range(len(existing_list), len(new_list))
                 )

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -96,7 +96,7 @@ def _compute_per_key_hashes(prefs: dict[str, Any]) -> dict[_PrefsKey, str]:
 
 
 def _is_no_prefs_error(error_msg: str) -> bool:
-    """True if an error string from send_websocket_message indicates
+    """Return True if an error string from send_websocket_message indicates
     ``ERR_NOT_FOUND "No prefs"`` from HA Core's energy/get_prefs handler.
 
     HA Core wraps the error as ``f"Command failed: {message}"``; the
@@ -147,7 +147,7 @@ def _shape_check(
     config: dict[str, Any],
     validate_only: dict[str, set[int]] | None = None,
 ) -> list[dict[str, str]]:
-    """Cheap local shape check before sending to the server.
+    """Perform a cheap local shape check before sending to the server.
 
     Validates that top-level keys have the expected list-of-dicts shape and
     that required identifying fields are present. Does NOT validate semantic
@@ -1212,7 +1212,7 @@ class EnergyTools:
         dry_run: bool,
         preview_payload: dict[str, Any],
     ) -> dict[str, Any]:
-        """Read-modify-write loop for convenience modes.
+        """Run the read-modify-write loop for convenience modes.
 
         Atomicity is with respect to the *entire* prefs snapshot, not just
         ``target_key``: ``_set_prefs`` validates the full ``config_hash``, so

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -161,10 +161,12 @@ def _shape_check(
     indices outside each key's set are skipped per-entry. The "must be a
     list" structural check still fires for any present-and-listed key with a
     non-list value, so ``validate_only`` cannot be used to bypass structural
-    sanity. An empty dict skips the entire per-entry pass (used by
-    convenience-mode write paths whose mutator did not append any new
-    entries — e.g. remove operations). See issue #1086 for the asymmetric
-    over-validation problem this addresses.
+    sanity. A dict with an empty set for a key (``{key: set()}``) skips the
+    per-entry pass for that key while preserving the structural check —
+    this is what convenience-mode write paths pass for remove operations
+    (no new entries to validate, but the list shape is still checked). An
+    empty dict (``{}``) skips all keys entirely. See issue #1086 for the
+    asymmetric over-validation problem this addresses.
     """
     errors: list[dict[str, str]] = []
 

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -674,19 +674,15 @@ class EnergyTools:
         provided, the internal re-read is skipped — the convenience-mode
         path uses this to avoid a second ``energy/get_prefs`` round trip
         per attempt (the snapshot was already fetched by ``_mutate_atomic``).
-<<<<<<< HEAD
         Convenience modes always pass a ``str`` hash; the dict form is
-        only reachable via direct mode='set' callers.
-=======
-        The hash check still runs against the provided snapshot as a
-        defensive guard.
+        only reachable via direct mode='set' callers. The hash check still
+        runs against the provided snapshot as a defensive guard.
 
         ``validate_only`` is forwarded to ``_shape_check`` and lets a caller
         scope the per-entry check to specific top-level keys / indices.
         Convenience-mode writes pass the appended tail indices so
         pre-existing (HA-validated) entries are not re-validated against the
         local schema — see issue #1086.
->>>>>>> 0825a15 (refactor: validate only new entries on convenience-mode writes (#1086))
         """
         try:
             # 1. Shape check (fast local, fail closed)

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -241,6 +241,47 @@ def _shape_check(
     return errors
 
 
+def _appended_tail_indices(existing: list[Any], new: list[Any]) -> set[int]:
+    """Return the indices in ``new`` that lie past the end of ``existing``.
+
+    Per issue #1086, this builds the ``validate_only`` index set scoped to the
+    appended tail of an append-only / shrink-only mutation, so pre-existing
+    HA-validated siblings are not re-checked on every add/remove:
+
+    - Append-only mutators (``_add_*``): returns indices of the new entries.
+    - Shrink-only mutators (``_remove_*``): returns an empty set — nothing
+      new to validate, and the surviving entries already passed HA validation.
+
+    Refuses in-place mutators where ``len(new) == len(existing)`` but the
+    contents differ — the appended-tail formula would yield an empty index
+    set on a list whose entries actually changed, silently bypassing
+    per-entry validation. Add explicit handling (e.g. an
+    ``_indices_of_modified_entries`` helper) before introducing such a
+    mutator; do not extend this one.
+    """
+    if len(new) == len(existing) and new != existing:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.INTERNAL_ERROR,
+                "_appended_tail_indices: in-place mutation detected "
+                "(same length, different content) — the appended-tail "
+                "validation heuristic only covers append-only / shrink-only "
+                "mutators. Add explicit per-entry validation handling for "
+                "in-place mutators before reusing this helper.",
+                context={
+                    "existing_len": len(existing),
+                    "new_len": len(new),
+                },
+                suggestions=[
+                    "If introducing a _replace_* / _update_* mutator, "
+                    "compute the indices of modified entries explicitly "
+                    "and pass those to _shape_check via validate_only.",
+                ],
+            )
+        )
+    return set(range(len(existing), len(new)))
+
+
 class EnergyTools:
     """Energy Dashboard preference management tools for Home Assistant."""
 
@@ -1237,18 +1278,10 @@ class EnergyTools:
                 new_list = mutator(existing_list)
 
                 # Backstop shape-check, mirroring the real-run path through
-                # ``_set_prefs`` — keeps dry_run/real-run shape-equivalent
-                # if the entry-construction logic ever changes. ``validate_only``
-                # scopes it to the appended tail (per issue #1086): for add_*
-                # this is the new entry, for remove_* this is an empty set so
-                # nothing is re-validated. The heuristic assumes append-only /
-                # shrink-only mutators (current set: _add_*, _remove_*). An
-                # in-place mutator (where len(new) == len(existing) but content
-                # changed) would yield an empty appended_indices and skip the
-                # per-entry pass entirely — revisit before adding such a mutator.
-                appended_indices = set(
-                    range(len(existing_list), len(new_list))
-                )
+                # ``_set_prefs`` — keeps dry_run/real-run shape-equivalent if
+                # the entry-construction logic ever changes. See
+                # ``_appended_tail_indices`` for the validate_only contract.
+                appended_indices = _appended_tail_indices(existing_list, new_list)
                 shape_errors = _shape_check(
                     {target_key: new_list},
                     validate_only={target_key: appended_indices},
@@ -1286,19 +1319,11 @@ class EnergyTools:
                 new_list = mutator(existing_list)
 
                 partial_config = {target_key: new_list}
-                # Per issue #1086: validate only the appended tail entries,
-                # so a pre-existing (HA-validated) entry that would now fail
-                # a tightened ``_shape_check`` cannot block an unrelated
-                # add. For remove_* this set is empty — nothing new to
-                # re-validate. The heuristic assumes append-only / shrink-
-                # only mutators (current set: _add_*, _remove_*). An
-                # in-place mutator (where len(new) == len(existing) but
-                # content changed) would yield an empty appended_indices
-                # and skip the per-entry pass entirely — revisit before
-                # adding such a mutator.
-                appended_indices = set(
-                    range(len(existing_list), len(new_list))
-                )
+                # Per issue #1086: validate only the appended tail so a
+                # pre-existing HA-validated entry cannot block an unrelated
+                # add/remove. See ``_appended_tail_indices`` for the
+                # validate_only contract.
+                appended_indices = _appended_tail_indices(existing_list, new_list)
                 try:
                     set_result = await self._set_prefs(
                         partial_config,
@@ -1348,10 +1373,21 @@ class EnergyTools:
             # Unreachable as long as every iteration either returns or raises:
             # the only ``continue`` is gated on ``attempt + 1 < max_attempts``,
             # which is False on the final iteration — so the bare ``raise``
-            # in the except block always fires there.
-            raise AssertionError(
-                f"_mutate_atomic({mode}, {target_key}): "
-                "retry loop exited without a return or raise"
+            # in the except block always fires there. Surface as an actionable
+            # structured error rather than a bare AssertionError that would
+            # otherwise fall through to ``except Exception`` and lose context.
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"_mutate_atomic({mode}, {target_key}): retry loop exited "
+                    "without a return or raise",
+                    context={"mode": mode, "target_key": target_key},
+                    suggestions=[
+                        "This indicates a bug in the optimistic-concurrency "
+                        "loop logic — please file an issue with the mode and "
+                        "target_key from the context.",
+                    ],
+                )
             )
 
         except ToolError:

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -151,6 +151,87 @@ class TestShapeCheck:
 
 
 # -----------------------------------------------------------------------------
+# _shape_check(validate_only=...) — issue #1086 (scope per-entry check)
+# -----------------------------------------------------------------------------
+
+
+class TestShapeCheckValidateOnly:
+    """``validate_only`` lets convenience-mode write paths skip re-validating
+    pre-existing entries that HA already accepted. ``None`` is the original
+    full-validation contract; a dict scopes per-key/per-index; an empty dict
+    skips the per-entry pass entirely."""
+
+    def test_none_validates_everything(self):
+        # Default behaviour preserved — invalid entry surfaces.
+        bad = {"device_consumption": [{"name": "no-stat"}]}
+        assert _shape_check(bad, validate_only=None)
+        assert _shape_check(bad)  # default arg, identical contract
+
+    def test_empty_dict_skips_all_per_entry_checks(self):
+        bad = {"device_consumption": [{"name": "no-stat"}]}
+        assert _shape_check(bad, validate_only={}) == []
+
+    def test_unlisted_key_is_skipped(self):
+        # Bad entry under device_consumption — but validate_only only asks
+        # for energy_sources, so device_consumption is skipped entirely.
+        config = {
+            "device_consumption": [{"name": "no-stat"}],
+            "energy_sources": [{"type": "grid"}],
+        }
+        assert (
+            _shape_check(
+                config, validate_only={"energy_sources": {0}}
+            )
+            == []
+        )
+
+    def test_unlisted_indices_within_a_key_are_skipped(self):
+        # device_consumption[0] is bad, [1] is good. validate_only={1} only
+        # checks the good index — no errors surface.
+        config = {
+            "device_consumption": [
+                {"name": "no-stat-bad"},
+                {"stat_consumption": "sensor.good"},
+            ],
+        }
+        assert _shape_check(config, validate_only={"device_consumption": {1}}) == []
+
+    def test_listed_index_with_bad_entry_still_raises(self):
+        # validate_only including a bad index still surfaces it.
+        config = {
+            "device_consumption": [
+                {"stat_consumption": "sensor.good"},
+                {"name": "no-stat-bad"},
+            ],
+        }
+        errors = _shape_check(
+            config, validate_only={"device_consumption": {1}}
+        )
+        assert any("stat_consumption" in e["message"] for e in errors)
+
+    def test_structural_must_be_a_list_check_still_fires_for_listed_keys(self):
+        # The "must be a list" structural check is independent of
+        # validate_only's per-entry filter — caller cannot bypass it for a
+        # key they explicitly listed.
+        errors = _shape_check(
+            {"device_consumption": "not a list"},
+            validate_only={"device_consumption": {0}},
+        )
+        assert {"path": "device_consumption", "message": "must be a list"} in errors
+
+    def test_structural_must_be_a_list_check_skipped_for_unlisted_keys(self):
+        # …but a non-list value under an UNLISTED key is skipped, since
+        # the caller did not ask for that key.
+        assert (
+            _shape_check(
+                {"device_consumption": "not a list"},
+                validate_only={"energy_sources": set()},
+            )
+            == []
+        )
+
+
+# -----------------------------------------------------------------------------
 # ha_manage_energy_prefs — mode="get"
 # -----------------------------------------------------------------------------
 
@@ -1106,6 +1187,164 @@ class TestConvenienceModesPassStrHash:
             },
         )
         assert captured["config_hash_type"] == "str"
+
+
+# -----------------------------------------------------------------------------
+# issue #1086 — convenience-mode writes do not re-validate pre-existing entries
+# -----------------------------------------------------------------------------
+
+
+class TestConvenienceModesPreExistingInvalid:
+    """Regression for issue #1086. ``_set_prefs`` previously ran
+    ``_shape_check`` over the full union ``existing + new``, so a
+    pre-existing entry that fails the local schema would block an
+    unrelated add/remove. The fix scopes the check to the appended tail
+    via ``validate_only``: ``add_*`` validates only the new entry,
+    ``remove_*`` validates nothing (the snapshot was already HA-valid).
+    Reproduced here by feeding back a deliberately-invalid pre-existing
+    entry from ``energy/get_prefs``.
+    """
+
+    async def test_add_device_succeeds_with_invalid_pre_existing(self, tools):
+        invalid_prefs = {
+            "energy_sources": [],
+            "device_consumption": [{"name": "broken_no_stat"}],  # invalid
+            "device_consumption_water": [],
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": invalid_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="add_device", stat_consumption="sensor.fridge_energy"
+        )
+        assert result["success"] is True
+        # The pre-existing broken entry survives unchanged in the saved
+        # payload — full-replace semantics on the top-level key.
+        save_payload = tools._client.send_websocket_message.call_args_list[
+            1
+        ].args[0]
+        assert save_payload["device_consumption"] == [
+            {"name": "broken_no_stat"},
+            {"stat_consumption": "sensor.fridge_energy"},
+        ]
+
+    async def test_add_source_succeeds_with_invalid_pre_existing(self, tools):
+        invalid_prefs = {
+            # An energy_sources entry missing the required stat_energy_from
+            # for non-grid types (would fail local _shape_check today).
+            "energy_sources": [{"type": "solar"}],
+            "device_consumption": [],
+            "device_consumption_water": [],
+        }
+        new_source = {
+            "type": "battery",
+            "stat_energy_from": "sensor.battery_in",
+            "stat_energy_to": "sensor.battery_out",
+        }
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": invalid_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="add_source", source=new_source
+        )
+        assert result["success"] is True
+        save_payload = tools._client.send_websocket_message.call_args_list[
+            1
+        ].args[0]
+        assert save_payload["energy_sources"][1] == new_source
+
+    async def test_remove_device_succeeds_with_invalid_pre_existing(self, tools):
+        invalid_prefs = {
+            "energy_sources": [],
+            "device_consumption": [
+                {"stat_consumption": "sensor.fridge_energy"},
+                {"name": "broken_no_stat"},  # invalid sibling
+            ],
+            "device_consumption_water": [],
+        }
+
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": invalid_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="remove_device", stat_consumption="sensor.fridge_energy"
+        )
+        assert result["success"] is True
+        # The unaffected (still-broken) entry remains in the saved payload.
+        save_payload = tools._client.send_websocket_message.call_args_list[
+            1
+        ].args[0]
+        assert save_payload["device_consumption"] == [
+            {"name": "broken_no_stat"},
+        ]
+
+    async def test_add_device_dry_run_succeeds_with_invalid_pre_existing(
+        self, tools
+    ):
+        """Dry-run path's backstop ``_shape_check`` is also scoped to the
+        appended tail (mirroring the real-run path)."""
+        invalid_prefs = {
+            "energy_sources": [],
+            "device_consumption": [{"name": "broken_no_stat"}],
+            "device_consumption_water": [],
+        }
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": invalid_prefs,
+        }
+
+        result = await tools.ha_manage_energy_prefs(
+            mode="add_device",
+            stat_consumption="sensor.new",
+            dry_run=True,
+        )
+        assert result["success"] is True
+        assert result["dry_run"] is True
+
+    async def test_add_device_still_rejects_a_genuinely_invalid_new_entry(
+        self, tools
+    ):
+        """The fix does NOT silence validation of the genuinely new entry —
+        it only stops re-validating pre-existing siblings. A new entry that
+        fails the per-entry shape check still raises VALIDATION_FAILED.
+        Verified via the convenience helper's structural-by-construction
+        guarantee: ``_add_device`` constructs a well-formed entry from
+        typed parameters, so the only surface for a "bad new entry" is
+        ``mode='set'`` directly. See ``TestSetPrefs.test_shape_error_*``
+        for that path; this test pins the boundary by confirming the
+        snapshot's broken sibling is NOT silenced when ``mode='set'`` is
+        used directly with an unscoped ``validate_only=None`` (default).
+        """
+        invalid_prefs = {
+            "energy_sources": [],
+            "device_consumption": [{"name": "broken_no_stat"}],
+            "device_consumption_water": [],
+        }
+        full_hash = compute_config_hash(invalid_prefs)
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": invalid_prefs},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_manage_energy_prefs(
+                mode="set",
+                config=invalid_prefs,
+                config_hash=full_hash,
+            )
+        err = json.loads(str(exc_info.value))
+        # mode='set' direct path is unchanged: full _shape_check runs and
+        # surfaces the broken sibling.
+        assert "VALIDATION_FAILED" in json.dumps(err)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -171,6 +171,24 @@ class TestShapeCheckValidateOnly:
         bad = {"device_consumption": [{"name": "no-stat"}]}
         assert _shape_check(bad, validate_only={}) == []
 
+    def test_listed_key_with_empty_index_set_skips_per_entry_but_keeps_structural(self):
+        # ``{key: set()}`` is "key listed, no per-entry indices" — distinct
+        # from ``{}`` (skip everything). The list-shape structural check
+        # still fires for that key; per-entry checks are skipped. This is
+        # the shape ``_remove_*`` mutators pass through ``_appended_tail_indices``
+        # after a shrink (no new entries to validate, surviving entries
+        # already passed HA validation).
+        bad = {
+            "device_consumption": [
+                {"name": "no-stat-bad-1"},
+                {"name": "no-stat-bad-2"},
+            ],
+        }
+        assert (
+            _shape_check(bad, validate_only={"device_consumption": set()})
+            == []
+        )
+
     def test_unlisted_key_is_skipped(self):
         # Bad entry under device_consumption — but validate_only only asks
         # for energy_sources, so device_consumption is skipped entirely.
@@ -1288,42 +1306,83 @@ class TestConvenienceModesPreExistingInvalid:
             {"name": "broken_no_stat"},
         ]
 
-    async def test_add_device_dry_run_succeeds_with_invalid_pre_existing(
-        self, tools
+    @pytest.mark.parametrize(
+        "mode, kwargs, invalid_prefs",
+        [
+            (
+                "add_device",
+                {"stat_consumption": "sensor.new"},
+                {
+                    "energy_sources": [],
+                    "device_consumption": [{"name": "broken_no_stat"}],
+                    "device_consumption_water": [],
+                },
+            ),
+            (
+                "add_source",
+                {
+                    "source": {
+                        "type": "battery",
+                        "stat_energy_from": "sensor.battery_in",
+                        "stat_energy_to": "sensor.battery_out",
+                    },
+                },
+                {
+                    "energy_sources": [{"type": "solar"}],  # missing stat_energy_from
+                    "device_consumption": [],
+                    "device_consumption_water": [],
+                },
+            ),
+            (
+                "remove_device",
+                {"stat_consumption": "sensor.fridge_energy"},
+                {
+                    "energy_sources": [],
+                    "device_consumption": [
+                        {"stat_consumption": "sensor.fridge_energy"},
+                        {"name": "broken_no_stat"},  # broken sibling, not removed
+                    ],
+                    "device_consumption_water": [],
+                },
+            ),
+        ],
+        ids=["add_device", "add_source", "remove_device"],
+    )
+    async def test_dry_run_succeeds_with_invalid_pre_existing(
+        self, tools, mode, kwargs, invalid_prefs
     ):
-        """Dry-run path's backstop ``_shape_check`` is also scoped to the
-        appended tail (mirroring the real-run path)."""
-        invalid_prefs = {
-            "energy_sources": [],
-            "device_consumption": [{"name": "broken_no_stat"}],
-            "device_consumption_water": [],
-        }
+        """Dry-run path's backstop ``_shape_check`` is scoped to the
+        appended tail (mirroring the real-run path) for every convenience-
+        mode mutator. Symmetry with the real-run regression block above
+        guards against future divergence between the two ``_mutate_atomic``
+        branches.
+        """
         tools._client.send_websocket_message.return_value = {
             "success": True,
             "result": invalid_prefs,
         }
 
         result = await tools.ha_manage_energy_prefs(
-            mode="add_device",
-            stat_consumption="sensor.new",
-            dry_run=True,
+            mode=mode, dry_run=True, **kwargs
         )
         assert result["success"] is True
         assert result["dry_run"] is True
 
-    async def test_add_device_still_rejects_a_genuinely_invalid_new_entry(
+    async def test_direct_set_mode_still_validates_full_config_when_validate_only_is_none(
         self, tools
     ):
-        """The fix does NOT silence validation of the genuinely new entry —
-        it only stops re-validating pre-existing siblings. A new entry that
-        fails the per-entry shape check still raises VALIDATION_FAILED.
-        Verified via the convenience helper's structural-by-construction
-        guarantee: ``_add_device`` constructs a well-formed entry from
-        typed parameters, so the only surface for a "bad new entry" is
-        ``mode='set'`` directly. See ``TestSetPrefs.test_shape_error_*``
-        for that path; this test pins the boundary by confirming the
-        snapshot's broken sibling is NOT silenced when ``mode='set'`` is
-        used directly with an unscoped ``validate_only=None`` (default).
+        """Boundary pin: the ``validate_only`` scoping only applies on
+        convenience-mode write paths (``add_*``/``remove_*``), which thread
+        an explicit ``validate_only={target_key: appended_indices}`` through
+        ``_set_prefs``. Direct ``mode='set'`` keeps the original full-
+        validation contract (``validate_only=None`` default), so a
+        snapshot's broken sibling still surfaces — the fix does NOT
+        silently relax the direct-set path.
+
+        The convenience helpers' "bad new entry" surface is closed by
+        structural-by-construction (``_add_device`` builds a well-formed
+        entry from typed parameters); see ``TestSetPrefs.test_shape_error_*``
+        for the direct-set per-entry coverage.
         """
         invalid_prefs = {
             "energy_sources": [],


### PR DESCRIPTION
## What does this PR do?

Closes #1086. Convenience-mode writes (`_add_device`, `_add_source`, `_remove_device`) build a `partial_config` equal to the FULL existing list ± one entry, then route it through `_set_prefs` which ran `_shape_check` on that union — re-validating pre-existing (HA-validated) siblings on every add/remove. If `_shape_check` is ever tightened past HA's voluptuous schema, an unrelated add would fail because a SIBLING entry would now fail the local check.

Scope `_shape_check` on the convenience-mode write path to just the appended tail:

- `_shape_check` accepts `validate_only: dict[str, set[int]] | None`. `None` preserves the original full-validation contract. An empty dict skips the entire per-entry pass. Structural "must be a dict" / "must be a list" checks still fire for listed keys.
- `_set_prefs` accepts and forwards `validate_only` as a kwarg-only param.
- `_mutate_atomic` computes `appended_indices = range(len(existing_list), len(new_list))` and passes `{target_key: appended_indices}` on both the real-run write and the dry-run backstop. For `add_*` this is the new entry only; for `remove_*` this is `set()` so nothing is re-validated.
- Direct `mode='set'` callers are **unchanged** — `validate_only` defaults to `None` and the full check still runs.

Assumes append-only/remove-only mutator semantics; revisit if an in-place mutator is ever added.

**No reachable bug on master today** — the local `_shape_check` is currently a strict subset of HA's voluptuous schema, so any HA-accepted entry passes the local check. This is forward-looking robustness; see issue body for the full motivation.

Touches `_set_prefs` alongside the in-flight #1098 (per-key `config_hash`). Both add kwarg-only params to the same signature; otherwise distinct validation logic. Whichever lands second rebases trivially.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — local Alpine env lacks Python 3.13; will check after CI green
- [x] Code follows style guidelines (`uv run ruff check`) — repo-pinned ruff 0.15.12 clean on changed files

Tests added:

- `TestShapeCheckValidateOnly` (7 unit tests): `validate_only=None` parity, empty-dict full skip, unlisted-key skip, unlisted-index skip within a key, listed-bad-index still raises, structural "must be a list" check fires for listed keys but skipped for unlisted keys.
- `TestConvenienceModesPreExistingInvalid` (5 regression tests): `add_device` / `add_source` / `remove_device` succeed despite a deliberately-invalid pre-existing sibling; dry-run mirrors real-run; direct `mode='set'` still rejects an invalid config (boundary).

## Checklist
- [x] I have updated documentation if needed — `_shape_check`'s and `_set_prefs`'s docstrings document `validate_only`; `_mutate_atomic`'s real-run and dry-run paths carry inline notes pinning the heuristic to #1086.