### PR TITLE
docs: add brew install option for mcp-proxy on macOS

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -55,6 +55,8 @@ Claude Desktop requires a proxy to connect to HTTP MCP servers. Install **mcp-pr
 uv tool install mcp-proxy
 # or
 pipx install mcp-proxy
+# or (macOS)
+brew install mcp-proxy
 ```
 
 Then add to your Claude Desktop configuration file:

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1538,10 +1538,13 @@ ingress:
 
     // mcp-proxy instructions for stdio-only clients
     if (needsMcpProxy) {
+      const brewNote = platformId === 'macos'
+        ? `<p class="text-xs text-slate-400 mt-2">Or install ahead of time with Homebrew: <code>brew install mcp-proxy</code></p>`
+        : '';
       const mcpProxyInstr = `<div class="instruction-block border-yellow-700/50 bg-yellow-900/10">
         <h4 class="instruction-title text-yellow-300">mcp-proxy Required</h4>
         <p class="text-slate-300 mb-2">${state.client.name} only supports stdio. Use mcp-proxy to connect to HTTP servers:</p>
-        <pre class="code-block"><code># mcp-proxy is run automatically via uvx in the config below</code></pre>
+        <pre class="code-block"><code># mcp-proxy is run automatically via uvx in the config below</code></pre>${brewNote}
       </div>`;
       instructions.push(mcpProxyInstr);
     }


### PR DESCRIPTION
## What does this PR do?

Closes #1158. Adds `brew install mcp-proxy` as a macOS-only install hint to the setup wizard's `mcp-proxy Required` instruction block, and to the `homeassistant-addon/DOCS.md` Claude Desktop install snippet alongside the existing `uv tool install` / `pipx install` options.

In `site/src/pages/setup.astro`, the brew line is gated on `platformId === 'macos'` to match the pattern used by the existing `Install uv (macOS)` block — Linux/Windows/Docker users see the wording unchanged.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Future improvements

<!-- none -->

## Checklist
- [x] I have updated documentation if needed