### PR TITLE
docs: clarify standard-mode HTTP deployment guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,10 +414,12 @@ docker run -d -p 127.0.0.1:8086:8086 \
   -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 
-# HTTP mode (LAN-reachable) — set MCP_SECRET_PATH before binding to all interfaces
+# HTTP mode (LAN-reachable) — generate the secret first so you can configure the MCP client with it
+MCP_SECRET="/private_$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')"
+echo "MCP_SECRET_PATH=$MCP_SECRET"
 docker run -d -p 8086:8086 \
   -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
-  -e MCP_SECRET_PATH="/private_$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')" \
+  -e MCP_SECRET_PATH="$MCP_SECRET" \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,7 +417,7 @@ docker run -d -p 127.0.0.1:8086:8086 \
 # HTTP mode (LAN-reachable) — set MCP_SECRET_PATH before binding to all interfaces
 docker run -d -p 8086:8086 \
   -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
-  -e MCP_SECRET_PATH="/private_$(openssl rand -hex 16)" \
+  -e MCP_SECRET_PATH="/private_$(python -c 'import secrets; print(secrets.token_urlsafe(16))')" \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,8 +423,11 @@ docker run -d -p 8086:8086 \
 
 The standard-mode HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by
 URL-path secrecy: any request to the configured path (default `/mcp`,
-overridable via `MCP_SECRET_PATH`) is authorised. Bind to `127.0.0.1` for
-same-host LLM clients; on LAN-reachable interfaces set a 128-bit-entropy
+overridable via `MCP_SECRET_PATH`) is authorised. The MCP client must use the
+full URL including this path (e.g. `http://host:8086/private_<random>`); the
+web settings UI mounts under the same path (`<MCP_SECRET_PATH>/settings`), so
+operators reach it through the secret-prefixed URL too. Bind to `127.0.0.1`
+for same-host LLM clients; on LAN-reachable interfaces set a 128-bit-entropy
 `MCP_SECRET_PATH` (the Home Assistant add-on auto-generates one with
 `secrets.token_urlsafe(16)`). Internet-facing deployments need the OAuth
 entrypoint (`ha-mcp-oauth`) behind a TLS-terminating reverse proxy — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,12 +404,31 @@ uv run mypy src/
 
 ### Docker
 ```bash
-# Stdio mode (Claude Desktop)
-docker run --rm -i -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... ghcr.io/homeassistant-ai/ha-mcp:latest
+# Stdio mode (Claude Desktop) — local-only, no network exposure
+docker run --rm -i \
+  -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
+  ghcr.io/homeassistant-ai/ha-mcp:latest
 
-# HTTP mode (web clients)
-docker run -d -p 8086:8086 -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
+# HTTP mode (loopback only, same-host LLM client)
+docker run -d -p 127.0.0.1:8086:8086 \
+  -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
+  ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
+
+# HTTP mode (LAN-reachable) — set MCP_SECRET_PATH before binding to all interfaces
+docker run -d -p 8086:8086 \
+  -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
+  -e MCP_SECRET_PATH="/private_$(openssl rand -hex 16)" \
+  ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 ```
+
+The standard-mode HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by
+URL-path secrecy: any request to the configured path (default `/mcp`,
+overridable via `MCP_SECRET_PATH`) is authorised. Bind to `127.0.0.1` for
+same-host LLM clients; on LAN-reachable interfaces set a 128-bit-entropy
+`MCP_SECRET_PATH` (the Home Assistant add-on auto-generates one with
+`secrets.token_urlsafe(16)`). Internet-facing deployments need the OAuth
+entrypoint (`ha-mcp-oauth`) behind a TLS-terminating reverse proxy — see
+[SECURITY.md](SECURITY.md).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,7 @@ docker run --rm -i \
   ghcr.io/homeassistant-ai/ha-mcp:latest
 
 # HTTP mode (loopback only, same-host LLM client)
