### PR TITLE
feat: add "Advanced debug logging" toggle for kill-signal diagnostics

### DIFF
--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -28,6 +28,7 @@ options:
   disabled_tools: ""
   pinned_tools: ""
   verify_ssl: true
+  advanced_debug_logging: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
@@ -41,5 +42,6 @@ schema:
   disabled_tools: str?
   pinned_tools: str?
   verify_ssl: bool?
+  advanced_debug_logging: bool?
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -28,7 +28,6 @@ options:
   disabled_tools: ""
   pinned_tools: ""
   verify_ssl: true
-  advanced_debug_logging: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -85,3 +85,10 @@ configuration:
       certificate or hostname mismatch. Disabling weakens transport
       security — leave on unless you know you need it. Requires restart
       to take effect.
+  advanced_debug_logging:
+    name: Advanced debug logging
+    description: >-
+      Captures extra diagnostic info on kill/shutdown — sender PID,
+      memory state, and recent tool activity. Useful when reporting
+      unexplained add-on stops or crash loops. Off by default to keep
+      logs concise. Requires restart to take effect.

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -88,7 +88,7 @@ configuration:
   advanced_debug_logging:
     name: Advanced debug logging
     description: >-
-      Captures extra diagnostic info on kill/shutdown — sender PID,
-      memory state, and recent tool activity. Useful when reporting
-      unexplained add-on stops or crash loops. Off by default to keep
-      logs concise. Requires restart to take effect.
+      Captures extra diagnostic info on kill/shutdown — sender PID
+      and memory state. Useful when reporting unexplained add-on
+      stops or crash loops. Off by default to keep logs concise.
+      Requires restart to take effect.

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -31,6 +31,7 @@ options:
   enable_skills_as_tools: true
   enable_tool_search: false
   verify_ssl: true
+  advanced_debug_logging: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
@@ -38,6 +39,7 @@ schema:
   enable_skills_as_tools: bool?
   enable_tool_search: bool?
   verify_ssl: bool?
+  advanced_debug_logging: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:
   9583/tcp: 9583

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -31,7 +31,6 @@ options:
   enable_skills_as_tools: true
   enable_tool_search: false
   verify_ssl: true
-  advanced_debug_logging: false
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -390,14 +390,15 @@ def main() -> int:
     from ha_mcp.settings_ui import register_settings_routes
 
     if advanced_debug_logging:
-        # Captures sender PID + /proc state on SIGTERM/SIGINT/SIGHUP.
+        # Defers SA_SIGINFO install until uvicorn's capture_signals has
+        # run. Otherwise uvicorn's signal.signal() call would overwrite
+        # our handler before any signal arrived.
         # Wrapped because diagnostics must never block addon startup.
         try:
             from ha_mcp.utils.kill_signal_diagnostics import (
-                install_kill_signal_diagnostics,
+                schedule_install_after_uvicorn,
             )
-            if not install_kill_signal_diagnostics():
-                log_info("advanced_debug_logging requested but handler not installed; continuing")
+            schedule_install_after_uvicorn()
         except Exception as e:
             log_error(f"advanced_debug_logging install failed: {e!r}; continuing")
 

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -390,12 +390,16 @@ def main() -> int:
     from ha_mcp.settings_ui import register_settings_routes
 
     if advanced_debug_logging:
-        # Install kill-signal diagnostics so a future SIGTERM (e.g. the
-        # unexplained shutdowns reported in #1109) leaves a record of who
-        # sent the signal and what state the process was in. Off by default;
-        # users opt in via the "Advanced debug logging" addon option.
-        from ha_mcp.utils.kill_signal_diagnostics import install_kill_signal_diagnostics
-        install_kill_signal_diagnostics()
+        # Captures sender PID + /proc state on SIGTERM/SIGINT/SIGHUP.
+        # Wrapped because diagnostics must never block addon startup.
+        try:
+            from ha_mcp.utils.kill_signal_diagnostics import (
+                install_kill_signal_diagnostics,
+            )
+            if not install_kill_signal_diagnostics():
+                log_info("advanced_debug_logging requested but handler not installed; continuing")
+        except Exception as e:
+            log_error(f"advanced_debug_logging install failed: {e!r}; continuing")
 
     register_browser_landing(mcp, secret_path)
     # Mount settings UI routes both at root (for HA ingress proxy) and

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -279,6 +279,7 @@ def main() -> int:
     disabled_tools_raw = ""  # default
     pinned_tools_raw = ""  # default
     verify_ssl = True  # default
+    advanced_debug_logging = False  # default
     config_read_ok = True
 
     if config_file.exists():
@@ -306,6 +307,7 @@ def main() -> int:
             raw_pinned = config.get("pinned_tools", "")
             pinned_tools_raw = raw_pinned if isinstance(raw_pinned, str) else ""
             verify_ssl = resolve_bool_option(config, "verify_ssl", True)
+            advanced_debug_logging = resolve_bool_option(config, "advanced_debug_logging", False)
         except Exception as e:
             log_error(f"Failed to read config: {e}, using defaults")
             config_read_ok = False
@@ -337,6 +339,7 @@ def main() -> int:
 
     log_info(f"Backup hint mode: {backup_hint}")
     log_info(f"Verify SSL: {verify_ssl}")
+    log_info(f"Advanced debug logging: {advanced_debug_logging}")
 
     # Set up environment for ha-mcp
     os.environ["HOMEASSISTANT_URL"] = "http://supervisor/core"
@@ -385,6 +388,14 @@ def main() -> int:
         register_browser_landing,
     )
     from ha_mcp.settings_ui import register_settings_routes
+
+    if advanced_debug_logging:
+        # Install kill-signal diagnostics so a future SIGTERM (e.g. the
+        # unexplained shutdowns reported in #1109) leaves a record of who
+        # sent the signal and what state the process was in. Off by default;
+        # users opt in via the "Advanced debug logging" addon option.
+        from ha_mcp.utils.kill_signal_diagnostics import install_kill_signal_diagnostics
+        install_kill_signal_diagnostics()
 
     register_browser_landing(mcp, secret_path)
     # Mount settings UI routes both at root (for HA ingress proxy) and

