### PR TITLE
feat: expose device_class + options on ha_set_entity / ha_get_entity (Show As)

### DIFF
--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -38,6 +38,9 @@ def _format_entity_entry(entry: dict[str, Any]) -> dict[str, Any]:
         "aliases": entry.get("aliases", []),
         "labels": entry.get("labels", []),
         "categories": entry.get("categories", {}),
+        "device_class": entry.get("device_class"),
+        "original_device_class": entry.get("original_device_class"),
+        "options": entry.get("options", {}),
     }
 
 
@@ -75,6 +78,8 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         parsed_expose_to: dict[str, bool] | None,
         new_entity_id: str | None = None,
         new_device_name: str | None = None,
+        device_class: str | None = None,
+        parsed_options: dict[str, dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Update a single entity. Returns the response dict."""
         # For add/remove operations, we need to fetch current labels first
@@ -119,6 +124,14 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         if icon is not None:
             message["icon"] = icon if icon else None
             updates_made.append(f"icon='{icon}'" if icon else "icon cleared")
+
+        if device_class is not None:
+            message["device_class"] = device_class if device_class else None
+            updates_made.append(
+                f"device_class='{device_class}'"
+                if device_class
+                else "device_class cleared"
+            )
 
         if enabled is not None:
             try:
@@ -203,13 +216,17 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         if new_device_name is not None:
             updates_made.append(f"device_name -> {new_device_name}")
 
+        if parsed_options:
+            for _domain, _sub in parsed_options.items():
+                updates_made.append(f"options[{_domain}]={_sub}")
+
         if not updates_made:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
                     "No updates specified",
                     suggestions=[
-                        "Provide at least one of: area_id, name, icon, enabled, hidden, aliases, categories, labels, expose_to, new_entity_id, or new_device_name"
+                        "Provide at least one of: area_id, name, icon, device_class, enabled, hidden, aliases, categories, labels, options, expose_to, new_entity_id, or new_device_name"
                     ],
                 )
             )
@@ -241,15 +258,19 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "Verify the entity_id exists using ha_search_entities()",
                 ]
                 if new_entity_id is not None:
-                    suggestions.extend([
-                        "Check that the new entity_id doesn't already exist",
-                        "Ensure the entity has a unique_id (some legacy entities cannot be renamed)",
-                    ])
+                    suggestions.extend(
+                        [
+                            "Check that the new entity_id doesn't already exist",
+                            "Ensure the entity has a unique_id (some legacy entities cannot be renamed)",
+                        ]
+                    )
                 else:
-                    suggestions.extend([
-                        "Check that area_id exists if specified",
-                        "Some entities may not support all update options",
-                    ])
+                    suggestions.extend(
+                        [
+                            "Check that area_id exists if specified",
+                            "Some entities may not support all update options",
+                        ]
+                    )
                 raise_tool_error(
                     create_error_response(
                         ErrorCode.SERVICE_CALL_FAILED,
@@ -264,6 +285,41 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             # If entity was renamed, update entity_id for subsequent operations
             if new_entity_id:
                 entity_id = new_entity_id
+
+        # Per-domain options updates: HA's `config/entity_registry/update` WS schema
+        # treats `options_domain` + `options` as a `vol.Inclusive("entity_option")`
+        # group — they MUST be sent paired, and `options` carries only ONE domain's
+        # sub-dict per call. So an agent-supplied {domain: {...}, ...} is split into
+        # one WS call per domain.
+        if parsed_options:
+            for opts_domain, opts_sub in parsed_options.items():
+                opts_msg: dict[str, Any] = {
+                    "type": "config/entity_registry/update",
+                    "entity_id": entity_id,
+                    "options_domain": opts_domain,
+                    "options": opts_sub,
+                }
+                opts_result = await client.send_websocket_message(opts_msg)
+                if not opts_result.get("success"):
+                    error = opts_result.get("error", {})
+                    error_msg = (
+                        error.get("message", str(error))
+                        if isinstance(error, dict)
+                        else str(error)
+                    )
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            f"Failed to update options for domain '{opts_domain}': {error_msg}",
+                            context={
+                                "entity_id": entity_id,
+                                "options_domain": opts_domain,
+                            },
+                        )
+                    )
+                entity_entry = opts_result.get("result", {}).get(
+                    "entity_entry", entity_entry
+                )
 
         # Handle new_device_name — rename the associated device
         # Normalize empty string to None (no-op, don't clear device name)
@@ -281,12 +337,16 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 if get_result.get("success"):
                     entity_entry = get_result.get("result", {})
                 else:
-                    logger.warning(f"Entity registry lookup failed for {entity_id}: {get_result.get('error')}")
+                    logger.warning(
+                        f"Entity registry lookup failed for {entity_id}: {get_result.get('error')}"
+                    )
                     device_rename_result = {
                         "warning": "Entity registry lookup failed — could not determine device. Retry may succeed.",
                     }
 
-            device_id = entity_entry.get("device_id") if not device_rename_result else None
+            device_id = (
+                entity_entry.get("device_id") if not device_rename_result else None
+            )
             if not device_id:
                 device_rename_result = {
                     "warning": "Entity has no associated device — device rename skipped",
@@ -351,12 +411,16 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     if has_registry_updates:
                         context["partial"] = True
                         context["entity_entry"] = _format_entity_entry(entity_entry)
-                    raise_tool_error(create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        f"Exposure failed: {error_msg}",
-                        context=context,
-                        suggestions=["Check Home Assistant connection and entity availability"],
-                    ))
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            f"Exposure failed: {error_msg}",
+                            context=context,
+                            suggestions=[
+                                "Check Home Assistant connection and entity availability"
+                            ],
+                        )
+                    )
 
                 # Track successful exposures
                 for a in assistants:
@@ -374,15 +438,20 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             if get_result.get("success"):
                 entity_entry = get_result.get("result", {})
             else:
-                raise_tool_error(create_error_response(
-                    ErrorCode.ENTITY_NOT_FOUND,
-                    f"Entity '{entity_id}' not found in registry after applying exposure changes",
-                    context={"entity_id": entity_id, "exposure_succeeded": exposure_result},
-                    suggestions=[
-                        "Verify the entity_id exists using ha_search_entities()",
-                        "The entity's exposure settings were likely changed, but its current state could not be confirmed.",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        f"Entity '{entity_id}' not found in registry after applying exposure changes",
+                        context={
+                            "entity_id": entity_id,
+                            "exposure_succeeded": exposure_result,
+                        },
+                        suggestions=[
+                            "Verify the entity_id exists using ha_search_entities()",
+                            "The entity's exposure settings were likely changed, but its current state could not be confirmed.",
+                        ],
+                    )
+                )
 
         response_data: dict[str, Any] = {
             "success": True,
@@ -448,6 +517,33 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             str | None,
             Field(
                 description="Icon for the entity (e.g., 'mdi:thermometer'). Use empty string '' to remove custom icon. Single entity only.",
+                default=None,
+            ),
+        ] = None,
+        device_class: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Override the entity's display device class — what the HA UI's "
+                    "'Show As' dropdown writes. Use empty string '' to clear the "
+                    "override and fall back to the integration default. Single entity only. "
+                    "Examples: 'window', 'door', 'motion' for binary_sensor; "
+                    "'temperature', 'humidity' for sensor."
+                ),
+                default=None,
+            ),
+        ] = None,
+        options: Annotated[
+            str | dict[str, dict[str, Any]] | None,
+            Field(
+                description=(
+                    "Per-domain entity registry options (e.g. sensor 'display_precision', "
+                    "weather 'forecast_type'). Pass a dict mapping domain to a sub-dict, "
+                    'e.g. {"sensor": {"display_precision": 2}}. JSON-string form also accepted. '
+                    "Multiple domains are sent as separate registry updates. "
+                    "For 'Show As' use the dedicated `device_class` parameter — that is "
+                    "what the HA UI Show As dropdown writes. Single entity only."
+                ),
                 default=None,
             ),
         ] = None,
@@ -540,17 +636,29 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         """Update entity properties in the entity registry.
 
         Allows modifying entity metadata such as area assignment, display name,
-        icon, enabled/disabled state, visibility, aliases, labels, voice
-        assistant exposure, and entity_id rename in a single call.
+        icon, "Show As" device class override, per-domain registry options,
+        enabled/disabled state, visibility, aliases, labels, voice assistant
+        exposure, and entity_id rename in a single call.
 
         BULK OPERATIONS:
         When entity_id is a list, only labels, expose_to, and categories parameters are supported.
-        Other parameters (area_id, name, icon, enabled, hidden, aliases, new_entity_id, new_device_name) require single entity.
+        Other parameters (area_id, name, icon, device_class, options, enabled, hidden, aliases, new_entity_id, new_device_name) require single entity.
 
         LABEL OPERATIONS:
         - label_operation="set" (default): Replace all labels with the provided list. Use [] to clear.
         - label_operation="add": Add labels to existing ones without removing any.
         - label_operation="remove": Remove specified labels from the entity.
+
+        SHOW AS / DEVICE CLASS:
+        device_class overrides the entity's display device class — equivalent to the
+        HA UI's "Show As" dropdown. Use empty string '' to clear. Applies instantly,
+        no reload needed.
+
+        REGISTRY OPTIONS:
+        options carries per-domain registry options (sensor display_precision,
+        weather forecast_type, etc). Pass {domain: {key: value}}; multi-domain
+        dicts are sent as separate registry updates because HA's WS schema
+        requires options_domain + options to be paired one domain at a time.
 
         ENTITY ID RENAME:
         Use new_entity_id to change an entity's ID (e.g., sensor.old -> sensor.new).
@@ -576,6 +684,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         Single entity:
         - Assign to area: ha_set_entity("sensor.temp", area_id="living_room")
         - Rename display name: ha_set_entity("sensor.temp", name="Living Room Temperature")
+        - Set Show As: ha_set_entity("binary_sensor.zone_10", device_class="window")
+        - Clear Show As: ha_set_entity("binary_sensor.zone_10", device_class="")
+        - Set sensor precision: ha_set_entity("sensor.power", options={"sensor": {"display_precision": 2}})
         - Rename entity_id: ha_set_entity("light.old_name", new_entity_id="light.new_name")
         - Rename entity and device: ha_set_entity("light.old", new_entity_id="light.new", new_device_name="New Lamp")
         - Rename entity_id with friendly name: ha_set_entity("sensor.old", new_entity_id="sensor.new", name="New Name")
@@ -638,6 +749,8 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "area_id": area_id,
                 "name": name,
                 "icon": icon,
+                "device_class": device_class,
+                "options": options,
                 "enabled": enabled,
                 "hidden": hidden,
                 "aliases": aliases,
@@ -655,7 +768,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         f"Bulk operations (multiple entity_ids) only support categories, labels, and expose_to. "
                         f"Single-entity parameters provided: {non_null_single_params}",
                         suggestions=[
-                            "Use a single entity_id for area_id, name, icon, enabled, hidden, or aliases",
+                            "Use a single entity_id for area_id, name, icon, device_class, options, enabled, hidden, or aliases",
                             "Or remove single-entity parameters to use bulk categories/labels/expose_to",
                         ],
                     )
