### PR TITLE
fix: survive read-only filesystems at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,10 @@ LABEL org.opencontainers.image.title="Home Assistant MCP Server" \
       org.opencontainers.image.licenses="MIT" \
       io.modelcontextprotocol.server.name="io.github.homeassistant-ai/ha-mcp"
 
-# Create non-root user. The base image's HOME_MODE is 0700 — fine when running
-# as mcpuser, but it makes /home/mcpuser un-traversable when users override
-# `--user UID:GID` (the issue #1125 reporter does so). Any code that stats a
-# path under HOME (set below) then raises PermissionError. chmod 0755 makes
-# the dir traversable for any uid; write access stays restricted to mcpuser.
+# Create non-root user. /home/mcpuser is mode 0755 (not the default 0700) so
+# that callers running with `--user UID:GID` overrides — common in hardened
+# Docker setups, see issue #1125 — can stat HOME-relative paths. Write
+# access stays restricted to mcpuser via ownership.
 RUN groupadd -r mcpuser \
     && useradd -r -g mcpuser -m mcpuser \
     && chmod 0755 /home/mcpuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,14 @@ LABEL org.opencontainers.image.title="Home Assistant MCP Server" \
       org.opencontainers.image.licenses="MIT" \
       io.modelcontextprotocol.server.name="io.github.homeassistant-ai/ha-mcp"
 
-# Create non-root user for security
-RUN groupadd -r mcpuser && useradd -r -g mcpuser -m mcpuser
+# Create non-root user. The base image's HOME_MODE is 0700 — fine when running
+# as mcpuser, but it makes /home/mcpuser un-traversable when users override
+# `--user UID:GID` (the issue #1125 reporter does so). Any code that stats a
+# path under HOME (set below) then raises PermissionError. chmod 0755 makes
+# the dir traversable for any uid; write access stays restricted to mcpuser.
+RUN groupadd -r mcpuser \
+    && useradd -r -g mcpuser -m mcpuser \
+    && chmod 0755 /home/mcpuser
 
 WORKDIR /app
 
@@ -42,6 +48,12 @@ COPY --chown=mcpuser:mcpuser --from=builder /app/src /app/src
 COPY --chown=mcpuser:mcpuser fastmcp.json fastmcp-http.json ./
 
 USER mcpuser
+
+# Set HOME explicitly. Docker doesn't auto-derive HOME from /etc/passwd when
+# a USER directive is set (moby/moby#2968), leaving HOME=/ at runtime. That
+# made Path.home() resolve to "/" and ha-mcp tried to mkdir "/.ha-mcp" on
+# every start — fatal under `read_only: true` (issue #1125).
+ENV HOME=/home/mcpuser
 
 # Activate virtual environment via PATH
 ENV PATH="/app/.venv/bin:$PATH"

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -21,6 +21,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 
 from .errors import ErrorCode, create_error_response
 from .transforms import DEFAULT_PINNED_TOOLS
+from .utils.data_paths import get_data_dir
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -112,23 +113,37 @@ def _is_addon() -> bool:
 
 
 def _get_config_path() -> Path:
-    """Return the path to the tool config JSON file."""
-    if _is_addon():
-        return Path("/data") / "tool_config.json"
-    home_dir = Path.home() / ".ha-mcp"
-    home_dir.mkdir(parents=True, exist_ok=True)
-    return home_dir / "tool_config.json"
+    """Return the path to the tool config JSON file.
+
+    Delegates directory resolution to :func:`utils.data_paths.get_data_dir`,
+    which handles ``HA_MCP_CONFIG_DIR`` override, add-on ``/data``,
+    home-dir, and tmpdir fallback (memoized).
+    """
+    return get_data_dir() / "tool_config.json"
 
 
 def load_tool_config(settings: Settings | None = None) -> dict[str, Any]:
     """Load persisted tool config, seeding from env vars if no file exists."""
     path = _get_config_path()
-    if path.exists():
+    # ``Path.exists()`` only swallows ``ENOENT/ENOTDIR/EBADF/ELOOP``; an
+    # ``EACCES`` (e.g. ``HA_MCP_CONFIG_DIR`` pointing at a dir that exists
+    # but isn't readable by the runtime UID) propagates. Read directly and
+    # treat ``FileNotFoundError`` as "no config yet"; log other ``OSError``s.
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        raw = None
+    except OSError:
+        logger.warning("Cannot read tool config at %s", path)
+        raw = None
+
+    if raw is not None:
         try:
-            result: dict[str, Any] = json.loads(path.read_text())
+            result: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Tool config at %s is not valid JSON; ignoring.", path)
+        else:
             return result
-        except (OSError, json.JSONDecodeError):
-            logger.warning("Failed to read tool config from %s", path)
 
     if settings is None:
         return {}
@@ -156,14 +171,23 @@ def load_tool_config(settings: Settings | None = None) -> dict[str, Any]:
     return {}
 
 
-def save_tool_config(config: dict[str, Any]) -> None:
-    """Persist tool config to disk."""
+def save_tool_config(config: dict[str, Any]) -> bool:
+    """Persist tool config to disk.
+
+    Returns True on success, False on failure (read-only filesystem,
+    permission denied, etc.). Caller is responsible for surfacing the
+    failure to the user — the HTTP route at ``_save_tools`` returns 500
+    so the UI's ``saveConfig`` shows "Save failed!" instead of the
+    misleading "Saved — restart required".
+    """
     path = _get_config_path()
     try:
         path.write_text(json.dumps(config, indent=2))
-        logger.info("Saved tool config to %s", path)
     except OSError:
         logger.exception("Failed to save tool config to %s", path)
+        return False
+    logger.info("Saved tool config to %s", path)
+    return True
 
 
 async def _get_tool_metadata(server: HomeAssistantSmartMCPServer) -> list[dict[str, Any]]:
