### PR TITLE
fix: resolve disabled entities via entity_registry in helper deletion

### DIFF
--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -982,21 +982,19 @@ class IntegrationTools:
                     f"(attempt {attempt + 1}/{max_retries})"
                 )
 
-                # Fast state check first. Disabled entities are removed from
-                # the state machine but remain in the entity registry, so a
-                # missing state_check must NOT skip the registry lookup below
-                # (see issue #1057). The retry/sleep is preserved as a race-
-                # condition guard for entities that just transitioned state.
+                # Informational state check — disabled entities are removed
+                # from the state machine but remain in the entity registry,
+                # so a missing state_check must NOT skip the registry lookup
+                # below (see issue #1057). Retry/backoff is provided by the
+                # post-registry-fail block further down — no separate sleep
+                # needed here.
                 try:
                     state_check = await client.get_entity_state(entity_id)
                     if not state_check:
-                        if attempt < max_retries - 1:
-                            wait_time = 0.5 * (2**attempt)
-                            logger.debug(
-                                f"Entity {entity_id} not in state, waiting "
-                                f"{wait_time}s before fallthrough to registry"
-                            )
-                            await asyncio.sleep(wait_time)
+                        logger.debug(
+                            f"Entity {entity_id} not in state; "
+                            "proceeding to registry lookup"
+                        )
                 except HomeAssistantAPIError as e:
                     # State check is best-effort here; an APIError (e.g. 404)
                     # is informational. Auth/connection errors must propagate

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -982,7 +982,11 @@ class IntegrationTools:
                     f"(attempt {attempt + 1}/{max_retries})"
                 )
 
-                # Fast state check first
+                # Fast state check first. Disabled entities are removed from
+                # the state machine but remain in the entity registry, so a
+                # missing state_check must NOT skip the registry lookup below
+                # (see issue #1057). The retry/sleep is preserved as a race-
+                # condition guard for entities that just transitioned state.
                 try:
                     state_check = await client.get_entity_state(entity_id)
                     if not state_check:
@@ -990,10 +994,9 @@ class IntegrationTools:
                             wait_time = 0.5 * (2**attempt)
                             logger.debug(
                                 f"Entity {entity_id} not in state, waiting "
-                                f"{wait_time}s before retry..."
+                                f"{wait_time}s before fallthrough to registry"
                             )
                             await asyncio.sleep(wait_time)
-                            continue
                 except HomeAssistantAPIError as e:
                     # State check is best-effort here; an APIError (e.g. 404)
                     # is informational. Auth/connection errors must propagate

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -982,12 +982,9 @@ class IntegrationTools:
                     f"(attempt {attempt + 1}/{max_retries})"
                 )
 
-                # Informational state check — disabled entities are removed
-                # from the state machine but remain in the entity registry,
-                # so a missing state_check must NOT skip the registry lookup
-                # below (see issue #1057). Retry/backoff is provided by the
-                # post-registry-fail block further down — no separate sleep
-                # needed here.
+                # State check is informational — disabled entities are
+                # missing from the state machine but resolved via the
+                # registry below (issue #1057).
                 try:
                     state_check = await client.get_entity_state(entity_id)
                     if not state_check:

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -971,7 +971,8 @@ class IntegrationTools:
         )
 
         try:
-            # Try to get unique_id with retry logic (race-condition guard)
+            # Resolve unique_id via the entity registry, with a retry loop
+            # for transient registry failures.
             unique_id = None
             registry_result: dict[str, Any] | None = None
             max_retries = 3
@@ -982,9 +983,11 @@ class IntegrationTools:
                     f"(attempt {attempt + 1}/{max_retries})"
                 )
 
-                # State check is informational — disabled entities are
-                # missing from the state machine but resolved via the
-                # registry below (issue #1057).
+                # State check is informational only — disabled entities are
+                # missing from the state machine but resolved via the registry
+                # below (issue #1057). Kept as a debug breadcrumb rather than
+                # removed; full removal is option 3.2 in #1057, deferred to a
+                # separate PR for minimal blast radius here.
                 try:
                     state_check = await client.get_entity_state(entity_id)
                     if not state_check:
@@ -1007,8 +1010,8 @@ class IntegrationTools:
                     registry_result = await client.send_websocket_message(
                         registry_msg
                     )
-                    if registry_result.get("success"):
-                        entity_entry = registry_result.get("result", {})
+                    if (registry_result or {}).get("success"):
+                        entity_entry = (registry_result or {}).get("result") or {}
                         unique_id = entity_entry.get("unique_id")
                         if unique_id:
                             logger.info(
@@ -1073,29 +1076,82 @@ class IntegrationTools:
                             )
                     return response
 