+# Connect URL: http://127.0.0.1:8086/mcp  (default MCP_SECRET_PATH)
 docker run -d -p 127.0.0.1:8086:8086 \
   -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
@@ -423,17 +424,16 @@ docker run -d -p 8086:8086 \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 ```
 
-The standard-mode HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by
-URL-path secrecy: any request to the configured path (default `/mcp`,
-overridable via `MCP_SECRET_PATH`) is authorized. The MCP client must use the
-full URL including this path (e.g. `http://host:8086/private_<random>`); the
-web settings UI mounts under the same path (`<MCP_SECRET_PATH>/settings`), so
+The standard-mode `ha-mcp-web` HTTP entrypoint authenticates by URL-path
+secrecy: any request to the configured path (default `/mcp`, overridable
+via `MCP_SECRET_PATH`) is accepted. The MCP client must use the full URL
+including this path (e.g. `http://host:8086/private_<random>`); the web
+settings UI mounts under the same path (`<MCP_SECRET_PATH>/settings`), so
 operators reach it through the secret-prefixed URL too. Bind to `127.0.0.1`
 for same-host LLM clients; on LAN-reachable interfaces set a 128-bit-entropy
 `MCP_SECRET_PATH` (the Home Assistant add-on auto-generates one with
-`secrets.token_urlsafe(16)`). Internet-facing deployments need the OAuth
-entrypoint (`ha-mcp-oauth`) behind a TLS-terminating reverse proxy — see
-[SECURITY.md](SECURITY.md).
+`secrets.token_urlsafe(16)`). Internet-facing deployments need a different
+mode — see [SECURITY.md](SECURITY.md).
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,13 +417,13 @@ docker run -d -p 127.0.0.1:8086:8086 \
 # HTTP mode (LAN-reachable) — set MCP_SECRET_PATH before binding to all interfaces
 docker run -d -p 8086:8086 \
   -e HOMEASSISTANT_URL=... -e HOMEASSISTANT_TOKEN=... \
-  -e MCP_SECRET_PATH="/private_$(python -c 'import secrets; print(secrets.token_urlsafe(16))')" \
+  -e MCP_SECRET_PATH="/private_$(python3 -c 'import secrets; print(secrets.token_urlsafe(16))')" \
   ghcr.io/homeassistant-ai/ha-mcp:latest ha-mcp-web
 ```
 
 The standard-mode HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by
 URL-path secrecy: any request to the configured path (default `/mcp`,
-overridable via `MCP_SECRET_PATH`) is authorised. The MCP client must use the
+overridable via `MCP_SECRET_PATH`) is authorized. The MCP client must use the
 full URL including this path (e.g. `http://host:8086/private_<random>`); the
 web settings UI mounts under the same path (`<MCP_SECRET_PATH>/settings`), so
 operators reach it through the secret-prefixed URL too. Bind to `127.0.0.1`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,16 @@
   this is a configuration or usage issue, not a security vulnerability.
   Tool visibility controls (`ENABLED_TOOL_MODULES`, group toggles) exist for this purpose.
 - Vulnerabilities that are only exploitable due to a misconfigured deployment