@@ -760,7 +784,18 @@ def register_settings_routes(
 
         config = load_tool_config()
         config["tools"] = states
-        save_tool_config(config)
+        if not save_tool_config(config):
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    "Failed to persist tool config to disk",
+                    suggestions=[
+                        "Set HA_MCP_CONFIG_DIR to a writable path (read-only filesystem?)",
+                        "Check the server logs for the underlying OSError",
+                    ],
+                ),
+                status_code=500,
+            )
 
         disabled_count = sum(1 for s in states.values() if s == "disabled")
         pinned_count = sum(1 for s in states.values() if s == "pinned")

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -19,6 +19,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 
+from ._version import is_running_in_addon
 from .errors import ErrorCode, create_error_response
 from .transforms import DEFAULT_PINNED_TOOLS
 from .utils.data_paths import get_data_dir
@@ -100,18 +101,6 @@ FEATURE_GATED_TOOLS: dict[str, dict[str, str]] = {
 }
 
 
-def _is_addon() -> bool:
-    """Return True when running inside the Home Assistant add-on container.
-
-    Mirrors the existing convention in this module (and ``__main__.py``)
-    of treating ``SUPERVISOR_TOKEN`` as the add-on detector. Using the env
-    var is more reliable than checking for ``/data`` because some Docker
-    setups (and macOS dev environments) have a ``/data`` directory that
-    isn't the add-on data dir.
-    """
-    return bool(os.environ.get("SUPERVISOR_TOKEN"))
-
-
 def _get_config_path() -> Path:
     """Return the path to the tool config JSON file.
 
@@ -134,7 +123,7 @@ def load_tool_config(settings: Settings | None = None) -> dict[str, Any]:
     except FileNotFoundError:
         raw = None
     except OSError:
-        logger.warning("Cannot read tool config at %s", path)
+        logger.warning("Cannot read tool config at %s", path, exc_info=True)
         raw = None
 
     if raw is not None:
@@ -858,11 +847,11 @@ def register_settings_routes(
 
     async def _settings_info(_: Request) -> JSONResponse:
         return JSONResponse({
-            "is_addon": _is_addon(),
+            "is_addon": is_running_in_addon(),
         })
 
     secret_prefix = secret_path.rstrip("/") if secret_path else ""
-    is_addon = _is_addon()
+    is_addon = is_running_in_addon()
 
     if not is_addon and not secret_prefix:
         logger.warning(

--- a/src/ha_mcp/utils/data_paths.py
+++ b/src/ha_mcp/utils/data_paths.py
@@ -40,16 +40,24 @@ def get_data_dir() -> Path:
        server start; users wanting persistence should set
        ``HA_MCP_CONFIG_DIR`` to a writable path.
 
-    Memoized so the fallback warning emits once at startup rather than on
-    every save/load HTTP request. Tests reset via
-    ``get_data_dir.cache_clear()``.
+    Memoized so the fallback warning typically emits once at startup
+    rather than on every save/load HTTP request. ``lru_cache`` serializes
+    its internal dict but does not serialize the wrapped call when the
+    cache is empty, so two threads racing on first access (e.g.
+    ``UsageLogger.__init__`` from a worker thread plus a settings UI HTTP
+    handler) may each run ``_resolve_data_dir`` once and emit the warning
+    twice. The mkdir calls are idempotent, so this is cosmetic.
+    Tests reset via ``get_data_dir.cache_clear()``.
     """
     return _resolve_data_dir()
 
 
 def _resolve_data_dir() -> Path:
     """Resolve the data directory (uncached); see ``get_data_dir`` for priority."""
-    config_dir_env = os.environ.get("HA_MCP_CONFIG_DIR")
+    # ``.strip()``: ``HA_MCP_CONFIG_DIR="   "`` is truthy and ``Path("   ")``
+    # resolves cwd-relative, which would mkdir a literal whitespace-named
+    # directory next to whatever cwd happens to be at startup.
+    config_dir_env = os.environ.get("HA_MCP_CONFIG_DIR", "").strip()
     preferred: Path | None = None
     if config_dir_env:
         custom_dir = Path(config_dir_env)
@@ -68,7 +76,26 @@ def _resolve_data_dir() -> Path:
             return custom_dir
 
     if is_running_in_addon():
-        return Path("/data")
+        addon_dir = Path("/data")
+        try:
+            addon_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                "/data is not writable in add-on mode (%s: %s); "
+                "falling back. Set HA_MCP_CONFIG_DIR to override.",
+                type(e).__name__,
+                e,
+            )
+            if preferred is None:
+                preferred = addon_dir
+        else:
+            # Honor an explicit HA_MCP_CONFIG_DIR override even in add-on
+            # mode: if the user set it and its mkdir failed (preferred is
+            # not None), fall through to the tmpdir fallback rather than
+            # silently writing to /data — they chose the override
+            # deliberately.
+            if preferred is None:
+                return addon_dir
 
     if preferred is None:
         home_dir = Path.home() / ".ha-mcp"
@@ -85,8 +112,10 @@ def _resolve_data_dir() -> Path:
     except OSError as e:
         # Even the tmpdir is unwritable. Return the path anyway: callers
         # that wrap writes in try/except OSError can degrade gracefully
