### PR TITLE
feat: add HA_VERIFY_SSL toggle to disable TLS verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,8 @@ HA_TIMEOUT=30
 HA_MAX_RETRIES=3
 
 # Verify the Home Assistant server's TLS certificate. Set to "false" to
-# accept self-signed certificates or hostname mismatches (e.g. when
-# connecting to https://homeassistant.local:8123 from a LAN). Disabling
-# this weakens transport security — only use it on networks you trust.
+# accept self-signed certs or hostname mismatches (e.g. https://homeassistant.local:8123).
+# Trusted networks only.
 # HA_VERIFY_SSL=true
 
 # Tool Configuration

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ HOMEASSISTANT_TOKEN=your_long_lived_access_token_here
 HA_TIMEOUT=30
 HA_MAX_RETRIES=3
 
+# Verify the Home Assistant server's TLS certificate. Set to "false" to
+# accept self-signed certificates or hostname mismatches (e.g. when
+# connecting to https://homeassistant.local:8123 from a LAN). Disabling
+# this weakens transport security — only use it on networks you trust.
+# HA_VERIFY_SSL=true
+
 # Tool Configuration
 FUZZY_THRESHOLD=60
 ENTITY_SEARCH_LIMIT=20

--- a/homeassistant-addon-dev/DOCS.md
+++ b/homeassistant-addon-dev/DOCS.md
@@ -23,6 +23,7 @@ The dev add-on uses the same configuration as the stable version. See the main a
 | `tool_search_max_results` | Max results from `ha_search_tools` (range 2-10) | `5` |
 | `disabled_tools` | Comma-separated list of tool names to disable (seed value; web UI is primary) | empty |
 | `pinned_tools` | Comma-separated list of tool names to pin when tool search is enabled (seed value; web UI is primary) | empty |
+| `verify_ssl` | Verify the HA server's TLS certificate. Disable for self-signed certs or hostname mismatches. Weakens security — leave on unless needed. | `true` |
 
 Beta options are hidden under "Show unused optional configuration options" in the add-on Configuration tab. See [beta.md](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md) for details.
 

--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -27,6 +27,7 @@ options:
   tool_search_max_results: 5
   disabled_tools: ""
   pinned_tools: ""
+  verify_ssl: true
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
@@ -39,5 +40,6 @@ schema:
   tool_search_max_results: int(2,10)?
   disabled_tools: str?
   pinned_tools: str?
+  verify_ssl: bool?
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -75,3 +75,13 @@ configuration:
       For a visual interface, click "Open Web UI" on the addon info page. This field
       seeds the initial config when the web UI hasn't been used yet.
       Requires restart.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: >-
+      Verify the Home Assistant server's TLS certificate. The add-on
+      connects via the Supervisor proxy, so this normally has no effect
+      and should stay enabled. Disable only if you've reconfigured the
+      add-on to talk to HA over a public HTTPS hostname with a self-signed
+      certificate or hostname mismatch. Disabling weakens transport
+      security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -233,11 +233,11 @@ Custom secret path override. **Leave empty for auto-generation** (recommended).
 
 Verify the Home Assistant server's TLS certificate.
 
-The add-on talks to HA via the Supervisor proxy (`http://supervisor/core`), so this option has no effect for the default install. Disable it only if you have reconfigured the add-on to point at a public HTTPS hostname (e.g., behind Cloudflare with mTLS) or a local HTTPS endpoint where the certificate doesn't match the hostname (e.g., `https://homeassistant.local:8123`).
+The add-on talks to HA via the Supervisor proxy (`http://supervisor/core`), so this option has no effect for the default install. Disable it only if you have reconfigured the add-on to point at an HTTPS endpoint whose certificate doesn't match the hostname being called — for example a local HTTPS endpoint at `https://homeassistant.local:8123`, or a public hostname fronted by a reverse proxy whose certificate is issued for a different name.
 
-When disabled, both the REST and WebSocket clients connect with hostname checking and certificate verification turned off, and a warning is logged on each connect.
+When disabled, both the REST and WebSocket clients connect with hostname checking and certificate verification turned off, and a warning is logged once per client.
 
-**Disabling weakens transport security.** Leave this on unless you know you need it.
+**Note:** Disabling weakens transport security. Leave this on unless you know you need it. The OAuth flow inherits the server-wide setting — there's no per-user verify_ssl override.
 
 Requires add-on restart to take effect.
 

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -227,6 +227,20 @@ Custom secret path override. **Leave empty for auto-generation** (recommended).
 
 **Note:** This is an advanced option. Enable "Show unused optional configuration options" in the add-on configuration UI to see it.
 
+### verify_ssl (Advanced)
+
+**Default:** `true`
+
+Verify the Home Assistant server's TLS certificate.
+
+The add-on talks to HA via the Supervisor proxy (`http://supervisor/core`), so this option has no effect for the default install. Disable it only if you have reconfigured the add-on to point at a public HTTPS hostname (e.g., behind Cloudflare with mTLS) or a local HTTPS endpoint where the certificate doesn't match the hostname (e.g., `https://homeassistant.local:8123`).
+
+When disabled, both the REST and WebSocket clients connect with hostname checking and certificate verification turned off, and a warning is logged on each connect.
+
+**Disabling weakens transport security.** Leave this on unless you know you need it.
+
+Requires add-on restart to take effect.
+
 ### enable_tool_search
 
 **Default:** `false`

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -30,12 +30,14 @@ options:
   enable_skills: true
   enable_skills_as_tools: true
   enable_tool_search: false
