### PR TITLE
fix(search): apply domain_filter when area_filter is set (#1162)

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -32,20 +32,13 @@ def _build_pagination_metadata(
     """Build standardized pagination metadata for search responses.
 
     Thin wrapper around the shared ``build_pagination_metadata`` helper that
-    keeps the existing call-site signature (accepts a *results* list and uses
-    ``total_matches`` as the key name expected by search tools).
+    keeps the existing call-site signature (accepts a *results* list) and
+    renames ``total_count`` → ``total_matches`` to match the search tools'
+    response shape.
     """
     meta = build_pagination_metadata(total_matches, offset, limit, len(results))
-    # Search tools use "total_matches" instead of "total_count" —
-    # construct explicitly to avoid fragile dependency on shared helper's key names
-    return {
-        "total_matches": meta["total_count"],
-        "offset": meta["offset"],
-        "limit": meta["limit"],
-        "count": meta["count"],
-        "has_more": meta["has_more"],
-        "next_offset": meta["next_offset"],
-    }
+    meta["total_matches"] = meta.pop("total_count")
+    return meta
 
 
 async def _exact_match_search(

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -242,31 +242,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 # If we also have a query, filter the area results
                 if query and query.strip():
                     # Collect entities from all matched areas, applying
-                    # domain_filter if present.
+                    # domain_filter if present. get_entities_by_area is called
+                    # with group_by_domain=True above, so entities is always a
+                    # dict keyed by domain.
                     all_area_entities = []
-                    if "areas" in area_result:
-                        for area_data in area_result["areas"].values():
-                            entities = area_data.get("entities")
-                            if not entities:
-                                continue
-                            if isinstance(entities, dict):  # grouped by domain
-                                if domain_filter:
-                                    all_area_entities.extend(
-                                        entities.get(domain_filter, [])
-                                    )
-                                else:
-                                    for domain_entities in entities.values():
-                                        all_area_entities.extend(domain_entities)
-                            else:  # flat list
-                                if domain_filter:
-                                    prefix = f"{domain_filter}."
-                                    all_area_entities.extend(
-                                        e
-                                        for e in entities
-                                        if e.get("entity_id", "").startswith(prefix)
-                                    )
-                                else:
-                                    all_area_entities.extend(entities)
+                    for area_data in area_result.get("areas", {}).values():
+                        entities = area_data.get("entities") or {}
+                        if domain_filter:
+                            all_area_entities.extend(entities.get(domain_filter, []))
+                        else:
+                            for domain_entities in entities.values():
+                                all_area_entities.extend(domain_entities)
 
                     # Apply fuzzy search to area entities
                     from ..utils.fuzzy_search import create_fuzzy_searcher
@@ -337,24 +323,15 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         # Build a flat results list, applying domain_filter and
                         # tagging each entity with its `domain` so the optional
                         # by_domain rebuild below can group without re-parsing
-                        # entity_id. Both dict and flat shapes from
-                        # get_entities_by_area are handled to mirror its two
-                        # return shapes. Using `{**entity, "domain": domain}`
-                        # avoids mutating dicts owned by the helper.
+                        # entity_id. `{**entity, "domain": domain}` avoids
+                        # mutating dicts owned by the helper.
                         all_results: list[dict[str, Any]] = []
-                        if isinstance(entities_data, dict):
-                            for domain, entities in entities_data.items():
-                                if domain_filter and domain != domain_filter:
-                                    continue
-                                all_results.extend(
-                                    {**entity, "domain": domain} for entity in entities
-                                )
-                        elif entities_data:  # flat list
-                            for entity in entities_data:
-                                domain = entity.get("entity_id", "").split(".", 1)[0]
-                                if domain_filter and domain != domain_filter:
-                                    continue
-                                all_results.append({**entity, "domain": domain})
+                        for domain, entities in (entities_data or {}).items():
+                            if domain_filter and domain != domain_filter:
+                                continue
+                            all_results.extend(
+                                {**entity, "domain": domain} for entity in entities
+                            )
 
                         paginated = all_results[offset : offset + limit]
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -241,20 +241,32 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                 # If we also have a query, filter the area results
                 if query and query.strip():
-                    # Get all entities from all areas in the result
+                    # Collect entities from all matched areas, applying
+                    # domain_filter if present (issue #1162).
                     all_area_entities = []
                     if "areas" in area_result:
                         for area_data in area_result["areas"].values():
-                            if "entities" in area_data:
-                                if isinstance(
-                                    area_data["entities"], dict
-                                ):  # grouped by domain
-                                    for domain_entities in area_data[
-                                        "entities"
-                                    ].values():
+                            entities = area_data.get("entities")
+                            if not entities:
+                                continue
+                            if isinstance(entities, dict):  # grouped by domain
+                                if domain_filter:
+                                    all_area_entities.extend(
+                                        entities.get(domain_filter, [])
+                                    )
+                                else:
+                                    for domain_entities in entities.values():
                                         all_area_entities.extend(domain_entities)
-                                else:  # flat list
-                                    all_area_entities.extend(area_data["entities"])
+                            else:  # flat list
+                                if domain_filter:
+                                    all_area_entities.extend(
+                                        e
+                                        for e in entities
+                                        if e.get("entity_id", "").split(".", 1)[0]
+                                        == domain_filter
+                                    )
+                                else:
+                                    all_area_entities.extend(entities)
 
                     # Apply fuzzy search to area entities
                     from ..utils.fuzzy_search import create_fuzzy_searcher
@@ -303,6 +315,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "results": results,
                         "search_type": "area_filtered_query",
                     }
+                    if domain_filter:
+                        search_data["domain_filter"] = domain_filter
 
                     if group_by_domain_bool:
                         by_domain: dict[str, list[dict[str, Any]]] = {}
@@ -318,35 +332,59 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # Just area filter, return area results with enhanced format
                     if area_result.get("areas"):
                         first_area = next(iter(area_result["areas"].values()))
-                        by_domain = first_area.get("entities", {})
+                        area_by_domain: dict[str, list[dict[str, Any]]] = (
+                            first_area.get("entities", {})
+                        )
 
-                        # Flatten for results while keeping by_domain structure
+                        # Apply domain_filter to the area's by_domain mapping
+                        # before flattening (issue #1162).
+                        if domain_filter:
+                            area_by_domain = {
+                                domain_filter: area_by_domain.get(domain_filter, [])
+                            }
+
+                        # Flatten to a single results list, then paginate.
                         all_results = []
-                        for domain, entities in by_domain.items():
+                        for domain, entities in area_by_domain.items():
                             for entity in entities:
                                 entity["domain"] = domain
                                 all_results.append(entity)
 
-                        area_search_data = {
+                        paginated = all_results[offset : offset + limit]
+
+                        # Rebuild by_domain from the paginated subset so the
+                        # grouped view matches the flat results.
+                        paginated_by_domain: dict[str, list[dict[str, Any]]] = {}
+                        for entity in paginated:
+                            d = entity["domain"]
+                            paginated_by_domain.setdefault(d, []).append(entity)
+
+                        area_search_data: dict[str, Any] = {
                             "success": True,
                             "area_filter": area_filter,
-                            "total_matches": len(all_results),
-                            "results": all_results,
-                            "by_domain": by_domain,
+                            **_build_pagination_metadata(
+                                len(all_results), offset, limit, paginated
+                            ),
+                            "results": paginated,
+                            "by_domain": paginated_by_domain,
                             "search_type": "area_only",
                             "area_name": first_area.get("area_name", area_filter),
                         }
+                        if domain_filter:
+                            area_search_data["domain_filter"] = domain_filter
                         return await add_timezone_metadata(client, area_search_data)
                     else:
-                        empty_area_data = {
+                        empty_area_data: dict[str, Any] = {
                             "success": True,
                             "area_filter": area_filter,
-                            "total_matches": 0,
+                            **_build_pagination_metadata(0, offset, limit, []),
                             "results": [],
                             "by_domain": {},
                             "search_type": "area_only",
                             "message": f"No entities found in area: {area_filter}",
                         }
+                        if domain_filter:
+                            empty_area_data["domain_filter"] = domain_filter
                         return await add_timezone_metadata(client, empty_area_data)
 
             # Regular entity search (no area filter)
@@ -929,22 +967,28 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         MAX_ENTITIES = 100
 
         if not isinstance(entity_ids, list) or not entity_ids:
-            raise_tool_error(create_validation_error(
-                "entity_id must be a non-empty string or list of entity ID strings",
-                parameter="entity_id",
-            ))
+            raise_tool_error(
+                create_validation_error(
+                    "entity_id must be a non-empty string or list of entity ID strings",
+                    parameter="entity_id",
+                )
+            )
 
         if not all(isinstance(eid, str) for eid in entity_ids):
-            raise_tool_error(create_validation_error(
-                "All entity_id values must be strings",
-                parameter="entity_id",
-            ))
+            raise_tool_error(
+                create_validation_error(
+                    "All entity_id values must be strings",
+                    parameter="entity_id",
+                )
+            )
 
         if len(entity_ids) > MAX_ENTITIES:
-            raise_tool_error(create_validation_error(
-                f"Too many entity IDs: {len(entity_ids)} exceeds maximum of {MAX_ENTITIES}",
-                parameter="entity_id",
-            ))
+            raise_tool_error(
+                create_validation_error(
+                    f"Too many entity IDs: {len(entity_ids)} exceeds maximum of {MAX_ENTITIES}",
+                    parameter="entity_id",
+                )
+            )
 
         # Deduplicate while preserving order
         unique_ids = list(dict.fromkeys(entity_ids))

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -259,11 +259,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                         all_area_entities.extend(domain_entities)
                             else:  # flat list
                                 if domain_filter:
+                                    prefix = f"{domain_filter}."
                                     all_area_entities.extend(
                                         e
                                         for e in entities
-                                        if e.get("entity_id", "").split(".", 1)[0]
-                                        == domain_filter
+                                        if e.get("entity_id", "").startswith(prefix)
                                     )
                                 else:
                                     all_area_entities.extend(entities)
@@ -335,11 +335,12 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         entities_data = first_area.get("entities")
 
                         # Build a flat results list, applying domain_filter and
-                        # handling both dict (grouped-by-domain) and flat-list
-                        # shapes from get_entities_by_area for defensive
-                        # symmetry with the with-query branch above. Using
-                        # `{**entity, "domain": domain}` avoids mutating the
-                        # caller's dicts.
+                        # tagging each entity with its `domain` so the optional
+                        # by_domain rebuild below can group without re-parsing
+                        # entity_id. Both dict and flat shapes from
+                        # get_entities_by_area are handled to mirror its two
+                        # return shapes. Using `{**entity, "domain": domain}`
+                        # avoids mutating dicts owned by the helper.
                         all_results: list[dict[str, Any]] = []
                         if isinstance(entities_data, dict):
                             for domain, entities in entities_data.items():
@@ -349,18 +350,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                     {**entity, "domain": domain} for entity in entities
                                 )
                         elif entities_data:  # flat list
-                            all_results.extend(
-                                {
-                                    **entity,
-                                    "domain": entity.get("entity_id", "").split(".", 1)[
-                                        0
-                                    ],
-                                }
-                                for entity in entities_data
-                                if not domain_filter
-                                or entity.get("entity_id", "").split(".", 1)[0]
-                                == domain_filter
-                            )
+                            for entity in entities_data:
+                                domain = entity.get("entity_id", "").split(".", 1)[0]
+                                if domain_filter and domain != domain_filter:
+                                    continue
+                                all_results.append({**entity, "domain": domain})
 
                         paginated = all_results[offset : offset + limit]
 
@@ -377,8 +371,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         if domain_filter:
                             area_search_data["domain_filter"] = domain_filter
                         if group_by_domain_bool:
-                            # Build by_domain from the paginated subset so the
-                            # grouped view matches the flat results.
+                            # Group the paginated slice (not all_results) so
+                            # by_domain and results stay in sync.
                             paginated_by_domain: dict[str, list[dict[str, Any]]] = {}
                             for entity in paginated:
                                 paginated_by_domain.setdefault(

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -242,7 +242,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 # If we also have a query, filter the area results
                 if query and query.strip():
                     # Collect entities from all matched areas, applying
-                    # domain_filter if present (issue #1162).
+                    # domain_filter if present.
                     all_area_entities = []
                     if "areas" in area_result:
                         for area_data in area_result["areas"].values():
@@ -332,32 +332,37 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # Just area filter, return area results with enhanced format
                     if area_result.get("areas"):
                         first_area = next(iter(area_result["areas"].values()))
-                        area_by_domain: dict[str, list[dict[str, Any]]] = (
-                            first_area.get("entities", {})
-                        )
+                        entities_data = first_area.get("entities")
 
-                        # Apply domain_filter to the area's by_domain mapping
-                        # before flattening (issue #1162).
-                        if domain_filter:
-                            area_by_domain = {
-                                domain_filter: area_by_domain.get(domain_filter, [])
-                            }
-
-                        # Flatten to a single results list, then paginate.
-                        all_results = []
-                        for domain, entities in area_by_domain.items():
-                            for entity in entities:
-                                entity["domain"] = domain
-                                all_results.append(entity)
+                        # Build a flat results list, applying domain_filter and
+                        # handling both dict (grouped-by-domain) and flat-list
+                        # shapes from get_entities_by_area for defensive
+                        # symmetry with the with-query branch above. Using
+                        # `{**entity, "domain": domain}` avoids mutating the
+                        # caller's dicts.
+                        all_results: list[dict[str, Any]] = []
+                        if isinstance(entities_data, dict):
+                            for domain, entities in entities_data.items():
+                                if domain_filter and domain != domain_filter:
+                                    continue
+                                all_results.extend(
+                                    {**entity, "domain": domain} for entity in entities
+                                )
+                        elif entities_data:  # flat list
+                            all_results.extend(
+                                {
+                                    **entity,
+                                    "domain": entity.get("entity_id", "").split(".", 1)[
+                                        0
+                                    ],
+                                }
+                                for entity in entities_data
+                                if not domain_filter
+                                or entity.get("entity_id", "").split(".", 1)[0]
+                                == domain_filter
+                            )
 
                         paginated = all_results[offset : offset + limit]
-
-                        # Rebuild by_domain from the paginated subset so the
-                        # grouped view matches the flat results.
-                        paginated_by_domain: dict[str, list[dict[str, Any]]] = {}
-                        for entity in paginated:
-                            d = entity["domain"]
-                            paginated_by_domain.setdefault(d, []).append(entity)
 
                         area_search_data: dict[str, Any] = {
                             "success": True,
@@ -366,12 +371,20 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 len(all_results), offset, limit, paginated
                             ),
                             "results": paginated,
-                            "by_domain": paginated_by_domain,
                             "search_type": "area_only",
                             "area_name": first_area.get("area_name", area_filter),
                         }
                         if domain_filter:
                             area_search_data["domain_filter"] = domain_filter
+                        if group_by_domain_bool:
+                            # Build by_domain from the paginated subset so the
+                            # grouped view matches the flat results.
+                            paginated_by_domain: dict[str, list[dict[str, Any]]] = {}
+                            for entity in paginated:
+                                paginated_by_domain.setdefault(
+                                    entity["domain"], []
+                                ).append(entity)
+                            area_search_data["by_domain"] = paginated_by_domain
                         return await add_timezone_metadata(client, area_search_data)
                     else:
                         empty_area_data: dict[str, Any] = {
@@ -379,12 +392,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             "area_filter": area_filter,
                             **_build_pagination_metadata(0, offset, limit, []),
                             "results": [],
-                            "by_domain": {},
                             "search_type": "area_only",
                             "message": f"No entities found in area: {area_filter}",
                         }
                         if domain_filter:
                             empty_area_data["domain_filter"] = domain_filter
+                        if group_by_domain_bool:
+                            empty_area_data["by_domain"] = {}
                         return await add_timezone_metadata(client, empty_area_data)
 
             # Regular entity search (no area filter)

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -562,7 +562,7 @@ class TestSearchEntitiesLimitValidation:
 
 
 # ============================================================================
-# Regression tests for issue #1162: area_filter + domain_filter interaction
+# Regression tests: area_filter + domain_filter interaction
 # ============================================================================
 
 
@@ -632,6 +632,7 @@ async def area_with_mixed_domains(mcp_client):
 
     yield {
         "area_id": area_id,
+        "area_name": area_name,
         "boolean_id": boolean_id,
         "number_id": number_id,
     }
@@ -771,6 +772,40 @@ async def test_area_filter_with_domain_filter_and_query(
 
 
 @pytest.mark.asyncio
+async def test_area_filter_query_with_domain_filter_group_by_domain(
+    mcp_client, area_with_mixed_domains
+):
+    """area_filter + domain_filter + query + group_by_domain restricts by_domain keys.
+
+    Mirror of test_area_filter_with_domain_filter_group_by_domain for the
+    area_filtered_query branch — verifies the grouped view in the with-query
+    code path is also restricted to the filtered domain.
+    """
+    fixture = area_with_mixed_domains
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["area_id"],
+            "domain_filter": "input_boolean",
+            "query": "1162",
+            "exact_match": False,
+            "group_by_domain": True,
+            "limit": 50,
+        },
+    )
+    raw = assert_mcp_success(result, "area+domain+query+group_by_domain")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_filtered_query"
+    assert "by_domain" in data
+    by_domain = data["by_domain"]
+    assert set(by_domain) <= {"input_boolean"}, (
+        f"by_domain leaked non-matching domains: {list(by_domain)}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
     """area_only branch respects limit/offset and emits full pagination metadata.
 
@@ -849,3 +884,108 @@ async def test_area_filter_empty_area_response_shape(mcp_client):
     assert "by_domain" not in data, (
         f"by_domain must only appear when group_by_domain=True: {data}"
     )
+
+
+@pytest.fixture
+async def two_areas_fuzzy_match(mcp_client):
+    """Two areas sharing a name prefix, each with one input_boolean helper.
+
+    Used to exercise fuzzy area-name resolution: a single shared prefix
+    should resolve to both areas in get_entities_by_area, and downstream
+    domain_filter logic must continue to work in that multi-area shape.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    prefix = f"e2e_fuzzy_{suffix}"
+    created: list[tuple[str, str]] = []  # (kind, id)
+
+    helpers: list[dict[str, str]] = []
+    for tag in ("alpha", "beta"):
+        area_result = await mcp_client.call_tool(
+            "ha_config_set_area",
+            {"name": f"{prefix}_{tag}", "icon": "mdi:test-tube"},
+        )
+        area_data = assert_mcp_success(area_result, f"Create area {tag}")
+        area_id = area_data["area_id"]
+        created.append(("area", area_id))
+
+        bool_result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_boolean",
+                "name": f"{prefix} bool {tag}",
+                "area_id": area_id,
+            },
+        )
+        bool_data = assert_mcp_success(bool_result, f"Create boolean {tag}")
+        bool_id = (
+            bool_data.get("entity_id")
+            or f"input_boolean.{bool_data['helper_data']['id']}"
+        )
+        created.append(("input_boolean", bool_id))
+        helpers.append({"area_id": area_id, "boolean_id": bool_id, "tag": tag})
+
+    expected_ids = {h["boolean_id"] for h in helpers}
+    await wait_for_tool_result(
+        mcp_client,
+        tool_name="ha_search_entities",
+        arguments={
+            "area_filter": prefix,
+            "domain_filter": "input_boolean",
+            "query": "bool",
+            "exact_match": False,
+            "limit": 50,
+        },
+        predicate=lambda d: expected_ids.issubset(
+            {e.get("entity_id") for e in d.get("data", d).get("results", [])}
+        ),
+        description="both fuzzy-matched helpers visible",
+    )
+
+    yield {"prefix": prefix, "helpers": helpers}
+
+    for kind, oid in reversed(created):
+        try:
+            if kind == "area":
+                await mcp_client.call_tool("ha_config_remove_area", {"area_id": oid})
+            else:
+                await mcp_client.call_tool(
+                    "ha_delete_helpers_integrations",
+                    {"target": oid, "helper_type": kind, "confirm": True},
+                )
+        except Exception as exc:  # pragma: no cover — cleanup best-effort
+            logger.warning(f"Cleanup failed for {kind} {oid}: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_filter_fuzzy_multi_area_with_query(
+    mcp_client, two_areas_fuzzy_match
+):
+    """Fuzzy area_filter resolving to multiple areas + domain_filter + query.
+
+    Exercises the with-query branch's iteration over `area_result["areas"]`
+    when `get_entities_by_area` resolves the fuzzy name to multiple areas.
+    Domain filter must apply across all matched areas.
+    """
+    fixture = two_areas_fuzzy_match
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["prefix"],
+            "domain_filter": "input_boolean",
+            "query": "bool",
+            "exact_match": False,
+            "limit": 50,
+        },
+    )
+    raw = assert_mcp_success(result, "fuzzy multi-area + domain + query")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_filtered_query"
+    assert data.get("domain_filter") == "input_boolean"
+    entity_ids = {r["entity_id"] for r in data["results"]}
+    expected = {h["boolean_id"] for h in fixture["helpers"]}
+    assert expected.issubset(entity_ids), (
+        f"Both fuzzy-matched areas' helpers should appear: missing {expected - entity_ids}"
+    )
+    assert all(eid.startswith("input_boolean.") for eid in entity_ids)

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -6,10 +6,12 @@ entities of that domain, not return empty results.
 """
 
 import logging
+import uuid
 
 import pytest
 
 from ..utilities.assertions import assert_mcp_success, parse_mcp_result, safe_call_tool
+from ..utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +147,9 @@ async def test_search_entities_area_filter_only(mcp_client):
         f"Expected search_type 'area_only', got '{data.get('search_type')}'"
     )
 
-    logger.info(f"area_filter='kitchen' returned {data.get('total_matches', 0)} matches")
+    logger.info(
+        f"area_filter='kitchen' returned {data.get('total_matches', 0)} matches"
+    )
 
 
 @pytest.mark.asyncio
@@ -555,3 +559,218 @@ class TestSearchEntitiesLimitValidation:
         assert inner["error"]["code"] == "VALIDATION_FAILED", (
             f"Expected VALIDATION_FAILED, got: {inner}"
         )
+
+
+# ============================================================================
+# Regression tests for issue #1162: area_filter + domain_filter interaction
+# ============================================================================
+
+
+@pytest.fixture
+async def area_with_mixed_domains(mcp_client):
+    """Create a test area with helpers in two distinct domains.
+
+    Yields a dict with:
+        - area_id: the created area's id
+        - boolean_id: input_boolean.* entity in the area
+        - number_id: input_number.* entity in the area
+
+    Cleans up area + helpers afterwards.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    area_name = f"e2e_1162_{suffix}"
+
+    area_result = await mcp_client.call_tool(
+        "ha_config_set_area", {"name": area_name, "icon": "mdi:test-tube"}
+    )
+    area_data = assert_mcp_success(area_result, "Create test area")
+    area_id = area_data["area_id"]
+
+    boolean_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": f"e2e 1162 bool {suffix}",
+            "area_id": area_id,
+        },
+    )
+    boolean_data = assert_mcp_success(boolean_result, "Create input_boolean")
+    boolean_id = (
+        boolean_data.get("entity_id")
+        or f"input_boolean.{boolean_data['helper_data']['id']}"
+    )
+
+    number_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_number",
+            "name": f"e2e 1162 num {suffix}",
+            "area_id": area_id,
+            "min_value": 0,
+            "max_value": 10,
+            "step": 1,
+        },
+    )
+    number_data = assert_mcp_success(number_result, "Create input_number")
+    number_id = (
+        number_data.get("entity_id")
+        or f"input_number.{number_data['helper_data']['id']}"
+    )
+
+    # Wait until both entities are visible under this area in the registries
+    # consulted by ha_search_entities (helper creation + area assignment is
+    # eventually-consistent across the entity / device / area registries).
+    await wait_for_tool_result(
+        mcp_client,
+        tool_name="ha_search_entities",
+        arguments={"area_filter": area_id, "limit": 50},
+        predicate=lambda d: {
+            e.get("entity_id") for e in d.get("data", d).get("results", [])
+        }.issuperset({boolean_id, number_id}),
+        description="both helpers visible in area search",
+    )
+
+    yield {
+        "area_id": area_id,
+        "boolean_id": boolean_id,
+        "number_id": number_id,
+    }
+
+    for entity_id, helper_type in (
+        (boolean_id, "input_boolean"),
+        (number_id, "input_number"),
+    ):
+        try:
+            await mcp_client.call_tool(
+                "ha_delete_helpers_integrations",
+                {
+                    "target": entity_id,
+                    "helper_type": helper_type,
+                    "confirm": True,
+                },
+            )
+        except Exception as exc:  # pragma: no cover — cleanup best-effort
+            logger.warning(f"Cleanup failed for {entity_id}: {exc}")
+    try:
+        await mcp_client.call_tool("ha_config_remove_area", {"area_id": area_id})
+    except Exception as exc:  # pragma: no cover — cleanup best-effort
+        logger.warning(f"Cleanup failed for area {area_id}: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_filter_with_domain_filter_no_query(
+    mcp_client, area_with_mixed_domains
+):
+    """Issue #1162: area_filter + domain_filter (no query) returns only domain matches.
+
+    Before the fix, the area_only branch ignored domain_filter and returned every
+    entity in the area regardless of domain.
+    """
+    fixture = area_with_mixed_domains
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["area_id"],
+            "domain_filter": "input_boolean",
+            "limit": 50,
+        },
+    )
+    raw = assert_mcp_success(result, "area+domain filter, no query")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_only"
+    assert data.get("domain_filter") == "input_boolean", (
+        f"Response should echo domain_filter, got: {data}"
+    )
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["boolean_id"] in entity_ids
+    assert fixture["number_id"] not in entity_ids
+    assert all(eid.startswith("input_boolean.") for eid in entity_ids), (
+        f"Non-boolean entities leaked through domain_filter: {entity_ids}"
+    )
+
+    # by_domain must reflect the domain restriction.
+    by_domain = data.get("by_domain", {})
+    assert set(by_domain.keys()) <= {"input_boolean"}, (
+        f"by_domain leaked non-matching domains: {list(by_domain)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_area_filter_with_domain_filter_and_query(
+    mcp_client, area_with_mixed_domains
+):
+    """Issue #1162: area_filter + domain_filter + query also respects the domain."""
+    fixture = area_with_mixed_domains
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["area_id"],
+            "domain_filter": "input_boolean",
+            "query": "1162",
+            "exact_match": False,
+            "limit": 50,
+        },
+    )
+    raw = assert_mcp_success(result, "area+domain+query")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_filtered_query"
+    assert data.get("domain_filter") == "input_boolean"
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["number_id"] not in entity_ids, (
+        f"input_number leaked through domain_filter on area+query branch: {entity_ids}"
+    )
+    assert all(eid.startswith("input_boolean.") for eid in entity_ids)
+
+
+@pytest.mark.asyncio
+async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
+    """Issue #1162 (bonus): area_only branch must respect limit/offset and emit pagination metadata.
+
+    Before the fix, the area_only branch returned every entity and omitted
+    has_more / next_offset / count, breaking response-shape consistency with
+    the rest of the search responses.
+    """
+    fixture = area_with_mixed_domains
+
+    page = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": fixture["area_id"], "limit": 1, "offset": 0},
+    )
+    raw = assert_mcp_success(page, "area_only with limit=1")
+    data = raw.get("data", raw)
+
+    # Pagination metadata fields must all be present.
+    for field in (
+        "total_matches",
+        "offset",
+        "limit",
+        "count",
+        "has_more",
+        "next_offset",
+    ):
+        assert field in data, f"Missing pagination field {field}: {data}"
+
+    assert data["limit"] == 1
+    assert data["offset"] == 0
+    assert data["count"] == len(data["results"]) == 1
+    assert data["total_matches"] >= 2, (
+        f"Fixture creates 2 entities; total_matches should reflect that: {data}"
+    )
+    assert data["has_more"] is True
+    assert data["next_offset"] == 1
+
+    # Second page should not overlap with first.
+    page2 = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": fixture["area_id"], "limit": 1, "offset": 1},
+    )
+    raw2 = assert_mcp_success(page2, "area_only second page")
+    data2 = raw2.get("data", raw2)
+
+    ids1 = {r["entity_id"] for r in data["results"]}
+    ids2 = {r["entity_id"] for r in data2["results"]}
+    assert ids1.isdisjoint(ids2), f"Pages overlap: {ids1 & ids2}"

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -674,9 +674,7 @@ async def test_area_filter_with_domain_filter_no_query(
 ):
     """area_filter + domain_filter (no query) returns only domain matches.
 
-    Before the fix, the area_only branch ignored domain_filter and returned every
-    entity in the area regardless of domain. by_domain must be absent when
-    group_by_domain is not requested (response-shape consistency).
+    by_domain must be absent when group_by_domain is not requested.
     """
     fixture = area_with_mixed_domains
 