-                # Fallback strategy 2: already-deleted check
+                # Fallback strategy 2: already-deleted check. Confirm via the
+                # registry too — a disabled entity is missing from the state
+                # machine but still registry-resident, so state-absence alone
+                # is not enough to declare success.
                 try:
                     final_state_check = await client.get_entity_state(entity_id)
                     if not final_state_check:
-                        logger.info(
-                            f"Entity {entity_id} no longer exists; "
-                            "treating as already deleted"
+                        registry_still_has_entry = False
+                        try:
+                            verify_result = await client.send_websocket_message(
+                                {
+                                    "type": "config/entity_registry/get",
+                                    "entity_id": entity_id,
+                                }
+                            )
+                            if (verify_result or {}).get("success"):
+                                verify_entry = (verify_result or {}).get("result") or {}
+                                if verify_entry.get("entity_id"):
+                                    registry_still_has_entry = True
+                        except HomeAssistantAPIError as verify_err:
+                            # On verify failure, conservatively assume the
+                            # entry is still there rather than silently
+                            # short-circuit to already_deleted.
+                            logger.debug(
+                                f"Registry verify for {entity_id} failed: "
+                                f"{verify_err}"
+                            )
+                            registry_still_has_entry = True
+
+                        if not registry_still_has_entry:
+                            logger.info(
+                                f"Entity {entity_id} absent from state and "
+                                "registry; treating as already deleted"
+                            )
+                            return {
+                                "success": True,
+                                "action": "delete",
+                                "target": target,
+                                "helper_type": helper_type,
+                                "method": "websocket_delete",
+                                "entry_id": None,
+                                "entity_ids": [entity_id],
+                                "require_restart": False,
+                                "message": (
+                                    f"Helper {target} was already deleted or "
+                                    "never properly registered."
+                                ),
+                                "fallback_used": "already_deleted",
+                            }
+
+                        logger.warning(
+                            f"Entity {entity_id} absent from state but still "
+                            "in registry; not already_deleted"
                         )
-                        return {
-                            "success": True,
-                            "action": "delete",
-                            "target": target,
-                            "helper_type": helper_type,
-                            "method": "websocket_delete",
-                            "entry_id": None,
-                            "entity_ids": [entity_id],
-                            "require_restart": False,
-                            "message": (
-                                f"Helper {target} was already deleted or "
-                                "never properly registered."
-                            ),
-                            "fallback_used": "already_deleted",
-                        }
+                        raise_tool_error(
+                            create_error_response(
+                                ErrorCode.SERVICE_CALL_FAILED,
+                                (
+                                    f"Helper {target} could not be deleted: "
+                                    "registry entry exists but unique_id was "
+                                    "absent and the direct-id fallback "
+                                    "delete failed."
+                                ),
+                                suggestions=[
+                                    "Re-enable the entity via "
+                                    "ha_set_entity(enabled=True), then retry "
+                                    "deletion.",
+                                    "Or inspect the entity registry entry "
+                                    "directly to confirm unique_id presence.",
+                                ],
+                                context={
+                                    "target": target,
+                                    "entity_id": entity_id,
+                                },
+                            )
+                        )
                 except HomeAssistantAPIError as e:
                     # 404 here means the state-check itself confirmed the
                     # entity is gone — treat as a soft signal and continue

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -681,15 +681,19 @@ class TestInputButtonCRUD:
         )
         delete_data = assert_mcp_success(delete_result, "Delete disabled helper")
 
-        # Crucially: the standard registry-driven delete path ran, NOT the
-        # already_deleted fallback that masked the bug.
-        assert delete_data.get("fallback_used") != "already_deleted", (
-            f"Bug regression — disabled entity hit already_deleted fallback. "
-            f"Delete data: {delete_data}"
-        )
+        # Standard registry-driven delete path ran — unique_id was resolved
+        # and no fallback fired. Tighter than `!= "already_deleted"`: also
+        # rejects `direct_id` and any future fallback variant.
         assert delete_data.get("method") == "websocket_delete", (
             f"Expected websocket_delete via unique_id; got "
             f"method={delete_data.get('method')}, data={delete_data}"
+        )
+        assert "unique_id" in delete_data, (
+            f"Standard path not taken (no unique_id in response): {delete_data}"
+        )
+        assert delete_data.get("fallback_used") is None, (
+            f"Expected no fallback; got fallback_used="
+            f"{delete_data.get('fallback_used')!r}, data={delete_data}"
         )
         logger.info(
             f"Disabled helper deleted via "

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -696,12 +696,8 @@ class TestInputButtonCRUD:
             f"{delete_data.get('method')} (unique_id={delete_data.get('unique_id')})"
         )
 