+  verify_ssl: true
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
   enable_skills: bool?
   enable_skills_as_tools: bool?
   enable_tool_search: bool?
+  verify_ssl: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -167,6 +167,18 @@ def maybe_persist_secret_path(
         )
 
 
+def resolve_bool_option(config: dict[str, Any], key: str, default: bool) -> bool:
+    """Read ``key`` from ``config`` as a bool, falling back to ``default``.
+
+    Mirrors the ``raw = config.get(key, default); raw if isinstance(raw, bool) else default``
+    pattern used inline in ``main()`` for other options. Extracted so the
+    verify_ssl plumbing can be unit-tested without standing up the full
+    addon container.
+    """
+    raw = config.get(key, default)
+    return raw if isinstance(raw, bool) else default
+
+
 SKILLS_AS_TOOLS_MIGRATION_MARKER = ".skills_as_tools_default_migration_v1"
 
 
@@ -293,8 +305,7 @@ def main() -> int:
             disabled_tools_raw = raw_disabled if isinstance(raw_disabled, str) else ""
             raw_pinned = config.get("pinned_tools", "")
             pinned_tools_raw = raw_pinned if isinstance(raw_pinned, str) else ""
-            raw_verify_ssl = config.get("verify_ssl", True)
-            verify_ssl = raw_verify_ssl if isinstance(raw_verify_ssl, bool) else True
+            verify_ssl = resolve_bool_option(config, "verify_ssl", True)
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
             config_read_ok = False
@@ -325,6 +336,7 @@ def main() -> int:
     maybe_persist_secret_path(config, secret_path, supervisor_token)
 
     log_info(f"Backup hint mode: {backup_hint}")
+    log_info(f"Verify SSL: {verify_ssl}")
 
     # Set up environment for ha-mcp
     os.environ["HOMEASSISTANT_URL"] = "http://supervisor/core"

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -266,6 +266,7 @@ def main() -> int:
     tool_search_max_results = 5  # default
     disabled_tools_raw = ""  # default
     pinned_tools_raw = ""  # default
+    verify_ssl = True  # default
     config_read_ok = True
 
     if config_file.exists():
@@ -292,6 +293,8 @@ def main() -> int:
             disabled_tools_raw = raw_disabled if isinstance(raw_disabled, str) else ""
             raw_pinned = config.get("pinned_tools", "")
             pinned_tools_raw = raw_pinned if isinstance(raw_pinned, str) else ""
+            raw_verify_ssl = config.get("verify_ssl", True)
+            verify_ssl = raw_verify_ssl if isinstance(raw_verify_ssl, bool) else True
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
             config_read_ok = False
@@ -335,6 +338,7 @@ def main() -> int:
     os.environ["TOOL_SEARCH_MAX_RESULTS"] = str(tool_search_max_results)
     os.environ["DISABLED_TOOLS"] = disabled_tools_raw
     os.environ["PINNED_TOOLS"] = pinned_tools_raw
+    os.environ["HA_VERIFY_SSL"] = str(verify_ssl).lower()
 
     os.environ["HOMEASSISTANT_TOKEN"] = supervisor_token
 

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -26,3 +26,13 @@ configuration:
       deferred tools or with smaller context windows. Tools are found via
       ha_search_tools and executed via categorized proxies (read/write/delete).
       Requires restart to take effect.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: >-
+      Verify the Home Assistant server's TLS certificate. The add-on
+      connects via the Supervisor proxy, so this normally has no effect
+      and should stay enabled. Disable only if you've reconfigured the
+      add-on to talk to HA over a public HTTPS hostname with a self-signed
+      certificate or hostname mismatch. Disabling weakens transport
+      security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -62,6 +62,7 @@ class HomeAssistantClient:
         base_url: str | None = None,
         token: str | None = None,
         timeout: int | None = None,
+        verify_ssl: bool | None = None,
     ):
         """
         Initialize Home Assistant client.
@@ -70,18 +71,32 @@ class HomeAssistantClient:
             base_url: Home Assistant URL (defaults to config)
             token: Long-lived access token (defaults to config)
             timeout: Request timeout in seconds (defaults to config)
+            verify_ssl: Whether to verify the HA server's TLS certificate
+                (defaults to ``settings.verify_ssl``, which is True). Pass
+                False to allow self-signed certs or hostname mismatches.
         """
-        # Only load settings if we need to use fallback values
-        if base_url is None or token is None:
+        # Load settings whenever any value falls back to config defaults
+        if base_url is None or token is None or verify_ssl is None:
             settings = get_global_settings()
             self.base_url = (base_url or settings.homeassistant_url).rstrip("/")
             self.token = token or settings.homeassistant_token
             self.timeout = timeout if timeout is not None else settings.timeout
+            self.verify_ssl = (
+                verify_ssl if verify_ssl is not None else settings.verify_ssl
+            )
         else:
-            # All required parameters provided, use them directly without loading settings
             self.base_url = base_url.rstrip("/")
             self.token = token
             self.timeout = timeout if timeout is not None else 30  # Default timeout
+            self.verify_ssl = verify_ssl
+
+        if not self.verify_ssl:
+            logger.warning(
+                "TLS verification disabled for Home Assistant REST client "
+                "(HA_VERIFY_SSL=false). Connections to %s will accept "
+                "self-signed and mismatched certificates.",
+                self.base_url,
+            )
 
         # Create HTTP client with authentication headers
         self.httpx_client = httpx.AsyncClient(
@@ -91,6 +106,7 @@ class HomeAssistantClient:
                 "Content-Type": "application/json",
             },
             timeout=httpx.Timeout(self.timeout),