-        # (no persistence, but the server still starts).
-        logger.warning(
+        # (no persistence, but the server still starts). ``error`` rather
+        # than ``warning`` because persistence is silently disabled — the
+        # supervisor log viewer surfaces errors more prominently.
+        logger.error(
             "Cannot write ha-mcp data to %s or fallback %s (%s: %s); "
             "persistence is disabled. "
             "Set HA_MCP_CONFIG_DIR to a writable path for persistence.",

--- a/src/ha_mcp/utils/data_paths.py
+++ b/src/ha_mcp/utils/data_paths.py
@@ -13,35 +13,32 @@ import os
 import tempfile
 from pathlib import Path
 
+from .._version import is_running_in_addon
+
 logger = logging.getLogger(__name__)
-
-
-def _is_addon() -> bool:
-    """Return True when running inside the Home Assistant add-on container.
-
-    Mirrors the convention in ``settings_ui.py`` of treating
-    ``SUPERVISOR_TOKEN`` as the add-on detector — more reliable than
-    checking for ``/data`` because some Docker setups have a ``/data``
-    directory that isn't the supervisor data dir.
-    """
-    return bool(os.environ.get("SUPERVISOR_TOKEN"))
 
 
 @functools.lru_cache(maxsize=1)
 def get_data_dir() -> Path:
     """Return a writable directory for ha-mcp persistent data (memoized).
 
-    Priority:
+    Resolution order:
 
     1. ``HA_MCP_CONFIG_DIR`` env var — explicit override, e.g. for hardened
        Docker setups bind-mounting a writable volume into a
        ``read_only: true`` container.
-    2. ``/data`` — Home Assistant add-on (writable supervisor data dir).
-    3. ``~/.ha-mcp`` — standard.
-    4. ``<tempdir>/ha-mcp`` — last-resort fallback when (1) and (3) fail
-       (read-only filesystem, or ``HOME`` unset so ``Path.home()`` resolves
-       to ``/``). Loses persistence across restarts but lets the server
-       start; users wanting persistence should set ``HA_MCP_CONFIG_DIR``.
+    2. ``/data`` — Home Assistant add-on (``SUPERVISOR_TOKEN`` set; writable
+       supervisor data dir).
+    3. ``~/.ha-mcp`` — standard install. Skipped when ``HA_MCP_CONFIG_DIR``
+       was set but failed: an explicit override means "use this exact
+       location", and silently writing to ``$HOME`` instead would surprise
+       users who chose the override deliberately.
+    4. ``<tempdir>/ha-mcp`` — last-resort fallback when the previously
+       chosen step fails (read-only filesystem; ``HOME`` unset so
+       ``Path.home()`` resolves to ``/``; or ``HA_MCP_CONFIG_DIR`` set but
+       its mkdir raises). Loses persistence across restarts but lets the
+       server start; users wanting persistence should set
+       ``HA_MCP_CONFIG_DIR`` to a writable path.
 
     Memoized so the fallback warning emits once at startup rather than on
     every save/load HTTP request. Tests reset via
@@ -70,7 +67,7 @@ def _resolve_data_dir() -> Path:
         else:
             return custom_dir
 
-    if _is_addon():
+    if is_running_in_addon():
         return Path("/data")
 
     if preferred is None:
@@ -86,10 +83,9 @@ def _resolve_data_dir() -> Path:
     try:
         fallback.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        # Even the tmpdir is unwritable. Return the path anyway so the
-        # caller's own try/except (save_tool_config wraps writes in
-        # try/except OSError; usage_logger disables itself) can degrade
-        # gracefully.
+        # Even the tmpdir is unwritable. Return the path anyway: callers
+        # that wrap writes in try/except OSError can degrade gracefully
+        # (no persistence, but the server still starts).
         logger.warning(
             "Cannot write ha-mcp data to %s or fallback %s (%s: %s); "
             "persistence is disabled. "

--- a/src/ha_mcp/utils/data_paths.py
+++ b/src/ha_mcp/utils/data_paths.py
@@ -1,0 +1,110 @@
+"""Resolve a writable directory for ha-mcp persistent data.
+
+Single source of truth for "where does ha-mcp write its files?" — used
+by both ``settings_ui`` (tool config) and ``usage_logger`` (rolling
+JSONL).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _is_addon() -> bool:
+    """Return True when running inside the Home Assistant add-on container.
+
+    Mirrors the convention in ``settings_ui.py`` of treating
+    ``SUPERVISOR_TOKEN`` as the add-on detector — more reliable than
+    checking for ``/data`` because some Docker setups have a ``/data``
+    directory that isn't the supervisor data dir.
+    """
+    return bool(os.environ.get("SUPERVISOR_TOKEN"))
+
+
+@functools.lru_cache(maxsize=1)
+def get_data_dir() -> Path:
+    """Return a writable directory for ha-mcp persistent data (memoized).
+
+    Priority:
+
+    1. ``HA_MCP_CONFIG_DIR`` env var — explicit override, e.g. for hardened
+       Docker setups bind-mounting a writable volume into a
+       ``read_only: true`` container.
+    2. ``/data`` — Home Assistant add-on (writable supervisor data dir).
+    3. ``~/.ha-mcp`` — standard.
+    4. ``<tempdir>/ha-mcp`` — last-resort fallback when (1) and (3) fail
+       (read-only filesystem, or ``HOME`` unset so ``Path.home()`` resolves
+       to ``/``). Loses persistence across restarts but lets the server
+       start; users wanting persistence should set ``HA_MCP_CONFIG_DIR``.
+
+    Memoized so the fallback warning emits once at startup rather than on
+    every save/load HTTP request. Tests reset via
+    ``get_data_dir.cache_clear()``.
+    """
+    return _resolve_data_dir()
+
+
+def _resolve_data_dir() -> Path:
+    """Resolve the data directory (uncached); see ``get_data_dir`` for priority."""
+    config_dir_env = os.environ.get("HA_MCP_CONFIG_DIR")
+    preferred: Path | None = None
+    if config_dir_env:
+        custom_dir = Path(config_dir_env)
+        try:
+            custom_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                "HA_MCP_CONFIG_DIR=%s could not be prepared (%s: %s); "
+                "falling back to a tmpdir.",
+                custom_dir,
+                type(e).__name__,
+                e,
+            )
+            preferred = custom_dir
+        else:
+            return custom_dir
+
+    if _is_addon():
+        return Path("/data")
+
+    if preferred is None:
+        home_dir = Path.home() / ".ha-mcp"
+        try:
+            home_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            preferred = home_dir
+        else:
+            return home_dir
+
+    fallback = Path(tempfile.gettempdir()) / "ha-mcp"
+    try:
+        fallback.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        # Even the tmpdir is unwritable. Return the path anyway so the
+        # caller's own try/except (save_tool_config wraps writes in
+        # try/except OSError; usage_logger disables itself) can degrade
+        # gracefully.
+        logger.warning(
+            "Cannot write ha-mcp data to %s or fallback %s (%s: %s); "
+            "persistence is disabled. "
+            "Set HA_MCP_CONFIG_DIR to a writable path for persistence.",
+            preferred,
+            fallback,
+            type(e).__name__,
+            e,
+        )
+    else:
+        logger.warning(
+            "Cannot write ha-mcp data to %s (read-only filesystem or HOME unset). "
+            "Falling back to %s — data will NOT persist across restarts. "
+            "Set HA_MCP_CONFIG_DIR to a writable path for persistence.",
+            preferred,
+            fallback,
+        )
+    return fallback

--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from .data_paths import get_data_dir
 
+logger = logging.getLogger(__name__)
+
 # Default ring buffer size - keeps last N entries in memory
 DEFAULT_RING_BUFFER_SIZE = 200
 
@@ -128,9 +130,17 @@ class UsageLogger:
 
         try:
             self.log_file_path.parent.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            # Directory creation failed (e.g., read-only filesystem)
-            # Disable logging silently to avoid disrupting the MCP server
+        except OSError as e:
+            # Directory creation failed (e.g., read-only filesystem). Surface
+            # the reason instead of silently dropping every log — operators
+            # otherwise see an empty mcp_usage.jsonl with no clue why.
+            logger.warning(
+                "Usage logging disabled — could not create %s (%s: %s). "
+                "Set HA_MCP_CONFIG_DIR to a writable path to enable persistence.",
+                self.log_file_path.parent,
+                type(e).__name__,
+                e,
+            )
             self._enabled = False
 
         # In-memory ring buffer for fast access to recent logs

--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from queue import Queue
 from typing import Any
 
+from .data_paths import get_data_dir
+
 # Default ring buffer size - keeps last N entries in memory
 DEFAULT_RING_BUFFER_SIZE = 200
 
@@ -46,13 +48,15 @@ class StartupLogCollector(logging.Handler):
             return
 
         with self._lock:
-            self._logs.append({
-                "timestamp": datetime.now(UTC).isoformat(),
-                "level": record.levelname,
-                "logger": record.name,
-                "message": record.getMessage(),
-                "elapsed_seconds": round(elapsed, 2),
-            })
+            self._logs.append(
+                {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "level": record.levelname,
+                    "logger": record.name,
+                    "message": record.getMessage(),
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+            )
 
     def get_logs(self) -> list[dict[str, Any]]:
         """Get collected startup logs."""
@@ -115,9 +119,12 @@ class UsageLogger:
         if log_file_path:
             self.log_file_path = Path(log_file_path)
         else:
-            # Use user's home directory by default to avoid read-only filesystem errors
-            # when running via uvx/npx which might have read-only CWD
-            self.log_file_path = Path.home() / ".ha-mcp" / "logs" / "mcp_usage.jsonl"
+            # Defer to the shared resolver so logs follow the same precedence
+            # as the settings-UI tool config (HA_MCP_CONFIG_DIR > /data >
+            # ~/.ha-mcp > tempdir). Avoids polluting the filesystem root when
+            # HOME is unset and avoids surprising users who bind-mount a
+            # writable volume via HA_MCP_CONFIG_DIR but find logs missing.
+            self.log_file_path = get_data_dir() / "logs" / "mcp_usage.jsonl"
 
         try:
             self.log_file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/src/unit/test_data_paths.py
+++ b/tests/src/unit/test_data_paths.py
@@ -115,6 +115,41 @@ class TestFallbacks:
         assert result.is_dir()
         assert not broken_target.exists()
 
+    def test_returns_unwritable_tmpdir_when_everything_fails(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Last-resort branch: env mkdir fails, home mkdir fails, tmpdir mkdir
+        fails. The resolver returns the tmpdir path anyway so callers (which
+        wrap their own writes in ``try/except OSError``) can degrade
+        gracefully rather than crashing the server. Warning fires.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        readonly_home = tmp_path / "ro-home"
+        readonly_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: readonly_home)
+        fake_tmp = tmp_path / "ro-tmp"
+        fake_tmp.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fake_tmp)
+        )
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self in (readonly_home / ".ha-mcp", fake_tmp / "ha-mcp"):
+                raise OSError(30, "Read-only file system")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+        with caplog.at_level(logging.WARNING, logger="ha_mcp.utils.data_paths"):
+            result = get_data_dir()
+
+        assert result == fake_tmp / "ha-mcp"
+        assert any(
+            "persistence is disabled" in r.getMessage() for r in caplog.records
+        )
+
 
 class TestMemoization:
     """The resolver must memoize so warnings emit once at startup."""

