### PR TITLE
fix(helpers): destructive UPDATE, input_number.initial, multi-step flows, switch_as_x (1/3)

### DIFF
--- a/src/ha_mcp/tools/tools_config_entry_flow.py
+++ b/src/ha_mcp/tools/tools_config_entry_flow.py
@@ -126,6 +126,25 @@ def _handle_menu_step(
     return str(menu_choice)
 
 
+def _extract_schema_field_names(data_schema: Any) -> set[str] | None:
+    """Extract the set of field names declared by a step's data_schema.
+
+    HA returns data_schema as a list of {name, selector, required, ...} dicts.
+    Returns ``None`` when the schema is absent or not a list (signalling
+    the caller to fall back to legacy submit-all behaviour). Returns a
+    (possibly empty) set when the schema is present and parseable.
+    """
+    if not isinstance(data_schema, list):
+        return None
+    names: set[str] = set()
+    for field in data_schema:
+        if isinstance(field, dict):
+            name = field.get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
 def _handle_form_step(
     flow_id: str,
     current_step: dict[str, Any],
@@ -133,8 +152,16 @@ def _handle_form_step(
 ) -> dict[str, Any]:
     """Validate a form step and return form data to submit.
 
-    Raises ToolError on validation errors. Returns the filtered form data
-    (menu selection keys stripped).
+    When the step's ``data_schema`` is provided, pops ONLY the keys declared
+    in that schema from ``remaining_config`` (mutating it) so any unconsumed
+    keys remain available for subsequent steps. Menu selection keys are never
+    submitted.
+
+    When ``data_schema`` is absent (HA didn't tell us field names), falls
+    back to legacy behaviour: submit all non-menu keys and clear them. This
+    keeps single-step flows working when HA omits the schema.
+
+    Raises ToolError on validation errors.
     """
     if current_step.get("errors"):
         raise_tool_error(create_error_response(
@@ -149,11 +176,25 @@ def _handle_form_step(
             },
         ))
 
-    return {
-        k: v
-        for k, v in remaining_config.items()
-        if k not in _MENU_SELECTION_KEYS
-    }
+    schema_fields = _extract_schema_field_names(current_step.get("data_schema"))
+
+    form_data: dict[str, Any] = {}
+    if schema_fields is None:
+        # Legacy fallback: no schema info — dump every non-menu key and
+        # consume them all so a follow-up step (rare without schema) won't
+        # re-submit the same data.
+        for key in list(remaining_config.keys()):
+            if key in _MENU_SELECTION_KEYS:
+                continue
+            form_data[key] = remaining_config.pop(key)
+    else:
+        for key in list(remaining_config.keys()):
+            if key in _MENU_SELECTION_KEYS:
+                continue
+            if key in schema_fields:
+                form_data[key] = remaining_config.pop(key)
+
+    return form_data
 
 
 async def _handle_flow_steps(
@@ -217,6 +258,10 @@ async def _handle_flow_steps(
             )
 
         elif result_type == _FlowType.FORM:
+            # _handle_form_step pops only the keys declared in the current
+            # step's data_schema, leaving any other keys in remaining_config
+            # for subsequent steps (HA can present multi-step forms, e.g.
+            # statistics: user step then pick-characteristic step).
             form_data = _handle_form_step(flow_id, current_step, remaining_config)
             logger.debug(
                 f"Flow step {step_num}: form submit "
@@ -226,8 +271,6 @@ async def _handle_flow_steps(
                 submit_fn(flow_id, form_data),
                 timeout=20.0,
             )
-            # Clear so subsequent steps don't re-submit the same data.
-            remaining_config = {}
 
         else:
             raise_tool_error(create_error_response(
@@ -241,6 +284,47 @@ async def _handle_flow_steps(
         f"Flow exceeded {max_steps} steps",
         context={"flow_id": flow_id, "max_steps": max_steps},
     ))
+
+
+async def get_user_step_field_names(
+    client: Any, helper_type: str
+) -> set[str] | None:
+    """Return field names in the user-step form schema for ``helper_type``.
+
+    Starts a config flow, peeks at the initial step's ``data_schema``,
+    and immediately aborts the flow. Used to decide whether to fold the
+    top-level ``name`` parameter into the form payload — some helpers
+    (e.g. ``switch_as_x``) take their entity name from the source switch
+    and reject ``name`` as an extra key.
+
+    Returns:
+        A set of field names if the initial step is a form. ``None`` if
+        the flow type is not introspectable from the top step (menu or
+        unexpected) — callers should fall back to the legacy behaviour
+        in that case to avoid regressing menu helpers (template, group).
+        Also returns ``None`` if the introspection itself fails; the
+        subsequent real flow will surface the error in context.
+    """
+    flow_id = None
+    try:
+        flow_result = await client.start_config_flow(helper_type)
+        flow_id = flow_result.get("flow_id")
+        if flow_result.get("type") != _FlowType.FORM:
+            return None
+        return _extract_schema_field_names(flow_result.get("data_schema"))
+    except Exception as e:
+        logger.debug(f"Schema introspection failed for {helper_type}: {e}")
+        return None
+    finally:
+        if flow_id:
+            try:
+                await asyncio.wait_for(
+                    client.abort_config_flow(flow_id), timeout=5.0
+                )
+            except Exception as abort_err:
+                logger.warning(
+                    f"Failed to abort introspection flow {flow_id}: {abort_err}"
+                )
 
 
 async def update_flow_helper(

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -8,6 +8,7 @@ input_number, input_text, input_datetime, counter, timer, schedule).
 
 import asyncio
 import logging
+import uuid
 from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
@@ -18,6 +19,7 @@ from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_e
 from .tools_config_entry_flow import (
     FLOW_HELPER_TYPES,
     create_flow_helper,
+    get_user_step_field_names,
     update_flow_helper,
 )
 from .util_helpers import (
@@ -44,6 +46,7 @@ SIMPLE_HELPER_TYPES: frozenset[str] = frozenset({
     "person",
     "tag",
 })
+
 
 logger = logging.getLogger(__name__)
 
@@ -226,12 +229,39 @@ async def _handle_flow_helper(
             context={"helper_type": helper_type},
         ))
 
-    # Fold the top-level `name` parameter into config_dict only for create:
-    # options (update) flows are strict about extra keys and will reject `name`
-    # with 400 "extra keys not allowed @ data['name']" — names on existing flow
-    # helpers are not renamed through the options flow.
+    # Pre-flow warnings (e.g. stripped `name` on update) collected here and
+    # surfaced alongside any later warnings on the result.
+    pre_warnings: list[str] = []
+
+    # Name handling differs between create and update flows:
+    #
+    # CREATE: most flow helpers accept `name` as a top-level form field, so the
+    # tool folds the top-level `name` parameter into the form payload. But some
+    # helpers — notably `switch_as_x` — derive the entity name from the source
+    # switch and reject `name` as an extra key with HA-side 400 "extra keys not
+    # allowed @ data['name']". Probe the user-step schema first; only inject if
+    # the schema actually accepts a `name` field. If introspection fails or the
+    # top step is a menu (template, group), fall back to the legacy behaviour
+    # of injecting — those helpers are known to accept `name`.
+    #
+    # UPDATE: options flows are strict about extra keys; HA rejects any
+    # caller-supplied `name` (you cannot rename a flow helper through its
+    # options flow). Strip `name` from config_dict and emit a warning so the
+    # caller learns their attempted rename was a no-op.
     if action == "create" and name and "name" not in config_dict:
-        config_dict["name"] = name
+        schema_fields = await get_user_step_field_names(client, helper_type)
+        if schema_fields is None or "name" in schema_fields:
+            config_dict["name"] = name
+        # else: schema is a form that explicitly does not include `name`
+        # (e.g. switch_as_x). Skip injection — HA would reject otherwise.
+    elif action == "update" and "name" in config_dict:
+        stripped_name = config_dict.pop("name")
+        pre_warnings.append(
+            f"Ignored 'name' in config: flow helper options flows do not "
+            f"support renaming (attempted name={stripped_name!r}). Use "
+            f"ha_set_entity to change the friendly name of the resulting "
+            f"entity."
+        )
 
     # Normalize labels to a list for registry updates below.
     try:
@@ -245,7 +275,11 @@ async def _handle_flow_helper(
 
     # Dispatch to the shared flow machinery.
     if action == "create":
-        if not config_dict.get("name"):
+        # Validate against EITHER the top-level `name` arg OR `config_dict["name"]`.
+        # Some helpers (switch_as_x) deliberately don't have `name` injected into
+        # config_dict because their schema rejects it — but the tool still
+        # requires `name` to be supplied so callers fail fast and consistently.
+        if not (name or config_dict.get("name")):
             raise_tool_error(create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
                 f'name is required for create action. Include "name" as a '
@@ -285,7 +319,7 @@ async def _handle_flow_helper(
     # Graduated polling: short intervals for the first retries catch local/small
     # instances quickly; steady 500ms matches typical entity_registry/list latency
     # on larger remote setups without missing entities near the deadline.
-    warnings: list[str] = []
+    warnings: list[str] = list(pre_warnings)
     wait_bool = coerce_bool_param(wait, "wait", default=True)
     entities: list[dict[str, Any]] = []
     if entry_id:
@@ -744,7 +778,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         tag_id: Annotated[
             str | None,
             Field(
-                description="Tag ID for tag (auto-generated if not provided)",
+                description=(
+                    "Tag ID for tag. On create, omit to auto-generate a "
+                    "uuid4 hex (HA's tag/create requires this field; the tool "
+                    "fills it in for you when omitted)."
+                ),
                 default=None,
             ),
         ] = None,
@@ -1060,9 +1098,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                 elif helper_type == "tag":
                     # Tag parameters: tag_id, description
-                    # Note: name goes into entity registry, not tag storage
-                    if tag_id:
-                        message["tag_id"] = tag_id
+                    # Note: name goes into entity registry, not tag storage.
+                    # Bug 9 (issue #1150): HA's tag/create requires tag_id;
+                    # auto-generate one when the caller omits it (matches
+                    # the docstring promise of auto-generation).
+                    message["tag_id"] = tag_id if tag_id else uuid.uuid4().hex
                     if description:
                         message["description"] = description
 

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -945,6 +945,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["unit_of_measurement"] = unit_of_measurement
                     if mode in ["box", "slider"]:
                         message["mode"] = mode
+                    # Bug 1 (issue #1150): `initial` was accepted in the function
+                    # signature but never written to the input_number/create
+                    # message, so the requested default was silently dropped.
+                    if initial is not None:
+                        message["initial"] = initial
 
                 elif helper_type == "input_text":
                     if min_value is not None:
@@ -1453,6 +1458,13 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 )
                             )
 
+                        # Bug 8 (issue #1150): HA's storage-collection update commands
+                        # are full-replace — fields missing from the message get
+                        # cleared. Per-type config fields below all use a merge
+                        # pattern: take the new value if the caller passed one,
+                        # else preserve the existing value. Without this, an
+                        # innocent rename wipes initial/icon/unit_of_measurement
+                        # and other fields the caller never intended to change.
                         update_msg = {
                             "type": f"{helper_type}/update",
                             f"{helper_type}_id": unique_id,
@@ -1460,8 +1472,15 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             if name is not None
                             else existing.get("name"),
                         }
-                        if icon is not None:
-                            update_msg["icon"] = icon
+                        # Icon lives in the helper's storage entry for all simple
+                        # types except person and tag; merge from existing so
+                        # rename-style updates don't wipe the previously set icon.
+                        if helper_type not in ("person", "tag"):
+                            icon_val = (
+                                icon if icon is not None else existing.get("icon")
+                            )
+                            if icon_val is not None:
+                                update_msg["icon"] = icon_val
 
                         if helper_type == "input_select":
                             update_msg["options"] = (
@@ -1469,8 +1488,13 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if options is not None
                                 else existing.get("options", [])
                             )
-                            if initial is not None:
-                                update_msg["initial"] = initial
+                            initial_val = (
+                                initial
+                                if initial is not None
+                                else existing.get("initial")
+                            )
+                            if initial_val is not None:
+                                update_msg["initial"] = initial_val
 
                         elif helper_type == "input_number":
                             update_msg["min"] = (
@@ -1483,22 +1507,64 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if max_value is not None
                                 else existing.get("max", 100)
                             )
-                            if step is not None:
-                                update_msg["step"] = step
-                            if unit_of_measurement is not None:
-                                update_msg["unit_of_measurement"] = unit_of_measurement
-                            if mode in ["box", "slider"]:
-                                update_msg["mode"] = mode
+                            step_val = (
+                                step if step is not None else existing.get("step")
+                            )
+                            if step_val is not None:
+                                update_msg["step"] = step_val
+                            unit_val = (
+                                unit_of_measurement
+                                if unit_of_measurement is not None
+                                else existing.get("unit_of_measurement")
+                            )
+                            if unit_val is not None:
+                                update_msg["unit_of_measurement"] = unit_val
+                            mode_val = (
+                                mode
+                                if mode in ["box", "slider"]
+                                else existing.get("mode")
+                            )
+                            if mode_val is not None:
+                                update_msg["mode"] = mode_val
+                            # Bug 1b (issue #1150): `initial` was accepted but
+                            # never written here, so updates always wiped it.
+                            initial_val = (
+                                initial
+                                if initial is not None
+                                else existing.get("initial")
+                            )
+                            if initial_val is not None:
+                                update_msg["initial"] = initial_val
 
                         elif helper_type == "input_text":
-                            if min_value is not None:
-                                update_msg["min"] = int(min_value)
-                            if max_value is not None:
-                                update_msg["max"] = int(max_value)
-                            if mode in ["text", "password"]:
-                                update_msg["mode"] = mode
-                            if initial is not None:
-                                update_msg["initial"] = initial
+                            min_val = (
+                                int(min_value)
+                                if min_value is not None
+                                else existing.get("min")
+                            )
+                            if min_val is not None:
+                                update_msg["min"] = min_val
+                            max_val = (
+                                int(max_value)
+                                if max_value is not None
+                                else existing.get("max")
+                            )
+                            if max_val is not None:
+                                update_msg["max"] = max_val
+                            mode_val = (
+                                mode
+                                if mode in ["text", "password"]
+                                else existing.get("mode")
+                            )
+                            if mode_val is not None:
+                                update_msg["mode"] = mode_val
+                            initial_val = (
+                                initial
+                                if initial is not None
+                                else existing.get("initial")
+                            )
+                            if initial_val is not None:
+                                update_msg["initial"] = initial_val
 
                         elif helper_type == "input_boolean":
                             if initial is not None:
@@ -1509,32 +1575,80 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                     "yes",
                                     "1",
                                 ]
+                            elif "initial" in existing:
+                                update_msg["initial"] = existing["initial"]
 
                         elif helper_type == "input_datetime":
-                            if has_date is not None:
-                                update_msg["has_date"] = has_date
-                            if has_time is not None:
-                                update_msg["has_time"] = has_time
-                            if initial is not None:
-                                update_msg["initial"] = initial
+                            update_msg["has_date"] = (
+                                has_date
+                                if has_date is not None
+                                else existing.get("has_date", False)
+                            )
+                            update_msg["has_time"] = (
+                                has_time
+                                if has_time is not None
+                                else existing.get("has_time", False)
+                            )
+                            initial_val = (
+                                initial
+                                if initial is not None
+                                else existing.get("initial")
+                            )
+                            if initial_val is not None:
+                                update_msg["initial"] = initial_val
 
                         elif helper_type == "counter":
-                            if initial is not None:
-                                update_msg["initial"] = int(initial)
-                            if min_value is not None:
-                                update_msg["minimum"] = int(min_value)
-                            if max_value is not None:
-                                update_msg["maximum"] = int(max_value)
-                            if step is not None:
-                                update_msg["step"] = int(step)
-                            if restore is not None:
-                                update_msg["restore"] = restore
+                            initial_val = (
+                                int(initial)
+                                if initial is not None
+                                else existing.get("initial")
+                            )
+                            if initial_val is not None:
+                                update_msg["initial"] = initial_val
+                            minimum_val = (
+                                int(min_value)
+                                if min_value is not None
+                                else existing.get("minimum")
+                            )
+                            if minimum_val is not None:
+                                update_msg["minimum"] = minimum_val
+                            maximum_val = (
+                                int(max_value)
+                                if max_value is not None
+                                else existing.get("maximum")
+                            )
+                            if maximum_val is not None:
+                                update_msg["maximum"] = maximum_val
+                            step_val = (
+                                int(step)
+                                if step is not None
+                                else existing.get("step")
+                            )
+                            if step_val is not None:
+                                update_msg["step"] = step_val
+                            restore_val = (
+                                restore
+                                if restore is not None
+                                else existing.get("restore")
+                            )
+                            if restore_val is not None:
+                                update_msg["restore"] = restore_val
 
                         elif helper_type == "timer":
-                            if duration is not None:
-                                update_msg["duration"] = duration
-                            if restore is not None:
-                                update_msg["restore"] = restore
+                            duration_val = (
+                                duration
+                                if duration is not None
+                                else existing.get("duration")
+                            )
+                            if duration_val is not None:
+                                update_msg["duration"] = duration_val
+                            restore_val = (
+                                restore
+                                if restore is not None
+                                else existing.get("restore")
+                            )
+                            if restore_val is not None:
+                                update_msg["restore"] = restore_val
 
                         # input_button has no type-specific params beyond name/icon
 

--- a/tests/src/e2e/workflows/config/test_helper_field_persistence.py
+++ b/tests/src/e2e/workflows/config/test_helper_field_persistence.py
@@ -1,0 +1,690 @@
+"""
+E2E tests for helper field persistence across UPDATE operations.
+
+These tests close the destructive-UPDATE coverage gap identified in
+``local/TEST_GAP_ANALYSIS.md``: existing CRUD tests verify HA state after
+CREATE but never re-verify HA state after UPDATE, so destructive UPDATE
+bugs (Bug 8 in issue #1150) — where a partial UPDATE silently wipes
+type-specific fields not provided in the call — slipped through.
+
+Pattern per simple type:
+
+1. CREATE the helper with FULL config (every type-specific field set to a
+   non-default value, plus icon).
+2. Wait for the entity to be registered, then read state via
+   ``ha_get_state`` and assert every configured field appears in
+   ``attributes``.
+3. UPDATE via ``ha_config_set_helper`` with ``helper_id`` set and ONLY the
+   ``name`` changed.
+4. Re-read state and assert every original field is STILL present — no
+   destructive wipe.
+
+Covers: input_boolean, input_select, input_number, input_text,
+input_datetime, counter, timer. Skips: schedule, zone, person, tag.
+
+Also includes a cross-cutting test: a fully-configured input_number
+updated with only ``min_value=70`` must preserve initial, mode,
+unit_of_measurement, step, and icon.
+"""
+
+import logging
+
+import pytest
+
+from ...utilities.assertions import (
+    assert_mcp_success,
+    parse_mcp_result,
+    safe_call_tool,
+)
+from ...utilities.wait_helpers import wait_for_condition
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Local helpers — duplicated from test_helper_crud.py to keep this file
+# self-contained without modifying the existing test module.
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_entity_registration(
+    mcp_client, entity_id: str, timeout: int = 20
+) -> bool:
+    """Poll until the entity is queryable via ``ha_get_state``."""
+
+    async def entity_exists():
+        data = await safe_call_tool(
+            mcp_client, "ha_get_state", {"entity_id": entity_id}
+        )
+        return "data" in data and data["data"] is not None
+
+    return await wait_for_condition(
+        entity_exists, timeout=timeout, condition_name=f"{entity_id} registration"
+    )
+
+
+def _entity_id_from_create(data: dict, helper_type: str) -> str | None:
+    """Extract entity_id from the ``ha_config_set_helper`` create response."""
+    entity_id = data.get("entity_id")
+    if not entity_id:
+        helper_id = data.get("helper_data", {}).get("id")
+        if helper_id:
+            entity_id = f"{helper_type}.{helper_id}"
+    return entity_id
+
+
+async def _get_attributes(mcp_client, entity_id: str) -> dict:
+    """Fetch entity state and return its ``attributes`` dict (or ``{}``)."""
+    state_result = await mcp_client.call_tool(
+        "ha_get_state", {"entity_id": entity_id}
+    )
+    state_data = parse_mcp_result(state_result)
+    return state_data.get("data", {}).get("attributes", {}) or {}
+
+
+async def _get_state_value(mcp_client, entity_id: str):
+    """Fetch entity state and return the top-level ``state`` value."""
+    state_result = await mcp_client.call_tool(
+        "ha_get_state", {"entity_id": entity_id}
+    )
+    state_data = parse_mcp_result(state_result)
+    return state_data.get("data", {}).get("state")
+
+
+def _assert_field(
+    attrs: dict, field: str, expected, *, phase: str, entity_id: str
+) -> None:
+    """Assert ``attrs[field] == expected`` with a clear error message."""
+    actual = attrs.get(field)
+    assert actual == expected, (
+        f"[{phase}] {entity_id} attribute {field!r}: "
+        f"expected {expected!r}, got {actual!r}. Full attrs: {attrs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-type destructive-UPDATE protection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputBooleanFieldPersistence:
+    """input_boolean fields must survive a name-only UPDATE."""
+
+    async def test_input_boolean_icon_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_boolean"
+        original_name = "E2E Persistence Boolean"
+        original_icon = "mdi:toggle-switch"
+
+        # CREATE with full config
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": original_name,
+                "icon": original_icon,
+                "initial": "on",
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_boolean")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        # POST-CREATE: icon attribute must reflect what we set
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        _assert_field(
+            post_create_attrs,
+            "icon",
+            original_icon,
+            phase="post-create",
+            entity_id=entity_id,
+        )
+
+        # UPDATE with ONLY the name changed
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Boolean Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update input_boolean (name only)")
+
+        # POST-UPDATE: icon must still be the originally configured one
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        _assert_field(
+            post_update_attrs,
+            "icon",
+            original_icon,
+            phase="post-update",
+            entity_id=entity_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputSelectFieldPersistence:
+    """input_select options + icon must survive a name-only UPDATE."""
+
+    async def test_input_select_options_persist_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_select"
+        original_options = ["Alpha", "Beta", "Gamma"]
+        original_icon = "mdi:format-list-bulleted"
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Select",
+                "options": original_options,
+                "initial": "Beta",
+                "icon": original_icon,
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_select")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        post_create_options = list(post_create_attrs.get("options", []))
+        for opt in original_options:
+            assert opt in post_create_options, (
+                f"[post-create] option {opt!r} missing from {post_create_options}"
+            )
+        _assert_field(
+            post_create_attrs,
+            "icon",
+            original_icon,
+            phase="post-create",
+            entity_id=entity_id,
+        )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Select Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update input_select (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        post_update_options = list(post_update_attrs.get("options", []))
+        for opt in original_options:
+            assert opt in post_update_options, (
+                f"[post-update] option {opt!r} was wiped from "
+                f"{post_update_options}. Full attrs: {post_update_attrs}"
+            )
+        _assert_field(
+            post_update_attrs,
+            "icon",
+            original_icon,
+            phase="post-update",
+            entity_id=entity_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputNumberFieldPersistence:
+    """input_number numeric/display fields must survive a name-only UPDATE."""
+
+    async def test_input_number_full_config_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_number"
+        original = {
+            "min": 0,
+            "max": 100,
+            "step": 5,
+            "mode": "slider",
+            "unit_of_measurement": "%",
+            "initial": 25,
+            "icon": "mdi:gauge",
+        }
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Number",
+                "min_value": original["min"],
+                "max_value": original["max"],
+                "step": original["step"],
+                "mode": original["mode"],
+                "unit_of_measurement": original["unit_of_measurement"],
+                "initial": original["initial"],
+                "icon": original["icon"],
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_number")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_create_attrs,
+                field,
+                expected,
+                phase="post-create",
+                entity_id=entity_id,
+            )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Number Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update input_number (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_update_attrs,
+                field,
+                expected,
+                phase="post-update",
+                entity_id=entity_id,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputTextFieldPersistence:
+    """input_text length/mode/icon must survive a name-only UPDATE."""
+
+    async def test_input_text_full_config_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_text"
+        # input_text exposes min/max (length) and mode in attributes.
+        original = {
+            "min": 3,
+            "max": 50,
+            "mode": "password",
+            "icon": "mdi:form-textbox-password",
+        }
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Text",
+                "min_value": original["min"],
+                "max_value": original["max"],
+                "mode": original["mode"],
+                "icon": original["icon"],
+                "initial": "secret",
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_text")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_create_attrs,
+                field,
+                expected,
+                phase="post-create",
+                entity_id=entity_id,
+            )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Text Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update input_text (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_update_attrs,
+                field,
+                expected,
+                phase="post-update",
+                entity_id=entity_id,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputDatetimeFieldPersistence:
+    """input_datetime has_date/has_time/icon must survive a name-only UPDATE."""
+
+    async def test_input_datetime_full_config_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_datetime"
+        # Use date-only (non-default would be has_date=False/has_time=True;
+        # we choose date-only so destructive-default behavior — silently
+        # re-enabling has_time — would be detected).
+        original = {
+            "has_date": True,
+            "has_time": False,
+            "icon": "mdi:calendar",
+        }
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Datetime",
+                "has_date": original["has_date"],
+                "has_time": original["has_time"],
+                "icon": original["icon"],
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_datetime")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_create_attrs,
+                field,
+                expected,
+                phase="post-create",
+                entity_id=entity_id,
+            )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Datetime Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update input_datetime (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_update_attrs,
+                field,
+                expected,
+                phase="post-update",
+                entity_id=entity_id,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestCounterFieldPersistence:
+    """counter min/max/step/initial/icon must survive a name-only UPDATE.
+
+    Note: counter exposes ``minimum`` and ``maximum`` as attribute names
+    (not ``min``/``max`` like input_number). The tool maps ``min_value``
+    -> ``minimum`` and ``max_value`` -> ``maximum`` per HA's counter API.
+    """
+
+    async def test_counter_full_config_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "counter"
+        original = {
+            "minimum": 0,
+            "maximum": 50,
+            "step": 2,
+            "initial": 10,
+            "icon": "mdi:counter",
+        }
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Counter",
+                "min_value": original["minimum"],
+                "max_value": original["maximum"],
+                "step": original["step"],
+                "initial": original["initial"],
+                "icon": original["icon"],
+                "restore": True,
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create counter")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_create_attrs,
+                field,
+                expected,
+                phase="post-create",
+                entity_id=entity_id,
+            )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Counter Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update counter (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in original.items():
+            _assert_field(
+                post_update_attrs,
+                field,
+                expected,
+                phase="post-update",
+                entity_id=entity_id,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestTimerFieldPersistence:
+    """timer duration + icon must survive a name-only UPDATE."""
+
+    async def test_timer_duration_persists_after_name_only_update(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "timer"
+        original_duration = "0:05:00"
+        original_icon = "mdi:timer"
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Persistence Timer",
+                "duration": original_duration,
+                "icon": original_icon,
+                "restore": True,
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create timer")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        # Timer exposes ``duration`` as an attribute (HH:MM:SS string).
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        _assert_field(
+            post_create_attrs,
+            "duration",
+            original_duration,
+            phase="post-create",
+            entity_id=entity_id,
+        )
+        _assert_field(
+            post_create_attrs,
+            "icon",
+            original_icon,
+            phase="post-create",
+            entity_id=entity_id,
+        )
+
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "name": "E2E Persistence Timer Renamed",
+            },
+        )
+        assert_mcp_success(update_result, "Update timer (name only)")
+
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        _assert_field(
+            post_update_attrs,
+            "duration",
+            original_duration,
+            phase="post-update",
+            entity_id=entity_id,
+        )
+        _assert_field(
+            post_update_attrs,
+            "icon",
+            original_icon,
+            phase="post-update",
+            entity_id=entity_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: partial UPDATE that touches one field must preserve the
+# other type-specific fields. This generalises the per-type tests above to
+# the case where the UPDATE *does* mutate a real attribute, not just the
+# name — which is the most common destructive-merge bug class.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.config
+class TestInputNumberPartialUpdatePreservesFields:
+    """A partial UPDATE that changes only ``min_value`` must preserve the
+    other type-specific fields (initial, mode, unit_of_measurement, step,
+    icon)."""
+
+    async def test_partial_min_value_update_preserves_other_fields(
+        self, mcp_client, cleanup_tracker
+    ):
+        helper_type = "input_number"
+        # Full original config
+        preserved = {
+            "max": 100,
+            "step": 5,
+            "mode": "slider",
+            "unit_of_measurement": "%",
+            "initial": 25,
+            "icon": "mdi:gauge",
+        }
+        new_min = 70  # update touches only this field
+
+        create_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": "E2E Partial Update Number",
+                "min_value": 0,
+                "max_value": preserved["max"],
+                "step": preserved["step"],
+                "mode": preserved["mode"],
+                "unit_of_measurement": preserved["unit_of_measurement"],
+                "initial": preserved["initial"],
+                "icon": preserved["icon"],
+            },
+        )
+        create_data = assert_mcp_success(create_result, "Create input_number")
+        entity_id = _entity_id_from_create(create_data, helper_type)
+        assert entity_id, f"Missing entity_id: {create_data}"
+        cleanup_tracker.track(helper_type, entity_id)
+
+        ready = await _wait_for_entity_registration(mcp_client, entity_id)
+        assert ready, f"{entity_id} not registered within timeout"
+
+        # Sanity check post-create
+        post_create_attrs = await _get_attributes(mcp_client, entity_id)
+        for field, expected in preserved.items():
+            _assert_field(
+                post_create_attrs,
+                field,
+                expected,
+                phase="post-create",
+                entity_id=entity_id,
+            )
+        _assert_field(
+            post_create_attrs, "min", 0, phase="post-create", entity_id=entity_id
+        )
+
+        # PARTIAL UPDATE: only min_value changes (and helper_id is required)
+        update_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "helper_id": entity_id,
+                "min_value": new_min,
+            },
+        )
+        assert_mcp_success(update_result, "Partial update (min_value only)")
+
+        # New min must apply, all other fields must be preserved
+        post_update_attrs = await _get_attributes(mcp_client, entity_id)
+        _assert_field(
+            post_update_attrs,
+            "min",
+            new_min,
+            phase="post-update",
+            entity_id=entity_id,
+        )
+        for field, expected in preserved.items():
+            _assert_field(
+                post_update_attrs,
+                field,
+                expected,
+                phase="post-update",
+                entity_id=entity_id,
+            )

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for multi-step config flow handling (Bug #18 / issue #1150).
+
+Verifies that ``_handle_flow_steps`` correctly walks a multi-step HA config
+flow, submitting only the keys declared in each step's ``data_schema`` and
+preserving the remaining keys for subsequent steps.
+
+Regression guard: prior code wiped ``remaining_config`` after the first form
+step, which made step 2+ submit ``{}`` and HA respond with HTTP 400. This
+broke ``statistics`` (multi-step user → pick-characteristic) and
+``utility_meter`` UPDATE.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from ha_mcp.tools.tools_config_entry_flow import (
+    _extract_schema_field_names,
+    _handle_flow_steps,
+    _handle_form_step,
+)
+
+
+class TestExtractSchemaFieldNames:
+    """Sanity-check the schema parser used to drive per-step key filtering."""
+
+    def test_extracts_names_from_dict_list(self) -> None:
+        schema = [
+            {"name": "name", "required": True, "selector": {"text": {}}},
+            {"name": "entity_id", "selector": {"entity": {}}},
+        ]
+        assert _extract_schema_field_names(schema) == {"name", "entity_id"}
+
+    def test_handles_missing_or_malformed_schema(self) -> None:
+        # Non-list inputs signal "schema not available" → None (legacy fallback).
+        assert _extract_schema_field_names(None) is None
+        assert _extract_schema_field_names({}) is None
+        # A list with no parseable name fields is still a valid (empty) schema.
+        assert _extract_schema_field_names([{"no_name_key": "x"}]) == set()
+        assert _extract_schema_field_names([{"name": 123}]) == set()
+
+
+class TestHandleFormStepFiltering:
+    """Direct test of the per-step filter that splits config across steps."""
+
+    def test_pops_only_schema_fields_leaves_rest(self) -> None:
+        remaining = {
+            "name": "Avg Temp",
+            "entity_id": "sensor.foo",
+            "state_characteristic": "mean",  # belongs to step 2
+            "extra_key": "should_remain",
+        }
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "name", "required": True},
+                {"name": "entity_id", "required": True},
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {"name": "Avg Temp", "entity_id": "sensor.foo"}
+        # Keys not in this step's schema must stay for later steps.
+        assert remaining == {
+            "state_characteristic": "mean",
+            "extra_key": "should_remain",
+        }
+
+    def test_strips_menu_selection_keys(self) -> None:
+        remaining = {"group_type": "light", "name": "x"}
+        step = {
+            "type": "form",
+            "step_id": "init",
+            "data_schema": [
+                {"name": "name"},
+                # Even if HA includes a key matching a menu selection name,
+                # _MENU_SELECTION_KEYS takes precedence as a safety check.
+                {"name": "group_type"},
+            ],
+        }
+        form_data = _handle_form_step("flow-1", step, remaining)
+        assert form_data == {"name": "x"}
+        # group_type was popped from remaining only via the menu-key skip
+        # branch — it stays put because the schema-field branch is not reached.
+        assert remaining == {"group_type": "light"}
+
+
+class TestMultiStepFlow:
+    """End-to-end walk of a fake 2-step flow via _handle_flow_steps."""
+
+    async def test_two_form_steps_each_get_correct_keys(self) -> None:
+        """Step 1 expects {name, entity_id}; step 2 expects {state_characteristic}.
+
+        Both steps must receive ONLY the keys that match their schemas, and
+        step 2 must NOT receive an empty dict (the original bug).
+        """
+        # Step 2 form, returned after step 1 is submitted.
+        step2_form: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-1",
+            "step_id": "state_characteristic",
+            "data_schema": [
+                {"name": "state_characteristic", "required": True},
+            ],
+        }
+        # Final create_entry, returned after step 2 is submitted.
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "flow_id": "flow-1",
+            "result": {
+                "entry_id": "entry-stat-1",
+                "title": "Avg Temp",
+                "domain": "statistics",
+            },
+        }
+
+        submit_fn = AsyncMock(side_effect=[step2_form, final_entry])
+
+        initial_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-1",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "name", "required": True},
+                {"name": "entity_id", "required": True},
+            ],
+        }
+
+        config = {
+            "name": "Avg Temp",
+            "entity_id": "sensor.foo",
+            "state_characteristic": "mean",
+        }
+
+        result = await _handle_flow_steps(
+            client=None,  # unused because submit_fn is provided
+            flow_id="flow-1",
+            initial_step=initial_step,
+            config=config,
+            submit_fn=submit_fn,
+        )
+
+        assert result == {"success": True, "entry": final_entry}
+        assert submit_fn.await_count == 2
+
+        # Step 1: the user step
+        first_call_args = submit_fn.await_args_list[0].args
+        assert first_call_args[0] == "flow-1"
+        assert first_call_args[1] == {
+            "name": "Avg Temp",
+            "entity_id": "sensor.foo",
+        }
+
+        # Step 2: the state_characteristic step — MUST receive its key,
+        # not {} (the bug). Must NOT receive step-1 keys.
+        second_call_args = submit_fn.await_args_list[1].args
+        assert second_call_args[0] == "flow-1"
+        assert second_call_args[1] == {"state_characteristic": "mean"}
+
+    async def test_extra_unknown_keys_are_dropped(self) -> None:
+        """Keys never declared by any step are silently dropped (HA will ignore)."""
+        final_entry = {
+            "type": "create_entry",
+            "result": {"entry_id": "e1", "title": "t", "domain": "min_max"},
+        }
+        submit_fn = AsyncMock(side_effect=[final_entry])
+
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-2",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "name"},
+                {"name": "entity_ids"},
+                {"name": "type"},
+            ],
+        }
+        config = {
+            "name": "x",
+            "entity_ids": ["sensor.a"],
+            "type": "mean",
+            "junk": "ignored",
+        }
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2",
+            initial_step=initial_step,
+            config=config,
+            submit_fn=submit_fn,
+        )
+
+        submitted = submit_fn.await_args_list[0].args[1]
+        assert "junk" not in submitted
+        assert submitted == {
+            "name": "x",
+            "entity_ids": ["sensor.a"],
+            "type": "mean",
+        }
+
+

