### PR TITLE
feat: add JMESPath response-filter middleware

### DIFF
--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -26,6 +26,7 @@ options:
   enable_tool_search: false
   enable_yaml_config_editing: false
   enable_code_mode: false
+  enable_jmespath_filter: false
   tool_search_max_results: 5
   disabled_tools: ""
   pinned_tools: ""
@@ -36,6 +37,7 @@ schema:
   enable_tool_search: bool?
   enable_yaml_config_editing: bool?
   enable_code_mode: bool?
+  enable_jmespath_filter: bool?
   enable_filesystem_tools: bool?
   enable_custom_component_integration: bool?
   tool_search_max_results: int(2,10)?

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -32,11 +32,13 @@ image: "ghcr.io/homeassistant-ai/ha-mcp-addon-{arch}"
 options:
   backup_hint: "normal"
   enable_tool_search: false
+  enable_jmespath_filter: false
   verify_ssl: true
 schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
   enable_tool_search: bool?
+  enable_jmespath_filter: bool?
   verify_ssl: bool?
   advanced_debug_logging: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -214,6 +214,7 @@ def main() -> int:
     custom_secret_path = ""  # default
     enable_tool_search = False  # default
     enable_yaml_config_editing = False  # default
+    enable_jmespath_filter = False  # default
     enable_filesystem_tools = False  # default
     enable_custom_component_integration = False  # default
     enable_code_mode = False  # default
@@ -233,6 +234,8 @@ def main() -> int:
             enable_tool_search = raw_tool_search if isinstance(raw_tool_search, bool) else False
             raw_yaml_config = config.get("enable_yaml_config_editing", False)
             enable_yaml_config_editing = raw_yaml_config if isinstance(raw_yaml_config, bool) else False
+            raw_jmespath = config.get("enable_jmespath_filter", False)
+            enable_jmespath_filter = raw_jmespath if isinstance(raw_jmespath, bool) else False
             raw_filesystem_tools = config.get("enable_filesystem_tools", False)
             enable_filesystem_tools = raw_filesystem_tools if isinstance(raw_filesystem_tools, bool) else False
             raw_custom_component = config.get("enable_custom_component_integration", False)
@@ -275,6 +278,7 @@ def main() -> int:
     os.environ["BACKUP_HINT"] = backup_hint
     os.environ["ENABLE_TOOL_SEARCH"] = str(enable_tool_search).lower()
     os.environ["ENABLE_YAML_CONFIG_EDITING"] = str(enable_yaml_config_editing).lower()
+    os.environ["ENABLE_JMESPATH_FILTER"] = str(enable_jmespath_filter).lower()
     os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = str(enable_filesystem_tools).lower()
     os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = str(enable_custom_component_integration).lower()
     os.environ["ENABLE_CODE_MODE"] = str(enable_code_mode).lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "fastmcp==3.2.4",
     "httpx[socks]==0.28.1",
+    "jmespath==1.0.1",
     "pydantic==2.13.3",
     "python-dotenv==1.2.2",
     "truststore==0.10.4",
@@ -75,7 +76,8 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = [
     "fastmcp.*",
-    "jq",
+    "jmespath",
+    "jmespath.*",
     "pydantic_monty",
     "pydantic_monty.*",
 ]

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     # files. Disabled by default; only for YAML-only features with no UI/API path.
     enable_yaml_config_editing: bool = Field(False, alias="ENABLE_YAML_CONFIG_EDITING")
 
+    # JMESPath response-filter middleware — injects an optional _jmespath parameter
+    # into every tool, allowing agents to filter responses server-side before they are
+    # returned. Reduces token usage for large HA payloads. Disabled by default.
+    enable_jmespath_filter: bool = Field(False, alias="ENABLE_JMESPATH_FILTER")
+
     # Seed values for tool visibility (comma-separated tool names).
     # Used as initial config when no tool_config.json exists.
     # The web settings UI (/settings) is the primary interface for managing these.

--- a/src/ha_mcp/middleware/__init__.py
+++ b/src/ha_mcp/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .response_filter import JMESPathFilterMiddleware
+
+__all__ = ["JMESPathFilterMiddleware"]

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -85,7 +85,7 @@ def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
     except jmespath.exceptions.JMESPathError as exc:
         warning: dict[str, Any] = dict(data) if isinstance(data, dict) else {"result": data}
         warning["_jmespath_warning"] = str(exc)
-        return ToolResult(content=warning, structured_content=warning)
+        return ToolResult(content=[mt.TextContent(type="text", text=json.dumps(warning))], structured_content=warning)
 
     if filtered is None:
         filtered_dict: dict[str, Any] = {}
