### PR TITLE
docs(addon): note tool-list (#985)/runtime divergence; fix #1139/#1162 test conflict

### DIFF
--- a/scripts/extract_tools.py
+++ b/scripts/extract_tools.py
@@ -185,6 +185,8 @@ def generate_docs_section(tools: list[dict]) -> str:
         "",
         f"The add-on provides {len(tools)}+ MCP tools for controlling Home Assistant:",
         "",
+        "> **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime — if so, calling it returns a not-found error until the next stable release.",
+        "",
     ]
     if any("beta" in t["tags"] for t in tools):
         lines.extend([

--- a/scripts/extract_tools.py
+++ b/scripts/extract_tools.py
@@ -185,7 +185,7 @@ def generate_docs_section(tools: list[dict]) -> str:
         "",
         f"The add-on provides {len(tools)}+ MCP tools for controlling Home Assistant:",
         "",
-        "> **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime — if so, calling it returns a not-found error until the next stable release.",
+        "> **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime. If so, calling it returns an \"unknown tool\" error until the next stable release.",
         "",
     ]
     if any("beta" in t["tags"] for t in tools):

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -581,7 +581,8 @@ async def area_with_mixed_domains(mcp_client):
     area_name = f"e2e_1162_{suffix}"
 
     area_result = await mcp_client.call_tool(
-        "ha_config_set_area", {"name": area_name, "icon": "mdi:test-tube"}
+        "ha_set_area_or_floor",
+        {"kind": "area", "name": area_name, "icon": "mdi:test-tube"},
     )
     area_data = assert_mcp_success(area_result, "Create test area")
     area_id = area_data["area_id"]
@@ -653,7 +654,9 @@ async def area_with_mixed_domains(mcp_client):
         except Exception as exc:  # pragma: no cover — cleanup best-effort
             logger.warning(f"Cleanup failed for {entity_id}: {exc}")
     try:
-        await mcp_client.call_tool("ha_config_remove_area", {"area_id": area_id})
+        await mcp_client.call_tool(
+            "ha_remove_area_or_floor", {"kind": "area", "id": area_id}
+        )
     except Exception as exc:  # pragma: no cover — cleanup best-effort
         logger.warning(f"Cleanup failed for area {area_id}: {exc}")
 
@@ -900,8 +903,8 @@ async def two_areas_fuzzy_match(mcp_client):
     helpers: list[dict[str, str]] = []
     for tag in ("alpha", "beta"):
         area_result = await mcp_client.call_tool(
-            "ha_config_set_area",
-            {"name": f"{prefix}_{tag}", "icon": "mdi:test-tube"},
+            "ha_set_area_or_floor",
+            {"kind": "area", "name": f"{prefix}_{tag}", "icon": "mdi:test-tube"},
         )
         area_data = assert_mcp_success(area_result, f"Create area {tag}")
         area_id = area_data["area_id"]
@@ -945,7 +948,9 @@ async def two_areas_fuzzy_match(mcp_client):
     for kind, oid in reversed(created):
         try:
             if kind == "area":
-                await mcp_client.call_tool("ha_config_remove_area", {"area_id": oid})
+                await mcp_client.call_tool(
+                    "ha_remove_area_or_floor", {"kind": "area", "id": oid}
+                )
             else:
                 await mcp_client.call_tool(
                     "ha_delete_helpers_integrations",


### PR DESCRIPTION
## What does this PR do?

Two related changes:

### 1. Static note in addon DOCS.md (closes #985)

Adds a static note above the auto-generated tool list in \`homeassistant-addon/DOCS.md\` explaining that the list is regenerated from \`master\` on every push, while the installed add-on image only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed there may not yet be present in the runtime image; if so, calling it returns an \"unknown tool\" error until the next stable release.

The change is a single block in \`scripts/extract_tools.py\`'s \`generate_docs_section\`. \`sync-tool-docs.yml\` will regenerate \`homeassistant-addon/DOCS.md\` automatically after merge — not regenerated here to keep the PR diff minimal.

#### Why this approach instead of #985's original proposal

#985 originally proposed a dynamic \`upcoming\` tag computed by diffing the current \`src/ha_mcp/tools/\` tree against the last stable git tag at every \`extract_tools.py\` invocation. That works, but adds:

- \`git describe\` + \`git ls-tree\` + per-file AST re-parse against the tag in the script
- \`fetch-depth: 0\` + \`fetch-tags: true\` tweaks to \`sync-tool-docs.yml\` and \`pr.yml\`
- New tests for the tag-comparison logic
- Edge-case handling (no stable tag yet, shallow checkout, \`git\` unavailable, renames)

For a documentation-tab problem with a 2-week worst-case window, a static blanket note covers the same ground without the engineering surface. Users still see the warning; they just don't see exactly which tools are upcoming. Acceptable trade-off given how rarely an end user would call a brand-new tool in the gap between releases.

### 2. Fix unrelated master breakage from #1139/#1162 race

While running CI for the docs change, e2e was failing with \`Unknown tool: 'ha_config_set_area'\` on \`tests/src/e2e/tools/test_search_entities.py\`. Same failure on master post-#1139.

Root cause: a semantic merge conflict between two PRs that were individually green:

- **#1162** (merged as #1165 at 13:27:23 UTC) added new \`test_area_filter_with_domain_filter_*\` tests calling the existing \`ha_config_set_area\` / \`ha_config_remove_area\` tools.
- **#1139** (merged at 13:40:14 UTC, base sha predates #1165) consolidated those tools into \`ha_set_area_or_floor\` / \`ha_remove_area_or_floor\` (with \`kind=\"area\"\`/\`kind=\"floor\"\` and \`id=\` instead of \`area_id=\`). #1139's branch did not contain the new tests, so its e2e was green; the merge commit was never re-tested against the post-#1165 master.

Updates four call sites in \`test_search_entities.py\` (two create, two cleanup) to the consolidated tool signatures. Response shape (\`area_data[\"area_id\"]\`) is unchanged.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

(Multi-checked: docs note + maintenance test fix.)

## Testing
- [x] Ran \`python scripts/extract_tools.py\` locally; only \`homeassistant-addon/DOCS.md\` changed (note appears in expected location, \`README.md\` and \`tools.json\` unaffected)
- [x] Ran \`python scripts/extract_tools.py --check\` after regenerating; reports in sync
- [x] Ran \`ruff check\` on both changed files; clean
- [ ] I have tested these changes with a LLM agent (n/a — docs note + test signature update)
- [x] All automated tests pass (\`uv run pytest\`) — relying on this PR's own e2e run to verify the test fix

## Checklist
- [x] I have updated documentation if needed