--- a/tests/src/unit/test_data_paths.py
+++ b/tests/src/unit/test_data_paths.py
@@ -1,0 +1,172 @@
+"""Unit tests for the shared data-directory resolver.
+
+The resolver is the single source of truth for where ha-mcp writes its
+persistent files (tool config, usage logs). These tests pin its priority
+order and the fallback behavior added for issue #1125.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from ha_mcp.utils.data_paths import _resolve_data_dir, get_data_dir
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Force every test to re-resolve from scratch."""
+    get_data_dir.cache_clear()
+    yield
+    get_data_dir.cache_clear()
+
+
+class TestPriorityOrder:
+    """HA_MCP_CONFIG_DIR > /data > ~/.ha-mcp > tempdir/ha-mcp."""
+
+    def test_addon_path_when_supervisor_token_set(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        assert get_data_dir() == Path("/data")
+
+    def test_home_path_when_no_supervisor_token(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = get_data_dir()
+        assert result == tmp_path / ".ha-mcp"
+        assert result.is_dir()
+
+    def test_ha_mcp_config_dir_overrides_supervisor_token(self, monkeypatch, tmp_path):
+        """HA_MCP_CONFIG_DIR takes precedence even in add-on mode.
+
+        Lets add-on users override the default ``/data`` location, and lets
+        hardened-Docker users bind-mount a writable volume without depending
+        on ``$HOME``.
+        """
+        custom_dir = tmp_path / "custom"
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(custom_dir))
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")  # would normally route to /data
+        result = get_data_dir()
+        assert result == custom_dir
+        assert custom_dir.is_dir()
+
+
+class TestFallbacks:
+    """Falls back to a writable tmpdir when the preferred location fails."""
+
+    def test_falls_back_to_tmpdir_when_home_unwritable(self, monkeypatch, tmp_path):
+        """Issue #1125 regression: ``read_only: true`` Docker, or ``HOME=/``.
+
+        ``mkdir(~/.ha-mcp)`` raises ``OSError(EROFS)``; resolver must fall
+        through to ``<tempdir>/ha-mcp`` instead of crashing.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        readonly_home = tmp_path / "readonly-home"
+        readonly_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: readonly_home)
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self == readonly_home / ".ha-mcp":
+                raise OSError(30, "Read-only file system")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+        fallback_root = tmp_path / "fallback-tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fallback_root)
+        )
+
+        result = get_data_dir()
+
+        assert result == fallback_root / "ha-mcp"
+        assert result.is_dir()
+
+    def test_ha_mcp_config_dir_unwritable_chains_to_tmpdir(self, monkeypatch, tmp_path):
+        """HA_MCP_CONFIG_DIR mkdir failure chains to tmpdir, doesn't return broken path."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        readonly_parent = tmp_path / "readonly-parent"
+        readonly_parent.mkdir()
+        broken_target = readonly_parent / "cannot-create"
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self == broken_target:
+                raise OSError(30, "Read-only file system")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(broken_target))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "unused-home")
+        fallback_root = tmp_path / "fallback-tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fallback_root)
+        )
+
+        result = get_data_dir()
+
+        assert result == fallback_root / "ha-mcp"
+        assert result.is_dir()
+        assert not broken_target.exists()
+
+
+class TestMemoization:
+    """The resolver must memoize so warnings emit once at startup."""
+
+    def test_warning_emitted_only_once_via_module_cache(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """``get_data_dir`` is hit on every settings UI HTTP request and on
+        every usage-log write — without the cache the fallback warning
+        would spam logs on every UI toggle.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        readonly_home = tmp_path / "readonly-home"
+        readonly_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: readonly_home)
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self == readonly_home / ".ha-mcp":
+                raise OSError(30, "Read-only file system")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+        fallback_root = tmp_path / "fallback-tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fallback_root)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ha_mcp.utils.data_paths"):
+            for _ in range(5):
+                get_data_dir()
+
+        fallback_warnings = [
+            r for r in caplog.records if "Falling back" in r.getMessage()
+        ]
+        assert len(fallback_warnings) == 1, (
+            f"expected single fallback warning, got {len(fallback_warnings)}"
+        )
+
+    def test_resolve_re_runs_when_cache_cleared(self, monkeypatch, tmp_path):
+        """``_resolve_data_dir`` (uncached) re-runs on every call.
+
+        Guards against future refactors that move the cache or accidentally
+        memoize the inner function.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(first))
+        assert _resolve_data_dir() == first
+
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(second))
+        assert _resolve_data_dir() == second

