### PR TITLE
fix: broaden template anti-pattern detection + skill discoverability (#1011)

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -58,6 +58,43 @@ class HaResourcesAsTools(ResourcesAsTools):
         "list_resources": LIST_TOOL_NAME,
         "read_resource": READ_TOOL_NAME,
     }
+    # Action-phrased descriptions for BM25 retrieval. FastMCP's defaults are
+    # terse ("List MCP resources") and don't surface on task-phrased
+    # tool_search queries that agents make when reaching for config-write
+    # tools. See issue #1011, Gap 1 — same treatment as the per-skill
+    # ha_get_skill_* tools below.
+    _DESCRIPTIONS: ClassVar[dict[str, str]] = {
+        LIST_TOOL_NAME: (
+            "List all available MCP resources, including bundled skill reference "
+            "files (automation-patterns.md, helper-selection.md, "
+            "template-guidelines.md, device-control.md, dashboard-guide.md, "
+            "safe-refactoring.md, examples.yaml). Use BEFORE: creating or editing "
+            "automations, scripts, scenes, helpers, or dashboards; writing "
+            "triggers, conditions, actions, or wait_template; renaming entities "
+            "or migrating device_id to entity_id; calling ha_config_set_*. "
+            "Pair with ha_read_resource to load a specific guide."
+        ),
+        READ_TOOL_NAME: (
+            "Read the contents of an MCP resource by URI. Use this to load skill "
+            "reference files (e.g., skill://home-assistant-best-practices/"
+            "references/automation-patterns.md) BEFORE creating or editing "
+            "automations, scripts, scenes, helpers, or dashboards; writing "
+            "triggers, conditions, actions, or wait_template; renaming entities; "
+            "or calling ha_config_set_*. The skill files cover native conditions "
+            "and triggers, helper selection, automation modes, template "
+            "guidelines, device control, and safe refactoring. Use "
+            "ha_list_resources to discover available URIs."
+        ),
+    }
+
+    @classmethod
+    def _rewrite(cls, tool: Tool, new_name: str) -> Tool:
+        """Return a copy of ``tool`` renamed and re-described for ha-mcp."""
+        update: dict[str, Any] = {"name": new_name}
+        description = cls._DESCRIPTIONS.get(new_name)
+        if description is not None:
+            update["description"] = description
+        return tool.model_copy(update=update)
 
     async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         # Scan the entire result rather than slicing the tail so a future
@@ -72,7 +109,7 @@ class HaResourcesAsTools(ResourcesAsTools):
             if new_name is None:
                 renamed.append(tool)
                 continue
-            renamed.append(tool.model_copy(update={"name": new_name}))
+            renamed.append(self._rewrite(tool, new_name))
             matches += 1
         if matches != len(self._RENAMES):
             logger.warning(
@@ -93,13 +130,9 @@ class HaResourcesAsTools(ResourcesAsTools):
         version: VersionSpec | None = None,
     ) -> Tool | None:
         if name == self.LIST_TOOL_NAME:
-            return self._make_list_resources_tool().model_copy(
-                update={"name": self.LIST_TOOL_NAME}
-            )
+            return self._rewrite(self._make_list_resources_tool(), self.LIST_TOOL_NAME)
         if name == self.READ_TOOL_NAME:
-            return self._make_read_resource_tool().model_copy(
-                update={"name": self.READ_TOOL_NAME}
-            )
+            return self._rewrite(self._make_read_resource_tool(), self.READ_TOOL_NAME)
         return await call_next(name, version=version)
 
 # Server icon configuration using GitHub-hosted images
@@ -772,9 +805,24 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             tool_name = f"ha_get_skill_{skill_name.replace('-', '_')}"
             uri = f"skill://{skill_name}/SKILL.md"
 
+            # Action-phrased keyword block for BM25 retrieval. The upstream
+            # SKILL.md description is symptom-framed ("Agent uses Jinja2
+            # templates where..."), which doesn't match the task-phrased
+            # tool_search queries agents make when reaching for config-write
+            # tools. This block ensures queries like "create automation" /
+            # "set automation config" / "writing trigger" surface the skill.
+            # See issue #1011, Gap 1.
             tool_description = (
                 f"CALL THIS FIRST before performing matching actions. "
                 f"{description}\n\n"
+                f"Use BEFORE: creating or editing automations, scripts, scenes, "
+                f"helpers, or dashboards; writing triggers, conditions, actions, "
+                f"wait_template, or service calls; renaming entities or migrating "
+                f"device_id to entity_id; calling ha_config_set_automation, "
+                f"ha_config_set_script, ha_config_set_scene, ha_config_set_helper, "
+                f"ha_config_set_dashboard, or ha_set_entity. The reference files "
+                f"below cover automation patterns, helper selection, template "
+                f"guidelines, device control, dashboards, and safe refactoring.\n\n"
                 f"Returns available reference files. Read each file via "
                 f"resources/read (or ha_read_resource as a fallback) using "
                 f"the file URI to load specific guides as needed."

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -75,7 +75,7 @@ class HaResourcesAsTools(ResourcesAsTools):
             "Pair with ha_read_resource to load a specific guide."
         ),
         READ_TOOL_NAME: (
-            "Read the contents of an MCP resource by URI. Use this to load skill "
+            "Get the contents of an MCP resource by URI. Use this to load skill "
             "reference files (e.g., skill://home-assistant-best-practices/"
             "references/automation-patterns.md) BEFORE creating or editing "
             "automations, scripts, scenes, helpers, or dashboards; writing "
@@ -813,6 +813,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             # "set automation config" / "writing trigger" surface the skill.
             # See issue #1011, Gap 1.
             tool_description = (
+                f"Get available reference files for the {skill_name} skill. "
                 f"CALL THIS FIRST before performing matching actions. "
                 f"{description}\n\n"
                 f"Use BEFORE: creating or editing automations, scripts, scenes, "
@@ -823,9 +824,9 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
                 f"ha_config_set_dashboard, or ha_set_entity. The reference files "
                 f"below cover automation patterns, helper selection, template "
                 f"guidelines, device control, dashboards, and safe refactoring.\n\n"
-                f"Returns available reference files. Read each file via "
-                f"resources/read (or ha_read_resource as a fallback) using "
-                f"the file URI to load specific guides as needed."
+                f"Read each reference file via resources/read (or ha_read_resource "
+                f"as a fallback) using the file URI to load specific guides as "
+                f"needed."
             )
 
             ref_files = self._collect_skill_ref_files(skill_dir, skill_name)

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -58,32 +58,37 @@ class HaResourcesAsTools(ResourcesAsTools):
         "list_resources": LIST_TOOL_NAME,
         "read_resource": READ_TOOL_NAME,
     }
-    # Action-phrased descriptions for BM25 retrieval. FastMCP's defaults are
-    # terse ("List MCP resources") and don't surface on task-phrased
-    # tool_search queries that agents make when reaching for config-write
-    # tools. See issue #1011, Gap 1 — same treatment as the per-skill
-    # ha_get_skill_* tools below.
+    # Shared action-phrased keyword block for retrieval. Some MCP clients
+    # (Claude Code, others) rank candidate tools by token-overlap between
+    # the user's natural-language query and each tool's `description`
+    # field; FastMCP's terse defaults ("List MCP resources") never overlap
+    # with task-phrased queries like "create automation" or "writing
+    # trigger". This block lists the workflow positions where consulting
+    # the bundled skill reference files matters, so retrieval surfaces
+    # this tool when an agent is about to write config.
+    _USE_BEFORE_KEYWORDS = (
+        "Use BEFORE: creating or editing automations, scripts, scenes, "
+        "helpers, or dashboards; writing triggers, conditions, actions, "
+        "wait_template, or service calls; renaming entities or migrating "
+        "device_id to entity_id; calling ha_config_set_automation, "
+        "ha_config_set_script, ha_config_set_helper, ha_config_set_dashboard, "
+        "or ha_set_entity."
+    )
     _DESCRIPTIONS: ClassVar[dict[str, str]] = {
         LIST_TOOL_NAME: (
-            "List all available MCP resources, including bundled skill reference "
-            "files (automation-patterns.md, helper-selection.md, "
-            "template-guidelines.md, device-control.md, dashboard-guide.md, "
-            "safe-refactoring.md, examples.yaml). Use BEFORE: creating or editing "
-            "automations, scripts, scenes, helpers, or dashboards; writing "
-            "triggers, conditions, actions, or wait_template; renaming entities "
-            "or migrating device_id to entity_id; calling ha_config_set_*. "
-            "Pair with ha_read_resource to load a specific guide."
+            "List all available MCP resources, including bundled skill "
+            "reference files. " + _USE_BEFORE_KEYWORDS + " Pair with "
+            "ha_read_resource to load a specific guide."
         ),
         READ_TOOL_NAME: (
-            "Get the contents of an MCP resource by URI. Use this to load skill "
-            "reference files (e.g., skill://home-assistant-best-practices/"
-            "references/automation-patterns.md) BEFORE creating or editing "
-            "automations, scripts, scenes, helpers, or dashboards; writing "
-            "triggers, conditions, actions, or wait_template; renaming entities; "
-            "or calling ha_config_set_*. The skill files cover native conditions "
-            "and triggers, helper selection, automation modes, template "
-            "guidelines, device control, and safe refactoring. Use "
-            "ha_list_resources to discover available URIs."
+            "Get the contents of an MCP resource by URI. Use this to load "
+            "skill reference files (e.g., "
+            "skill://home-assistant-best-practices/references/"
+            "automation-patterns.md) for guidance on native conditions and "
+            "triggers, helper selection, automation modes, template "
+            "guidelines, device control, and safe refactoring. "
+            + _USE_BEFORE_KEYWORDS
+            + " Use ha_list_resources to discover available URIs."
         ),
     }
 