-        # VERIFY entity is actually gone from the registry — pre-fix the
-        # tool reported success while leaving the registry entry behind.
-        # Post-delete, ha_get_entity returns success=False with "Entity not
-        # found" in the message; the exact error code may be
-        # ENTITY_NOT_FOUND or SERVICE_CALL_FAILED depending on which layer
-        # surfaces it first, so the assertion targets the message.
+        # Verify entity is gone — error code varies (ENTITY_NOT_FOUND vs
+        # SERVICE_CALL_FAILED), so the assertion targets the message.
         get_data = await safe_call_tool(
             mcp_client, "ha_get_entity", {"entity_id": entity_id}
         )

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -620,6 +620,107 @@ class TestInputButtonCRUD:
         )
         logger.info("Input button cleanup complete")
 
+    async def test_disabled_input_button_deletion_resolves_via_registry(
+        self, mcp_client, cleanup_tracker
+    ):
+        """Issue #1057 regression: a disabled helper (registered but absent
+        from the state machine) must be resolved via the entity registry,
+        not silently treated as already-deleted.
+
+        End-to-end mirror of the unit test
+        ``test_simple_path_disabled_entity_resolves_via_registry``: creates a
+        helper, disables its entity via ``ha_set_entity(enabled=False)``,
+        deletes it, and asserts the deletion took the standard
+        ``websocket_delete`` path (not the ``already_deleted`` fallback that
+        masked the bug pre-fix).
+        """
+        helper_name = "E2E Disabled Button"
+
+        # CREATE input_button
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_button",
+                "name": helper_name,
+                "icon": "mdi:gesture-tap-button",
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_button")
+        entity_id = get_entity_id_from_response(create_data, "input_button")
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track("input_button", entity_id)
+        logger.info(f"Created input_button: {entity_id}")
+
+        # Wait until entity is queryable
+        state_reached = await wait_for_entity_state(
+            mcp_client, entity_id, "unknown", timeout=10
+        )
+        assert state_reached, f"Entity {entity_id} not registered within timeout"
+
+        # DISABLE entity at registry level — this is what reproduces the bug
+        disable_result = await mcp_client.call_tool(
+            "ha_set_entity",
+            {"entity_id": entity_id, "enabled": False},
+        )
+        disable_data = assert_mcp_success(disable_result, "Disable entity")
+        assert disable_data.get("entity_entry", {}).get("disabled_by") == "user", (
+            f"Entity not registry-disabled: {disable_data}"
+        )
+        logger.info(f"Disabled entity {entity_id} (disabled_by=user)")
+
+        # DELETE — pre-fix this fell through to the ``already_deleted``
+        # short-circuit, leaving the registry entry in place. Post-fix the
+        # registry lookup runs every iteration and finds the unique_id.
+        delete_result = await mcp_client.call_tool(
+            "ha_delete_helpers_integrations",
+            {
+                "helper_type": "input_button",
+                "target": entity_id,
+                "confirm": True,
+            },
+        )
+        delete_data = assert_mcp_success(delete_result, "Delete disabled helper")
+
+        # Crucially: the standard registry-driven delete path ran, NOT the
+        # already_deleted fallback that masked the bug.
+        assert delete_data.get("fallback_used") != "already_deleted", (
+            f"Bug regression — disabled entity hit already_deleted fallback. "
+            f"Delete data: {delete_data}"
+        )
+        assert delete_data.get("method") == "websocket_delete", (
+            f"Expected websocket_delete via unique_id; got "
+            f"method={delete_data.get('method')}, data={delete_data}"
+        )
+        logger.info(
+            f"Disabled helper deleted via "
+            f"{delete_data.get('method')} (unique_id={delete_data.get('unique_id')})"
+        )
+
+        # VERIFY entity is actually gone from the registry — the bug let the
+        # tool report success while leaving the registry entry behind.
+        get_data = await safe_call_tool(
+            mcp_client, "ha_get_entity", {"entity_id": entity_id}
+        )
+        if get_data.get("success", True) is False:
+            # ENTITY_NOT_FOUND is the expected post-delete state
+            err_code = get_data.get("error", {}).get("code", "")
+            assert "NOT_FOUND" in err_code.upper(), (
+                f"Unexpected error after delete: {get_data}"
+            )
+        else:
+            # Successful response means entity_entry should be empty/None
+            entry = get_data.get("entity_entry") or get_data.get("data", {}).get(
+                "entity_entry"
+            )
+            assert not entry, (
+                f"Entity still present in registry after delete: {get_data}"
+            )
+
+        logger.info(
+            f"Issue #1057 regression test passed: disabled "
+            f"{entity_id} cleanly resolved via registry"
+        )
+
 
 @pytest.mark.asyncio
 @pytest.mark.config

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -696,25 +696,22 @@ class TestInputButtonCRUD:
             f"{delete_data.get('method')} (unique_id={delete_data.get('unique_id')})"
         )
 