+            verify=self.verify_ssl,
         )
 
         logger.info(f"Initialized Home Assistant client for {self.base_url}")

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -5,11 +5,26 @@ Home Assistant HTTP client with authentication and error handling.
 import asyncio
 import json
 import logging
+import ssl
 from typing import Any
 
 import httpx
 
 from ..config import get_global_settings
+
+
+def _is_ssl_error(exc: BaseException) -> bool:
+    """True if ``exc`` (or anything in its cause chain) is an SSL error.
+
+    httpx wraps ``ssl.SSLError`` inside ``httpx.ConnectError``; the only
+    reliable check is to walk ``__cause__`` / ``__context__``.
+    """
+    cur: BaseException | None = exc
+    while cur is not None:
+        if isinstance(cur, ssl.SSLError):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +87,9 @@ class HomeAssistantClient:
             token: Long-lived access token (defaults to config)
             timeout: Request timeout in seconds (defaults to config)
             verify_ssl: Whether to verify the HA server's TLS certificate
-                (defaults to ``settings.verify_ssl``, which is True). Pass
-                False to allow self-signed certs or hostname mismatches.
+                (defaults to ``settings.verify_ssl``). Pass False to allow
+                self-signed certs or hostname mismatches.
         """
-        # Load settings whenever any value falls back to config defaults
         if base_url is None or token is None or verify_ssl is None:
             settings = get_global_settings()
             self.base_url = (base_url or settings.homeassistant_url).rstrip("/")
@@ -164,6 +178,12 @@ class HomeAssistantClient:
             return response
 
         except httpx.ConnectError as e:
+            if _is_ssl_error(e) and self.verify_ssl:
+                raise HomeAssistantConnectionError(
+                    f"TLS verification failed for {self.base_url}: {e}. "
+                    "If this is a self-signed certificate or hostname "
+                    "mismatch, set HA_VERIFY_SSL=false to skip verification."
+                ) from e
             raise HomeAssistantConnectionError(
                 f"Failed to connect to Home Assistant: {e}"
             ) from e

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -21,7 +21,11 @@ from urllib.parse import urlparse
 import websockets
 
 from ..config import get_global_settings
-from .rest_client import HomeAssistantCommandError, HomeAssistantConnectionError
+from .rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantConnectionError,
+    _is_ssl_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -167,14 +171,25 @@ class HomeAssistantWebSocketClient:
             token: Home Assistant long-lived access token
             verify_ssl: Whether to verify the HA server's TLS certificate
                 for ``wss://`` connections. Defaults to
-                ``settings.verify_ssl`` (True). Pass False to allow
-                self-signed certs or hostname mismatches.
+                ``settings.verify_ssl``. Pass False to allow self-signed
+                certs or hostname mismatches.
         """
         self.base_url = url.rstrip("/")
         self.token = token
         if verify_ssl is None:
-            verify_ssl = get_global_settings().verify_ssl
+            try:
+                verify_ssl = get_global_settings().verify_ssl
+            except Exception as e:
+                # A bad env var elsewhere should not silently flip TLS off:
+                # log which key tripped and fall back to the secure default.
+                logger.warning(
+                    "Could not load settings while resolving verify_ssl "
+                    "(%s); falling back to verify_ssl=True.",
+                    e,
+                )
+                verify_ssl = True
         self.verify_ssl = verify_ssl
+        self._warned_verify_disabled = False
         self.websocket: websockets.ClientConnection | None = None
         self.background_task: asyncio.Task | None = None
         self._send_lock: asyncio.Lock | None = None
@@ -205,18 +220,22 @@ class HomeAssistantWebSocketClient:
             logger.info(f"Connecting to Home Assistant WebSocket: {self.ws_url}")
             self._state.reset_connection()
 
-            # Build an SSL context only for wss:// — passing ssl= to
-            # websockets.connect on a plain ws:// URL would force TLS.
+            # Only configure an SSLContext for wss://; ws:// (Supervisor
+            # proxy) doesn't use TLS and gets ssl=None.
             ssl_ctx: ssl.SSLContext | None = None
             if self.ws_url.startswith("wss://"):
                 ssl_ctx = ssl.create_default_context()
                 if not self.verify_ssl:
-                    logger.warning(
-                        "TLS verification disabled for Home Assistant "
-                        "WebSocket (HA_VERIFY_SSL=false). Connecting to "
-                        "%s with hostname/cert checks off.",
-                        self.ws_url,
-                    )
+                    if not self._warned_verify_disabled:
+                        # Once per client — pool reconnects/HA restarts
+                        # otherwise flood logs with the same warning.
+                        logger.warning(
+                            "TLS verification disabled for Home Assistant "
+                            "WebSocket (HA_VERIFY_SSL=false). Connecting to "
+                            "%s with hostname/cert checks off.",
+                            self.ws_url,
+                        )
+                        self._warned_verify_disabled = True
                     ssl_ctx.check_hostname = False
                     ssl_ctx.verify_mode = ssl.CERT_NONE
 
@@ -265,7 +284,16 @@ class HomeAssistantWebSocketClient:
             return True
 
         except Exception as e:
