### PR TITLE
fix(ci): break gemini-triage retrigger loop and bump turn budget

### DIFF
--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -74,6 +74,22 @@ jobs:
               return;
             }
 
+            // Circuit breaker: if a previous triage attempt posted the
+            // generic "temporarily unavailable" notice, the failure path
+            // applied `triage-failed`. Stop auto-retriggering on every
+            // subsequent comment — without this gate, large issues that
+            // exceed maxSessionTurns or otherwise consistently fail end
+            // up with a stack of identical "temporarily unavailable"
+            // notices, one per author comment. Maintainers can use
+            // workflow_dispatch to retry manually once the underlying
+            // cause is fixed; the success path also removes this label.
+            const hasTriageFailedLabel = issue.labels.some(l => l.name === 'triage-failed');
+            if (hasTriageFailedLabel && context.eventName !== 'workflow_dispatch') {
+              core.info('Skipping: Previous triage failed (has triage-failed label). Use workflow_dispatch to retry.');
+              core.setOutput('should_run', 'false');
+              return;
+            }
+
             // Don't run if bot commented. Broad `type === 'Bot'` (not just
             // `github-actions[bot]`) is intentional here — we want to ignore
             // retriggers from any bot, including Dependabot/Renovate update
@@ -427,7 +443,7 @@ jobs:
           settings: |
             {
               "model": {
-                "maxSessionTurns": 20
+                "maxSessionTurns": 50
               },
               "tools": {
                 "core": [
@@ -660,6 +676,10 @@ jobs:
 
             let analysisBody;
             let shouldAddTriagedLabel = false;
+            // Set on every path that posts GENERIC_FAILURE_BODY. Drives the
+            // `triage-failed` circuit-breaker label so the next comment from
+            // the issue author doesn't auto-retrigger another doomed run.
+            let shouldAddFailedLabel = false;
             let extraLabels = [];
 
             // CLI step failures must NEVER expose raw stderr to issue authors.
@@ -669,6 +689,7 @@ jobs:
             if (evaluateOutcome === 'failure' || geminiOutcome === 'failure') {
               core.error(`Gemini triage step failed (evaluate=${evaluateOutcome}, analysis=${geminiOutcome}); posting generic notice to issue.`);
               analysisBody = GENERIC_FAILURE_BODY;
+              shouldAddFailedLabel = true;
             } else if (geminiSummary) {
               const labelMatch = geminiSummary.match(/<!--\s*TRIAGE_LABELS:\s*([\w,\s-]+?)\s*-->/);
               if (labelMatch) {
@@ -743,6 +764,7 @@ jobs:
               if (looksLikeRefusal || tooLong) {
                 core.error(`evaluate output diverted to generic notice (looksLikeRefusal=${looksLikeRefusal}, length=${trimmed.length}); raw output: ${trimmed.slice(0, 200)}`);
                 analysisBody = GENERIC_FAILURE_BODY;
+                shouldAddFailedLabel = true;
               } else {
                 if (!matchesMissingInfoShape) {
                   core.warning(`evaluate output didn't match expected bullet/numbered/bold list shape (length=${trimmed.length}); posting LLM prose verbatim.`);
@@ -756,6 +778,7 @@ jobs:
             } else {
               core.error(`Triage produced no usable output (evaluateOutcome=${evaluateOutcome}, geminiOutcome=${geminiOutcome}); posting generic notice.`);
               analysisBody = GENERIC_FAILURE_BODY;
+              shouldAddFailedLabel = true;
             }
 
             try {
@@ -773,8 +796,9 @@ jobs:
               return;
             }
 
+            const issueNumber = ${{ steps.issue_number.outputs.number }};
+
             if (shouldAddTriagedLabel) {
-              const issueNumber = ${{ steps.issue_number.outputs.number }};
               const labelsToAdd = ['triaged', ...extraLabels];
               core.info(`Adding labels: ${labelsToAdd.join(', ')}`);
               try {
@@ -790,6 +814,49 @@ jobs:
                 // future comment, piling up placeholders. Fail loudly so a
                 // maintainer adds the label by hand.
                 core.setFailed(`addLabels failed for issue #${issueNumber} (${labelsToAdd.join(',')}): ${err.message}. Issue will re-trigger triage on next comment until 'triaged' is applied manually.`);
+              }
+
+              // Successful triage clears any prior `triage-failed` circuit-breaker
+              // so the issue's label state reflects the final outcome (this matters
+              // when a maintainer recovers a stuck issue via workflow_dispatch).
+              // 404 = label wasn't there to begin with; that's fine and not an error.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'triage-failed'
+                });
+                core.info(`Removed stale 'triage-failed' label from issue #${issueNumber}`);
+              } catch (err) {
+                if (err.status !== 404) {
+                  core.warning(`Failed to remove 'triage-failed' label from issue #${issueNumber}: ${err.message}`);
+                }
+              }
+            }
+
+            if (shouldAddFailedLabel) {
+              // Circuit breaker: applying `triage-failed` blocks the
+              // should_run gate from auto-retriggering on every subsequent
+              // author comment. Without it, a consistently-failing issue
+              // (e.g. one that exceeds maxSessionTurns) accumulates one
+              // "temporarily unavailable" notice per comment. Maintainers
+              // can clear the label or use workflow_dispatch to retry.
+              core.info(`Adding 'triage-failed' label to issue #${issueNumber} to break retrigger loop`);
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['triage-failed']
+                });
+              } catch (err) {
+                // Don't `setFailed` here — the failure-path job is already
+                // going to exit 1 in the trailing "Fail job if Gemini
+                // steps failed" step, and this label is a circuit breaker
+                // not a correctness gate. Warn so a maintainer notices if
+                // the label wasn't applied (without it, the loop persists).
+                core.warning(`addLabels failed for 'triage-failed' on issue #${issueNumber}: ${err.message}. Triage may retrigger on next comment until label is applied manually.`);
               }
             }
 

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -528,7 +528,7 @@ jobs:
             - `google_web_search <query>` - Search web for error messages or external docs
 
             **Critical Rules:**