--- a/tests/src/unit/test_data_paths.py
+++ b/tests/src/unit/test_data_paths.py
@@ -29,6 +29,16 @@ class TestPriorityOrder:
     def test_addon_path_when_supervisor_token_set(self, monkeypatch):
         monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
         monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        # ``/data`` is not present on dev/CI machines; stub the writability
+        # probe rather than relying on the real path.
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self == Path("/data"):
+                return None
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
         assert get_data_dir() == Path("/data")
 
     def test_home_path_when_no_supervisor_token(self, monkeypatch, tmp_path):
@@ -52,6 +62,19 @@ class TestPriorityOrder:
         result = get_data_dir()
         assert result == custom_dir
         assert custom_dir.is_dir()
+
+    def test_whitespace_only_ha_mcp_config_dir_is_ignored(self, monkeypatch, tmp_path):
+        """``HA_MCP_CONFIG_DIR="   "`` (e.g. trailing space in a .env file) is
+        truthy but ``Path("   ")`` resolves cwd-relative — without
+        ``.strip()`` the resolver would mkdir a literal three-space-named
+        directory. Whitespace-only must be treated as unset.
+        """
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", "   ")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = get_data_dir()
+        assert result == tmp_path / ".ha-mcp"
+        assert not (Path.cwd() / "   ").exists()
 
 
 class TestFallbacks:
@@ -115,13 +138,81 @@ class TestFallbacks:
         assert result.is_dir()
         assert not broken_target.exists()
 
+    def test_ha_mcp_config_dir_unwritable_in_addon_mode_chains_to_tmpdir(
+        self, monkeypatch, tmp_path
+    ):
+        """Silent-override-discard regression: ``HA_MCP_CONFIG_DIR`` mkdir
+        fails AND ``SUPERVISOR_TOKEN`` is set. The resolver must NOT
+        silently write to ``/data`` — the user picked the override
+        deliberately, so fall through to the tmpdir instead.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        readonly_parent = tmp_path / "readonly-parent"
+        readonly_parent.mkdir()
+        broken_target = readonly_parent / "cannot-create"
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self == broken_target:
+                raise OSError(30, "Read-only file system")
+            if self == Path("/data"):
+                return None  # /data is "writable" — must still be skipped
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(broken_target))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "unused-home")
+        fallback_root = tmp_path / "fallback-tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fallback_root)
+        )
+
+        result = get_data_dir()
+
+        assert result == fallback_root / "ha-mcp"
+        assert result.is_dir()
+
+    def test_falls_back_when_addon_data_dir_unwritable(self, monkeypatch, tmp_path):
+        """Residual same-class bug: ``/data`` may be read-only (degraded
+        supervisor, or supervisor container running with ``read_only:
+        true``). With no ``HA_MCP_CONFIG_DIR``, the resolver must fall
+        through to the home/tmpdir chain instead of returning a path the
+        first ``write_text`` will crash on.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        readonly_home = tmp_path / "readonly-home"
+        readonly_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: readonly_home)
+        fallback_root = tmp_path / "fallback-tmp"
+        fallback_root.mkdir()
+        monkeypatch.setattr(
+            "ha_mcp.utils.data_paths.tempfile.gettempdir", lambda: str(fallback_root)
+        )
+        original_mkdir = Path.mkdir
+
+        def fake_mkdir(self: Path, *args, **kwargs):
+            if self in (Path("/data"), readonly_home / ".ha-mcp"):
+                raise OSError(30, "Read-only file system")
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+        result = get_data_dir()
+
+        assert result == fallback_root / "ha-mcp"
+        assert result.is_dir()
+
     def test_returns_unwritable_tmpdir_when_everything_fails(
         self, monkeypatch, tmp_path, caplog
     ):
         """Last-resort branch: env mkdir fails, home mkdir fails, tmpdir mkdir
         fails. The resolver returns the tmpdir path anyway so callers (which
         wrap their own writes in ``try/except OSError``) can degrade
-        gracefully rather than crashing the server. Warning fires.
+        gracefully rather than crashing the server. Logged at ERROR because
+        persistence is silently disabled — operator-visible state, not just
+        a warning.
         """
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
@@ -146,9 +237,11 @@ class TestFallbacks:
             result = get_data_dir()
 
         assert result == fake_tmp / "ha-mcp"