-            logger.error(f"WebSocket connection failed: {e}")
+            if _is_ssl_error(e) and self.verify_ssl:
+                logger.error(
+                    "WebSocket TLS verification failed for %s: %s. "
+                    "If this is a self-signed certificate or hostname "
+                    "mismatch, set HA_VERIFY_SSL=false to skip verification.",
+                    self.ws_url,
+                    e,
+                )
+            else:
+                logger.error(f"WebSocket connection failed: {e}")
             await self.disconnect()
             return False
 

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import ssl
 import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
@@ -158,15 +159,22 @@ class WebSocketConnectionState:
 class HomeAssistantWebSocketClient:
     """WebSocket client for Home Assistant real-time communication."""
 
-    def __init__(self, url: str, token: str):
+    def __init__(self, url: str, token: str, verify_ssl: bool | None = None):
         """Initialize WebSocket client.
 
         Args:
             url: Home Assistant URL (e.g., 'https://homeassistant.local:8123')
             token: Home Assistant long-lived access token
+            verify_ssl: Whether to verify the HA server's TLS certificate
+                for ``wss://`` connections. Defaults to
+                ``settings.verify_ssl`` (True). Pass False to allow
+                self-signed certs or hostname mismatches.
         """
         self.base_url = url.rstrip("/")
         self.token = token
+        if verify_ssl is None:
+            verify_ssl = get_global_settings().verify_ssl
+        self.verify_ssl = verify_ssl
         self.websocket: websockets.ClientConnection | None = None
         self.background_task: asyncio.Task | None = None
         self._send_lock: asyncio.Lock | None = None
@@ -197,6 +205,21 @@ class HomeAssistantWebSocketClient:
             logger.info(f"Connecting to Home Assistant WebSocket: {self.ws_url}")
             self._state.reset_connection()
 
+            # Build an SSL context only for wss:// — passing ssl= to
+            # websockets.connect on a plain ws:// URL would force TLS.
+            ssl_ctx: ssl.SSLContext | None = None
+            if self.ws_url.startswith("wss://"):
+                ssl_ctx = ssl.create_default_context()
+                if not self.verify_ssl:
+                    logger.warning(
+                        "TLS verification disabled for Home Assistant "
+                        "WebSocket (HA_VERIFY_SSL=false). Connecting to "
+                        "%s with hostname/cert checks off.",
+                        self.ws_url,
+                    )
+                    ssl_ctx.check_hostname = False
+                    ssl_ctx.verify_mode = ssl.CERT_NONE
+
             # Connect to WebSocket
             # Include Authorization header for Supervisor proxy compatibility
             # (required when connecting via http://supervisor/core/websocket)
@@ -205,6 +228,7 @@ class HomeAssistantWebSocketClient:
                 ping_interval=30,
                 ping_timeout=10,
                 additional_headers={"Authorization": f"Bearer {self.token}"},
+                ssl=ssl_ctx,
                 # Increase max message size to 20MB for large responses
                 # (e.g., HACS repository list can be 2MB+)
                 max_size=20 * 1024 * 1024,

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -54,6 +54,13 @@ class Settings(BaseSettings):
     timeout: int = Field(30, alias="HA_TIMEOUT")
     max_retries: int = Field(3, alias="HA_MAX_RETRIES")
 
+    # SSL/TLS verification for the Home Assistant connection.
+    # Set to False to skip certificate validation when connecting via a
+    # self-signed cert or a hostname that doesn't match the certificate
+    # (e.g. https://homeassistant.local:8123). Disabling this weakens
+    # security — only use it for trusted local networks.
+    verify_ssl: bool = Field(True, alias="HA_VERIFY_SSL")
+
     # Tool configuration
     fuzzy_threshold: int = Field(60, alias="FUZZY_THRESHOLD")
     entity_search_limit: int = Field(20, alias="ENTITY_SEARCH_LIMIT")

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -54,11 +54,7 @@ class Settings(BaseSettings):
     timeout: int = Field(30, alias="HA_TIMEOUT")
     max_retries: int = Field(3, alias="HA_MAX_RETRIES")
 
-    # SSL/TLS verification for the Home Assistant connection.
-    # Set to False to skip certificate validation when connecting via a
-    # self-signed cert or a hostname that doesn't match the certificate
-    # (e.g. https://homeassistant.local:8123). Disabling this weakens
-    # security — only use it for trusted local networks.
+    # False = skip TLS verification (self-signed / hostname mismatch). Trusted networks only.
     verify_ssl: bool = Field(True, alias="HA_VERIFY_SSL")
 
     # Tool configuration
@@ -238,3 +234,13 @@ def get_global_settings() -> Settings:
     if _settings is None:
         _settings = get_settings()
     return _settings