@@ -747,6 +860,30 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                     )
 
+            parsed_options: dict[str, dict[str, Any]] | None = None
+            if options is not None:
+                try:
+                    parsed_opts = parse_json_param(options, "options")
+                except ValueError as e:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            f"Invalid options parameter: {e}",
+                        )
+                    )
+
+                if not isinstance(parsed_opts, dict) or not all(
+                    isinstance(v, dict) for v in parsed_opts.values()
+                ):
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            "options must be a dict mapping domain to a sub-dict, "
+                            'e.g. {"sensor": {"display_precision": 2}}',
+                        )
+                    )
+                parsed_options = parsed_opts
+
             # Parse and validate expose_to parameter
             parsed_expose_to: dict[str, bool] | None = None
             if expose_to is not None:
@@ -819,6 +956,8 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     parsed_expose_to,
                     new_entity_id=new_entity_id,
                     new_device_name=new_device_name,
+                    device_class=device_class,
+                    parsed_options=parsed_options,
                 )
 
             # Bulk case - process each entity
@@ -937,6 +1076,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - aliases: Voice assistant aliases
         - labels: Assigned label IDs
         - categories: Category assignments (dict mapping scope to category_id)
+        - device_class: User "Show As" override (null = use original_device_class)
+        - original_device_class: Default device class from the integration
+        - options: Per-domain registry options (e.g. sensor display_precision, voice exposure)
         - platform: Integration platform (e.g., "hue", "zwave_js")
         - device_id: Associated device ID (null if standalone)
         - unique_id: Integration's unique identifier
@@ -1005,6 +1147,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "aliases": entry.get("aliases", []),
                     "labels": entry.get("labels", []),
                     "categories": entry.get("categories", {}),
+                    "device_class": entry.get("device_class"),
+                    "original_device_class": entry.get("original_device_class"),
+                    "options": entry.get("options", {}),
                     "platform": entry.get("platform"),
                     "device_id": entry.get("device_id"),
                     "unique_id": entry.get("unique_id"),

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -138,10 +138,13 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             updates_made.append(f"icon='{icon}'" if icon else "icon cleared")
 
         if device_class is not None:
-            message["device_class"] = device_class if device_class else None
+            # Treat whitespace-only as the documented "clear" sentinel so
+            # accidental spaces don't reach HA as a literal validation error.
+            normalized_device_class = device_class.strip() or None
+            message["device_class"] = normalized_device_class
             updates_made.append(
-                f"device_class='{device_class}'"
-                if device_class
+                f"device_class='{normalized_device_class}'"
+                if normalized_device_class
                 else "device_class cleared"
             )
 
@@ -319,20 +322,31 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # `updates_applied` is the human-readable prose list
                     # including non-options updates (name=, icon=, etc.).
                     # Both are surfaced — they serve different consumers.
+                    options_failure_context: dict[str, Any] = {
+                        "entity_id": entity_id,
+                        "options_domain": opts_domain,
+                        "partial": partial,
+                        "options_succeeded": options_succeeded,
+                        "updates_applied": list(updates_made),
+                    }
+                    # Only include entity_entry when something actually mutated;
+                    # _format_entity_entry({}) returns an all-None stub that's
+                    # indistinguishable from "entity has nothing set". Mirrors
+                    # the expose_to failure path below.
+                    if partial:
+                        options_failure_context["entity_entry"] = _format_entity_entry(
+                            entity_entry
+                        )
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
                             f"{msg_prefix} domain '{opts_domain}': {err_msg}",
-                            context={
-                                "entity_id": entity_id,
-                                "options_domain": opts_domain,
-                                "partial": partial,
-                                "options_succeeded": options_succeeded,
-                                "updates_applied": list(updates_made),
-                                "entity_entry": _format_entity_entry(entity_entry),
-                            },
+                            context=options_failure_context,
                         )
                     )
+                # HA returns the cumulative entity_entry on each per-domain
+                # call, so last-call-wins reassignment leaves the final loop
+                # iteration carrying the full state.
                 entity_entry = opts_result.get("result", {}).get(
                     "entity_entry", entity_entry
                 )
@@ -575,7 +589,10 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     'e.g. {"sensor": {"display_precision": 2}}. JSON-string form also accepted. '
                     "Multiple domains are sent as separate registry updates. "
                     "For 'Show As' use the dedicated `device_class` parameter — that is "
-                    "what the HA UI Show As dropdown writes. Single entity only."
+                    "what the HA UI Show As dropdown writes. Voice-assistant exposure is "
+                    "stored under `options.<assistant>.should_expose` but must be managed "
+                    "via the dedicated `expose_to` parameter, not this options dict. "
+                    "Single entity only."
                 ),
                 default=None,
             ),

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -73,13 +73,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         }
         result = await client.send_websocket_message(get_msg)
         if not result.get("success"):
-            error = result.get("error", {})
-            error_msg = (
-                error.get("message", str(error))
-                if isinstance(error, dict)
-                else str(error)
-            )
-            return None, error_msg
+            return None, _extract_ws_error(result)
         return result.get("result", {}).get("labels", []), None
 
     async def _update_single_entity(
@@ -320,6 +314,11 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         if partial
                         else "Failed to update options for"
                     )
