### PR TITLE
feat: broaden python_transform AST allowlist + improve error UX

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -28,7 +28,11 @@ from ..errors import (
     create_error_response,
     create_validation_error,
 )
-from ..utils.python_sandbox import PythonSandboxError, safe_execute_expression
+from ..utils.python_sandbox import (
+    PythonSandboxError,
+    format_sandbox_error,
+    safe_execute_expression,
+)
 from .helpers import (
     exception_to_structured_error,
     get_connected_ws_client,
@@ -179,16 +183,19 @@ def _apply_response_transform(response: Any, expr: str) -> Any:
     try:
         return safe_execute_expression(expr, {"response": response}, "response")
     except PythonSandboxError as e:
+        message, suggestions = format_sandbox_error(e, expr)
+        # Addon helpers operate on a `response` variable, not `config` —
+        # prepend a one-liner so agents know which name to mutate.
+        suggestions = [
+            "Operate on the `response` variable (in-place or reassign)",
+            *suggestions,
+        ]
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_FAILED,
-                f"python_transform failed: {e!s}",
+                message,
                 context={"expression_preview": expr[:200]},
-                suggestions=[
-                    "Operate on the `response` variable (in-place or reassign)",
-                    "Allowed: dict/list access, assignment, loops, "
-                    "comprehensions, whitelisted str/list/dict methods",
-                ],
+                suggestions=suggestions,
             )
         )
 

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -183,13 +183,9 @@ def _apply_response_transform(response: Any, expr: str) -> Any:
     try:
         return safe_execute_expression(expr, {"response": response}, "response")
     except PythonSandboxError as e:
-        message, suggestions = format_sandbox_error(e, expr)
-        # Addon helpers operate on a `response` variable, not `config` —
-        # prepend a one-liner so agents know which name to mutate.
-        suggestions = [
-            "Operate on the `response` variable (in-place or reassign)",
-            *suggestions,
-        ]
+        message, suggestions = format_sandbox_error(
+            e, expr, variable_name="response"
+        )
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_FAILED,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -22,6 +22,7 @@ from ..errors import (
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
     PythonSandboxError,
+    format_sandbox_error,
     get_security_documentation,
     safe_execute,
 )
@@ -552,16 +553,12 @@ class AutomationConfigTools:
                 try:
                     transformed_config = safe_execute(python_transform, current_config)
                 except PythonSandboxError as e:
+                    message, suggestions = format_sandbox_error(e, python_transform)
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,
-                            str(e),
-                            suggestions=[
-                                "Check expression syntax",
-                                "Ensure only allowed operations are used",
-                                "See tool description for allowed operations",
-                                f"Expression: {python_transform[:100]}{'...' if len(python_transform) > 100 else ''}",
-                            ],
+                            message,
+                            suggestions=suggestions,
                             context={"action": "python_transform", "identifier": identifier},
                         )
                     )

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -16,6 +16,7 @@ from ..errors import ErrorCode, create_error_response, create_resource_not_found
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
     PythonSandboxError,
+    format_sandbox_error,
     get_security_documentation,
     safe_execute,
 )
@@ -1069,16 +1070,12 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 try:
                     transformed_config = safe_execute(python_transform, current_config)
                 except PythonSandboxError as e:
+                    message, suggestions = format_sandbox_error(e, python_transform)
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,
-                            str(e),
-                            suggestions=[
-                                "Check expression syntax",
-                                "Ensure only allowed operations are used",
-                                "See tool description for allowed operations",
-                                f"Expression: {python_transform[:100]}...",
-                            ],
+                            message,
+                            suggestions=suggestions,
                             context={
                                 "action": "python_transform",
                                 "url_path": url_path,

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -16,6 +16,7 @@ from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
     PythonSandboxError,
+    format_sandbox_error,
     get_security_documentation,
     safe_execute,
 )
@@ -446,16 +447,12 @@ class ConfigScriptTools:
                 try:
                     transformed_config = safe_execute(python_transform, actual_config)
                 except PythonSandboxError as e:
+                    message, suggestions = format_sandbox_error(e, python_transform)
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,
-                            str(e),
-                            suggestions=[
-                                "Check expression syntax",
-                                "Ensure only allowed operations are used",
-                                "See tool description for allowed operations",
-                                f"Expression: {python_transform[:100]}{'...' if len(python_transform) > 100 else ''}",
-                            ],
+                            message,
+                            suggestions=suggestions,
                             context={"action": "python_transform", "script_id": script_id},
                         )
                     )

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -50,7 +50,6 @@ def _truncate_for_error(text: str, limit: int = _EXECUTION_ERROR_TEXT_LIMIT) -> 
     return text[: limit - 3] + "..."
 
 