@@ -94,4 +94,4 @@ def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
     else:
         filtered_dict = {"result": filtered}
 
-    return ToolResult(content=filtered_dict, structured_content=filtered_dict)
+    return ToolResult(content=[mt.TextContent(type="text", text=json.dumps(filtered_dict))], structured_content=filtered_dict)

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -53,9 +53,7 @@ class JMESPathFilterMiddleware(Middleware):
         jmespath_expr: str | None = args.get(_PARAM_NAME)
 
         if jmespath_expr is not None:
-            clean_args = {k: v for k, v in args.items() if k != _PARAM_NAME}
-            new_message = context.message.model_copy(update={"arguments": clean_args})
-            context = context.copy(message=new_message)
+            context.message.arguments = {k: v for k, v in args.items() if k != _PARAM_NAME}
 
         result = await call_next(context)
 

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -21,7 +21,7 @@ _PARAM_NAME = "_jmespath"
 _PARAM_SCHEMA: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Optional JMESPath filter applied server-side before returning (see jmespath.org). "
+        "Optional JMESPath filter for results - see jmespath.org"
         "Examples: 'state', '{id: entity_id, state: state}', 'entities[?domain==`light`]'."
     ),
 }
@@ -42,10 +42,17 @@ class JMESPathFilterMiddleware(Middleware):
         call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
         tools = await call_next(context)
-        tools_copy = copy.deepcopy(list(tools))
-        for tool in tools_copy:
-            tool.parameters.setdefault("properties", {})[_PARAM_NAME] = _PARAM_SCHEMA
-        return tools_copy
+        result = []
+        for tool in tools:
+            # Shallow-copy the Tool to avoid mutating the registry.
+            # Full deepcopy raises "cannot pickle '_thread.RLock' object" because
+            # FastMCP Tool objects hold threading locks internally; only the
+            # parameters dict (plain JSON Schema) needs to be copied.
+            tool_copy = copy.copy(tool)
+            tool_copy.parameters = copy.deepcopy(tool.parameters)
+            tool_copy.parameters.setdefault("properties", {})[_PARAM_NAME] = _PARAM_SCHEMA
+            result.append(tool_copy)
+        return result
 
     async def on_call_tool(
         self,

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from collections.abc import Sequence
@@ -8,8 +9,11 @@ from typing import Any
 import jmespath
 import jmespath.exceptions
 import mcp.types as mt
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.base import Tool, ToolResult
+
+from ha_mcp.errors import ErrorCode, create_error_response
 
 logger = logging.getLogger(__name__)
 
@@ -17,14 +21,12 @@ _PARAM_NAME = "_jmespath"
 _PARAM_SCHEMA: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Optional JMESPath expression applied server-side to filter this tool's "
-        "response before it is returned, reducing token usage. "
-        "Examples: 'state' — single field; "
-        "'{id: entity_id, state: state}' — projection; "
-        "'entities[?domain==`light`].entity_id' — filter array. "
-        "On expression error the full response is returned with a '_jmespath_warning' key."
+        "Optional JMESPath filter applied server-side before returning (see jmespath.org). "
+        "Examples: 'state', '{id: entity_id, state: state}', 'entities[?domain==`light`]'."
     ),
 }
+
+_ENVELOPE_KEYS = ("success", "partial", "warning", "error", "count", "message")
 
 
 class JMESPathFilterMiddleware(Middleware):
@@ -40,9 +42,10 @@ class JMESPathFilterMiddleware(Middleware):
         call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
     ) -> Sequence[Tool]:
         tools = await call_next(context)
-        for tool in tools:
+        tools_copy = copy.deepcopy(list(tools))
+        for tool in tools_copy:
             tool.parameters.setdefault("properties", {})[_PARAM_NAME] = _PARAM_SCHEMA
-        return tools
+        return tools_copy
 
     async def on_call_tool(
         self,
@@ -64,7 +67,7 @@ class JMESPathFilterMiddleware(Middleware):
 
 
 def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
-    """Apply a JMESPath expression to the tool result, degrading gracefully on error."""
+    """Apply a JMESPath expression to the tool result."""
     data: Any = result.structured_content
 
     if data is None:
@@ -75,7 +78,7 @@ def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
                     data = json.loads(text)
                     break
                 except (json.JSONDecodeError, ValueError):
-                    pass
+                    logger.warning("_jmespath: text block is not JSON, skipping filter")
 
     if data is None:
         return result
@@ -83,15 +86,26 @@ def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
     try:
         filtered = jmespath.compile(expr).search(data)
     except jmespath.exceptions.JMESPathError as exc:
-        warning: dict[str, Any] = dict(data) if isinstance(data, dict) else {"result": data}
-        warning["_jmespath_warning"] = str(exc)
-        return ToolResult(content=[mt.TextContent(type="text", text=json.dumps(warning))], structured_content=warning)
+        raise ToolError(json.dumps(create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"Invalid JMESPath expression: {exc}",
+            context={"expression": expr},
+            suggestions=["Check JMESPath syntax — see https://jmespath.org/examples.html"],
+        ))) from exc
 
     if filtered is None:
-        filtered_dict: dict[str, Any] = {}
+        filtered_dict: dict[str, Any] = {"result": None}
     elif isinstance(filtered, dict):
         filtered_dict = filtered
     else:
         filtered_dict = {"result": filtered}
 
-    return ToolResult(content=[mt.TextContent(type="text", text=json.dumps(filtered_dict))], structured_content=filtered_dict)
+    if isinstance(data, dict):
+        for key in _ENVELOPE_KEYS:
+            if key in data and key not in filtered_dict:
+                filtered_dict[key] = data[key]
+
+    return ToolResult(
+        content=[mt.TextContent(type="text", text=json.dumps(filtered_dict))],
+        structured_content=filtered_dict,
+    )

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -21,8 +21,8 @@ _PARAM_NAME = "_jmespath"
 _PARAM_SCHEMA: dict[str, Any] = {
     "type": "string",
     "description": (
-        "Optional JMESPath filter for results - see jmespath.org"
-        "Examples: '{areas:areas[*].{id: area_id, name: name}'."
+        "Optional JMESPath filter — see https://jmespath.org. "
+        "Example: '{areas: areas[*].{id: area_id, name: name}}'."
     ),
 }
 

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -22,7 +22,7 @@ _PARAM_SCHEMA: dict[str, Any] = {
     "type": "string",
     "description": (
         "Optional JMESPath filter for results - see jmespath.org"
-        "Examples: 'state', '{id: entity_id, state: state}', 'entities[?domain==`light`]'."
+        "Examples: '{areas:areas[*].{id: area_id, name: name}'."
     ),
 }
 

--- a/src/ha_mcp/middleware/response_filter.py
+++ b/src/ha_mcp/middleware/response_filter.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import jmespath
+import jmespath.exceptions
+import mcp.types as mt
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+_PARAM_NAME = "_jmespath"
+_PARAM_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "description": (
+        "Optional JMESPath expression applied server-side to filter this tool's "
+        "response before it is returned, reducing token usage. "
+        "Examples: 'state' — single field; "
+        "'{id: entity_id, state: state}' — projection; "
+        "'entities[?domain==`light`].entity_id' — filter array. "
+        "On expression error the full response is returned with a '_jmespath_warning' key."
+    ),
+}
+
+
+class JMESPathFilterMiddleware(Middleware):
+    """Adds an optional _jmespath parameter to every tool.
+
+    Agents supply a JMESPath expression; the server filters the response before
+    returning it, reducing the tokens consumed by large HA payloads.
+    """
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        for tool in tools:
+            tool.parameters.setdefault("properties", {})[_PARAM_NAME] = _PARAM_SCHEMA
+        return tools
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        args = context.message.arguments or {}
+        jmespath_expr: str | None = args.get(_PARAM_NAME)
+
+        if jmespath_expr is not None:
+            clean_args = {k: v for k, v in args.items() if k != _PARAM_NAME}
+            new_message = context.message.model_copy(update={"arguments": clean_args})
+            context = context.copy(message=new_message)
+
+        result = await call_next(context)
+
+        if not jmespath_expr:
+            return result
+
+        return _apply_jmespath(result, jmespath_expr)
+
+
+def _apply_jmespath(result: ToolResult, expr: str) -> ToolResult:
+    """Apply a JMESPath expression to the tool result, degrading gracefully on error."""
+    data: Any = result.structured_content
+
+    if data is None:
+        for block in result.content:
+            text = getattr(block, "text", None)
+            if text is not None:
+                try:
+                    data = json.loads(text)
+                    break
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+    if data is None:
+        return result
+
+    try:
+        filtered = jmespath.compile(expr).search(data)
+    except jmespath.exceptions.JMESPathError as exc:
+        warning: dict[str, Any] = dict(data) if isinstance(data, dict) else {"result": data}
+        warning["_jmespath_warning"] = str(exc)
+        return ToolResult(content=warning, structured_content=warning)
+
+    if filtered is None:
+        filtered_dict: dict[str, Any] = {}
+    elif isinstance(filtered, dict):
+        filtered_dict = filtered
+    else:
+        filtered_dict = {"result": filtered}
+
+    return ToolResult(content=filtered_dict, structured_content=filtered_dict)

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -20,6 +20,7 @@ from fastmcp.server.transforms import ResourcesAsTools
 from mcp.types import Icon
 
 from .config import _PACKAGE_VERSION, get_global_settings