--- a/src/ha_mcp/utils/kill_signal_diagnostics.py
+++ b/src/ha_mcp/utils/kill_signal_diagnostics.py
@@ -9,12 +9,29 @@ that, on SIGTERM/SIGINT/SIGHUP, captures and logs:
   ``siginfo_t`` (Python's ``signal.signal`` only sees ``signum``).
 - ``/proc/self/status`` snapshot of memory + OOM context.
 
-Then re-raises with the default disposition so Uvicorn shuts down cleanly.
-Linux-only by design (HA add-ons run on HAOS).
+Then chains to whatever handler was previously installed (typically
+uvicorn's ``handle_exit`` for SIGTERM/SIGINT) so the server still shuts
+down cleanly. SIGHUP, which uvicorn doesn't capture, falls back to
+libc-direct ``SIG_DFL`` + re-raise. Linux-only by design.
 
 Without this, the addon only sees that ``mcp.run()`` returned cleanly —
 it can't tell whether Supervisor sent SIGTERM, the OOM killer fired, a
 container watchdog acted, or something else.
+
+Install ordering
+----------------
+``signal.signal(...)`` from CPython calls libc's ``sigaction`` with no
+``SA_SIGINFO`` flag, which overwrites any ``SA_SIGINFO`` handler we
+installed first. uvicorn's ``Server.capture_signals()`` does exactly
+this for SIGTERM and SIGINT immediately after ``serve()`` enters. So
+installing from ``start.py`` *before* ``mcp.run()`` would silently lose
+the SA_SIGINFO bit before any signal arrives.
+
+``schedule_install_after_uvicorn`` spawns a daemon thread that polls
+``signal.getsignal`` until uvicorn's handler is detected (or a timeout
+elapses), then calls ``install_kill_signal_diagnostics`` which captures
+the existing handler and overlays SA_SIGINFO on top. The handler chains
+to the captured handler so uvicorn still receives the shutdown signal.
 
 Async-signal-safety
 -------------------
@@ -25,16 +42,14 @@ The handler is best-effort, not strict POSIX AS-safe:
   ``threading.Lock`` is held by the main thread during normal tool calls
   and would deadlock the handler.
 - It uses ``os.write(STDERR_FILENO, ...)`` (AS-safe) instead of ``print``.
-- It restores default disposition via direct ``libc.signal(sig, SIG_DFL)``
-  and re-raises with ``kill(2)`` (both AS-safe), avoiding CPython's
-  ``signal.signal`` machinery which assumes main-thread + bytecode
-  boundary.
+- It chains to the captured uvicorn handler in pure Python (uvicorn's
+  ``handle_exit`` only sets attributes — synchronous, no locks). The
+  fallback re-raise path uses ``libc.signal(sig, SIG_DFL)`` and
+  ``kill(2)`` directly (both AS-safe).
 - ``/proc`` reads use ``open(2)``, which POSIX classifies as not strictly
   AS-safe. In practice the kernel side of ``/proc`` doesn't take
   userspace-allocator locks, so this is acceptable for an opt-in
-  diagnostic. If the assumption ever breaks, the worst case is a partial
-  diagnostic block — the libc-direct re-raise is still a single AS-safe
-  syscall and the kernel still delivers the default-disposition signal.
+  diagnostic.
 
 ctypes adds one more theoretical risk: the trampoline acquires the GIL
 on entry to Python code. In a single-threaded asyncio event loop (this
@@ -50,6 +65,9 @@ import logging
 import os
 import signal
 import sys
+import threading
+import time
+from collections.abc import Callable
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -224,6 +242,9 @@ def format_diagnostic_block(
 # it a future maintainer will delete it and ship a use-after-free.
 _handler_refs: list[Any] = []
 _libc: Any = None
+# Captured at install time so our handler can chain back to whatever
+# was installed before (typically uvicorn's handle_exit).
+_chained_handlers: dict[int, Any] = {}
 
 
 def _emit_block_safely(block: str) -> None:
@@ -248,6 +269,24 @@ def _restore_default_and_reraise(signum: int) -> None:
         except OSError:
             pass
     os.kill(os.getpid(), signum)
+
+
+def _chain_or_reraise(signum: int) -> None:
+    """Hand control to the previously-installed handler, or re-raise default.
+
+    Uvicorn's ``handle_exit`` only sets ``self.should_exit`` (synchronous,
+    no locks), so calling it directly from this trampoline is safe.
+    """
+    chained = _chained_handlers.get(signum)
+    if callable(chained):
+        try:
+            chained(signum, None)
+            return
+        except Exception:
+            # Fall through to the default-disposition path so the
+            # process still terminates if the chained handler explodes.
+            pass
+    _restore_default_and_reraise(signum)
 
 
 def _make_handler() -> Any:
@@ -283,18 +322,22 @@ def _make_handler() -> Any:
             except OSError:
                 pass
 
-        _restore_default_and_reraise(signum)
+        _chain_or_reraise(signum)
 
     return _SignalHandler(_handler)
 
 
 def install_kill_signal_diagnostics() -> bool:
-    """Install the SA_SIGINFO signal handler. Returns True if at least one
-    signal was installed; False on non-Linux, missing libc, or if every
-    sigaction call failed. Idempotent — second call is a no-op.
+    """Install the SA_SIGINFO signal handler.
 
-    Never raises: callers don't need to wrap in try/except. This contract
-    is load-bearing — diagnostics must not block addon startup.
+    Captures any previously-installed handler (e.g. uvicorn's
+    ``handle_exit``) via ``signal.getsignal`` so the SA_SIGINFO handler
+    can chain to it. Idempotent — second call is a no-op.
+
+    Returns True if at least one signal was installed; False on
+    non-Linux, missing libc, or if every sigaction call failed. Never
+    raises: callers don't need to wrap in try/except. This contract is
+    load-bearing — diagnostics must not block addon startup.
     """
     global _libc
 
@@ -326,6 +369,14 @@ def install_kill_signal_diagnostics() -> bool:
         libc.signal.argtypes = [ctypes.c_int, ctypes.c_void_p]
         _libc = libc
 
+        # Snapshot the existing handler for each instrumented signal
+        # before we overwrite. This is what we chain back to so uvicorn
+        # (or whoever was there) still receives the shutdown signal.
+        for sig in _INSTRUMENTED_SIGNALS:
+            existing = signal.getsignal(int(sig))
+            if callable(existing):
+                _chained_handlers[int(sig)] = existing
+
         handler = _make_handler()
         _handler_refs.append(handler)
 
@@ -353,15 +404,70 @@ def install_kill_signal_diagnostics() -> bool:
             exc,
         )
         _handler_refs.clear()
+        _chained_handlers.clear()
         _libc = None
         return False
 
     if installed_for:
+        chained_signals = sorted(signal.Signals(s).name for s in _chained_handlers)
         logger.info(
-            "advanced_debug_logging enabled — kill-signal diagnostics installed for: %s",
+            "advanced_debug_logging enabled — kill-signal diagnostics installed for: %s "
+            "(chains to existing handlers for: %s)",
             ", ".join(installed_for),
+            ", ".join(chained_signals) or "<none>",
         )
         return True
     _handler_refs.clear()
+    _chained_handlers.clear()
     _libc = None
     return False
+
+
+def schedule_install_after_uvicorn(
+    *,
+    timeout_secs: float = 10.0,
+    poll_interval_secs: float = 0.1,
+    install: Callable[[], bool] = install_kill_signal_diagnostics,
+) -> threading.Thread:
+    """Defer install until uvicorn's ``capture_signals()`` has run.
+
+    uvicorn's ``Server.capture_signals()`` calls
+    ``signal.signal(SIGTERM/SIGINT, handle_exit)`` immediately after
+    ``Server.serve()`` enters. Python's ``signal.signal`` reaches libc's
+    ``sigaction`` *without* ``SA_SIGINFO``, so any handler we installed
+    before ``mcp.run()`` would lose its SA_SIGINFO bit before any signal
+    arrived. This polls ``signal.getsignal(SIGTERM)`` from a daemon
+    thread until uvicorn replaces the default disposition, then calls
+    ``install`` so our SA_SIGINFO handler lands on top and chains to
+    uvicorn's ``handle_exit``.
+
+    If uvicorn never installs (e.g. addon was started without HTTP
+    transport), install runs anyway after ``timeout_secs``.
+
+    Returns the started thread so callers can ``.join()`` in tests.
+    """
+
+    def _wait_then_install() -> None:
+        deadline = time.monotonic() + timeout_secs
+        while time.monotonic() < deadline:
+            current = signal.getsignal(signal.SIGTERM)
+            if callable(current) and current not in (signal.SIG_DFL, signal.SIG_IGN):
+                logger.debug(
+                    "advanced_debug_logging: detected uvicorn signal handler; installing on top"
+                )
+                install()
+                return
+            time.sleep(poll_interval_secs)
+        logger.info(
+            "advanced_debug_logging: uvicorn handler not detected within %.1fs; installing anyway",
+            timeout_secs,
+        )
+        install()
+
+    thread = threading.Thread(
+        target=_wait_then_install,
+        name="kill-signal-diagnostics-install",
+        daemon=True,
+    )
+    thread.start()
+    return thread

--- a/src/ha_mcp/utils/kill_signal_diagnostics.py
+++ b/src/ha_mcp/utils/kill_signal_diagnostics.py
@@ -213,15 +213,30 @@ def format_diagnostic_block(
     sig_name = signal.Signals(signum).name if signum in signal.Signals.__members__.values() else str(signum)
     code_name = _SI_CODE_NAMES.get(si_code, f"SI_UNKNOWN({si_code})")
 
+    # si_pid == 0 from the kernel means the sender was outside our PID
+    # namespace (typically Supervisor or the host) — its PID didn't
+    # translate, so /proc/0/{comm,cmdline} can't resolve. Render an
+    # explicit label so the diagnostic isn't read as "we failed to
+    # capture the sender" — the cross-namespace case is itself the
+    # signal in #1109-style reports.
+    if sender_pid == 0:
+        sender_pid_str = "0 (cross-namespace; likely Supervisor or host process)"
+        sender_comm_str = "<cross-namespace>"
+        sender_cmdline_str = "<cross-namespace>"
+    else:
+        sender_pid_str = str(sender_pid)
+        sender_comm_str = sender_comm or "<unavailable>"
+        sender_cmdline_str = sender_cmdline or "<unavailable>"
+
     lines = [
         "=" * 80,
         "ADVANCED DEBUG LOGGING — kill-signal diagnostics",
         "=" * 80,
         f"Signal:         {sig_name} ({signum})",
         f"si_code:        {code_name}",
-        f"Sender PID:     {sender_pid}",
-        f"Sender comm:    {sender_comm or '<unavailable>'}",
-        f"Sender cmdline: {sender_cmdline or '<unavailable>'}",
+        f"Sender PID:     {sender_pid_str}",
+        f"Sender comm:    {sender_comm_str}",
+        f"Sender cmdline: {sender_cmdline_str}",
         "",
         "Process state (from /proc/self/status):",
     ]

--- a/src/ha_mcp/utils/kill_signal_diagnostics.py
+++ b/src/ha_mcp/utils/kill_signal_diagnostics.py
@@ -1,0 +1,312 @@
+"""Kill-signal diagnostics for the HA MCP add-on.
+
+Opt-in (gated by the `Advanced debug logging` add-on toggle) signal handler
+that, on SIGTERM/SIGINT/SIGHUP, captures and logs:
+
+- Signal name, `si_code`, and the sender PID/comm/cmdline (via Linux
+  `sigaction` + `SA_SIGINFO` through `ctypes` — Python's `signal.signal()`
+  doesn't expose `siginfo_t`).
+- `/proc/self/status` snapshot of memory and OOM context.
+- Recent tool-usage and startup log entries (in-memory, no extra collection).
+
+Then re-raises Python's default disposition for the signal so Uvicorn still
+shuts down cleanly. Linux-only by design (HA add-ons run on HAOS).
+
+The handler exists to surface *who* terminated the process when "watchdog
+disabled, server stops anyway" reports come in (see issue #1109). Without
+this, the add-on can only see that mcp.run() returned cleanly — not who
+asked for it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import logging
+import os
+import signal
+import sys
+from typing import Any
+
+from .usage_logger import get_recent_logs, get_startup_logs
+
+logger = logging.getLogger(__name__)
+
+# Signals we want to instrument. SIGKILL/SIGSTOP are uncatchable by design.
+_INSTRUMENTED_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
+
+# si_code constants (from <bits/siginfo-consts.h>). The values are stable across
+# glibc/musl and the Linux kernel ABI; replicating here avoids a libc lookup.
+_SI_CODE_NAMES = {
+    0: "SI_USER",  # kill(2), raise(3)
+    -1: "SI_KERNEL",
+    -2: "SI_QUEUE",  # sigqueue(3)
+    -3: "SI_TIMER",
+    -4: "SI_MESGQ",
+    -5: "SI_ASYNCIO",
+    -6: "SI_SIGIO",
+    -7: "SI_TKILL",  # tkill(2), tgkill(2)
+}
+
+
+class _Siginfo(ctypes.Structure):
+    """Minimal `siginfo_t` layout — we only need the leading kill-related fields.
+
+    The real struct is a tagged union with many cases; the first four ints
+    plus si_pid/si_uid are always present in the layout for kill-style signals
+    on Linux glibc/musl. We allocate a generous tail so writes past the union
+    boundary by the kernel can't corrupt adjacent stack/heap.
+    """
+
+    _fields_ = [
+        ("si_signo", ctypes.c_int),
+        ("si_errno", ctypes.c_int),
+        ("si_code", ctypes.c_int),
+        ("_pad0", ctypes.c_int),  # alignment to 8 on 64-bit
+        ("si_pid", ctypes.c_int),
+        ("si_uid", ctypes.c_uint),
+        ("_tail", ctypes.c_byte * 116),  # rest of siginfo_t (sigaction reserves 128 bytes)
+    ]
+
+
+_SignalHandler = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.POINTER(_Siginfo), ctypes.c_void_p)
+
+
+class _Sigaction(ctypes.Structure):
+    _fields_ = [
+        ("sa_sigaction", _SignalHandler),
+        ("sa_mask", ctypes.c_byte * 128),  # sigset_t — opaque, zeroed
+        ("sa_flags", ctypes.c_int),
+        ("sa_restorer", ctypes.c_void_p),
+    ]
+
+
+_SA_SIGINFO = 0x00000004
+_SA_RESTART = 0x10000000
+
+
+def read_proc_status_summary() -> dict[str, str]:
+    """Return a small dict of memory/OOM-relevant fields from /proc/self/status.
+
+    Returns an empty dict on non-Linux or if /proc/self/status is unreadable
+    so callers don't need to special-case missing data.
+    """
+    fields = {"VmRSS", "VmHWM", "VmPeak", "Threads", "State", "oom_score", "oom_score_adj"}
+    out: dict[str, str] = {}
+    try:
+        with open("/proc/self/status", encoding="utf-8") as f:
+            for line in f:
+                key, _, value = line.partition(":")
+                if key in fields:
+                    out[key] = value.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def read_proc_comm(pid: int) -> str:
+    """Return the `comm` (process name, max 15 chars) for the given PID.
+
+    Returns an empty string if the PID is gone or /proc isn't available.
+    """
+    if pid <= 0:
+        return ""
+    try:
+        with open(f"/proc/{pid}/comm", encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def read_proc_cmdline(pid: int) -> str:
+    """Return the cmdline (argv joined by spaces) for the given PID.
+
+    Cmdline can be more informative than comm (which is truncated to 15 chars
+    and often shows just "supervisor" for many distinct binaries). Returns an
+    empty string if unavailable.
+    """
+    if pid <= 0:
+        return ""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as f:
+            raw = f.read()
+    except OSError:
+        return ""
+    return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
+
+
+def format_diagnostic_block(
+    *,
+    signum: int,
+    si_code: int,
+    sender_pid: int,
+    sender_comm: str,
+    sender_cmdline: str,
+    proc_status: dict[str, str],
+    recent_tool_logs: list[dict[str, Any]],
+    startup_logs: list[dict[str, Any]],
+) -> str:
+    """Compose the multi-line log block written when a signal is caught."""
+    sig_name = signal.Signals(signum).name if signum in signal.Signals.__members__.values() else str(signum)
+    code_name = _SI_CODE_NAMES.get(si_code, f"SI_UNKNOWN({si_code})")
+
+    lines = [
+        "=" * 80,
+        "ADVANCED DEBUG LOGGING — kill-signal diagnostics",
+        "=" * 80,
+        f"Signal:         {sig_name} ({signum})",
+        f"si_code:        {code_name}",
+        f"Sender PID:     {sender_pid}",
+        f"Sender comm:    {sender_comm or '<unavailable>'}",
+        f"Sender cmdline: {sender_cmdline or '<unavailable>'}",
+        "",
+        "Process state (from /proc/self/status):",
+    ]
+    if proc_status:
+        lines.extend(
+            f"  {key}: {proc_status[key]}"
+            for key in ("State", "VmRSS", "VmHWM", "VmPeak", "Threads", "oom_score", "oom_score_adj")
+            if key in proc_status
+        )
+    else:
+        lines.append("  <unavailable — non-Linux or /proc not mounted>")
+
+    lines.append("")
+    lines.append(f"Last {len(recent_tool_logs)} tool calls:")
+    if recent_tool_logs:
+        for entry in recent_tool_logs:
+            ts = entry.get("timestamp", "?")
+            tool = entry.get("tool_name", "?")
+            ok = "OK" if entry.get("success") else "FAIL"
+            ms = entry.get("execution_time_ms", 0)
+            lines.append(f"  {ts} | {tool} | {ok} | {ms:.1f}ms")
+    else:
+        lines.append("  <ring buffer empty>")
+
+    lines.append("")
+    lines.append(f"Recent startup log ({len(startup_logs)} entries):")
+    if startup_logs:
+        for entry in startup_logs[-15:]:  # tail to keep the block bounded
+            ts = entry.get("elapsed_seconds", "?")
+            level = entry.get("level", "?")
+            msg = entry.get("message", "")
+            lines.append(f"  +{ts}s | {level} | {msg}")
+    else:
+        lines.append("  <startup buffer empty>")
+
+    lines.append("=" * 80)
+    return "\n".join(lines)
+
+
+# Keep references to ctypes objects for the lifetime of the process so the
+# kernel-installed pointer isn't garbage-collected mid-flight.
+_handler_refs: list[Any] = []
+
+
+def _make_handler() -> Any:
+    """Build the C-callable signal handler closure.
+
+    Returns a ``_SignalHandler`` (a ``ctypes.CFUNCTYPE`` instance). Annotated
+    as ``Any`` because Pyright doesn't accept dynamically-generated ctypes
+    function pointer types in static type expressions.
+    """
+
+    def _handler(signum: int, info_ptr: Any, _ucontext: int) -> None:
+        # Keep the handler small and async-signal-safe-ish: collect data, log,
+        # then re-raise the signal with the default disposition so Uvicorn
+        # observes a normal shutdown.
+        try:
+            info = info_ptr.contents
+            si_code = int(info.si_code)
+            sender_pid = int(info.si_pid)
+            sender_comm = read_proc_comm(sender_pid)
+            sender_cmdline = read_proc_cmdline(sender_pid)
+            proc_status = read_proc_status_summary()
+            try:
+                recent = get_recent_logs(max_entries=20)
+            except Exception:
+                recent = []
+            try:
+                startup = get_startup_logs()
+            except Exception:
+                startup = []
+
+            block = format_diagnostic_block(
+                signum=signum,
+                si_code=si_code,
+                sender_pid=sender_pid,
+                sender_comm=sender_comm,
+                sender_cmdline=sender_cmdline,
+                proc_status=proc_status,
+                recent_tool_logs=recent,
+                startup_logs=startup,
+            )
+            # Use stderr directly: logging may have async handlers that don't
+            # flush before the process re-raises and exits.
+            print(block, file=sys.stderr, flush=True)
+        except Exception as exc:  # pragma: no cover — last-resort safety
+            print(
+                f"advanced_debug_logging handler failed: {exc!r}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        # Restore default disposition and re-raise so the process exits the
+        # way Uvicorn (and Supervisor) expect.
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    return _SignalHandler(_handler)
+
+
+def install_kill_signal_diagnostics() -> bool:
+    """Install the SA_SIGINFO signal handler. Returns True if installed.
+
+    Logs a warning and returns False on non-Linux platforms or if libc
+    lookup fails — callers don't need to special-case those environments.
+    """
+    if sys.platform != "linux":
+        logger.warning(
+            "advanced_debug_logging is Linux-only; skipping signal handler install on %s",
+            sys.platform,
+        )
+        return False
+
+    libc_path = ctypes.util.find_library("c")
+    if libc_path is None:
+        logger.warning("advanced_debug_logging: libc not found; skipping signal handler install")
+        return False
+
+    libc = ctypes.CDLL(libc_path, use_errno=True)
+    libc.sigaction.restype = ctypes.c_int
+    libc.sigaction.argtypes = [ctypes.c_int, ctypes.POINTER(_Sigaction), ctypes.POINTER(_Sigaction)]
+
+    handler = _make_handler()
+    _handler_refs.append(handler)
+
+    sa = _Sigaction()
+    ctypes.memset(ctypes.byref(sa), 0, ctypes.sizeof(sa))
+    sa.sa_sigaction = handler
+    sa.sa_flags = _SA_SIGINFO | _SA_RESTART
+    _handler_refs.append(sa)
+
+    installed_for: list[str] = []
+    for sig in _INSTRUMENTED_SIGNALS:
+        rc = libc.sigaction(int(sig), ctypes.byref(sa), None)
+        if rc != 0:
+            err = ctypes.get_errno()
+            logger.warning(
+                "advanced_debug_logging: sigaction(%s) failed: errno=%d",
+                sig.name,
+                err,
+            )
+            continue
+        installed_for.append(sig.name)
+
+    if installed_for:
+        logger.info(
+            "advanced_debug_logging enabled — kill-signal diagnostics installed for: %s",
+            ", ".join(installed_for),
+        )
+        return True
+    return False

--- a/src/ha_mcp/utils/kill_signal_diagnostics.py
+++ b/src/ha_mcp/utils/kill_signal_diagnostics.py
@@ -1,21 +1,45 @@
 """Kill-signal diagnostics for the HA MCP add-on.
 
-Opt-in (gated by the `Advanced debug logging` add-on toggle) signal handler
+Opt-in (gated by the "Advanced debug logging" addon toggle) signal handler
 that, on SIGTERM/SIGINT/SIGHUP, captures and logs:
 
-- Signal name, `si_code`, and the sender PID/comm/cmdline (via Linux
-  `sigaction` + `SA_SIGINFO` through `ctypes` — Python's `signal.signal()`
-  doesn't expose `siginfo_t`).
-- `/proc/self/status` snapshot of memory and OOM context.
-- Recent tool-usage and startup log entries (in-memory, no extra collection).
+- Signal name + ``si_code`` (USER/KERNEL/QUEUE/TKILL/...).
+- Sender PID + its ``comm`` and ``cmdline`` from ``/proc/<pid>``, captured
+  via ``sigaction(SA_SIGINFO)`` through ``ctypes`` so we can read
+  ``siginfo_t`` (Python's ``signal.signal`` only sees ``signum``).
+- ``/proc/self/status`` snapshot of memory + OOM context.
 
-Then re-raises Python's default disposition for the signal so Uvicorn still
-shuts down cleanly. Linux-only by design (HA add-ons run on HAOS).
+Then re-raises with the default disposition so Uvicorn shuts down cleanly.
+Linux-only by design (HA add-ons run on HAOS).
 
-The handler exists to surface *who* terminated the process when "watchdog
-disabled, server stops anyway" reports come in (see issue #1109). Without
-this, the add-on can only see that mcp.run() returned cleanly — not who
-asked for it.
+Without this, the addon only sees that ``mcp.run()`` returned cleanly —
+it can't tell whether Supervisor sent SIGTERM, the OOM killer fired, a
+container watchdog acted, or something else.
+
+Async-signal-safety
+-------------------
+The handler is best-effort, not strict POSIX AS-safe:
+
+- It does **not** call any code that takes Python-level locks; the
+  ``usage_logger`` ring buffer is intentionally excluded because its
+  ``threading.Lock`` is held by the main thread during normal tool calls
+  and would deadlock the handler.
+- It uses ``os.write(STDERR_FILENO, ...)`` (AS-safe) instead of ``print``.
+- It restores default disposition via direct ``libc.signal(sig, SIG_DFL)``
+  and re-raises with ``kill(2)`` (both AS-safe), avoiding CPython's
+  ``signal.signal`` machinery which assumes main-thread + bytecode
+  boundary.
+- ``/proc`` reads use ``open(2)``, which POSIX classifies as not strictly
+  AS-safe. In practice the kernel side of ``/proc`` doesn't take
+  userspace-allocator locks, so this is acceptable for an opt-in
+  diagnostic. If the assumption ever breaks, the worst case is a partial
+  diagnostic block — the libc-direct re-raise is still a single AS-safe
+  syscall and the kernel still delivers the default-disposition signal.
+
+ctypes adds one more theoretical risk: the trampoline acquires the GIL
+on entry to Python code. In a single-threaded asyncio event loop (this
+addon's shape) the GIL acquisition is a no-op when the handler runs on
+the main thread. Multi-threaded callers should evaluate before enabling.
 """
 
 from __future__ import annotations
@@ -28,45 +52,60 @@ import signal
 import sys
 from typing import Any
 
-from .usage_logger import get_recent_logs, get_startup_logs
-
 logger = logging.getLogger(__name__)
 
-# Signals we want to instrument. SIGKILL/SIGSTOP are uncatchable by design.
+# SIGKILL/SIGSTOP omitted — uncatchable by design.
 _INSTRUMENTED_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP)
 
-# si_code constants (from <bits/siginfo-consts.h>). The values are stable across
-# glibc/musl and the Linux kernel ABI; replicating here avoids a libc lookup.
+# si_code constants from Linux's <asm-generic/siginfo.h>. Pinned in
+# tests so a wrong value can't silently mislabel diagnostics.
 _SI_CODE_NAMES = {
-    0: "SI_USER",  # kill(2), raise(3)
-    -1: "SI_KERNEL",
-    -2: "SI_QUEUE",  # sigqueue(3)
-    -3: "SI_TIMER",
-    -4: "SI_MESGQ",
-    -5: "SI_ASYNCIO",
-    -6: "SI_SIGIO",
-    -7: "SI_TKILL",  # tkill(2), tgkill(2)
+    0: "SI_USER",
+    0x80: "SI_KERNEL",
+    -1: "SI_QUEUE",
+    -2: "SI_TIMER",
+    -3: "SI_MESGQ",
+    -4: "SI_ASYNCIO",
+    -5: "SI_SIGIO",
+    -6: "SI_TKILL",
 }
 
 
 class _Siginfo(ctypes.Structure):
-    """Minimal `siginfo_t` layout — we only need the leading kill-related fields.
+    """Minimal ``siginfo_t`` for kill-style signals.
 
-    The real struct is a tagged union with many cases; the first four ints
-    plus si_pid/si_uid are always present in the layout for kill-style signals
-    on Linux glibc/musl. We allocate a generous tail so writes past the union
-    boundary by the kernel can't corrupt adjacent stack/heap.
+    Linux's ``siginfo_t`` is arch-dependent: on architectures without
+    ``__ARCH_HAS_SWAPPED_SIGINFO`` (x86, x86_64, arm, aarch64 — all of
+    the addon's target arches), the leading layout is ``si_signo``,
+    ``si_errno``, ``si_code``, then the ``_kill`` union starting with
+    ``si_pid`` / ``si_uid``. Trailing bytes are reserved padding from
+    the kernel's ``SI_MAX_SIZE = 128``.
     """
 
     _fields_ = [
         ("si_signo", ctypes.c_int),
         ("si_errno", ctypes.c_int),
         ("si_code", ctypes.c_int),
-        ("_pad0", ctypes.c_int),  # alignment to 8 on 64-bit
+        ("_pad0", ctypes.c_int),  # 64-bit alignment for the _kill union
         ("si_pid", ctypes.c_int),
         ("si_uid", ctypes.c_uint),
-        ("_tail", ctypes.c_byte * 116),  # rest of siginfo_t (sigaction reserves 128 bytes)
+        # Pad out to the kernel's SI_MAX_SIZE so libc writes the full
+        # union without truncating.
+        ("_tail", ctypes.c_byte * 104),
     ]
+
+
+# Pinned by SI_MAX_SIZE in the kernel. If a future ctypes change shifts
+# field offsets, fail loudly at import rather than during signal delivery.
+assert ctypes.sizeof(_Siginfo) == 128, (
+    f"_Siginfo size {ctypes.sizeof(_Siginfo)} != kernel SI_MAX_SIZE 128"
+)
+assert _Siginfo.si_pid.offset == 16, (
+    f"_Siginfo.si_pid offset {_Siginfo.si_pid.offset} != expected 16"
+)
+assert _Siginfo.si_uid.offset == 20, (
+    f"_Siginfo.si_uid offset {_Siginfo.si_uid.offset} != expected 20"
+)
 
 
 _SignalHandler = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.POINTER(_Siginfo), ctypes.c_void_p)
@@ -84,18 +123,23 @@ class _Sigaction(ctypes.Structure):
 _SA_SIGINFO = 0x00000004
 _SA_RESTART = 0x10000000
 
+# SIG_DFL = 0 cast to a function pointer; libc.signal accepts this to
+# restore the kernel's default disposition.
+_SIG_DFL_PTR = ctypes.c_void_p(0)
+
 
 def read_proc_status_summary() -> dict[str, str]:
     """Return a small dict of memory/OOM-relevant fields from /proc/self/status.
 
-    Returns an empty dict on non-Linux or if /proc/self/status is unreadable
-    so callers don't need to special-case missing data.
+    Empty dict on non-Linux or unreadable status — callers don't need
+    to special-case missing data.
     """
     fields = {"VmRSS", "VmHWM", "VmPeak", "Threads", "State", "oom_score", "oom_score_adj"}
     out: dict[str, str] = {}
     try:
-        with open("/proc/self/status", encoding="utf-8") as f:
-            for line in f:
+        with open("/proc/self/status", "rb") as f:
+            for raw_line in f:
+                line = raw_line.decode("utf-8", errors="replace")
                 key, _, value = line.partition(":")
                 if key in fields:
                     out[key] = value.strip()
@@ -105,15 +149,18 @@ def read_proc_status_summary() -> dict[str, str]:
 
 
 def read_proc_comm(pid: int) -> str:
-    """Return the `comm` (process name, max 15 chars) for the given PID.
+    """Return the ``comm`` (process name, ≤15 chars) for the given PID.
 
-    Returns an empty string if the PID is gone or /proc isn't available.
+    Empty string if the PID is gone or /proc isn't available. Reads as
+    bytes + ``errors="replace"`` because comm can contain arbitrary
+    bytes (set via ``prctl(PR_SET_NAME)``) — strict UTF-8 decode would
+    raise on those.
     """
     if pid <= 0:
         return ""
     try:
-        with open(f"/proc/{pid}/comm", encoding="utf-8") as f:
-            return f.read().strip()
+        with open(f"/proc/{pid}/comm", "rb") as f:
+            return f.read().decode("utf-8", errors="replace").strip()
     except OSError:
         return ""
 
@@ -121,9 +168,9 @@ def read_proc_comm(pid: int) -> str:
 def read_proc_cmdline(pid: int) -> str:
     """Return the cmdline (argv joined by spaces) for the given PID.
 
-    Cmdline can be more informative than comm (which is truncated to 15 chars
-    and often shows just "supervisor" for many distinct binaries). Returns an
-    empty string if unavailable.
+    Cmdline can be more informative than ``comm`` (which is truncated to
+    15 chars and often shows just "supervisor" for many distinct
+    binaries). Empty string if unavailable.
     """
     if pid <= 0:
         return ""
@@ -143,8 +190,6 @@ def format_diagnostic_block(
     sender_comm: str,
     sender_cmdline: str,
     proc_status: dict[str, str],
-    recent_tool_logs: list[dict[str, Any]],
-    startup_logs: list[dict[str, Any]],
 ) -> str:
     """Compose the multi-line log block written when a signal is caught."""
     sig_name = signal.Signals(signum).name if signum in signal.Signals.__members__.values() else str(signum)
@@ -170,101 +215,89 @@ def format_diagnostic_block(
         )
     else:
         lines.append("  <unavailable — non-Linux or /proc not mounted>")
-
-    lines.append("")
-    lines.append(f"Last {len(recent_tool_logs)} tool calls:")
-    if recent_tool_logs:
-        for entry in recent_tool_logs:
-            ts = entry.get("timestamp", "?")
-            tool = entry.get("tool_name", "?")
-            ok = "OK" if entry.get("success") else "FAIL"
-            ms = entry.get("execution_time_ms", 0)
-            lines.append(f"  {ts} | {tool} | {ok} | {ms:.1f}ms")
-    else:
-        lines.append("  <ring buffer empty>")
-
-    lines.append("")
-    lines.append(f"Recent startup log ({len(startup_logs)} entries):")
-    if startup_logs:
-        for entry in startup_logs[-15:]:  # tail to keep the block bounded
-            ts = entry.get("elapsed_seconds", "?")
-            level = entry.get("level", "?")
-            msg = entry.get("message", "")
-            lines.append(f"  +{ts}s | {level} | {msg}")
-    else:
-        lines.append("  <startup buffer empty>")
-
     lines.append("=" * 80)
     return "\n".join(lines)
 
 
-# Keep references to ctypes objects for the lifetime of the process so the
-# kernel-installed pointer isn't garbage-collected mid-flight.
+# Module-level reference set so the kernel-installed pointer isn't GC'd
+# mid-flight. Comment exists because the variable looks unused — without
+# it a future maintainer will delete it and ship a use-after-free.
 _handler_refs: list[Any] = []
+_libc: Any = None
+
+
+def _emit_block_safely(block: str) -> None:
+    """Write ``block`` to stderr using only async-signal-safe primitives."""
+    payload = (block + "\n").encode("utf-8", errors="replace")
+    try:
+        os.write(2, payload)
+    except OSError:
+        pass
+
+
+def _restore_default_and_reraise(signum: int) -> None:
+    """Reset disposition to SIG_DFL via direct libc and re-raise.
+
+    Uses ``libc.signal(signum, SIG_DFL)`` (AS-safe) instead of Python's
+    ``signal.signal`` because the latter mutates CPython signal-state
+    bookkeeping that assumes main-thread + bytecode-boundary calls.
+    """
+    if _libc is not None:
+        try:
+            _libc.signal(int(signum), _SIG_DFL_PTR)
+        except OSError:
+            pass
+    os.kill(os.getpid(), signum)
 
 
 def _make_handler() -> Any:
     """Build the C-callable signal handler closure.
 
-    Returns a ``_SignalHandler`` (a ``ctypes.CFUNCTYPE`` instance). Annotated
-    as ``Any`` because Pyright doesn't accept dynamically-generated ctypes
-    function pointer types in static type expressions.
+    Returns a ``_SignalHandler`` (``ctypes.CFUNCTYPE`` instance), typed
+    as ``Any`` because Pyright doesn't accept dynamically-generated
+    ctypes function-pointer types in static type expressions.
     """
 
     def _handler(signum: int, info_ptr: Any, _ucontext: int) -> None:
-        # Keep the handler small and async-signal-safe-ish: collect data, log,
-        # then re-raise the signal with the default disposition so Uvicorn
-        # observes a normal shutdown.
         try:
             info = info_ptr.contents
             si_code = int(info.si_code)
             sender_pid = int(info.si_pid)
-            sender_comm = read_proc_comm(sender_pid)
-            sender_cmdline = read_proc_cmdline(sender_pid)
-            proc_status = read_proc_status_summary()
-            try:
-                recent = get_recent_logs(max_entries=20)
-            except Exception:
-                recent = []
-            try:
-                startup = get_startup_logs()
-            except Exception:
-                startup = []
-
             block = format_diagnostic_block(
                 signum=signum,
                 si_code=si_code,
                 sender_pid=sender_pid,
-                sender_comm=sender_comm,
-                sender_cmdline=sender_cmdline,
-                proc_status=proc_status,
-                recent_tool_logs=recent,
-                startup_logs=startup,
+                sender_comm=read_proc_comm(sender_pid),
+                sender_cmdline=read_proc_cmdline(sender_pid),
+                proc_status=read_proc_status_summary(),
             )
-            # Use stderr directly: logging may have async handlers that don't
-            # flush before the process re-raises and exits.
-            print(block, file=sys.stderr, flush=True)
+            _emit_block_safely(block)
         except Exception as exc:  # pragma: no cover — last-resort safety
-            print(
-                f"advanced_debug_logging handler failed: {exc!r}",
-                file=sys.stderr,
-                flush=True,
-            )
+            try:
+                os.write(
+                    2,
+                    f"advanced_debug_logging handler failed for signal {signum}: {exc!r}\n".encode(
+                        "utf-8", errors="replace"
+                    ),
+                )
+            except OSError:
+                pass
 
-        # Restore default disposition and re-raise so the process exits the
-        # way Uvicorn (and Supervisor) expect.
-        signal.signal(signum, signal.SIG_DFL)
-        os.kill(os.getpid(), signum)
+        _restore_default_and_reraise(signum)
 
     return _SignalHandler(_handler)
 
 
 def install_kill_signal_diagnostics() -> bool:
-    """Install the SA_SIGINFO signal handler. Returns True if installed.
+    """Install the SA_SIGINFO signal handler. Returns True if at least one
+    signal was installed; False on non-Linux, missing libc, or if every
+    sigaction call failed. Idempotent — second call is a no-op.
 
-    Logs a warning and returns False on non-Linux platforms or if libc
-    lookup fails — callers don't need to special-case those environments.
+    Never raises: callers don't need to wrap in try/except. This contract
+    is load-bearing — diagnostics must not block addon startup.
     """
+    global _libc
+
     if sys.platform != "linux":
         logger.warning(
             "advanced_debug_logging is Linux-only; skipping signal handler install on %s",
@@ -272,36 +305,56 @@ def install_kill_signal_diagnostics() -> bool:
         )
         return False
 
-    libc_path = ctypes.util.find_library("c")
-    if libc_path is None:
-        logger.warning("advanced_debug_logging: libc not found; skipping signal handler install")
+    if _handler_refs:
+        logger.warning(
+            "advanced_debug_logging: install_kill_signal_diagnostics already called; skipping"
+        )
+        return True
+
+    try:
+        libc_path = ctypes.util.find_library("c")
+        if libc_path is None:
+            logger.warning("advanced_debug_logging: libc not found; skipping signal handler install")
+            return False
+
+        libc = ctypes.CDLL(libc_path, use_errno=True)
+        libc.sigaction.restype = ctypes.c_int
+        libc.sigaction.argtypes = [ctypes.c_int, ctypes.POINTER(_Sigaction), ctypes.POINTER(_Sigaction)]
+        # signal(int, sighandler_t) — used by the handler itself to
+        # restore SIG_DFL via the AS-safe libc entry point.
+        libc.signal.restype = ctypes.c_void_p
+        libc.signal.argtypes = [ctypes.c_int, ctypes.c_void_p]
+        _libc = libc
+
+        handler = _make_handler()
+        _handler_refs.append(handler)
+
+        sa = _Sigaction()
+        ctypes.memset(ctypes.byref(sa), 0, ctypes.sizeof(sa))
+        sa.sa_sigaction = handler
+        sa.sa_flags = _SA_SIGINFO | _SA_RESTART
+        _handler_refs.append(sa)
+
+        installed_for: list[str] = []
+        for sig in _INSTRUMENTED_SIGNALS:
+            rc = libc.sigaction(int(sig), ctypes.byref(sa), None)
+            if rc != 0:
+                err = ctypes.get_errno()
+                logger.warning(
+                    "advanced_debug_logging: sigaction(%s) failed: errno=%d",
+                    sig.name,
+                    err,
+                )
+                continue
+            installed_for.append(sig.name)
+    except Exception as exc:
+        logger.warning(
+            "advanced_debug_logging: install failed (%r); continuing without diagnostics",
+            exc,
+        )
+        _handler_refs.clear()
+        _libc = None
         return False
-
-    libc = ctypes.CDLL(libc_path, use_errno=True)
-    libc.sigaction.restype = ctypes.c_int
-    libc.sigaction.argtypes = [ctypes.c_int, ctypes.POINTER(_Sigaction), ctypes.POINTER(_Sigaction)]
-
-    handler = _make_handler()
-    _handler_refs.append(handler)
-
-    sa = _Sigaction()
-    ctypes.memset(ctypes.byref(sa), 0, ctypes.sizeof(sa))
-    sa.sa_sigaction = handler
-    sa.sa_flags = _SA_SIGINFO | _SA_RESTART
-    _handler_refs.append(sa)
-
-    installed_for: list[str] = []
-    for sig in _INSTRUMENTED_SIGNALS:
-        rc = libc.sigaction(int(sig), ctypes.byref(sa), None)
-        if rc != 0:
-            err = ctypes.get_errno()
-            logger.warning(
-                "advanced_debug_logging: sigaction(%s) failed: errno=%d",
-                sig.name,
-                err,
-            )
-            continue
-        installed_for.append(sig.name)
 
     if installed_for:
         logger.info(
@@ -309,4 +362,6 @@ def install_kill_signal_diagnostics() -> bool:
             ", ".join(installed_for),
         )
         return True
+    _handler_refs.clear()
+    _libc = None
     return False

--- a/tests/src/unit/test_kill_signal_diagnostics.py
+++ b/tests/src/unit/test_kill_signal_diagnostics.py
@@ -9,7 +9,9 @@ gating, and the kernel ABI constants the diagnostic block depends on).
 from __future__ import annotations
 
 import ctypes
+import signal
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -37,9 +39,11 @@ def _write(tmp_path: Path, name: str, content: str) -> Path:
 def _reset_module_state():
     """Each test starts with a clean install state (idempotency tests need this)."""
     ksd._handler_refs.clear()
+    ksd._chained_handlers.clear()
     ksd._libc = None
     yield
     ksd._handler_refs.clear()
+    ksd._chained_handlers.clear()
     ksd._libc = None
 
 
@@ -300,3 +304,135 @@ class TestInstallKillSignalDiagnostics:
             # Second call short-circuits before touching libc.
             assert install_kill_signal_diagnostics() is True
             assert fake_libc.sigaction.call_count == first_call_count
+
+
+class TestUvicornOverwriteScenario:
+    """Regression tests for the install ordering bug Patch76 caught.
+
+    uvicorn's ``Server.capture_signals`` calls ``signal.signal(SIGTERM,
+    handle_exit)`` which goes through libc's ``sigaction`` *without*
+    ``SA_SIGINFO``, overwriting any handler we'd installed earlier. The
+    fix is to schedule install AFTER uvicorn so it captures uvicorn's
+    handler and chains to it.
+    """
+
+    def test_install_after_signal_signal_captures_existing_handler(self) -> None:
+        # Simulates uvicorn having already installed handle_exit before
+        # we get to install. Our install should snapshot it so the
+        # SA_SIGINFO trampoline can chain back to it.
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+
+        captured_calls: list[int] = []
+
+        def fake_uvicorn_handle_exit(signum, frame):
+            captured_calls.append(signum)
+
+        # Mimic uvicorn — install via signal.signal without SA_SIGINFO.
+        original = signal.signal(signal.SIGTERM, fake_uvicorn_handle_exit)
+        try:
+            fake_libc = MagicMock()
+            fake_libc.sigaction.return_value = 0
+            with patch(
+                "ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library",
+                return_value="libc.so.6",
+            ), patch(
+                "ha_mcp.utils.kill_signal_diagnostics.ctypes.CDLL",
+                return_value=fake_libc,
+            ):
+                assert install_kill_signal_diagnostics() is True
+
+            assert ksd._chained_handlers.get(int(signal.SIGTERM)) is fake_uvicorn_handle_exit
+        finally:
+            signal.signal(signal.SIGTERM, original)
+
+    def test_chain_or_reraise_invokes_captured_handler(self) -> None:
+        captured_calls: list[int] = []
+
+        def fake_handler(signum, frame):
+            captured_calls.append(signum)
+
+        ksd._chained_handlers[int(signal.SIGTERM)] = fake_handler
+        ksd._chain_or_reraise(int(signal.SIGTERM))
+        assert captured_calls == [int(signal.SIGTERM)]
+
+    def test_chain_or_reraise_falls_back_to_default_when_no_chain(self) -> None:
+        # SIGHUP is the realistic case: uvicorn doesn't capture it, so
+        # there's no chained handler. The trampoline must fall through
+        # to the libc-direct re-raise path.
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics._restore_default_and_reraise"
+        ) as mock_restore:
+            ksd._chain_or_reraise(int(signal.SIGHUP))
+        mock_restore.assert_called_once_with(int(signal.SIGHUP))
+
+    def test_chain_or_reraise_falls_back_when_chained_raises(self) -> None:
+        def broken_handler(signum, frame):
+            raise RuntimeError("handler exploded")
+
+        ksd._chained_handlers[int(signal.SIGTERM)] = broken_handler
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics._restore_default_and_reraise"
+        ) as mock_restore:
+            ksd._chain_or_reraise(int(signal.SIGTERM))
+        # Even if the chain target explodes, the process must still
+        # head toward termination via the default-disposition path.
+        mock_restore.assert_called_once_with(int(signal.SIGTERM))
+
+
+class TestScheduleInstallAfterUvicorn:
+    def test_waits_until_uvicorn_handler_detected_then_installs(self) -> None:
+        # Scenario: uvicorn hasn't installed yet (signal disposition is
+        # SIG_DFL). We schedule install. Briefly later, "uvicorn"
+        # installs a handler. Our scheduler should detect the handler
+        # within the timeout and call install_*().
+        from ha_mcp.utils.kill_signal_diagnostics import schedule_install_after_uvicorn
+
+        original = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        try:
+            install_calls: list[int] = []
+
+            def fake_install() -> bool:
+                install_calls.append(1)
+                return True
+
+            thread = schedule_install_after_uvicorn(
+                timeout_secs=2.0,
+                poll_interval_secs=0.01,
+                install=fake_install,
+            )
+            time.sleep(0.05)
+            # Simulate uvicorn installing its handler.
+            signal.signal(signal.SIGTERM, lambda s, f: None)
+            thread.join(timeout=2.0)
+
+            assert install_calls == [1]
+        finally:
+            signal.signal(signal.SIGTERM, original)
+
+    def test_falls_back_to_install_after_timeout(self) -> None:
+        # If uvicorn never installs (e.g. addon was started outside the
+        # http transport), install should still run after the timeout
+        # so the user gets at least best-effort coverage.
+        from ha_mcp.utils.kill_signal_diagnostics import schedule_install_after_uvicorn
+
+        original = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        try:
+            install_calls: list[int] = []
+
+            def fake_install() -> bool:
+                install_calls.append(1)
+                return True
+
+            thread = schedule_install_after_uvicorn(
+                timeout_secs=0.05,
+                poll_interval_secs=0.01,
+                install=fake_install,
+            )
+            thread.join(timeout=2.0)
+
+            assert install_calls == [1]
+        finally:
+            signal.signal(signal.SIGTERM, original)

--- a/tests/src/unit/test_kill_signal_diagnostics.py
+++ b/tests/src/unit/test_kill_signal_diagnostics.py
@@ -191,20 +191,43 @@ class TestFormatDiagnosticBlock:
         assert "VmRSS: 131072 kB" in block
         assert "oom_score_adj: -500" in block
 
-    def test_falls_back_when_sender_metadata_missing(self) -> None:
+    def test_cross_namespace_sender_renders_explicit_label(self) -> None:
+        # si_pid == 0 means the sender was outside our PID namespace
+        # (typically Supervisor or the host process) and its PID didn't
+        # translate. The block should call this out instead of showing
+        # bare "0" + "<unavailable>", which would read as a capture
+        # failure rather than the (informative) cross-namespace case.
         block = format_diagnostic_block(
             signum=15,
-            si_code=0x80,  # SI_KERNEL
+            si_code=0,  # SI_USER + si_pid=0 == cross-namespace kill (e.g. Supervisor stop)
             sender_pid=0,
             sender_comm="",
             sender_cmdline="",
             proc_status={},
         )
 
-        assert "SI_KERNEL" in block
+        assert "Sender PID:     0 (cross-namespace; likely Supervisor or host process)" in block
+        assert "Sender comm:    <cross-namespace>" in block
+        assert "Sender cmdline: <cross-namespace>" in block
+        assert "<unavailable — non-Linux or /proc not mounted>" in block
+
+    def test_in_namespace_sender_with_missing_proc_renders_unavailable(self) -> None:
+        # In-namespace sender (sender_pid > 0) but /proc/<pid>/comm
+        # came back empty (race: sender exited before we read /proc).
+        # Should still say "<unavailable>" for the missing fields, not
+        # the cross-namespace label.
+        block = format_diagnostic_block(
+            signum=15,
+            si_code=0,
+            sender_pid=17,
+            sender_comm="",
+            sender_cmdline="",
+            proc_status={},
+        )
+
+        assert "Sender PID:     17" in block
         assert "Sender comm:    <unavailable>" in block
         assert "Sender cmdline: <unavailable>" in block
-        assert "<unavailable — non-Linux or /proc not mounted>" in block
 
     @pytest.mark.parametrize(
         ("code", "name"),

--- a/tests/src/unit/test_kill_signal_diagnostics.py
+++ b/tests/src/unit/test_kill_signal_diagnostics.py
@@ -1,0 +1,190 @@
+"""Unit tests for the advanced-debug-logging kill-signal diagnostics module.
+
+The module installs a Linux-only `sigaction(SA_SIGINFO)` handler. We don't
+exercise the kernel signal path in CI; instead we verify the helpers that
+build the diagnostic block — `/proc` parsing, formatting, and the install
+path's platform gating.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from ha_mcp.utils.kill_signal_diagnostics import (
+    format_diagnostic_block,
+    install_kill_signal_diagnostics,
+    read_proc_cmdline,
+    read_proc_comm,
+    read_proc_status_summary,
+)
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    path = tmp_path / name
+    path.write_text(content)
+    return path
+
+
+class TestReadProcStatusSummary:
+    def test_returns_only_whitelisted_fields(self, tmp_path: Path) -> None:
+        sample = _write(
+            tmp_path,
+            "status",
+            (
+                "Name:\tha_mcp\n"
+                "State:\tS (sleeping)\n"
+                "Pid:\t1\n"
+                "VmPeak:\t  524288 kB\n"
+                "VmRSS:\t  131072 kB\n"
+                "VmHWM:\t  262144 kB\n"
+                "Threads:\t9\n"
+                "oom_score:\t0\n"
+                "oom_score_adj:\t-500\n"
+                "SigPnd:\t0000000000000000\n"
+            ),
+        )
+
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value = sample.open(encoding="utf-8")
+            out = read_proc_status_summary()
+
+        assert out["State"] == "S (sleeping)"
+        assert out["VmRSS"] == "131072 kB"
+        assert out["VmHWM"] == "262144 kB"
+        assert out["VmPeak"] == "524288 kB"
+        assert out["Threads"] == "9"
+        assert out["oom_score"] == "0"
+        assert out["oom_score_adj"] == "-500"
+        # Pid and SigPnd were not in the whitelist.
+        assert "Pid" not in out
+        assert "SigPnd" not in out
+        assert "Name" not in out
+
+    def test_returns_empty_dict_when_proc_missing(self) -> None:
+        with patch("builtins.open", side_effect=OSError("no /proc")):
+            assert read_proc_status_summary() == {}
+
+
+class TestReadProcComm:
+    def test_returns_stripped_comm(self) -> None:
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = "supervisor\n"
+            assert read_proc_comm(42) == "supervisor"
+
+    def test_returns_empty_for_invalid_pid(self) -> None:
+        # Don't touch /proc for sentinel/non-positive PIDs (kernel signal
+        # delivery can present si_pid=0 for kernel-originated signals).
+        assert read_proc_comm(0) == ""
+        assert read_proc_comm(-1) == ""
+
+    def test_returns_empty_when_pid_gone(self) -> None:
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            assert read_proc_comm(99999) == ""
+
+
+class TestReadProcCmdline:
+    def test_replaces_nul_separators_with_spaces(self) -> None:
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = (
+                b"/usr/bin/python3\x00/app/start.py\x00--foo\x00"
+            )
+            assert read_proc_cmdline(42) == "/usr/bin/python3 /app/start.py --foo"
+
+    def test_returns_empty_for_invalid_pid(self) -> None:
+        assert read_proc_cmdline(0) == ""
+
+    def test_returns_empty_when_unreadable(self) -> None:
+        with patch("builtins.open", side_effect=PermissionError):
+            assert read_proc_cmdline(1) == ""
+
+
+class TestFormatDiagnosticBlock:
+    def test_includes_signal_name_and_sender_info(self) -> None:
+        block = format_diagnostic_block(
+            signum=15,  # SIGTERM
+            si_code=0,  # SI_USER
+            sender_pid=42,
+            sender_comm="supervisor",
+            sender_cmdline="/usr/bin/supervisor --foo",
+            proc_status={"VmRSS": "131072 kB", "Threads": "9", "oom_score_adj": "-500"},
+            recent_tool_logs=[],
+            startup_logs=[],
+        )
+
+        assert "SIGTERM" in block
+        assert "SI_USER" in block
+        assert "Sender PID:     42" in block
+        assert "supervisor" in block
+        assert "/usr/bin/supervisor --foo" in block
+        assert "VmRSS: 131072 kB" in block
+        assert "oom_score_adj: -500" in block
+
+    def test_falls_back_when_sender_metadata_missing(self) -> None:
+        block = format_diagnostic_block(
+            signum=15,
+            si_code=-1,  # SI_KERNEL
+            sender_pid=0,
+            sender_comm="",
+            sender_cmdline="",
+            proc_status={},
+            recent_tool_logs=[],
+            startup_logs=[],
+        )
+
+        assert "SI_KERNEL" in block
+        assert "Sender comm:    <unavailable>" in block
+        assert "Sender cmdline: <unavailable>" in block
+        assert "<unavailable — non-Linux or /proc not mounted>" in block
+        assert "<ring buffer empty>" in block
+        assert "<startup buffer empty>" in block
+
+    def test_unknown_si_code_is_labeled_with_value(self) -> None:
+        block = format_diagnostic_block(
+            signum=15,
+            si_code=99,
+            sender_pid=1,
+            sender_comm="init",
+            sender_cmdline="/sbin/init",
+            proc_status={},
+            recent_tool_logs=[],
+            startup_logs=[],
+        )
+        # Unknown codes should still surface the raw value so reporters can look it up.
+        assert "SI_UNKNOWN(99)" in block
+
+    def test_truncates_startup_logs_to_recent_tail(self) -> None:
+        startup = [
+            {"elapsed_seconds": i, "level": "INFO", "message": f"msg{i}"} for i in range(40)
+        ]
+        block = format_diagnostic_block(
+            signum=1,
+            si_code=0,
+            sender_pid=1,
+            sender_comm="init",
+            sender_cmdline="",
+            proc_status={},
+            recent_tool_logs=[],
+            startup_logs=startup,
+        )
+        # Only the last 15 entries should appear — earlier ones suppressed
+        # to keep the kill block bounded.
+        assert "msg0" not in block
+        assert "msg25" in block
+        assert "msg39" in block
+
+
+class TestInstallKillSignalDiagnostics:
+    def test_returns_false_on_non_linux(self) -> None:
+        with patch.object(sys, "platform", "darwin"):
+            assert install_kill_signal_diagnostics() is False
+
+    def test_returns_false_when_libc_lookup_fails(self) -> None:
+        # On Linux, exercise the libc-not-found branch by stubbing
+        # ctypes.util.find_library to None.
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        with patch("ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library", return_value=None):
+            assert install_kill_signal_diagnostics() is False

--- a/tests/src/unit/test_kill_signal_diagnostics.py
+++ b/tests/src/unit/test_kill_signal_diagnostics.py
@@ -1,19 +1,23 @@
 """Unit tests for the advanced-debug-logging kill-signal diagnostics module.
 
-The module installs a Linux-only `sigaction(SA_SIGINFO)` handler. We don't
-exercise the kernel signal path in CI; instead we verify the helpers that
-build the diagnostic block — `/proc` parsing, formatting, and the install
-path's platform gating.
+The module installs a Linux-only sigaction(SA_SIGINFO) handler. We don't
+exercise the kernel signal path; instead we verify the helpers that
+build the diagnostic block (/proc parsing, formatting, the install path's
+gating, and the kernel ABI constants the diagnostic block depends on).
 """
 
 from __future__ import annotations
 
+import ctypes
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from ha_mcp.utils import kill_signal_diagnostics as ksd
 from ha_mcp.utils.kill_signal_diagnostics import (
+    _SI_CODE_NAMES,
+    _Siginfo,
     format_diagnostic_block,
     install_kill_signal_diagnostics,
     read_proc_cmdline,
@@ -26,6 +30,58 @@ def _write(tmp_path: Path, name: str, content: str) -> Path:
     path = tmp_path / name
     path.write_text(content)
     return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Each test starts with a clean install state (idempotency tests need this)."""
+    ksd._handler_refs.clear()
+    ksd._libc = None
+    yield
+    ksd._handler_refs.clear()
+    ksd._libc = None
+
+
+class TestSiCodeAbiPinning:
+    """Pin _SI_CODE_NAMES values to <asm-generic/siginfo.h>.
+
+    A wrong value here silently mislabels the diagnostic block — defeating
+    the feature. Pinning each value catches "fix this and break it again"
+    regressions.
+    """
+
+    @pytest.mark.parametrize(
+        ("code", "name"),
+        [
+            (0, "SI_USER"),
+            (0x80, "SI_KERNEL"),
+            (-1, "SI_QUEUE"),
+            (-2, "SI_TIMER"),
+            (-3, "SI_MESGQ"),
+            (-4, "SI_ASYNCIO"),
+            (-5, "SI_SIGIO"),
+            (-6, "SI_TKILL"),
+        ],
+    )
+    def test_kernel_abi_constants(self, code: int, name: str) -> None:
+        assert _SI_CODE_NAMES[code] == name
+
+
+class TestSiginfoLayout:
+    """Pin the load-bearing offsets and size at the test level too.
+
+    The module has matching import-time asserts; this is the regression
+    guard if those ever get loosened.
+    """
+
+    def test_size_matches_kernel_si_max_size(self) -> None:
+        assert ctypes.sizeof(_Siginfo) == 128
+
+    def test_si_pid_offset(self) -> None:
+        assert _Siginfo.si_pid.offset == 16
+
+    def test_si_uid_offset(self) -> None:
+        assert _Siginfo.si_uid.offset == 20
 
 
 class TestReadProcStatusSummary:
@@ -48,7 +104,7 @@ class TestReadProcStatusSummary:
         )
 
         with patch("builtins.open", create=True) as mock_open:
-            mock_open.return_value = sample.open(encoding="utf-8")
+            mock_open.return_value = sample.open("rb")
             out = read_proc_status_summary()
 
         assert out["State"] == "S (sleeping)"
@@ -58,7 +114,6 @@ class TestReadProcStatusSummary:
         assert out["Threads"] == "9"
         assert out["oom_score"] == "0"
         assert out["oom_score_adj"] == "-500"
-        # Pid and SigPnd were not in the whitelist.
         assert "Pid" not in out
         assert "SigPnd" not in out
         assert "Name" not in out
@@ -71,12 +126,23 @@ class TestReadProcStatusSummary:
 class TestReadProcComm:
     def test_returns_stripped_comm(self) -> None:
         with patch("builtins.open", create=True) as mock_open:
-            mock_open.return_value.__enter__.return_value.read.return_value = "supervisor\n"
+            mock_open.return_value.__enter__.return_value.read.return_value = b"supervisor\n"
             assert read_proc_comm(42) == "supervisor"
 
+    def test_handles_non_utf8_process_name(self) -> None:
+        # PR_SET_NAME accepts arbitrary bytes; strict-UTF-8 decode would
+        # raise on those. Verify we fall back to replacement chars.
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = b"\xff\xfe\xfd\n"
+            result = read_proc_comm(42)
+            # Don't assert the exact replacement char output; just that
+            # we returned a string and didn't raise.
+            assert isinstance(result, str)
+
     def test_returns_empty_for_invalid_pid(self) -> None:
-        # Don't touch /proc for sentinel/non-positive PIDs (kernel signal
-        # delivery can present si_pid=0 for kernel-originated signals).
+        # Don't touch /proc for sentinel/non-positive PIDs (kernel
+        # signal delivery presents si_pid=0 for kernel-originated
+        # signals).
         assert read_proc_comm(0) == ""
         assert read_proc_comm(-1) == ""
 
@@ -110,8 +176,6 @@ class TestFormatDiagnosticBlock:
             sender_comm="supervisor",
             sender_cmdline="/usr/bin/supervisor --foo",
             proc_status={"VmRSS": "131072 kB", "Threads": "9", "oom_score_adj": "-500"},
-            recent_tool_logs=[],
-            startup_logs=[],
         )
 
         assert "SIGTERM" in block
@@ -125,21 +189,37 @@ class TestFormatDiagnosticBlock:
     def test_falls_back_when_sender_metadata_missing(self) -> None:
         block = format_diagnostic_block(
             signum=15,
-            si_code=-1,  # SI_KERNEL
+            si_code=0x80,  # SI_KERNEL
             sender_pid=0,
             sender_comm="",
             sender_cmdline="",
             proc_status={},
-            recent_tool_logs=[],
-            startup_logs=[],
         )
 
         assert "SI_KERNEL" in block
         assert "Sender comm:    <unavailable>" in block
         assert "Sender cmdline: <unavailable>" in block
         assert "<unavailable — non-Linux or /proc not mounted>" in block
-        assert "<ring buffer empty>" in block
-        assert "<startup buffer empty>" in block
+
+    @pytest.mark.parametrize(
+        ("code", "name"),
+        [
+            (0, "SI_USER"),
+            (0x80, "SI_KERNEL"),
+            (-1, "SI_QUEUE"),
+            (-6, "SI_TKILL"),
+        ],
+    )
+    def test_known_si_codes_render_symbolic_names(self, code: int, name: str) -> None:
+        block = format_diagnostic_block(
+            signum=15,
+            si_code=code,
+            sender_pid=1,
+            sender_comm="x",
+            sender_cmdline="",
+            proc_status={},
+        )
+        assert name in block
 
     def test_unknown_si_code_is_labeled_with_value(self) -> None:
         block = format_diagnostic_block(
@@ -149,31 +229,10 @@ class TestFormatDiagnosticBlock:
             sender_comm="init",
             sender_cmdline="/sbin/init",
             proc_status={},
-            recent_tool_logs=[],
-            startup_logs=[],
         )
-        # Unknown codes should still surface the raw value so reporters can look it up.
+        # Unknown codes should still surface the raw value so reporters
+        # can look it up in <asm-generic/siginfo.h>.
         assert "SI_UNKNOWN(99)" in block
-
-    def test_truncates_startup_logs_to_recent_tail(self) -> None:
-        startup = [
-            {"elapsed_seconds": i, "level": "INFO", "message": f"msg{i}"} for i in range(40)
-        ]
-        block = format_diagnostic_block(
-            signum=1,
-            si_code=0,
-            sender_pid=1,
-            sender_comm="init",
-            sender_cmdline="",
-            proc_status={},
-            recent_tool_logs=[],
-            startup_logs=startup,
-        )
-        # Only the last 15 entries should appear — earlier ones suppressed
-        # to keep the kill block bounded.
-        assert "msg0" not in block
-        assert "msg25" in block
-        assert "msg39" in block
 
 
 class TestInstallKillSignalDiagnostics:
@@ -182,9 +241,61 @@ class TestInstallKillSignalDiagnostics:
             assert install_kill_signal_diagnostics() is False
 
     def test_returns_false_when_libc_lookup_fails(self) -> None:
-        # On Linux, exercise the libc-not-found branch by stubbing
-        # ctypes.util.find_library to None.
         if sys.platform != "linux":
             pytest.skip("Linux-only branch")
         with patch("ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library", return_value=None):
             assert install_kill_signal_diagnostics() is False
+
+    def test_install_never_raises_on_libc_load_error(self) -> None:
+        # Diagnostics must not block addon startup. If libc loading or
+        # symbol resolution fails, the install function returns False
+        # rather than propagating.
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics.ctypes.CDLL",
+            side_effect=OSError("simulated libc load failure"),
+        ):
+            assert install_kill_signal_diagnostics() is False
+
+    def test_happy_path_installs_for_all_signals(self) -> None:
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        fake_libc = MagicMock()
+        fake_libc.sigaction.return_value = 0  # success
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library", return_value="libc.so.6"
+        ), patch("ha_mcp.utils.kill_signal_diagnostics.ctypes.CDLL", return_value=fake_libc):
+            assert install_kill_signal_diagnostics() is True
+
+        # Three signals (SIGTERM, SIGINT, SIGHUP) → three sigaction calls.
+        assert fake_libc.sigaction.call_count == 3
+        # Two refs pinned: handler + sigaction struct.
+        assert len(ksd._handler_refs) == 2
+
+    def test_partial_install_returns_true_when_any_signal_succeeds(self) -> None:
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        fake_libc = MagicMock()
+        # First two calls succeed, third fails.
+        fake_libc.sigaction.side_effect = [0, 0, 1]
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library", return_value="libc.so.6"
+        ), patch("ha_mcp.utils.kill_signal_diagnostics.ctypes.CDLL", return_value=fake_libc), patch(
+            "ha_mcp.utils.kill_signal_diagnostics.ctypes.get_errno", return_value=22
+        ):
+            assert install_kill_signal_diagnostics() is True
+
+    def test_idempotent_second_call_is_noop(self) -> None:
+        if sys.platform != "linux":
+            pytest.skip("Linux-only branch")
+        fake_libc = MagicMock()
+        fake_libc.sigaction.return_value = 0
+        with patch(
+            "ha_mcp.utils.kill_signal_diagnostics.ctypes.util.find_library", return_value="libc.so.6"
+        ), patch("ha_mcp.utils.kill_signal_diagnostics.ctypes.CDLL", return_value=fake_libc):
+            assert install_kill_signal_diagnostics() is True
+            first_call_count = fake_libc.sigaction.call_count
+            # Second call short-circuits before touching libc.
+            assert install_kill_signal_diagnostics() is True
+            assert fake_libc.sigaction.call_count == first_call_count

--- a/tests/src/unit/test_kill_signal_diagnostics.py
+++ b/tests/src/unit/test_kill_signal_diagnostics.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from ha_mcp.utils import kill_signal_diagnostics as ksd
 from ha_mcp.utils.kill_signal_diagnostics import (
     _SI_CODE_NAMES,


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in **"Advanced debug logging"** toggle (default off) to the addon Configuration tab. When enabled, the addon installs a `SIGTERM`/`SIGINT`/`SIGHUP` handler (after uvicorn's `capture_signals()` runs, then chained to its `handle_exit`) that, on signal arrival, logs:

- Signal name + `si_code` (`SI_USER` / `SI_KERNEL` / `SI_TKILL` / etc.) — captured via `sigaction(SA_SIGINFO)` through `ctypes`, since Python's `signal.signal()` does not expose `siginfo_t`.
- Sender PID, with its `comm` and `cmdline` resolved from `/proc/<pid>`.
- Memory + OOM snapshot from `/proc/self/status` (`VmRSS`, `VmHWM`, `Threads`, `State`, `oom_score`, `oom_score_adj`).

The handler then chains to whatever handler was previously installed (typically uvicorn's `handle_exit` for SIGTERM/SIGINT) so shutdown still happens cleanly. SIGHUP, which uvicorn doesn't capture, falls back to libc-direct `SIG_DFL` + re-raise. No behavior change beyond the extra log block when the toggle is on; complete no-op when off.

Addresses the diagnostic gap behind #1109: when the addon is killed unexpectedly with watchdog disabled, the only signal in the log today is `[INFO] MCP server stopped` (i.e. `mcp.run()` returned cleanly after SIGTERM) — we can't see who sent the signal or what state we were in. This change lets reporters opt in and capture that context. Single named umbrella so future diagnostics can land under the same flag.

Linux-only; gracefully no-ops on other platforms. Translation lives in `homeassistant-addon-dev/translations/en.yaml` per the dev-first translation rule; stable sibling syncs at release.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`)
- [x] Code follows style guidelines (\`uv run ruff check\`)

## Checklist
- [x] I have updated documentation if needed