### PR TITLE
fix: return newest automation traces, add offset+order pagination (#1177)

### DIFF
--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -63,27 +63,12 @@ class TraceTools:
         limit: Annotated[
             int,
             Field(
-                description="Maximum number of traces to return when listing (default: 10, max: 50). Combined with `offset` and `order` to page through stored traces.",
+                description="Maximum number of traces to return when listing (default: 10, max: 50).",
                 default=10,
                 ge=1,
                 le=50,
             ),
         ] = 10,
-        offset: Annotated[
-            int,
-            Field(
-                description="Number of traces to skip from the start of the requested order. Use with `limit` to page through stored traces when `total_available > limit`.",
-                default=0,
-                ge=0,
-            ),
-        ] = 0,
-        order: Annotated[
-            Literal["newest", "oldest"],
-            Field(
-                description="Order traces are returned in. 'newest' (default) returns most-recent first; 'oldest' returns chronological-first.",
-                default="newest",
-            ),
-        ] = "newest",
         deduplicate: Annotated[
             bool,
             Field(
@@ -109,6 +94,21 @@ class TraceTools:
                 default=None,
             ),
         ] = None,
+        offset: Annotated[
+            int,
+            Field(
+                description="Number of traces to skip from the start of the requested order. Use with `limit` to page through stored traces when `total_available > limit`.",
+                default=0,
+                ge=0,
+            ),
+        ] = 0,
+        order: Annotated[
+            Literal["newest", "oldest"],
+            Field(
+                description="Order traces are returned in. 'newest' (default) returns most-recent first; 'oldest' returns chronological-first.",
+                default="newest",
+            ),
+        ] = "newest",
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         """
@@ -507,7 +507,7 @@ def _format_trace_list(
     """
     # HA's trace/list returns traces oldest-first. Pick a window from the end
     # for newest-first, or from the start for oldest-first, with offset for
-    # pagination through stored traces beyond `limit` (issue #1177).
+    # pagination through stored traces beyond `limit`.
     if order == "newest":
         end = len(traces) - offset
         start = max(end - limit, 0)

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -7,7 +7,7 @@ to help debug automation and script issues.
 
 import json
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
@@ -63,12 +63,27 @@ class TraceTools:
         limit: Annotated[
             int,
             Field(
-                description="Maximum number of traces to return when listing (default: 10, max: 50)",
+                description="Maximum number of traces to return when listing (default: 10, max: 50). Combined with `offset` and `order` to page through stored traces.",
                 default=10,
                 ge=1,
                 le=50,
             ),
         ] = 10,
+        offset: Annotated[
+            int,
+            Field(
+                description="Number of traces to skip from the start of the requested order. Use with `limit` to page through stored traces when `total_available > limit`.",
+                default=0,
+                ge=0,
+            ),
+        ] = 0,
+        order: Annotated[
+            Literal["newest", "oldest"],
+            Field(
+                description="Order traces are returned in. 'newest' (default) returns most-recent first; 'oldest' returns chronological-first.",
+                default="newest",
+            ),
+        ] = "newest",
         deduplicate: Annotated[
             bool,
             Field(
@@ -111,6 +126,8 @@ class TraceTools:
         1. List recent traces (omit run_id):
            ha_get_automation_traces("automation.motion_light")
            Returns a summary of recent execution runs with timestamps, triggers, and status.
+           Use `offset` to page deeper when `has_more` is true, or `order="oldest"` to
+           start from the earliest stored trace instead of the most recent.
 
         2. Get detailed trace (provide run_id):
            ha_get_automation_traces("automation.motion_light", run_id="1705312800.123456")
@@ -268,7 +285,12 @@ class TraceTools:
                             ctx, progress=3, total=3, message="diagnostics complete"
                         )
                         return _format_trace_list(
-                            automation_id, traces_data, limit, diagnostics
+                            automation_id,
+                            traces_data,
+                            limit,
+                            diagnostics,
+                            offset=offset,
+                            order=order,
                         )
 
                     await safe_progress(
@@ -277,7 +299,13 @@ class TraceTools:
                         total=3,
                         message=f"listed {len(traces_data)} traces",
                     )
-                    return _format_trace_list(automation_id, traces_data, limit)
+                    return _format_trace_list(
+                        automation_id,
+                        traces_data,
+                        limit,
+                        offset=offset,
+                        order=order,
+                    )
 
             finally:
                 await ws_client.disconnect()
@@ -463,18 +491,32 @@ def _format_trace_list(
     traces: list[dict[str, Any]],
     limit: int,
     diagnostics: dict[str, Any] | None = None,
+    *,
+    offset: int = 0,
+    order: Literal["newest", "oldest"] = "newest",
 ) -> dict[str, Any]:
     """Format trace list for AI consumption.
 
     Args:
         automation_id: The automation or script entity_id
-        traces: List of trace data from Home Assistant
+        traces: List of trace data from Home Assistant (oldest-first)
         limit: Maximum number of traces to include
         diagnostics: Optional diagnostic information when traces are empty
+        offset: Number of traces to skip from the start of the requested order
+        order: 'newest' (default) returns most-recent first; 'oldest' chronological
     """
-    formatted_traces = []
+    # HA's trace/list returns traces oldest-first. Pick a window from the end
+    # for newest-first, or from the start for oldest-first, with offset for
+    # pagination through stored traces beyond `limit` (issue #1177).
+    if order == "newest":
+        end = len(traces) - offset
+        start = max(end - limit, 0)
+        window = list(reversed(traces[start:end])) if end > 0 else []
+    else:
+        window = traces[offset:offset + limit]
 
-    for trace in traces[:limit]:
+    formatted_traces = []
+    for trace in window:
         # Extract key information from trace
         trace_info: dict[str, Any] = {
             "run_id": trace.get("run_id"),
@@ -503,6 +545,9 @@ def _format_trace_list(
         "automation_id": automation_id,
         "trace_count": len(formatted_traces),
         "total_available": len(traces),
+        "offset": offset,
+        "order": order,
+        "has_more": offset + len(formatted_traces) < len(traces),
         "traces": formatted_traces,
         "hint": "Use run_id with this tool to get detailed trace information",
     }

--- a/tests/src/unit/test_tools_traces.py
+++ b/tests/src/unit/test_tools_traces.py
@@ -78,6 +78,113 @@ class TestFormatTraceList:
         assert result["trace_count"] == 3
         assert result["total_available"] == 5
 
+    def test_returns_newest_traces_when_total_exceeds_limit(self):
+        """When traces exceed limit, return the newest N (not the oldest).
+
+        HA's trace/list returns traces in chronological order (oldest first).
+        Slicing [:limit] would return the oldest N, leaving recent traces
+        unreachable when stored_traces > limit. See issue #1177.
+        """
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 2)
+
+        assert result["trace_count"] == 2
+        run_ids = [t["run_id"] for t in result["traces"]]
+        assert "run_4" in run_ids
+        assert "run_3" in run_ids
+        assert "run_0" not in run_ids
+        assert "run_1" not in run_ids
+
+    def test_returned_traces_are_newest_first(self):
+        """Returned traces are ordered newest-first for user convenience."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 3)
+
+        run_ids = [t["run_id"] for t in result["traces"]]
+        assert run_ids == ["run_4", "run_3", "run_2"]
+
+    def test_order_oldest_returns_oldest_first(self):
+        """order='oldest' returns the oldest N traces in chronological order."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 3, order="oldest")
+
+        run_ids = [t["run_id"] for t in result["traces"]]
+        assert run_ids == ["run_0", "run_1", "run_2"]
+        assert result["order"] == "oldest"
+
+    def test_offset_pages_through_newest_first(self):
+        """offset skips past the most-recent traces when order='newest'."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 2, offset=2)
+
+        run_ids = [t["run_id"] for t in result["traces"]]
+        assert run_ids == ["run_2", "run_1"]
+        assert result["offset"] == 2
+
+    def test_offset_pages_through_oldest_first(self):
+        """offset skips past the earliest traces when order='oldest'."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 2, offset=2, order="oldest")
+
+        run_ids = [t["run_id"] for t in result["traces"]]
+        assert run_ids == ["run_2", "run_3"]
+
+    def test_has_more_true_when_more_traces_remain(self):
+        """has_more is True when the requested page does not cover the buffer."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(5)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 2)
+
+        assert result["has_more"] is True
+
+    def test_has_more_false_when_buffer_exhausted(self):
+        """has_more is False when offset+returned reaches total."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(3)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 10)
+
+        assert result["has_more"] is False
+
+    def test_offset_beyond_total_returns_empty(self):
+        """offset >= total returns no traces and has_more=False."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(3)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 10, offset=10)
+
+        assert result["traces"] == []
+        assert result["trace_count"] == 0
+        assert result["total_available"] == 3
+        assert result["has_more"] is False
+
     def test_trace_with_error_included(self):
         """Traces with errors include the error field."""
         traces = [

--- a/tests/src/unit/test_tools_traces.py
+++ b/tests/src/unit/test_tools_traces.py
@@ -83,7 +83,7 @@ class TestFormatTraceList:
 
         HA's trace/list returns traces in chronological order (oldest first).
         Slicing [:limit] would return the oldest N, leaving recent traces
-        unreachable when stored_traces > limit. See issue #1177.
+        unreachable when stored_traces > limit.
         """
         traces = [
             {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
@@ -169,6 +169,19 @@ class TestFormatTraceList:
 
         result = _format_trace_list("automation.test", traces, 10)
 
+        assert result["has_more"] is False
+
+    def test_offset_equal_to_total_returns_empty(self):
+        """offset == total returns no traces and has_more=False (boundary)."""
+        traces = [
+            {"run_id": f"run_{i}", "timestamp": f"2025-11-30T15:0{i}:00Z", "state": "stopped"}
+            for i in range(3)
+        ]
+
+        result = _format_trace_list("automation.test", traces, 10, offset=3)
+
+        assert result["traces"] == []
+        assert result["trace_count"] == 0
         assert result["has_more"] is False
 
     def test_offset_beyond_total_returns_empty(self):


### PR DESCRIPTION
## What does this PR do?

Closes #1177.

`ha_get_automation_traces` (list mode) was sliced as `traces[:limit]` against HA's `trace/list`, which returns traces oldest-first. With `stored_traces > limit` the user only ever saw the *oldest* N traces — recent runs were unreachable through the tool.

- Returns newest traces by default (most common debugging case).
- New `offset` parameter pages through stored traces beyond `limit`.
- New `order` parameter (`newest` | `oldest`) restores chronological access when needed.
- Response now echoes `offset`, `order`, and adds `has_more` so an agent can paginate.

The reporter's case (200 stored, `limit=50`, only oldest visible) is now solved by either the default newest-first behavior or `offset` for paging deeper.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

Behavior of the default `limit=N` call changes (now newest-first instead of oldest-first), but the previous behavior was unusable when `total_available > limit`, so this is a fix rather than a breaking change. Pre-existing oldest-first behavior is recoverable via `order=\"oldest\"`.

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`)
- [ ] Code follows style guidelines (\`uv run ruff check\`)

Reproduced live against an automation with 5 stored traces — calling with `limit=2` returned the oldest 2 (run timestamps confirmed). New unit tests cover newest/oldest ordering, offset paging in both directions, and the `has_more` flag at boundaries.

## Future improvements

None for this PR. If trace volume / pagination ergonomics become a concern, a `since` / `until` timestamp filter would be a natural next step but is out of scope here.

## Checklist
- [x] I have updated documentation if needed

Tool docstring and field descriptions updated to mention `offset` / `order` / `has_more`.