--- a/tests/src/unit/test_flow_name_injection.py
+++ b/tests/src/unit/test_flow_name_injection.py
@@ -1,0 +1,370 @@
+"""
+Unit tests for flow-helper `name` injection logic (issue #1150, Bug 19).
+
+The tool injects the top-level ``name`` parameter into the flow form
+payload for create actions, but only when the helper's user-step schema
+actually accepts a ``name`` field. ``switch_as_x`` is the canonical
+counter-example: its user step takes only ``entity_id`` and ``target_domain``;
+HA rejects an extra ``name`` key with ``"extra keys not allowed @ data['name']"``.
+
+For update actions, options flows never accept ``name`` (you cannot rename
+a flow helper through its options flow). Any caller-supplied ``name``
+inside ``config`` must be stripped, and the response must surface a
+warning so the caller learns the rename attempt was a no-op.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def register_tools(mock_client):
+    """Register helper config tools and return the captured tool functions."""
+    from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+    registered_tools: dict[str, Any] = {}
+
+    def capture_tool(**kwargs):
+        def decorator(fn):
+            registered_tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = capture_tool
+    register_config_helper_tools(mock_mcp, mock_client)
+    return registered_tools
+
+
+def _make_start_config_flow(
+    schema_fields: list[str] | None,
+    *,
+    flow_id: str = "introspect-flow",
+    entry_id: str = "entry-1",
+    title: str = "probe",
+    domain: str = "min_max",
+    intro_calls: list[str] | None = None,
+    submit_capture: list[dict] | None = None,
+):
+    """Build a stateful start_config_flow side-effect that handles two phases:
+
+    1. Schema introspection call (returns a form with the given schema_fields,
+       or ``type=menu`` when schema_fields is None to simulate a menu helper).
+    2. Real create call — returns a form whose submission yields create_entry.
+
+    ``intro_calls`` is appended to with the helper_type each time
+    start_config_flow is invoked, so tests can verify the introspection
+    happened. ``submit_capture`` collects the final submitted form data.
+    """
+    state = {"calls": 0}
+
+    async def start_flow(helper_type: str) -> dict[str, Any]:
+        state["calls"] += 1
+        if intro_calls is not None:
+            intro_calls.append(helper_type)
+        if state["calls"] == 1:
+            # Introspection phase
+            if schema_fields is None:
+                return {
+                    "type": "menu",
+                    "flow_id": flow_id + "-intro",
+                    "menu_options": ["sensor", "binary_sensor"],
+                }
+            return {
+                "type": "form",
+                "flow_id": flow_id + "-intro",
+                "step_id": "user",
+                "data_schema": [
+                    {"name": fname} for fname in schema_fields
+                ],
+            }
+        # Real flow phase
+        return {
+            "type": "form",
+            "flow_id": flow_id,
+            "step_id": "user",
+            "data_schema": [
+                {"name": fname} for fname in (schema_fields or ["name"])
+            ],
+        }
+
+    async def submit(_flow_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        if submit_capture is not None:
+            submit_capture.append(dict(data))
+        return {
+            "type": "create_entry",
+            "result": {
+                "entry_id": entry_id,
+                "title": title,
+                "domain": domain,
+            },
+        }
+
+    return start_flow, submit
+
+
+class TestSwitchAsXNameNotInjected:
+    """switch_as_x's user-step schema has no `name` field — name must NOT be
+    folded into config. Otherwise HA replies 400 'extra keys not allowed'."""
+
+    async def test_switch_as_x_create_omits_name_from_submitted_config(
+        self, register_tools, mock_client
+    ):
+        intro_calls: list[str] = []
+        submit_capture: list[dict] = []
+        start_flow, submit = _make_start_config_flow(
+            schema_fields=["entity_id", "target_domain"],
+            entry_id="entry-sax",
+            domain="switch_as_x",
+            intro_calls=intro_calls,
+            submit_capture=submit_capture,
+        )
+
+        mock_client.start_config_flow = AsyncMock(side_effect=start_flow)
+        mock_client.submit_config_flow_step = AsyncMock(side_effect=submit)
+        mock_client.abort_config_flow = AsyncMock(return_value={})
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="switch_as_x",
+            name="My Light From Switch",
+            config={
+                "entity_id": "switch.basement",
+                "target_domain": "light",
+            },
+            wait=False,
+        )
+
+        assert result["success"] is True, result
+        # The actual create flow start happens after the introspection start;
+        # both call start_config_flow with helper_type="switch_as_x".
+        assert intro_calls.count("switch_as_x") >= 1
+        # No submitted payload should contain the 'name' key.
+        assert submit_capture, "expected at least one form submission"
+        for payload in submit_capture:
+            assert "name" not in payload, (
+                f"switch_as_x submission must not include 'name', got: {payload}"
+            )
+
+
+class TestTemplateAndFormHelperNameInjected:
+    """Helpers whose user step accepts `name` (template, min_max, etc.)
+    must still receive the top-level `name` in their submitted config."""
+
+    async def test_min_max_create_includes_name(
+        self, register_tools, mock_client
+    ):
+        submit_capture: list[dict] = []
+        start_flow, submit = _make_start_config_flow(
+            schema_fields=["name", "entity_ids", "type"],
+            entry_id="entry-mm",
+            domain="min_max",
+            submit_capture=submit_capture,
+        )
+
+        mock_client.start_config_flow = AsyncMock(side_effect=start_flow)
+        mock_client.submit_config_flow_step = AsyncMock(side_effect=submit)
+        mock_client.abort_config_flow = AsyncMock(return_value={})
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="min_max",
+            name="avg_temp",
+            config={"entity_ids": ["sensor.a", "sensor.b"], "type": "mean"},
+            wait=False,
+        )
+
+        assert result["success"] is True, result
+        assert submit_capture, "expected at least one form submission"
+        # The form-step submission for min_max should carry name.
+        names_seen = [p.get("name") for p in submit_capture if "name" in p]
+        assert "avg_temp" in names_seen, (
+            f"expected 'avg_temp' in submitted name fields, got: {submit_capture}"
+        )
+
+    async def test_template_menu_helper_still_injects_name(
+        self, register_tools, mock_client
+    ):
+        """Template's top step is a menu — introspection returns type=menu
+        and we have no field-list to check. The legacy fallback (inject
+        anyway) keeps template/group working unchanged."""
+        submit_capture: list[dict] = []
+        # schema_fields=None signals "introspection sees a menu, not a form"
+        start_flow, submit = _make_start_config_flow(
+            schema_fields=None,
+            entry_id="entry-tpl",
+            domain="template",
+            submit_capture=submit_capture,
+        )
+
+        # Real flow: menu -> sensor sub-form -> create_entry
+        submit_responses = [
+            # First submit: menu choice -> form with `name`
+            {
+                "type": "form",
+                "flow_id": "real-flow",
+                "step_id": "sensor",
+                "data_schema": [{"name": "name"}, {"name": "state"}],
+            },
+            # Second submit: form values -> create_entry
+            {
+                "type": "create_entry",
+                "result": {
+                    "entry_id": "entry-tpl",
+                    "title": "tpl",
+                    "domain": "template",
+                },
+            },
+        ]
+
+        async def real_submit(_flow_id: str, data: dict[str, Any]) -> dict:
+            submit_capture.append(dict(data))
+            return submit_responses.pop(0)
+
+        mock_client.start_config_flow = AsyncMock(
+            side_effect=[
+                # Call #1 (intro): menu — returns None from get_user_step_field_names
+                {
+                    "type": "menu",
+                    "flow_id": "intro",
+                    "menu_options": ["sensor", "binary_sensor"],
+                },
+                # Call #2 (real create): also a menu, walked by _handle_flow_steps
+                {
+                    "type": "menu",
+                    "flow_id": "real",
+                    "menu_options": ["sensor", "binary_sensor"],
+                },
+            ]
+        )
+        mock_client.submit_config_flow_step = AsyncMock(side_effect=real_submit)
+        mock_client.abort_config_flow = AsyncMock(return_value={})
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="template",
+            name="my_template",
+            config={
+                "menu_option": "sensor",
+                "state": "{{ states('sensor.x') }}",
+            },
+            wait=False,
+        )
+
+        assert result["success"] is True, result
+        # The form-step submission must carry name (menu fallback injects it).
+        names_seen = [p.get("name") for p in submit_capture if "name" in p]
+        assert "my_template" in names_seen, (
+            f"expected name to be injected for template (menu fallback), "
+            f"got: {submit_capture}"
+        )
+
+
+class TestUpdateStripsName:
+    """Options flows reject `name` as an extra key. The tool must strip it
+    from caller-supplied config and surface a warning."""
+
+    async def test_update_strips_name_and_warns(
+        self, register_tools, mock_client
+    ):
+        submit_capture: list[dict] = []
+
+        mock_client.get_config_entry = AsyncMock(
+            return_value={"domain": "min_max", "entry_id": "entry-1"}
+        )
+        mock_client.start_options_flow = AsyncMock(
+            return_value={
+                "type": "form",
+                "flow_id": "options-flow",
+                "step_id": "init",
+                "data_schema": [{"name": "type"}, {"name": "entity_ids"}],
+            }
+        )
+
+        async def submit(_flow_id: str, data: dict[str, Any]) -> dict[str, Any]:
+            submit_capture.append(dict(data))
+            return {
+                "type": "create_entry",
+                "result": {"entry_id": "entry-1", "title": "avg"},
+            }
+
+        mock_client.submit_options_flow_step = AsyncMock(side_effect=submit)
+        mock_client.abort_options_flow = AsyncMock(return_value={})
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="min_max",
+            helper_id="entry-1",
+            config={
+                # Caller mistakenly tries to rename the helper here.
+                "name": "renamed_helper",
+                "entity_ids": ["sensor.x", "sensor.y"],
+                "type": "max",
+            },
+            wait=False,
+        )
+
+        assert result["success"] is True, result
+        assert result["action"] == "update"
+
+        # No submission should have carried `name` to the options flow.
+        for payload in submit_capture:
+            assert "name" not in payload, (
+                f"options flow submission must not include 'name', "
+                f"got: {payload}"
+            )
+
+        # The result must surface a warning explaining the strip.
+        assert "warnings" in result, result
+        assert any(
+            "name" in w.lower() and "rename" in w.lower()
+            for w in result["warnings"]
+        ), f"expected rename warning, got: {result['warnings']}"
+
+    async def test_update_without_name_in_config_no_warning(
+        self, register_tools, mock_client
+    ):
+        """Updates that don't include `name` should NOT emit a rename warning."""
+        mock_client.get_config_entry = AsyncMock(
+            return_value={"domain": "min_max", "entry_id": "entry-2"}
+        )
+        mock_client.start_options_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "options-flow",
+                "result": {"entry_id": "entry-2", "title": "avg"},
+            }
+        )
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="min_max",
+            helper_id="entry-2",
+            config={"entity_ids": ["sensor.x"], "type": "max"},
+            wait=False,
+        )
+
+        assert result["success"] is True
+        # If warnings exist they must not be the rename warning.
+        for w in result.get("warnings", []):
+            assert "rename" not in w.lower(), (
+                f"unexpected rename warning when name was not in config: {w}"
+            )

