### PR TITLE
test(e2e): pin config_hash stability for dashboards

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -248,6 +248,8 @@ class AutomationConfigTools:
 
         Returns the complete configuration including triggers, conditions, actions, and mode settings.
 
+        The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
+
         EXAMPLES:
         - Get automation: ha_config_get_automation("automation.morning_routine")
         - Get by unique_id: ha_config_get_automation("my_unique_automation_id")

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -483,6 +483,8 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
           Returns the full Lovelace dashboard config, defaulting to the
           main dashboard if url_path is omitted.
 
+        The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
+
         EXAMPLES:
         - List all dashboards: ha_config_get_dashboard(list_only=True)
         - Get default dashboard: ha_config_get_dashboard(url_path="default")

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -483,7 +483,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
           Returns the full Lovelace dashboard config, defaulting to the
           main dashboard if url_path is omitted.
 
-        The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
+        Return a stable `config_hash` (Get and Search modes only; not present in list_only mode) across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
 
         EXAMPLES:
         - List all dashboards: ha_config_get_dashboard(list_only=True)

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -95,6 +95,8 @@ class ConfigScriptTools:
 
         Returns the complete configuration for a script, including sequence, mode, fields, and other settings.
 
+        The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
+
         EXAMPLES:
         - Get script: ha_config_get_script("morning_routine")
         - Get script: ha_config_get_script("backup_script")

--- a/src/ha_mcp/utils/config_hash.py
+++ b/src/ha_mcp/utils/config_hash.py
@@ -13,6 +13,14 @@ def compute_config_hash(config: dict[str, Any]) -> str:
 
     Uses SHA256 truncated to 16 hex characters (64 bits). Deterministic
     via sorted keys and minimal separators.
+
+    Stability across reads is the caller's contract, not this function's.
+    Automations canonicalize via ``_normalize_config_for_roundtrip`` before
+    hashing; scripts and dashboards hash raw HA responses, so their
+    stability depends on HA returning byte-identical responses on
+    consecutive reads. The ``test_config_hash_stable_across_reads`` E2E
+    tests pin this for each tool family. See issue #980 for the
+    contract analysis.
     """
     config_str = json.dumps(config, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(config_str.encode()).hexdigest()[:16]

--- a/src/ha_mcp/utils/config_hash.py
+++ b/src/ha_mcp/utils/config_hash.py
@@ -17,9 +17,10 @@ def compute_config_hash(config: dict[str, Any]) -> str:
     Stability across reads is the caller's contract, not this function's.
     Automations canonicalize via ``_normalize_config_for_roundtrip`` before
     hashing; scripts and dashboards hash raw HA responses, so their
-    stability depends on HA returning byte-identical responses on
-    consecutive reads. The ``test_config_hash_stable_across_reads`` E2E
-    tests pin this for each tool family. See issue #980 for the
+    stability depends on HA returning structurally identical responses on
+    consecutive reads (``sort_keys=True`` canonicalizes dict-key order but
+    not list-element order). The ``test_config_hash_stable_across_reads``
+    E2E tests pin this for each tool family. See issue #980 for the
     contract analysis.
     """
     config_str = json.dumps(config, sort_keys=True, separators=(",", ":"))

--- a/tests/src/e2e/workflows/automation/test_python_transform.py
+++ b/tests/src/e2e/workflows/automation/test_python_transform.py
@@ -390,6 +390,7 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
         "ha_config_get_automation", {"identifier": entity_id}
     )
 
+    assert isinstance(read1["config_hash"], str) and len(read1["config_hash"]) == 16
     assert read1["config_hash"] == read2["config_hash"]
 
 
@@ -421,6 +422,7 @@ async def test_plural_key_hash_stability(mcp_client, ha_client):
         "ha_config_get_automation", {"identifier": entity_id}
     )
 
+    assert isinstance(read1["config_hash"], str) and len(read1["config_hash"]) == 16
     assert read1["config_hash"] == read2["config_hash"]
 
     # Transform using the hash should succeed

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -356,4 +356,5 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
         "ha_config_get_dashboard", {"url_path": "test-hash-stability"}
     )
 
+    assert isinstance(read1["config_hash"], str) and len(read1["config_hash"]) == 16
     assert read1["config_hash"] == read2["config_hash"]

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -306,3 +306,54 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
     # Verify error message mentions conflict
     error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_config_hash_stable_across_reads(mcp_client, ha_client):
+    """Test that two consecutive reads of a dashboard return the same config_hash.
+
+    Dashboards (unlike automations) hash the raw HA Lovelace response without
+    a normalize-for-roundtrip step, so stability across reads depends on HA
+    returning byte-identical responses. This test pins that contract; if HA
+    ever introduces non-determinism in the response shape (computed fields,
+    ordered-set semantics, etc.), the optimistic-locking surface would
+    silently degrade. Mirror of `test_config_hash_stable_across_reads` in
+    `automation/test_python_transform.py` and `scripts/test_python_transform.py`.
+    See issue #980 for the contract analysis.
+    """
+    mcp = MCPAssertions(mcp_client)
+
+    # Non-trivial config — multiple views, mixed card types — to exercise
+    # any HA-side ordering or normalization differences.
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-hash-stability",
+            "config": {
+                "views": [
+                    {
+                        "title": "View 1",
+                        "cards": [
+                            {"type": "button", "entity": "light.test_a", "icon": "mdi:lamp"},
+                            {"type": "entities", "entities": ["light.test_b", "switch.test_c"]},
+                        ],
+                    },
+                    {
+                        "title": "View 2",
+                        "cards": [
+                            {"type": "markdown", "content": "## Hello"},
+                        ],
+                    },
+                ],
+            },
+        },
+    )
+
+    read1 = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-hash-stability"}
+    )
+    read2 = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-hash-stability"}
+    )
+
+    assert read1["config_hash"] == read2["config_hash"]

--- a/tests/src/e2e/workflows/scripts/test_python_transform.py
+++ b/tests/src/e2e/workflows/scripts/test_python_transform.py
@@ -205,6 +205,7 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
         "ha_config_get_script", {"script_id": "test_hash_stability"}
     )
 
+    assert isinstance(read1["config_hash"], str) and len(read1["config_hash"]) == 16
     assert read1["config_hash"] == read2["config_hash"]
 
 


### PR DESCRIPTION
## What does this PR do?

Pins the dashboard side of the `config_hash` stability contract identified in #980 — the asymmetry where automations canonicalize via `_normalize_config_for_roundtrip` before hashing, while scripts and dashboards hash raw HA responses.

- Adds `test_config_hash_stable_across_reads` for dashboards, mirroring the existing automation/scripts pendants from #968.
- Documents the stability contract on `compute_config_hash` itself.
- Cross-references the contract from the three get-tool docstrings (`ha_config_get_script`, `ha_config_get_automation`, `ha_config_get_dashboard`).

Implements Option 2 from the issue (test + docstring), per the 2026-05-04 issue comment.

Closes #980.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — full E2E suite runs on CI; local Docker not available in this environment
- [x] Code follows style guidelines (`uv run ruff check`) — verified locally with ruff 0.15.12 (matches `uv.lock`)

## Checklist
- [x] I have updated documentation if needed