@@ -805,28 +810,27 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             tool_name = f"ha_get_skill_{skill_name.replace('-', '_')}"
             uri = f"skill://{skill_name}/SKILL.md"
 
-            # Action-phrased keyword block for BM25 retrieval. The upstream
-            # SKILL.md description is symptom-framed ("Agent uses Jinja2
-            # templates where..."), which doesn't match the task-phrased
-            # tool_search queries agents make when reaching for config-write
-            # tools. This block ensures queries like "create automation" /
-            # "set automation config" / "writing trigger" surface the skill.
-            # See issue #1011, Gap 1.
+            # Action-phrased keyword block for retrieval. Some MCP clients
+            # rank candidate tools by token-overlap between the user's
+            # query and each tool's `description`; the upstream SKILL.md
+            # description is symptom-framed ("Agent uses Jinja2 templates
+            # where..."), which doesn't overlap with task-phrased queries
+            # like "create automation" / "set automation config" / "writing
+            # trigger". This block re-anchors the description in those
+            # task verbs so it surfaces when an agent is about to write
+            # config. Same shared keyword block as
+            # HaResourcesAsTools._USE_BEFORE_KEYWORDS above.
             tool_description = (
                 f"Get available reference files for the {skill_name} skill. "
                 f"CALL THIS FIRST before performing matching actions. "
                 f"{description}\n\n"
-                f"Use BEFORE: creating or editing automations, scripts, scenes, "
-                f"helpers, or dashboards; writing triggers, conditions, actions, "
-                f"wait_template, or service calls; renaming entities or migrating "
-                f"device_id to entity_id; calling ha_config_set_automation, "
-                f"ha_config_set_script, ha_config_set_scene, ha_config_set_helper, "
-                f"ha_config_set_dashboard, or ha_set_entity. The reference files "
-                f"below cover automation patterns, helper selection, template "
-                f"guidelines, device control, dashboards, and safe refactoring.\n\n"
-                f"Read each reference file via resources/read (or ha_read_resource "
-                f"as a fallback) using the file URI to load specific guides as "
-                f"needed."
+                f"{HaResourcesAsTools._USE_BEFORE_KEYWORDS} The reference "
+                f"files below cover automation patterns, helper selection, "
+                f"template guidelines, device control, dashboards, and safe "
+                f"refactoring.\n\n"
+                f"Read each reference file via resources/read (or "
+                f"ha_read_resource as a fallback) using the file URI to load "
+                f"specific guides as needed."
             )
 
             ref_files = self._collect_skill_ref_files(skill_dir, skill_name)

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -8,6 +8,23 @@ file via the bundled SkillsDirectoryProvider. The ``skill_prefix`` kwarg
 lets callers pass any URL prefix (e.g., a GitHub mirror) when skill://
 isn't reachable, or ``None`` to omit references entirely.
 
+Each warning carries the native alternative inline (a concrete example or
+short explanation) before the URI suffix, so clients that don't auto-fetch
+resource URIs still receive actionable guidance.
+
+The checker covers two layers:
+
+1. *Specific* detectors for known anti-pattern shapes — each emits a tailored
+   message that names the native alternative concretely.
+2. A *generic* fallback that fires when ``{{ ... }}`` or ``{% ... %}`` shows
+   up in a logic position (condition / trigger / wait_template / target field)
+   without matching a specific pattern. This catches new template misuse
+   without waiting for a regex to be added — see issue #1011.
+
+Templates in legitimate positions (action ``data`` fields, notification
+``message``/``title``, ``event_data``, ``variables``) are *not* inspected and
+therefore never flagged — those are the documented dynamic-data cases.
+
 Anti-patterns sourced from:
   https://github.com/homeassistant-ai/skills
   skill://home-assistant-best-practices
@@ -39,6 +56,12 @@ _RE_WEEKDAY = re.compile(
     r"\bnow\(\)\s*\.\s*(?:weekday|isoweekday)\s*\("
     r"|\bnow\(\)\s*\.\s*strftime\s*\(\s*['\"]%[Aaw]['\"]"
 )
+# Date-component checks: now().date(), now().year/month/day
+# (issue #1011 — agent first reached for `now().date().isoformat() == '...'`)
+_RE_NOW_DATE = re.compile(
+    r"\bnow\(\)\s*\.\s*date\s*\("
+    r"|\bnow\(\)\s*\.\s*(?:year|month|day)\b(?!\s*\()"
+)
 # sun.sun entity references
 _RE_SUN = re.compile(r"(?:is_state|state_attr|states)\s*\(\s*['\"]sun\.sun['\"]")
 # states('x') in [...] or states('x') in (...)
@@ -47,6 +70,13 @@ _RE_STATE_IN = re.compile(r"states\s*\([^)]+\)\s+in\s+[\[(]")
 _RE_DIRECT_STATE = re.compile(r"\bstates\.\w+\.\w+\.state\b")
 # Motion entity pattern
 _RE_MOTION = re.compile(r"binary_sensor\.\w*motion", re.IGNORECASE)