-        # VERIFY entity is actually gone from the registry — the bug let the
-        # tool report success while leaving the registry entry behind.
+        # VERIFY entity is actually gone from the registry — pre-fix the
+        # tool reported success while leaving the registry entry behind.
+        # Post-delete, ha_get_entity returns success=False with "Entity not
+        # found" in the message; the exact error code may be
+        # ENTITY_NOT_FOUND or SERVICE_CALL_FAILED depending on which layer
+        # surfaces it first, so the assertion targets the message.
         get_data = await safe_call_tool(
             mcp_client, "ha_get_entity", {"entity_id": entity_id}
         )
-        if get_data.get("success", True) is False:
-            # ENTITY_NOT_FOUND is the expected post-delete state
-            err_code = get_data.get("error", {}).get("code", "")
-            assert "NOT_FOUND" in err_code.upper(), (
-                f"Unexpected error after delete: {get_data}"
-            )
-        else:
-            # Successful response means entity_entry should be empty/None
-            entry = get_data.get("entity_entry") or get_data.get("data", {}).get(
-                "entity_entry"
-            )
-            assert not entry, (
-                f"Entity still present in registry after delete: {get_data}"
-            )
+        assert get_data.get("success", True) is False, (
+            f"Entity still present in registry after delete: {get_data}"
+        )
+        err_msg = (get_data.get("error", {}).get("message") or "").lower()
+        assert "not found" in err_msg, (
+            f"Expected 'not found' in error message, got: {get_data}"
+        )
 
         logger.info(
             f"Issue #1057 regression test passed: disabled "

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -249,6 +249,48 @@ class TestDeleteHelpersIntegrations:
         delete_call = mock_client.send_websocket_message.call_args_list[1]
         assert delete_call[0][0]["input_button_id"] == "uid-123"
 
+    async def test_simple_path_disabled_entity_resolves_via_registry(
+        self, tools, mock_client
+    ):
+        """Issue #1057 regression: a disabled entity (registered but absent
+        from the state machine) must be resolved via the entity registry,
+        not silently treated as already-deleted.
+
+        Pre-fix behavior: state_check returned None, the loop hit ``continue``
+        and skipped the registry lookup for all 3 attempts; the code then
+        fell through to direct_id and finally to the ``already_deleted``
+        short-circuit, leaving the registry entry in place while the tool
+        reported success. Post-fix: the registry lookup runs every iteration,
+        finds the disabled entity's unique_id, and the standard delete path
+        cleans it up properly.
+        """
+        # Disabled entity: not in state machine.
+        mock_client.get_entity_state.return_value = None
+        # Registry has the entity with a unique_id; the type/delete then succeeds.
+        mock_client.send_websocket_message.side_effect = [
+            {"success": True, "result": {"unique_id": "uid-disabled-456"}},
+            {"success": True},
+        ]
+
+        result = await tools.ha_delete_helpers_integrations(
+            target="my_disabled_button",
+            helper_type="input_button",
+            confirm=True,
+            wait=False,
+        )
+        assert result["success"] is True
+        assert result["method"] == "websocket_delete"
+        assert result["unique_id"] == "uid-disabled-456"
+        # Crucially: the registry lookup ran (not skipped via the old
+        # state_check ``continue``) and the entity was NOT misclassified
+        # as already_deleted.
+        assert result.get("fallback_used") != "already_deleted"
+        # The registry call actually happened — the bug was that
+        # send_websocket_message was never called during the retry loop.
+        registry_call = mock_client.send_websocket_message.call_args_list[0]
+        assert registry_call[0][0]["type"] == "config/entity_registry/get"
+        assert registry_call[0][0]["entity_id"] == "input_button.my_disabled_button"
+
     async def test_simple_path_fallback_direct_id(self, tools, mock_client):
         """Registry has no unique_id → direct_id fallback succeeds."""
         # 3 retries all return "no unique_id", then direct delete succeeds

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -11,6 +11,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
     HomeAssistantAuthError,
     HomeAssistantConnectionError,
 )
