### PR TITLE
docs: warn against enable_tool_search on Claude Sonnet/Opus (#1088)

### DIFF
--- a/homeassistant-addon-dev/DOCS.md
+++ b/homeassistant-addon-dev/DOCS.md
@@ -16,7 +16,7 @@ The dev add-on uses the same configuration as the stable version. See the main a
 | `secret_path` | Custom secret path (optional) | auto-generated |
 | `enable_skills` | Serve bundled HA best-practice skills as MCP resources | `true` |
 | `enable_skills_as_tools` | Expose skills via list_resources/read_resource tools | `true` |
-| `enable_tool_search` | Replace full tool catalog with search-based discovery (~46K → ~5K tokens). ⚠️ Do NOT enable for Claude Sonnet/Opus — conflicts with their built-in deferred tools and breaks tool discovery (issue #1088). | `false` |
+| `enable_tool_search` | Replace full tool catalog with search-based discovery (~46K → ~5K tokens). ⚠️ Do NOT enable for Claude Sonnet/Opus — their built-in tool search conflicts with ha-mcp's. Disable one or the other. | `false` |
 | `enable_yaml_config_editing` *(beta)* | Enables `ha_config_set_yaml` for editing `configuration.yaml` directly. Requires `ha_mcp_tools` custom component. | `false` |
 | `enable_filesystem_tools` *(beta)* | Enables file read/write tools (`ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`). Requires `ha_mcp_tools` custom component. | `false` |
 | `enable_custom_component_integration` *(beta)* | Enables `ha_install_mcp_tools` installer tool for the `ha_mcp_tools` custom component. | `false` |

--- a/homeassistant-addon-dev/DOCS.md
+++ b/homeassistant-addon-dev/DOCS.md
@@ -16,7 +16,7 @@ The dev add-on uses the same configuration as the stable version. See the main a
 | `secret_path` | Custom secret path (optional) | auto-generated |
 | `enable_skills` | Serve bundled HA best-practice skills as MCP resources | `true` |
 | `enable_skills_as_tools` | Expose skills via list_resources/read_resource tools | `true` |
-| `enable_tool_search` | Replace full tool catalog with search-based discovery (~46K → ~5K tokens) | `false` |
+| `enable_tool_search` | Replace full tool catalog with search-based discovery (~46K → ~5K tokens). ⚠️ Do NOT enable for Claude Sonnet/Opus — conflicts with their built-in deferred tools and breaks tool discovery (issue #1088). | `false` |
 | `enable_yaml_config_editing` *(beta)* | Enables `ha_config_set_yaml` for editing `configuration.yaml` directly. Requires `ha_mcp_tools` custom component. | `false` |
 | `enable_filesystem_tools` *(beta)* | Enables file read/write tools (`ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`). Requires `ha_mcp_tools` custom component. | `false` |
 | `enable_custom_component_integration` *(beta)* | Enables `ha_install_mcp_tools` installer tool for the `ha_mcp_tools` custom component. | `false` |

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -22,10 +22,14 @@ configuration:
     name: Enable tool search
     description: >-
       Replace the full tool catalog with search-based discovery. Reduces
-      idle context from ~46K to ~5K tokens. Use this if using an LLM without
-      deferred tools or with smaller context windows. Tools are found via
-      ha_search_tools and executed via categorized proxies (read/write/delete).
-      Requires restart to take effect.
+      idle context from ~46K to ~5K tokens. ⚠️ Do NOT enable this if you
+      use Claude in Sonnet or Opus modes — those models have their own
+      built-in tool search / deferred tools, which conflicts with ours
+      and breaks tool discovery (see issue #1088). Use this only with
+      LLMs that lack native deferred tools (e.g. Claude Haiku, local
+      OpenAI-compatible models) or with smaller context windows. Tools
+      are found via ha_search_tools and executed via categorized proxies
+      (read/write/delete). Requires restart to take effect.
   enable_yaml_config_editing:
     name: Enable YAML config editing (beta)
     description: >-

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -24,8 +24,9 @@ configuration:
       Replace the full tool catalog with search-based discovery. Reduces
       idle context from ~46K to ~5K tokens. ⚠️ Do NOT enable this if you
       use Claude in Sonnet or Opus modes — those models have their own
-      built-in tool search / deferred tools, which conflicts with ours
-      and breaks tool discovery (see issue #1088). Use this only with
+      built-in tool search / deferred tools, which conflicts with ours.
+      To use ha-mcp's tool search with Claude, disable Claude's built-in
+      tool search first; otherwise leave this off. Use this only with
       LLMs that lack native deferred tools (e.g. Claude Haiku, local
       OpenAI-compatible models) or with smaller context windows. Tools
       are found via ha_search_tools and executed via categorized proxies

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -248,7 +248,7 @@ Requires add-on restart to take effect.
 
 Replaces the full tool catalog (~86 tools, ~46K tokens) with search-based discovery (~4 proxy tools, ~5K tokens). When enabled, tools are found via `ha_search_tools` and executed through categorized proxies (read/write/delete).
 
-> ⚠️ **Do NOT enable this if you use Claude in Sonnet or Opus modes.** Sonnet and Opus run Claude's own built-in deferred tool search, and stacking ha-mcp's search transform on top of it actively breaks tool discovery — read-only tools (e.g. `ha_call_read_tool`) can fail to surface, leaving every read tool unreachable. See [issue #1088](https://github.com/homeassistant-ai/ha-mcp/issues/1088). If you want ha-mcp's search with Claude anyway, you must first turn off Claude's own internal tool search / deferred tools in your client settings — running both at once does not work.
+> ⚠️ **Do NOT enable this if you use Claude in Sonnet or Opus modes.** Those models run their own built-in tool search / deferred tools, which conflicts with ha-mcp's — running both at once does not work. To use ha-mcp's tool search with Claude, disable Claude's built-in tool search first; otherwise leave this off.
 
 **When to enable:**
 - Models **without native deferred tool support** — this includes OpenAI-compatible local models, and also **Claude Haiku** which does not use Claude's built-in deferred tool loading. Haiku users will see significant token savings with this enabled.
@@ -256,7 +256,7 @@ Replaces the full tool catalog (~86 tools, ~46K tokens) with search-based discov
 - MCP clients that **cap total tools** (e.g. at 100) — reduces visible tool count to ~4
 
 **When to leave disabled (default):**
-- **Claude in Sonnet or Opus modes** — leave this off. Their built-in deferred tool loader collides with ha-mcp's search transform and breaks tool discovery (issue #1088).
+- **Claude in Sonnet or Opus modes** — their built-in tool search conflicts with ha-mcp's. Disable one or the other.
 - Other clients with native deferred tool support — tools are loaded on demand, so the full catalog has no idle context cost.
 - When you need direct tool access without the search step.
 

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -248,14 +248,17 @@ Requires add-on restart to take effect.
 
 Replaces the full tool catalog (~86 tools, ~46K tokens) with search-based discovery (~4 proxy tools, ~5K tokens). When enabled, tools are found via `ha_search_tools` and executed through categorized proxies (read/write/delete).
 
+> ⚠️ **Do NOT enable this if you use Claude in Sonnet or Opus modes.** Sonnet and Opus run Claude's own built-in deferred tool search, and stacking ha-mcp's search transform on top of it actively breaks tool discovery — read-only tools (e.g. `ha_call_read_tool`) can fail to surface, leaving every read tool unreachable. See [issue #1088](https://github.com/homeassistant-ai/ha-mcp/issues/1088). If you want ha-mcp's search with Claude anyway, you must first turn off Claude's own internal tool search / deferred tools in your client settings — running both at once does not work.
+
 **When to enable:**
 - Models **without native deferred tool support** — this includes OpenAI-compatible local models, and also **Claude Haiku** which does not use Claude's built-in deferred tool loading. Haiku users will see significant token savings with this enabled.
 - Models with **limited context windows** (≤200K) or deployments where context cost is a concern
 - MCP clients that **cap total tools** (e.g. at 100) — reduces visible tool count to ~4
 
 **When to leave disabled (default):**
-- Claude Sonnet/Opus or other clients with deferred tool support — tools are loaded on demand, so the full catalog has no idle context cost
-- When you need direct tool access without the search step
+- **Claude in Sonnet or Opus modes** — leave this off. Their built-in deferred tool loader collides with ha-mcp's search transform and breaks tool discovery (issue #1088).
+- Other clients with native deferred tool support — tools are loaded on demand, so the full catalog has no idle context cost.
+- When you need direct tool access without the search step.
 
 Requires add-on restart to take effect.
 

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -22,10 +22,14 @@ configuration:
     name: Enable tool search
     description: >-
       Replace the full tool catalog with search-based discovery. Reduces
-      idle context from ~46K to ~5K tokens. Use this if using an LLM without
-      deferred tools or with smaller context windows. Tools are found via
-      ha_search_tools and executed via categorized proxies (read/write/delete).
-      Requires restart to take effect.
+      idle context from ~46K to ~5K tokens. ⚠️ Do NOT enable this if you
+      use Claude in Sonnet or Opus modes — those models have their own
+      built-in tool search / deferred tools, which conflicts with ours
+      and breaks tool discovery (see issue #1088). Use this only with
+      LLMs that lack native deferred tools (e.g. Claude Haiku, local
+      OpenAI-compatible models) or with smaller context windows. Tools
+      are found via ha_search_tools and executed via categorized proxies
+      (read/write/delete). Requires restart to take effect.
   verify_ssl:
     name: Verify TLS certificate
     description: >-

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -24,8 +24,9 @@ configuration:
       Replace the full tool catalog with search-based discovery. Reduces
       idle context from ~46K to ~5K tokens. ⚠️ Do NOT enable this if you
       use Claude in Sonnet or Opus modes — those models have their own
-      built-in tool search / deferred tools, which conflicts with ours
-      and breaks tool discovery (see issue #1088). Use this only with
+      built-in tool search / deferred tools, which conflicts with ours.
+      To use ha-mcp's tool search with Claude, disable Claude's built-in
+      tool search first; otherwise leave this off. Use this only with
       LLMs that lack native deferred tools (e.g. Claude Haiku, local
       OpenAI-compatible models) or with smaller context windows. Tools
       are found via ha_search_tools and executed via categorized proxies


### PR DESCRIPTION
## What does this PR do?

Closes #1088 (documentation portion).

The previous `enable_tool_search` docs framed Claude Sonnet/Opus as "you don't need it" rather than "it actively breaks." Issue #1088 confirmed that running ha-mcp's categorized search transform on top of Claude's native deferred tool loader double-defers — read-only tools (e.g. `ha_call_read_tool`) silently fail to surface, leaving every read tool unreachable.

This PR rewords the user-facing docs and the addon UI toggle so the failure mode and the workaround are unmissable, on both the stable and dev addon variants.

**Files changed:**
- `homeassistant-addon/DOCS.md` — adds an explicit blockquote warning above "When to enable", restates the warning in the "When to leave disabled" bullet, and links #1088.
- `homeassistant-addon/translations/en.yaml` — appends the warning to the toggle's description so it shows directly under the switch in the addon configuration UI.
- `homeassistant-addon-dev/DOCS.md` — same warning condensed into the option summary table row.
- `homeassistant-addon-dev/translations/en.yaml` — kept identical to the stable addon's toggle text.

The wording also tells users that, if they really want ha-mcp's search on Claude, they must first turn off Claude's own internal tool search / deferred tools — running both at once does not work.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — docs-only change; YAML lint via `python -c "import yaml; yaml.safe_load(open(...))"` confirmed both translation files still parse.
- [x] Code follows style guidelines (`uv run ruff check`) — no Python touched.

## Checklist
- [x] I have updated documentation if needed

## Not in this PR (deliberately deferred)

Issue #1088 also suggested an *optional* startup-time log warning if a Claude client connects with `enable_tool_search=true`. I scoped it out:

- FastMCP middleware on `on_initialize` could read `clientInfo.name`, but the exact string Claude/Claude Desktop sends is not pinned in this repo and shipping a hardcoded guess would either miss the client or false-positive on Haiku. Worth a follow-up after sniffing the value off a live connection.
- The addon runs FastMCP in stateless HTTP mode, so a per-session "warn once" flag would need to key on something durable (origin URL, OAuth client_id) rather than session id.

Happy to do this in a follow-up PR once we've captured the actual client identifier.