-
 # Whitelist of safe AST node types
 SAFE_NODES = {
     # Structural
@@ -365,6 +364,12 @@ def safe_execute_expression(
 
     try:
         exec(expr, safe_globals, safe_locals)
+    except (MemoryError, RecursionError):
+        # Resource exhaustion — let the host decide. Reframing
+        # "ran out of memory" as "your transform was bad" would
+        # mislead the agent into rewriting an expression that
+        # was structurally fine.
+        raise
     except Exception as e:
         # Truncate so embedded reprs of input data (config dicts, tokens,
         # etc.) don't reach the caller verbatim.

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -414,7 +414,9 @@ def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
 
 
 def format_sandbox_error(
-    error: PythonSandboxError, expr: str
+    error: PythonSandboxError,
+    expr: str,
+    variable_name: str = "config",
 ) -> tuple[str, list[str]]:
     """Build a (message, suggestions) pair appropriate for the error subclass.
 
@@ -424,6 +426,12 @@ def format_sandbox_error(
     but raised at runtime — suggestions point at keys/types/values.
     Plain ``PythonSandboxError`` (no subclass) falls back to the
     validation form.
+
+    ``variable_name`` is the name of the mutable target the expression
+    operates on. The default ``"config"`` matches the dashboard /
+    automation / script callers; addon helpers pass ``"response"`` and
+    a one-liner about that name is prepended to the suggestions so
+    agents know which variable to mutate.
 
     Used by ``ha_config_set_*`` and addon helpers so each caller emits
     the same shape of MCP error without duplicating the boilerplate.
@@ -444,6 +452,11 @@ def format_sandbox_error(
             "Ensure only allowed operations are used",
             "See tool description for allowed operations",
             f"Expression: {preview}",
+        ]
+    if variable_name != "config":
+        suggestions = [
+            f"Operate on the `{variable_name}` variable (in-place or reassign)",
+            *suggestions,
         ]
     return message, suggestions
 

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -11,7 +11,43 @@ from typing import Any, cast
 
 
 class PythonSandboxError(Exception):
-    """Raised when expression validation fails."""
+    """Base class for sandbox failures.
+
+    Catch this when callers don't need to distinguish validation-time
+    rejection from runtime exceptions — otherwise prefer the subclasses.
+    """
+
+
+class PythonSandboxValidationError(PythonSandboxError):
+    """Raised when AST validation rejects the expression before execution.
+
+    The expression contains a forbidden node, function, or method, or
+    failed to parse. The user can fix the input.
+    """
+
+
+class PythonSandboxExecutionError(PythonSandboxError):
+    """Raised when a validated expression raised at runtime.
+
+    The expression passed AST validation but produced a Python exception
+    when executed (e.g. KeyError on a missing key, TypeError on a bad
+    operation). Different from a validation failure: the *shape* of the
+    expression is fine, but it doesn't apply cleanly to the input data.
+    """
+
+
+# Cap on how much of a runtime exception's text gets surfaced. HA configs
+# can carry tokens / passwords / device addresses, and Python's default
+# repr happily embeds dict and list values into KeyError/TypeError text.
+# 240 chars is enough to identify the failure (exception type + a short
+# snippet) without pasting the input config back to the caller.
+_EXECUTION_ERROR_TEXT_LIMIT = 240
+
+
+def _truncate_for_error(text: str, limit: int = _EXECUTION_ERROR_TEXT_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
 
 
 
@@ -46,7 +82,7 @@ SAFE_NODES = {
     ast.Dict,
     ast.Tuple,
     ast.Set,
-    ast.Starred,  # *args / [*list] unpacking
+    ast.Starred,  # *iterable in calls/literals: f(*xs), [*xs, y]
     # Operations
     ast.Delete,
     ast.BinOp,
@@ -84,16 +120,24 @@ SAFE_NODES = {
     ast.SetComp,
     ast.GeneratorExp,  # (x for x in ...)
     ast.comprehension,
-    # Lambda (for comprehensions)
+    # Lambda — useful as `key=` for sorted/min/max. ast.arguments and
+    # ast.arg are the structure nodes ast.walk descends into for the
+    # parameter list; they have no execution semantics on their own
+    # (FunctionDef would be blocked at the SAFE_NODES check above).
     ast.Lambda,
+    ast.arguments,
+    ast.arg,
 }
 
 
 # Hints to help agents recover when a forbidden node is encountered.
-# Keyed on AST class name. Empty / unknown keys fall through to the
-# generic message.
+# Keyed on AST class name (string, not class) so entries for
+# version-specific nodes like Match (3.10+) or TryStar (3.11+) stay
+# evaluable on any Python. Unmapped keys fall through to the generic
+# "Forbidden node type: X" message in `_validate_node`.
 _NODE_SUGGESTIONS: dict[str, str] = {
     "Try": "validate inputs with isinstance/in/.get() instead of try/except",
+    "TryStar": "validate inputs with isinstance/in/.get() instead of try/except",
     "ExceptHandler": "validate inputs with isinstance/in/.get() instead of try/except",
     "With": "perform the inner logic directly; with-blocks aren't supported",
     "AsyncWith": "perform the inner logic directly; with-blocks aren't supported",
@@ -106,6 +150,7 @@ _NODE_SUGGESTIONS: dict[str, str] = {
     "Nonlocal": "assign directly to the variable; scope keywords aren't supported",
     "Import": "imports aren't available; built-ins like isinstance/len/range are exposed",
     "ImportFrom": "imports aren't available; built-ins like isinstance/len/range are exposed",
+    "Match": "use if/elif/else or a dict lookup instead of match/case",
 }
 
 # Whitelist of safe methods that can be called
@@ -227,7 +272,14 @@ def validate_expression(expr: str) -> tuple[bool, str]:
 
 
 def _validate_node(node: ast.AST) -> str | None:
-    """Validate a single AST node. Returns error message or None if safe."""
+    """Validate a single AST node. Returns error message or None if safe.
+
+    Whitelist check first: any node not in ``SAFE_NODES`` is rejected with
+    its class name and (when available) a recovery hint from
+    ``_NODE_SUGGESTIONS``. After that, only nodes that *are* safe but need
+    extra checks (Attribute → block dunder access, Call → block forbidden
+    functions/methods) get further validation.
+    """
     if type(node) not in SAFE_NODES:
         name = type(node).__name__
         hint = _NODE_SUGGESTIONS.get(name)
@@ -235,24 +287,12 @@ def _validate_node(node: ast.AST) -> str | None:
             return f"Forbidden node type: {name} — {hint}"
         return f"Forbidden node type: {name}"
 
-    if isinstance(node, (ast.Import, ast.ImportFrom)):
-        return "Forbidden: imports not allowed"
-
     if isinstance(node, ast.Attribute):
         if node.attr.startswith("__") and node.attr.endswith("__"):
             return f"Forbidden: dunder attribute access ({node.attr})"
 
     if isinstance(node, ast.Call):
         return _validate_call_node(node)
-
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-        return "Forbidden: function/class definitions not allowed"
-
-    if isinstance(node, (ast.With, ast.AsyncWith)):
-        return "Forbidden: with statements not allowed"
-
-    if isinstance(node, (ast.Try, ast.ExceptHandler)):
-        return "Forbidden: try/except not allowed"
 
     return None
 
@@ -309,10 +349,10 @@ def safe_execute_expression(
     """
     valid, error = validate_expression(expr)
     if not valid:
-        raise PythonSandboxError(f"Expression validation failed: {error}")
+        raise PythonSandboxValidationError(error)
 
     if result_key not in variables:
-        raise PythonSandboxError(
+        raise PythonSandboxValidationError(
             f"result_key {result_key!r} not found in variables",
         )
 
@@ -326,7 +366,10 @@ def safe_execute_expression(
     try:
         exec(expr, safe_globals, safe_locals)
     except Exception as e:
-        raise PythonSandboxError(f"Execution error: {type(e).__name__}: {e}") from e
+        # Truncate so embedded reprs of input data (config dicts, tokens,
+        # etc.) don't reach the caller verbatim.
+        detail = _truncate_for_error(f"{type(e).__name__}: {e}")
+        raise PythonSandboxExecutionError(detail) from e
 
     return safe_locals[result_key]
 
@@ -365,6 +408,41 @@ def safe_execute(expr: str, config: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def format_sandbox_error(
+    error: PythonSandboxError, expr: str
+) -> tuple[str, list[str]]:
+    """Build a (message, suggestions) pair appropriate for the error subclass.
+
+    ``PythonSandboxValidationError`` means the expression's shape was
+    rejected before execution — suggestions point at syntax/allowed-ops.
+    ``PythonSandboxExecutionError`` means the expression was accepted
+    but raised at runtime — suggestions point at keys/types/values.
+    Plain ``PythonSandboxError`` (no subclass) falls back to the
+    validation form.
+
+    Used by ``ha_config_set_*`` and addon helpers so each caller emits
+    the same shape of MCP error without duplicating the boilerplate.
+    """
+    preview = expr[:100] + ("..." if len(expr) > 100 else "")
+    if isinstance(error, PythonSandboxExecutionError):
+        message = f"Expression raised at runtime: {error}"
+        suggestions = [
+            "Verify referenced keys/indices exist in the input",
+            "Check that types match (e.g. dict vs list operations)",
+            "Use .get(key, default) to handle missing keys",
+            f"Expression: {preview}",
+        ]
+    else:
+        message = f"Expression validation failed: {error}"
+        suggestions = [
+            "Check expression syntax",
+            "Ensure only allowed operations are used",
+            "See tool description for allowed operations",
+            f"Expression: {preview}",
+        ]
+    return message, suggestions
+
+
 def get_security_documentation() -> str:
     """
     Get formatted documentation of security restrictions.
@@ -384,8 +462,10 @@ PYTHON TRANSFORM SECURITY:
 - Loops: for, while, if/else, pass, break, continue
 - Comprehensions: [x for x in ...], {k: v for ...}, (x for x in ...)
 - Ternary: x if condition else y
-- Unpacking: [*list], {**dict}, func(*args, **kwargs)
+- Iterable unpacking (* in calls/literals): f(*xs), [*xs, y]
+- Dict unpacking (**) in calls and dict literals: {**d, 'k': v}
 - Keyword arguments: func(key=value)
+- Lambdas (e.g. for `key=`): sorted(items, key=lambda x: x['score'])
 - String methods: startswith, endswith, lower, upper, split, join
 - Safe builtins: isinstance, len, range, enumerate, zip, sorted, reversed,
   min, max, sum, abs, any, all, round, str, int, float, bool, list, dict,
@@ -401,9 +481,10 @@ PYTHON TRANSFORM SECURITY:
 
 🎯 PATTERNS:
 - Filter cards: cards = [c for c in cards if keep(c)]
-- Skip in a loop: use `continue`, not a `pass` branch
-- Conditionally include: cards.append(x) only when wanted, instead of
-  rebuilding the list with if/pass branches
+- Skip in a loop: prefer `continue` over an empty `pass` branch (clearer)
+- Conditionally include: build a new list and `.append(x)` only the
+  cards you want, instead of iterating the original and using if/pass
+  branches to drop entries
 - Modify in place when possible (single pass, fewer surprises) over
   reconstructing the entire list
 """.strip()

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -82,6 +82,8 @@ SAFE_NODES = {
     ast.Tuple,
     ast.Set,
     ast.Starred,  # *iterable in calls/literals: f(*xs), [*xs, y]
+    ast.JoinedStr,  # f"…" — outer node holding parts
+    ast.FormattedValue,  # the {expr} part inside an f-string
     # Operations
     ast.Delete,
     ast.BinOp,
@@ -150,6 +152,16 @@ _NODE_SUGGESTIONS: dict[str, str] = {
     "Import": "imports aren't available; built-ins like isinstance/len/range are exposed",
     "ImportFrom": "imports aren't available; built-ins like isinstance/len/range are exposed",
     "Match": "use if/elif/else or a dict lookup instead of match/case",
+    # If Match ever enters SAFE_NODES, the sub-pattern nodes shouldn't
+    # silently slip through with a generic message.
+    "MatchAs": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchValue": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchClass": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchSingleton": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchSequence": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchMapping": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchOr": "use if/elif/else or a dict lookup instead of match/case",
+    "MatchStar": "use if/elif/else or a dict lookup instead of match/case",
 }
 
 # Whitelist of safe methods that can be called
@@ -369,6 +381,13 @@ def safe_execute_expression(
         # "ran out of memory" as "your transform was bad" would
         # mislead the agent into rewriting an expression that
         # was structurally fine.
+        #
+        # FastMCP's tool dispatch (server.py call_tool) catches
+        # `except Exception` and wraps in
+        # ``ToolError(f"Error calling tool {name!r}: {e}") from e`` —
+        # so the original exception's class name and text reach the
+        # agent, with the raw exception preserved as ``__cause__``.
+        # That's an acceptable surfacing (not opaque INTERNAL_ERROR).
         raise
     except Exception as e:
         # Truncate so embedded reprs of input data (config dicts, tokens,

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -23,16 +23,19 @@ SAFE_NODES = {
     ast.Assign,
     ast.AugAssign,  # +=, -=, etc.
     ast.AnnAssign,  # type annotations
+    ast.Pass,  # explicit no-op
     # Control flow
     ast.If,
     ast.For,
     ast.While,
     ast.Break,
     ast.Continue,
+    ast.IfExp,  # ternary: x if c else y
     # Data access
     ast.Subscript,
     ast.Attribute,
     ast.Index,
+    ast.Slice,  # list[1:3]
     ast.Name,
     ast.Load,
     ast.Store,
@@ -43,6 +46,7 @@ SAFE_NODES = {
     ast.Dict,
     ast.Tuple,
     ast.Set,
+    ast.Starred,  # *args / [*list] unpacking
     # Operations
     ast.Delete,
     ast.BinOp,
@@ -73,13 +77,35 @@ SAFE_NODES = {
     ast.IsNot,
     # Function calls (validated separately)
     ast.Call,
+    ast.keyword,  # keyword arguments: func(key=value)
     # Comprehensions
     ast.ListComp,
     ast.DictComp,
     ast.SetComp,
+    ast.GeneratorExp,  # (x for x in ...)
     ast.comprehension,
     # Lambda (for comprehensions)
     ast.Lambda,
+}
+
+
+# Hints to help agents recover when a forbidden node is encountered.
+# Keyed on AST class name. Empty / unknown keys fall through to the
+# generic message.
+_NODE_SUGGESTIONS: dict[str, str] = {
+    "Try": "validate inputs with isinstance/in/.get() instead of try/except",
+    "ExceptHandler": "validate inputs with isinstance/in/.get() instead of try/except",
+    "With": "perform the inner logic directly; with-blocks aren't supported",
+    "AsyncWith": "perform the inner logic directly; with-blocks aren't supported",
+    "FunctionDef": "use a list comprehension or inline the logic",
+    "AsyncFunctionDef": "use a list comprehension or inline the logic",
+    "ClassDef": "use a dict literal instead of defining a class",
+    "Yield": "build a list with a comprehension or for-loop append",
+    "YieldFrom": "build a list with a comprehension or for-loop append",
+    "Global": "assign directly to the variable; scope keywords aren't supported",
+    "Nonlocal": "assign directly to the variable; scope keywords aren't supported",
+    "Import": "imports aren't available; built-ins like isinstance/len/range are exposed",
+    "ImportFrom": "imports aren't available; built-ins like isinstance/len/range are exposed",
 }
 
 # Whitelist of safe methods that can be called
@@ -203,7 +229,11 @@ def validate_expression(expr: str) -> tuple[bool, str]:
 def _validate_node(node: ast.AST) -> str | None:
     """Validate a single AST node. Returns error message or None if safe."""
     if type(node) not in SAFE_NODES:
-        return f"Forbidden node type: {type(node).__name__}"
+        name = type(node).__name__
+        hint = _NODE_SUGGESTIONS.get(name)
+        if hint:
+            return f"Forbidden node type: {name} — {hint}"
+        return f"Forbidden node type: {name}"
 
     if isinstance(node, (ast.Import, ast.ImportFrom)):
         return "Forbidden: imports not allowed"
@@ -346,12 +376,16 @@ PYTHON TRANSFORM SECURITY:
 
 ✅ ALLOWED:
 - Dictionary/list access: config['views'][0]['cards'][1]
+- Slicing: config['views'][0]['cards'][1:3]
 - Assignment: config['key'] = 'value'
 - Deletion: del config['key'] or config.pop('key')
 - List methods: append, insert, pop, remove, clear, extend
 - Dict methods: update, get, setdefault, keys, values, items
-- Loops: for, while, if/else
-- Comprehensions: [x for x in ...]
+- Loops: for, while, if/else, pass, break, continue
+- Comprehensions: [x for x in ...], {k: v for ...}, (x for x in ...)
+- Ternary: x if condition else y
+- Unpacking: [*list], {**dict}, func(*args, **kwargs)
+- Keyword arguments: func(key=value)
 - String methods: startswith, endswith, lower, upper, split, join
 - Safe builtins: isinstance, len, range, enumerate, zip, sorted, reversed,
   min, max, sum, abs, any, all, round, str, int, float, bool, list, dict,
@@ -363,5 +397,13 @@ PYTHON TRANSFORM SECURITY:
 - Dunder access: __class__, __bases__, __subclasses__
 - Dangerous builtins: eval, exec, compile, getattr, setattr, delattr, hasattr
 - Function definitions: def, class
-- Exception handling: try/except (use validation instead)
+- Exception handling: try/except (validate with isinstance/in/.get() instead)
+
+🎯 PATTERNS:
+- Filter cards: cards = [c for c in cards if keep(c)]
+- Skip in a loop: use `continue`, not a `pass` branch
+- Conditionally include: cards.append(x) only when wanted, instead of
+  rebuilding the list with if/pass branches
+- Modify in place when possible (single pass, fewer surprises) over
+  reconstructing the entire list
 """.strip()

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -87,6 +87,121 @@ class TestUnaryOperators:
         assert result["value"] == -5
 
 
+class TestSafeNodes1159:
+    """Regression tests for issue #1159 — safe AST nodes that were over-restricted.
+
+    The sandbox is documented as a sanity-check whitelist (not a security
+    boundary), so missing pure-AST nodes cause spurious rejections of
+    legitimate Python idioms. These tests pin the gap shut.
+    """
+
+    def test_pass_statement(self):
+        """`pass` is a no-op; rejecting it forced agents to invent dummy expressions."""
+        expr = """
+for view in config['views']:
+    if view.get('path') == 'skip-me':
+        pass
+"""
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_generator_expression(self):
+        """`sum(x for x in ...)` and similar generator-arg patterns must validate."""
+        expr = "config['count'] = sum(1 for c in config['views'][0]['cards'] if c.get('type') == 'tile')"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_ternary_expression(self):
+        """`x if c else y` — fundamental Python idiom."""
+        expr = "config['icon'] = 'mdi:on' if config.get('state') == 'on' else 'mdi:off'"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_keyword_argument_in_call(self):
+        """`func(key=value)` — kwargs in calls must validate."""
+        expr = "config['views'] = sorted(config['views'], key=len, reverse=True)"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_starred_unpacking_in_list(self):
+        """`[*existing, new]` — list spread is a common merge idiom."""
+        expr = "config['views'][0]['cards'] = [*config['views'][0]['cards'], {'type': 'button'}]"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_dict_double_star_unpacking(self):
+        """`{**existing, 'k': v}` — dict spread is a common merge idiom."""
+        expr = "config['views'][0] = {**config['views'][0], 'icon': 'mdi:home'}"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_slice_expression(self):
+        """`list[1:3]` — slicing must validate."""
+        expr = "config['views'][0]['cards'] = config['views'][0]['cards'][:5]"
+        valid, error = validate_expression(expr)
+        assert valid is True, error
+
+    def test_reporter_pattern_executes(self):
+        """End-to-end: reconstruct cards list with conditional skip via `pass`.
+
+        This is the exact shape of the transform from issue #1159 — pass branch
+        inside an if inside a loop. Now executes and produces the expected result.
+        """
+        config = {
+            "views": [
+                {
+                    "path": "home",
+                    "cards": [
+                        {"type": "tile", "name": "keep-1"},
+                        {"type": "tile", "name": "drop"},
+                        {"type": "tile", "name": "keep-2"},
+                    ],
+                }
+            ]
+        }
+        expr = """
+new_cards = []
+for card in config['views'][0]['cards']:
+    if card.get('name') == 'drop':
+        pass
+    else:
+        new_cards.append(card)
+config['views'][0]['cards'] = new_cards
+"""
+        result = safe_execute(expr, config)
+        names = [c["name"] for c in result["views"][0]["cards"]]
+        assert names == ["keep-1", "keep-2"]
+
+
+class TestErrorSuggestions1159:
+    """Issue #1159 — node-rejection errors should hint at the right alternative."""
+
+    def test_try_block_includes_hint(self):
+        """try/except is rejected with a hint pointing at validation alternatives."""
+        expr = "try:\n    config['x'] = 1\nexcept Exception:\n    config['x'] = 0"
+        valid, error = validate_expression(expr)
+        assert valid is False
+        assert "Try" in error
+        assert "isinstance" in error or "validate" in error.lower()
+
+    def test_function_def_includes_hint(self):
+        """Function definitions are rejected with a hint pointing at comprehensions."""
+        expr = "def helper():\n    return 1"
+        valid, error = validate_expression(expr)
+        assert valid is False
+        assert "FunctionDef" in error
+        assert "comprehension" in error.lower() or "inline" in error.lower()
+
+    def test_unmapped_node_falls_back_to_generic(self):
+        """Nodes without a mapped suggestion produce a bare 'Forbidden node type: X'."""
+        # match statements (3.10+) — Match isn't in SAFE_NODES and we don't
+        # map a hint for it, so the message is the legacy format with no hint.
+        expr = "match config:\n    case _:\n        config['x'] = 1"
+        valid, error = validate_expression(expr)
+        assert valid is False
+        assert error == "Forbidden node type: Match"
+
+
 class TestBlockedOperations:
     """Test that dangerous operations are blocked."""
 

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -659,3 +659,23 @@ class TestFormatSandboxError:
         message, suggestions = format_sandbox_error(err, "x = 1")
         assert message.startswith("Expression validation failed:")
         assert any("syntax" in s.lower() for s in suggestions)
+
+    def test_default_variable_name_omits_target_hint(self):
+        """The default `config` callers don't get a redundant variable-name hint."""
+        err = PythonSandboxValidationError("Forbidden node type: Try")
+        _, suggestions = format_sandbox_error(err, "try: pass\nexcept: pass")
+        assert not any(
+            "Operate on the" in s and "variable" in s for s in suggestions
+        )
+
+    def test_non_default_variable_name_prepends_hint(self):
+        """A non-`config` caller (e.g. addons with `response`) gets a leading
+        'Operate on the `<name>` variable' suggestion so the agent knows what
+        to mutate."""
+        err = PythonSandboxExecutionError("KeyError: 'foo'")
+        _, suggestions = format_sandbox_error(
+            err, "response['foo']", variable_name="response"
+        )
+        assert suggestions[0] == (
+            "Operate on the `response` variable (in-place or reassign)"
+        )

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -4,6 +4,9 @@ import pytest
 
 from ha_mcp.utils.python_sandbox import (
     PythonSandboxError,
+    PythonSandboxExecutionError,
+    PythonSandboxValidationError,
+    format_sandbox_error,
     safe_execute,
     safe_execute_expression,
     validate_expression,
@@ -105,41 +108,94 @@ for view in config['views']:
         valid, error = validate_expression(expr)
         assert valid is True, error
 
-    def test_generator_expression(self):
-        """`sum(x for x in ...)` and similar generator-arg patterns must validate."""
+    def test_generator_expression_executes(self):
+        """`sum(x for x in ...)` validates AND runs."""
+        config = {"views": [{"cards": [{"type": "tile"}, {"type": "btn"}, {"type": "tile"}]}]}
         expr = "config['count'] = sum(1 for c in config['views'][0]['cards'] if c.get('type') == 'tile')"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+        result = safe_execute(expr, config)
+        assert result["count"] == 2
 
-    def test_ternary_expression(self):
-        """`x if c else y` — fundamental Python idiom."""
+    def test_ternary_expression_executes(self):
+        """`x if c else y` validates AND runs."""
+        config = {"state": "on"}
         expr = "config['icon'] = 'mdi:on' if config.get('state') == 'on' else 'mdi:off'"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+        result = safe_execute(expr, config)
+        assert result["icon"] == "mdi:on"
 
-    def test_keyword_argument_in_call(self):
-        """`func(key=value)` — kwargs in calls must validate."""
-        expr = "config['views'] = sorted(config['views'], key=len, reverse=True)"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+    def test_keyword_argument_in_call_executes(self):
+        """`sorted(..., key=len, reverse=True)` validates AND runs (sorted/len are safe builtins)."""
+        config = {"items": ["aaa", "b", "cc"]}
+        expr = "config['items'] = sorted(config['items'], key=len, reverse=True)"
+        result = safe_execute(expr, config)
+        assert result["items"] == ["aaa", "cc", "b"]
 
-    def test_starred_unpacking_in_list(self):
-        """`[*existing, new]` — list spread is a common merge idiom."""
-        expr = "config['views'][0]['cards'] = [*config['views'][0]['cards'], {'type': 'button'}]"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+    def test_starred_unpacking_in_list_executes(self):
+        """`[*existing, new]` validates AND runs."""
+        config = {"cards": [{"type": "a"}, {"type": "b"}]}
+        expr = "config['cards'] = [*config['cards'], {'type': 'c'}]"
+        result = safe_execute(expr, config)
+        assert [c["type"] for c in result["cards"]] == ["a", "b", "c"]
 
-    def test_dict_double_star_unpacking(self):
-        """`{**existing, 'k': v}` — dict spread is a common merge idiom."""
-        expr = "config['views'][0] = {**config['views'][0], 'icon': 'mdi:home'}"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+    def test_dict_double_star_unpacking_executes(self):
+        """`{**existing, 'k': v}` validates AND runs (Dict node, not Starred)."""
+        config = {"view": {"icon": "old", "title": "Home"}}
+        expr = "config['view'] = {**config['view'], 'icon': 'mdi:home'}"
+        result = safe_execute(expr, config)
+        assert result["view"] == {"icon": "mdi:home", "title": "Home"}
 
-    def test_slice_expression(self):
-        """`list[1:3]` — slicing must validate."""
-        expr = "config['views'][0]['cards'] = config['views'][0]['cards'][:5]"
-        valid, error = validate_expression(expr)
-        assert valid is True, error
+    def test_slice_expression_executes(self):
+        """`list[:N]` validates AND runs."""
+        config = {"cards": list(range(10))}
+        expr = "config['cards'] = config['cards'][:5]"
+        result = safe_execute(expr, config)
+        assert result["cards"] == [0, 1, 2, 3, 4]
+
+    def test_slice_with_step_executes(self):
+        """`list[::2]` — slice with step (uses ast.Slice with step field)."""
+        config = {"cards": list(range(10))}
+        expr = "config['cards'] = config['cards'][::2]"
+        result = safe_execute(expr, config)
+        assert result["cards"] == [0, 2, 4, 6, 8]
+
+    def test_lambda_as_kwarg_executes(self):
+        """`sorted(..., key=lambda x: ...)` — the canonical lambda use case.
+
+        Previously broken: ast.Lambda was whitelisted but the ast.arguments
+        / ast.arg structure nodes inside it were not, so any lambda failed
+        validation despite the comment "Lambda (for comprehensions)" claiming
+        otherwise.
+        """
+        config = {"items": [{"n": 3}, {"n": 1}, {"n": 2}]}
+        expr = "config['items'] = sorted(config['items'], key=lambda x: x['n'])"
+        result = safe_execute(expr, config)
+        assert [i["n"] for i in result["items"]] == [1, 2, 3]
+
+    def test_compositional_pattern_executes(self):
+        """Realistic agent code: ternary inside a comprehension, kwarg call,
+        starred unpacking — all in one transform."""
+        config = {
+            "cards": [
+                {"name": "a", "score": 3},
+                {"name": "b", "score": 1},
+                {"name": "c", "score": 2},
+            ],
+            "extras": [{"name": "z", "score": 99}],
+        }
+        # Sort by score (kwarg call), pick top 2 (slice), tag each (ternary
+        # inside comprehension), then unpack with extras (starred).
+        expr = """
+top = sorted(config['cards'], key=lambda c: c['score'], reverse=True)[:2]
+config['cards'] = [
+    {**c, 'tier': 'gold' if c['score'] >= 3 else 'silver'}
+    for c in top
+]
+config['cards'] = [*config['cards'], *config['extras']]
+"""
+        result = safe_execute(expr, config)
+        names = [c["name"] for c in result["cards"]]
+        assert names == ["a", "c", "z"]
+        tiers = [c.get("tier") for c in result["cards"]]
+        assert tiers == ["gold", "silver", None]
 
     def test_reporter_pattern_executes(self):
         """End-to-end: reconstruct cards list with conditional skip via `pass`.
@@ -177,29 +233,48 @@ class TestErrorSuggestions1159:
     """Issue #1159 — node-rejection errors should hint at the right alternative."""
 
     def test_try_block_includes_hint(self):
-        """try/except is rejected with a hint pointing at validation alternatives."""
+        """try/except is rejected with the exact mapped hint."""
         expr = "try:\n    config['x'] = 1\nexcept Exception:\n    config['x'] = 0"
         valid, error = validate_expression(expr)
         assert valid is False
-        assert "Try" in error
-        assert "isinstance" in error or "validate" in error.lower()
+        assert error == (
+            "Forbidden node type: Try — "
+            "validate inputs with isinstance/in/.get() instead of try/except"
+        )
 
     def test_function_def_includes_hint(self):
-        """Function definitions are rejected with a hint pointing at comprehensions."""
+        """Function definitions are rejected with the exact mapped hint."""
         expr = "def helper():\n    return 1"
         valid, error = validate_expression(expr)
         assert valid is False
-        assert "FunctionDef" in error
-        assert "comprehension" in error.lower() or "inline" in error.lower()
+        assert error == (
+            "Forbidden node type: FunctionDef — "
+            "use a list comprehension or inline the logic"
+        )
 
-    def test_unmapped_node_falls_back_to_generic(self):
-        """Nodes without a mapped suggestion produce a bare 'Forbidden node type: X'."""
-        # match statements (3.10+) — Match isn't in SAFE_NODES and we don't
-        # map a hint for it, so the message is the legacy format with no hint.
+    def test_match_statement_includes_hint(self):
+        """match/case (3.10+) is rejected with the mapped hint."""
         expr = "match config:\n    case _:\n        config['x'] = 1"
         valid, error = validate_expression(expr)
         assert valid is False
-        assert error == "Forbidden node type: Match"
+        assert error == (
+            "Forbidden node type: Match — "
+            "use if/elif/else or a dict lookup instead of match/case"
+        )
+
+    def test_unmapped_node_falls_back_to_generic(self):
+        """Nodes without a mapped suggestion produce a bare 'Forbidden node type: X'.
+
+        ``raise`` is a deliberately unmapped node — it isn't in SAFE_NODES
+        and intentionally has no recovery hint (raising in transforms is
+        nonsense; the right fix is to not raise at all). Picking a node
+        that's structurally unfit for any hint keeps the test stable as
+        new hints get added.
+        """
+        expr = "raise ValueError('nope')"
+        valid, error = validate_expression(expr)
+        assert valid is False
+        assert error == "Forbidden node type: Raise"
 
 
 class TestBlockedOperations:
@@ -346,17 +421,17 @@ for card in config['views'][0]['cards']:
         assert result["views"][0]["cards"][2]["icon"] == "old"  # Not a light
 
     def test_blocked_expression_raises(self):
-        """Test that blocked expressions raise PythonSandboxError."""
+        """Test that blocked expressions raise PythonSandboxValidationError."""
         config = {}
         expr = "import os"
-        with pytest.raises(PythonSandboxError, match="validation failed"):
+        with pytest.raises(PythonSandboxValidationError):
             safe_execute(expr, config)
 
     def test_execution_error_raises(self):
         """Test that execution errors are caught."""
         config = {}
         expr = "config['nonexistent']['key'] = 'value'"
-        with pytest.raises(PythonSandboxError, match="Execution error"):
+        with pytest.raises(PythonSandboxExecutionError):
             safe_execute(expr, config)
 
 
@@ -389,20 +464,20 @@ class TestSafeExecuteExpression:
         assert original == [1, 2, 3, 4]  # same reference, mutated
 
     def test_missing_result_key_raises(self):
-        """If result_key is not in variables, raise PythonSandboxError up front."""
-        with pytest.raises(PythonSandboxError, match="result_key"):
+        """If result_key is not in variables, raise PythonSandboxValidationError up front."""
+        with pytest.raises(PythonSandboxValidationError, match="result_key"):
             safe_execute_expression(
                 "response = 1", {"other": 1}, "response"
             )
 
     def test_validation_failure_raises(self):
-        """Invalid expressions raise with 'validation failed' prefix."""
-        with pytest.raises(PythonSandboxError, match="validation failed"):
+        """Invalid expressions raise PythonSandboxValidationError."""
+        with pytest.raises(PythonSandboxValidationError):
             safe_execute_expression("import os", {"response": None}, "response")
 
     def test_execution_error_raises(self):
-        """Runtime errors in the expression raise with 'Execution error' prefix."""
-        with pytest.raises(PythonSandboxError, match="Execution error"):
+        """Runtime errors raise PythonSandboxExecutionError."""
+        with pytest.raises(PythonSandboxExecutionError):
             safe_execute_expression(
                 "response['missing']['key'] = 1",
                 {"response": {}},
@@ -443,14 +518,14 @@ class TestSafeExecuteExpression:
 
     def test_builtins_do_not_include_open(self):
         """Dangerous builtins like open remain blocked at AST validation."""
-        with pytest.raises(PythonSandboxError, match="validation failed"):
+        with pytest.raises(PythonSandboxValidationError):
             safe_execute_expression(
                 "open('/etc/passwd')", {"response": None}, "response"
             )
 
     def test_builtins_do_not_include_getattr(self):
         """getattr remains blocked at AST validation."""
-        with pytest.raises(PythonSandboxError, match="validation failed"):
+        with pytest.raises(PythonSandboxValidationError):
             safe_execute_expression(
                 "getattr(response, '__class__')",
                 {"response": []},
@@ -462,3 +537,95 @@ class TestSafeExecuteExpression:
         config = {"views": [{"icon": "old"}]}
         result = safe_execute("config['views'][0]['icon'] = 'new'", config)
         assert result["views"][0]["icon"] == "new"
+
+
+class TestSandboxErrorSubclasses1159:
+    """Issue #1159 — distinguish validation-time vs runtime sandbox failures.
+
+    Both subclasses inherit ``PythonSandboxError`` so any pre-existing
+    ``except PythonSandboxError`` block still catches them; but new code
+    can branch on the subclass to give the user the right suggestion.
+    """
+
+    def test_subclasses_inherit_base(self):
+        """Backward compat: callers catching the base class still work."""
+        assert issubclass(PythonSandboxValidationError, PythonSandboxError)
+        assert issubclass(PythonSandboxExecutionError, PythonSandboxError)
+
+    def test_validation_error_is_distinct_from_execution_error(self):
+        """A validation failure should not match an execution-error catcher."""
+        with pytest.raises(PythonSandboxValidationError):
+            safe_execute("import os", {})
+        # And the execution-error class shouldn't catch a validation failure.
+        try:
+            safe_execute("import os", {})
+        except PythonSandboxExecutionError:
+            pytest.fail("validation error matched PythonSandboxExecutionError")
+        except PythonSandboxValidationError:
+            pass
+
+    def test_execution_error_is_distinct_from_validation_error(self):
+        """A runtime failure should not match a validation-error catcher."""
+        with pytest.raises(PythonSandboxExecutionError):
+            safe_execute("config['nope']['x'] = 1", {})
+        try:
+            safe_execute("config['nope']['x'] = 1", {})
+        except PythonSandboxValidationError:
+            pytest.fail("execution error matched PythonSandboxValidationError")
+        except PythonSandboxExecutionError:
+            pass
+
+    def test_execution_error_truncates_long_exception_text(self):
+        """Runtime exception text is capped so embedded config/data isn't pasted whole.
+
+        HA dashboards/automations may carry tokens or device IDs that get
+        reflected back in KeyError messages; without truncation those would
+        reach the caller verbatim.
+        """
+        long_key = "x" * 1000
+        # KeyError on a missing key embeds the key (repr'd) in its str().
+        expr = f"config[{long_key!r}]"
+        with pytest.raises(PythonSandboxExecutionError) as exc_info:
+            safe_execute(expr, {})
+        text = str(exc_info.value)
+        assert len(text) <= 240, f"runtime error text not truncated: {len(text)} chars"
+        assert text.endswith("...")
+
+
+class TestFormatSandboxError1159:
+    """Issue #1159 — caller-facing helper that picks message + suggestions
+    based on the exception subclass."""
+
+    def test_validation_error_suggestions_point_at_syntax(self):
+        err = PythonSandboxValidationError("Forbidden node type: Try")
+        message, suggestions = format_sandbox_error(err, "try: pass\nexcept: pass")
+        assert message.startswith("Expression validation failed:")
+        assert any("syntax" in s.lower() for s in suggestions)
+        assert any("allowed operations" in s.lower() for s in suggestions)
+
+    def test_execution_error_suggestions_point_at_data(self):
+        err = PythonSandboxExecutionError("KeyError: 'foo'")
+        message, suggestions = format_sandbox_error(err, "config['foo']['bar'] = 1")
+        assert message.startswith("Expression raised at runtime:")
+        # Should NOT advise the user to fix syntax — the syntax was fine.
+        assert not any("syntax" in s.lower() for s in suggestions)
+        assert any(
+            "key" in s.lower() or ".get" in s.lower() or "type" in s.lower()
+            for s in suggestions
+        )
+
+    def test_expression_preview_truncates_long_input(self):
+        long_expr = "config['x'] = " + ("'a' + " * 50) + "'end'"
+        err = PythonSandboxExecutionError("boom")
+        _, suggestions = format_sandbox_error(err, long_expr)
+        preview = next(s for s in suggestions if s.startswith("Expression:"))
+        assert preview.endswith("...")
+        # Body of the preview (after "Expression: ") is exactly 100 chars + "..."
+        assert len(preview) <= len("Expression: ") + 103
+
+    def test_plain_base_error_falls_back_to_validation_form(self):
+        """A bare PythonSandboxError (no subclass) should not look like a runtime failure."""
+        err = PythonSandboxError("legacy")
+        message, suggestions = format_sandbox_error(err, "x = 1")
+        assert message.startswith("Expression validation failed:")
+        assert any("syntax" in s.lower() for s in suggestions)

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -3,6 +3,7 @@
 import pytest
 
 from ha_mcp.utils.python_sandbox import (
+    _EXECUTION_ERROR_TEXT_LIMIT,
     PythonSandboxError,
     PythonSandboxExecutionError,
     PythonSandboxValidationError,
@@ -539,7 +540,7 @@ class TestSafeExecuteExpression:
         assert result["views"][0]["icon"] == "new"
 
 
-class TestSandboxErrorSubclasses1159:
+class TestSandboxErrorSubclasses:
     """Issue #1159 — distinguish validation-time vs runtime sandbox failures.
 
     Both subclasses inherit ``PythonSandboxError`` so any pre-existing
@@ -580,7 +581,8 @@ class TestSandboxErrorSubclasses1159:
 
         HA dashboards/automations may carry tokens or device IDs that get
         reflected back in KeyError messages; without truncation those would
-        reach the caller verbatim.
+        reach the caller verbatim. Asserts on the constant + cap rather than
+        the literal sentinel so the test survives a sentinel change.
         """
         long_key = "x" * 1000
         # KeyError on a missing key embeds the key (repr'd) in its str().
@@ -588,11 +590,39 @@ class TestSandboxErrorSubclasses1159:
         with pytest.raises(PythonSandboxExecutionError) as exc_info:
             safe_execute(expr, {})
         text = str(exc_info.value)
-        assert len(text) <= 240, f"runtime error text not truncated: {len(text)} chars"
-        assert text.endswith("...")
+        assert len(text) <= _EXECUTION_ERROR_TEXT_LIMIT, (
+            f"runtime error text not truncated: {len(text)} chars"
+        )
+        # Without truncation the message would include the full 1000-char key
+        # plus the KeyError/repr framing — we want strict evidence that
+        # nothing close to that survived.
+        assert len(text) < len(long_key)
+
+    def test_memory_error_propagates(self):
+        """Resource-exhaustion errors must not be reframed as user-input failures.
+
+        MemoryError / RecursionError from exec() aren't transform-syntax
+        issues the agent can fix by trying again — they're infrastructure
+        signals the host needs to handle. Wrapping them in
+        PythonSandboxExecutionError with "verify keys/types" suggestions
+        would mislead.
+        """
+        from unittest.mock import patch
+
+        for infra_exc in (MemoryError("oom"), RecursionError("too deep")):
+            with (
+                patch(
+                    "ha_mcp.utils.python_sandbox.exec",
+                    side_effect=infra_exc,
+                ),
+                pytest.raises(type(infra_exc)),
+            ):
+                safe_execute_expression(
+                    "response = 1", {"response": 0}, "response"
+                )
 
 
-class TestFormatSandboxError1159:
+class TestFormatSandboxError:
     """Issue #1159 — caller-facing helper that picks message + suggestions
     based on the exception subclass."""
 

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -171,6 +171,62 @@ for view in config['views']:
         result = safe_execute(expr, config)
         assert [i["n"] for i in result["items"]] == [1, 2, 3]
 
+    def test_fstring_executes(self):
+        """f-strings (`ast.JoinedStr` / `ast.FormattedValue`) — common in
+        transform expressions like setting `name = f"{prefix}_thing"`."""
+        config = {"prefix": "lr", "card": {}}
+        expr = "config['card']['entity'] = f\"light.{config['prefix']}_main\""
+        result = safe_execute(expr, config)
+        assert result["card"]["entity"] == "light.lr_main"
+
+    def test_fstring_with_format_spec_executes(self):
+        """f-strings with format specifiers exercise the FormattedValue node fully."""
+        config = {"score": 7.5, "card": {}}
+        expr = "config['card']['label'] = f\"{config['score']:.1f}/10\""
+        result = safe_execute(expr, config)
+        assert result["card"]["label"] == "7.5/10"
+
+    def test_match_family_includes_hint(self):
+        """Sub-pattern Match nodes get the same hint as Match itself.
+
+        These nodes are unreachable today (Match itself is rejected at the
+        SAFE_NODES check first), but if Match ever enters SAFE_NODES the
+        sub-patterns shouldn't silently slip through with a generic message.
+        Test by validating each sub-pattern node directly.
+        """
+        import ast
+
+        for node_name in (
+            "MatchAs",
+            "MatchValue",
+            "MatchClass",
+            "MatchSingleton",
+            "MatchSequence",
+            "MatchMapping",
+            "MatchOr",
+            "MatchStar",
+        ):
+            assert hasattr(ast, node_name), f"ast.{node_name} not present"
+        # Indirectly verify via _NODE_SUGGESTIONS — every Match* family
+        # member is mapped to a recovery hint.
+        from ha_mcp.utils.python_sandbox import _NODE_SUGGESTIONS
+
+        for node_name in (
+            "Match",
+            "MatchAs",
+            "MatchValue",
+            "MatchClass",
+            "MatchSingleton",
+            "MatchSequence",
+            "MatchMapping",
+            "MatchOr",
+            "MatchStar",
+        ):
+            assert node_name in _NODE_SUGGESTIONS, (
+                f"{node_name} missing from _NODE_SUGGESTIONS"
+            )
+            assert "if/elif/else" in _NODE_SUGGESTIONS[node_name]
+
     def test_compositional_pattern_executes(self):
         """Realistic agent code: ternary inside a comprehension, kwarg call,
         starred unpacking — all in one transform."""

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -2058,22 +2058,24 @@ class TestApplyResponseTransform:
         assert {"level": "ERROR", "msg": "boom"} in result
 
     def test_invalid_expression_raises_tool_error(self):
-        """Forbidden operations raise ToolError with VALIDATION_FAILED."""
+        """Forbidden operations raise ToolError with the validation-error
+        message produced by ``format_sandbox_error``."""
         with pytest.raises(ToolError) as exc_info:
             _apply_response_transform([1, 2, 3], "import os")
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "python_transform failed" in result["error"]["message"]
+        assert "Expression validation failed" in result["error"]["message"]
 
     def test_runtime_error_raises_tool_error(self):
-        """Runtime execution errors surface as ToolError with preview."""
+        """Runtime execution errors surface as ToolError with the
+        runtime-error message (distinct from validation failures)."""
         with pytest.raises(ToolError) as exc_info:
             _apply_response_transform(
                 {}, "response['missing']['key'] = 1"
             )
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "python_transform failed" in result["error"]["message"]
+        assert "Expression raised at runtime" in result["error"]["message"]
 
 
 class TestCallAddonWsNewParams:
@@ -2343,7 +2345,7 @@ class TestCallAddonWsNewParams:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "python_transform failed" in result["error"]["message"]
+        assert "Expression validation failed" in result["error"]["message"]
 
 
 class TestCallAddonApiPythonTransform:
@@ -2447,7 +2449,7 @@ class TestCallAddonApiPythonTransform:
 
         result = _parse_tool_error(exc_info)
         assert result["success"] is False
-        assert "python_transform failed" in result["error"]["message"]
+        assert "Expression validation failed" in result["error"]["message"]
 
 
 # Mock Supervisor API responses for list_addons tests


### PR DESCRIPTION
Closes #1159

## What does this PR do?

The Python expression sandbox used by `python_transform` (dashboards, automations, scripts, addons) over-rejects several pure-AST nodes that are everyday Python idioms. The file's own module docstring is explicit that this is a sanity-check whitelist, **not** a security boundary, so missing these nodes only causes spurious failures with no defensive upside.

### Newly allowed `SAFE_NODES`
- `ast.Pass` — explicit no-op
- `ast.GeneratorExp` — `sum(x for x in ...)`
- `ast.IfExp` — ternary `x if c else y`
- `ast.keyword` — keyword arguments in calls
- `ast.Starred` — `[*list, x]` / `f(*args)`
- `ast.Slice` — `cards[1:3]`, `cards[::2]`
- `ast.arguments` / `ast.arg` — needed for `lambda` to actually validate (was whitelisted but unusable; same category as #1159, fixed inline)
- `ast.JoinedStr` / `ast.FormattedValue` — f-strings (`name = f"{prefix}_thing"`); same pure-AST gap

### Validation vs runtime errors are now distinct
Split `PythonSandboxError` into `PythonSandboxValidationError` (AST rejected) and `PythonSandboxExecutionError` (validated expression raised). Both inherit the base for backward compatibility. New `format_sandbox_error(error, expr, variable_name="config")` helper picks appropriate suggestions per subclass — fixes a long-standing UX issue where runtime `KeyError`/`TypeError` failures were reported with "fix your syntax" suggestions. The `variable_name` kwarg lets the addons caller pass `"response"` so the helper itself emits the "Operate on the `<name>` variable" hint instead of each caller doing its own prepend.

### Other fixes
- Runtime exception text truncated (240 chars) — was leaking config values embedded in `KeyError` reprs.
- `MemoryError` / `RecursionError` propagate raw from `exec()` instead of being wrapped — infrastructure failures shouldn't be misclassified as user-input errors. Verified that FastMCP 3.2.4 wraps these as `ToolError(f"Error calling tool {name!r}: {e}") from e`, so the original class name + text still reach the agent (with the raw exception preserved as `__cause__`); not opaque `INTERNAL_ERROR`. Documented inline.
- Removed dead `isinstance()` blocks in `_validate_node` that were unreachable after the SAFE_NODES check; rejections now surface the mapped recovery hint.
- `_NODE_SUGGESTIONS` map for actionable rejection messages — Try/TryStar, With/AsyncWith, FunctionDef/AsyncFunctionDef/ClassDef, Yield/YieldFrom, Global/Nonlocal, Import/ImportFrom, and the full Match-pattern family (`Match`, `MatchAs`, `MatchValue`, `MatchClass`, `MatchSingleton`, `MatchSequence`, `MatchMapping`, `MatchOr`, `MatchStar`).
- Documentation updates: PATTERNS section, Starred comment, Unpacking line.

## Tests
~35 new unit tests covering each newly-allowed node end-to-end through `safe_execute`, the subclass split, the `format_sandbox_error` helper (with and without `variable_name`), exception-text truncation, infra-error propagation (mocked `MemoryError` / `RecursionError`), hint enrichment, the full Match-family hint mapping, f-strings (basic + format-spec + inside comprehension), and a compositional pattern combining ternary + comprehension + lambda + slice + starred unpacking.

## Investigation context
The reporter's transform was a list-reconstruction with `if/pass` skip branches. Reproduced the original error on a real HA dashboard. Then ran four minimal-context agent reproductions of the underlying task ("add a sensor to a card") — none chose the reconstruction strategy; all used `.append()`. So the lockout is real (this PR), but the reporter's specific scenario was also partly an agent-strategy issue — addressed via the PATTERNS docstring nudges and the actionable error messages.