+
+
+def _reset_global_settings() -> None:
+    """Drop the cached settings singleton.
+
+    Test-only seam so suites that mutate ``HA_*`` env vars can force a
+    re-read without reaching into module-private state.
+    """
+    global _settings
+    _settings = None

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -179,7 +179,9 @@ async def create_backup(
 
     try:
         # Connect to WebSocket
-        ws_client, error = await get_connected_ws_client(client.base_url, client.token)
+        ws_client, error = await get_connected_ws_client(
+            client.base_url, client.token, verify_ssl=client.verify_ssl
+        )
         if error:
             raise_tool_error(error or create_error_response(
                 ErrorCode.CONNECTION_FAILED,
@@ -300,7 +302,9 @@ async def restore_backup(
 
     try:
         # Connect to WebSocket
-        ws_client, error = await get_connected_ws_client(client.base_url, client.token)
+        ws_client, error = await get_connected_ws_client(
+            client.base_url, client.token, verify_ssl=client.verify_ssl
+        )
         if error:
             raise_tool_error(error or create_error_response(
                 ErrorCode.CONNECTION_FAILED,

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -78,7 +78,7 @@ def extract_tool_error_message(te: ToolError) -> str:
 
 
 async def get_connected_ws_client(
-    base_url: str, token: str
+    base_url: str, token: str, verify_ssl: bool | None = None
 ) -> tuple[HomeAssistantWebSocketClient | None, dict[str, Any] | None]:
     """
     Create and connect a WebSocket client.
@@ -86,11 +86,15 @@ async def get_connected_ws_client(
     Args:
         base_url: Home Assistant base URL
         token: Authentication token
+        verify_ssl: TLS verification override. Pass ``client.verify_ssl``
+            from the calling REST client so a programmatic
+            ``HomeAssistantClient(verify_ssl=False)`` propagates to the
+            WebSocket too. ``None`` falls back to ``settings.verify_ssl``.
 
     Returns:
         Tuple of (ws_client, error_dict). If connection fails, ws_client is None.
     """
-    ws_client = HomeAssistantWebSocketClient(base_url, token)
+    ws_client = HomeAssistantWebSocketClient(base_url, token, verify_ssl=verify_ssl)
     connected = await ws_client.connect()
     if not connected:
         return None, create_connection_error(

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -232,7 +232,9 @@ async def _supervisor_api_call(
     """
     ws_client = None
     try:
-        ws_client, error = await get_connected_ws_client(client.base_url, client.token)
+        ws_client, error = await get_connected_ws_client(
+            client.base_url, client.token, verify_ssl=client.verify_ssl
+        )
         if error or ws_client is None:
             return error or create_connection_error(
                 "Failed to establish WebSocket connection",

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -290,7 +290,9 @@ class HistoryTools:
 
             # Connect to WebSocket (shared by both sources)
             ws_client, error = await get_connected_ws_client(
-                self._client.base_url, self._client.token
+                self._client.base_url,
+                self._client.token,
+                verify_ssl=self._client.verify_ssl,
             )
             if error or ws_client is None:
                 raise_tool_error(error or create_error_response(

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -415,7 +415,9 @@ class SystemTools:
             for subsequent optional fetches.
         """
         ws_client, error = await get_connected_ws_client(
-            self._client.base_url, self._client.token
+            self._client.base_url,
+            self._client.token,
+            verify_ssl=self._client.verify_ssl,
         )
         if error or ws_client is None:
             raise_tool_error(error or create_error_response(

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -167,7 +167,9 @@ class TraceTools:
 
             # Connect to WebSocket
             ws_client, error = await get_connected_ws_client(
-                self._client.base_url, self._client.token
+                self._client.base_url,
+                self._client.token,
+                verify_ssl=self._client.verify_ssl,
             )
             if error or ws_client is None:
                 raise_tool_error(error or create_error_response(

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -491,6 +491,51 @@ def _build_addon_image():
         pytest.fail(f"Failed to build {IMAGE_TAG}:\n{result.stderr}")
 
 
+class TestResolveBoolOption:
+    """Unit tests for the resolve_bool_option helper used for verify_ssl."""
+
+    @pytest.fixture(autouse=True)
+    def addon(self):
+        self.addon = _load_addon_start()
+
+    def test_missing_key_returns_default(self):
+        assert self.addon.resolve_bool_option({}, "verify_ssl", True) is True
+        assert self.addon.resolve_bool_option({}, "verify_ssl", False) is False
+
+    def test_explicit_false_returns_false(self):
+        assert (
+            self.addon.resolve_bool_option({"verify_ssl": False}, "verify_ssl", True)
+            is False
+        )
+
+    def test_explicit_true_returns_true(self):
+        assert (
+            self.addon.resolve_bool_option({"verify_ssl": True}, "verify_ssl", False)
+            is True
+        )
+
+    def test_string_value_falls_back_to_default(self):
+        # HA Supervisor coerces YAML scalars to the schema type, so a string
+        # here means user-edited options.json with a bad type. The secure
+        # default must win — never accept "false" as a string.
+        assert (
+            self.addon.resolve_bool_option({"verify_ssl": "false"}, "verify_ssl", True)
+            is True
+        )
+
+    def test_int_value_falls_back_to_default(self):
+        assert (
+            self.addon.resolve_bool_option({"verify_ssl": 0}, "verify_ssl", True)
+            is True
+        )
+
+    def test_none_value_falls_back_to_default(self):
+        assert (
+            self.addon.resolve_bool_option({"verify_ssl": None}, "verify_ssl", True)
+            is True
+        )
+
+
 @pytest.mark.slow
 class TestAddonStartup:
     """Test add-on container startup behavior."""

--- a/tests/src/unit/test_ssl_verification.py
+++ b/tests/src/unit/test_ssl_verification.py
@@ -1,0 +1,185 @@
+"""Unit tests for the HA_VERIFY_SSL toggle.
+
+Verifies that the verify_ssl setting flows from configuration into the
+REST httpx client and the WebSocket SSL context.
+"""
+
+import ssl
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_settings():
+    """Force ``get_global_settings`` to re-read environment in each test."""
+    import ha_mcp.config as cfg
+
+    cfg._settings = None
+    yield
+    cfg._settings = None
+
+
+class TestSettingsDefault:
+    """``Settings.verify_ssl`` reads from ``HA_VERIFY_SSL``."""
+
+    def test_default_is_true(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.config import get_settings
+
+        assert get_settings().verify_ssl is True
+
+    @pytest.mark.parametrize("falsey", ["false", "False", "0", "no", "off"])
+    def test_disabled_via_env(self, monkeypatch, falsey):
+        monkeypatch.setenv("HA_VERIFY_SSL", falsey)
+        from ha_mcp.config import get_settings
+
+        assert get_settings().verify_ssl is False
+
+    @pytest.mark.parametrize("truthy", ["true", "True", "1", "yes", "on"])
+    def test_enabled_via_env(self, monkeypatch, truthy):
+        monkeypatch.setenv("HA_VERIFY_SSL", truthy)
+        from ha_mcp.config import get_settings
+
+        assert get_settings().verify_ssl is True
+
+
+class TestRestClientUsesVerifySsl:
+    """``HomeAssistantClient`` forwards ``verify_ssl`` to ``httpx.AsyncClient``."""
+
+    def test_default_passes_verify_true(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
+            HomeAssistantClient(base_url="https://ha.local:8123", token="t")
+            kwargs = mock_async.call_args.kwargs
+            assert kwargs["verify"] is True
+
+    def test_explicit_false_disables_verification(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
+            HomeAssistantClient(
+                base_url="https://ha.local:8123", token="t", verify_ssl=False
+            )
+            kwargs = mock_async.call_args.kwargs
+            assert kwargs["verify"] is False
+
+    def test_env_false_propagates_to_httpx(self, monkeypatch):
+        monkeypatch.setenv("HA_VERIFY_SSL", "false")
+        monkeypatch.setenv("HOMEASSISTANT_URL", "https://ha.local:8123")
+        monkeypatch.setenv("HOMEASSISTANT_TOKEN", "t")
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
+            HomeAssistantClient()
+            kwargs = mock_async.call_args.kwargs
+            assert kwargs["verify"] is False
+
+    def test_warning_logged_when_disabled(self, monkeypatch, caplog):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with (
+            patch("ha_mcp.client.rest_client.httpx.AsyncClient"),
+            caplog.at_level("WARNING", logger="ha_mcp.client.rest_client"),
+        ):
+            HomeAssistantClient(
+                base_url="https://ha.local:8123",
+                token="t",
+                verify_ssl=False,
+            )
+        assert any("TLS verification disabled" in r.message for r in caplog.records)
+
+
+class TestWebSocketClientUsesVerifySsl:
+    """``HomeAssistantWebSocketClient`` builds an SSL context for wss:// URLs."""
+
+    @pytest.mark.asyncio
+    async def test_wss_with_verification_uses_default_context(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://ha.example.com:8123", token="t"
+        )
+
+        captured: dict = {}
+
+        async def fake_connect(*_args, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError("stop after capture")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        ctx = captured.get("ssl")
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+
+    @pytest.mark.asyncio
+    async def test_wss_without_verification_disables_checks(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://ha.example.com:8123", token="t", verify_ssl=False
+        )
+
+        captured: dict = {}
+
+        async def fake_connect(*_args, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError("stop after capture")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        ctx = captured.get("ssl")
+        assert isinstance(ctx, ssl.SSLContext)
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+    @pytest.mark.asyncio
+    async def test_ws_url_does_not_attach_ssl_context(self, monkeypatch):
+        """Plain ws:// URLs (e.g. supervisor proxy) must not get an SSL context."""
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="http://supervisor/core", token="t", verify_ssl=False
+        )
+
+        captured: dict = {}
+
+        async def fake_connect(*_args, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError("stop after capture")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert captured.get("ssl") is None
+
+    def test_constructor_falls_back_to_settings(self, monkeypatch):
+        monkeypatch.setenv("HA_VERIFY_SSL", "false")
+        monkeypatch.setenv("HOMEASSISTANT_URL", "https://ha.local:8123")
+        monkeypatch.setenv("HOMEASSISTANT_TOKEN", "t")
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://ha.local:8123", token="t"
+        )
+        assert client.verify_ssl is False

--- a/tests/src/unit/test_ssl_verification.py
+++ b/tests/src/unit/test_ssl_verification.py
@@ -4,6 +4,7 @@ Verifies that the verify_ssl setting flows from configuration into the
 REST httpx client and the WebSocket SSL context.
 """
 
+import logging
 import ssl
 from unittest.mock import patch
 
@@ -11,13 +12,13 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _reset_global_settings():
+def _reset_settings_singleton():
     """Force ``get_global_settings`` to re-read environment in each test."""
-    import ha_mcp.config as cfg
+    from ha_mcp.config import _reset_global_settings
 
-    cfg._settings = None
+    _reset_global_settings()
     yield
-    cfg._settings = None
+    _reset_global_settings()
 
 
 class TestSettingsDefault:
@@ -52,20 +53,22 @@ class TestRestClientUsesVerifySsl:
         from ha_mcp.client.rest_client import HomeAssistantClient
 
         with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
-            HomeAssistantClient(base_url="https://ha.local:8123", token="t")
+            client = HomeAssistantClient(base_url="https://ha.local:8123", token="t")
             kwargs = mock_async.call_args.kwargs
             assert kwargs["verify"] is True
+            assert client.verify_ssl is True
 
     def test_explicit_false_disables_verification(self, monkeypatch):
         monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
         from ha_mcp.client.rest_client import HomeAssistantClient
 
         with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
-            HomeAssistantClient(
+            client = HomeAssistantClient(
                 base_url="https://ha.local:8123", token="t", verify_ssl=False
             )
             kwargs = mock_async.call_args.kwargs
             assert kwargs["verify"] is False
+            assert client.verify_ssl is False
 
     def test_env_false_propagates_to_httpx(self, monkeypatch):
         monkeypatch.setenv("HA_VERIFY_SSL", "false")
@@ -78,20 +81,85 @@ class TestRestClientUsesVerifySsl:
             kwargs = mock_async.call_args.kwargs
             assert kwargs["verify"] is False
 
+    def test_oauth_path_falls_back_to_settings(self, monkeypatch):
+        # OAuth path passes base_url + token but no verify_ssl; setting
+        # in env must still take effect.
+        monkeypatch.setenv("HA_VERIFY_SSL", "false")
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with patch("ha_mcp.client.rest_client.httpx.AsyncClient"):
+            client = HomeAssistantClient(base_url="https://ha.local:8123", token="t")
+            assert client.verify_ssl is False
+
     def test_warning_logged_when_disabled(self, monkeypatch, caplog):
         monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
         from ha_mcp.client.rest_client import HomeAssistantClient
 
         with (
             patch("ha_mcp.client.rest_client.httpx.AsyncClient"),
-            caplog.at_level("WARNING", logger="ha_mcp.client.rest_client"),
+            caplog.at_level(logging.WARNING, logger="ha_mcp.client.rest_client"),
         ):
             HomeAssistantClient(
                 base_url="https://ha.local:8123",
                 token="t",
                 verify_ssl=False,
             )
-        assert any("TLS verification disabled" in r.message for r in caplog.records)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING when verify_ssl is False"
+
+    def test_no_warning_when_verification_enabled(self, monkeypatch, caplog):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.rest_client import HomeAssistantClient
+
+        with (
+            patch("ha_mcp.client.rest_client.httpx.AsyncClient"),
+            caplog.at_level(logging.WARNING, logger="ha_mcp.client.rest_client"),
+        ):
+            HomeAssistantClient(
+                base_url="https://ha.local:8123",
+                token="t",
+                verify_ssl=True,
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not warnings, (
+            f"expected no WARNINGs when verify_ssl=True, got: {warnings}"
+        )
+
+    def test_ssl_error_surfaces_actionable_hint(self, monkeypatch):
+        """A TLS failure with verify_ssl=True should mention HA_VERIFY_SSL."""
+        import httpx
+
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.rest_client import (
+            HomeAssistantClient,
+            HomeAssistantConnectionError,
+        )
+
+        underlying = ssl.SSLCertVerificationError("self-signed certificate")
+        wrapped = httpx.ConnectError("[SSL] certificate verify failed")
+        wrapped.__cause__ = underlying
+
+        with patch("ha_mcp.client.rest_client.httpx.AsyncClient") as mock_async:
+            mock_async.return_value.request = _AsyncRaiser(wrapped)
+            client = HomeAssistantClient(
+                base_url="https://ha.local:8123", token="t", verify_ssl=True
+            )
+
+            import asyncio
+
+            with pytest.raises(HomeAssistantConnectionError) as exc:
+                asyncio.run(client._raw_request("GET", "/states"))
+            assert "HA_VERIFY_SSL=false" in str(exc.value)
+
+
+class _AsyncRaiser:
+    """Minimal awaitable callable that always raises the given exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def __call__(self, *_args, **_kwargs):
+        raise self._exc
 
 
 class TestWebSocketClientUsesVerifySsl:
@@ -150,6 +218,38 @@ class TestWebSocketClientUsesVerifySsl:
         assert ctx.check_hostname is False
 
     @pytest.mark.asyncio
+    async def test_wss_with_path_still_attaches_ssl_context(self, monkeypatch):
+        """Path-bearing https URLs (proxy setups) must still build an SSL context."""
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://my-ha.example.com/proxy/core",
+            token="t",
+            verify_ssl=False,
+        )
+        # URL transform should produce wss:// preserving the path.
+        assert client.ws_url.startswith("wss://")
+        assert client.ws_url.endswith("/proxy/core/websocket")
+
+        captured_args: list = []
+        captured_kwargs: dict = {}
+
+        async def fake_connect(*args, **kwargs):
+            captured_args.extend(args)
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("stop after capture")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert captured_args[0].startswith("wss://")
+        assert isinstance(captured_kwargs.get("ssl"), ssl.SSLContext)
+
+    @pytest.mark.asyncio
     async def test_ws_url_does_not_attach_ssl_context(self, monkeypatch):
         """Plain ws:// URLs (e.g. supervisor proxy) must not get an SSL context."""
         monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
@@ -173,6 +273,40 @@ class TestWebSocketClientUsesVerifySsl:
 
         assert captured.get("ssl") is None
 
+    @pytest.mark.asyncio
+    async def test_warning_emitted_only_once_per_client(self, monkeypatch, caplog):
+        """Reconnect storms shouldn't spam the warning."""
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://ha.example.com:8123", token="t", verify_ssl=False
+        )
+
+        async def fake_connect(*_args, **_kwargs):
+            raise RuntimeError("stop after capture")
+
+        with (
+            patch(
+                "ha_mcp.client.websocket_client.websockets.connect",
+                side_effect=fake_connect,
+            ),
+            caplog.at_level(logging.WARNING, logger="ha_mcp.client.websocket_client"),
+        ):
+            await client.connect()
+            await client.connect()
+            await client.connect()
+
+        ssl_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "TLS verification disabled" in r.getMessage()
+        ]
+        assert len(ssl_warnings) == 1, (
+            f"expected exactly one TLS-disabled warning across 3 connects, got {len(ssl_warnings)}"
+        )
+
     def test_constructor_falls_back_to_settings(self, monkeypatch):
         monkeypatch.setenv("HA_VERIFY_SSL", "false")
         monkeypatch.setenv("HOMEASSISTANT_URL", "https://ha.local:8123")
@@ -183,3 +317,68 @@ class TestWebSocketClientUsesVerifySsl:
             url="https://ha.local:8123", token="t"
         )
         assert client.verify_ssl is False
+
+    def test_constructor_safe_default_when_settings_load_fails(
+        self, monkeypatch, caplog
+    ):
+        """Bad env elsewhere shouldn't silently flip TLS off."""
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        with (
+            patch(
+                "ha_mcp.client.websocket_client.get_global_settings",
+                side_effect=RuntimeError("settings unloadable"),
+            ),
+            caplog.at_level(logging.WARNING, logger="ha_mcp.client.websocket_client"),
+        ):
+            client = HomeAssistantWebSocketClient(
+                url="https://ha.local:8123", token="t"
+            )
+        assert client.verify_ssl is True
+        assert any(
+            "Could not load settings" in r.getMessage() for r in caplog.records
+        )
+
+
+class TestPoolFactoryHonorsEnv:
+    """``WebSocketManager``-built clients pick up ``HA_VERIFY_SSL`` from env."""
+
+    def test_factory_default_picks_up_env(self, monkeypatch):
+        monkeypatch.setenv("HA_VERIFY_SSL", "false")
+        monkeypatch.setenv("HOMEASSISTANT_URL", "https://ha.local:8123")
+        monkeypatch.setenv("HOMEASSISTANT_TOKEN", "t")
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        # The pool factory always calls the constructor positionally with
+        # only (url, token) — no verify_ssl. This mirrors that exact call
+        # shape so a regression where the factory starts hard-coding True
+        # is caught here.
+        client = HomeAssistantWebSocketClient("https://ha.local:8123", "t")
+        assert client.verify_ssl is False
+
+
+class TestHelperPropagatesVerifySsl:
+    """``get_connected_ws_client`` forwards ``verify_ssl`` to the WS client."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_false_propagates(self, monkeypatch):
+        monkeypatch.delenv("HA_VERIFY_SSL", raising=False)
+        from ha_mcp.tools import helpers as helpers_mod
+
+        captured: dict = {}
+
+        class FakeWsClient:
+            def __init__(self, base_url, token, *, verify_ssl=None):
+                captured["verify_ssl"] = verify_ssl
+
+            async def connect(self):
+                return True
+
+        with patch.object(
+            helpers_mod, "HomeAssistantWebSocketClient", FakeWsClient
+        ):
+            ws, error = await helpers_mod.get_connected_ws_client(
+                "https://ha.local:8123", "t", verify_ssl=False
+            )
+        assert error is None
+        assert captured["verify_ssl"] is False


### PR DESCRIPTION
## What does this PR do?

Closes #1018.

Adds a single `HA_VERIFY_SSL` boolean to disable TLS certificate verification on the REST + WebSocket clients. Some users (e.g. the reporter on #1018) connect to HA over HTTPS through a hostname that doesn't match the cert (`https://homeassistant.local:8123` with a Cloudflare-issued public cert, self-signed certs, etc.). `PYTHONHTTPSVERIFY=0` is not honored by `httpx` or `websockets`, so the only working fix is to plumb `verify=` and an `ssl.SSLContext` through the clients.

The toggle is exposed three ways so every install path covers it:

- **HA OS add-on** — new `verify_ssl` option (stable + dev `config.yaml` schemas, with translations + DOCS.md entries), wired through `homeassistant-addon/start.py` to the env var, sitting next to `enable_skills_as_tools` / `enable_tool_search` like the issue requested.
- **Docker / pip / pypi** — `HA_VERIFY_SSL=true|false` env var on `Settings`, documented in `.env.example`.
- **Programmatic** — `HomeAssistantClient(..., verify_ssl=False)` and `HomeAssistantWebSocketClient(..., verify_ssl=False)` for callers that construct clients directly.

When the toggle is off, both clients log a WARNING on every connect so the weakened state is visible in logs. `wss://` URLs get an `SSLContext` with `check_hostname=False` and `verify_mode=CERT_NONE`; plain `ws://` (Supervisor proxy) keeps getting `ssl=None` so we don't accidentally force TLS where there isn't any.

Default is `True` — nobody's existing setup changes unless they opt in.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit tests in `tests/src/unit/test_ssl_verification.py` cover:

- `HA_VERIFY_SSL` env-var parsing (truthy/falsey/default)
- `httpx.AsyncClient` receives the right `verify=` value (default, explicit, env-driven)
- WARNING is logged when the toggle is off
- WebSocket `wss://` builds an `SSLContext` with the expected `verify_mode` / `check_hostname` for both states
- Plain `ws://` URLs do **not** get an SSL context attached
- `HomeAssistantWebSocketClient` falls back to `Settings.verify_ssl` when no kwarg is passed

19 new tests pass; the existing `test_rest_client_*`, `test_websocket_client`, and the broader unit suite are unaffected (1473 passing on my box; the 3 pre-existing `test_resources.py` failures are an uninitialized `skills-vendor/` submodule on this checkout, unrelated).

`uv run mypy src/ha_mcp/{config,client/rest_client,client/websocket_client}.py` is clean.

## Checklist
- [x] I have updated documentation if needed