@@ -249,47 +250,54 @@ class TestDeleteHelpersIntegrations:
         delete_call = mock_client.send_websocket_message.call_args_list[1]
         assert delete_call[0][0]["input_button_id"] == "uid-123"
 
+    @pytest.mark.parametrize(
+        "helper_type",
+        [
+            "input_button",
+            "input_boolean",
+            "input_number",
+            "input_select",
+            "input_text",
+            "input_datetime",
+        ],
+    )
     async def test_simple_path_disabled_entity_resolves_via_registry(
-        self, tools, mock_client
+        self, tools, mock_client, helper_type
     ):
         """Issue #1057 regression: a disabled entity (registered but absent
-        from the state machine) must be resolved via the entity registry,
-        not silently treated as already-deleted.
-
-        Pre-fix behavior: state_check returned None, the loop hit ``continue``
-        and skipped the registry lookup for all 3 attempts; the code then
-        fell through to direct_id and finally to the ``already_deleted``
-        short-circuit, leaving the registry entry in place while the tool
-        reported success. Post-fix: the registry lookup runs every iteration,
-        finds the disabled entity's unique_id, and the standard delete path
-        cleans it up properly.
+        from the state machine) must be resolved via the entity registry
+        and deleted via the standard websocket_delete path — not via the
+        direct_id fallback (which also reports method=websocket_delete) and
+        not via the already_deleted short-circuit.
         """
-        # Disabled entity: not in state machine.
         mock_client.get_entity_state.return_value = None
-        # Registry has the entity with a unique_id; the type/delete then succeeds.
         mock_client.send_websocket_message.side_effect = [
             {"success": True, "result": {"unique_id": "uid-disabled-456"}},
             {"success": True},
         ]
+        target = f"my_disabled_{helper_type}_target"
 
         result = await tools.ha_delete_helpers_integrations(
-            target="my_disabled_button",
-            helper_type="input_button",
+            target=target,
+            helper_type=helper_type,
             confirm=True,
             wait=False,
         )
         assert result["success"] is True
         assert result["method"] == "websocket_delete"
+        # Distinguishes from direct_id (no unique_id key) and already_deleted
+        # (no unique_id, fallback_used set) — together these pin the standard
+        # registry-driven path specifically.
+        assert "unique_id" in result, (
+            f"Standard path not taken (no unique_id in response): {result}"
+        )
         assert result["unique_id"] == "uid-disabled-456"
-        # Crucially: the registry lookup ran (not skipped via the old
-        # state_check ``continue``) and the entity was NOT misclassified
-        # as already_deleted.
-        assert result.get("fallback_used") != "already_deleted"
-        # The registry call actually happened — the bug was that
-        # send_websocket_message was never called during the retry loop.
+        assert result.get("fallback_used") is None, (
+            f"Expected standard websocket_delete path; got fallback: {result}"
+        )
         registry_call = mock_client.send_websocket_message.call_args_list[0]
         assert registry_call[0][0]["type"] == "config/entity_registry/get"
-        assert registry_call[0][0]["entity_id"] == "input_button.my_disabled_button"
+        assert registry_call[0][0]["entity_id"] == f"{helper_type}.{target}"
 
     async def test_simple_path_fallback_direct_id(self, tools, mock_client):
         """Registry has no unique_id → direct_id fallback succeeds."""
@@ -313,13 +321,16 @@ class TestDeleteHelpersIntegrations:
     async def test_simple_path_fallback_already_deleted(
         self, tools, mock_client
     ):
-        """Registry empty + direct delete fails + state=None → already_deleted."""
-        # 3x registry no unique_id, 1x direct delete fails, then state=None
+        """Registry empty + direct delete fails + state=None + registry-verify
+        confirms gone → already_deleted."""
+        # 3x registry no unique_id, 1x direct delete fails, 1x verify-registry
+        # confirms entity is truly gone (success=False)
         mock_client.send_websocket_message.side_effect = (
             [{"success": True, "result": {}}] * 3
             + [{"success": False, "error": "not found"}]
+            + [{"success": False, "error": "not_found"}]
         )