--- a/tests/src/unit/test_helper_field_persistence.py
+++ b/tests/src/unit/test_helper_field_persistence.py
@@ -1,0 +1,409 @@
+"""Unit tests for helper field persistence — tracking issue #1150.
+
+Closes the test gap identified in TEST_GAP_ANALYSIS: existing tests assert that
+the right *message type* is sent (`input_number/update`), but echo-reflect the
+payload back as the result, so a bug that silently drops fields from the
+payload still produces ``success: True`` and passes.
+
+These tests instead assert the **contents** of the outgoing WebSocket payload.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_client():
+    """Mock client that records every WS message sent."""
+    client = MagicMock()
+
+    def make_ws_responses(helper_type: str, unique_id: str = "abc123",
+                         existing_config: dict[str, Any] | None = None):
+        """Build a ws_handler. ``existing_config`` is what {type}/list returns."""
+        existing = existing_config or {
+            "id": unique_id,
+            "name": "Existing Helper",
+        }
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+
+            if msg_type == "config/entity_registry/get":
+                return {
+                    "success": True,
+                    "result": {
+                        "entity_id": msg["entity_id"],
+                        "unique_id": unique_id,
+                        "platform": helper_type,
+                    },
+                }
+
+            if msg_type.endswith("/list"):
+                return {"success": True, "result": [existing]}
+
+            if msg_type.endswith("/update") or msg_type.endswith("/create"):
+                # Echo back so the tool's success path runs to completion.
+                return {
+                    "success": True,
+                    "result": {
+                        "id": unique_id,
+                        **{k: v for k, v in msg.items() if k != "type"},
+                    },
+                }
+
+            if msg_type == "config/entity_registry/update":
+                return {
+                    "success": True,
+                    "result": {"entity_entry": {"entity_id": msg["entity_id"]}},
+                }
+
+            return {"success": True, "result": {}}
+
+        return ws_handler
+
+    client._make_ws_responses = make_ws_responses
+    return client
+
+
+@pytest.fixture
+def register_tools(mock_client):
+    """Register helper config tools and return the captured tool functions."""
+    from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+    registered: dict[str, Any] = {}
+
+    def capture_tool(**kwargs):
+        def decorator(fn):
+            registered[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = capture_tool
+    register_config_helper_tools(mock_mcp, mock_client)
+    return registered
+
+
+def _find_msg(client: Any, msg_type: str) -> dict | None:
+    """Find the first WS message of ``msg_type`` from the recorded calls."""
+    for call in client.send_websocket_message.call_args_list:
+        msg = call[0][0]
+        if msg.get("type") == msg_type:
+            return msg
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: input_number CREATE silently drops `initial`
+# ---------------------------------------------------------------------------
+
+
+class TestInputNumberInitialPersistence:
+    """input_number create+update must include `initial` in the WS payload (Bug 1, 1b)."""
+
+    async def test_create_includes_initial_in_payload(self, register_tools, mock_client):
+        """Bug 1: input_number CREATE message must contain `initial` if caller passed it."""
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_number")
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_number",
+                name="Thermostat",
+                min_value=60,
+                max_value=85,
+                initial=72,
+            )
+
+        create_msg = _find_msg(mock_client, "input_number/create")
+        assert create_msg is not None, "input_number/create message not sent"
+        assert create_msg.get("initial") == 72, (
+            f"Bug 1: `initial` was not in the create message payload. "
+            f"Sent: {create_msg!r}"
+        )
+
+    async def test_update_includes_initial_in_payload(self, register_tools, mock_client):
+        """Bug 1b: input_number UPDATE message must contain `initial` if caller passed it."""
+        existing = {
+            "id": "abc123",
+            "name": "Thermostat",
+            "min": 60,
+            "max": 85,
+            "step": 1,
+            "mode": "slider",
+            "initial": 72,
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_number", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_number",
+                helper_id="abc123",
+                initial=80,
+            )
+
+        update_msg = _find_msg(mock_client, "input_number/update")
+        assert update_msg is not None, "input_number/update message not sent"
+        assert update_msg.get("initial") == 80, (
+            f"Bug 1b: `initial` was not in the update message payload. "
+            f"Sent: {update_msg!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 8: destructive UPDATE — fields not re-passed must be merged from existing
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMergePreservesExistingFields:
+    """UPDATE must preserve fields the caller didn't re-pass (Bug 8)."""
+
+    async def test_input_number_update_name_only_preserves_initial_unit_step(
+        self, register_tools, mock_client
+    ):
+        """Renaming an input_number must not wipe initial/unit_of_measurement/step/mode."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "min": 60,
+            "max": 85,
+            "step": 0.5,
+            "mode": "box",
+            "initial": 72,
+            "unit_of_measurement": "°F",
+            "icon": "mdi:thermometer",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_number", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_number",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "input_number/update")
+        assert msg is not None
+        # Every type-specific field must be present in the outgoing update message
+        # (HA's input_number/update is full-replace, so missing = wiped).
+        assert msg.get("name") == "NewName"
+        assert msg.get("min") == 60, f"Bug 8: min wiped on rename. msg={msg!r}"
+        assert msg.get("max") == 85, f"Bug 8: max wiped on rename. msg={msg!r}"
+        assert msg.get("step") == 0.5, f"Bug 8: step wiped on rename. msg={msg!r}"
+        assert msg.get("mode") == "box", f"Bug 8: mode wiped on rename. msg={msg!r}"
+        assert msg.get("initial") == 72, f"Bug 8: initial wiped on rename. msg={msg!r}"
+        assert msg.get("unit_of_measurement") == "°F", f"Bug 8: unit wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:thermometer", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_input_text_update_name_only_preserves_min_max_mode_initial(
+        self, register_tools, mock_client
+    ):
+        """Renaming an input_text must not wipe min/max/mode/initial/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "min": 5,
+            "max": 50,
+            "mode": "password",
+            "initial": "starter",
+            "icon": "mdi:note-text",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_text", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_text",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "input_text/update")
+        assert msg is not None
+        assert msg.get("min") == 5, f"Bug 8: min wiped. msg={msg!r}"
+        assert msg.get("max") == 50, f"Bug 8: max wiped. msg={msg!r}"
+        assert msg.get("mode") == "password", f"Bug 8: mode wiped. msg={msg!r}"
+        assert msg.get("initial") == "starter", f"Bug 8: initial wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:note-text", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_counter_update_name_only_preserves_all_fields(
+        self, register_tools, mock_client
+    ):
+        """Renaming a counter must not wipe initial/min/max/step/restore/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "initial": 5,
+            "minimum": 0,
+            "maximum": 100,
+            "step": 2,
+            "restore": True,
+            "icon": "mdi:counter",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("counter", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="counter",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "counter/update")
+        assert msg is not None
+        assert msg.get("initial") == 5, f"Bug 8: initial wiped. msg={msg!r}"
+        assert msg.get("minimum") == 0, f"Bug 8: minimum wiped. msg={msg!r}"
+        assert msg.get("maximum") == 100, f"Bug 8: maximum wiped. msg={msg!r}"
+        assert msg.get("step") == 2, f"Bug 8: step wiped. msg={msg!r}"
+        assert msg.get("restore") is True, f"Bug 8: restore wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:counter", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_timer_update_name_only_preserves_duration_restore_icon(
+        self, register_tools, mock_client
+    ):
+        """Renaming a timer must not wipe duration/restore/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "duration": "0:30:00",
+            "restore": True,
+            "icon": "mdi:timer",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("timer", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="timer",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "timer/update")
+        assert msg is not None
+        assert msg.get("duration") == "0:30:00", f"Bug 8: duration wiped. msg={msg!r}"
+        assert msg.get("restore") is True, f"Bug 8: restore wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:timer", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_input_boolean_update_name_only_preserves_initial_icon(
+        self, register_tools, mock_client
+    ):
+        """Renaming an input_boolean must not wipe initial/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "initial": True,
+            "icon": "mdi:toggle-switch-on",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_boolean", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "input_boolean/update")
+        assert msg is not None
+        assert msg.get("initial") is True, f"Bug 8: initial wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:toggle-switch-on", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_input_datetime_update_name_only_preserves_has_date_has_time_initial(
+        self, register_tools, mock_client
+    ):
+        """Renaming an input_datetime must not wipe has_date/has_time/initial/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "has_date": True,
+            "has_time": True,
+            "initial": "2026-12-31 23:59:59",
+            "icon": "mdi:calendar",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_datetime", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "input_datetime/update")
+        assert msg is not None
+        assert msg.get("has_date") is True, f"Bug 8: has_date wiped. msg={msg!r}"
+        assert msg.get("has_time") is True, f"Bug 8: has_time wiped. msg={msg!r}"
+        assert msg.get("initial") == "2026-12-31 23:59:59", f"Bug 8: initial wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:calendar", f"Bug 8: icon wiped. msg={msg!r}"
+
+    async def test_input_select_update_name_only_preserves_options_initial_icon(
+        self, register_tools, mock_client
+    ):
+        """Renaming an input_select must not wipe options/initial/icon."""
+        existing = {
+            "id": "abc123",
+            "name": "OldName",
+            "options": ["Alpha", "Beta", "Gamma"],
+            "initial": "Beta",
+            "icon": "mdi:menu",
+        }
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=mock_client._make_ws_responses("input_select", existing_config=existing)
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="abc123",
+                name="NewName",
+            )
+
+        msg = _find_msg(mock_client, "input_select/update")
+        assert msg is not None
+        assert msg.get("options") == ["Alpha", "Beta", "Gamma"], f"Bug 8: options wiped. msg={msg!r}"
+        assert msg.get("initial") == "Beta", f"Bug 8: initial wiped. msg={msg!r}"
+        assert msg.get("icon") == "mdi:menu", f"Bug 8: icon wiped. msg={msg!r}"