-            - **TIME BUDGET**: You have ~8 minutes. Limit yourself to ~10 tool calls total. If you can't find something after 2 searches, move on. Focus on the single most likely root cause.
+            - **TIME BUDGET**: You have ~8 minutes. Aim for ~10 tool calls; if you genuinely need more (long issue, multiple files), the harness allows up to 50 turns total — use them sparingly. If you can't find something after 2 searches, move on. Focus on the single most likely root cause.
             - **YOU ARE READ-ONLY**: You cannot modify files, create PRs, or make code changes
             - If you identify a fix, provide it as a diff in the Technical Analysis section
             - ONLY reference file paths you actually found with `grep` or `find`
@@ -683,11 +683,20 @@ jobs:
             let extraLabels = [];
 
             // CLI step failures must NEVER expose raw stderr to issue authors.
-            // Step-level `cancelled` (e.g. step-timeout, rare) is treated like
-            // failure here; job-level cancellation is filtered by the step's
+            // Match anything that isn't `success` or `skipped` — that includes
+            // step-level `failure`, step-level `cancelled` (e.g. step-timeout,
+            // rare), and any future outcome value the action may emit. We
+            // explicitly do NOT include `skipped`: the evaluate step is
+            // skipped via `skip_preanalysis`, and the analysis step is
+            // skipped on the missing-info path; both are normal flow, not
+            // failures. Job-level cancellation is filtered by the step's
             // `if: !cancelled()` guard above and never reaches this script.