@@ -769,6 +767,11 @@ async def test_area_filter_with_domain_filter_and_query(
         f"input_number leaked through domain_filter on area+query branch: {entity_ids}"
     )
     assert all(eid.startswith("input_boolean.") for eid in entity_ids)
+    # Fixture has one input_boolean in the area; domain_filter must drop the
+    # input_number before fuzzy search, so total_matches == 1.
+    assert data["total_matches"] == 1, (
+        f"Expected exactly 1 match after domain_filter pre-filtered: {data}"
+    )
 
 
 @pytest.mark.asyncio
@@ -807,12 +810,7 @@ async def test_area_filter_query_with_domain_filter_group_by_domain(
 
 @pytest.mark.asyncio
 async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
-    """area_only branch respects limit/offset and emits full pagination metadata.
-
-    Before the fix, the area_only branch returned every entity and omitted
-    has_more / next_offset / count, breaking response-shape consistency with
-    the rest of the search responses.
-    """
+    """area_only branch respects limit/offset and emits full pagination metadata."""
     fixture = area_with_mixed_domains
 
     page = await mcp_client.call_tool(
@@ -890,8 +888,9 @@ async def test_area_filter_empty_area_response_shape(mcp_client):
 async def two_areas_fuzzy_match(mcp_client):
     """Two areas sharing a name prefix, each with one input_boolean helper.
 
-    Used to exercise fuzzy area-name resolution: a single shared prefix
-    should resolve to both areas in get_entities_by_area, and downstream
+    Used to exercise fuzzy area-name resolution: a query that fuzzy-matches
+    multiple registered areas (`partial_ratio >= 80` in
+    `get_entities_by_area`) should yield all of them, and downstream
     domain_filter logic must continue to work in that multi-area shape.
     """
     suffix = uuid.uuid4().hex[:8]
@@ -983,9 +982,14 @@ async def test_area_filter_fuzzy_multi_area_with_query(
 
     assert data["search_type"] == "area_filtered_query"
     assert data.get("domain_filter") == "input_boolean"
+    for field in PAGINATION_FIELDS:
+        assert field in data, f"Missing pagination field {field}: {data}"
     entity_ids = {r["entity_id"] for r in data["results"]}
     expected = {h["boolean_id"] for h in fixture["helpers"]}
     assert expected.issubset(entity_ids), (
         f"Both fuzzy-matched areas' helpers should appear: missing {expected - entity_ids}"
     )
     assert all(eid.startswith("input_boolean.") for eid in entity_ids)
+    assert data["total_matches"] == 2, (
+        f"Both fuzzy-matched areas contribute one input_boolean each: {data}"
+    )

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -657,14 +657,25 @@ async def area_with_mixed_domains(mcp_client):
         logger.warning(f"Cleanup failed for area {area_id}: {exc}")
 
 
+PAGINATION_FIELDS = (
+    "total_matches",
+    "offset",
+    "limit",
+    "count",
+    "has_more",
+    "next_offset",
+)
+
+
 @pytest.mark.asyncio
 async def test_area_filter_with_domain_filter_no_query(
     mcp_client, area_with_mixed_domains
 ):
-    """Issue #1162: area_filter + domain_filter (no query) returns only domain matches.
+    """area_filter + domain_filter (no query) returns only domain matches.
 
     Before the fix, the area_only branch ignored domain_filter and returned every
-    entity in the area regardless of domain.
+    entity in the area regardless of domain. by_domain must be absent when
+    group_by_domain is not requested (response-shape consistency).
     """
     fixture = area_with_mixed_domains
 
@@ -689,11 +700,44 @@ async def test_area_filter_with_domain_filter_no_query(
     assert all(eid.startswith("input_boolean.") for eid in entity_ids), (
         f"Non-boolean entities leaked through domain_filter: {entity_ids}"
     )
+    assert "by_domain" not in data, (
+        f"by_domain must only appear when group_by_domain=True: {data}"
+    )
 
-    # by_domain must reflect the domain restriction.
-    by_domain = data.get("by_domain", {})
-    assert set(by_domain.keys()) <= {"input_boolean"}, (
-        f"by_domain leaked non-matching domains: {list(by_domain)}"
+
+@pytest.mark.asyncio
+async def test_area_filter_with_domain_filter_group_by_domain(
+    mcp_client, area_with_mixed_domains
+):
+    """area_filter + domain_filter + group_by_domain restricts by_domain keys.
+
+    Verifies the by_domain rebuild is also restricted to the filtered domain,
+    not just the flat results list.
+    """
+    fixture = area_with_mixed_domains
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["area_id"],
+            "domain_filter": "input_boolean",
+            "group_by_domain": True,
+            "limit": 50,
+        },
+    )
+    raw = assert_mcp_success(result, "area+domain+group_by_domain")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_only"
+    assert "by_domain" in data, (
+        f"by_domain must appear when group_by_domain=True: {data}"
+    )
+    by_domain = data["by_domain"]
+    assert set(by_domain) == {"input_boolean"}, (
+        f"by_domain must be restricted to filtered domain: {list(by_domain)}"
+    )
+    assert all(
+        e["entity_id"].startswith("input_boolean.") for e in by_domain["input_boolean"]
     )
 
 
@@ -701,7 +745,7 @@ async def test_area_filter_with_domain_filter_no_query(
 async def test_area_filter_with_domain_filter_and_query(
     mcp_client, area_with_mixed_domains
 ):
-    """Issue #1162: area_filter + domain_filter + query also respects the domain."""
+    """area_filter + domain_filter + query also respects the domain."""
     fixture = area_with_mixed_domains
 
     result = await mcp_client.call_tool(
@@ -728,7 +772,7 @@ async def test_area_filter_with_domain_filter_and_query(
 
 @pytest.mark.asyncio
 async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
-    """Issue #1162 (bonus): area_only branch must respect limit/offset and emit pagination metadata.
+    """area_only branch respects limit/offset and emits full pagination metadata.
 
     Before the fix, the area_only branch returned every entity and omitted
     has_more / next_offset / count, breaking response-shape consistency with
@@ -743,22 +787,16 @@ async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
     raw = assert_mcp_success(page, "area_only with limit=1")
     data = raw.get("data", raw)
 
-    # Pagination metadata fields must all be present.
-    for field in (
-        "total_matches",
-        "offset",
-        "limit",
-        "count",
-        "has_more",
-        "next_offset",
-    ):
+    for field in PAGINATION_FIELDS:
         assert field in data, f"Missing pagination field {field}: {data}"
 
     assert data["limit"] == 1
     assert data["offset"] == 0
     assert data["count"] == len(data["results"]) == 1
-    assert data["total_matches"] >= 2, (
-        f"Fixture creates 2 entities; total_matches should reflect that: {data}"
+    # Fixture provisions exactly two entities into the unique area, so
+    # total_matches must equal 2 — anything else means the area leaked.
+    assert data["total_matches"] == 2, (
+        f"Expected exactly 2 entities in fixture area: {data}"
     )
     assert data["has_more"] is True
     assert data["next_offset"] == 1
@@ -774,3 +812,40 @@ async def test_area_filter_only_paginates(mcp_client, area_with_mixed_domains):
     ids1 = {r["entity_id"] for r in data["results"]}
     ids2 = {r["entity_id"] for r in data2["results"]}
     assert ids1.isdisjoint(ids2), f"Pages overlap: {ids1 & ids2}"
+
+
+@pytest.mark.asyncio
+async def test_area_filter_empty_area_response_shape(mcp_client):
+    """Empty-area branch emits full pagination metadata + domain_filter echo.
+
+    Covers the `area_result["areas"]` empty path: a regression there would
+    silently ship a response without has_more / next_offset / count or
+    domain_filter echo, breaking consistency with the populated branch.
+    """
+    nonexistent_area = f"e2e_1162_no_such_area_{uuid.uuid4().hex[:8]}"
+
+    result = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": nonexistent_area,
+            "domain_filter": "input_boolean",
+            "limit": 5,
+        },
+    )
+    raw = assert_mcp_success(result, "empty-area branch")
+    data = raw.get("data", raw)
+
+    assert data["search_type"] == "area_only"
+    assert data["total_matches"] == 0
+    assert data["results"] == []
+    assert data.get("domain_filter") == "input_boolean", (
+        f"Empty-area response must still echo domain_filter: {data}"
+    )
+    for field in PAGINATION_FIELDS:
+        assert field in data, f"Missing pagination field {field}: {data}"
+    assert data["has_more"] is False
+    assert data["next_offset"] is None
+    # group_by_domain not requested, so by_domain must be absent.
+    assert "by_domain" not in data, (
+        f"by_domain must only appear when group_by_domain=True: {data}"
+    )


### PR DESCRIPTION
## What does this PR do?

Closes #1162.

The `if area_filter:` block in `ha_search_entities` (`src/ha_mcp/tools/tools_search.py`) never reads `domain_filter`, so callers passing both got every entity in the area regardless of domain. Reproduced live: `area_filter=\"kitchen\", domain_filter=\"light\", limit=50` returned 134 entities across 13 domains — exactly 1 of which was a light.

While in the same code path I also fixed three response-shape bugs the issue's "consistent response" note alluded to:

1. **Main bug** — `domain_filter` is now applied in both area branches (with-query and area-only).
2. **`limit` / `offset` ignored** in the area-only branch — it returned every entity in the area regardless of `limit`.
3. **Pagination metadata missing** in the area-only response — no `has_more` / `next_offset` / `count`, breaking shape consistency with every other search response.
4. **`domain_filter` echo missing** in the area_filter responses (other branches do echo it).

### Origin of the bug

The buggy `area_filter` block has been there since `tools_search.py` was first added. #1004 didn't change the buggy code path — but it's what made the bug practically reachable for agents:

- Pre-#1004, `query` was a required `str`, so `area_filter + domain_filter` (no query) failed schema validation. Hitting the bug required passing an explicit `query=\"\"`.
- Post-#1004, `query` is optional and the new docstring actively invites the standalone `domain_filter` / `area_filter` form (e.g. *\"omit \`query\` and pass \`domain_filter\`\"*).

So #1004 raised the encounter rate from "almost never" to "first thing an agent tries."

### Scope of the fix

- `src/ha_mcp/tools/tools_search.py`: filter by domain in both area branches; paginate the area-only branch via `_build_pagination_metadata`; rebuild `by_domain` from the paginated subset; echo `domain_filter` in all area_filter responses.
- `tests/src/e2e/tools/test_search_entities.py`: two fixtures (`area_with_mixed_domains`: one area with input_boolean + input_number, both assigned at creation, polled until visible, cleaned up after; `two_areas_fuzzy_match`: two areas sharing a name prefix for multi-area fuzzy resolution). Eight regression tests across all four area_filter response modes:
  - `test_area_filter_with_domain_filter_no_query` — area_only branch filters by domain
  - `test_area_filter_with_domain_filter_group_by_domain` — area_only `by_domain` keys restricted to filtered domain
  - `test_area_filter_with_domain_filter_and_query` — area_filtered_query branch filters by domain
  - `test_area_filter_query_with_domain_filter_group_by_domain` — area_filtered_query `by_domain` keys restricted to filtered domain
  - `test_area_filter_only_paginates` — `limit` / `offset` and full pagination metadata respected
  - `test_area_filter_empty_area_response_shape` — empty-area branch emits full pagination metadata + `domain_filter` echo + `by_domain` absence
  - `test_area_filter_fuzzy_multi_area_with_query` — fuzzy area resolution matching multiple areas + domain filter on the with-query branch

### Behavior change to call out

The area-only branch now paginates. Before this PR, `area_filter=\"kitchen\", limit=10` returned all entities in the area (the limit was silently ignored); after this PR it returns 10 with `has_more=true, next_offset=10`. Aligns with every other search response, but worth flagging for anyone relying on the old "give me everything" behavior.

Additionally, `by_domain` in the area_only branches (populated and empty) now respects `group_by_domain`. Previously this branch unconditionally included `by_domain` even when `group_by_domain` was False — the only outlier among the four search response modes. Aligns area_only with with-query / domain_listing / regular search; not breaking — callers wanting the grouped view pass `group_by_domain=true` like every other search mode.

While in the same code path, also dropped the dead flat-list branches in both area_filter sub-branches: `get_entities_by_area` is called with `group_by_domain=True` so the flat-list shape can never occur. Pre-existing dead code in the with-query branch since the initial release; the area_only flat-list was added earlier in this PR for defensive symmetry with that pre-existing branch and was dropped together with it. Net: −23 lines in the area_filter block.

Finally, `_build_pagination_metadata` was simplified from explicit dict reconstruction to a single in-place rename (`total_count` → `total_matches`). Same output, less fragility — new keys in the shared helper now flow through automatically.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