+from .middleware import JMESPathFilterMiddleware
 from .tools.enhanced import EnhancedToolsMixin
 from .transforms import DEFAULT_PINNED_TOOLS
 
@@ -200,6 +201,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             icons=SERVER_ICONS,
             instructions=instructions,
         )
+        self.mcp.add_middleware(JMESPathFilterMiddleware())
 
         # Register all tools and expert prompts
         self._initialize_server()

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -201,7 +201,8 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             icons=SERVER_ICONS,
             instructions=instructions,
         )
-        self.mcp.add_middleware(JMESPathFilterMiddleware())
+        if self.settings.enable_jmespath_filter:
+            self.mcp.add_middleware(JMESPathFilterMiddleware())
 
         # Register all tools and expert prompts
         self._initialize_server()

--- a/tests/src/e2e/basic/test_jmespath_filter.py
+++ b/tests/src/e2e/basic/test_jmespath_filter.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from ..utilities.assertions import parse_mcp_result
+from ..utilities.assertions import parse_mcp_result, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,26 @@ async def test_jmespath_param_present_on_all_tools(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_on_list_tools_idempotent(mcp_client):
+    """Calling list_tools twice must not accumulate or change the _jmespath schema."""
+    tools_first = await mcp_client.list_tools()
+    tools_second = await mcp_client.list_tools()
+
+    schema_first = {
+        t.name: (t.inputSchema or {}).get("properties", {}).get("_jmespath")
+        for t in tools_first
+    }
+    schema_second = {
+        t.name: (t.inputSchema or {}).get("properties", {}).get("_jmespath")
+        for t in tools_second
+    }
+    assert schema_first == schema_second, (
+        "_jmespath schema must be identical across list_tools calls (no mutation of registry objects)"
+    )
+    logger.info(f"✅ _jmespath schema stable across {len(tools_first)} tools")
+
+
+@pytest.mark.asyncio
 async def test_jmespath_projection_reduces_response(mcp_client):
     """A projection expression returns only the requested fields."""
     result = await mcp_client.call_tool(
@@ -43,19 +63,52 @@ async def test_jmespath_projection_reduces_response(mcp_client):
 
 
 @pytest.mark.asyncio
-async def test_jmespath_invalid_expression_degrades_gracefully(mcp_client):
-    """An invalid JMESPath expression returns the full response plus a warning."""
+async def test_jmespath_projection_preserves_envelope(mcp_client):
+    """Envelope fields (success, partial, warning) survive a sub-field projection."""
     result = await mcp_client.call_tool(
+        "ha_get_state",
+        {"entity_id": "sun.sun", "_jmespath": "data.state"},
+    )
+    data = parse_mcp_result(result)
+
+    # ha_get_state returns success=True; a scalar projection wraps in {"result": ...}
+    # but the envelope key must be re-attached by the middleware
+    assert "success" in data, f"Envelope 'success' must be preserved; got keys: {list(data)}"
+    logger.info(f"✅ Envelope preserved after projection: {data}")
+
+
+@pytest.mark.asyncio
+async def test_jmespath_invalid_expression_raises_error(mcp_client):
+    """An invalid JMESPath expression raises a structured ToolError."""
+    data = await safe_call_tool(
+        mcp_client,
         "ha_get_state",
         {"entity_id": "sun.sun", "_jmespath": "!!not valid!!"},
     )
 
+    assert data.get("success") is False, (
+        f"Expected success=False for invalid expression; got: {data}"
+    )
+    error = data.get("error", {})
+    assert isinstance(error, dict), f"Expected structured error dict; got: {error!r}"
+    assert error.get("code") == "VALIDATION_INVALID_PARAMETER", (
+        f"Expected VALIDATION_INVALID_PARAMETER error code; got: {error.get('code')!r}"
+    )
+    logger.info(f"✅ Invalid expression raised ToolError: {error.get('message')!r}")
+
+
+@pytest.mark.asyncio
+async def test_jmespath_none_result(mcp_client):
+    """An expression that matches nothing returns explicit null, not an empty dict."""
+    result = await mcp_client.call_tool(
+        "ha_get_state",
+        {"entity_id": "sun.sun", "_jmespath": "nonexistent_field_xyz"},
+    )
     data = parse_mcp_result(result)
 
-    assert "_jmespath_warning" in data, (
-        f"Expected _jmespath_warning in degraded response; got keys: {list(data)}"
-    )
-    logger.info(f"✅ Graceful degradation: warning = {data['_jmespath_warning']!r}")
+    assert "result" in data, f"None-match must use explicit {{'result': None}}; got: {data}"
+    assert data["result"] is None, f"result must be null; got: {data['result']!r}"
+    logger.info("✅ None-match returned {'result': None}")
 
 
 @pytest.mark.asyncio

--- a/tests/src/e2e/basic/test_jmespath_filter.py
+++ b/tests/src/e2e/basic/test_jmespath_filter.py
@@ -1,6 +1,5 @@
 """E2E tests for the JMESPath response-filter middleware."""
 
-import json
 import logging
 
 import pytest

--- a/tests/src/e2e/basic/test_jmespath_filter.py
+++ b/tests/src/e2e/basic/test_jmespath_filter.py
@@ -1,0 +1,81 @@
+"""E2E tests for the JMESPath response-filter middleware."""
+
+import json
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_jmespath_param_present_on_all_tools(mcp_client):
+    """Every tool advertised by the server must include the _jmespath parameter."""
+    tools = await mcp_client.list_tools()
+    assert tools, "Server should expose at least one tool"
+
+    missing = [
+        t.name
+        for t in tools
+        if "_jmespath" not in (t.inputSchema or {}).get("properties", {})
+    ]
+    assert not missing, (
+        f"Tools missing _jmespath in schema ({len(missing)}): {missing[:10]}"
+    )
+    logger.info(f"✅ _jmespath present on all {len(tools)} tools")
+
+
+@pytest.mark.asyncio
+async def test_jmespath_projection_reduces_response(mcp_client):
+    """A projection expression returns only the requested fields."""
+    result = await mcp_client.call_tool(
+        "ha_get_state",
+        {"entity_id": "sun.sun", "_jmespath": "{entity_id: data.entity_id, state: data.state}"},
+    )
+
+    assert result, "Expected a non-empty result"
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    data = json.loads(text)
+
+    assert "entity_id" in data, f"Projection must include entity_id; got {data}"
+    assert "state" in data, f"Projection must include state; got {data}"
+    assert "attributes" not in data, f"Projection must exclude attributes; got {data}"
+    logger.info(f"✅ Projection returned: {data}")
+
+
+@pytest.mark.asyncio
+async def test_jmespath_invalid_expression_degrades_gracefully(mcp_client):
+    """An invalid JMESPath expression returns the full response plus a warning."""
+    result = await mcp_client.call_tool(
+        "ha_get_state",
+        {"entity_id": "sun.sun", "_jmespath": "!!not valid!!"},
+    )
+
+    assert result, "Expected a non-empty result"
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    data = json.loads(text)
+
+    assert "_jmespath_warning" in data, (
+        f"Expected _jmespath_warning in degraded response; got keys: {list(data)}"
+    )
+    logger.info(f"✅ Graceful degradation: warning = {data['_jmespath_warning']!r}")
+
+
+@pytest.mark.asyncio
+async def test_jmespath_param_not_passed_to_tool(mcp_client):
+    """The _jmespath parameter must be stripped before the tool receives arguments."""
+    # ha_get_state has a strict required param 'entity_id'. If _jmespath were passed
+    # through, FastMCP schema validation would reject it on a tool with no extra=allow.
+    # A successful call proves the middleware stripped it cleanly.
+    result = await mcp_client.call_tool(
+        "ha_get_state",
+        {"entity_id": "sun.sun", "_jmespath": "data.state"},
+    )
+    assert result, "Call should succeed (proves _jmespath was stripped)"
+    text = result[0].text if hasattr(result[0], "text") else str(result[0])
+    data = json.loads(text)
+    # With 'data.state' expression the result should be a single string wrapped in {"result": ...}
+    assert "result" in data or isinstance(data.get("result"), str) or isinstance(data, dict), (
+        f"Unexpected shape: {data}"
+    )
+    logger.info(f"✅ Tool received clean args; filtered result: {data}")

--- a/tests/src/e2e/basic/test_jmespath_filter.py
+++ b/tests/src/e2e/basic/test_jmespath_filter.py
@@ -65,15 +65,19 @@ async def test_jmespath_projection_reduces_response(mcp_client):
 @pytest.mark.asyncio
 async def test_jmespath_projection_preserves_envelope(mcp_client):
     """Envelope fields (success, partial, warning) survive a sub-field projection."""
+    # ha_config_list_areas returns {"success": True, "count": N, "areas": [...]} directly
+    # (no add_timezone_metadata wrapper), so success is at the top level where the
+    # middleware's envelope merge loop looks for it.
     result = await mcp_client.call_tool(
-        "ha_get_state",
-        {"entity_id": "sun.sun", "_jmespath": "data.state"},
+        "ha_config_list_areas",
+        {"_jmespath": "areas[*].name"},
     )
     data = parse_mcp_result(result)
 
-    # ha_get_state returns success=True; a scalar projection wraps in {"result": ...}
-    # but the envelope key must be re-attached by the middleware
+    # areas[*].name returns a list — wrapped in {"result": [...]} by the middleware.
+    # The envelope key "success" must be re-attached alongside the filtered result.
     assert "success" in data, f"Envelope 'success' must be preserved; got keys: {list(data)}"
+    assert "result" in data, f"Filtered list must be under 'result'; got keys: {list(data)}"
     logger.info(f"✅ Envelope preserved after projection: {data}")
 
 

--- a/tests/src/e2e/basic/test_jmespath_filter.py
+++ b/tests/src/e2e/basic/test_jmespath_filter.py
@@ -5,6 +5,8 @@ import logging
 
 import pytest
 
+from ..utilities.assertions import parse_mcp_result
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,9 +35,7 @@ async def test_jmespath_projection_reduces_response(mcp_client):
         {"entity_id": "sun.sun", "_jmespath": "{entity_id: data.entity_id, state: data.state}"},
     )
 
-    assert result, "Expected a non-empty result"
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    data = json.loads(text)
+    data = parse_mcp_result(result)
 
     assert "entity_id" in data, f"Projection must include entity_id; got {data}"
     assert "state" in data, f"Projection must include state; got {data}"
@@ -51,9 +51,7 @@ async def test_jmespath_invalid_expression_degrades_gracefully(mcp_client):
         {"entity_id": "sun.sun", "_jmespath": "!!not valid!!"},
     )
 