-  (e.g., standard-mode instance exposed to the internet without TLS)
+  (e.g., standard-mode instance exposed to the internet without TLS, or a
+  network-reachable HTTP entrypoint without `MCP_SECRET_PATH` set).
+
+  **Standard-mode threat model.** The HTTP entrypoints (`ha-mcp-web`,
+  `ha-mcp-sse`) authenticate by URL-path secrecy and are designed for
+  same-host stdio, loopback HTTP, or LAN HTTP with a 128-bit-entropy
+  `MCP_SECRET_PATH`. For internet-facing deployments use the OAuth
+  entrypoint (`ha-mcp-oauth`) behind a TLS-terminating reverse proxy
+  (see [OAuth Mode](#oauth-mode--beta-warning) below). Deployment
+  guidance: [AGENTS.md → Docker](AGENTS.md#docker).
 
 ## OAuth Mode — Beta Warning
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,13 +31,14 @@
   (e.g., standard-mode instance exposed to the internet without TLS, or a
   network-reachable HTTP entrypoint using the default `MCP_SECRET_PATH`).
 
-  **Standard-mode threat model.** The HTTP entrypoints (`ha-mcp-web`,
-  `ha-mcp-sse`) authenticate by URL-path secrecy and are designed for
-  same-host stdio, loopback HTTP, or LAN HTTP with a 128-bit-entropy
-  `MCP_SECRET_PATH`. For internet-facing deployments use the OAuth
-  entrypoint (`ha-mcp-oauth`) behind a TLS-terminating reverse proxy
-  (see [OAuth Mode](#oauth-mode--beta-warning) below). Deployment
-  guidance: [AGENTS.md → Docker](AGENTS.md#docker).
+### Standard-mode threat model
+
+The HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by URL-path
+secrecy and are designed for loopback HTTP or LAN HTTP with a high-entropy
+`MCP_SECRET_PATH`. For internet-facing deployments use the OAuth entrypoint
+(`ha-mcp-oauth`) behind a TLS-terminating reverse proxy (see
+[OAuth Mode](#oauth-mode--beta-warning) below). Deployment guidance:
+[AGENTS.md → Docker](AGENTS.md#docker).
 
 ## OAuth Mode — Beta Warning
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@
   Tool visibility controls (`ENABLED_TOOL_MODULES`, group toggles) exist for this purpose.
 - Vulnerabilities that are only exploitable due to a misconfigured deployment
   (e.g., standard-mode instance exposed to the internet without TLS, or a
-  network-reachable HTTP entrypoint without `MCP_SECRET_PATH` set).
+  network-reachable HTTP entrypoint using the default `MCP_SECRET_PATH`).
 
   **Standard-mode threat model.** The HTTP entrypoints (`ha-mcp-web`,
   `ha-mcp-sse`) authenticate by URL-path secrecy and are designed for


### PR DESCRIPTION
## What does this PR do?

The single-line HTTP-mode Docker example in `AGENTS.md` collapsed two distinct deployment shapes (loopback for same-host clients vs LAN-reachable) into one binding-to-all-interfaces command without surfacing `MCP_SECRET_PATH`. Split it into three intent-named examples and add a short paragraph naming the URL-secrecy auth model:

- **stdio** — local-only, no network exposure
- **HTTP loopback** — `127.0.0.1:8086` for same-host LLM clients
- **HTTP LAN-reachable** — generate `MCP_SECRET="/private_$(python3 -c '...')"`, echo it for the operator, then pass via `-e MCP_SECRET_PATH="$MCP_SECRET"` so the URL-path-secrecy auth has 128-bit entropy and the operator sees the path they need to configure the MCP client with

`SECURITY.md`'s misconfigured-deployment exclusion (existing line 30) gets a parallel two-paragraph expansion describing the standard-mode threat model and pointing at the OAuth entrypoint for internet-facing deployments. The clause already covered this shape; the addition makes the deployment guidance discoverable without chasing through `AGENTS.md`.

**No code paths change.** Diff: +39 / −6 across two files.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — N/A (docs-only, no code paths touched)
- [x] Code follows style guidelines (`uv run ruff check`) — Markdown only, no Python touched

## Future improvements

- The setup wizard's network-mode flow (`site/src/pages/setup.astro`) could surface a more visible warning about `MCP_SECRET_PATH` requirements. Currently relies on the wizard's conditional secret-path generation, with line 461's `* Should not be exposed externally (No HTTPS). Use Remote for internet access.` as the only inline note. Out of scope here — touches site code, not docs.
- A `docs/dev-channel.md` cross-reference from `AGENTS.md → Docker` would help users coming via the dev-channel install path. Not folded in because `dev-channel.md` was not opened during this work and a one-line reference shouldn't be added blind.

## Checklist
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — N/A (docs-only)
- [x] New and existing unit tests pass locally — N/A (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