-            if (evaluateOutcome === 'failure' || geminiOutcome === 'failure') {
-              core.error(`Gemini triage step failed (evaluate=${evaluateOutcome}, analysis=${geminiOutcome}); posting generic notice to issue.`);
+            const stepHadNonSuccess = (
+              (evaluateOutcome && evaluateOutcome !== 'success' && evaluateOutcome !== 'skipped') ||
+              (geminiOutcome && geminiOutcome !== 'success' && geminiOutcome !== 'skipped')
+            );
+            if (stepHadNonSuccess) {
+              core.error(`Gemini triage step did not succeed (evaluate=${evaluateOutcome}, analysis=${geminiOutcome}); posting generic notice to issue.`);
               analysisBody = GENERIC_FAILURE_BODY;
               shouldAddFailedLabel = true;
             } else if (geminiSummary) {
@@ -748,9 +757,16 @@ jobs:
                 /^i'?m (unable|not able)\s+to\s+(help|assist|comply|do that|do this|fulfill|answer that|answer this|continue|process)/i,
                 /^we (cannot|can'?t|are unable)\s+(help|assist|comply|fulfill)/i,
                 /^i refuse to\b/i,
-                // Policy / guideline refusals — narrower phrases that don't
-                // realistically appear in non-refusal prose
-                /\b(safety policy|content policy|i refuse|won'?t help|cannot assist)\b/i,
+                // Policy / guideline refusals — narrow noun-phrases that don't
+                // realistically appear in non-refusal prose. Earlier revisions
+                // included bare `\bcannot assist\b` and `\bi refuse\b` here;
+                // both are removed because they false-positive on legitimate
+                // missing-info phrasing like "The user can run X; without it,
+                // I refuse to guess". `cannot assist` as a refusal lead-in is
+                // already covered by the anchored verb-pairing pattern above
+                // (`^i cannot ... (assist|...)`), and `i refuse to` is covered
+                // by its own anchored pattern.
+                /\b(safety policy|content policy|won'?t help)\b/i,
                 /\bviolates? (my|our|the) (guidelines|policies|terms)\b/i,
               ];
               const looksLikeRefusal = REFUSAL_PATTERNS.some(re => re.test(trimmed));
@@ -820,6 +836,12 @@ jobs:
               // so the issue's label state reflects the final outcome (this matters
               // when a maintainer recovers a stuck issue via workflow_dispatch).
               // 404 = label wasn't there to begin with; that's fine and not an error.
+              // For other failures (5xx, network, auth) we only warn rather than
+              // setFailed: the should_run gate at the top of this workflow checks
+              // `triaged` BEFORE `triage-failed`, so a stale `triage-failed` label
+              // alongside `triaged` doesn't actually block re-triage — the issue's
+              // label set looks inconsistent until a maintainer cleans it up, but
+              // no behavior breaks.
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
@@ -851,20 +873,42 @@ jobs:
                   labels: ['triage-failed']
                 });
               } catch (err) {
-                // Don't `setFailed` here — the failure-path job is already
-                // going to exit 1 in the trailing "Fail job if Gemini
-                // steps failed" step, and this label is a circuit breaker
-                // not a correctness gate. Warn so a maintainer notices if
-                // the label wasn't applied (without it, the loop persists).
+                // Warn instead of setFailed — the run is already going red
+                // either via the trailing "Fail job if Gemini steps failed"
+                // step (when a CLI step had a non-success outcome) or via
+                // the explicit setFailed below (when divert paths fired
+                // without any step failure). The label itself is a circuit
+                // breaker not a correctness gate, so a missed addLabels
+                // here only reverts to pre-#1131 behavior; the warning
+                // surfaces in the Actions log so a maintainer can apply
+                // the label by hand if needed.
                 core.warning(`addLabels failed for 'triage-failed' on issue #${issueNumber}: ${err.message}. Triage may retrigger on next comment until label is applied manually.`);
+              }
+
+              // Divert paths (refusal/too-long/no-output at lines 767/783)
+              // set `shouldAddFailedLabel = true` even though both Gemini
+              // steps returned `success`. The trailing "Fail job if Gemini
+              // steps failed" step won't fire in those cases, so without
+              // this `setFailed` the run exits green even though the user
+              // got a "temporarily unavailable" notice — exactly the silent
+              // failure pattern this PR is meant to eliminate. Skip when a
+              // step already had a non-success outcome to avoid stacking
+              // redundant failure messages.
+              if (!stepHadNonSuccess) {
+                core.setFailed(`Triage diverted to generic notice with no Gemini step failure (evaluate=${evaluateOutcome}, analysis=${geminiOutcome}). See "Update comment and labels" log above for the divert reason (refusal pattern, too-long output, or no usable output).`);
               }
             }
 
-      # Surface Gemini step failures as a red X. Only fires on actual `failure`
-      # outcomes — `cancelled` is intentionally excluded so concurrency
-      # cancel-in-progress (a normal occurrence) doesn't paint runs red.
+      # Surface Gemini step failures as a red X. Fires on any non-success/
+      # non-skipped outcome (`failure`, step-level `cancelled` from a step
+      # timeout, or any future outcome value). Job-level cancellation from
+      # concurrency `cancel-in-progress` is filtered by the `!cancelled()`
+      # guard so superseded runs don't paint red. Divert paths (refusal/
+      # too-long/no-output) where both steps returned `success` are surfaced
+      # by `core.setFailed` inside the "Update comment and labels" script,
+      # not here.
       - name: Fail job if Gemini steps failed
