### PR TITLE
fix(helpers): clarify name-required-on-create for ha_config_set_helper

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -248,9 +248,12 @@ async def _handle_flow_helper(
         if not config_dict.get("name"):
             raise_tool_error(create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
-                "name is required for create action",
+                f'name is required for create action. Include "name" as a '
+                f'top-level argument, e.g. {{"helper_type": "{helper_type}", '
+                f'"name": "<display name>"}}.',
                 suggestions=[
-                    "Pass the name argument directly or include 'name' in config",
+                    'Add name="<display name>" as a top-level argument',
+                    'Or include "name": "<display name>" inside the config dict',
                 ],
                 context={"helper_type": helper_type},
             ))
@@ -533,11 +536,12 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             str | None,
             Field(
                 description=(
-                    "Display name for the helper. Required on create; optional on "
-                    "update (pass helper_id to skip). For flow-based helper types on "
-                    "update (template, group, utility_meter, ...), this is typically "
-                    "ignored — options flows don't expose renaming. Rename a flow "
-                    "helper by deleting and recreating instead."
+                    "REQUIRED when creating (no helper_id provided). Display name "
+                    "for the helper. Optional on update — pass helper_id instead. "
+                    "For flow-based helper types on update (template, group, "
+                    "utility_meter, ...), this is typically ignored — options flows "
+                    "don't expose renaming. Rename a flow helper by deleting and "
+                    "recreating instead."
                 ),
                 default=None,
             ),