+                    # `options_succeeded` is the structured retriable form
+                    # (agent can re-feed it minus the failing domain).
+                    # `updates_applied` is the human-readable prose list
+                    # including non-options updates (name=, icon=, etc.).
+                    # Both are surfaced — they serve different consumers.
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
@@ -357,7 +356,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     entity_entry = get_result.get("result", {})
                 else:
                     logger.warning(
-                        f"Entity registry lookup failed for {entity_id}: {get_result.get('error')}"
+                        "Entity registry lookup failed for %s: %s",
+                        entity_id,
+                        _extract_ws_error(get_result),
                     )
                     device_rename_result = {
                         "warning": "Entity registry lookup failed — could not determine device. Retry may succeed.",
@@ -381,7 +382,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     device_rename_result = {"success": True, "device_id": device_id}
                 else:
                     device_rename_result = {
-                        "warning": f"Entity updated but device rename failed: {device_result.get('error', 'Unknown error')}",
+                        "warning": f"Entity updated but device rename failed: {_extract_ws_error(device_result)}",
                         "device_id": device_id,
                     }
 
@@ -417,14 +418,31 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 if not expose_result.get("success"):
                     error_msg = _extract_ws_error(expose_result)
                     failed = dict.fromkeys(assistants, should_expose)
+                    # `partial` must reflect every prior mutation in the function:
+                    # main registry update, per-domain options, device rename, and
+                    # any expose_to batch (e.g. expose_true) that ran before this
+                    # one (expose_false) failed. Anything truthy in those means
+                    # the registry already moved.
+                    prior_mutation = (
+                        has_registry_updates
+                        or bool(options_succeeded)
+                        or bool(succeeded)
+                        or bool(
+                            device_rename_result and device_rename_result.get("success")
+                        )
+                    )
                     context: dict[str, Any] = {
                         "entity_id": entity_id,
                         "exposure_succeeded": succeeded,
                         "exposure_failed": failed,
                     }
-                    if has_registry_updates:
+                    if prior_mutation:
                         context["partial"] = True
                         context["entity_entry"] = _format_entity_entry(entity_entry)
+                        if options_succeeded:
+                            context["options_succeeded"] = options_succeeded
+                        if device_rename_result and device_rename_result.get("success"):
+                            context["device_rename_succeeded"] = True
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
@@ -510,7 +528,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         entity_id: Annotated[
             str | list[str],
             Field(
-                description="Entity ID or list of entity IDs to update. Bulk operations (list) only support labels and expose_to parameters."
+                description="Entity ID or list of entity IDs to update. Bulk operations (list) only support labels, expose_to, and categories parameters."
             ),
         ],
         area_id: Annotated[
@@ -1031,19 +1049,15 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             "error": str(result),
                         }
                     )
-                elif result.get("success"):
+                else:
+                    # _update_single_entity always returns success-shape or
+                    # raises ToolError (caught above as BaseException), so the
+                    # `result.get("success") is False` branch is unreachable.
                     succeeded.append(
                         {
                             "entity_id": eid,
                             "entity_entry": result.get("entity_entry"),
                             "updates": result.get("updates"),
-                        }
-                    )
-                else:
-                    failed.append(
-                        {
-                            "entity_id": eid,
-                            "error": result.get("error", "Unknown error"),
                         }
                     )
 
@@ -1163,13 +1177,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 result = await client.send_websocket_message(message)
 
                 if not result.get("success"):