--- a/tests/src/unit/test_helper_field_persistence.py
+++ b/tests/src/unit/test_helper_field_persistence.py
@@ -5,7 +5,8 @@ the right *message type* is sent (`input_number/update`), but echo-reflect the
 payload back as the result, so a bug that silently drops fields from the
 payload still produces ``success: True`` and passes.
 
-These tests instead assert the **contents** of the outgoing WebSocket payload.
+These tests instead assert the **contents** of the outgoing WebSocket payload,
+and that inapplicable typed params are rejected rather than silently dropped.
 """
 
 from typing import Any

--- a/tests/src/unit/test_helper_update_persistence.py
+++ b/tests/src/unit/test_helper_update_persistence.py
@@ -484,7 +484,11 @@ class TestFlowHelperRouting:
         assert result["method"] == "config_flow"
         assert result["entry_id"] == "entry-1"
         assert result["entity_ids"] == ["sensor.avg_temp"]
-        mock_client.start_config_flow.assert_awaited_once_with("min_max")
+        # start_config_flow is awaited twice for create: once for schema
+        # introspection (to decide whether to inject `name`), once for the
+        # real flow. Both calls pass the same helper_type.
+        for call in mock_client.start_config_flow.await_args_list:
+            assert call.args == ("min_max",)
 
     async def test_flow_helper_update_routes_via_options_flow(
         self, register_tools, mock_client
@@ -847,7 +851,10 @@ class TestFlowHelperRouting:
         assert result["action"] == "create"
         assert result["method"] == "config_flow"
         assert result["entry_id"] == "entry-empty"
-        mock_client.start_config_flow.assert_awaited_once_with("min_max")
+        # start_config_flow is awaited twice for create: introspection + real
+        # flow. Both calls use the same helper_type.
+        for call in mock_client.start_config_flow.await_args_list:
+            assert call.args == ("min_max",)
 
     async def test_flow_helper_clears_area_on_empty_string(
         self, register_tools, mock_client


### PR DESCRIPTION
## What does this PR do?

The first of three stacked PRs closing the audit findings in #1150. This one fixes the **most pressing regressions** — bugs that destroy data, prevent helper creation, or fail silently with `success: true` and a wiped/missing helper.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only (8 e2e + 20 unit added)
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent (haiku, sonnet, opus — full no-context runs against real HA via a Python dev harness)
- [x] All automated tests pass (`uv run pytest`) — 45 helper-related unit tests + 8 e2e tests, 0 regressions
- [x] Code follows style guidelines (`uv run ruff check src/ tests/` clean, `uv run mypy src/` clean)

## Bugs fixed in this PR (6 of 19 from #1150)

| # | Bug | Mechanism |
|---|---|---|
| 1 | `input_number.initial` silently dropped on CREATE | `initial` was accepted in the function signature but never written to the `input_number/create` message |
| 1b | `input_number.initial` silently dropped on UPDATE | UPDATE message never included `initial`, so HA's full-replace API wiped it on every update |
| **8** | **UPDATE silently destroys non-passed type-specific fields** | HA's `{type}/update` is full-replace, not partial-patch. The tool's UPDATE branches only included fields the caller explicitly re-passed, so renaming a helper wiped its `initial`/`icon`/`unit_of_measurement`/etc. Applied across `input_select`, `input_number`, `input_text`, `input_boolean`, `input_datetime`, `counter`, `timer` |
| 9 | `tag` create silently fails when `tag_id` omitted | The docstring promised auto-generation but the tool didn't actually generate; HA rejected with cryptic "Unknown error". Now auto-generates `uuid.uuid4().hex` |
| **18** | **Multi-step Config Entry flows submit empty payloads on step 2+** | `_handle_form_step` was clearing `remaining_config` after the first form submit. Step 2+ then submitted empty data and HA returned 400. Affects `statistics`, `utility_meter` UPDATE |
| **19** | **`name` force-injected into flow create config** | Top-level `name` was unconditionally added to `config_dict`. For helpers like `switch_as_x` where the user-step schema doesn't include `name`, HA rejected with "extra keys not allowed". Made `switch_as_x` uncreatable through this tool |

## Out of scope (deferred to stacked PRs)

This PR is the first in a 3-PR stack:
- **PR 2** (next): the validation framework. Bugs 4a, 4b, 7c, 10, 13, 14, 16, 17 (per-helper-type allowlist, range/options/schedule pre-validation, registry-ID validation).
- **PR 3** (final): control-flow + polish. Bugs 2, 3, 5, 6, 7a, 7b, 11, 12, 15 (kwarg aliases, action discriminator, name-collision detection, mode/truthy/preflight, flow 400 parsing) plus perf parallelization and dedup. **PR 3 closes #1150.**

This PR also defers:
- Issue #1149 (schema-awareness consolidation) — separate feature work
- Issue #1152 (replace polling with WS event subscriptions) — separate refactor

## Future improvements

Documented in the audit issue + the follow-up issues; nothing to do inline here.

## Checklist
- [x] I have updated documentation if needed (docstrings reflect the new behavior; no doc files needed updating)

## Why didn't existing tests catch this?

Existing unit tests use mock clients whose `ws_handler` echo-reflects the payload, so a bug that drops a field still produces `success: True` and passes. Existing e2e tests verified HA state after CREATE but never after UPDATE, missing the destructive UPDATE entirely. This PR adds:
- `test_helper_field_persistence.py` (unit, 9 tests) — assert outgoing WS payload contents, not just message type
- `test_helper_field_persistence.py` (e2e, 8 tests) — assert HA state matches request after both CREATE and UPDATE
- `test_flow_multistep.py` (unit, 6 tests) — per-step config filtering
- `test_flow_name_injection.py` (unit, 5 tests) — schema-aware name handling

## Test plan for live HA validation

The `PRTEST_` prefix scenarios from #1150's master test plan that exercise this PR's bugs:

- **Bug 1**: `ha_config_set_helper(helper_type="input_number", name="PRTEST_thermostat", min_value=60, max_value=85, initial=72)` → `ha_get_state` should show `attributes.initial == 72`.
- **Bug 1b**: same helper, then `ha_config_set_helper(helper_type="input_number", helper_id="prtest_thermostat", initial=80)` → `attributes.initial == 80` AND every other field unchanged.
- **Bug 8**: create input_number with full config (min=60, max=85, step=0.5, initial=72, mode=box, unit=°F, icon=mdi:thermometer); rename it; verify all 7 fields STILL present in `ha_get_state`. Repeat for input_text and counter.
- **Bug 9**: `ha_config_set_helper(helper_type="tag", name="PRTEST_autotag")` (no `tag_id`) → expect success with auto-generated tag_id.
- **Bug 18**: `ha_config_set_helper(helper_type="statistics", name="PRTEST_stats", config={"entity_id":"sensor.<a sensor>","state_characteristic":"mean","max_age":{"hours":1},"sampling_size":20,"keep_last_sample":false,"percentile":50,"precision":2})` → expect success.
- **Bug 19**: `ha_config_set_helper(helper_type="switch_as_x", name="PRTEST_swx", config={"entity_id":"switch.<a switch>","target_domain":"light"})` → expect success (was uncreatable before).

Refs #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