-        assert any(
-            "persistence is disabled" in r.getMessage() for r in caplog.records
-        )
+        persistence_records = [
+            r for r in caplog.records if "persistence is disabled" in r.getMessage()
+        ]
+        assert persistence_records, "expected a persistence-disabled log record"
+        assert all(r.levelno == logging.ERROR for r in persistence_records)
 
 
 class TestMemoization:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -137,19 +137,80 @@ class TestApplyToolVisibility:
         mcp.disable.assert_not_called()
 
 
+@pytest.fixture(autouse=True)
+def _reset_data_dir_cache():
+    """Clear the shared resolved-dir cache between tests."""
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    get_data_dir.cache_clear()
+    yield
+    get_data_dir.cache_clear()
+
+
 class TestConfigPath:
-    """Test _get_config_path uses SUPERVISOR_TOKEN, not /data heuristic."""
+    """Thin wrapper around utils.data_paths.get_data_dir; full priority
+    order is tested in tests/src/unit/test_data_paths.py.
+    """
 
-    def test_addon_path_when_supervisor_token_set(self, monkeypatch):
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
-        assert _get_config_path() == Path("/data/tool_config.json")
-
-    def test_home_path_when_no_supervisor_token(self, monkeypatch, tmp_path):
+    def test_returns_data_dir_plus_filename(self, monkeypatch, tmp_path):
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        result = _get_config_path()
-        assert result == tmp_path / ".ha-mcp" / "tool_config.json"
-        assert (tmp_path / ".ha-mcp").is_dir()
+        assert _get_config_path() == tmp_path / ".ha-mcp" / "tool_config.json"
+
+    def test_load_tool_config_does_not_crash_on_unreadable_config_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """Regression for #1125 + the same-class follow-up bug.
+
+        When the resolved path's parent isn't traversable by the runtime
+        UID (e.g. ``HA_MCP_CONFIG_DIR`` pointing at an existing 0700 dir
+        owned by another user), ``Path.exists()`` would raise
+        ``PermissionError`` because ``EACCES`` is not in
+        ``pathlib._IGNORED_ERRNOS``. ``load_tool_config()`` must treat it
+        as "no config yet" instead of crashing.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        unreadable_dir = tmp_path / "unreadable"
+        unreadable_dir.mkdir()
+        cfg_path = unreadable_dir / "tool_config.json"
+        monkeypatch.setattr("ha_mcp.settings_ui._get_config_path", lambda: cfg_path)
+
+        original_read = Path.read_text
+
+        def fake_read_text(self: Path, *args, **kwargs):
+            if self == cfg_path:
+                raise PermissionError(13, "Permission denied")
+            return original_read(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+        # Must not raise.
+        assert load_tool_config() == {}
+
+
+class TestSaveToolConfig:
+    """Tests for the bool return contract added so the HTTP route can
+    surface failures to the UI instead of lying that the save succeeded."""
+
+    def test_returns_true_on_success(self, tmp_path):
+        cfg_path = tmp_path / "tool_config.json"
+        with patch("ha_mcp.settings_ui._get_config_path", return_value=cfg_path):
+            assert save_tool_config({"tools": {"x": "disabled"}}) is True
+        assert cfg_path.exists()
+
+    def test_returns_false_on_oserror(self, monkeypatch, tmp_path):
+        cfg_path = tmp_path / "tool_config.json"
+        monkeypatch.setattr("ha_mcp.settings_ui._get_config_path", lambda: cfg_path)
+
+        def fake_write_text(self: Path, *args, **kwargs):
+            if self == cfg_path:
+                raise OSError(30, "Read-only file system")
+            return Path.write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", fake_write_text)
+        assert save_tool_config({"tools": {"x": "disabled"}}) is False
 
 
 class TestFeatureGatedTools:
@@ -168,7 +229,12 @@ class TestFeatureGatedTools:
         # disabled_by should reference the dev addon option name (matches
         # how the JS renders "set <code>{disabled_by}</code> in the dev
         # add-on config or the matching env var (see docs/beta.md)").
-        for name in ("ha_list_files", "ha_read_file", "ha_write_file", "ha_delete_file"):
+        for name in (
+            "ha_list_files",
+            "ha_read_file",
+            "ha_write_file",
+            "ha_delete_file",
+        ):
             assert FEATURE_GATED_TOOLS[name]["disabled_by"] == "enable_filesystem_tools"
 
 
@@ -230,6 +296,7 @@ class TestSaveToolsValidation:
                 if path == "/api/settings/tools" and "POST" in methods:
                     captured["save"] = fn
                 return fn
+
             return decorator
 
         mcp = MagicMock()
@@ -276,13 +343,32 @@ class TestSaveToolsValidation:
         config_path = tmp_path / "tool_config.json"
         monkeypatch.setattr("ha_mcp.settings_ui._get_config_path", lambda: config_path)
         save = self._capture_handler(monkeypatch)
-        resp = await save(self._make_request({
-            "states": {
-                "ha_good_tool": "disabled",
-                "ha_bad_value": "not_a_real_state",
-                42: "disabled",  # non-string key
-            },
-        }))
+        resp = await save(
+            self._make_request(
+                {
+                    "states": {
+                        "ha_good_tool": "disabled",
+                        "ha_bad_value": "not_a_real_state",
+                        42: "disabled",  # non-string key
+                    },
+                }
+            )
+        )
         assert resp.status_code == 200
         saved = json.loads(config_path.read_text())
         assert saved["tools"] == {"ha_good_tool": "disabled"}
+
+    @pytest.mark.asyncio
+    async def test_returns_500_when_save_fails(self, monkeypatch, tmp_path):
+        """``save_tool_config`` returning False (read-only fs, etc.) must
+        surface as a 500 to the UI — otherwise the JS shows "Saved" while
+        the change was lost."""
+        config_path = tmp_path / "tool_config.json"
+        monkeypatch.setattr("ha_mcp.settings_ui._get_config_path", lambda: config_path)
+        monkeypatch.setattr("ha_mcp.settings_ui.save_tool_config", lambda _: False)
+        save = self._capture_handler(monkeypatch)
+        resp = await save(self._make_request({"states": {"ha_good_tool": "disabled"}}))
+        assert resp.status_code == 500
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert "HA_MCP_CONFIG_DIR" in str(body)

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -188,6 +190,34 @@ class TestConfigPath:
 
         # Must not raise.
         assert load_tool_config() == {}
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="chmod 0o000 doesn't model POSIX EACCES on Windows",
+    )
+    def test_load_tool_config_handles_real_eacces_on_posix(
+        self, monkeypatch, tmp_path
+    ):
+        """End-to-end variant of the EACCES regression: a real 0o000 dir.
+
+        The mocked-``read_text`` test above pins the going-forward contract,
+        but a future maintainer who reintroduces an upstream ``Path.exists()``
+        check would not be caught by it. This test exercises the actual
+        permission boundary: ``read_text`` on a file under a 0o000 dir
+        raises ``PermissionError`` (errno EACCES) from the kernel.
+        """
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
+        locked_dir = tmp_path / "locked"
+        locked_dir.mkdir()
+        cfg_path = locked_dir / "tool_config.json"
+        cfg_path.write_text("{}")
+        monkeypatch.setattr("ha_mcp.settings_ui._get_config_path", lambda: cfg_path)
+        os.chmod(locked_dir, 0o000)
+        try:
+            assert load_tool_config() == {}
+        finally:
+            os.chmod(locked_dir, 0o755)  # let pytest clean up tmp_path
 
 
 class TestSaveToolConfig:

--- a/tests/src/unit/test_usage_logger.py
+++ b/tests/src/unit/test_usage_logger.py
@@ -170,11 +170,33 @@ class TestUsageLoggerRingBuffer:
 class TestUsageLoggerDefaults:
     """Test UsageLogger default behavior."""
 
-    def test_default_log_path(self):
-        """Test that default log path is in user home directory."""
+    @pytest.fixture(autouse=True)
+    def _reset_data_dir_cache(self):
+        from ha_mcp.utils.data_paths import get_data_dir
+
+        get_data_dir.cache_clear()
+        yield
+        get_data_dir.cache_clear()
+
+    def test_default_log_path(self, monkeypatch):
+        """Default log path lives under ``~/.ha-mcp/logs/`` when no
+        overrides are in play."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
         logger = UsageLogger()
         assert str(logger.log_file_path).startswith(str(Path.home()))
         assert ".ha-mcp" in str(logger.log_file_path)
