### PR TITLE
docs: add Cloudflared add-on hostname alternative for tunnel service

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -149,12 +149,12 @@ additional_hosts:
     service: http://localhost:9583
 ```
 
-**If `localhost` doesn't work**, you can also point the tunnel at the MCP add-on's container hostname (shown on the MCP Server add-on's **Information** page, e.g. `b37de126-ha-mcp`):
+**If `localhost` doesn't reach the MCP add-on** (the Cloudflared add-on tunnels from inside its own container), point the tunnel at the MCP add-on's container hostname instead — find it on the MCP Server add-on's **Information** page (e.g. `b37de126-ha-mcp`):
 
 ```yaml
 additional_hosts:
   - hostname: ha-mcp.yourdomain.com
-    service: http://b37de126-ha-mcp:9583
+    service: http://<your-prefix>-ha-mcp:9583
 ```
 
 ##### Authenticate and Get Your Public URL

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -149,6 +149,14 @@ additional_hosts:
     service: http://localhost:9583
 ```
 
+**If `localhost` doesn't work**, you can also point the tunnel at the MCP add-on's container hostname (shown on the MCP Server add-on's **Information** page, e.g. `b37de126-ha-mcp`):
+
+```yaml
+additional_hosts:
+  - hostname: ha-mcp.yourdomain.com
+    service: http://b37de126-ha-mcp:9583
+```
+
 ##### Authenticate and Get Your Public URL
 
 When you first start Cloudflared:

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1448,7 +1448,7 @@ ingress:
   - hostname: ha-mcp.yourdomain.com
     service: http://homeassistant.local:9583</code></pre>
             <p class="text-xs text-slate-400 mt-2">Replace <code>homeassistant.local</code> with your HA host's IP or hostname — match the IP from the MCP add-on's log line (e.g. <code>http://192.168.1.100:9583/...</code>). The Cloudflared add-on tunnels from inside its own container, so <code>localhost</code> won't reach the MCP add-on.</p>
-            <p class="text-xs text-slate-400 mt-2">Or, point the tunnel at the MCP add-on's container hostname (shown on the MCP Server add-on's <strong>Information</strong> page, e.g. <code>b37de126-ha-mcp</code>): <code>service: http://b37de126-ha-mcp:9583</code>.</p>
+            <p class="text-xs text-slate-400 mt-2">Or, point the tunnel at the MCP add-on's container hostname (shown on the MCP Server add-on's <strong>Information</strong> page, e.g. <code>b37de126-ha-mcp</code>): <code>service: http://&lt;your-prefix&gt;-ha-mcp:9583</code>.</p>
           </details>
           <div class="bg-amber-900/20 border border-amber-700/50 rounded-lg p-3 mt-4">
             <p class="text-amber-300 text-sm font-medium">Disable "Block AI Training Bots"</p>

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1448,6 +1448,7 @@ ingress:
   - hostname: ha-mcp.yourdomain.com
     service: http://homeassistant.local:9583</code></pre>
             <p class="text-xs text-slate-400 mt-2">Replace <code>homeassistant.local</code> with your HA host's IP or hostname — match the IP from the MCP add-on's log line (e.g. <code>http://192.168.1.100:9583/...</code>). The Cloudflared add-on tunnels from inside its own container, so <code>localhost</code> won't reach the MCP add-on.</p>
+            <p class="text-xs text-slate-400 mt-2">Or, point the tunnel at the MCP add-on's container hostname (shown on the MCP Server add-on's <strong>Information</strong> page, e.g. <code>b37de126-ha-mcp</code>): <code>service: http://b37de126-ha-mcp:9583</code>.</p>
           </details>
           <div class="bg-amber-900/20 border border-amber-700/50 rounded-lg p-3 mt-4">
             <p class="text-amber-300 text-sm font-medium">Disable "Block AI Training Bots"</p>


### PR DESCRIPTION
## What does this PR do?

Adds an alternative method for routing the Cloudflared add-on tunnel to the MCP Server add-on, using the MCP add-on's container hostname (e.g. `b37de126-ha-mcp`) instead of `localhost`. Existing `localhost:9583` instructions are unchanged — this just documents a fallback that worked for users where `localhost` didn't reach the MCP add-on.

Credit to @beercity for finding and documenting this workaround in discussion #1076.

Closes #1099.

## Type of change
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Future improvements

## Checklist
- [x] I have updated documentation if needed