@@ -783,7 +787,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         """
         Create or update Home Assistant helper entities (27 types, unified interface).
 
-        Creates new helper if helper_id is omitted, updates existing if helper_id is provided.
+        Create requires `name`; update requires `helper_id`.
 
         SIMPLE types (structured params, WebSocket API): input_boolean, input_button,
         input_select, input_number, input_text, input_datetime, counter, timer, schedule,
@@ -869,7 +873,13 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "name is required for create action",
+                            f'name is required for create action. Include '
+                            f'"name" as a top-level argument, e.g. '
+                            f'{{"helper_type": "{helper_type}", "name": '
+                            f'"<display name>"}}.',
+                            suggestions=[
+                                'Add name="<display name>" as a top-level argument',
+                            ],
                             context={"helper_type": helper_type},
                         )
                     )

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -252,8 +252,8 @@ async def _handle_flow_helper(
                 f'top-level argument, e.g. {{"helper_type": "{helper_type}", '
                 f'"name": "<display name>"}}.',
                 suggestions=[
-                    'Add name="<display name>" as a top-level argument',
-                    'Or include "name": "<display name>" inside the config dict',
+                    'Add "name": "<display name>" at the top level of the JSON arguments',
+                    'Or include "name": "<display name>" inside the "config" dict',
                 ],
                 context={"helper_type": helper_type},
             ))
@@ -878,7 +878,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             f'{{"helper_type": "{helper_type}", "name": '
                             f'"<display name>"}}.',
                             suggestions=[
-                                'Add name="<display name>" as a top-level argument',
+                                'Add "name": "<display name>" at the top level of the JSON arguments',
+                                'Or pass "helper_id": "<existing>" if you intended to update an existing helper',
                             ],
                             context={"helper_type": helper_type},
                         )

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -250,10 +250,10 @@ async def _handle_flow_helper(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
                 f'name is required for create action. Include "name" as a '
                 f'top-level argument, e.g. {{"helper_type": "{helper_type}", '
-                f'"name": "<display name>"}}.',
+                f'"name": "My Helper"}}.',
                 suggestions=[
-                    'Add "name": "<display name>" at the top level of the JSON arguments',
-                    'Or include "name": "<display name>" inside the "config" dict',
+                    'Add "name": "My Helper" at the top level of the JSON arguments',
+                    'Or include "name": "My Helper" inside the "config" dict',
                 ],
                 context={"helper_type": helper_type},
             ))
@@ -549,7 +549,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         helper_id: Annotated[
             str | None,
             Field(
-                description="Helper ID for updates (e.g., 'my_button' or 'input_button.my_button'). If not provided, creates a new helper.",
+                description="REQUIRED when updating an existing helper. Bare ID ('my_button') or full entity ID ('input_button.my_button'). Omit to create a new helper.",
                 default=None,
             ),
         ] = None,
@@ -876,10 +876,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             f'name is required for create action. Include '
                             f'"name" as a top-level argument, e.g. '
                             f'{{"helper_type": "{helper_type}", "name": '
-                            f'"<display name>"}}.',
+                            f'"My Helper"}}.',
                             suggestions=[
-                                'Add "name": "<display name>" at the top level of the JSON arguments',
-                                'Or pass "helper_id": "<existing>" if you intended to update an existing helper',
+                                'Add "name": "My Helper" at the top level of the JSON arguments',
+                                'Or pass "helper_id": "my_helper" if you intended to update an existing helper',
                             ],
                             context={"helper_type": helper_type},
                         )


### PR DESCRIPTION
## What does this PR do?

Closes #1074. The runtime check at `tools_config_helpers.py:251` (flow path) and `:872` (simple path) correctly rejects `ha_config_set_helper` create calls that omit the required `name` argument, but the surfaces communicating the create-vs-update contract were too thin to prevent the omission at emission time. The reporter (#1074) and at least one maintainer-side reproduction observed an LLM emitting `{"helper_type": "input_number", "min_value": 0, "max_value": 100, "initial": 50}` (no `name`) and looping through 14+ identical retries — symptoms of the agent locking into a wrong call shape early.

Three coordinated low-token-cost surface changes. **No schema change, no signature change, no test churn.**

### 1. Docstring discriminator line at `:786`
Replaces a routing-rule sentence with a parameter-named contract:

\`\`\`diff
-Creates new helper if helper_id is omitted, updates existing if helper_id is provided.
+Create requires \`name\`; update requires \`helper_id\`.
\`\`\`

Same line count, names the conditional contract at the top of the tool description (which FastMCP renders as the model-visible top-level \`description\` per \`function_tool.py:225-227\`).

### 2. \`name\` Field description prefix at \`:535-541\`
Leads with \`"REQUIRED when creating (no helper_id provided). "\` so the contract surfaces in the JSON Schema's \`properties.name.description\` that the model reads at parameter-emission time.

### 3. Runtime errors at \`:251\` (flow) and \`:872\` (simple)
Both branches now include a literal JSON-arguments example in the message and aligned \`suggestions[]\` arrays, mirroring the pattern #1055 established at \`tools_config_automations.py:527,539\`. The simple-path branch previously had no \`suggestions[]\` array; this PR adds one, fixing an asymmetry with the flow branch.

The substring \`"name is required for create"\` is preserved at both sites, so the regression fixture at \`tests/src/unit/test_helper_update_persistence.py:1063\` still matches without modification. Error code remains \`VALIDATION_INVALID_PARAMETER\` for the same reason and to mirror peer tools in #1055's territory.

## Lineage

Continues the small-model-failure-mode line of work from #1055 (sergeykad / kingpanther13). #1055 covered \`ha_config_set_automation\` and the proxy tools; this PR closes the parallel gap on \`ha_config_set_helper\`. Same fix shape: targeted docstring + Field + error-message work; nothing structural.

The schema's \`name: str | None = None\` from #1012 commit \`f362e14f\` is intentionally preserved (matches \`ha_set_entity\` sister-tool convention; \`TestOptionalNameOnUpdate\` is the binding contract for the create-vs-update asymmetry).

## Bounding principle for future LLM-mitigation PRs

Communication-channel improvements (docstrings, error messages, schema metadata) are in scope. Server-side fabrication of values the user did not provide (defaulting \`name\` to a timestamp, inferring from \`helper_type\`) is not.

## Reproduction

With explicit kwargs the tool always succeeds. The bug is **intermittent and rare under organic prompting**:

- The original reporter (#1074) hit it 14+ times in a row in a single session — symptomatic of an agent locking into a malformed call shape early and repeating it across retries.
- A maintainer-side reproduction was only able to reproduce it when the agent was deliberately steered toward the wrong call shape.
- **~50 fresh agent attempts on master (haiku/sonnet/opus × directive and natural prompts × single-helper and multi-step plans) failed to reproduce it under organic prompting** — full breakdown in the [testing-summary comment below](#issuecomment-4384884755).

Explicit kwarg-form prompting is the reliable workaround on the existing build. The intervention in this PR raises the visibility of the create-vs-update contract at exactly the points where the model decides which arguments to emit, addressing the lock-in path without changing the schema.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`) — pending CI
- [ ] Code follows style guidelines (\`uv run ruff check\`) — pending CI

## Checklist
- [x] I have updated documentation if needed (docstring + Field description are the documentation surfaces; tool list will be regenerated by CI)