### PR TITLE
perf+refactor(helpers): parallelize registry-id validation; dedupe mode/id-set helpers (3/3)

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -485,8 +485,7 @@ async def _validate_registry_ids(
                     "category registry.",
                     context={"category": category},
                     suggestions=[
-                        "Use ha_config_get_category(scope='helpers') to list "
-                        "valid category IDs.",
+                        "Use ha_config_get_category(scope='helpers') to list valid category IDs.",
                         "Use ha_config_set_category() to create a new category.",
                         f"Available category_ids: {sorted(valid_category_ids)}",
                     ],

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -388,6 +388,12 @@ async def _validate_registry_ids(
     Raises VALIDATION_INVALID_PARAMETER on the first unknown ID encountered, with
     the available IDs included in the suggestions list so the caller can correct.
     """
+    # Early-out: nothing to validate.
+    needs_area = area_id is not None and area_id != ""
+    needs_labels = bool(labels)
+    needs_category = category is not None and category != ""
+    if not (needs_area or needs_labels or needs_category):
+        return
 
     async def _ws_list(
         message: dict[str, Any],
@@ -413,9 +419,37 @@ async def _validate_registry_ids(
                 return True, inner
         return False, []
 
-    # Validate area_id (skip None and empty-string clear).
-    if area_id is not None and area_id != "":
-        ok, areas = await _ws_list({"type": "config/area_registry/list"})
+    # Run the three registry lookups concurrently — they're independent and
+    # each is a separate WS round-trip.
+    area_lookup = (
+        _ws_list({"type": "config/area_registry/list"})
+        if needs_area
+        else None
+    )
+    label_lookup = (
+        _ws_list({"type": "config/label_registry/list"})
+        if needs_labels
+        else None
+    )
+    category_lookup = (
+        _ws_list({"type": "config/category_registry/list", "scope": "helpers"})
+        if needs_category
+        else None
+    )
+    coros = [c for c in (area_lookup, label_lookup, category_lookup) if c is not None]
+    results = await asyncio.gather(*coros)
+    # Re-associate results with the parameter they belong to.
+    by_param: dict[str, tuple[bool, list[dict[str, Any]]]] = {}
+    if needs_area:
+        by_param["area"] = results.pop(0)
+    if needs_labels:
+        by_param["labels"] = results.pop(0)
+    if needs_category:
+        by_param["category"] = results.pop(0)
+
+    # Validate area_id.
+    if needs_area:
+        ok, areas = by_param["area"]
         valid_area_ids: list[str] = [
             aid
             for a in areas
@@ -436,9 +470,9 @@ async def _validate_registry_ids(
                 )
             )
 
-    # Validate labels (skip None; empty list is allowed as a "clear").
-    if labels is not None and labels:
-        ok, ws_labels = await _ws_list({"type": "config/label_registry/list"})
+    # Validate labels.
+    if needs_labels:
+        ok, ws_labels = by_param["labels"]
         valid_label_ids: list[str] = [
             lid
             for label in ws_labels
@@ -448,7 +482,7 @@ async def _validate_registry_ids(
         if ok:
             unknown = [
                 label_id
-                for label_id in labels
+                for label_id in labels or []
                 if label_id and label_id not in valid_label_ids
             ]
             if unknown:
@@ -466,11 +500,9 @@ async def _validate_registry_ids(
                     )
                 )
 
-    # Validate category (skip None and empty-string clear).
-    if category is not None and category != "":
-        ok, categories = await _ws_list(
-            {"type": "config/category_registry/list", "scope": "helpers"}
-        )
+    # Validate category.
+    if needs_category:
+        ok, categories = by_param["category"]
         valid_category_ids: list[str] = [
             cid
             for cat in categories
@@ -680,10 +712,19 @@ async def _apply_registry_updates_to_entity(
     """
     applied: dict[str, Any] = {"entity_id": entity_id}
 
-    # area_id + labels in one entity_registry/update.
-    # Use `is not None` to distinguish "not provided" (no change) from
-    # "explicit clear" (empty string / empty list). Mirrors ha_set_entity.
-    if area_id is not None or labels is not None:
+    # Run the two independent registry calls concurrently:
+    # 1. config/entity_registry/update for area_id + labels (combined)
+    # 2. apply_entity_category for category (separate WS shape).
+    # `is not None` distinguishes "not provided" from "explicit clear" (empty
+    # string / empty list). Mirrors ha_set_entity. A transient raise on either
+    # call is captured via return_exceptions so a multi-entity flow helper
+    # (e.g. utility_meter with N tariffs) can still report partial success.
+    needs_registry = area_id is not None or labels is not None
+    needs_category = bool(category)
+    if not (needs_registry or needs_category):
+        return applied
+
+    async def _do_registry_update() -> Any:
         update_message: dict[str, Any] = {
             "type": "config/entity_registry/update",
             "entity_id": entity_id,
@@ -692,25 +733,39 @@ async def _apply_registry_updates_to_entity(
             update_message["area_id"] = area_id if area_id else None
         if labels is not None:
             update_message["labels"] = labels
-        try:
-            ws_result = await client.send_websocket_message(update_message)
-        except Exception as e:
-            # Transient raise (timeout, connection drop) mid-loop must not
-            # abort the remaining entities for a multi-entity flow helper
-            # (e.g. utility_meter with tariffs #3..#5 of 5). Record and
-            # continue; soft-failure via ws_result["success"]=False is
-            # already handled below.
-            warnings.append(
-                f"{entity_id}: entity registry update raised: {e}"
-            )
-            return applied
-        if ws_result.get("success"):
+        return await client.send_websocket_message(update_message)
+
+    async def _do_category_apply() -> dict[str, Any]:
+        cat_ack: dict[str, Any] = {}
+        # `category` is non-None whenever we entered this branch (needs_category).
+        assert category is not None
+        await apply_entity_category(
+            client, entity_id, category, "helpers", cat_ack, "helper"
+        )
+        return cat_ack
+
+    reg_task = _do_registry_update() if needs_registry else None
+    cat_task = _do_category_apply() if needs_category else None
+    coros = [c for c in (reg_task, cat_task) if c is not None]
+    raw_results: list[Any] = list(
+        await asyncio.gather(*coros, return_exceptions=True)
+    )
+    reg_result = raw_results.pop(0) if needs_registry else None
+    cat_result = raw_results.pop(0) if needs_category else None
+
+    # Handle entity_registry/update outcome.
+    if isinstance(reg_result, BaseException):
+        warnings.append(
+            f"{entity_id}: entity registry update raised: {reg_result}"
+        )
+    elif reg_result is not None:
+        if reg_result.get("success"):
             if area_id is not None:
                 applied["area_id"] = area_id if area_id else None
             if labels is not None:
                 applied["labels"] = labels
         else:
-            error_detail = ws_result.get("error", {})
+            error_detail = reg_result.get("error", {})
             error_msg = (
                 error_detail.get("message", "Unknown error")
                 if isinstance(error_detail, dict)
@@ -720,21 +775,16 @@ async def _apply_registry_updates_to_entity(
                 f"{entity_id}: entity registry update failed: {error_msg}"
             )
 
-    # category via shared helper (consistent with simple helpers / automations / scripts)
-    if category:
-        cat_ack: dict[str, Any] = {}
-        await apply_entity_category(
-            client,
-            entity_id,
-            category,
-            "helpers",
-            cat_ack,
-            "helper",
+    # Handle category outcome.
+    if isinstance(cat_result, BaseException):
+        warnings.append(
+            f"{entity_id}: category apply raised: {cat_result}"
         )
-        if "category" in cat_ack:
-            applied["category"] = cat_ack["category"]
-        elif "category_warning" in cat_ack:
-            warnings.append(f"{entity_id}: {cat_ack['category_warning']}")
+    elif cat_result is not None:
+        if "category" in cat_result:
+            applied["category"] = cat_result["category"]
+        elif "category_warning" in cat_result:
+            warnings.append(f"{entity_id}: {cat_result['category_warning']}")
 
     return applied
 
@@ -935,12 +985,19 @@ async def _handle_flow_helper(
     if entity_ids and (
         area_id is not None or labels_list is not None or category is not None
     ):
-        applied_per_entity: list[dict[str, Any]] = []
-        for eid in entity_ids:
-            applied = await _apply_registry_updates_to_entity(
-                client, eid, area_id, labels_list, category, warnings
+        # Apply per-entity updates concurrently — each entity's update is
+        # independent, so a multi-entity helper (e.g. utility_meter with N
+        # tariffs) finishes in one round-trip instead of N.
+        applied_per_entity = list(
+            await asyncio.gather(
+                *(
+                    _apply_registry_updates_to_entity(
+                        client, eid, area_id, labels_list, category, warnings
+                    )
+                    for eid in entity_ids
+                )
             )
-            applied_per_entity.append(applied)
+        )
         if area_id is not None:
             result["area_id"] = area_id if area_id else None
         if labels_list is not None:

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -87,6 +87,33 @@ _TYPE_TYPED_PARAMS: dict[str, frozenset[str]] = {
 _ALL_TYPED_PARAMS: frozenset[str] = frozenset().union(*_TYPE_TYPED_PARAMS.values())
 
 
+# Bug 6 (issue #1150): valid mode values per helper type. The CREATE and
+# UPDATE branches both validate against this; an invalid value is rejected
+# instead of silently coerced to HA's default.
+_MODE_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "input_number": ("box", "slider"),
+    "input_text": ("text", "password"),
+}
+
+
+def _validate_mode(helper_type: str, mode: str | None) -> None:
+    """Reject an invalid `mode` value for the chosen helper_type (Bug 6)."""
+    if mode is None:
+        return
+    allowed = _MODE_BY_TYPE.get(helper_type)
+    if allowed is None or mode in allowed:
+        return
+    options = " or ".join(repr(m) for m in allowed)
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"mode={mode!r} is not valid for {helper_type}. Use {options}.",
+            context={"helper_type": helper_type, "mode": mode},
+            suggestions=[f"Pass mode={allowed[0]!r} or mode={allowed[1]!r}"],
+        )
+    )
+
+
 def _validate_applicable_params(
     helper_type: str,
     passed: dict[str, Any],
@@ -419,43 +446,33 @@ async def _validate_registry_ids(
                 return True, inner
         return False, []
 
+    def _id_set(items: list[dict[str, Any]], field: str) -> list[str]:
+        """Pull non-empty string values of `field` from a list of dicts."""
+        return [
+            v
+            for it in items
+            if isinstance(it, dict) and isinstance((v := it.get(field)), str)
+        ]
+
     # Run the three registry lookups concurrently — they're independent and
     # each is a separate WS round-trip.
-    area_lookup = (
-        _ws_list({"type": "config/area_registry/list"})
-        if needs_area
-        else None
-    )
-    label_lookup = (
-        _ws_list({"type": "config/label_registry/list"})
-        if needs_labels
-        else None
-    )
-    category_lookup = (
-        _ws_list({"type": "config/category_registry/list", "scope": "helpers"})
-        if needs_category
-        else None
-    )
-    coros = [c for c in (area_lookup, label_lookup, category_lookup) if c is not None]
-    results = await asyncio.gather(*coros)
-    # Re-associate results with the parameter they belong to.
-    by_param: dict[str, tuple[bool, list[dict[str, Any]]]] = {}
+    lookups: list[tuple[str, Any]] = []
     if needs_area:
-        by_param["area"] = results.pop(0)
+        lookups.append(("area", _ws_list({"type": "config/area_registry/list"})))
     if needs_labels:
-        by_param["labels"] = results.pop(0)
+        lookups.append(("labels", _ws_list({"type": "config/label_registry/list"})))
     if needs_category:
-        by_param["category"] = results.pop(0)
+        lookups.append((
+            "category",
+            _ws_list({"type": "config/category_registry/list", "scope": "helpers"}),
+        ))
+    raw = await asyncio.gather(*(coro for _, coro in lookups))
+    by_param = {key: result for (key, _), result in zip(lookups, raw, strict=True)}
 
-    # Validate area_id.
+    # Validate area_id (single value).
     if needs_area:
         ok, areas = by_param["area"]
-        valid_area_ids: list[str] = [
-            aid
-            for a in areas
-            if isinstance(a, dict)
-            and isinstance((aid := a.get("area_id")), str)
-        ]
+        valid_area_ids = _id_set(areas, "area_id")
         if ok and area_id not in valid_area_ids:
             raise_tool_error(
                 create_error_response(
@@ -470,15 +487,10 @@ async def _validate_registry_ids(
                 )
             )
 
-    # Validate labels.
+    # Validate labels (list of values).
     if needs_labels:
         ok, ws_labels = by_param["labels"]
-        valid_label_ids: list[str] = [
-            lid
-            for label in ws_labels
-            if isinstance(label, dict)
-            and isinstance((lid := label.get("label_id")), str)
-        ]
+        valid_label_ids = _id_set(ws_labels, "label_id")
         if ok:
             unknown = [
                 label_id
@@ -500,15 +512,10 @@ async def _validate_registry_ids(
                     )
                 )
 
-    # Validate category.
+    # Validate category (single value).
     if needs_category:
         ok, categories = by_param["category"]
-        valid_category_ids: list[str] = [
-            cid
-            for cat in categories
-            if isinstance(cat, dict)
-            and isinstance((cid := cat.get("category_id")), str)
-        ]
+        valid_category_ids = _id_set(categories, "category_id")
         if ok and category not in valid_category_ids:
             raise_tool_error(
                 create_error_response(
@@ -1596,19 +1603,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 },
             )
 
-            # Bug 11 (issue #1150): the create-vs-update mode is implicit in
-            # which of `name` / `helper_id` was passed. Passing both used to
-            # Bug 12 (issue #1150): on create, HA auto-suffixes name collisions
-            # with `_2`/`_3`/..., so a caller asking to create something that
-            # already exists silently gets a duplicate. Detect the slug
-            # collision before sending and point them at the existing helper.
-            #
-            # Bug 11 note: the implicit create/update discriminator (presence
-            # of helper_id) is preserved. Passing both name+helper_id is the
-            # legitimate rename pattern — we don't reject it. The original
-            # symptom (confusing ENTITY_NOT_FOUND on misspelled helper_id) is
-            # mitigated by the per-type update branch that already includes
-            # the entity_id in the error context with helpful suggestions.
+            # Bug 12: HA auto-suffixes duplicate names with `_2`/`_3`/...
+            # Detect the slug collision before sending so a caller intending
+            # to update an existing helper isn't silently given a duplicate.
             if action == "create":
                 await _check_name_collision(client, helper_type, name)
 
@@ -1760,24 +1757,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["step"] = step
                     if unit_of_measurement:
                         message["unit_of_measurement"] = unit_of_measurement
-                    # Bug 6 (issue #1150): reject invalid mode values instead
-                    # of silently coercing to the HA default. Caller learns
-                    # which values are valid for input_number.
+                    _validate_mode(helper_type, mode)
                     if mode is not None:
-                        if mode not in ("box", "slider"):
-                            raise_tool_error(
-                                create_error_response(
-                                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                    f"mode='{mode}' is not valid for input_number. "
-                                    "Use 'box' or 'slider'.",
-                                    context={"helper_type": helper_type, "mode": mode},
-                                    suggestions=["Pass mode='slider' or mode='box'"],
-                                )
-                            )
                         message["mode"] = mode
-                    # Bug 1 (issue #1150): `initial` was accepted in the function
-                    # signature but never written to the input_number/create
-                    # message, so the requested default was silently dropped.
                     if initial is not None:
                         message["initial"] = initial
 
@@ -1786,21 +1768,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["min"] = int(min_value)
                     if max_value is not None:
                         message["max"] = int(max_value)
-                    # Bug 6 (issue #1150): reject invalid mode for input_text.
+                    _validate_mode(helper_type, mode)
                     if mode is not None:
-                        if mode not in ("text", "password"):
-                            raise_tool_error(
-                                create_error_response(
-                                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                    f"mode='{mode}' is not valid for input_text. "
-                                    "Use 'text' or 'password'.",
-                                    context={"helper_type": helper_type, "mode": mode},
-                                    suggestions=["Pass mode='text' or mode='password'"],
-                                )
-                            )
                         message["mode"] = mode
-                    # Bug 5 (issue #1150): "" is a valid initial for input_text
-                    # — the truthy check `if initial:` previously dropped it.
+                    # `is not None` so initial="" is honored; HA accepts empty.
                     if initial is not None:
                         message["initial"] = initial
 
@@ -1840,14 +1811,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
                         )
 
-                    # Bug 5 (issue #1150): use `is not None` so a deliberate
-                    # zero-time `initial="00:00:00"` (rare but valid) isn't
-                    # silently dropped by a truthy check.
                     if initial is not None:
                         message["initial"] = initial
 
                 elif helper_type == "counter":
-                    # Counter parameters: initial, minimum, maximum, step, restore
                     if initial is not None:
                         message["initial"] = (
                             int(initial) if isinstance(initial, str) else initial
@@ -1862,9 +1829,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["restore"] = restore
 
                 elif helper_type == "timer":
-                    # Timer parameters: duration, restore
-                    # Bug 5 (issue #1150): use `is not None` so an explicitly-
-                    # passed "0:00:00" or 0 isn't silently dropped.
+                    # `is not None` so explicit "0:00:00" or 0 isn't dropped.
                     if duration is not None:
                         message["duration"] = duration
                     if restore is not None:
@@ -2370,13 +2335,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 )
                             )
 
-                        # Bug 8 (issue #1150): HA's storage-collection update commands
-                        # are full-replace — fields missing from the message get
-                        # cleared. Per-type config fields below all use a merge
-                        # pattern: take the new value if the caller passed one,
-                        # else preserve the existing value. Without this, an
-                        # innocent rename wipes initial/icon/unit_of_measurement
-                        # and other fields the caller never intended to change.
+                        # HA's storage-collection update is full-replace, so per-type
+                        # config fields below all merge: take the new value if
+                        # the caller passed one, else preserve the existing value.
                         update_msg = {
                             "type": f"{helper_type}/update",
                             f"{helper_type}_id": unique_id,
@@ -2431,25 +2392,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
                             if unit_val is not None:
                                 update_msg["unit_of_measurement"] = unit_val
-                            # Bug 6 (issue #1150): reject invalid mode values
-                            # explicitly instead of falling back to existing.
-                            if mode is not None and mode not in ("box", "slider"):
-                                raise_tool_error(
-                                    create_error_response(
-                                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                        f"mode='{mode}' is not valid for input_number. "
-                                        "Use 'box' or 'slider'.",
-                                        context={"helper_type": helper_type, "mode": mode},
-                                        suggestions=[
-                                            "Pass mode='slider' or mode='box'",
-                                        ],
-                                    )
-                                )
+                            _validate_mode(helper_type, mode)
                             mode_val = mode if mode is not None else existing.get("mode")
                             if mode_val is not None:
                                 update_msg["mode"] = mode_val
-                            # Bug 1b (issue #1150): `initial` was accepted but
-                            # never written here, so updates always wiped it.
                             initial_val = (
                                 initial
                                 if initial is not None
@@ -2473,20 +2419,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
                             if max_val is not None:
                                 update_msg["max"] = max_val
-                            # Bug 6 (issue #1150): reject invalid mode values
-                            # explicitly for input_text too.
-                            if mode is not None and mode not in ("text", "password"):
-                                raise_tool_error(
-                                    create_error_response(
-                                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                        f"mode='{mode}' is not valid for input_text. "
-                                        "Use 'text' or 'password'.",
-                                        context={"helper_type": helper_type, "mode": mode},
-                                        suggestions=[
-                                            "Pass mode='text' or mode='password'",
-                                        ],
-                                    )
-                                )
+                            _validate_mode(helper_type, mode)
                             mode_val = mode if mode is not None else existing.get("mode")
                             if mode_val is not None:
                                 update_msg["mode"] = mode_val

--- a/tests/src/e2e/workflows/config/test_helper_field_persistence.py
+++ b/tests/src/e2e/workflows/config/test_helper_field_persistence.py
@@ -613,7 +613,11 @@ class TestInputNumberPartialUpdatePreservesFields:
         self, mcp_client, cleanup_tracker
     ):
         helper_type = "input_number"
-        # Full original config
+        # Full original config. The test must change min within a range that
+        # still contains the existing initial; otherwise HA's voluptuous schema
+        # (correctly) rejects "Initial value 25 not in range 30-100". The
+        # purpose of the test is to verify the merge preserves the other
+        # fields, not to test the cross-field range constraint.
         preserved = {
             "max": 100,
             "step": 5,
@@ -622,7 +626,7 @@ class TestInputNumberPartialUpdatePreservesFields:
             "initial": 25,
             "icon": "mdi:gauge",
         }
-        new_min = 70  # update touches only this field
+        new_min = 20  # 0 -> 20; still <= initial=25 so HA accepts
 
         create_result = await mcp_client.call_tool(
             "ha_config_set_helper",

--- a/tests/src/unit/test_flow_name_injection.py
+++ b/tests/src/unit/test_flow_name_injection.py
@@ -201,8 +201,10 @@ class TestTemplateAndFormHelperNameInjected:
         and we have no field-list to check. The legacy fallback (inject
         anyway) keeps template/group working unchanged."""
         submit_capture: list[dict] = []
-        # schema_fields=None signals "introspection sees a menu, not a form"
-        start_flow, submit = _make_start_config_flow(
+        # schema_fields=None signals "introspection sees a menu, not a form".
+        # The factory installs handlers on `mock_client` directly; the returned
+        # tuple is unused here.
+        _make_start_config_flow(
             schema_fields=None,
             entry_id="entry-tpl",
             domain="template",


### PR DESCRIPTION
## What does this PR do?

The third and final PR closing #1150. **Stacked on PR 2** (`fix-helper-validation`). Pure polish: performance parallelization, source-code de-duplication, and review-bot-comment fixes. No new bug fixes — this is the cleanup pass on top of the 19-bug audit fixes from PR 1 + PR 2.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [x] 🧪 Tests only (test fix for the e2e partial-update assertion)
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent (the same full no-context test set from PR 1 and PR 2 — 12 agents total, 236/236 PASS at the stack tip)
- [x] All automated tests pass (`uv run pytest`) — 341 helper-related unit tests + 8 e2e tests, 0 regressions
- [x] Code follows style guidelines (`uv run ruff check` clean, `uv run mypy src/` clean)

## What's in this PR

Three commits, all from the simplify-skill review of the original combined PR:

1. **`test: address review-bot comments; fix e2e partial-update test`**
   - Resolves 4 inline comments from `github-code-quality` bot (implicit string concatenation in a list, unused tuple-unpack in a test, unused `ToolError` import).
   - Fixes the `test_partial_min_value_update_preserves_other_fields` e2e test — the original test changed range to 70-100 while existing initial was 25, which HA's voluptuous schema correctly rejects ("Initial value 25 not in range 70-100"). Adjusted to a range-compatible new_min so the merge-preserves-other-fields assertion runs as intended.

2. **`perf: parallelize registry-id validation + per-entity registry updates`**
   - `_validate_registry_ids`: short-circuit early-out when no registry IDs are passed; run the area/label/category lookups concurrently via `asyncio.gather` instead of three sequential awaits. Saves 2 WS RTTs (~20-100ms on remote HA) when multiple registry IDs are passed.
   - `_apply_registry_updates_to_entity`: run the entity-registry-update WS call concurrently with the apply-category call. Uses `asyncio.gather(return_exceptions=True)` so a partial failure is reported as a warning and doesn't abort the other op.
   - `_handle_flow_helper`: per-entity registry updates now run concurrently. For a multi-entity flow helper (e.g. `utility_meter` with N tariff sensors), this collapses N WS round-trips into one wall-clock RTT.

3. **`refactor: dedupe mode validation, registry-id extraction, narrative comments`**
   - Extracted `_validate_mode(helper_type, mode)` + `_MODE_BY_TYPE` table. Replaces 4 near-identical 8-line blocks (input_number / input_text CREATE + UPDATE) with a 1-line call. -32 net lines.
   - Extracted `_id_set(items, field)` helper inside `_validate_registry_ids` — replaces 3 copies of the same list comprehension. -10 net lines.
   - Trimmed narrative comments that explained change history ("Bug 1 was…, now writes initial") rather than the WHY. The bug numbers and `Co-Authored-By` lines in commit messages preserve provenance; the source no longer narrates the diff.

## Out of scope (left as future improvements)

Documented in PR 2's description and the audit-issue follow-ups:
- **Extract `_TYPE_FIELD_SPEC` table** to unify the per-helper-type CREATE+UPDATE elif chains. The simplify-skill review flagged this as HIGH-severity but each helper type has quirks (string-to-bool for input_boolean, int casting for counter, has_date/has_time defaulting, schedule day formatting, zone preflight) that don't fit cleanly into one spec. Worth a focused follow-up PR after this lands.
- **Issue #1149** (schema-awareness consolidation): merging `ha_get_helper_schema` into `ha_config_set_helper`.
- **Issue #1152** (WS event subscriptions to replace `wait_for_entity_registered` REST polling).

## Future improvements

The two simplify-skill HIGH-severity findings, both noted above. No bug regressions — every fix from PR 1 and PR 2 is preserved.

## Checklist
- [x] I have updated documentation if needed

## Closes

Closes #1150.

Refs PR 1 (`fix-helper-critical`) and PR 2 (`fix-helper-validation`) — this PR is stacked on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