-                    error = result.get("error", {})
-                    error_msg = (
-                        error.get("message", str(error))
-                        if isinstance(error, dict)
-                        else str(error)
-                    )
-                    raise ValueError(error_msg)
+                    raise ValueError(_extract_ws_error(result))
 
                 entry = result.get("result", {})
                 return {
@@ -1314,12 +1322,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
 
             if not result.get("success"):
-                error = result.get("error", {})
-                error_msg = (
-                    error.get("message", str(error))
-                    if isinstance(error, dict)
-                    else str(error)
-                )
+                error_msg = _extract_ws_error(result)
                 if "not found" in error_msg.lower():
                     raise_tool_error(
                         create_error_response(

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -44,6 +44,24 @@ def _format_entity_entry(entry: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _extract_ws_error(result: dict[str, Any]) -> str:
+    """Pull a user-readable message out of a failed WebSocket response.
+
+    Falls back to a static placeholder + warning log when HA returns an
+    empty or malformed error envelope, so the user-facing message never
+    degrades to literal "{}".
+    """
+    error = result.get("error")
+    if isinstance(error, dict):
+        msg = error.get("message")
+        if isinstance(msg, str) and msg:
+            return msg
+    elif isinstance(error, str) and error:
+        return error
+    logger.warning("HA WS response had no usable error detail: %r", result)
+    return "no error detail returned by Home Assistant"
+
+
 def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register entity management tools with the MCP server."""
 
@@ -216,11 +234,10 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         if new_device_name is not None:
             updates_made.append(f"device_name -> {new_device_name}")
 
-        if parsed_options:
-            for _domain, _sub in parsed_options.items():
-                updates_made.append(f"options[{_domain}]={_sub}")
-
-        if not updates_made:
+        # parsed_options entries are appended to updates_made AFTER each per-domain
+        # WS call succeeds, so the response never falsely claims an unwritten domain
+        # was updated. Empty-input check below treats them as "pending" updates.
+        if not updates_made and not parsed_options:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -248,12 +265,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             result = await client.send_websocket_message(message)
 
             if not result.get("success"):
-                error = result.get("error", {})
-                error_msg = (
-                    error.get("message", str(error))
-                    if isinstance(error, dict)
-                    else str(error)
-                )
+                error_msg = _extract_ws_error(result)
                 suggestions = [
                     "Verify the entity_id exists using ha_search_entities()",
                 ]
@@ -286,11 +298,11 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             if new_entity_id:
                 entity_id = new_entity_id
 
-        # Per-domain options updates: HA's `config/entity_registry/update` WS schema
-        # treats `options_domain` + `options` as a `vol.Inclusive("entity_option")`
-        # group — they MUST be sent paired, and `options` carries only ONE domain's
-        # sub-dict per call. So an agent-supplied {domain: {...}, ...} is split into
-        # one WS call per domain.
+        # Per-domain options updates: HA's WS schema requires `options_domain`
+        # and `options` to be sent paired one domain per call (the API takes a
+        # single domain's sub-dict). An agent-supplied {domain: {...}, ...} is
+        # therefore split into one registry update per domain.
+        options_succeeded: dict[str, dict[str, Any]] = {}
         if parsed_options:
             for opts_domain, opts_sub in parsed_options.items():
                 opts_msg: dict[str, Any] = {
@@ -301,25 +313,32 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 }
                 opts_result = await client.send_websocket_message(opts_msg)
                 if not opts_result.get("success"):
-                    error = opts_result.get("error", {})
-                    error_msg = (
-                        error.get("message", str(error))
-                        if isinstance(error, dict)
-                        else str(error)
+                    err_msg = _extract_ws_error(opts_result)
+                    partial = bool(options_succeeded) or has_registry_updates
+                    msg_prefix = (
+                        "Partially updated entity; failed updating options for"
+                        if partial
+                        else "Failed to update options for"
                     )
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
-                            f"Failed to update options for domain '{opts_domain}': {error_msg}",
+                            f"{msg_prefix} domain '{opts_domain}': {err_msg}",
                             context={
                                 "entity_id": entity_id,
                                 "options_domain": opts_domain,
+                                "partial": partial,
+                                "options_succeeded": options_succeeded,
+                                "updates_applied": list(updates_made),
+                                "entity_entry": _format_entity_entry(entity_entry),
                             },
                         )
                     )
                 entity_entry = opts_result.get("result", {}).get(
                     "entity_entry", entity_entry
                 )
+                options_succeeded[opts_domain] = opts_sub
+                updates_made.append(f"options[{opts_domain}]={opts_sub}")
 
         # Handle new_device_name — rename the associated device
         # Normalize empty string to None (no-op, don't clear device name)
@@ -396,12 +415,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 expose_result = await client.send_websocket_message(expose_msg)
 
                 if not expose_result.get("success"):
-                    error = expose_result.get("error", {})
-                    error_msg = (
-                        error.get("message", str(error))
-                        if isinstance(error, dict)
-                        else str(error)
-                    )
+                    error_msg = _extract_ws_error(expose_result)
                     failed = dict.fromkeys(assistants, should_expose)
                     context: dict[str, Any] = {
                         "entity_id": entity_id,
@@ -526,9 +540,10 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 description=(
                     "Override the entity's display device class — what the HA UI's "
                     "'Show As' dropdown writes. Use empty string '' to clear the "
-                    "override and fall back to the integration default. Single entity only. "
-                    "Examples: 'window', 'door', 'motion' for binary_sensor; "
-                    "'temperature', 'humidity' for sensor."
+                    "override and fall back to the integration default. None (the "
+                    "default) means 'no change' — pass an explicit '' to clear. "
+                    "Single entity only. Examples: 'window', 'door', 'motion' for "
+                    "binary_sensor; 'temperature', 'humidity' for sensor."
                 ),
                 default=None,
             ),
@@ -872,14 +887,35 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                     )
 
-                if not isinstance(parsed_opts, dict) or not all(
-                    isinstance(v, dict) for v in parsed_opts.values()
-                ):
+                if not isinstance(parsed_opts, dict):
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "options must be a dict mapping domain to a sub-dict, "
+                            f"options must be a dict mapping domain to a sub-dict "
+                            f"(got {type(parsed_opts).__name__}), "
                             'e.g. {"sensor": {"display_precision": 2}}',
+                        )
+                    )
+                if not parsed_opts:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            "options cannot be an empty dict — pass at least one "
+                            'domain entry, e.g. {"sensor": {"display_precision": 2}}, '
+                            "or omit the parameter entirely.",
+                        )
+                    )
+                bad_subs = [
+                    f"{k!r}: {type(v).__name__}"
+                    for k, v in parsed_opts.items()
+                    if not isinstance(v, dict)
+                ]
+                if bad_subs:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            "options sub-values must be dicts, got non-dict for: "
+                            f"{', '.join(bad_subs)}",
                         )
                     )
                 parsed_options = parsed_opts
@@ -1078,7 +1114,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - categories: Category assignments (dict mapping scope to category_id)
         - device_class: User "Show As" override (null = use original_device_class)
         - original_device_class: Default device class from the integration
-        - options: Per-domain registry options (e.g. sensor display_precision, voice exposure)
+        - options: Per-domain registry options (e.g. sensor display_precision).
+          Voice-assistant exposure is also stored here but should be set/cleared
+          via the ha_set_entity(expose_to=...) parameter, not the options dict.
         - platform: Integration platform (e.g., "hue", "zwave_js")
         - device_id: Associated device ID (null if standalone)
         - unique_id: Integration's unique identifier

--- a/tests/initial_test_state/configuration.yaml
+++ b/tests/initial_test_state/configuration.yaml
@@ -38,10 +38,14 @@ demo:
 template:
   - sensor:
       - name: demo Temperature
+        unique_id: e2e_demo_temperature
         state: "{{ 22.5 }}"
         device_class: temperature
+        state_class: measurement
         unit_of_measurement: "°C"
       - name: demo Outside Temperature
+        unique_id: e2e_demo_outside_temperature
         state: "{{ 10.0 }}"
         device_class: temperature
+        state_class: measurement
         unit_of_measurement: "°C"

--- a/tests/initial_test_state/configuration.yaml
+++ b/tests/initial_test_state/configuration.yaml
@@ -20,3 +20,28 @@ http:
     - 192.168.0.0/16
 
 demo:
+
+# YAML-configured template sensors providing the `sensor.demo_temperature`
+# and `sensor.demo_outside_temperature` names that several existing e2e
+# tests reference (test_helper_crud.py, test_config_entry_flow.py). The
+# bare `demo:` line above does NOT create entities in modern HA — the
+# demo integration is config-flow-only since it was migrated — so without
+# these YAML fixtures those tests passed only because HA helper configs
+# accept unknown entity IDs (the helper's state would be 'unknown' at
+# runtime, but the helper itself was created successfully).
+#
+# These same fixtures double as the non-helper integration entity for
+# tests/src/e2e/workflows/entities/test_show_as.py — YAML template
+# entities aren't reachable via ha_config_set_helper (which uses the
+# config-flow API), so they're a legitimate "integration-provided" fixture
+# for proving ha_set_entity works on entities with no helper alternative.
+template:
+  - sensor:
+      - name: demo Temperature
+        state: "{{ 22.5 }}"
+        device_class: temperature
+        unit_of_measurement: "°C"
+      - name: demo Outside Temperature
+        state: "{{ 10.0 }}"
+        device_class: temperature
+        unit_of_measurement: "°C"

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -194,3 +194,84 @@ class TestShowAs:
             assert opts.get("conversation", {}).get("should_expose") is False
         finally:
             await _delete_template_helper(mcp_client, entity_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.registry
+class TestShowAsOnIntegrationEntity:
+    """Round-trip on an INTEGRATION-PROVIDED entity (the demo platform's
+    sensor.demo_temperature), not a helper.
+
+    Helpers can already be (re)configured with a device_class via
+    ha_config_set_helper for the template binary_sensor / template sensor
+    subtypes — so the helper-based tests above don't *literally* prove the
+    new ha_set_entity capability for the original-issue case (an integration
+    entity like envisalink's binary_sensor.alarm_zone_10). This test does:
+    sensor.demo_temperature comes from configuration.yaml's `demo:` line and
+    has no helper-creation alternative. The Z-Wave / Zigbee / envisalink
+    user path goes through the same `config/entity_registry/update` WS call
+    we're exercising here, so this is a legitimate stand-in.
+    """
+
+    TARGET = "sensor.demo_temperature"
+
+    async def test_set_show_as_on_integration_provided_sensor(self, mcp_client):
+        pre = await mcp_client.call_tool("ha_get_entity", {"entity_id": self.TARGET})
+        pre_data = assert_mcp_success(pre, "Read pre-state")
+        original_override = pre_data["entity_entry"]["device_class"]
+        original_device_class = pre_data["entity_entry"]["original_device_class"]
+        # Demo integration ships this as a temperature sensor — guarantee that
+        # the override slot and the integration's own slot are distinct so we
+        # know the test is exercising what we think it is.
+        assert original_device_class == "temperature"
+
+        try:
+            # Override Show As to a different device class
+            set_result = await mcp_client.call_tool(
+                "ha_set_entity",
+                {"entity_id": self.TARGET, "device_class": "humidity"},
+            )
+            set_data = assert_mcp_success(set_result, "Set Show As=humidity")
+            assert set_data["entity_entry"]["device_class"] == "humidity"
+            # original_device_class must NOT be touched by the override
+            assert set_data["entity_entry"]["original_device_class"] == "temperature"
+
+            get_result = await mcp_client.call_tool(
+                "ha_get_entity", {"entity_id": self.TARGET}
+            )
+            get_data = assert_mcp_success(get_result, "Read overridden device_class")
+            assert get_data["entity_entry"]["device_class"] == "humidity"
+
+            # Set per-domain options on the same integration entity (proves
+            # ha_config_set_helper isn't even a possible alternative path here)
+            await mcp_client.call_tool(
+                "ha_set_entity",
+                {
+                    "entity_id": self.TARGET,
+                    "options": {"sensor": {"display_precision": 3}},
+                },
+            )
+            opts_result = await mcp_client.call_tool(
+                "ha_get_entity", {"entity_id": self.TARGET}
+            )
+            opts_data = assert_mcp_success(opts_result, "Read options")
+            assert (
+                opts_data["entity_entry"]["options"]
+                .get("sensor", {})
+                .get("display_precision")
+                == 3
+            )
+        finally:
+            # Restore the override slot to its pre-test value (None or whatever
+            # it was) so we don't leak state to other tests sharing the demo
+            # entity inside this test container.
+            restore_dc = "" if original_override is None else original_override
+            await mcp_client.call_tool(
+                "ha_set_entity",
+                {"entity_id": self.TARGET, "device_class": restore_dc},
+            )
+            # Clear the sensor sub-options we added.
+            await mcp_client.call_tool(
+                "ha_set_entity",
+                {"entity_id": self.TARGET, "options": {"sensor": {}}},
+            )

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -201,18 +201,23 @@ class TestShowAs:
 @pytest.mark.asyncio
 @pytest.mark.registry
 class TestShowAsOnIntegrationEntity:
-    """Round-trip on an INTEGRATION-PROVIDED entity (the demo platform's
-    sensor.demo_temperature), not a helper.
+    """Round-trip on an INTEGRATION-PROVIDED entity (a YAML-configured
+    template sensor), not a helper.
 
     Helpers can already be (re)configured with a device_class via
     ha_config_set_helper for the template binary_sensor / template sensor
     subtypes — so the helper-based tests above don't *literally* prove the
     new ha_set_entity capability for the original-issue case (an integration
     entity like envisalink's binary_sensor.alarm_zone_10). This test does:
-    sensor.demo_temperature comes from configuration.yaml's `demo:` line and
-    has no helper-creation alternative. The Z-Wave / Zigbee / envisalink
-    user path goes through the same `config/entity_registry/update` WS call
-    we're exercising here, so this is a legitimate stand-in.
+    sensor.demo_temperature is declared in
+    tests/initial_test_state/configuration.yaml under a `template:` block
+    (the bare `demo:` line above it is a no-op in modern HA — the demo
+    integration is config-flow-only). YAML-template entities are owned by
+    the template integration and have NO config entry, so
+    ha_config_set_helper (which routes through config_entries / the
+    config-flow API) cannot manage them. Z-Wave / Zigbee / envisalink user
+    paths go through the same `config/entity_registry/update` WS call we're
+    exercising here, so this is a legitimate stand-in.
     """
 
     TARGET = "sensor.demo_temperature"
@@ -225,9 +230,9 @@ class TestShowAsOnIntegrationEntity:
         # Capture the entity's pre-test sensor sub-options so the restore can
         # put them back exactly, rather than blindly clearing the dict.
         original_sensor_options = pre_data["entity_entry"]["options"].get("sensor", {})
-        # Demo integration ships this as a temperature sensor — guarantee that
-        # the override slot and the integration's own slot are distinct so we
-        # know the test is exercising what we think it is.
+        # The YAML fixture declares device_class: temperature — guarantee
+        # the override slot and the integration's own slot are distinct so
+        # we know the test is exercising what we think it is.
         assert original_device_class == "temperature"
 
         try:

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -281,11 +281,14 @@ class TestShowAsOnIntegrationEntity:
                 {"entity_id": self.TARGET, "device_class": restore_dc},
             )
             # Restore the sensor sub-options to their pre-test value so any
-            # demo-platform default we overwrote is put back intact.
-            await mcp_client.call_tool(
-                "ha_set_entity",
-                {
-                    "entity_id": self.TARGET,
-                    "options": {"sensor": dict(original_sensor_options)},
-                },
-            )
+            # demo-platform default we overwrote is put back intact. Skip the
+            # round-trip when there was nothing captured — sending an empty
+            # sub-dict would otherwise emit a no-op options={"sensor": {}} call.
+            if original_sensor_options:
+                await mcp_client.call_tool(
+                    "ha_set_entity",
+                    {
+                        "entity_id": self.TARGET,
+                        "options": {"sensor": dict(original_sensor_options)},
+                    },
+                )

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -10,6 +10,12 @@ from tests.src.e2e.utilities.assertions import assert_mcp_success
 
 logger = logging.getLogger(__name__)
 
+ORPHAN_NAME_PREFIXES = (
+    "e2e_show_as_test",
+    "e2e_options_test",
+    "e2e_multi_options_test",
+)
+
 
 async def _delete_template_helper(mcp_client, entity_id: str) -> None:
     """Best-effort cleanup for a template helper (no built-in cleaner support)."""
@@ -22,8 +28,39 @@ async def _delete_template_helper(mcp_client, entity_id: str) -> None:
         logger.warning(f"Cleanup of {entity_id} failed: {e}")
 
 
+@pytest.fixture
+async def template_orphan_sweep(mcp_client):
+    """Remove any leftover template helpers from prior failed runs of this file.
+
+    Template helpers go through HA's config-flow wizard; if a previous run
+    crashed mid-flow the helper can be left behind, polluting later runs.
+    Yields nothing — purely a teardown-style sweep run before each test.
+    """
+
+    async def sweep():
+        for prefix in ORPHAN_NAME_PREFIXES:
+            for domain in ("binary_sensor", "sensor"):
+                eid = f"{domain}.{prefix}"
+                try:
+                    res = await mcp_client.call_tool(
+                        "ha_get_entity", {"entity_id": eid}
+                    )
+                    parsed = res if isinstance(res, dict) else {}
+                    if parsed.get("success"):
+                        await _delete_template_helper(mcp_client, eid)
+                except Exception:
+                    # ha_get_entity raises ToolError when the entity is missing —
+                    # that's the expected state, swallow and move on.
+                    pass
+
+    await sweep()
+    yield
+    await sweep()
+
+
 @pytest.mark.asyncio
 @pytest.mark.registry
+@pytest.mark.usefixtures("template_orphan_sweep")
 class TestShowAs:
     """Round-trip ha_set_entity / ha_get_entity for device_class + options."""
 
@@ -35,7 +72,7 @@ class TestShowAs:
             "ha_config_set_helper",
             {
                 "helper_type": "template",
-                "name": "E2E Show As Test",
+                "name": "e2e_show_as_test",
                 "config": {
                     "next_step_id": "binary_sensor",
                     "state": "{{ true }}",
@@ -54,7 +91,6 @@ class TestShowAs:
             )
             set_data = assert_mcp_success(set_result, "Set Show As=window")
             assert set_data["entity_entry"]["device_class"] == "window"
-            assert "device_class='window'" in str(set_data["updates"])
 
             get_result = await mcp_client.call_tool(
                 "ha_get_entity", {"entity_id": entity_id}
@@ -79,7 +115,7 @@ class TestShowAs:
             "ha_config_set_helper",
             {
                 "helper_type": "template",
-                "name": "E2E Options Test",
+                "name": "e2e_options_test",
                 "config": {
                     "next_step_id": "sensor",
                     "state": "{{ 1.234 }}",
@@ -114,5 +150,47 @@ class TestShowAs:
                 .get("display_precision")
                 == 2
             )
+        finally:
+            await _delete_template_helper(mcp_client, entity_id)
+
+    async def test_set_multi_domain_options_round_trip(self, mcp_client):
+        """Multi-domain options must be applied as separate WS calls and the final
+        registry entry must reflect every domain — exercises the loop end-to-end.
+        """
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "template",
+                "name": "e2e_multi_options_test",
+                "config": {
+                    "next_step_id": "sensor",
+                    "state": "{{ 9.87 }}",
+                    "unit_of_measurement": "kWh",
+                },
+            },
+        )
+        data = assert_mcp_success(create_result, "Create template sensor")
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"helper response missing entity_ids: {data}"
+        entity_id = entity_ids[0]
+
+        try:
+            await mcp_client.call_tool(
+                "ha_set_entity",
+                {
+                    "entity_id": entity_id,
+                    "options": {
+                        "sensor": {"display_precision": 1},
+                        "conversation": {"should_expose": False},
+                    },
+                },
+            )
+            get_result = await mcp_client.call_tool(
+                "ha_get_entity", {"entity_id": entity_id}
+            )
+            get_data = assert_mcp_success(get_result, "Read back multi-domain options")
+            opts = get_data["entity_entry"]["options"]
+            assert opts.get("sensor", {}).get("display_precision") == 1
+            assert opts.get("conversation", {}).get("should_expose") is False
         finally:
             await _delete_template_helper(mcp_client, entity_id)

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -5,6 +5,7 @@ E2E tests for ha_set_entity device_class (Show As) and per-domain options round-
 import logging
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from tests.src.e2e.utilities.assertions import assert_mcp_success
 
@@ -48,9 +49,10 @@ async def template_orphan_sweep(mcp_client):
                     parsed = res if isinstance(res, dict) else {}
                     if parsed.get("success"):
                         await _delete_template_helper(mcp_client, eid)
-                except Exception:
+                except ToolError:
                     # ha_get_entity raises ToolError when the entity is missing —
-                    # that's the expected state, swallow and move on.
+                    # that's the expected state for a clean run. Anything else
+                    # (network, auth) we want to bubble.
                     pass
 
     await sweep()
@@ -220,6 +222,9 @@ class TestShowAsOnIntegrationEntity:
         pre_data = assert_mcp_success(pre, "Read pre-state")
         original_override = pre_data["entity_entry"]["device_class"]
         original_device_class = pre_data["entity_entry"]["original_device_class"]
+        # Capture the entity's pre-test sensor sub-options so the restore can
+        # put them back exactly, rather than blindly clearing the dict.
+        original_sensor_options = pre_data["entity_entry"]["options"].get("sensor", {})
         # Demo integration ships this as a temperature sensor — guarantee that
         # the override slot and the integration's own slot are distinct so we
         # know the test is exercising what we think it is.
@@ -270,8 +275,12 @@ class TestShowAsOnIntegrationEntity:
                 "ha_set_entity",
                 {"entity_id": self.TARGET, "device_class": restore_dc},
             )
-            # Clear the sensor sub-options we added.
+            # Restore the sensor sub-options to their pre-test value so any
+            # demo-platform default we overwrote is put back intact.
             await mcp_client.call_tool(
                 "ha_set_entity",
-                {"entity_id": self.TARGET, "options": {"sensor": {}}},
+                {
+                    "entity_id": self.TARGET,
+                    "options": {"sensor": dict(original_sensor_options)},
+                },
             )

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -1,0 +1,118 @@
+"""
+E2E tests for ha_set_entity device_class (Show As) and per-domain options round-trips.
+"""
+
+import logging
+
+import pytest
+
+from tests.src.e2e.utilities.assertions import assert_mcp_success
+
+logger = logging.getLogger(__name__)
+
+
+async def _delete_template_helper(mcp_client, entity_id: str) -> None:
+    """Best-effort cleanup for a template helper (no built-in cleaner support)."""
+    try:
+        await mcp_client.call_tool(
+            "ha_delete_helpers_integrations",
+            {"target": entity_id, "helper_type": "template", "confirm": True},
+        )
+    except Exception as e:  # pragma: no cover - cleanup best-effort
+        logger.warning(f"Cleanup of {entity_id} failed: {e}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.registry
+class TestShowAs:
+    """Round-trip ha_set_entity / ha_get_entity for device_class + options."""
+
+    async def test_set_show_as_device_class(self, mcp_client):
+        """ha_set_entity(device_class='window') lands on the top-level field
+        (the slot HA's UI Show As dropdown writes); ha_get_entity reads it back.
+        """
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "template",
+                "name": "E2E Show As Test",
+                "config": {
+                    "next_step_id": "binary_sensor",
+                    "state": "{{ true }}",
+                },
+            },
+        )
+        data = assert_mcp_success(create_result, "Create template binary_sensor")
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"helper response missing entity_ids: {data}"
+        entity_id = entity_ids[0]
+
+        try:
+            set_result = await mcp_client.call_tool(
+                "ha_set_entity",
+                {"entity_id": entity_id, "device_class": "window"},
+            )
+            set_data = assert_mcp_success(set_result, "Set Show As=window")
+            assert set_data["entity_entry"]["device_class"] == "window"
+            assert "device_class='window'" in str(set_data["updates"])
+
+            get_result = await mcp_client.call_tool(
+                "ha_get_entity", {"entity_id": entity_id}
+            )
+            get_data = assert_mcp_success(get_result, "Read back device_class")
+            assert get_data["entity_entry"]["device_class"] == "window"
+
+            cleared = await mcp_client.call_tool(
+                "ha_set_entity",
+                {"entity_id": entity_id, "device_class": ""},
+            )
+            cleared_data = assert_mcp_success(cleared, "Clear Show As")
+            assert cleared_data["entity_entry"]["device_class"] is None
+        finally:
+            await _delete_template_helper(mcp_client, entity_id)
+
+    async def test_set_per_domain_options_display_precision(self, mcp_client):
+        """ha_set_entity(options={'sensor': {'display_precision': 2}}) splits into
+        an options_domain+options paired WS update and persists on the registry entry.
+        """
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "template",
+                "name": "E2E Options Test",
+                "config": {
+                    "next_step_id": "sensor",
+                    "state": "{{ 1.234 }}",
+                    "unit_of_measurement": "kWh",
+                },
+            },
+        )
+        data = assert_mcp_success(create_result, "Create template sensor")
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"helper response missing entity_ids: {data}"
+        entity_id = entity_ids[0]
+
+        try:
+            set_result = await mcp_client.call_tool(
+                "ha_set_entity",
+                {
+                    "entity_id": entity_id,
+                    "options": {"sensor": {"display_precision": 2}},
+                },
+            )
+            set_data = assert_mcp_success(set_result, "Set sensor display_precision")
+            sensor_opts = set_data["entity_entry"]["options"].get("sensor", {})
+            assert sensor_opts.get("display_precision") == 2
+
+            get_result = await mcp_client.call_tool(
+                "ha_get_entity", {"entity_id": entity_id}
+            )
+            get_data = assert_mcp_success(get_result, "Read back options")
+            assert (
+                get_data["entity_entry"]["options"]
+                .get("sensor", {})
+                .get("display_precision")
+                == 2
+            )
+        finally:
+            await _delete_template_helper(mcp_client, entity_id)

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -22,6 +22,7 @@ class TestHaSetEntityLabels:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -129,9 +130,7 @@ class TestHaSetEntityLabels:
         register_entity_tools(mock_mcp, mock_client)
         tool = self.registered_tools["ha_set_entity"]
 
-        result = await tool(
-            entity_id="light.test", labels='["label1", "label2"]'
-        )
+        result = await tool(entity_id="light.test", labels='["label1", "label2"]')
 
         assert result["success"] is True
         call_args = mock_client.send_websocket_message.call_args[0][0]
@@ -146,7 +145,9 @@ class TestHaSetEntityLabels:
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
         error = error_data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "labels" in error_msg.lower() or "invalid" in error_msg.lower()
 
     @pytest.mark.asyncio
@@ -192,6 +193,7 @@ class TestHaSetEntityExposeTo:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -302,8 +304,12 @@ class TestHaSetEntityExposeTo:
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
         error = error_data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
-        assert "invalid_assistant" in error_msg.lower() or "invalid" in error_msg.lower()
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
+        assert (
+            "invalid_assistant" in error_msg.lower() or "invalid" in error_msg.lower()
+        )
 
     @pytest.mark.asyncio
     async def test_expose_to_json_string(self, mock_mcp, mock_client):
@@ -395,6 +401,7 @@ class TestHaSetEntityCombined:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -470,7 +477,9 @@ class TestHaSetEntityCombined:
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
         error = error_data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "No updates specified" in error_msg
 
     @pytest.mark.asyncio
@@ -557,7 +566,10 @@ class TestHaSetEntityCombined:
         mock_client.send_websocket_message = AsyncMock(
             side_effect=[
                 {"success": True},  # expose_true succeeds
-                {"success": False, "error": {"message": "Failed"}},  # expose_false fails
+                {
+                    "success": False,
+                    "error": {"message": "Failed"},
+                },  # expose_false fails
             ]
         )
         register_entity_tools(mock_mcp, mock_client)
@@ -582,7 +594,10 @@ class TestHaSetEntityCombined:
         mock_client.send_websocket_message = AsyncMock(
             side_effect=[
                 {"success": True},  # expose call succeeds
-                {"success": False, "error": {"message": "Entity not found"}},  # get entity fails
+                {
+                    "success": False,
+                    "error": {"message": "Entity not found"},
+                },  # get entity fails
             ]
         )
         register_entity_tools(mock_mcp, mock_client)
@@ -611,7 +626,9 @@ class TestHaSetEntityCombined:
         result = json.loads(str(exc_info.value))
         assert result["success"] is False
         error = result.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "enabled" in error_msg.lower() or "boolean" in error_msg.lower()
 
     @pytest.mark.asyncio
@@ -626,7 +643,9 @@ class TestHaSetEntityCombined:
         result = json.loads(str(exc_info.value))
         assert result["success"] is False
         error = result.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "hidden" in error_msg.lower() or "boolean" in error_msg.lower()
 
     @pytest.mark.asyncio
@@ -723,6 +742,7 @@ class TestHaSetEntityLabelOperations:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -889,6 +909,7 @@ class TestHaSetEntityBulkOperations:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -984,7 +1005,9 @@ class TestHaSetEntityBulkOperations:
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
         error = error_data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "Single-entity parameters" in error_msg or "name" in error_msg
 
     @pytest.mark.asyncio
@@ -1039,7 +1062,9 @@ class TestHaSetEntityBulkOperations:
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
         error = error_data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "empty" in error_msg.lower()
 
     @pytest.mark.asyncio
@@ -1113,6 +1138,7 @@ class TestHaSetEntityRegistryDisableGuardrail:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -1155,7 +1181,9 @@ class TestHaSetEntityRegistryDisableGuardrail:
         mock_client.send_websocket_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_disable_automation_string_false_blocked(self, set_entity_tool, mock_client):
+    async def test_disable_automation_string_false_blocked(
+        self, set_entity_tool, mock_client
+    ):
         """enabled='false' (string) on automation entity should also be blocked."""
         with pytest.raises(ToolError) as exc_info:
             await set_entity_tool(entity_id="automation.morning", enabled="false")
@@ -1166,7 +1194,9 @@ class TestHaSetEntityRegistryDisableGuardrail:
         mock_client.send_websocket_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_disable_automation_string_capital_false_blocked(self, set_entity_tool, mock_client):
+    async def test_disable_automation_string_capital_false_blocked(
+        self, set_entity_tool, mock_client
+    ):
         """enabled='False' (capital F, common from Python agents) should also be blocked."""
         with pytest.raises(ToolError) as exc_info:
             await set_entity_tool(entity_id="automation.evening", enabled="False")
@@ -1177,7 +1207,9 @@ class TestHaSetEntityRegistryDisableGuardrail:
         mock_client.send_websocket_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_disable_automation_single_element_list_blocked(self, set_entity_tool, mock_client):
+    async def test_disable_automation_single_element_list_blocked(
+        self, set_entity_tool, mock_client
+    ):
         """enabled=False on single-element list ['automation.test'] should also be blocked."""
         with pytest.raises(ToolError) as exc_info:
             await set_entity_tool(entity_id=["automation.test"], enabled=False)
@@ -1251,6 +1283,7 @@ class TestHaRemoveEntity:
             def wrapper(func):
                 self.registered_tools[func.__name__] = func
                 return func
+
             return wrapper
 
         mcp.tool = tool_decorator
@@ -1329,3 +1362,224 @@ class TestHaRemoveEntity:
 
         error_msg = str(exc_info.value).lower()
         assert "permission denied" in error_msg
+
+
+class TestHaSetEntityShowAs:
+    """ha_set_entity device_class (Show As) and options parameter."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return client
+
+    def _registry_response(self, **overrides):
+        entry = {
+            "entity_id": "binary_sensor.test",
+            "name": None,
+            "original_name": "Test",
+            "icon": None,
+            "area_id": None,
+            "disabled_by": None,
+            "hidden_by": None,
+            "aliases": [],
+            "labels": [],
+            "categories": {},
+            "device_class": None,
+            "original_device_class": None,
+            "options": {},
+        }
+        entry.update(overrides)
+        return {"success": True, "result": {"entity_entry": entry}}
+
+    @pytest.mark.asyncio
+    async def test_device_class_sets_top_level_field(self, mock_mcp, mock_client):
+        """device_class='window' must send top-level device_class on the WS update."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value=self._registry_response(device_class="window")
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        result = await tool(entity_id="binary_sensor.test", device_class="window")
+
+        assert result["success"] is True
+        ws_msg = mock_client.send_websocket_message.call_args[0][0]
+        assert ws_msg["type"] == "config/entity_registry/update"
+        assert ws_msg["device_class"] == "window"
+        # Show As must NOT be routed through options — that's a separate slot
+        # the UI does not read.
+        assert "options" not in ws_msg
+        assert "options_domain" not in ws_msg
+        assert "device_class='window'" in str(result["updates"])
+
+    @pytest.mark.asyncio
+    async def test_device_class_empty_string_clears(self, mock_mcp, mock_client):
+        """device_class='' clears the override (sends None)."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value=self._registry_response(device_class=None)
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        await tool(entity_id="binary_sensor.test", device_class="")
+
+        ws_msg = mock_client.send_websocket_message.call_args[0][0]
+        assert ws_msg["device_class"] is None
+
+    @pytest.mark.asyncio
+    async def test_options_single_domain_pairs_options_domain(
+        self, mock_mcp, mock_client
+    ):
+        """options={'sensor': {'display_precision': 2}} -> one WS call w/ options_domain=sensor."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value=self._registry_response(
+                options={"sensor": {"display_precision": 2}}
+            )
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        await tool(
+            entity_id="sensor.temp",
+            options={"sensor": {"display_precision": 2}},
+        )
+
+        assert mock_client.send_websocket_message.call_count == 1
+        ws_msg = mock_client.send_websocket_message.call_args[0][0]
+        assert ws_msg["options_domain"] == "sensor"
+        assert ws_msg["options"] == {"display_precision": 2}
+
+    @pytest.mark.asyncio
+    async def test_options_multi_domain_splits_into_separate_calls(
+        self, mock_mcp, mock_client
+    ):
+        """A multi-domain options dict must be split — HA schema requires one domain per call."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value=self._registry_response()
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        await tool(
+            entity_id="sensor.temp",
+            options={
+                "sensor": {"display_precision": 1},
+                "weather": {"forecast_type": "hourly"},
+            },
+        )
+
+        calls = [c.args[0] for c in mock_client.send_websocket_message.call_args_list]
+        domains = sorted(c["options_domain"] for c in calls)
+        assert domains == ["sensor", "weather"]
+        for c in calls:
+            assert "options_domain" in c and "options" in c
+
+    @pytest.mark.asyncio
+    async def test_options_json_string_is_parsed(self, mock_mcp, mock_client):
+        """options as a JSON string should be parsed transparently."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value=self._registry_response()
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        await tool(
+            entity_id="sensor.temp",
+            options='{"sensor": {"display_precision": 0}}',
+        )
+
+        ws_msg = mock_client.send_websocket_message.call_args[0][0]
+        assert ws_msg["options_domain"] == "sensor"
+        assert ws_msg["options"] == {"display_precision": 0}
+
+    @pytest.mark.asyncio
+    async def test_options_invalid_shape_raises_validation_error(
+        self, mock_mcp, mock_client
+    ):
+        """options must be a dict mapping domain to sub-dict — list rejected."""
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id="sensor.temp", options=["not", "a", "dict"])
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+
+class TestHaGetEntityRegistryOptions:
+    """ha_get_entity must surface device_class + options so agents can read state."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_get_entity_includes_device_class_and_options(
+        self, mock_mcp, mock_client
+    ):
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "entity_id": "binary_sensor.test",
+                    "name": None,
+                    "original_name": "Test",
+                    "icon": None,
+                    "area_id": None,
+                    "disabled_by": None,
+                    "hidden_by": None,
+                    "aliases": [],
+                    "labels": [],
+                    "categories": {},
+                    "device_class": "window",
+                    "original_device_class": None,
+                    "options": {"sensor": {"display_precision": 2}},
+                    "platform": "template",
+                    "device_id": None,
+                    "unique_id": "abc",
+                },
+            }
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_get_entity"]
+
+        result = await tool(entity_id="binary_sensor.test")
+
+        entry = result["entity_entry"]
+        assert entry["device_class"] == "window"
+        assert entry["original_device_class"] is None
+        assert entry["options"] == {"sensor": {"display_precision": 2}}

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -1670,6 +1670,11 @@ class TestHaSetEntityShowAs:
         assert body["options_succeeded"] == {}
         assert body["error"]["message"].startswith("Failed to update options for")
         assert "Partially" not in body["error"]["message"]
+        # entity_entry must NOT be present on a clean failure: the captured
+        # entity_entry is the empty stub {}, and surfacing it would be
+        # indistinguishable from "entity has nothing set". Mirrors the
+        # expose_to failure path which gates entity_entry on prior_mutation.
+        assert "entity_entry" not in body
 
     @pytest.mark.asyncio
     async def test_options_failure_with_empty_error_envelope_uses_fallback(

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -1644,6 +1644,93 @@ class TestHaSetEntityShowAs:
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "options" in body["error"]["message"]
 
+    @pytest.mark.asyncio
+    async def test_options_first_call_failure_is_not_partial(
+        self, mock_mcp, mock_client
+    ):
+        """When the very first per-domain call fails (no prior registry update,
+        no prior succeeded domains), partial must be False and the message must
+        say 'Failed to update' — not 'Partially updated'. A regression that
+        flips this would silently turn clean failures into partial-success lies.
+        """
+        fail = {"success": False, "error": {"message": "unsupported_domain"}}
+        mock_client.send_websocket_message = AsyncMock(side_effect=[fail])
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(
+                entity_id="sensor.temp",
+                options={"sensor": {"display_precision": 2}},
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert body["partial"] is False
+        assert body["options_succeeded"] == {}
+        assert body["error"]["message"].startswith("Failed to update options for")
+        assert "Partially" not in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_options_failure_with_empty_error_envelope_uses_fallback(
+        self, mock_mcp, mock_client
+    ):
+        """If HA returns success=False with no usable error key, the error
+        message must NOT degrade to literal "{}" — _extract_ws_error's fallback
+        string surfaces instead.
+        """
+        fail = {"success": False}  # no error key at all
+        mock_client.send_websocket_message = AsyncMock(side_effect=[fail])
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(
+                entity_id="sensor.temp",
+                options={"sensor": {"display_precision": 2}},
+            )
+
+        body = json.loads(str(exc_info.value))
+        msg = body["error"]["message"]
+        assert "no error detail returned by Home Assistant" in msg
+        # Critical: must NOT have rendered the empty dict literal.
+        assert ": {}" not in msg
+        assert "{}" not in msg.split(":", 1)[1]
+
+    @pytest.mark.asyncio
+    async def test_device_class_and_options_in_one_call(self, mock_mcp, mock_client):
+        """device_class and options together: one main registry update carries
+        device_class, then a separate per-domain WS call carries options. A
+        future refactor could short-circuit the options loop when the main
+        update already succeeded — this test catches that.
+        """
+        main_response = self._registry_response(device_class="window")
+        opts_response = self._registry_response(
+            device_class="window",
+            options={"binary_sensor": {}, "sensor": {"display_precision": 2}},
+        )
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=[main_response, opts_response]
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        await tool(
+            entity_id="binary_sensor.test",
+            device_class="window",
+            options={"sensor": {"display_precision": 2}},
+        )
+
+        calls = [c.args[0] for c in mock_client.send_websocket_message.call_args_list]
+        assert len(calls) == 2
+        # Main update carries device_class but NOT options_domain
+        assert calls[0]["device_class"] == "window"
+        assert "options_domain" not in calls[0]
+        # Per-domain update carries options_domain and the right sub-dict
+        assert calls[1]["options_domain"] == "sensor"
+        assert calls[1]["options"] == {"display_precision": 2}
+        assert "device_class" not in calls[1]
+
 
 class TestHaGetEntityRegistryOptions:
     """ha_get_entity must surface device_class + options so agents can read state."""

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -1430,17 +1430,18 @@ class TestHaSetEntityShowAs:
 
     @pytest.mark.asyncio
     async def test_device_class_empty_string_clears(self, mock_mcp, mock_client):
-        """device_class='' clears the override (sends None)."""
+        """device_class='' clears the override (sends None) and surfaces 'cleared' in updates."""
         mock_client.send_websocket_message = AsyncMock(
             return_value=self._registry_response(device_class=None)
         )
         register_entity_tools(mock_mcp, mock_client)
         tool = self.registered_tools["ha_set_entity"]
 
-        await tool(entity_id="binary_sensor.test", device_class="")
+        result = await tool(entity_id="binary_sensor.test", device_class="")
 
         ws_msg = mock_client.send_websocket_message.call_args[0][0]
         assert ws_msg["device_class"] is None
+        assert "device_class cleared" in str(result["updates"])
 
     @pytest.mark.asyncio
     async def test_options_single_domain_pairs_options_domain(
@@ -1462,6 +1463,15 @@ class TestHaSetEntityShowAs:
 
         assert mock_client.send_websocket_message.call_count == 1
         ws_msg = mock_client.send_websocket_message.call_args[0][0]
+        # When options is the only param, the main registry update is skipped
+        # and the per-domain update carries exactly these keys — no spurious
+        # device_class=None or other accidental fields.
+        assert set(ws_msg.keys()) == {
+            "type",
+            "entity_id",
+            "options_domain",
+            "options",
+        }
         assert ws_msg["options_domain"] == "sensor"
         assert ws_msg["options"] == {"display_precision": 2}
 
@@ -1469,14 +1479,27 @@ class TestHaSetEntityShowAs:
     async def test_options_multi_domain_splits_into_separate_calls(
         self, mock_mcp, mock_client
     ):
-        """A multi-domain options dict must be split — HA schema requires one domain per call."""
+        """A multi-domain options dict must be split — HA schema requires one domain per call.
+
+        Uses side_effect so each call gets its own response, exercising the loop's
+        entity_entry reassignment from each per-domain response.
+        """
+        sensor_response = self._registry_response(
+            options={"sensor": {"display_precision": 1}}
+        )
+        weather_response = self._registry_response(
+            options={
+                "sensor": {"display_precision": 1},
+                "weather": {"forecast_type": "hourly"},
+            }
+        )
         mock_client.send_websocket_message = AsyncMock(
-            return_value=self._registry_response()
+            side_effect=[sensor_response, weather_response]
         )
         register_entity_tools(mock_mcp, mock_client)
         tool = self.registered_tools["ha_set_entity"]
 
-        await tool(
+        result = await tool(
             entity_id="sensor.temp",
             options={
                 "sensor": {"display_precision": 1},
@@ -1485,10 +1508,47 @@ class TestHaSetEntityShowAs:
         )
 
         calls = [c.args[0] for c in mock_client.send_websocket_message.call_args_list]
-        domains = sorted(c["options_domain"] for c in calls)
-        assert domains == ["sensor", "weather"]
+        domains = [c["options_domain"] for c in calls]
+        assert domains == ["sensor", "weather"]  # insertion order preserved
         for c in calls:
             assert "options_domain" in c and "options" in c
+        # Final entity_entry reflects the LAST per-domain response (loop reassigns).
+        assert result["entity_entry"]["options"]["weather"] == {
+            "forecast_type": "hourly"
+        }
+        assert result["entity_entry"]["options"]["sensor"] == {"display_precision": 1}
+
+    @pytest.mark.asyncio
+    async def test_options_partial_failure_surfaces_partial_state(
+        self, mock_mcp, mock_client
+    ):
+        """If domain N+1 fails after 1..N succeeded, the error must report partial=True
+        and list which domains were already written. Otherwise callers retry blindly
+        and risk applying earlier changes twice or missing them entirely.
+        """
+        ok = self._registry_response(options={"sensor": {"display_precision": 1}})
+        fail = {"success": False, "error": {"message": "unsupported_domain"}}
+        mock_client.send_websocket_message = AsyncMock(side_effect=[ok, fail])
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(
+                entity_id="sensor.temp",
+                options={
+                    "sensor": {"display_precision": 1},
+                    "weather": {"forecast_type": "hourly"},
+                },
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "weather" in body["error"]["message"]
+        assert "unsupported_domain" in body["error"]["message"]
+        # create_error_response merges `context` into the top-level response.
+        assert body["options_domain"] == "weather"
+        assert body["partial"] is True
+        assert body["options_succeeded"] == {"sensor": {"display_precision": 1}}
 
     @pytest.mark.asyncio
     async def test_options_json_string_is_parsed(self, mock_mcp, mock_client):
@@ -1512,7 +1572,8 @@ class TestHaSetEntityShowAs:
     async def test_options_invalid_shape_raises_validation_error(
         self, mock_mcp, mock_client
     ):
-        """options must be a dict mapping domain to sub-dict — list rejected."""
+        """options must be a dict mapping domain to sub-dict — list rejected,
+        and the error message names the actual type the caller passed."""
         register_entity_tools(mock_mcp, mock_client)
         tool = self.registered_tools["ha_set_entity"]
 
@@ -1521,6 +1582,67 @@ class TestHaSetEntityShowAs:
 
         body = json.loads(str(exc_info.value))
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "got list" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_options_inner_value_must_be_dict(self, mock_mcp, mock_client):
+        """options={'sensor': 'not-a-dict'} must be rejected with a targeted message."""
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id="sensor.temp", options={"sensor": "not-a-dict"})
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "sensor" in body["error"]["message"]
+        assert "str" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_options_empty_dict_rejected(self, mock_mcp, mock_client):
+        """options={} must be rejected at validation rather than falling through to
+        the generic 'No updates specified' error."""
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id="sensor.temp", options={})
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "empty" in body["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_rejects_device_class(self, mock_mcp, mock_client):
+        """device_class is single-entity-only — passing it with a list raises."""
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(
+                entity_id=["binary_sensor.a", "binary_sensor.b"],
+                device_class="window",
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "device_class" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_bulk_rejects_options(self, mock_mcp, mock_client):
+        """options is single-entity-only — passing it with a list raises."""
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(
+                entity_id=["sensor.a", "sensor.b"],
+                options={"sensor": {"display_precision": 2}},
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "options" in body["error"]["message"]
 
 
 class TestHaGetEntityRegistryOptions:


### PR DESCRIPTION
## What does this PR do?

Closes #1114.

Adds the registry-options write surface that's been missing from `ha_set_entity`, plus the matching read fields on `ha_get_entity`:

- **`device_class`** on `ha_set_entity` — the top-level field HA's UI Show As dropdown writes. Empty string clears the override and falls back to the integration's `original_device_class`. Applies instantly, no reload needed.
- **`options`** on `ha_set_entity` — per-domain registry options dict, e.g. `{"sensor": {"display_precision": 2}}`. Multi-domain dicts are split into one `config/entity_registry/update` call per domain, because HA's WS schema requires `options_domain` + `options` to be sent paired (`vol.Inclusive` group `entity_option`) with `options` carrying ONE domain's sub-dict per call.
- `ha_get_entity` now returns `device_class`, `original_device_class`, and `options` so agents can read state before deciding whether to mutate.

### Why two parameters, not one

Live verification on a deployed HA instance (template `binary_sensor`) confirmed the UI's "Show As" dropdown writes the **top-level** `device_class` field — *not* `options.binary_sensor.device_class`, which exists in the registry but is unused by the frontend. Routing Show As through `options` would silently no-op in the UI. The original issue's request was specifically "Show As", so it gets the dedicated parameter; the generic `options` parameter still covers `display_precision`, `unit_of_measurement`, `forecast_type`, etc.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent (manual roundtrip on the live deployment)
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit (`tests/src/unit/test_tools_entities.py`):
- `TestHaSetEntityShowAs` — top-level `device_class` field, empty-string clear, `options` single-domain pairing, multi-domain split, JSON-string parsing, validation error on bad shape
- `TestHaGetEntityRegistryOptions` — response includes the three new fields

E2E (`tests/src/e2e/workflows/entities/test_show_as.py`):
- Round-trip `device_class` set → get → clear on a template binary_sensor
- Round-trip `options.sensor.display_precision` on a template sensor

## Checklist
- [x] I have updated documentation if needed