### PR TITLE
docs: address #1094 review nits on OpenCode mirror comments

### DIFF
--- a/site/src/content/clients/opencode.md
+++ b/site/src/content/clients/opencode.md
@@ -26,7 +26,9 @@ OpenCode merges configs from all locations (project overrides global). See [conf
 <!-- The uvx-stdio shape below (type, command, enabled, environment) is mirrored in: -->
 <!--   - site/src/pages/setup.astro (wizard `isOpenCode` branch) -->
 <!--   - site/src/data/clients.ts (legacy mirror entry) -->
-<!-- Keep all three aligned when editing. -->
+<!-- Keep these aligned when editing. -->
+<!-- Note: the Docker variant in setup.astro intentionally omits the top-level -->
+<!-- `environment` key (env vars are inlined as `-e KEY=VAL` in the command array). -->
 
 ```json
 {

--- a/site/src/data/clients.ts
+++ b/site/src/data/clients.ts
@@ -395,7 +395,9 @@ HOMEASSISTANT_TOKEN = "your_long_lived_token"`,
     configLocation: '~/.config/opencode/opencode.json (global) or opencode.json (project)',
     description: 'AI coding agent by Anomaly with native MCP support over stdio and streamable HTTP.',
     // uvx-stdio shape (type, command, enabled, environment) is mirrored in
-    // site/src/content/clients/opencode.md and site/src/pages/setup.astro — keep all three aligned.
+    // site/src/content/clients/opencode.md and site/src/pages/setup.astro — keep aligned.
+    // Note: the Docker variant in setup.astro intentionally omits the top-level
+    // `environment` key (env vars are inlined as `-e KEY=VAL` in the command array).
     config: `{
   "$schema": "https://opencode.ai/config.json",
   "mcp": {

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1335,7 +1335,7 @@ cloudflared tunnel run ha-mcp</code></pre>
         } else if (isOpenCode) {
           // OpenCode-specific stdio shape: type:"local", single command array, "environment" not "env"
           // The uvx-stdio shape (type, command, enabled, environment) is mirrored in
-          // site/src/content/clients/opencode.md and site/src/data/clients.ts — keep all three aligned.
+          // site/src/content/clients/opencode.md and site/src/data/clients.ts — keep aligned.
           // The Docker branch below intentionally omits the top-level `environment` key (env vars are
           // inlined as `-e KEY=VAL` in the command array), so the asymmetry is deliberate.
           const opencodeStdio = isDocker


### PR DESCRIPTION
## What does this PR do?

Two minor wording follow-ups to PR #1094, addressing optional nits from KP13's review (https://github.com/homeassistant-ai/ha-mcp/pull/1094#pullrequestreview-4216474820, marked "neither blocks merge"):

- Drop the hard-coded `"all three"` / `"Keep all three aligned"` phrasing in the OpenCode mirror cross-reference comments at `clients.ts:397`, `opencode.md:29`, and `setup.astro:1338`. The mirror peers are listed by name in each comment; the count adds noise without value.
- Add the Docker-asymmetry explanatory note to `clients.ts` and `opencode.md`, mirroring the existing note at `setup.astro:1339-1340`. Without it, a reader on either of those two files could misread the missing top-level `environment` key in the Docker variant as a bug.

No behaviour change; pure comments in `.ts` / `.md` / `.astro`.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent — N/A, comment-only changes
- [ ] All automated tests pass (`uv run pytest`) — N/A, no Python touched
- [ ] Code follows style guidelines (`uv run ruff check`) — N/A, no Python touched

## Checklist
- [x] I have updated documentation if needed — these are the documentation updates