+# Any Jinja template marker — catch-all and target-field scan.
+_RE_ANY_TEMPLATE = re.compile(r"\{\{|\{%")
+# `this.X` self-reference (e.g. `{{ this.entity_id }}`)
+_RE_THIS_REFERENCE = re.compile(r"\bthis\s*\.\s*\w+")
+
+# Target sub-fields scanned for templates (issue #1011).
+_TARGET_FIELDS = ("entity_id", "device_id", "area_id", "floor_id", "label_id")
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +106,7 @@ def check_automation_config(
     # Condition templates
     _check_condition_templates(config.get("condition", []), warnings, skill_prefix)
 
-    # Action tree (wait_template + nested conditions)
+    # Action tree (wait_template + nested conditions + target templates)
     _check_action_tree(config.get("action", []), warnings, skill_prefix)
 
     # Trigger templates + device_id
@@ -132,12 +162,12 @@ def _check_condition_templates(
     for cond in _as_list(conditions):
         if isinstance(cond, str) and "{{" in cond:
             # Shorthand template condition
-            _check_template_string(cond, warnings, skill_prefix)
+            _check_template_string(cond, warnings, skill_prefix, "condition")
         elif isinstance(cond, dict):
             if cond.get("condition") == "template":
                 vt = cond.get("value_template", "")
                 if isinstance(vt, str):
-                    _check_template_string(vt, warnings, skill_prefix)
+                    _check_template_string(vt, warnings, skill_prefix, "condition")
             # Recurse into compound conditions (and/or/not)
             nested = cond.get("conditions")
             if nested:
@@ -145,52 +175,94 @@ def _check_condition_templates(
 
 
 def _check_template_string(
-    template: str, warnings: list[str], skill_prefix: str | None
+    template: str,
+    warnings: list[str],
+    skill_prefix: str | None,
+    position: str,
 ) -> None:
-    """Check a single template string for known anti-patterns."""
+    """Check a single template string for known anti-patterns.
+
+    ``position`` is "condition" or "trigger" — used by the generic fallback
+    when none of the specific detectors match, so the message can name the
+    position concretely.
+    """
+    initial_count = len(warnings)
+
     if _RE_NUMERIC_CMP.search(template):
         warnings.append(
             "Condition uses template with float/int comparison — use native "
-            "`numeric_state` condition instead."
+            "`numeric_state` condition instead "
+            "(e.g., `condition: numeric_state, entity_id: sensor.temp, above: 25`). "
+            "Native conditions are validated at config load and don't bypass HA's schema."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_SUN.search(template):
         warnings.append(
             "Condition uses template referencing `sun.sun` — use native "
-            "`sun` condition instead."
+            "`sun` condition instead "
+            "(e.g., `condition: sun, after: sunset` or `before: sunrise`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     elif _RE_IS_STATE.search(template):
         # Only flag if not already flagged as sun pattern
         warnings.append(
             "Condition uses template with `is_state()` — use native "
-            "`state` condition instead."
+            "`state` condition instead "
+            "(e.g., `condition: state, entity_id: light.bedroom, state: 'on'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_NOW_TIME.search(template):
         warnings.append(
             "Condition uses template with `now().hour/minute` — use native "
-            "`time` condition instead."
+            "`time` condition instead "
+            "(e.g., `condition: time, after: '09:00:00', before: '17:00:00'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_WEEKDAY.search(template):
         warnings.append(
             "Condition uses template for day-of-week check — use native "
-            "`time` condition with `weekday:` list instead."
+            "`time` condition with `weekday:` list instead "
+            "(e.g., `condition: time, weekday: ['mon', 'tue', 'wed']`)."
+            + _ref(skill_prefix, "automation-patterns.md#native-conditions")
+        )
+    if _RE_NOW_DATE.search(template):
+        warnings.append(
+            "Condition uses date-based check (`now().date()` / `now().year/month/day`) — "
+            "for one-shot date-specific firing, use a `time` trigger and self-disable via "
+            "`automation.turn_off` with a hardcoded `entity_id` (the next `00:01` fire IS the "
+            "target date on creation day). For recurring date logic, expose a `sensor.date` via "
+            "the `time_date` integration and use a `state` trigger/condition."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_STATE_IN.search(template):
         warnings.append(
             "Condition uses template with `states(...) in [...]` — use native "
-            "`state` condition with `state:` list instead."
+            "`state` condition with `state:` list instead "
+            "(e.g., `condition: state, entity_id: climate.living_room, state: ['heat', 'cool']`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_DIRECT_STATE.search(template):
         warnings.append(
             "Template uses `states.domain.entity.state` direct access which "
-            "errors if entity doesn't exist — use `states('entity_id')` "
-            "function instead."
+            "errors if entity doesn't exist — use the `states('entity_id')` "
+            "function instead (returns 'unknown' if missing rather than raising)."
             + _ref(skill_prefix, "template-guidelines.md#common-patterns")
+        )
+
+    # Generic fallback: any Jinja in this logic position that didn't match
+    # a specific detector. Catches new anti-patterns (issue #1011) and
+    # reframes #695 from "enumerate bad shapes" to "surface every template
+    # in a logic position". Specific detectors above keep their tailored
+    # messages.
+    if (
+        len(warnings) == initial_count
+        and _RE_ANY_TEMPLATE.search(template)
+    ):
+        warnings.append(
+            f"Template detected in {position} — if this maps to a native option "
+            "(`numeric_state`, `state`, `time`, `sun`, `zone`, `device`), use that "
+            "instead. Templates fail silently at runtime and bypass schema validation."
+            + _ref(skill_prefix, "template-guidelines.md#when-to-avoid-templates")
         )
 
 
@@ -223,10 +295,19 @@ def _check_repeat_actions(
 def _check_action_tree(
     actions: Any, warnings: list[str], skill_prefix: str | None
 ) -> None:
-    """Walk action tree checking for wait_template and nested conditions."""
+    """Walk action tree checking for wait_template, nested conditions, and target templates."""
     for action in _as_list(actions):
         if not isinstance(action, dict):
             continue
+
+        # Inline condition steps (e.g. `- condition: template, value_template: ...`
+        # in a sequence). Without this, templates in condition shorthand inside
+        # scripts and automation actions slipped past the checker — only
+        # conditions in `if:`, `choose.conditions`, and `repeat.while/until`
+        # were inspected.
+        cond_kind = action.get("condition")
+        if isinstance(cond_kind, str) and "service" not in action:
+            _check_condition_templates([action], warnings, skill_prefix)
 
         if "wait_template" in action:
             warnings.append(
@@ -236,6 +317,20 @@ def _check_action_tree(
                 "passes immediately if already true)."
                 + _ref(skill_prefix, "automation-patterns.md#wait-actions")
             )
+
+        # Templated service dispatch: `service:` containing `{{ }}` or any
+        # `service_template:` field. The native alternative is a `choose`
+        # (or `if/then/else`) action that picks between hardcoded service
+        # names based on state.
+        _check_service_template(action, warnings, skill_prefix)
+
+        # Templates in target sub-fields (issue #1011 — `{{ this.entity_id }}`
+        # in target.entity_id was missed by #695). Service `data`, `event_data`,
+        # and notification message/title are intentionally NOT scanned — those
+        # are the documented legitimate dynamic-data positions.
+        target = action.get("target")
+        if isinstance(target, dict):
+            _check_target_dict(target, warnings, skill_prefix)
 
         # Nested conditions in choose/if/repeat
         if "choose" in action:
@@ -251,6 +346,70 @@ def _check_action_tree(
 
         if "repeat" in action and isinstance(action["repeat"], dict):
             _check_repeat_actions(action["repeat"], warnings, skill_prefix)
+
+
+def _check_service_template(
+    action: dict[str, Any], warnings: list[str], skill_prefix: str | None
+) -> None:
+    """Flag template-based service dispatch in an action.
+
+    Two shapes:
+    - ``service_template:`` — the explicit (deprecated) way to template a
+      service name. Flag any value.
+    - ``service:`` containing ``{{`` — modern syntax with a template.
+
+    The native alternative is a ``choose`` (or ``if/then/else``) action that
+    dispatches to different hardcoded service names based on state.
+    """
+    if "service_template" in action:
+        warnings.append(
+            "Action uses `service_template` — use a `choose` (or `if/then/else`) "
+            "action that dispatches to different hardcoded `service:` names based "
+            "on state. Native dispatch validates each service name at config load."
+            + _ref(skill_prefix, "automation-patterns.md#ifthen-vs-choose")
+        )
+        return
+    service = action.get("service")
+    if isinstance(service, str) and _RE_ANY_TEMPLATE.search(service):
+        warnings.append(
+            "Action `service:` field contains a template — use a `choose` "
+            "(or `if/then/else`) action with hardcoded service names instead. "
+            "Templates here bypass HA's service-name validation and fail "
+            "silently if the resolved string is invalid."
+            + _ref(skill_prefix, "automation-patterns.md#ifthen-vs-choose")
+        )
+
+
+def _check_target_dict(
+    target: dict[str, Any], warnings: list[str], skill_prefix: str | None
+) -> None:
+    """Flag any Jinja in target.entity_id/device_id/area_id/floor_id/label_id.
+
+    Targets are resolved at write time — every legitimate use case can be
+    written as a literal. `{{ this.entity_id }}` self-references in particular
+    are pure noise (the agent already knows the entity_id).
+    """
+    for field in _TARGET_FIELDS:
+        value = target.get(field)
+        for item in _as_list(value):
+            if not isinstance(item, str) or not _RE_ANY_TEMPLATE.search(item):
+                continue
+            if _RE_THIS_REFERENCE.search(item):
+                warnings.append(
+                    f"Action `target.{field}` uses a `this.*` self-reference template — "
+                    f"hardcode the literal value instead. The self-reference is always "
+                    f"resolvable at write time, so the template adds runtime cost without "
+                    f"any flexibility."
+                    + _ref(skill_prefix, "template-guidelines.md#when-to-avoid-templates")
+                )
+            else:
+                warnings.append(
+                    f"Action `target.{field}` uses a template — prefer a hardcoded literal, "
+                    f"or use a `choose` action with native conditions to dispatch to different "
+                    f"hardcoded targets. Templates in target fields fail silently if they "
+                    f"resolve to a non-existent entity."
+                    + _ref(skill_prefix, "template-guidelines.md#when-to-avoid-templates")
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -277,14 +436,16 @@ def _check_triggers(
                 + _ref(skill_prefix, "device-control.md#entity-id-vs-device-id")
             )
 
-        # Template trigger with detectable native alternative
+        # Template trigger — specific shapes first, generic fallback after.
         if platform == "template":
             vt = trigger.get("value_template", "")
             if isinstance(vt, str):
+                initial = len(warnings)
                 if _RE_NUMERIC_CMP.search(vt):
                     warnings.append(
                         "Trigger uses template with float/int comparison — "
-                        "use native `numeric_state` trigger instead."
+                        "use native `numeric_state` trigger instead "
+                        "(e.g., `platform: numeric_state, entity_id: sensor.temp, above: 30`)."
                         + _ref(
                             skill_prefix,
                             "automation-patterns.md#trigger-types",
@@ -293,7 +454,20 @@ def _check_triggers(
                 if _RE_IS_STATE.search(vt):
                     warnings.append(
                         "Trigger uses template with `is_state()` — use "
-                        "native `state` trigger instead."
+                        "native `state` trigger instead "
+                        "(e.g., `platform: state, entity_id: light.x, to: 'on'`)."
+                        + _ref(
+                            skill_prefix,
+                            "automation-patterns.md#trigger-types",
+                        )
+                    )
+                # Generic fallback for unmatched template triggers (issue #1011).
+                if len(warnings) == initial and _RE_ANY_TEMPLATE.search(vt):
+                    warnings.append(
+                        "Trigger uses `template` platform — if this maps to a native option "
+                        "(`state`, `numeric_state`, `time`, `time_pattern`, `sun`, `zone`, "
+                        "`event`), use that instead. Native triggers are event-driven; "
+                        "template triggers re-evaluate on every state change."
                         + _ref(
                             skill_prefix,
                             "automation-patterns.md#trigger-types",

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -182,15 +182,16 @@ def _check_template_string(
 ) -> None:
     """Check a single template string for known anti-patterns.
 
-    ``position`` is "condition" or "trigger" — used by the generic fallback
-    when none of the specific detectors match, so the message can name the
-    position concretely.
+    ``position`` is "condition" or "trigger" — used in every warning so the
+    function stays accurate if reused from a non-condition caller in the
+    future. The generic catch-all also names the position concretely.
     """
     initial_count = len(warnings)
+    label = position.capitalize()
 
     if _RE_NUMERIC_CMP.search(template):
         warnings.append(
-            "Condition uses template with float/int comparison — use native "
+            f"{label} uses template with float/int comparison — use native "
             "`numeric_state` condition instead "
             "(e.g., `condition: numeric_state, entity_id: sensor.temp, above: 25`). "
             "Native conditions are validated at config load and don't bypass HA's schema."
@@ -198,7 +199,7 @@ def _check_template_string(
         )
     if _RE_SUN.search(template):
         warnings.append(
-            "Condition uses template referencing `sun.sun` — use native "
+            f"{label} uses template referencing `sun.sun` — use native "
             "`sun` condition instead "
             "(e.g., `condition: sun, after: sunset` or `before: sunrise`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
@@ -206,28 +207,28 @@ def _check_template_string(
     elif _RE_IS_STATE.search(template):
         # Only flag if not already flagged as sun pattern
         warnings.append(
-            "Condition uses template with `is_state()` — use native "
+            f"{label} uses template with `is_state()` — use native "
             "`state` condition instead "
             "(e.g., `condition: state, entity_id: light.bedroom, state: 'on'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_NOW_TIME.search(template):
         warnings.append(
-            "Condition uses template with `now().hour/minute` — use native "
+            f"{label} uses template with `now().hour/minute` — use native "
             "`time` condition instead "
             "(e.g., `condition: time, after: '09:00:00', before: '17:00:00'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_WEEKDAY.search(template):
         warnings.append(
-            "Condition uses template for day-of-week check — use native "
+            f"{label} uses template for day-of-week check — use native "
             "`time` condition with `weekday:` list instead "
             "(e.g., `condition: time, weekday: ['mon', 'tue', 'wed']`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_NOW_DATE.search(template):
         warnings.append(
-            "Condition uses date-based check (`now().date()` / `now().year/month/day`) — "
+            f"{label} uses date-based check (`now().date()` / `now().year/month/day`) — "
             "for one-shot date-specific firing, use a `time` trigger and self-disable via "
             "`automation.turn_off` with a hardcoded `entity_id` (the next `00:01` fire IS the "
             "target date on creation day). For recurring date logic, expose a `sensor.date` via "
@@ -236,14 +237,14 @@ def _check_template_string(
         )
     if _RE_STATE_IN.search(template):
         warnings.append(
-            "Condition uses template with `states(...) in [...]` — use native "
+            f"{label} uses template with `states(...) in [...]` — use native "
             "`state` condition with `state:` list instead "
             "(e.g., `condition: state, entity_id: climate.living_room, state: ['heat', 'cool']`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_DIRECT_STATE.search(template):
         warnings.append(
-            "Template uses `states.domain.entity.state` direct access which "
+            f"{label} template uses `states.domain.entity.state` direct access which "
             "errors if entity doesn't exist — use the `states('entity_id')` "
             "function instead (returns 'unknown' if missing rather than raising)."
             + _ref(skill_prefix, "template-guidelines.md#common-patterns")

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -19,11 +19,18 @@ The checker covers two layers:
 2. A *generic* fallback that fires when ``{{ ... }}`` or ``{% ... %}`` shows
    up in a logic position (condition / trigger / wait_template / target field)
    without matching a specific pattern. This catches new template misuse
-   without waiting for a regex to be added — see issue #1011.
+   without waiting for a regex to be added.
 
-Templates in legitimate positions (action ``data`` fields, notification
-``message``/``title``, ``event_data``, ``variables``) are *not* inspected and
-therefore never flagged — those are the documented dynamic-data cases.
+Allowlist by design — these positions are NOT walked by any recursion path,
+so templates in them never trigger a warning even when present. They are the
+documented legitimate dynamic-data positions per
+``template-guidelines.md#when-templates-are-appropriate``:
+
+* Action ``data.*`` fields (notification messages, brightness, volume, etc.)
+* Notification ``message`` / ``title`` bodies
+* Action ``event_data.*`` (HA evaluates event_data as a template at runtime)
+* Top-level ``variables.*``
+* Action ``service_data.*`` (legacy alias for ``data``)
 
 Anti-patterns sourced from:
   https://github.com/homeassistant-ai/skills
@@ -56,8 +63,10 @@ _RE_WEEKDAY = re.compile(
     r"\bnow\(\)\s*\.\s*(?:weekday|isoweekday)\s*\("
     r"|\bnow\(\)\s*\.\s*strftime\s*\(\s*['\"]%[Aaw]['\"]"
 )
-# Date-component checks: now().date(), now().year/month/day
-# (issue #1011 — agent first reached for `now().date().isoformat() == '...'`)
+# Date-component checks: now().date(), now().year/month/day.
+# `\b` after year/month/day prevents matching `day_of_week`/`day_of_year`/etc.;
+# `(?!\s*\()` rejects method-call shapes like `now().day()` that don't exist
+# in HA's Jinja env.
 _RE_NOW_DATE = re.compile(
     r"\bnow\(\)\s*\.\s*date\s*\("
     r"|\bnow\(\)\s*\.\s*(?:year|month|day)\b(?!\s*\()"
@@ -75,8 +84,13 @@ _RE_ANY_TEMPLATE = re.compile(r"\{\{|\{%")
 # `this.X` self-reference (e.g. `{{ this.entity_id }}`)
 _RE_THIS_REFERENCE = re.compile(r"\bthis\s*\.\s*\w+")
 
-# Target sub-fields scanned for templates (issue #1011).
+# Target sub-fields scanned for templates. These are the only keys allowed
+# under ``target:`` in HA's modern action schema.
 _TARGET_FIELDS = ("entity_id", "device_id", "area_id", "floor_id", "label_id")
+
+# Keys that hold the service/action name in an action step. HA accepts both
+# ``service:`` (legacy) and ``action:`` (modern, 2024+) for the same field.
+_SERVICE_KEYS = ("service", "action")
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +182,14 @@ def _check_condition_templates(
                 vt = cond.get("value_template", "")
                 if isinstance(vt, str):
                     _check_template_string(vt, warnings, skill_prefix, "condition")
+            else:
+                # Non-template conditions (numeric_state, state, etc.) can
+                # still carry a `value_template` field (numeric_state uses one
+                # to compute the numeric value being compared). Scan it too,
+                # otherwise these templates slip past every detector.
+                vt = cond.get("value_template", "")
+                if isinstance(vt, str) and "{{" in vt:
+                    _check_template_string(vt, warnings, skill_prefix, "condition")
             # Recurse into compound conditions (and/or/not)
             nested = cond.get("conditions")
             if nested:
@@ -182,9 +204,11 @@ def _check_template_string(
 ) -> None:
     """Check a single template string for known anti-patterns.
 
-    ``position`` is "condition" or "trigger" — used in every warning so the
-    function stays accurate if reused from a non-condition caller in the
-    future. The generic catch-all also names the position concretely.
+    ``position`` is currently only "condition" (the function is called from
+    ``_check_condition_templates``). It's parameterized so both the warning
+    prefix AND the suggestion text adapt if a future caller passes "trigger".
+    The native shapes named here (numeric_state, state, time, sun) work as
+    both conditions and triggers in HA — only the noun changes.
     """
     initial_count = len(warnings)
     label = position.capitalize()
@@ -192,38 +216,38 @@ def _check_template_string(
     if _RE_NUMERIC_CMP.search(template):
         warnings.append(
             f"{label} uses template with float/int comparison — use native "
-            "`numeric_state` condition instead "
-            "(e.g., `condition: numeric_state, entity_id: sensor.temp, above: 25`). "
+            f"`numeric_state` {position} instead "
+            f"(e.g., `{position}: numeric_state, entity_id: sensor.temp, above: 25`). "
             "Native conditions are validated at config load and don't bypass HA's schema."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_SUN.search(template):
         warnings.append(
             f"{label} uses template referencing `sun.sun` — use native "
-            "`sun` condition instead "
-            "(e.g., `condition: sun, after: sunset` or `before: sunrise`)."
+            f"`sun` {position} instead "
+            f"(e.g., `{position}: sun, after: sunset` or `before: sunrise`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     elif _RE_IS_STATE.search(template):
         # Only flag if not already flagged as sun pattern
         warnings.append(
             f"{label} uses template with `is_state()` — use native "
-            "`state` condition instead "
-            "(e.g., `condition: state, entity_id: light.bedroom, state: 'on'`)."
+            f"`state` {position} instead "
+            f"(e.g., `{position}: state, entity_id: light.bedroom, state: 'on'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_NOW_TIME.search(template):
         warnings.append(
             f"{label} uses template with `now().hour/minute` — use native "
-            "`time` condition instead "
-            "(e.g., `condition: time, after: '09:00:00', before: '17:00:00'`)."
+            f"`time` {position} instead "
+            f"(e.g., `{position}: time, after: '09:00:00', before: '17:00:00'`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_WEEKDAY.search(template):
         warnings.append(
             f"{label} uses template for day-of-week check — use native "
-            "`time` condition with `weekday:` list instead "
-            "(e.g., `condition: time, weekday: ['mon', 'tue', 'wed']`)."
+            f"`time` {position} with `weekday:` list instead "
+            f"(e.g., `{position}: time, weekday: ['mon', 'tue', 'wed']`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_NOW_DATE.search(template):
@@ -232,14 +256,14 @@ def _check_template_string(
             "for one-shot date-specific firing, use a `time` trigger and self-disable via "
             "`automation.turn_off` with a hardcoded `entity_id` (the next `00:01` fire IS the "
             "target date on creation day). For recurring date logic, expose a `sensor.date` via "
-            "the `time_date` integration and use a `state` trigger/condition."
+            f"the `time_date` integration and use a `state` {position}."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_STATE_IN.search(template):
         warnings.append(
             f"{label} uses template with `states(...) in [...]` — use native "
-            "`state` condition with `state:` list instead "
-            "(e.g., `condition: state, entity_id: climate.living_room, state: ['heat', 'cool']`)."
+            f"`state` {position} with `state:` list instead "
+            f"(e.g., `{position}: state, entity_id: climate.living_room, state: ['heat', 'cool']`)."
             + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
     if _RE_DIRECT_STATE.search(template):
@@ -302,12 +326,14 @@ def _check_action_tree(
             continue
 
         # Inline condition steps (e.g. `- condition: template, value_template: ...`
-        # in a sequence). Without this, templates in condition shorthand inside
-        # scripts and automation actions slipped past the checker — only
-        # conditions in `if:`, `choose.conditions`, and `repeat.while/until`
-        # were inspected.
+        # in a sequence). Detect by `condition: <str>` AND no service/action key
+        # present — a service-call step uses `condition:` as a legacy run-if
+        # filter, not as a step kind. Without this branch, templates in
+        # condition shorthand inside scripts/automation actions slipped past
+        # the checker; only conditions in `if:`, `choose.conditions`, and
+        # `repeat.while/until` were inspected.
         cond_kind = action.get("condition")
-        if isinstance(cond_kind, str) and "service" not in action:
+        if isinstance(cond_kind, str) and not any(k in action for k in _SERVICE_KEYS):
             _check_condition_templates([action], warnings, skill_prefix)
 
         if "wait_template" in action:
@@ -319,16 +345,16 @@ def _check_action_tree(
                 + _ref(skill_prefix, "automation-patterns.md#wait-actions")
             )
 
-        # Templated service dispatch: `service:` containing `{{ }}` or any
-        # `service_template:` field. The native alternative is a `choose`
-        # (or `if/then/else`) action that picks between hardcoded service
-        # names based on state.
+        # Templated service dispatch: `service:`/`action:` containing `{{ }}`
+        # or any `service_template:` field. The native alternative is a
+        # `choose` (or `if/then/else`) action that picks between hardcoded
+        # service names based on state.
         _check_service_template(action, warnings, skill_prefix)
 
-        # Templates in target sub-fields (issue #1011 — `{{ this.entity_id }}`
-        # in target.entity_id was missed by #695). Service `data`, `event_data`,
-        # and notification message/title are intentionally NOT scanned — those
-        # are the documented legitimate dynamic-data positions.
+        # Templates in target sub-fields. Action `data`, `event_data`,
+        # `service_data`, notification message/title, and `variables` are
+        # legitimate dynamic-data positions per template-guidelines.md and
+        # are not walked by any recursion path here.
         target = action.get("target")
         if isinstance(target, dict):
             _check_target_dict(target, warnings, skill_prefix)
@@ -348,37 +374,47 @@ def _check_action_tree(
         if "repeat" in action and isinstance(action["repeat"], dict):
             _check_repeat_actions(action["repeat"], warnings, skill_prefix)
 
+        # `parallel:` runs sub-actions concurrently — same shape as `sequence`,
+        # different semantics. Recurse so templates inside parallel branches
+        # are inspected the same as templates inside choose/repeat sequences.
+        if "parallel" in action and isinstance(action["parallel"], list):
+            _check_action_tree(action["parallel"], warnings, skill_prefix)
+
 
 def _check_service_template(
     action: dict[str, Any], warnings: list[str], skill_prefix: str | None
 ) -> None:
     """Flag template-based service dispatch in an action.
 
-    Two shapes:
-    - ``service_template:`` — the explicit (deprecated) way to template a
-      service name. Flag any value.
+    Three shapes:
+    - ``service_template:`` — legacy explicit way to template a service name.
+      Flag any value.
     - ``service:`` containing ``{{`` — modern syntax with a template.
+    - ``action:`` containing ``{{`` — HA's 2024+ rename of ``service:``.
 
     The native alternative is a ``choose`` (or ``if/then/else``) action that
     dispatches to different hardcoded service names based on state.
     """
     if "service_template" in action:
         warnings.append(
-            "Action uses `service_template` — use a `choose` (or `if/then/else`) "
-            "action that dispatches to different hardcoded `service:` names based "
-            "on state. Native dispatch validates each service name at config load."
+            "Action uses `service_template` (legacy templated service dispatch) — "
+            "use a `choose` (or `if/then/else`) action that dispatches to different "
+            "hardcoded `action:` names based on state. Native dispatch validates "
+            "each service name at config load."
             + _ref(skill_prefix, "automation-patterns.md#ifthen-vs-choose")
         )
         return
-    service = action.get("service")
-    if isinstance(service, str) and _RE_ANY_TEMPLATE.search(service):
-        warnings.append(
-            "Action `service:` field contains a template — use a `choose` "
-            "(or `if/then/else`) action with hardcoded service names instead. "
-            "Templates here bypass HA's service-name validation and fail "
-            "silently if the resolved string is invalid."
-            + _ref(skill_prefix, "automation-patterns.md#ifthen-vs-choose")
-        )
+    for key in _SERVICE_KEYS:
+        value = action.get(key)
+        if isinstance(value, str) and _RE_ANY_TEMPLATE.search(value):
+            warnings.append(
+                f"Action `{key}:` field contains a template — use a `choose` "
+                "(or `if/then/else`) action with hardcoded service names instead. "
+                "Templates here bypass HA's service-name validation and fail "
+                "silently if the resolved string is invalid."
+                + _ref(skill_prefix, "automation-patterns.md#ifthen-vs-choose")
+            )
+            return
 
 
 def _check_target_dict(
@@ -386,9 +422,11 @@ def _check_target_dict(
 ) -> None:
     """Flag any Jinja in target.entity_id/device_id/area_id/floor_id/label_id.
 
-    Targets are resolved at write time — every legitimate use case can be
-    written as a literal. `{{ this.entity_id }}` self-references in particular
-    are pure noise (the agent already knows the entity_id).
+    Templates in target fields bypass HA's entity-existence validation at
+    config load and fail silently if they resolve to a non-existent entity.
+    `{{ this.entity_id }}`-style self-references are especially pointless —
+    the calling automation/script already knows its own entity_id, so
+    hardcoding the literal is both simpler and safer.
     """
     for field in _TARGET_FIELDS:
         value = target.get(field)
@@ -462,7 +500,7 @@ def _check_triggers(
                             "automation-patterns.md#trigger-types",
                         )
                     )
-                # Generic fallback for unmatched template triggers (issue #1011).
+                # Generic fallback for unmatched template triggers.
                 if len(warnings) == initial and _RE_ANY_TEMPLATE.search(vt):
                     warnings.append(
                         "Trigger uses `template` platform — if this maps to a native option "

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -371,6 +371,25 @@ class AutomationConfigTools:
         """
         Create or update a Home Assistant automation.
 
+        PREFER NATIVE SOLUTIONS OVER TEMPLATES (read this before writing any `{{ ... }}`):
+        Native triggers/conditions/actions are validated at config load, fail loudly, and
+        do not bypass HA's schema. Templates fail silently at runtime and obscure intent.
+        - `condition: numeric_state` instead of `{{ states('x') | float > N }}`
+        - `condition: state` (with `state:` list) instead of `{{ is_state(...) }}` /
+          `{{ states(x) in [...] }}`
+        - `condition: time` instead of `{{ now().hour ... }}` or `{{ now().weekday() ... }}`
+        - `condition: sun` instead of `{{ is_state('sun.sun', ...) }}`
+        - `wait_for_trigger` instead of `wait_template`
+        - `choose` action instead of template-based service names
+        - For one-shot date firing, use a `time` trigger plus `automation.turn_off` on a
+          hardcoded entity_id — not `{{ now().date() ... }}`.
+        - Hardcode `target.entity_id` literals — never `{{ this.entity_id }}`.
+        Templates are appropriate ONLY in `data.*` fields, notification message/title,
+        `event_data`, and `variables`. The reactive best-practice checker on this tool
+        will surface anything in a logic position that should be native; consult the
+        `best_practice_warnings` field on the response and fix before re-submitting.
+        For comprehensive guidance, call `ha_get_skill_home_assistant_best_practices`.
+
         Supports two modes: full config replacement OR Python transformation.
 
         WHEN TO USE WHICH MODE:
@@ -477,14 +496,6 @@ class AutomationConfigTools:
                 }
             }
         )
-
-        PREFER NATIVE SOLUTIONS OVER TEMPLATES:
-        Before using template triggers/conditions/actions, check if a native option exists:
-        - Use `condition: state` with `state: [list]` instead of template for multiple states
-        - Use `condition: state` with `attribute:` instead of template for attribute checks
-        - Use `condition: numeric_state` instead of template for number comparisons
-        - Use `wait_for_trigger` instead of `wait_template` when waiting for state changes
-        - Use `choose` action instead of template-based service names
 
         TRIGGER TYPES: time, time_pattern, sun, state, numeric_state, event, device, zone, template, and more
         CONDITION TYPES: state, numeric_state, time, sun, template, device, zone, and more

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -285,6 +285,19 @@ class ConfigScriptTools:
         """
         Create or update a Home Assistant script.
 
+        PREFER NATIVE ACTIONS OVER TEMPLATES (read this before writing any `{{ ... }}`):
+        Native actions are validated at config load, fail loudly, and do not bypass HA's
+        schema. Templates in logic positions fail silently and obscure intent.
+        - `choose` / `if/then/else` instead of template-based service names
+        - `wait_for_trigger` instead of `wait_template`
+        - `repeat` with `for_each` instead of template loops
+        - Hardcode `target.entity_id` literals — never `{{ this.entity_id }}`.
+        Templates are appropriate ONLY in `data.*` fields, notification message/title,
+        `event_data`, and `variables`. The reactive best-practice checker on this tool
+        will surface anything in a logic position that should be native; consult the
+        `best_practice_warnings` field on the response and fix before re-submitting.
+        For comprehensive guidance, call `ha_get_skill_home_assistant_best_practices`.
+
         Supports two modes: full config replacement OR Python transformation.
 
         WHEN TO USE WHICH MODE:
@@ -392,16 +405,6 @@ class ConfigScriptTools:
                 }
             }
         })
-
-        PREFER NATIVE ACTIONS OVER TEMPLATES:
-        Before using template-based logic in scripts, check if native actions exist:
-        - Use `choose` action instead of template-based service names
-        - Use `if/then/else` action instead of template conditions
-        - Use `repeat` action with `for_each` instead of template loops
-        - Use `wait_for_trigger` instead of `wait_template` when waiting for state changes
-        - Use native action variables instead of complex template calculations
-
-        For detailed script configuration help, use ha_get_skill_home_assistant_best_practices.
 
         Note: Scripts use Home Assistant's action syntax. Check the documentation for advanced
         features like conditions, variables, parallel execution, and service call options.

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -514,3 +514,386 @@ class TestDeduplication:
         warnings = check_automation_config(config)
         float_warnings = [w for w in warnings if "float/int comparison" in w]
         assert len(float_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Date-based condition detection (issue #1011, regex extension)
+# ---------------------------------------------------------------------------
+
+
+class TestDateBasedCondition:
+    """Templates checking date components should suggest one-shot patterns."""
+
+    def test_now_date_isoformat(self):
+        """The exact pattern from issue #1011: now().date().isoformat() == 'YYYY-MM-DD'."""
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().date().isoformat() == '2026-04-19' }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "date")
+        # Should suggest a native alternative inline
+        assert _has_warning_containing(warnings, "self-disable") or _has_warning_containing(
+            warnings, "one-shot"
+        ) or _has_warning_containing(warnings, "sensor.date")
+
+    def test_now_year(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().year == 2026 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "date")
+
+    def test_now_month(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().month == 12 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "date")
+
+    def test_now_day(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().day == 1 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "date")
+
+
+# ---------------------------------------------------------------------------
+# Target-field template detection (issue #1011)
+# ---------------------------------------------------------------------------
+
+
+class TestTargetTemplate:
+    """Templates in target.entity_id / device_id / area_id / floor_id / label_id."""
+
+    def test_this_entity_id_in_target(self):
+        """The exact pattern from issue #1011: {{ this.entity_id }} in target."""
+        config = {
+            "trigger": [{"platform": "time", "at": "00:01:00"}],
+            "action": [{
+                "service": "automation.turn_off",
+                "target": {"entity_id": "{{ this.entity_id }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+        # Inline guidance should suggest hardcoding
+        assert _has_warning_containing(warnings, "hardcode") or _has_warning_containing(
+            warnings, "literal"
+        )
+
+    def test_this_attributes_in_target(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "00:01:00"}],
+            "action": [{
+                "service": "automation.turn_off",
+                "target": {"entity_id": "{{ this.attributes.id }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+
+    def test_template_in_target_area_id(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "input_select.house_mode"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"area_id": "{{ states('input_select.house_mode') }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+
+    def test_target_list_with_template(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"entity_id": ["light.kitchen", "{{ this.entity_id }}"]},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+
+    def test_clean_literal_target_no_warning(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"entity_id": "light.kitchen"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert not _has_warning_containing(warnings, "target")
+
+
+# ---------------------------------------------------------------------------
+# Generic any-template-in-logic-position fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGenericAnyTemplate:
+    """Templates in logic positions with no specific detector should still warn."""
+
+    def test_unknown_template_in_condition(self):
+        """Arbitrary template logic that doesn't match the 12 specific detectors."""
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ (states('sensor.a') | length) % 2 == 0 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # Should produce a generic warning since no specific pattern matched
+        assert warnings
+        assert any("template" in w.lower() for w in warnings)
+
+    def test_unknown_template_in_trigger(self):
+        config = {
+            "trigger": [{
+                "platform": "template",
+                "value_template": "{{ (now() - states.sensor.x.last_updated).total_seconds() > 300 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert warnings
+        assert any("trigger" in w.lower() or "template" in w.lower() for w in warnings)
+
+    def test_specific_pattern_does_not_double_flag(self):
+        """When a specific detector fires, generic should NOT also fire for same template."""
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ states('sensor.temp') | float > 25 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # The float-comparison warning fires
+        float_warnings = [w for w in warnings if "float/int comparison" in w]
+        assert len(float_warnings) == 1
+        # No additional generic-template warning for the same condition
+        generic_warnings = [
+            w for w in warnings
+            if "template detected" in w.lower() and "float/int" not in w
+        ]
+        assert len(generic_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Allowlist — legitimate template positions
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistLegitimatePositions:
+    """Templates in service data, notification bodies, etc. must NOT be flagged."""
+
+    def test_template_in_notification_message_clean(self):
+        """Notification message templates are legitimate per template-guidelines.md."""
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "binary_sensor.door"}],
+            "action": [{
+                "service": "notify.mobile_app",
+                "data": {
+                    "message": "Door {{ trigger.to_state.attributes.friendly_name }} opened",
+                    "title": "Alert: {{ now().strftime('%H:%M') }}",
+                },
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert warnings == []
+
+    def test_template_in_brightness_data_clean(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "input_number.target_brightness"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"entity_id": "light.x"},
+                "data": {"brightness": "{{ states('input_number.target_brightness') | int }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert warnings == []
+
+    def test_template_in_event_data_clean(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "sensor.x"}],
+            "action": [{
+                "event": "custom_event",
+                "event_data": {
+                    "value": "{{ states('sensor.x') | float * 2 }}",
+                },
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert warnings == []
+
+    def test_template_in_variables_clean(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "sensor.x"}],
+            "variables": {"computed": "{{ states('sensor.x') | float + 10 }}"},
+            "action": [{"service": "light.turn_on", "target": {"entity_id": "light.x"}}],
+        }
+        warnings = check_automation_config(config)
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Inline condition steps inside action sequences (pre-existing checker gap)
+# ---------------------------------------------------------------------------
+
+
+class TestInlineConditionSteps:
+    """Condition-shorthand steps inside sequences/then/else were not inspected."""
+
+    def test_template_condition_step_in_script_sequence(self):
+        config = {
+            "sequence": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ is_state('light.x', 'on') }}",
+                },
+                {"service": "light.turn_off", "target": {"entity_id": "light.x"}},
+            ],
+        }
+        warnings = check_script_config(config)
+        assert _has_warning_containing(warnings, "is_state()")
+
+    def test_template_condition_step_in_automation_action(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ now().hour < 12 }}",
+                },
+                {"service": "light.turn_on", "target": {"entity_id": "light.x"}},
+            ],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "now().hour/minute")
+
+    def test_compound_condition_step_in_sequence(self):
+        config = {
+            "sequence": [
+                {
+                    "condition": "and",
+                    "conditions": [
+                        {
+                            "condition": "template",
+                            "value_template": "{{ states('sensor.x') | float > 5 }}",
+                        },
+                    ],
+                },
+            ],
+        }
+        warnings = check_script_config(config)
+        assert _has_warning_containing(warnings, "float/int comparison")
+
+
+# ---------------------------------------------------------------------------
+# Templates in action service dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestActionServiceTemplate:
+    """Templates in `service:` or `service_template:` are anti-patterns."""
+
+    def test_service_template_field_flagged(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service_template": "{{ 'light.turn_on' if is_state('x', 'on') else 'light.turn_off' }}",
+                "target": {"entity_id": "light.x"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert any("service" in w.lower() for w in warnings)
+        assert any(
+            "choose" in w.lower() or "if/then" in w.lower() or "if-then" in w.lower()
+            for w in warnings
+        )
+
+    def test_service_with_template_value_flagged(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "{{ states('input_select.service') }}",
+                "target": {"entity_id": "light.x"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert any("service" in w.lower() for w in warnings)
+
+    def test_clean_literal_service_no_warning(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"entity_id": "light.x"},
+                "data": {"brightness": "{{ states('input_number.b') | int }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        # No service-template warning; data templates are allowlisted
+        assert not any(
+            "service:" in w.lower() and "template" in w.lower() for w in warnings
+        )
+
+
+# ---------------------------------------------------------------------------
+# Inline guidance — warnings should carry native alternative text inline
+# ---------------------------------------------------------------------------
+
+
+class TestInlineGuidance:
+    """Each warning should carry a native alternative inline, not just a URI."""
+
+    def test_numeric_warning_has_inline_alternative(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ states('sensor.temp') | float > 25 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # Inline guidance: should mention the native alternative concretely
+        assert any(
+            "above:" in w.lower() or "below:" in w.lower() or "numeric_state" in w
+            for w in warnings
+        )
+
+    def test_is_state_warning_has_inline_alternative(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ is_state('light.x', 'on') }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert any(
+            "condition: state" in w.lower()
+            or "state condition" in w.lower()
+            or "entity_id:" in w
+            for w in warnings
+        )

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -897,3 +897,417 @@ class TestInlineGuidance:
             or "entity_id:" in w
             for w in warnings
         )
+
+
+# ---------------------------------------------------------------------------
+# Modern `action:` step key (HA 2024+ rename of `service:`)
+# ---------------------------------------------------------------------------
+
+
+class TestActionKeyStep:
+    """HA accepts both `service:` and `action:` for the service-name field
+    in an action step. Both must be checked for templated dispatch, and
+    neither should be confused with an inline `condition:` step."""
+
+    def test_action_key_with_template_flagged(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "action": "{{ states('input_select.service') }}",
+                "target": {"entity_id": "light.x"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert any("action:" in w.lower() and "choose" in w.lower() for w in warnings)
+
+    def test_action_key_clean_literal_no_warning(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "action": "light.turn_on",
+                "target": {"entity_id": "light.x"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert not any("template" in w.lower() and "service" in w.lower() for w in warnings)
+
+    def test_action_key_step_with_legacy_condition_filter_not_double_flagged(self):
+        """A service-call step with an `action:` key plus a legacy `condition:`
+        run-if filter (a dict) must NOT be cross-checked as an inline
+        condition step. The inline-condition-step branch should bail when any
+        service-key is present, regardless of which key (service/action)."""
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "action": "light.turn_on",
+                "target": {"entity_id": "light.x"},
+                "condition": "state",  # legacy run-if filter shorthand
+            }],
+        }
+        # We don't expect a condition-related warning here because this is a
+        # service-call step, not a standalone condition step.
+        warnings = check_automation_config(config)
+        # The action's "condition: state" string is a stub legacy filter,
+        # not a templated condition — should produce no warnings.
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# `parallel:` action container
+# ---------------------------------------------------------------------------
+
+
+class TestParallelContainer:
+    """`parallel:` runs sub-actions concurrently and must be walked the same
+    as `sequence` so templates inside parallel branches are inspected."""
+
+    def test_wait_template_inside_parallel(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "parallel": [
+                    {"wait_template": "{{ is_state('door.x', 'open') }}"},
+                    {"service": "light.turn_on", "target": {"entity_id": "light.x"}},
+                ],
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "wait_template")
+
+    def test_target_template_inside_parallel(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "parallel": [
+                    {
+                        "service": "automation.turn_off",
+                        "target": {"entity_id": "{{ this.entity_id }}"},
+                    },
+                ],
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+
+    def test_inline_condition_step_inside_parallel(self):
+        config = {
+            "sequence": [{
+                "parallel": [
+                    {
+                        "condition": "template",
+                        "value_template": "{{ is_state('light.x', 'on') }}",
+                    },
+                    {"service": "light.turn_off", "target": {"entity_id": "light.x"}},
+                ],
+            }],
+        }
+        warnings = check_script_config(config)
+        assert _has_warning_containing(warnings, "is_state()")
+
+
+# ---------------------------------------------------------------------------
+# value_template on non-template conditions (numeric_state etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericStateValueTemplate:
+    """A `condition: numeric_state` block can carry a `value_template:` field
+    that computes the numeric value being compared. That template was
+    previously not scanned (only `condition: template` was)."""
+
+    def test_value_template_on_numeric_state_flagged(self):
+        config = {
+            "condition": [{
+                "condition": "numeric_state",
+                "entity_id": "sensor.temp",
+                "above": 25,
+                "value_template": "{{ states('sensor.raw_temp') | float * 1.8 + 32 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # The value_template contains float arithmetic and `> 0`-style
+        # comparisons aren't required for the generic catch-all to fire.
+        assert any("template" in w.lower() for w in warnings)
+
+    def test_value_template_on_numeric_state_with_is_state_flagged(self):
+        config = {
+            "condition": [{
+                "condition": "numeric_state",
+                "entity_id": "sensor.x",
+                "above": 0,
+                "value_template": "{{ 1 if is_state('switch.x', 'on') else 0 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # Specific is_state detector should fire on the value_template.
+        assert _has_warning_containing(warnings, "is_state()")
+
+
+# ---------------------------------------------------------------------------
+# Negative tests for new specific detectors
+# ---------------------------------------------------------------------------
+
+
+class TestNewDetectorNegativeCases:
+    """Look-alikes that should NOT trigger a specific detector. They may
+    still fire the generic catch-all, but the SPECIFIC pattern's targeted
+    message should not appear."""
+
+    def test_now_day_of_week_does_not_match_now_date_pattern(self):
+        """`now().day_of_week` is a real Jinja accessor on datetime; it must
+        not collide with the now().day specific message."""
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().day_of_week == 0 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        # No "date-based check" specific message — falls through to generic
+        assert not any("date-based check" in w for w in warnings)
+
+    def test_now_day_method_call_does_not_match(self):
+        """`now().day(` (with parens) is a method call shape that doesn't
+        exist in HA's Jinja env — the negative lookahead in _RE_NOW_DATE
+        should reject it."""
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now().day() == 1 }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert not any("date-based check" in w for w in warnings)
+
+    def test_this_house_does_not_match_this_reference(self):
+        """`this_house.entity_id` looks like `this.entity_id` but the `\\b`
+        boundary in _RE_THIS_REFERENCE rejects it."""
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "light.turn_on",
+                "target": {"entity_id": "{{ this_house.entity_id }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        # Still fires a target-template warning (any template in target is
+        # flagged), but NOT the `this.*` self-reference specific message.
+        target_warnings = [w for w in warnings if "target" in w.lower()]
+        assert target_warnings  # fired generic target warning
+        assert not any("self-reference" in w for w in target_warnings)
+
+    def test_service_data_does_not_match_service_template(self):
+        """`service_data:` is a legacy alias for `data:` — has nothing to do
+        with `service_template:`. Templates in service_data must not be
+        flagged as templated service dispatch."""
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "sensor.x"}],
+            "action": [{
+                "service": "notify.mobile",
+                "service_data": {"message": "{{ states('sensor.x') | float }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        # service_data is allowlisted (treated like data)
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Recursion through nested action containers for new detectors
+# ---------------------------------------------------------------------------
+
+
+class TestNewDetectorRecursion:
+    """Every new detector hook (target, service template, inline condition
+    step) must work the same when the action lives inside a nested choose,
+    if/then/else, or repeat container."""
+
+    def test_target_template_inside_choose(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "choose": [{
+                    "conditions": [{"condition": "state", "entity_id": "x", "state": "on"}],
+                    "sequence": [{
+                        "service": "automation.turn_off",
+                        "target": {"entity_id": "{{ this.entity_id }}"},
+                    }],
+                }],
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "target")
+
+    def test_service_template_inside_then(self):
+        config = {
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "if": [{"condition": "state", "entity_id": "x", "state": "on"}],
+                "then": [{
+                    "service_template": "{{ 'a.b' if x else 'c.d' }}",
+                }],
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert any("service_template" in w.lower() for w in warnings)
+
+    def test_inline_date_condition_step_inside_repeat(self):
+        config = {
+            "sequence": [{
+                "repeat": {
+                    "while": [{"condition": "state", "entity_id": "x", "state": "on"}],
+                    "sequence": [
+                        {
+                            "condition": "template",
+                            "value_template": "{{ now().date().isoformat() == '2026-01-01' }}",
+                        },
+                        {"service": "light.turn_on", "target": {"entity_id": "light.x"}},
+                    ],
+                },
+            }],
+        }
+        warnings = check_script_config(config)
+        assert _has_warning_containing(warnings, "date-based check")
+
+
+# ---------------------------------------------------------------------------
+# Specific-pattern detectors don't double-flag with generic catch-all
+# ---------------------------------------------------------------------------
+
+
+class TestNoGenericDoubleFlag:
+    """For each specific detector that fires, confirm no additional generic
+    'Template detected in <position>' warning appears. The float case is
+    already covered in TestGenericAnyTemplate; this class covers the rest."""
+
+    def _assert_no_generic(self, warnings: list[str]) -> None:
+        generic = [w for w in warnings if w.startswith("Template detected in")]
+        assert not generic, f"Unexpected generic warning: {generic}"
+
+    def test_is_state_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ is_state('x', 'on') }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_sun_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ is_state('sun.sun', 'below_horizon') }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_now_hour_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ now().hour > 9 }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_weekday_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ now().weekday() == 0 }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_now_date_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ now().date().isoformat() == '2026-04-19' }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_states_in_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ states('x') in ['a', 'b'] }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+    def test_direct_state_no_generic(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ states.sensor.x.state | float > 0 }}"}],
+            "action": [],
+        })
+        self._assert_no_generic(warnings)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist: data.entity_id (some integrations use it)
+# ---------------------------------------------------------------------------
+
+
+class TestDataEntityIdAllowlist:
+    """`data.entity_id` is used by some HA service calls (notify.notify with
+    `data.entity_id` for camera attachments, etc.). Templates here are NOT
+    in a logic position and must not be flagged."""
+
+    def test_template_in_data_entity_id_not_flagged(self):
+        config = {
+            "trigger": [{"platform": "state", "entity_id": "sensor.x"}],
+            "action": [{
+                "service": "notify.mobile_app",
+                "data": {"entity_id": "{{ trigger.entity_id }}"},
+            }],
+        }
+        warnings = check_automation_config(config)
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# skill_prefix=None mode for the new detector categories
+# ---------------------------------------------------------------------------
+
+
+class TestSkillPrefixNoneNewDetectors:
+    """Every new detector must respect `skill_prefix=None` (warnings still
+    fire, but without `See skill://...` suffix). Locks the contract so a
+    careless future detector author who forgets `+ _ref(...)` breaks it
+    loudly in tests."""
+
+    @staticmethod
+    def _assert_clean(warnings: list[str]) -> None:
+        assert warnings, "Expected a warning"
+        for w in warnings:
+            assert "skill://" not in w
+            assert " See " not in w
+
+    def test_date_detector(self):
+        warnings = check_automation_config({
+            "condition": [{"condition": "template", "value_template": "{{ now().date() == today }}"}],
+            "action": [],
+        }, skill_prefix=None)
+        self._assert_clean(warnings)
+
+    def test_target_self_reference(self):
+        warnings = check_automation_config({
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{
+                "service": "automation.turn_off",
+                "target": {"entity_id": "{{ this.entity_id }}"},
+            }],
+        }, skill_prefix=None)
+        self._assert_clean(warnings)
+
+    def test_service_template(self):
+        warnings = check_automation_config({
+            "trigger": [{"platform": "time", "at": "08:00:00"}],
+            "action": [{"service_template": "{{ x }}"}],
+        }, skill_prefix=None)
+        self._assert_clean(warnings)
+
+    def test_generic_catchall(self):
+        warnings = check_automation_config({
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ (states('sensor.a') | length) % 2 == 0 }}",
+            }],
+            "action": [],
+        }, skill_prefix=None)
+        self._assert_clean(warnings)

--- a/tests/src/unit/test_ha_resources_as_tools.py
+++ b/tests/src/unit/test_ha_resources_as_tools.py
@@ -22,6 +22,19 @@ def test_transform_generated_tool_names_match_class_constants():
     )
 
 
+def test_descriptions_keys_match_rename_targets():
+    """_DESCRIPTIONS must have exactly one entry per rename target so a
+    future rename can't drift to a tool name with no override (silent
+    fallback to FastMCP default) or an orphan description (typo'd key
+    that's never applied)."""
+    rename_targets = set(HaResourcesAsTools._RENAMES.values())
+    description_keys = set(HaResourcesAsTools._DESCRIPTIONS.keys())
+    assert description_keys == rename_targets, (
+        f"_DESCRIPTIONS keys {description_keys} must equal "
+        f"_RENAMES.values() {rename_targets}"
+    )
+
+
 @pytest.fixture
 def transform():
     """A real HaResourcesAsTools wired to a fresh FastMCP server."""

--- a/tests/src/unit/test_ha_resources_as_tools.py
+++ b/tests/src/unit/test_ha_resources_as_tools.py
@@ -109,3 +109,60 @@ class TestGetTool:
         call_next = AsyncMock(return_value=None)
         await transform.get_tool("ha_search_entities", call_next)
         call_next.assert_awaited_once_with("ha_search_entities", version=None)
+
+
+class TestDescriptionOverride:
+    """Tool descriptions get BM25-tuned, action-phrased text on rename.
+
+    FastMCP's defaults are terse and don't surface on the task-phrased
+    tool_search queries agents make when reaching for config-write tools.
+    Issue #1011, Gap 1.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_resources_description_has_action_keywords(self, transform):
+        result = await transform.list_tools([])
+        list_tool = next(
+            t for t in result if t.name == HaResourcesAsTools.LIST_TOOL_NAME
+        )
+        description = (list_tool.description or "").lower()
+        # Must mention the workflow positions agents query for
+        assert "automation" in description
+        assert "script" in description
+        # Must include a "use BEFORE" anchor for task-phrased queries
+        assert "before" in description
+        # Must mention skill reference files so the listing intent is clear
+        assert "skill" in description or "reference" in description
+
+    @pytest.mark.asyncio
+    async def test_read_resource_description_has_action_keywords(self, transform):
+        result = await transform.list_tools([])
+        read_tool = next(
+            t for t in result if t.name == HaResourcesAsTools.READ_TOOL_NAME
+        )
+        description = (read_tool.description or "").lower()
+        assert "automation" in description
+        assert "script" in description
+        assert "before" in description
+        # Must point at ha_list_resources for discovery
+        assert "ha_list_resources" in description
+
+    @pytest.mark.asyncio
+    async def test_get_tool_returns_overridden_description(self, transform):
+        list_tool = await transform.get_tool(
+            HaResourcesAsTools.LIST_TOOL_NAME, AsyncMock()
+        )
+        read_tool = await transform.get_tool(
+            HaResourcesAsTools.READ_TOOL_NAME, AsyncMock()
+        )
+        assert list_tool is not None and read_tool is not None
+        # Both code paths (list_tools, get_tool) must produce the same
+        # description so the catalog and per-call lookups agree.
+        assert (
+            list_tool.description
+            == HaResourcesAsTools._DESCRIPTIONS[HaResourcesAsTools.LIST_TOOL_NAME]
+        )
+        assert (
+            read_tool.description
+            == HaResourcesAsTools._DESCRIPTIONS[HaResourcesAsTools.READ_TOOL_NAME]
+        )


### PR DESCRIPTION
## What does this PR do?

Closes #1011 with defense-in-depth on the same failure mode. Each of the four actionable gaps from the issue gets its own fix; only Gap 3 (FastMCP `instructions` reaching the client — a known client-side limitation) is intentionally out of scope.

**1. Reactive checker broadened from pattern-matching to any-Jinja-in-logic-position.** PR #695's 12 specific detectors are kept verbatim with their targeted messages. A generic catch-all now fires when `{{ ... }}` or `{% ... %}` lands in a *logic* position without matching a specific pattern. Reframes the checker from "enumerate bad shapes" (intractable — every new failure mode needs a regex extension) to "surface every template in a logic position" (tractable, with a small allowlist of known-legitimate dynamic-data positions).

**2. Specific detectors for the two patterns that slipped #695 in the issue:**
- `now().date()` / `now().year` / `.month` / `.day` → suggest one-shot pattern (time trigger + `automation.turn_off` on a hardcoded entity_id) or `sensor.date` from the `time_date` integration.
- `{{ this.entity_id }}` / `{{ this.attributes.* }}` in `target.entity_id` / `device_id` / `area_id` / `floor_id` / `label_id` → hardcode the literal (always resolvable at write time).

**3. Inline native alternatives in every warning.** Each warning now carries a concrete example inline (e.g., `condition: numeric_state, entity_id: sensor.temp, above: 25`) before the `skill://` URI suffix, so clients that don't auto-fetch resource URIs still get actionable guidance. The 12 existing specific messages keep their tailored wording.

**4. Skill discoverability for `tool_search` (Gap 1, BM25) — all three skill-system tools.**
- `ha_get_skill_home_assistant_best_practices` (auto-registered per bundled skill in `_register_skill_guidance_tools`): description augmented with action-phrased keywords (\"Use BEFORE: creating automations, scripts, scenes, helpers, or dashboards; writing triggers, conditions, actions, wait_template; calling ha_config_set_*\").
- `ha_list_resources` and `ha_read_resource` (FastMCP-renamed via `HaResourcesAsTools`): previously inherited terse FastMCP defaults. Both descriptions are now overridden during the rename to add the same action-phrased anchors, with `ha_read_resource` cross-referencing `ha_list_resources` for URI discovery. The submodule is intentionally untouched — only the constructed/overridden descriptions change.

**5. `PREFER NATIVE SOLUTIONS` promoted** to the second paragraph of `ha_config_set_automation` and `ha_config_set_script` docstrings (was ~80 lines deep, after multiple full examples). Removes the duplicate buried block.

**Adjacent fixes found while reviewing the checker:**
- **Pre-existing bug:** condition shorthand steps inside `sequence:` / `action:` lists (e.g. `- condition: template, value_template: ...`) were not inspected — only conditions in `if:`, `choose.conditions`, and `repeat.while/until` were. Now walked.
- **In-scope gap from "or actions":** templates in `service:` (e.g. `service: \"{{ ... }}\"`) and the deprecated `service_template:` field weren't flagged anywhere. Now flagged with a `choose` / `if/then/else` recommendation.

### Allowlist (templates here are intentionally NOT flagged)
- `action[*].data.*` (notification message/title, brightness, etc.)
- `event_data.*`, `variables.*`, `service_data.*`
- Anywhere outside trigger / condition / wait_template / value_template / target.* / service / service_template

### Known limitations
- **Scenes are not yet covered** — `tools_config_scenes` doesn't wire the checker (PR #695 added it only to `tools_config_automations` and `tools_config_scripts`). Scenes don't have logic-position fields in the same shape, so adding a scene-shaped detector is a follow-up rather than a regex extension.
- **Gap 3** (FastMCP `instructions` reaching the client) is a known client-side limitation, intentionally out of scope.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent (BAT validation pending — will run before ready)
- [x] All unit tests pass (63 tests in `test_best_practice_checker.py` — 45 existing + 18 new across 7 test classes; 3 new tests in `test_ha_resources_as_tools.py` for description override)
- [x] Code follows style guidelines (\`ruff check\`)

### Test coverage added
- \`TestDateBasedCondition\` (4) — \`now().date()\` / \`.year\` / \`.month\` / \`.day\`
- \`TestTargetTemplate\` (5) — \`{{ this.* }}\` and arbitrary templates in \`target.*\`, target lists, clean literals
- \`TestGenericAnyTemplate\` (3) — generic catch-all fires; specific detectors don't double-flag
- \`TestAllowlistLegitimatePositions\` (4) — notification message/title, brightness, \`event_data\`, \`variables\` are NOT flagged
- \`TestInlineGuidance\` (2) — concrete native alternatives present inline
- \`TestInlineConditionSteps\` (3) — pre-existing checker gap on condition shorthand in sequences
- \`TestActionServiceTemplate\` (3) — \`service_template:\` and templated \`service:\` field flagged; clean literal service unchanged
- \`TestDescriptionOverride\` (3) — ha_list_resources and ha_read_resource carry action-phrased BM25 descriptions through both the \`list_tools\` and \`get_tool\` paths

## Future improvements
- Wire a scene-shaped checker into \`tools_config_scenes\` (templates in entity-state values).
- Sync action-phrased keywords upstream into \`homeassistant-ai/skills\` SKILL.md frontmatter so the description improves at the source.

## Checklist
- [x] I have updated documentation if needed (tool docstrings + module docstring on the checker)