-    assert result, "Expected a non-empty result"
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    data = json.loads(text)
+    data = parse_mcp_result(result)
 
     assert "_jmespath_warning" in data, (
         f"Expected _jmespath_warning in degraded response; got keys: {list(data)}"
@@ -71,11 +69,7 @@ async def test_jmespath_param_not_passed_to_tool(mcp_client):
         "ha_get_state",
         {"entity_id": "sun.sun", "_jmespath": "data.state"},
     )
-    assert result, "Call should succeed (proves _jmespath was stripped)"
-    text = result[0].text if hasattr(result[0], "text") else str(result[0])
-    data = json.loads(text)
-    # With 'data.state' expression the result should be a single string wrapped in {"result": ...}
-    assert "result" in data or isinstance(data.get("result"), str) or isinstance(data, dict), (
-        f"Unexpected shape: {data}"
-    )
+    data = parse_mcp_result(result)
+    # With 'data.state' expression the result should be a scalar wrapped in {"result": ...}
+    assert "result" in data, f"Expected scalar result wrapped in dict; got: {data}"
     logger.info(f"✅ Tool received clean args; filtered result: {data}")

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -378,6 +378,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         os.environ["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
         # Enable feature flags for e2e tests
         os.environ["ENABLE_YAML_CONFIG_EDITING"] = "true"
+        os.environ["ENABLE_JMESPATH_FILTER"] = "true"
         os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = "true"
         os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = "true"
 

--- a/tests/src/unit/test_response_filter.py
+++ b/tests/src/unit/test_response_filter.py
@@ -10,7 +10,11 @@ import pytest
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.base import ToolResult
 
-from ha_mcp.middleware.response_filter import JMESPathFilterMiddleware, _PARAM_NAME, _apply_jmespath
+from ha_mcp.middleware.response_filter import (
+    _PARAM_NAME,
+    JMESPathFilterMiddleware,
+    _apply_jmespath,
+)
 
 
 def _make_result(data: dict) -> ToolResult:

--- a/tests/src/unit/test_response_filter.py
+++ b/tests/src/unit/test_response_filter.py
@@ -1,0 +1,99 @@
+"""Unit tests for JMESPath response-filter middleware (_apply_jmespath)."""
+
+import json
+
+import mcp.types as mt
+import pytest
+from fastmcp.exceptions import ToolError
+from fastmcp.tools.base import ToolResult
+
+from ha_mcp.middleware.response_filter import _apply_jmespath
+
+
+def _make_result(data: dict) -> ToolResult:
+    return ToolResult(
+        content=[mt.TextContent(type="text", text=json.dumps(data))],
+        structured_content=data,
+    )
+
+
+class TestApplyJmesPath:
+    def test_basic_field_extraction(self):
+        result = _make_result({"success": True, "data": {"state": "on", "entity_id": "light.x"}})
+        out = _apply_jmespath(result, "data.state")
+        parsed = json.loads(out.content[0].text)
+        assert parsed["result"] == "on"
+
+    def test_projection_returns_dict_directly(self):
+        result = _make_result({"success": True, "data": {"state": "on", "entity_id": "light.x"}})
+        out = _apply_jmespath(result, "{s: data.state, id: data.entity_id}")
+        parsed = json.loads(out.content[0].text)
+        assert parsed["s"] == "on"
+        assert parsed["id"] == "light.x"
+        assert "result" not in parsed
+
+    def test_scalar_result_wrapped(self):
+        result = _make_result({"value": 42})
+        out = _apply_jmespath(result, "value")
+        parsed = json.loads(out.content[0].text)
+        assert parsed == {"result": 42}
+
+    def test_none_result_explicit(self):
+        result = _make_result({"data": "hello"})
+        out = _apply_jmespath(result, "no_such_key")
+        parsed = json.loads(out.content[0].text)
+        assert parsed == {"result": None}
+
+    def test_envelope_keys_preserved_on_scalar(self):
+        result = _make_result({"success": True, "partial": True, "warning": "degraded", "data": "x"})
+        out = _apply_jmespath(result, "data")
+        parsed = json.loads(out.content[0].text)
+        assert parsed["result"] == "x"
+        assert parsed["success"] is True
+        assert parsed["partial"] is True
+        assert parsed["warning"] == "degraded"
+
+    def test_envelope_keys_preserved_on_projection(self):
+        result = _make_result({"success": True, "data": {"state": "on"}})
+        out = _apply_jmespath(result, "{s: data.state}")
+        parsed = json.loads(out.content[0].text)
+        assert parsed["s"] == "on"
+        assert parsed["success"] is True
+
+    def test_envelope_key_in_filtered_result_not_overwritten(self):
+        result = _make_result({"success": True, "data": {"success": False}})
+        out = _apply_jmespath(result, "data")
+        parsed = json.loads(out.content[0].text)
+        # filtered result is {"success": False}, envelope "success"=True must NOT overwrite it
+        assert parsed["success"] is False
+
+    def test_invalid_expression_raises_tool_error(self):
+        result = _make_result({"data": "x"})
+        with pytest.raises(ToolError) as exc_info:
+            _apply_jmespath(result, "!!not valid!!")
+        error = json.loads(str(exc_info.value))
+        assert error["success"] is False
+        assert error["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    def test_null_structured_content_falls_back_to_text(self):
+        text_result = ToolResult(
+            content=[mt.TextContent(type="text", text=json.dumps({"state": "off"}))],
+            structured_content=None,
+        )
+        out = _apply_jmespath(text_result, "state")
+        parsed = json.loads(out.content[0].text)
+        assert parsed["result"] == "off"
+
+    def test_no_parseable_content_passthrough(self):
+        raw_result = ToolResult(
+            content=[mt.TextContent(type="text", text="not json at all")],
+            structured_content=None,
+        )
+        out = _apply_jmespath(raw_result, "state")
+        assert out is raw_result
+
+    def test_structured_content_none_match_explicit(self):
+        result = _make_result({"items": []})
+        out = _apply_jmespath(result, "items[0]")
+        parsed = json.loads(out.content[0].text)
+        assert parsed == {"result": None}

--- a/tests/src/unit/test_response_filter.py
+++ b/tests/src/unit/test_response_filter.py
@@ -1,13 +1,16 @@
 """Unit tests for JMESPath response-filter middleware (_apply_jmespath)."""
 
+import copy
 import json
+import threading
+from unittest.mock import AsyncMock, MagicMock
 
 import mcp.types as mt
 import pytest
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.base import ToolResult
 
-from ha_mcp.middleware.response_filter import _apply_jmespath
+from ha_mcp.middleware.response_filter import JMESPathFilterMiddleware, _PARAM_NAME, _apply_jmespath
 
 
 def _make_result(data: dict) -> ToolResult:
@@ -97,3 +100,40 @@ class TestApplyJmesPath:
         out = _apply_jmespath(result, "items[0]")
         parsed = json.loads(out.content[0].text)
         assert parsed == {"result": None}
+
+
+class _ToolStub:
+    """Minimal stand-in for a FastMCP Tool that holds a threading.RLock."""
+
+    def __init__(self):
+        self.parameters = {"type": "object", "properties": {}}
+        self._lock = threading.RLock()
+
+
+class TestOnListToolsDeepCopy:
+    """Regression: deepcopy of FastMCP Tool raises 'cannot pickle _thread.RLock'."""
+
+    def test_deepcopy_of_rlock_object_raises(self):
+        with pytest.raises(TypeError, match="cannot pickle"):
+            copy.deepcopy(_ToolStub())
+
+    @pytest.mark.asyncio
+    async def test_on_list_tools_succeeds_when_tool_has_rlock(self):
+        context = MagicMock()
+        call_next = AsyncMock(return_value=[_ToolStub()])
+        middleware = JMESPathFilterMiddleware()
+
+        result = await middleware.on_list_tools(context, call_next)
+
+        assert _PARAM_NAME in result[0].parameters["properties"]
+
+    @pytest.mark.asyncio
+    async def test_on_list_tools_does_not_mutate_original_parameters(self):
+        stub = _ToolStub()
+        context = MagicMock()
+        call_next = AsyncMock(return_value=[stub])
+        middleware = JMESPathFilterMiddleware()
+
+        await middleware.on_list_tools(context, call_next)
+
+        assert _PARAM_NAME not in stub.parameters["properties"]

--- a/uv.lock
+++ b/uv.lock
@@ -419,6 +419,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx", extra = ["socks"] },
+    { name = "jmespath" },
     { name = "pydantic" },
     { name = "pydantic-monty" },
     { name = "python-dotenv" },
@@ -450,6 +451,7 @@ requires-dist = [
     { name = "cryptography", specifier = "==47.0.0" },
     { name = "fastmcp", specifier = "==3.2.4" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
+    { name = "jmespath", specifier = "==1.0.1" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-monty", specifier = "==0.0.9" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -614,6 +616,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
     { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Adds an optional `_jmespath` parameter to every MCP tool via server-level middleware. Agents can provide a [JMESPath](https://jmespath.org/) expression and the server filters the response **server-side** before returning it, reducing context-window token usage by 80–90% on large HA payloads — without any per-tool changes.    

  **Example:** 

Before:

```bash
> fastmcp call http://localhost:8086/mcp ha_config_list_areas
{
  "success": true,
  "count": 16,
  "areas": [
    {
      "aliases": [],
      "area_id": "basement",
      "floor_id": "basement",
      ...
> fastmcp call http://localhost:8086/mcp ha_config_list_areas | wc
     215     411    5519
```

After:
```bash
> fastmcp call http://localhost:8086/mcp ha_config_list_areas '_jmespath={success: success, areas:areas[*].{id: area_id, name: name}}' 
{
  "success": true,
  "areas": [
    {
      "id": "basement",
      "name": "Basement"
    },
...
> fastmcp call http://localhost:8086/mcp ha_config_list_areas '_jmespath={success: success, areas:areas[*].{id: area_id, name: name}}' | wc
     69     117    1153
```

## Changes

  - `src/ha_mcp/middleware/response_filter.py` — JMESPathFilterMiddleware with two hooks:
    - `on_list_tools`: injects `_jmespath` into every tool's advertised JSONSchema so agents discover it automatically. Uses shallow copy + parameters-only deepcopy to avoid "cannot pickle '_thread.RLock' object" (FastMCP Tool objects contain threading locks internally)
    - `on_call_tool`: strips `_jmespath` from arguments before the underlying tool sees them, then applies the expression to `structured_content`
  - `src/ha_mcp/server.py` — one-line middleware registration
  - `pyproject.toml` — adds `jmespath==1.0.1` (pure Python, no native extensions; important for the HA add-on and Docker images); removes the stale `jq` entry from mypy overrides (was never imported)

##  Behaviour on failure

  Invalid JMESPath expressions raise `ToolError` with `VALIDATION_INVALID_PARAMETER`. Non-matching expressions (result is `None`) return `{"result": null}`. Envelope keys (`success`, `partial`, `warning`, etc.) are always preserved in the filtered response.

##  Test plan

  - `_jmespath` present in `inputSchema.properties` for all tools
  - Projection `{entity_id: data.entity_id, state: data.state}` returns only those two keys
  - Invalid expression `!!not valid!!` raises `ToolError` with `VALIDATION_INVALID_PARAMETER`
  - `_jmespath` is stripped from tool args before delegation (proves middleware strips it before FastMCP schema validation)
  - Regression: `on_list_tools` does not raise when Tool objects contain `threading.RLock` (unit test with `_ToolStub`)
  - Regression: `on_list_tools` does not mutate the original tool's parameters
  - Full E2E suite passes

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed