### PR TITLE
fix(security): write YAML backups outside www/ (GHSA-g39v-cvjh-8fpf)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -740,7 +740,8 @@ def _migrate_legacy_backup_dir(config_dir: Path) -> tuple[int, int]:
     try:
         legacy_dir.rmdir()
     except OSError as err:
-        if err.errno != errno.ENOTEMPTY:
+        # ENOTEMPTY on Linux/APFS; EEXIST on some pre-APFS macOS filesystems.
+        if err.errno not in (errno.ENOTEMPTY, errno.EEXIST):
             _LOGGER.warning(
                 "Could not remove legacy backup dir %s: [%s] %s",
                 legacy_dir,

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import (
     HomeAssistant,
@@ -399,9 +400,12 @@ def _build_edit_yaml_config_handler(hass):
                 data = {}
                 raw_content = ""
 
-            # Create backup before editing (from already-read content, not disk)
+            # Create backup before editing (from already-read content, not disk).
+            # Backups go under .ha_mcp_tools_backups/ at the config root — NOT
+            # under www/, which Home Assistant serves unauthenticated at /local/
+            # (GHSA-g39v-cvjh-8fpf).
             if do_backup and raw_content:
-                backup_dir = config_dir / "www" / "yaml_backups"
+                backup_dir = config_dir / ".ha_mcp_tools_backups"
                 await hass.async_add_executor_job(
                     lambda: backup_dir.mkdir(parents=True, exist_ok=True)
                 )
@@ -677,9 +681,70 @@ def _parse_and_validate_yaml_path(
     return "lovelace_dashboard", parts, None
 
 
+def _migrate_legacy_backup_dir(config_dir: Path) -> int:
+    """Move pre-fix backups out of www/ (GHSA-g39v-cvjh-8fpf).
+
+    Pre-fix versions wrote backups under www/yaml_backups/, which HA serves
+    unauthenticated at /local/. Move any leftover .bak files into the new
+    .ha_mcp_tools_backups/ directory and remove the old directory if empty.
+    Returns the number of files moved.
+    """
+    legacy_dir = config_dir / "www" / "yaml_backups"
+    if not legacy_dir.is_dir():
+        return 0
+
+    new_dir = config_dir / ".ha_mcp_tools_backups"
+    new_dir.mkdir(parents=True, exist_ok=True)
+
+    moved = 0
+    for src in legacy_dir.iterdir():
+        if not src.is_file():
+            continue
+        dest = new_dir / src.name
+        # Avoid clobbering if a same-named file already exists in the new dir.
+        if dest.exists():
+            dest = new_dir / f"{src.stem}.legacy{src.suffix}"
+        src.rename(dest)
+        moved += 1
+
+    # Remove the legacy dir if we emptied it (leave alone if user dropped
+    # other files in there).
+    try:
+        legacy_dir.rmdir()
+    except OSError:
+        pass
+
+    return moved
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HA MCP Tools from a config entry."""
     config_dir = Path(hass.config.config_dir)
+
+    # One-time migration of pre-fix YAML backups out of the publicly-served
+    # www/ directory (GHSA-g39v-cvjh-8fpf).
+    moved = await hass.async_add_executor_job(
+        _migrate_legacy_backup_dir, config_dir
+    )
+    if moved:
+        message = (
+            f"Moved {moved} YAML backup file(s) from `www/yaml_backups/` to "
+            "`.ha_mcp_tools_backups/`. The previous location was reachable "
+            "without authentication via `/local/yaml_backups/` "
+            "([GHSA-g39v-cvjh-8fpf](https://github.com/homeassistant-ai/ha-mcp/security/advisories/GHSA-g39v-cvjh-8fpf)). "
+            "**Rotate any secrets** that appeared in those YAML files "
+            "(MQTT/REST credentials, webhook IDs, `shell_command` "
+            "definitions, geofence coordinates). If you version-control "
+            "your Home Assistant config, also add `.ha_mcp_tools_backups/` "
+            "to your `.gitignore` so future backups are not committed."
+        )
+        _LOGGER.error(message)
+        persistent_notification.async_create(
+            hass,
+            message,
+            title="HA MCP Tools — credential exposure (GHSA-g39v-cvjh-8fpf)",
+            notification_id="ha_mcp_tools_ghsa_g39v_cvjh_8fpf",
+        )
 
     async def handle_list_files(call: ServiceCall) -> ServiceResponse:
         """Handle the list_files service call."""

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -6,10 +6,12 @@ enabling AI assistants to perform advanced operations like file management.
 
 from __future__ import annotations
 
+import errno
 import fnmatch
 import logging
 import os
 import re
+import shutil
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
@@ -681,40 +683,71 @@ def _parse_and_validate_yaml_path(
     return "lovelace_dashboard", parts, None
 
 
-def _migrate_legacy_backup_dir(config_dir: Path) -> int:
+def _migrate_legacy_backup_dir(config_dir: Path) -> tuple[int, int]:
     """Move pre-fix backups out of www/ (GHSA-g39v-cvjh-8fpf).
 
     Pre-fix versions wrote backups under www/yaml_backups/, which HA serves
-    unauthenticated at /local/. Move any leftover .bak files into the new
+    unauthenticated at /local/. Move .bak files into the new
     .ha_mcp_tools_backups/ directory and remove the old directory if empty.
-    Returns the number of files moved.
+    Returns (moved, failed) — counts of files successfully relocated and
+    files that could not be moved (left in legacy_dir, still exposed).
     """
     legacy_dir = config_dir / "www" / "yaml_backups"
     if not legacy_dir.is_dir():
-        return 0
+        return 0, 0
 
     new_dir = config_dir / ".ha_mcp_tools_backups"
     new_dir.mkdir(parents=True, exist_ok=True)
 
     moved = 0
+    failed = 0
     for src in legacy_dir.iterdir():
-        if not src.is_file():
+        # Only migrate regular .bak files. Skip directories, symlinks,
+        # sockets/fifos, and any user-deposited stray files.
+        if not src.is_file() or src.is_symlink() or src.suffix != ".bak":
             continue
+
+        # Pick a non-colliding destination name. If <name>.bak exists, try
+        # <name>.legacy.bak, then .legacy1.bak, .legacy2.bak, etc. Required
+        # because Path.rename / shutil.move overwrite the destination
+        # silently on POSIX, which would lose data.
         dest = new_dir / src.name
-        # Avoid clobbering if a same-named file already exists in the new dir.
         if dest.exists():
             dest = new_dir / f"{src.stem}.legacy{src.suffix}"
-        src.rename(dest)
-        moved += 1
+            counter = 1
+            while dest.exists():
+                dest = new_dir / f"{src.stem}.legacy{counter}{src.suffix}"
+                counter += 1
 
-    # Remove the legacy dir if we emptied it (leave alone if user dropped
-    # other files in there).
+        try:
+            # shutil.move falls back to copy+unlink on EXDEV (cross-device),
+            # which Path.rename does not handle — required for setups where
+            # /config/www is a separate mount (Docker bind, LXC, NFS).
+            shutil.move(str(src), str(dest))
+            moved += 1
+        except OSError as err:
+            failed += 1
+            _LOGGER.error(
+                "Failed to migrate %s out of www/: %s. File remains "
+                "exposed via /local/yaml_backups/.",
+                src.name,
+                err,
+            )
+
+    # Remove the legacy dir if we emptied it. Narrow the swallowed errno
+    # to ENOTEMPTY (user-dropped non-.bak files block removal — fine);
+    # surface anything else (permissions, read-only FS, etc.).
     try:
         legacy_dir.rmdir()
-    except OSError:
-        pass
+    except OSError as err:
+        if err.errno != errno.ENOTEMPTY:
+            _LOGGER.warning(
+                "Could not remove legacy backup dir %s: %s",
+                legacy_dir,
+                err,
+            )
 
-    return moved
+    return moved, failed
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -722,16 +755,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     config_dir = Path(hass.config.config_dir)
 
     # One-time migration of pre-fix YAML backups out of the publicly-served
-    # www/ directory (GHSA-g39v-cvjh-8fpf).
-    moved = await hass.async_add_executor_job(
-        _migrate_legacy_backup_dir, config_dir
-    )
-    if moved:
+    # www/ directory (GHSA-g39v-cvjh-8fpf). Wrapped so a migration failure
+    # cannot prevent the integration from loading — the integration's
+    # normal value (file ops, edit_yaml_config) is unaffected by this.
+    try:
+        moved, failed = await hass.async_add_executor_job(
+            _migrate_legacy_backup_dir, config_dir
+        )
+    except Exception as err:
+        # Defensive: a migration failure must not block setup_entry, since
+        # the integration's normal value (file ops, edit_yaml_config) is
+        # unaffected by whether old backups got relocated.
+        _LOGGER.error(
+            "GHSA-g39v-cvjh-8fpf migration failed: %s. Pre-fix backups "
+            "may still be present in www/yaml_backups/ and reachable "
+            "via /local/yaml_backups/ — manual cleanup required.",
+            err,
+        )
+        moved, failed = 0, 0
+
+    if moved or failed:
+        if failed:
+            heading = (
+                f"Migrated {moved} YAML backup file(s); **{failed} could "
+                "not be moved** and remain in `www/yaml_backups/`, still "
+                "reachable without authentication via `/local/yaml_backups/`. "
+                "Move or delete them manually before continuing."
+            )
+        else:
+            heading = (
+                f"Moved {moved} YAML backup file(s) from `www/yaml_backups/` "
+                "to `.ha_mcp_tools_backups/`. The previous location was "
+                "reachable without authentication via `/local/yaml_backups/`."
+            )
         message = (
-            f"Moved {moved} YAML backup file(s) from `www/yaml_backups/` to "
-            "`.ha_mcp_tools_backups/`. The previous location was reachable "
-            "without authentication via `/local/yaml_backups/` "
-            "([GHSA-g39v-cvjh-8fpf](https://github.com/homeassistant-ai/ha-mcp/security/advisories/GHSA-g39v-cvjh-8fpf)). "
+            f"{heading} See "
+            "[GHSA-g39v-cvjh-8fpf](https://github.com/homeassistant-ai/ha-mcp/security/advisories/GHSA-g39v-cvjh-8fpf). "
             "**Rotate any secrets** that appeared in those YAML files "
             "(MQTT/REST credentials, webhook IDs, `shell_command` "
             "definitions, geofence coordinates). If you version-control "
@@ -739,12 +798,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "to your `.gitignore` so future backups are not committed."
         )
         _LOGGER.error(message)
-        persistent_notification.async_create(
-            hass,
-            message,
-            title="HA MCP Tools — credential exposure (GHSA-g39v-cvjh-8fpf)",
-            notification_id="ha_mcp_tools_ghsa_g39v_cvjh_8fpf",
-        )
+        try:
+            persistent_notification.async_create(
+                hass,
+                message,
+                title="HA MCP Tools — credential exposure (GHSA-g39v-cvjh-8fpf)",
+                notification_id="ha_mcp_tools_ghsa_g39v_cvjh_8fpf",
+            )
+        except Exception as err:
+            # Defensive: log line above is the source of truth; the
+            # notification is best-effort UX and must not block setup.
+            _LOGGER.warning(
+                "Could not create persistent notification for "
+                "GHSA-g39v-cvjh-8fpf migration: %s",
+                err,
+            )
 
     async def handle_list_files(call: ServiceCall) -> ServiceResponse:
         """Handle the list_files service call."""

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -742,8 +742,9 @@ def _migrate_legacy_backup_dir(config_dir: Path) -> tuple[int, int]:
     except OSError as err:
         if err.errno != errno.ENOTEMPTY:
             _LOGGER.warning(
-                "Could not remove legacy backup dir %s: %s",
+                "Could not remove legacy backup dir %s: [%s] %s",
                 legacy_dir,
+                type(err).__name__,
                 err,
             )
 
@@ -810,7 +811,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # notification is best-effort UX and must not block setup.
             _LOGGER.warning(
                 "Could not create persistent notification for "
-                "GHSA-g39v-cvjh-8fpf migration: %s",
+                "GHSA-g39v-cvjh-8fpf migration: [%s] %s",
+                type(err).__name__,
                 err,
             )
 

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -51,7 +51,7 @@ This tool edits `configuration.yaml` and package files directly, bypassing Home 
 
 **Recovery requires filesystem access.** If an edit causes HA to enter recovery mode (e.g., a bad `!include` reference), `ha_config_set_yaml` cannot fix its own damage since the custom component doesn't load in recovery mode. Recovery requires SSH, the File Editor add-on, or `docker exec`.
 
-**Backups are filesystem-only.** Per-edit backups are written to `www/yaml_backups/` but no ha-mcp tool can restore them. They are a safety net for manual recovery.
+**Backups are filesystem-only.** Per-edit backups are written to `.ha_mcp_tools_backups/` (at the Home Assistant config root) but no ha-mcp tool can restore them. They are a safety net for manual recovery.
 
 **Recommended prerequisites:**
 - Comfort with editing `configuration.yaml` via SSH or File Editor when things go wrong

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -166,7 +166,7 @@ def register_yaml_config_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 default=True,
                 description=(
                     "Create a backup before editing. Defaults to True. "
-                    "Backups are saved to www/yaml_backups/."
+                    "Backups are saved to .ha_mcp_tools_backups/."
                 ),
             ),
         ] = True,

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -447,13 +447,13 @@ class TestYamlConfigSafeguards:
             assert inner.get("success") is True, f"Replace should succeed: {data}"
             backup_path = inner.get("backup_path", "")
             assert backup_path, f"Backup path should be present: {data}"
-            # Backups must NOT be under www/ (HA serves www/ unauthenticated
-            # at /local/) — see GHSA-g39v-cvjh-8fpf.
-            assert not backup_path.startswith("www/"), (
-                f"Backup path must not be under www/ (publicly served): {backup_path}"
-            )
-            assert ".ha_mcp_tools_backups" in backup_path, (
-                f"Backup path should be under .ha_mcp_tools_backups/: {backup_path}"
+            # Backups must live directly under .ha_mcp_tools_backups/ (config
+            # root, not served by HA's /local/ static handler). Anything else
+            # — including a www/.ha_mcp_tools_backups/ variant or any other
+            # publicly-served prefix — is a regression of GHSA-g39v-cvjh-8fpf.
+            assert backup_path.startswith(".ha_mcp_tools_backups/"), (
+                f"Backup path must start with .ha_mcp_tools_backups/ "
+                f"(not under www/ or any served path): {backup_path}"
             )
             logger.info(f"Backup created at: {backup_path}")
 

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -445,9 +445,17 @@ class TestYamlConfigSafeguards:
             )
             inner = data
             assert inner.get("success") is True, f"Replace should succeed: {data}"
-            assert inner.get("backup_path"), f"Backup path should be present: {data}"
-            assert "yaml_backups" in inner.get("backup_path", "")
-            logger.info(f"Backup created at: {inner.get('backup_path')}")
+            backup_path = inner.get("backup_path", "")
+            assert backup_path, f"Backup path should be present: {data}"
+            # Backups must NOT be under www/ (HA serves www/ unauthenticated
+            # at /local/) — see GHSA-g39v-cvjh-8fpf.
+            assert not backup_path.startswith("www/"), (
+                f"Backup path must not be under www/ (publicly served): {backup_path}"
+            )
+            assert ".ha_mcp_tools_backups" in backup_path, (
+                f"Backup path should be under .ha_mcp_tools_backups/: {backup_path}"
+            )
+            logger.info(f"Backup created at: {backup_path}")
 
     async def test_config_check_included_in_response(self, mcp_client_with_yaml_config):
         """Config check result should be included in the response."""

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -554,3 +554,23 @@ class TestMigrateLegacyBackupDir:
         # Symlink left in place; legacy dir not removed because non-empty.
         assert (legacy / "link.bak").is_symlink()
         assert legacy.exists()
+
+    def test_async_setup_entry_wires_migration_and_notification(self):
+        """Source-level guard: async_setup_entry must call the migration helper
+        and create a persistent notification referencing the GHSA. Brittle on
+        purpose — this is a security regression guard, not a behavioral test.
+        """
+        import inspect
+
+        from custom_components.ha_mcp_tools import async_setup_entry
+
+        src = inspect.getsource(async_setup_entry)
+        assert "_migrate_legacy_backup_dir" in src, (
+            "async_setup_entry must invoke the legacy-backup migration"
+        )
+        assert "persistent_notification.async_create" in src, (
+            "async_setup_entry must surface migration via persistent_notification"
+        )
+        assert "GHSA-g39v-cvjh-8fpf" in src, (
+            "persistent notification must reference the security advisory"
+        )

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -458,9 +458,9 @@ class TestMigrateLegacyBackupDir:
     """Test _migrate_legacy_backup_dir helper (GHSA-g39v-cvjh-8fpf)."""
 
     def test_no_legacy_dir_is_noop(self, tmp_path):
-        """Returns 0 and creates nothing when legacy dir is absent."""
-        moved = _migrate_legacy_backup_dir(tmp_path)
-        assert moved == 0
+        """Returns (0, 0) and creates nothing when legacy dir is absent."""
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
+        assert (moved, failed) == (0, 0)
         assert not (tmp_path / ".ha_mcp_tools_backups").exists()
         assert not (tmp_path / "www" / "yaml_backups").exists()
 
@@ -471,9 +471,9 @@ class TestMigrateLegacyBackupDir:
         (legacy / "configuration.yaml.20260101_120000.bak").write_text("a: 1")
         (legacy / "packages_test.yaml.20260102_120000.bak").write_text("b: 2")
 
-        moved = _migrate_legacy_backup_dir(tmp_path)
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
 
-        assert moved == 2
+        assert (moved, failed) == (2, 0)
         new_dir = tmp_path / ".ha_mcp_tools_backups"
         assert new_dir.is_dir()
         moved_names = sorted(p.name for p in new_dir.iterdir())
@@ -494,12 +494,32 @@ class TestMigrateLegacyBackupDir:
         (legacy / "x.bak").write_text("from legacy")
         (new_dir / "x.bak").write_text("already here")
 
-        moved = _migrate_legacy_backup_dir(tmp_path)
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
 
-        assert moved == 1
+        assert (moved, failed) == (1, 0)
         assert (new_dir / "x.bak").read_text() == "already here"
         # Legacy file is renamed during migration so it isn't lost.
         assert (new_dir / "x.legacy.bak").read_text() == "from legacy"
+
+    def test_collision_counter_when_legacy_suffix_taken(self, tmp_path):
+        """If <name>.bak AND <name>.legacy.bak both exist, use .legacy1.bak."""
+        legacy = tmp_path / "www" / "yaml_backups"
+        legacy.mkdir(parents=True)
+        new_dir = tmp_path / ".ha_mcp_tools_backups"
+        new_dir.mkdir()
+
+        (legacy / "x.bak").write_text("incoming")
+        (new_dir / "x.bak").write_text("already here")
+        (new_dir / "x.legacy.bak").write_text("older legacy")
+
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
+
+        assert (moved, failed) == (1, 0)
+        # Both pre-existing files preserved.
+        assert (new_dir / "x.bak").read_text() == "already here"
+        assert (new_dir / "x.legacy.bak").read_text() == "older legacy"
+        # New file lands at next free .legacyN suffix.
+        assert (new_dir / "x.legacy1.bak").read_text() == "incoming"
 
     def test_leaves_legacy_dir_when_other_files_present(self, tmp_path):
         """Doesn't remove legacy dir if user dropped non-.bak files in it."""
@@ -507,10 +527,30 @@ class TestMigrateLegacyBackupDir:
         legacy.mkdir(parents=True)
         (legacy / "stray_subdir").mkdir()
         (legacy / "config.bak").write_text("data")
+        (legacy / "notes.txt").write_text("user dropped this")
 
-        moved = _migrate_legacy_backup_dir(tmp_path)
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
 
-        assert moved == 1
-        # Subdirectory left in place; rmdir() fails silently.
+        assert (moved, failed) == (1, 0)
+        # Subdirectory and stray non-.bak file left in place.
         assert legacy.exists()
         assert (legacy / "stray_subdir").is_dir()
+        assert (legacy / "notes.txt").read_text() == "user dropped this"
+
+    def test_skips_symlinks(self, tmp_path):
+        """Symlinks in legacy dir are not migrated (avoids surprise dereferencing)."""
+        legacy = tmp_path / "www" / "yaml_backups"
+        legacy.mkdir(parents=True)
+        target = tmp_path / "elsewhere.bak"
+        target.write_text("target content")
+        (legacy / "link.bak").symlink_to(target)
+        (legacy / "real.bak").write_text("real content")
+
+        moved, failed = _migrate_legacy_backup_dir(tmp_path)
+
+        assert (moved, failed) == (1, 0)
+        new_dir = tmp_path / ".ha_mcp_tools_backups"
+        assert (new_dir / "real.bak").read_text() == "real content"
+        # Symlink left in place; legacy dir not removed because non-empty.
+        assert (legacy / "link.bak").is_symlink()
+        assert legacy.exists()

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -15,6 +15,8 @@ import pytest
 # Mock the Home Assistant imports before importing the module
 sys.modules['voluptuous'] = MagicMock()
 sys.modules['homeassistant'] = MagicMock()
+sys.modules['homeassistant.components'] = MagicMock()
+sys.modules['homeassistant.components.persistent_notification'] = MagicMock()
 sys.modules['homeassistant.config_entries'] = MagicMock()
 sys.modules['homeassistant.core'] = MagicMock()
 sys.modules['homeassistant.helpers'] = MagicMock()
@@ -28,6 +30,7 @@ from custom_components.ha_mcp_tools import (  # noqa: E402
     _is_path_allowed_for_read,
     _list_files_sync,
     _mask_secrets_content,
+    _migrate_legacy_backup_dir,
     _read_file_sync,
     _write_file_sync,
 )
@@ -449,3 +452,65 @@ class TestDeleteFileSync:
         result = _delete_file_sync(tmp_path)
         assert result == {"_error": "not_a_file"}
         assert tmp_path.exists()
+
+
+class TestMigrateLegacyBackupDir:
+    """Test _migrate_legacy_backup_dir helper (GHSA-g39v-cvjh-8fpf)."""
+
+    def test_no_legacy_dir_is_noop(self, tmp_path):
+        """Returns 0 and creates nothing when legacy dir is absent."""
+        moved = _migrate_legacy_backup_dir(tmp_path)
+        assert moved == 0
+        assert not (tmp_path / ".ha_mcp_tools_backups").exists()
+        assert not (tmp_path / "www" / "yaml_backups").exists()
+
+    def test_moves_files_and_removes_legacy_dir(self, tmp_path):
+        """Moves .bak files out of www/yaml_backups/ and removes the empty dir."""
+        legacy = tmp_path / "www" / "yaml_backups"
+        legacy.mkdir(parents=True)
+        (legacy / "configuration.yaml.20260101_120000.bak").write_text("a: 1")
+        (legacy / "packages_test.yaml.20260102_120000.bak").write_text("b: 2")
+
+        moved = _migrate_legacy_backup_dir(tmp_path)
+
+        assert moved == 2
+        new_dir = tmp_path / ".ha_mcp_tools_backups"
+        assert new_dir.is_dir()
+        moved_names = sorted(p.name for p in new_dir.iterdir())
+        assert moved_names == [
+            "configuration.yaml.20260101_120000.bak",
+            "packages_test.yaml.20260102_120000.bak",
+        ]
+        # Legacy dir should be removed once empty.
+        assert not legacy.exists()
+
+    def test_does_not_clobber_existing_backups(self, tmp_path):
+        """Preserves an existing same-named file in the new dir."""
+        legacy = tmp_path / "www" / "yaml_backups"
+        legacy.mkdir(parents=True)
+        new_dir = tmp_path / ".ha_mcp_tools_backups"
+        new_dir.mkdir()
+
+        (legacy / "x.bak").write_text("from legacy")
+        (new_dir / "x.bak").write_text("already here")
+
+        moved = _migrate_legacy_backup_dir(tmp_path)
+
+        assert moved == 1
+        assert (new_dir / "x.bak").read_text() == "already here"
+        # Legacy file is renamed during migration so it isn't lost.
+        assert (new_dir / "x.legacy.bak").read_text() == "from legacy"
+
+    def test_leaves_legacy_dir_when_other_files_present(self, tmp_path):
+        """Doesn't remove legacy dir if user dropped non-.bak files in it."""
+        legacy = tmp_path / "www" / "yaml_backups"
+        legacy.mkdir(parents=True)
+        (legacy / "stray_subdir").mkdir()
+        (legacy / "config.bak").write_text("data")
+
+        moved = _migrate_legacy_backup_dir(tmp_path)
+
+        assert moved == 1
+        # Subdirectory left in place; rmdir() fails silently.
+        assert legacy.exists()
+        assert (legacy / "stray_subdir").is_dir()


### PR DESCRIPTION
## Summary

Fixes [GHSA-g39v-cvjh-8fpf](https://github.com/homeassistant-ai/ha-mcp/security/advisories/GHSA-g39v-cvjh-8fpf) — pre-edit YAML backups were written to `<config>/www/yaml_backups/`, which Home Assistant serves unauthenticated at `/local/`. Anyone reachable on port 8123 could fetch the most recent pre-edit `configuration.yaml` (typically containing plaintext MQTT/REST credentials, webhook IDs, geofence coordinates, `shell_command` definitions) with no auth.

CWE-552 · CVSS 6.5 (medium) · `ENABLE_YAML_CONFIG_EDITING=true` is dev-channel only — the stable addon's `config.yaml` does not expose this flag, so production-addon users are not reachable. At-risk population: dev addon users + non-addon explicit opt-in (uvx, pip, Docker non-addon).

## Changes

**Backup write path** (`custom_components/ha_mcp_tools/__init__.py`)
- `<config>/www/yaml_backups/` → `<config>/.ha_mcp_tools_backups/` (config root, not served by HA's `/local/` static handler).

**One-time migration helper** (`_migrate_legacy_backup_dir`)
- Uses `shutil.move` (handles EXDEV cross-device renames — Docker bind mounts, LXC, NFS-backed `www/` — which `Path.rename` does not).
- Filters to `.bak` files; skips symlinks, directories, and stray non-`.bak` files.
- Counter-loop unique destination names (`.legacy`, `.legacy1`, `.legacy2`, ...) so a second collision can't silently overwrite preserved data.
- Returns `(moved, failed)`; per-file failures logged at ERROR with the still-exposed filename.
- `rmdir()` exception narrowed to `errno.ENOTEMPTY`; other `OSError`s surface at WARNING.

**Setup-entry orchestration** (`async_setup_entry`)
- Migration call wrapped in try/except — a failure must not block the integration from loading.
- Persistent notification (stable `notification_id` to dedupe across reloads) + ERROR log surface the result in HA's UI Notifications panel. Only fires when files were actually moved or failed.
- Notification message tells users to rotate any secrets that were exposed and to add `.ha_mcp_tools_backups/` to `.gitignore` if they version-control their HA config.
- If migration partial-failed, the message says so and instructs manual cleanup of the still-exposed legacy directory.
- `persistent_notification.async_create` also wrapped — the log line is the source of truth.

**MCP tool docstring** (`src/ha_mcp/tools/tools_yaml_config.py`)
- `backup` parameter description updated.

**Beta docs** (`docs/beta.md`)
- Backup location reference updated.

## Why this directory

`.ha_mcp_tools_backups/` at config root chosen over alternatives:
- `.storage/` — reserved for HA's `Store` API; mixing arbitrary `.bak` files would pollute a managed namespace.
- `<config>/backups/` — owned by the `backup` integration (full-system tarballs).
- HA `BackupManager` API — semantically wrong (full-system snapshots, not file shadows).
- Reporter's `.ha_mcp_backups/` — shorter but doesn't match the integration domain (`ha_mcp_tools`).

Follows the `.<domain>_*` convention (`.cloud`, `.uuid`, `.storage`). Confirmed `hass.http` only serves `/local/` (→`www/`) and explicitly registered `StaticPathConfig` paths — a dotted dir at config root has no path-mounted route.

## Test plan

- [x] 5 new unit tests for `_migrate_legacy_backup_dir`: noop, happy-path-with-rmdir, clobber-avoidance via `.legacy`, **counter-loop when `.legacy.bak` is also taken**, leave-legacy-when-non-empty, **skip symlinks**.
- [x] Existing `test_backup_created` updated: now asserts `backup_path.startswith(".ha_mcp_tools_backups/")` (catches any `www/<...>` or other prefix regression).
- [x] Local: 55/55 unit tests pass (Python 3.13)
- [x] Local: ruff clean on all 5 changed files
- [ ] CI: full E2E suite (Docker testcontainers — requires CI runner)
- [ ] Manual: verify persistent notification appears in HA UI when pre-fix backups exist

## Closes the documented PoC

| Step | Before | After |
|---|---|---|
| `ha_config_set_yaml(...)` returns | `backup_path: www/yaml_backups/...` | `backup_path: .ha_mcp_tools_backups/...` |
| `GET /local/yaml_backups/...` | HTTP 200, leaks YAML | HTTP 404 |
| Discovery via return value/INFO log/timestamp enumeration | Filename enables fetch | Filename returned but path unreachable |

Reported by @bharat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)