-        if: ${{ !cancelled() && (steps.evaluate.outcome == 'failure' || steps.gemini_analysis.outcome == 'failure') }}
+        if: ${{ !cancelled() && ((steps.evaluate.outcome != 'success' && steps.evaluate.outcome != 'skipped') || (steps.gemini_analysis.outcome != 'success' && steps.gemini_analysis.outcome != 'skipped')) }}
         run: |
-          echo "::error::Gemini triage failed (evaluate=${{ steps.evaluate.outcome }}, analysis=${{ steps.gemini_analysis.outcome }}). The issue received a generic 'temporarily unavailable' notice; check the step logs above for the underlying CLI error."
+          echo "::error::Gemini triage step did not succeed (evaluate=${{ steps.evaluate.outcome }}, analysis=${{ steps.gemini_analysis.outcome }}). The issue received a generic 'temporarily unavailable' notice; check the step logs above for the underlying CLI error."
           exit 1

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -752,11 +752,21 @@ jobs:
                 /^(unfortunately|sorry|i'?m sorry|i apologize|my apologies|error:)/i,
                 /^as an? (ai|language model|assistant|llm)\b/i,
                 // First-person refusal verb + help-action pairing
-                /^i (cannot|can'?t|won'?t)\s+(help|assist|comply|do that|do this|fulfill|answer that|answer this|provide that|provide this|continue|process this)/i,
+                /^i (cannot|can'?t|won'?t)\s+(help|assist|comply|do that|do this|fulfill|answer that|answer this|provide that|provide this|provide assistance|continue|process this)/i,
                 /^i am (unable|not able)\s+to\s+(help|assist|comply|do that|do this|fulfill|answer that|answer this|continue|process)/i,
                 /^i'?m (unable|not able)\s+to\s+(help|assist|comply|do that|do this|fulfill|answer that|answer this|continue|process)/i,
                 /^we (cannot|can'?t|are unable)\s+(help|assist|comply|fulfill)/i,
                 /^i refuse to\b/i,
+                // Additional Gemini refusal lead-ins flagged in PR #1122 review.
+                // "I am afraid..." / "I'm afraid..." paired with a refusal verb
+                // (cannot/can't/won't) covers the polite-decline phrasing without
+                // false-positiving on standalone "I'm afraid the version isn't
+                // mentioned" info-request prose.
+                /^i('?m| am) afraid (i )?(cannot|can'?t|won'?t)/i,
+                // Bare "Unable to help..." (no leading "I'm") — Gemini sometimes
+                // drops the pronoun entirely. Narrow help-action set so prose
+                // like "Unable to determine the version" doesn't false-positive.
+                /^unable to (help|assist|comply)/i,
                 // Policy / guideline refusals — narrow noun-phrases that don't
                 // realistically appear in non-refusal prose. Earlier revisions
                 // included bare `\bcannot assist\b` and `\bi refuse\b` here;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ When implementing features or debugging, consult these resources:
 | `needs-info` | Awaiting clarification from reporter |
 | `priority: high/medium/low` | Relative priority |
 | `triaged` | Automated Gemini triage complete |
-| `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on author comments. Clear it (or run via `workflow_dispatch`) to retry. |
+| `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on comments. Clear it (or run via `workflow_dispatch`) to retry |
 | `issue-analyzed` | Deep Claude analysis complete |
 
 ### Issue Analysis Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ When implementing features or debugging, consult these resources:
 | `needs-info` | Awaiting clarification from reporter |
 | `priority: high/medium/low` | Relative priority |
 | `triaged` | Automated Gemini triage complete |
+| `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on author comments. Clear it (or run via `workflow_dispatch`) to retry. |
 | `issue-analyzed` | Deep Claude analysis complete |
 
 ### Issue Analysis Workflow


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1122. That PR replaced the raw stderr dumps with a friendly
*"⚠️ Triage bot temporarily unavailable"* notice — but a new failure mode
is now spamming user issues, with #1109 being the visible canary.

Two complementary fixes:

### 1. `maxSessionTurns` 20 → 50 on the full-analysis step

`#1109` consistently dies with `FatalTurnLimitedError: Reached max session
turns for this session.`. Triggers from the analysis runs:

- Issue body ~12K chars + 6 long diagnostic comments → giant prompt
- Analysis prompt grants `read_file` / `grep` / `git log` / `google_web_search` etc., so the model takes several tool turns to ground its answer
- In one of the captured failed runs ([25373456978](https://github.com/homeassistant-ai/ha-mcp/actions/runs/25373456978)), `google_web_search` returned **HTTP 500 from Google's backend**, which the CLI retries internally — burning turns the user never asked for
- 20-turn budget runs out before the model can write its summary

Doubling-and-a-bit to 50 leaves headroom for both the long-issue case and a few transient `google_web_search` 5xx retries without changing the prompt or tool surface.

### 2. New `triage-failed` label acts as a circuit breaker

The structural bug is in label management: only the success path applied
`triaged`, so failures retriggered on every author comment. From #1109's timeline:

```
2026-05-05T11:14:21Z  ⚠️ Triage bot temporarily unavailable.   ← run 1
2026-05-05T11:24:08Z  ⚠️ Triage bot temporarily unavailable.   ← run 2
2026-05-05T11:35:24Z  🤖 Issue Triage Bot is analyzing...      ← run 3 placeholder
```

Each of those is a separate workflow run kicked off by Fauteck's helpful follow-up comments — not desirable. As the maintainer put it: *"usually each comment retriggers till it finally runs and gives an analysis."*

This PR fixes that:

- **Gate added in the `should_run` job**: if `triage-failed` is on the issue, comment-triggered runs are skipped. `workflow_dispatch` still bypasses the gate so a maintainer can retry once the underlying cause (e.g. Gemini outage, prompt drift, model deprecation) is resolved.
- **All three `GENERIC_FAILURE_BODY` paths** now set `shouldAddFailedLabel = true`:
  - CLI step `failure` outcome (the FatalTurnLimit case in #1109)
  - Refusal/too-long divert from the missing-info path
  - "No usable output" fallthrough
- **Successful re-triage removes any prior `triage-failed`** via `removeLabel`, so a `workflow_dispatch` recovery leaves the issue's label state consistent with the final outcome. 404 from `removeLabel` (label wasn't there) is swallowed.
- **`addLabels` failure for `triage-failed` is a `core.warning`, not `core.setFailed`** — the trailing *"Fail job if Gemini steps failed"* step already exits 1, and a missing circuit-breaker label only reverts behavior to what's shipping today (loop persists until label is applied manually).

### Pre-flight: label created out-of-band

The `triage-failed` label has been created on the repo (`#d73a4a`, description `"Automated Gemini triage failed; clear (or use workflow_dispatch) to retry"`) so the workflow doesn't 422 on the first failure-path run after merge.

### Out of scope (intentional)

- **Drop `google_web_search` from the analysis tool surface.** This was option (3) in the diagnosis. Skipped per maintainer call — it's the proximate source of the 5xx-retry turn burn but also the only way the model can verify recent HA / addon SDK / dependency behavior. `maxSessionTurns: 50` covers the worst-case retry budget without losing the capability.
- **Truncate issue body / comments before injection.** Option (4). Skipped — would be more invasive than the budget bump and risks losing the long diagnostic detail that's exactly what makes triage on issues like #1109 useful.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (\`uv run pytest\`)
- [x] Code follows style guidelines (\`uv run ruff check\`)

CI YAML only — pytest/ruff aren't applicable, and the existing PR Validation Pipeline runs against this branch. Real validation happens on the next triage failure after merge:

- **Healthy `gemini` step** → normal analysis comment posted, `triaged` applied, any prior `triage-failed` cleared.
- **Broken `gemini` step on a fresh issue** → generic notice + `triage-failed` applied + red Actions run. **Subsequent author comments are skipped** (the loop is broken).
- **Maintainer recovery via `workflow_dispatch`** on a `triage-failed` issue → analysis runs, success path adds `triaged` and removes `triage-failed`.
- **`#1109` itself**: I've left this issue's labels untouched so the merge can immediately exercise the gate. After merge, posting a comment on #1109 should now trigger triage one more time (label not yet applied), and either succeed (50-turn budget covers it) or fail-and-stop (`triage-failed` applied, no further loop).

## Checklist
- [x] I have updated documentation if needed _(AGENTS.md issue-labels table updated)_