+        assert str(logger.log_file_path).endswith("/logs/mcp_usage.jsonl")
+        logger.shutdown()
+
+    def test_honors_ha_mcp_config_dir(self, monkeypatch, tmp_path):
+        """``HA_MCP_CONFIG_DIR`` redirects logs the same way it redirects
+        the settings-UI tool config — the two share ``get_data_dir()``."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        custom = tmp_path / "custom"
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(custom))
+        logger = UsageLogger()
+        assert logger.log_file_path == custom / "logs" / "mcp_usage.jsonl"
         logger.shutdown()
 
 

--- a/tests/src/unit/test_usage_logger.py
+++ b/tests/src/unit/test_usage_logger.py
@@ -184,9 +184,7 @@ class TestUsageLoggerDefaults:
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.delenv("HA_MCP_CONFIG_DIR", raising=False)
         logger = UsageLogger()
-        assert str(logger.log_file_path).startswith(str(Path.home()))
-        assert ".ha-mcp" in str(logger.log_file_path)
-        assert str(logger.log_file_path).endswith("/logs/mcp_usage.jsonl")
+        assert logger.log_file_path == Path.home() / ".ha-mcp" / "logs" / "mcp_usage.jsonl"
         logger.shutdown()
 
     def test_honors_ha_mcp_config_dir(self, monkeypatch, tmp_path):

--- a/tests/test_docker/test_docker_build.py
+++ b/tests/test_docker/test_docker_build.py
@@ -50,3 +50,43 @@ class TestDockerBuild:
             text=True,
         )
         assert "Python 3.1" in result.stdout
+
+    def test_home_env_set_to_mcpuser(self):
+        """Verify ``ENV HOME=/home/mcpuser`` is honored at runtime.
+
+        Issue #1125 regression: without this, Docker leaves ``HOME=/`` under
+        a ``USER`` directive (moby/moby#2968), so ``Path.home()`` resolves
+        to ``/`` and ha-mcp tries to mkdir ``/.ha-mcp`` — fatal under
+        ``read_only: true``. This test catches a future PR that
+        accidentally removes the ``ENV HOME`` line.
+        """
+        result = subprocess.run(
+            ["docker", "run", "--rm", "ha-mcp-test", "sh", "-c", "echo $HOME"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == "/home/mcpuser"
+
+    def test_home_dir_is_world_traversable(self):
+        """Verify ``/home/mcpuser`` is mode 0755 (not the default 0700).
+
+        Hardened-Docker users frequently set ``--user UID:GID`` overrides;
+        if ``$HOME`` isn't world-traversable they get ``PermissionError``
+        when ha-mcp stats a path under it. The chmod is the second half of
+        the issue #1125 fix.
+        """
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "ha-mcp-test",
+                "stat",
+                "-c",
+                "%a",
+                "/home/mcpuser",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == "755"


### PR DESCRIPTION
## What does this PR do?

Fixes #1125 — `ghcr.io/homeassistant-ai/ha-mcp:latest` crashes at startup
under hardened Docker setups (`read_only: true`, `user: 1000:1000`,
`tmpfs: /tmp`):

```
OSError: [Errno 30] Read-only file system: '/.ha-mcp'
  in _get_config_path() → home_dir.mkdir(parents=True, exist_ok=True)
```

Two contributing factors:

1. The Dockerfile didn't set `ENV HOME`, so under `USER mcpuser` Docker
   left `HOME=/` ([moby/moby#2968](https://github.com/moby/moby/issues/2968)).
   `Path.home()` resolved to `/`, ha-mcp tried to mkdir `/.ha-mcp`, and
   `read_only: true` made that fatal. Even on writable filesystems this
   silently polluted the container's filesystem root with a `/.ha-mcp/`
   directory.
2. `_get_config_path()` (added in #960) unconditionally `mkdir`s the
   home dir on every server start, with no fallback.

### Coordinated changes

**Shared resolver** (`src/ha_mcp/utils/data_paths.py`, new):
single source of truth for "where does ha-mcp write its persistent files".

| # | Source                       | Used for                                |
|---|------------------------------|-----------------------------------------|
| 1 | `HA_MCP_CONFIG_DIR` env var  | Hardened Docker bind-mount override     |
| 2 | `/data` (when `SUPERVISOR_TOKEN` set) | Home Assistant add-on persistent dir |
| 3 | `~/.ha-mcp`                  | Standard install                        |
| 4 | `<tempdir>/ha-mcp`           | Last-resort fallback (server still runs, no persistence) |

The resolved dir is memoized at module level so the fallback warning
emits **once at startup** instead of on every save/load HTTP request.

**`settings_ui`**:
- `_get_config_path` becomes a thin `get_data_dir() / "tool_config.json"` wrapper.
- `load_tool_config` replaces the `path.exists()` + `read_text()` two-step with a single `try: read_text() except OSError:`. `Path.exists()` only swallows `ENOENT/ENOTDIR/EBADF/ELOOP`, so `EACCES` (e.g. `HA_MCP_CONFIG_DIR` pointing at an existing 0700 dir owned by another UID) would re-introduce the same class of crash. Confirmed empirically: `errno=13` propagates from `pathlib.Path.exists()`.
- `save_tool_config` now returns `bool`, and the `_save_tools` HTTP route returns 500 when the write fails. The JS already handles `!resp.ok` with "Save failed!" — it was never given the chance.

**`utils/usage_logger`**: switch the default log path from `Path.home() / ".ha-mcp" / "logs"` to `get_data_dir() / "logs"`. Logs now follow the same precedence as the tool config — `HA_MCP_CONFIG_DIR` works for them too, and add-on mode lands in `/data/logs/` (the supervisor's persistent location, was previously ephemeral `~/.ha-mcp/logs/`).

**`Dockerfile`**:
- `ENV HOME=/home/mcpuser` so `Path.home()` resolves correctly under the default user.
- `chmod 0755 /home/mcpuser` because the base image's `/etc/login.defs` sets `HOME_MODE=0700`; that's fine when the container runs as mcpuser, but un-traversable when users override `--user UID:GID` (the issue reporter does so) — anything that stats a path under HOME then raises `PermissionError`. Mode 0755 keeps write access restricted to mcpuser.

### Tests

| File | Class | What it pins |
|---|---|---|
| `test_data_paths.py` (new) | `TestPriorityOrder` | `HA_MCP_CONFIG_DIR > /data > ~/.ha-mcp` |
| | `TestFallbacks` | Issue #1125 regression; `HA_MCP_CONFIG_DIR` mkdir-fail chains to tmpdir |
| | `TestMemoization` | Single warning per startup; resolver re-runs when cache cleared |
| `test_settings_ui.py` | `TestConfigPath` | Wrapper sanity; `load_tool_config` doesn't crash on EACCES (same-class regression guard) |
| | `TestSaveToolConfig` (new) | bool return contract |
| | `TestSaveToolsValidation` | 500 surfaced when save fails |
| `test_usage_logger.py` | `TestUsageLoggerDefaults` | Honors `HA_MCP_CONFIG_DIR` |

Full unit suite: **1684 passed, 1 skipped** (numpy not installed, unrelated). `ruff check` clean. `mypy src/` clean.

### Local Docker verification

Built locally and confirmed three real scenarios:

| Scenario                                                          | Before | After |
|-------------------------------------------------------------------|--------|-------|
| Reporter's compose: `--read-only --user 1000:1000 --tmpfs /tmp`   | crash  | runs (config falls back to `/tmp/ha-mcp/`)  |
| Default user (no overrides)                                       | "works" but creates `/.ha-mcp` 🚨 | works (creates `~/.ha-mcp`) |
| `HA_MCP_CONFIG_DIR=/data/ha-mcp` with bind-mount + read-only      | n/a    | runs, settings + logs persist to bind-mount |

In all "after" cases the FastMCP banner displays and uvicorn binds `http://0.0.0.0:8086`. The original stack trace from #1125 no longer reproduces.

### Release note

Users who ran `:latest` between #960 (2026-05-02) and this fix and had a writable `/` (default Docker, no `read_only: true`) will have had their settings UI tool config silently written to `/.ha-mcp/tool_config.json` at the filesystem root, because Docker leaves `HOME=/` under `USER mcpuser` without an explicit `ENV HOME` (moby/moby#2968). After this fix the resolver writes to `~/.ha-mcp` (or `HA_MCP_CONFIG_DIR` / `/data` when applicable) and no code path reads from `/.ha-mcp/` — any per-tool enable/disable/pin choices made on broken `:latest` need to be recreated in the settings UI after upgrading. (Users who hit the actual #1125 crash had nothing persisted, so nothing to migrate.)

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — 1684 passed, 1 skipped
- [x] Code follows style guidelines (`uv run ruff check`) — and `mypy src/` clean

## Checklist
- [x] I have updated documentation if needed — `HA_MCP_CONFIG_DIR` is documented in the resolver's docstring; happy to surface it in `README.md` or the setup wizard if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
