### PR TITLE
docs: surface tool-discovery / categorized search

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,43 @@ Skills can still be installed manually for clients that prefer local skill files
 
 ---
 
+## 🔍 Tool Discovery for AI Agents
+
+By default, the full tool catalog (~86 tools) is listed to the client through the standard MCP `tools/list` response. Clients with deferred / on-demand tool loading (Claude Sonnet, Claude Opus, claude.ai) handle that fine — tools are pulled into context only when needed, so idle context cost is near-zero.
+
+For models *without* deferred tool support — Claude Haiku, OpenAI-compatible local models, smaller open-weights models — listing 86 tools eats ~46K tokens of idle context. To address that, the server ships with a **search-based discovery mode** built on top of FastMCP's BM25 search transform.
+
+### Enable search-based discovery
+
+Set `ENABLE_TOOL_SEARCH=true` (or toggle the option in the HA add-on). The full catalog is replaced with four entry points plus a small set of always-visible "pinned" tools (`ha_search_entities`, `ha_get_overview`, `ha_restart`, etc.):
+
+| Tool | Purpose |
+|------|---------|
+| `ha_search_tools` | BM25 keyword search across all tools. Returns name, description, parameters, and annotations (`readOnlyHint` / `destructiveHint`) so the agent can pick the right one. |
+| `ha_call_read_tool` | Execute a `readOnlyHint` tool by name. Safe — clients can auto-approve. |
+| `ha_call_write_tool` | Execute a write tool that creates or updates data. |
+| `ha_call_delete_tool` | Execute a tool that removes / deletes data. |
+
+The proxy split lets MCP clients apply different permission policies per category (e.g. auto-approve reads, prompt for writes, confirm deletes) without parsing tool docstrings.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ENABLE_TOOL_SEARCH` | `false` | Replace full tool catalog with search-based discovery (~46K → ~5K idle tokens). |
+| `TOOL_SEARCH_MAX_RESULTS` | `5` | Max results returned by `ha_search_tools` (range 2–10). |
+| `PINNED_TOOLS` | empty | Comma-separated tool names to keep always visible. The web settings UI is the primary way to manage this. |
+
+### When to enable
+
+- **Claude Haiku, OpenAI-compatible local models, or any model without native deferred tool support** — large idle-context savings.
+- **MCP clients that cap total tool count** (some cap at 100) — surfaces ~4 tools instead of 86.
+- **Cost-sensitive deployments** — fewer idle tokens per turn.
+
+Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step.
+
+For the HA add-on, the same option is documented in [`homeassistant-addon/DOCS.md`](homeassistant-addon/DOCS.md#enable_tool_search) along with the in-add-on settings UI for fine-grained tool enable/disable/pin.
+
+---
+
 ## 🧪 Dev Channel
 
 Want early access to new features and fixes? Dev releases (`.devN`) are published on every push to master.

--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ Skills can still be installed manually for clients that prefer local skill files
 
 ## 🔍 Tool Discovery for AI Agents
 
-By default, the full tool catalog (~86 tools) is listed to the client through the standard MCP `tools/list` response. Clients with deferred / on-demand tool loading (Claude Sonnet, Claude Opus, claude.ai) handle that fine — tools are pulled into context only when needed, so idle context cost is near-zero.
+By default, the full tool catalog (~86 tools) is listed to the client through the standard MCP `tools/list` response. Clients with deferred / on-demand tool loading (Claude Sonnet, Claude Opus,) handle that fine — tools are pulled into context only when needed, so idle context cost is near-zero.
 
-For models *without* deferred tool support — Claude Haiku, OpenAI-compatible local models, smaller open-weights models — listing 86 tools eats ~46K tokens of idle context. To address that, the server ships with a **search-based discovery mode** built on top of FastMCP's BM25 search transform.
+For models *without* deferred tool support — Claude Haiku, Gemini, ChatGPT OpenAI-compatible local models, smaller open-weights models — listing 86 tools eats ~46K tokens of idle context. To address that, the server ships with a **search-based discovery mode** built on top of FastMCP's BM25 search transform.
 
 ### Enable search-based discovery
 
@@ -263,11 +263,11 @@ The proxy split lets MCP clients apply different permission policies per categor
 
 ### When to enable
 
-- **Claude Haiku, OpenAI-compatible local models, or any model without native deferred tool support** — large idle-context savings.
+- **Claude Haiku, OpenAI-compatible local models, Gemini, ChatGPT or any model without native deferred tool support** — large idle-context savings.
 - **MCP clients that cap total tool count** (some cap at 100) — surfaces ~4 tools instead of 86.
 - **Cost-sensitive deployments** — fewer idle tokens per turn.
 
-Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step.
+Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step. If you choose to use our toolsearch then you should disable the native Claude Opus/Sonnet toolsearch, which is called deferred tools in the settings.
 
 For the HA add-on, the same option is documented in [`homeassistant-addon/DOCS.md`](homeassistant-addon/DOCS.md#enable_tool_search) along with the in-add-on settings UI for fine-grained tool enable/disable/pin.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ For models *without* deferred tool support — Claude Haiku, Gemini, ChatGPT Ope
 
 ### Enable search-based discovery
 
-Set `ENABLE_TOOL_SEARCH=true` (or toggle the option in the HA add-on). The full catalog is replaced with four entry points plus a small set of always-visible "pinned" tools (`ha_search_entities`, `ha_get_overview`, `ha_restart`, etc.):
+Set ENABLE_TOOL_SEARCH=true (or toggle the option in the HA add-on). The full catalog is replaced in the tool list with four entry points plus a small set of always-visible "pinned" tools (ha_search_entities, ha_get_overview, ha_restart, etc.). All tools remain callable directly by name once discovered:
 
 | Tool | Purpose |
 |------|---------|
@@ -264,7 +264,7 @@ The proxy split lets MCP clients apply different permission policies per categor
 ### When to enable
 
 - **Claude Haiku, OpenAI-compatible local models, Gemini, ChatGPT or any model without native deferred tool support** — large idle-context savings.
-- **MCP clients that cap total tool count** (some cap at 100) — surfaces ~4 tools instead of 86.
+- MCP clients that cap total tool count (some cap at 100) — surfaces a minimal set (~10 tools) instead of 86.
 - **Cost-sensitive deployments** — fewer idle tokens per turn.
 
 Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step. If you choose to use our toolsearch then you should disable the native Claude Opus/Sonnet toolsearch, which is called deferred tools in the settings.


### PR DESCRIPTION
## Why

The repo already ships an LLM-facing tool-discovery surface: `CategorizedSearchTransform` in `src/ha_mcp/transforms/categorized_search.py` (subclass of FastMCP's `BM25SearchTransform`) replaces the full tool catalog with `ha_search_tools` plus three categorized read/write/delete proxies when `ENABLE_TOOL_SEARCH=true`. The categorized split lets MCP clients apply different permission policies per category without parsing tool docstrings.

The HA add-on docs cover this thoroughly (`homeassistant-addon/DOCS.md#enable_tool_search` and the dev-channel docs), but the project README says nothing about it. Non-add-on users — PyPI, Docker, Claude Desktop, custom MCP clients — currently have no pointer to:

- the `ENABLE_TOOL_SEARCH` setting and what it does,
- the four entry points (`ha_search_tools`, `ha_call_read_tool`, `ha_call_write_tool`, `ha_call_delete_tool`),
- when to enable it (Haiku, OpenAI-compatible local models, clients that cap tool count),
- when to leave it off (Sonnet/Opus and other clients with deferred tool support, where the full catalog has near-zero idle context cost).

## What

One new section in `README.md`, parallel to the existing Skills section: short prose, a 4-row tool table, a 3-row settings table (`ENABLE_TOOL_SEARCH`, `TOOL_SEARCH_MAX_RESULTS`, `PINNED_TOOLS`), and “when to enable” / “when to leave off” guidance. Links back to `homeassistant-addon/DOCS.md#enable_tool_search` for the in-add-on UI deep dive.

## Why not add a new tool

I evaluated adding a `ha_discover_tools` catalog tool first. Skipped because:

- It would duplicate `ha_search_tools` when `ENABLE_TOOL_SEARCH=true` (same payload shape: name, description, parameters, annotations).
- It would duplicate the standard MCP `tools/list` response when `ENABLE_TOOL_SEARCH=false` (default) — clients already get the full catalog there.
- `AGENTS.md` calls out reducing tool count as a priority and tells contributors to consolidate redundant tools, not add more.

The genuine gap was discoverability for end users, which is fixed by docs.

## Out of scope

- No code changes, no new tool, no behavior changes.
- No tag/annotation changes on existing tools.
- No CHANGELOG entry — `docs:` doesn't trigger a release per `AGENTS.md` semantic-release table.

## Test plan

Docs-only diff (37 lines added to `README.md`). No tests required.

- [x] `git diff --stat` shows only `README.md`
- [x] Anchor target `homeassistant-addon/DOCS.md#enable_tool_search` exists
- [x] Cross-references match current settings (`ENABLE_TOOL_SEARCH`, `TOOL_SEARCH_MAX_RESULTS` 2–10 range, `PINNED_TOOLS`) in `src/ha_mcp/config.py`
- [x] Tool list (`ha_search_tools`, `ha_call_{read,write,delete}_tool`) matches `CategorizedSearchTransform`