-        # State check at the end returns None → entity already gone
+        # State check at the end returns None → entity gone from state machine
         mock_client.get_entity_state.side_effect = (
             [{"state": "off"}] * 3  # during retries
             + [None]  # final check after direct-delete fail
@@ -333,6 +344,68 @@ class TestDeleteHelpersIntegrations:
         )
         assert result["success"] is True
         assert result["fallback_used"] == "already_deleted"
+
+    async def test_simple_path_disabled_no_unique_id_surfaces_error(
+        self, tools, mock_client
+    ):
+        """Issue #1057 residual hazard: a disabled entity that is registry-
+        resident but missing unique_id (and direct-id delete fails) must NOT
+        be silently classified as already_deleted. The previous fallback
+        relied on state-absence alone, which is exactly the symptom of a
+        disabled entity — masking the bug. Post-fix: registry-verify confirms
+        the entry is still there and we surface SERVICE_CALL_FAILED instead.
+        """
+        # 3x registry returns entry but no unique_id, 1x direct delete fails,
+        # 1x verify-registry shows entity STILL registered
+        mock_client.send_websocket_message.side_effect = (
+            [{"success": True, "result": {"entity_id": "input_button.my_button"}}] * 3
+            + [{"success": False, "error": "not found"}]
+            + [{
+                "success": True,
+                "result": {"entity_id": "input_button.my_button"},
+            }]
+        )
+        # Disabled entity: state-absent throughout
+        mock_client.get_entity_state.return_value = None
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_delete_helpers_integrations(
+                target="my_button",
+                helper_type="input_button",
+                confirm=True,
+                wait=False,
+            )
+        err = json.loads(str(exc_info.value))
+        assert err["success"] is False
+        assert err["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "registry entry exists" in err["error"]["message"]
+
+    async def test_simple_path_disabled_state_check_apierror_resolves_via_registry(
+        self, tools, mock_client
+    ):
+        """The HomeAssistantAPIError branch in the state-check try/except
+        must not derail registry resolution. A disabled entity often responds
+        404 to the state-check; that's informational, the registry path
+        still has to run.
+        """
+        mock_client.get_entity_state.side_effect = HomeAssistantAPIError(
+            "404 simulated"
+        )
+        mock_client.send_websocket_message.side_effect = [
+            {"success": True, "result": {"unique_id": "uid-disabled-apierror"}},
+            {"success": True},
+        ]
+
+        result = await tools.ha_delete_helpers_integrations(
+            target="my_disabled_button",
+            helper_type="input_button",
+            confirm=True,
+            wait=False,
+        )
+        assert result["success"] is True
+        assert result["method"] == "websocket_delete"
+        assert result.get("fallback_used") is None
+        assert result["unique_id"] == "uid-disabled-apierror"
 
     async def test_simple_path_all_fallbacks_exhausted(
         self, tools, mock_client


### PR DESCRIPTION
## What does this PR do?

Closes #1057. The `_delete_simple_helper` registry-lookup loop in `tools_integrations.py` skipped the registry lookup whenever `get_entity_state` returned None — which is exactly the case for **disabled** entities (`disabled_by != null`). They're removed from the state machine but remain in the entity registry. Pre-fix, this fell through to the `already_deleted` short-circuit, leaving the registry entry in place while the tool reported success.

Per option 3.1 from the issue thread (minimal blast radius): drop the `continue` so the registry lookup runs every iteration. After Gemini's G2 perf review, the state-check `asyncio.sleep` was also dropped — with the `continue` gone, that sleep no longer acted as a race-condition guard, and the registry-fail backoff already provides retry-cadence. The state-check itself stays as an informational debug log.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Two regression tests guard the fix:
- **Unit**: `test_simple_path_disabled_entity_resolves_via_registry` (`tests/src/unit/test_tools_integrations.py`) — mocks `get_entity_state=None` + a registry-success response and asserts the standard `websocket_delete` path runs (not the `already_deleted` fallback).
- **E2E**: `test_disabled_input_button_deletion_resolves_via_registry` (`tests/src/e2e/workflows/config/test_helper_crud.py`) — creates a real `input_button` helper, disables its entity via `ha_set_entity(enabled=False)`, deletes it, and verifies both that the deletion took the standard path and that the registry entry is actually gone afterwards.

## Checklist
- [ ] I have updated documentation if needed

No public-tool API change in this PR; the bug is on internal helper code, no docstring/site-doc update needed.

---

**Out of scope**: option 3.2 (remove the state-check fast-path entirely, including the informational debug log) is a wider behavior change for a separate PR.

**Refs**: #1056 (consolidation PR where Gemini surfaced the bug), #1007 (consolidation parent).
