### PR TITLE
refactor: surface client identity, AI model, config toggles, and prompt context in ha_report_issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/agent_behavior.yml
@@ -15,6 +15,12 @@ body:
 
         **This is NOT for bugs in ha-mcp** (use Runtime Bug template instead).
 
+        > 📝 **Title tip:** replace the default `[AGENT] ` with a one-line summary
+        > of what the agent did wrong (e.g. `[AGENT] re-runs ha_search_entities
+        > instead of caching the result`). If `ha_report_issue` gave you a
+        > submission link, the title is already filled in — keep it or refine it,
+        > just don't leave it as a bare `[AGENT]`.
+
   - type: textarea
     id: user_commentary
     attributes:

--- a/.github/ISSUE_TEMPLATE/runtime_bug.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_bug.yml
@@ -15,6 +15,12 @@ body:
 
         **Not for startup issues** (use Startup/Installation Bug template instead).
 
+        > 📝 **Title tip:** replace the default `[BUG] ` with a one-line summary of what
+        > broke (e.g. `[BUG] ha_call_service times out on light.turn_on`). If you ran
+        > `ha_report_issue` and clicked the submission link it gave you, the title
+        > field is already filled in — keep it or refine it, just don't leave it as
+        > a bare `[BUG]`.
+
   - type: textarea
     id: user_commentary
     attributes:

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -15,11 +15,12 @@ from typing import Annotated, Any
 from urllib.parse import quote_plus
 
 import httpx
+from fastmcp import Context
 from pydantic import Field
 
 from ha_mcp import __version__
 
-from ..config import get_global_settings
+from ..config import Settings, get_global_settings
 from ..utils.usage_logger import (
     AVG_LOG_ENTRIES_PER_TOOL,
     get_recent_logs,
@@ -31,8 +32,12 @@ from .util_helpers import ANSI_ESCAPE_RE
 logger = logging.getLogger(__name__)
 
 # GitHub issue template URLs
-RUNTIME_BUG_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
-AGENT_BEHAVIOR_URL = "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
+RUNTIME_BUG_URL = (
+    "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
+)
+AGENT_BEHAVIOR_URL = (
+    "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
+)
 
 # Max characters to include from addon container logs.
 # 3000 chars ≈ 750 LLM tokens — keeps the tool response well below context budgets
@@ -102,6 +107,139 @@ def _detect_platform() -> dict[str, str]:
         "architecture": platform.machine(),
         "python_version": platform.python_version(),
     }
+
+
+# Tool-surface-shaping toggles surfaced in bug reports. The set is small on
+# purpose: only flags that materially change which tools the agent sees, since
+# the same bug report behaves very differently depending on these. New
+# tool-shaping toggles should be added here so triage doesn't have to ask.
+_CONFIG_TOGGLE_FIELDS: tuple[str, ...] = (
+    "enable_websocket",
+    "enable_dashboard_partial_tools",
+    "enable_tool_search",
+    "tool_search_max_results",
+    "enable_yaml_config_editing",
+    "enable_code_mode",
+    "enabled_tool_modules",
+)
+
+
+def _get_config_toggles(settings: Settings | None = None) -> dict[str, Any]:
+    """Read tool-surface-shaping config toggles from Settings.
+
+    Defaults to the global settings singleton; tests can pass a fake Settings
+    instance instead. Returns an empty dict if Settings construction fails so
+    a misconfigured environment can't break the bug report path itself.
+    """
+    try:
+        s = settings if settings is not None else get_global_settings()
+    except Exception as e:  # pragma: no cover — defensive guard
+        logger.warning("Failed to read settings for bug report toggles: %s", e)
+        return {}
+
+    toggles: dict[str, Any] = {}
+    for field in _CONFIG_TOGGLE_FIELDS:
+        value = getattr(s, field, None)
+        if value is None:
+            continue
+        toggles[field] = value
+
+    # Summarize list-shaped seeds rather than dumping the full strings, which
+    # may include private tool names or be very long.
+    for list_field in ("disabled_tools", "pinned_tools"):
+        raw = getattr(s, list_field, "") or ""
+        count = len([item for item in raw.split(",") if item.strip()])
+        toggles[f"{list_field}_count"] = count
+
+    return toggles
+
+
+def _extract_client_info(ctx: Context | None) -> dict[str, str]:
+    """Pull the connecting MCP client's self-identification off the request context.
+
+    The MCP ``initialize`` handshake carries a ``clientInfo`` Implementation
+    object (``name``/``version``/optional ``title``). FastMCP exposes the
+    underlying server session as ``ctx.session``, and the MCP server session
+    keeps the parsed initialize params on ``client_params``. This is the
+    ground truth for which application is talking to ha-mcp — we use it
+    instead of asking the LLM to self-report ``Client application``.
+
+    Returns ``{"name": ..., "version": ..., "title": ...}`` with ``"unknown"``
+    for fields the client didn't send. Returns an empty dict if no context is
+    available (tool invoked outside an MCP request, e.g. unit tests) so the
+    bug-report path stays robust.
+    """
+    if ctx is None:
+        return {}
+    try:
+        session = getattr(ctx, "session", None)
+        params = (
+            getattr(session, "client_params", None) if session is not None else None
+        )
+        client = getattr(params, "clientInfo", None) if params is not None else None
+        if client is None:
+            return {}
+        return {
+            "name": getattr(client, "name", None) or "unknown",
+            "version": getattr(client, "version", None) or "unknown",
+            "title": getattr(client, "title", None) or "",
+        }
+    except Exception as e:  # pragma: no cover — defensive guard
+        logger.debug("Failed to read MCP client info from context: %s", e)
+        return {}
+
+
+def _format_client_info_for_template(info: dict[str, str]) -> str:
+    """Render the MCP client identification as a single human-readable line.
+
+    Falls back to ``unknown (no client_info on context)`` when the handshake
+    didn't carry a ``clientInfo`` block — this happens for direct MCP clients
+    that skip the optional field, or when the bug report tool runs outside a
+    live request.
+    """
+    if not info:
+        return "unknown (no client_info on context)"
+    name = info.get("name") or "unknown"
+    version = info.get("version") or "unknown"
+    title = info.get("title") or ""
+    base = f"{name} {version}"
+    if title and title != name:
+        return f"{base}  _(advertised title: {title})_"
+    return base
+
+
+def _detect_mcp_transport() -> str:
+    """Best-effort MCP transport detection.
+
+    Returns ``stdio`` / ``http`` / ``sse`` / ``unknown``. We can't observe the
+    transport perfectly from a tool call, so we look at the entrypoint name
+    and well-known env hints. The result is informational — the bug template
+    surfaces it as an auto-detect that the agent or user can override.
+    """
+    # Entry-point script name (e.g. ``ha-mcp-web`` for HTTP).
+    argv0 = (sys.argv[0] if sys.argv else "").lower()
+    basename = os.path.basename(argv0)
+    if basename.endswith("-web") or basename.endswith("-http"):
+        return "http"
+    if basename.endswith("-sse"):
+        return "sse"
+
+    # Env hints set by HTTP wrappers / supervisors.
+    transport_env = os.environ.get("FASTMCP_TRANSPORT", "").strip().lower()
+    if transport_env in {"http", "stdio", "sse"}:
+        return transport_env
+    if os.environ.get("MCP_HTTP_PORT") or os.environ.get("FASTMCP_PORT"):
+        return "http"
+
+    # If stdin is a real TTY, ha-mcp wasn't launched by an MCP host pipe —
+    # it's almost certainly a manual run, not stdio MCP traffic.
+    try:
+        if not sys.stdin.isatty():
+            return "stdio"
+    except Exception:  # pragma: no cover — sys.stdin can be None in tests
+        pass
+
+    return "unknown"
 
 
 def _sanitize_log_text(text: str) -> str:
@@ -190,9 +328,7 @@ async def _fetch_addon_logs() -> str:
                 headers={"Authorization": f"Bearer {token}"},
             )
             if resp.status_code != 200:
-                logger.info(
-                    "Addon log fetch returned HTTP %s", resp.status_code
-                )
+                logger.info("Addon log fetch returned HTTP %s", resp.status_code)
                 return ""
 
             # Strip ANSI escape codes first, then sanitize, then truncate.
@@ -221,8 +357,8 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "Report Issue or Feedback"
-        }
+            "title": "Report Issue or Feedback",
+        },
     )
     @log_tool_usage
     async def ha_report_issue(
@@ -240,6 +376,7 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ),
             ),
         ] = 10,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """
         Collect diagnostic information for filing issue reports or feedback.
@@ -279,14 +416,20 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
           empty string otherwise)
         - `suggested_title`, `duplicate_check_urls`, `anonymization_guide`
         """
-        # Detect installation method and platform
+        # Detect installation method, platform, and runtime config.
         install_method = _detect_installation_method()
         platform_info = _detect_platform()
+        config_toggles = _get_config_toggles()
+        mcp_transport = _detect_mcp_transport()
+        client_info = _extract_client_info(ctx)
 
         diagnostic_info: dict[str, Any] = {
             "ha_mcp_version": __version__,
             "installation_method": install_method,
             "platform": platform_info,
+            "mcp_transport": mcp_transport,
+            "mcp_client_info": client_info,
+            "config_toggles": config_toggles,
             "connection_status": "Unknown",
             "home_assistant_version": "Unknown",
             "entity_count": 0,
@@ -296,9 +439,7 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         try:
             config = await client.get_config()
             diagnostic_info["connection_status"] = "Connected"
-            diagnostic_info["home_assistant_version"] = config.get(
-                "version", "Unknown"
-            )
+            diagnostic_info["home_assistant_version"] = config.get("version", "Unknown")
             diagnostic_info["location_name"] = config.get("location_name", "Unknown")
             diagnostic_info["time_zone"] = config.get("time_zone", "Unknown")
         except Exception as e:
@@ -336,7 +477,9 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             "",
             f"ha-mcp Version: {diagnostic_info['ha_mcp_version']}",
             f"Installation Method: {diagnostic_info['installation_method']}",
-            f"Platform: {platform_info['os']} {platform_info['os_release']} ({platform_info['architecture']})",
+            f"MCP Transport: {mcp_transport}",
+            f"MCP Client: {_format_client_info_for_template(client_info)}",
+            f"Operating System: {platform_info['os']} {platform_info['os_release']} ({platform_info['architecture']})",
             f"Python Version: {platform_info['python_version']}",
             f"Home Assistant Version: {diagnostic_info['home_assistant_version']}",
             f"Connection Status: {diagnostic_info['connection_status']}",
@@ -349,44 +492,69 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         if "time_zone" in diagnostic_info:
             report_lines.append(f"Time Zone: {diagnostic_info['time_zone']}")
 
+        if config_toggles:
+            report_lines.extend(["", "=== ha-mcp Config Toggles ==="])
+            for key, value in config_toggles.items():
+                report_lines.append(f"  {key}: {value}")
+
         if startup_logs:
-            report_lines.extend([
-                "",
-                f"=== Startup Logs ({len(startup_logs)} entries) ===",
-                startup_log_summary,
-            ])
+            report_lines.extend(
+                [
+                    "",
+                    f"=== Startup Logs ({len(startup_logs)} entries) ===",
+                    startup_log_summary,
+                ]
+            )
 
         if recent_logs:
-            report_lines.extend([
-                "",
-                f"=== Recent Tool Calls ({len(recent_logs)} entries) ===",
-                log_summary,
-            ])
+            report_lines.extend(
+                [
+                    "",
+                    f"=== Recent Tool Calls ({len(recent_logs)} entries) ===",
+                    log_summary,
+                ]
+            )
 
         if addon_logs:
-            report_lines.extend([
-                "",
-                "=== Add-on Container Logs ===",
-                addon_logs,
-            ])
+            report_lines.extend(
+                [
+                    "",
+                    "=== Add-on Container Logs ===",
+                    addon_logs,
+                ]
+            )
 
         formatted_report = "\n".join(report_lines)
 
+        # Generate suggested title up-front so it can be folded into the
+        # submission URLs as a `&title=` query param. This auto-fills the
+        # GitHub issue title field — without it, users routinely submit reports
+        # titled just "[BUG]".
+        suggested_title = _generate_bug_title(diagnostic_info, recent_logs)
+        title_query = quote_plus(suggested_title)
+        runtime_bug_submit_url = f"{RUNTIME_BUG_URL}&title={title_query}"
+        agent_behavior_submit_url = f"{AGENT_BEHAVIOR_URL}&title={title_query}"
+
         # Generate BOTH templates
         runtime_bug_template = _generate_runtime_bug_template(
-            diagnostic_info, log_summary, startup_log_summary, recent_logs, startup_logs,
+            diagnostic_info,
+            log_summary,
+            startup_log_summary,
+            recent_logs,
+            startup_logs,
             addon_logs=addon_logs,
+            submit_url=runtime_bug_submit_url,
         )
 
         agent_behavior_template = _generate_agent_behavior_template(
-            diagnostic_info, log_summary, recent_logs
+            diagnostic_info,
+            log_summary,
+            recent_logs,
+            submit_url=agent_behavior_submit_url,
         )
 
         # Anonymization instructions
         anonymization_guide = _generate_anonymization_guide()
-
-        # Generate suggested title
-        suggested_title = _generate_bug_title(diagnostic_info, recent_logs)
 
         # Generate search keywords and URLs for duplicate check
         search_keywords = _generate_search_keywords(diagnostic_info, recent_logs)
@@ -408,12 +576,14 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             "agent_behavior_template": agent_behavior_template,
             "anonymization_guide": anonymization_guide,
             "suggested_title": suggested_title,
+            "runtime_bug_submit_url": runtime_bug_submit_url,
+            "agent_behavior_submit_url": agent_behavior_submit_url,
             "duplicate_check_urls": duplicate_check_urls,
             "instructions": (
                 "WORKFLOW FOR PRESENTING BUG REPORTS:\n\n"
                 "1. **Check for duplicates FIRST** (before presenting the template):\n"
                 "   - Use the duplicate_check_urls to search for similar issues\n"
-                "   - If gh CLI is available: use `gh issue list --search \"keyword\"`\n"
+                '   - If gh CLI is available: use `gh issue list --search "keyword"`\n'
                 "   - Otherwise: inform user to check the duplicate_check_urls\n"
                 "   - If duplicates found, ask user if they want to comment on existing issue instead\n\n"
                 "2. **Determine which template to present**:\n"
@@ -435,18 +605,47 @@ def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "   d. Verify no tokens, passwords, or IPs are visible\n"
                 "   e. Keep entity domains, error messages, and technical details\n"
                 "   See anonymization_guide for full details.\n\n"
-                "4. **Present the anonymized report to the user**:\n"
-                "   a. Show the suggested_title (user can edit if needed)\n"
+                "4. **Fill in the self-reported fields BEFORE presenting**:\n"
+                "   - `**AI Model:**` — write your identity on this line (provider/family + the\n"
+                "     most specific version you know, in whatever form you'd describe yourself).\n"
+                "     Do not invent a version number. If you don't know it, say so or omit the\n"
+                "     version. There are no options to pick from — just answer honestly.\n"
+                "   - `**Triggering Prompt & Tool Call:** <fill in>` — the EXACT user message\n"
+                "     and the tool call(s) that produced the bug, copy-pasted verbatim. Truncate\n"
+                "     long inputs only after anonymization. This is the single most useful field\n"
+                "     for triage — do not skip it.\n"
+                "   `MCP Transport` and `MCP Client` are auto-detected by the server (the latter\n"
+                "   from the MCP `initialize` handshake); leave both as-is unless they're clearly\n"
+                "   wrong.\n\n"
+                "5. **Present the anonymized report to the user**:\n"
+                "   a. Show the suggested_title (user can edit if needed) and tell them GitHub's\n"
+                "      title field is now pre-filled via the submission URL — they don't need to\n"
+                "      retype it.\n"
                 "   b. Present the chosen ANONYMIZED template IN A MARKDOWN CODE BLOCK (```markdown...```) for easy copy/paste\n"
-                "   c. PROMINENTLY display the submission URL at the top:\n"
-                f"      - Runtime bugs: {RUNTIME_BUG_URL}\n"
-                f"      - Agent behavior: {AGENT_BEHAVIOR_URL}\n"
+                "   c. PROMINENTLY display the submission URL at the top — these include the\n"
+                "      pre-filled title:\n"
+                "      - Runtime bugs: see runtime_bug_submit_url\n"
+                "      - Agent behavior: see agent_behavior_submit_url\n"
                 "   d. Ask them to fill in the description sections\n"
                 "   e. For HA add-on installs, the runtime bug template includes a collapsible '📦 Add-on Container Logs' section auto-filled from addon_logs — keep it as-is\n"
                 "   f. Remind them to review for any remaining personal information before submitting\n\n"
                 "CRITICAL: Always ANONYMIZE the report BEFORE presenting it in markdown code blocks!"
             ),
         }
+
+
+def _format_config_toggles_for_template(toggles: dict[str, Any]) -> str:
+    """Render config toggle snapshot as a markdown bullet list.
+
+    Returns a placeholder line when no toggles were collected (e.g. Settings
+    construction failed) so the template stays consistent.
+    """
+    if not toggles:
+        return "_(config toggles unavailable)_"
+    lines = []
+    for key, value in toggles.items():
+        lines.append(f"- **{key}:** `{value}`")
+    return "\n".join(lines)
 
 
 def _format_logs_for_report(logs: list[dict[str, Any]]) -> str:
@@ -564,7 +763,9 @@ def _generate_search_keywords(
     keywords = set()
 
     # Find the most recent error from logs
-    last_error_log = next((log for log in reversed(recent_logs) if log.get("error_message")), None)
+    last_error_log = next(
+        (log for log in reversed(recent_logs) if log.get("error_message")), None
+    )
 
     if last_error_log:
         tool_name = last_error_log.get("tool_name")
@@ -602,6 +803,7 @@ def _generate_runtime_bug_template(
     startup_logs: list[dict[str, Any]],
     *,
     addon_logs: str = "",
+    submit_url: str = RUNTIME_BUG_URL,
 ) -> str:
     """
     Generate a runtime bug report template matching runtime_bug.md format.
@@ -610,10 +812,19 @@ def _generate_runtime_bug_template(
     copy-paste without format conflicts.
     """
     platform_info = diagnostic_info.get("platform", {})
+    config_toggles = diagnostic_info.get("config_toggles") or {}
+    mcp_transport = diagnostic_info.get("mcp_transport", "unknown")
+    client_info = diagnostic_info.get("mcp_client_info") or {}
 
     # Extract error messages from recent logs
     error_messages = _extract_error_messages(recent_logs)
-    error_section = "\n".join(error_messages) if error_messages else "<!-- No errors detected in recent logs -->"
+    error_section = (
+        "\n".join(error_messages)
+        if error_messages
+        else "<!-- No errors detected in recent logs -->"
+    )
+
+    config_toggles_section = _format_config_toggles_for_template(config_toggles)
 
     # Show startup logs section only if they exist
     startup_section = ""
@@ -657,7 +868,9 @@ def _generate_runtime_bug_template(
 > All environment info and logs below were collected automatically.
 
 **Submit this report at:**
-{RUNTIME_BUG_URL}
+{submit_url}
+
+(The submission link above pre-fills the issue title — you don't need to retype it.)
 
 ---
 
@@ -682,15 +895,47 @@ def _generate_runtime_bug_template(
 
 ---
 
+## 💬 Triggering Prompt & Tool Call
+
+<!-- The calling AI agent fills this in. Paste, verbatim, the user message that
+     triggered this bug AND the tool call(s) that produced it. Truncate only
+     after anonymizing tokens / personal names. This is the highest-leverage
+     field for triage. -->
+
+**User prompt:** <fill in>
+
+**Tool call(s):**
+```
+<fill in — name + arguments + (truncated) response, e.g.:
+ha_call_service(domain="light", service="turn_on", entity_id="light.example")
+→ ToolError: Service not found
+>
+```
+
+---
+
 ## 🔧 Environment
 
-- **ha-mcp Version:** {diagnostic_info.get('ha_mcp_version', 'Unknown')}
-- **Installation Method:** {diagnostic_info.get('installation_method', 'Unknown')}
-- **Platform:** {platform_info.get('os', 'Unknown')} {platform_info.get('os_release', '')} ({platform_info.get('architecture', 'Unknown')})
-- **Python Version:** {platform_info.get('python_version', 'Unknown')}
-- **Home Assistant Version:** {diagnostic_info.get('home_assistant_version', 'Unknown')}
-- **Connection Status:** {diagnostic_info.get('connection_status', 'Unknown')}
-- **Entity Count:** {diagnostic_info.get('entity_count', 0)}
+- **ha-mcp Version:** {diagnostic_info.get("ha_mcp_version", "Unknown")}
+- **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
+- **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
+- **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
+- **AI Model:**
+- **Operating System:** {platform_info.get("os", "Unknown")} {platform_info.get("os_release", "")} ({platform_info.get("architecture", "Unknown")})
+- **Python Version:** {platform_info.get("python_version", "Unknown")}
+- **Home Assistant Version:** {diagnostic_info.get("home_assistant_version", "Unknown")}
+- **Connection Status:** {diagnostic_info.get("connection_status", "Unknown")}
+- **Entity Count:** {diagnostic_info.get("entity_count", 0)}
+
+---
+
+## ⚙️ ha-mcp Configuration
+
+These flags shape which tools the agent sees, so the same report can mean
+different things depending on toggle state. Auto-collected from the running
+server:
+
+{config_toggles_section}
 
 ---
 
@@ -734,13 +979,23 @@ def _generate_agent_behavior_template(
     diagnostic_info: dict[str, Any],
     log_summary: str,
     recent_logs: list[dict[str, Any]],
+    *,
+    submit_url: str = AGENT_BEHAVIOR_URL,
 ) -> str:
     """
     Generate an agent behavior feedback template matching agent_behavior_feedback.md format.
 
     This template focuses on AI agent tool usage patterns and inefficiencies.
     """
-    platform_info = diagnostic_info.get("platform", {})
+    config_toggles = diagnostic_info.get("config_toggles") or {}
+    mcp_transport = diagnostic_info.get("mcp_transport", "unknown")
+    client_info = diagnostic_info.get("mcp_client_info") or {}
+    config_toggles_section = _format_config_toggles_for_template(config_toggles)
+
+    # _extract_error_messages and recent_logs are unused in the agent template;
+    # tool sequence already lives in log_summary. Kept in the signature so
+    # callers don't have to remember which template needs which arg.
+    del recent_logs  # explicit: not used in agent template
 
     return f"""## 🤖 Auto-Generated by `ha_report_issue` Tool
 
@@ -748,7 +1003,9 @@ def _generate_agent_behavior_template(
 > Tool call history was collected automatically to help analyze agent behavior.
 
 **Submit this feedback at:**
-{AGENT_BEHAVIOR_URL}
+{submit_url}
+
+(The submission link above pre-fills the issue title — you don't need to retype it.)
 
 ---
 
@@ -773,6 +1030,21 @@ def _generate_agent_behavior_template(
 <!-- Provide context about what you were trying to do -->
 <!-- Example: "I asked the agent to create an automation that..." -->
 
+
+---
+
+## 💬 Triggering Prompt & Tool Call
+
+<!-- The AI agent fills this in. Paste, verbatim, the user message that
+     prompted the questionable behavior AND the tool call(s) the agent made
+     in response. Truncate only after anonymizing tokens / personal names. -->
+
+**User prompt:** <fill in>
+
+**Tool call(s) the agent chose:**
+```
+<fill in — name + arguments + (truncated) response>
+```
 
 ---
 
@@ -806,11 +1078,23 @@ def _generate_agent_behavior_template(
 
 ---
 
-## 📊 Environment (Optional)
+## 📊 Environment
 
-- **ha-mcp Version:** {diagnostic_info.get('ha_mcp_version', 'Unknown')}
-- **AI Client:** (Claude Desktop / Claude Code / Other)
-- **Home Assistant Version:** {diagnostic_info.get('home_assistant_version', 'Unknown')}
+- **ha-mcp Version:** {diagnostic_info.get("ha_mcp_version", "Unknown")}
+- **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
+- **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
+- **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
+- **AI Model:**
+- **Home Assistant Version:** {diagnostic_info.get("home_assistant_version", "Unknown")}
+
+---
+
+## ⚙️ ha-mcp Configuration
+
+These flags shape which tools the agent sees, so the same behavior may be
+expected vs. surprising depending on toggle state:
+
+{config_toggles_section}
 
 ---
 

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -128,30 +128,36 @@ def _get_config_toggles(settings: Settings | None = None) -> dict[str, Any]:
     """Read tool-surface-shaping config toggles from Settings.
 
     Defaults to the global settings singleton; tests can pass a fake Settings
-    instance instead. Returns an empty dict if Settings construction fails so
-    a misconfigured environment can't break the bug report path itself.
+    instance instead. Returns an empty dict on any failure (Settings
+    construction, attribute coercion, list-field split) so a misconfigured
+    environment can't break the bug report path itself.
     """
     try:
         s = settings if settings is not None else get_global_settings()
-    except Exception as e:  # pragma: no cover — defensive guard
-        logger.warning("Failed to read settings for bug report toggles: %s", e)
+
+        toggles: dict[str, Any] = {}
+        for field in _CONFIG_TOGGLE_FIELDS:
+            value = getattr(s, field, None)
+            if value is None:
+                continue
+            toggles[field] = value
+
+        # Summarize list-shaped seeds as counts rather than dumping the full
+        # strings — they can be very long, and listing the exact tools the
+        # user disabled isn't useful for triage.
+        for list_field in ("disabled_tools", "pinned_tools"):
+            raw = getattr(s, list_field, "") or ""
+            count = len([item for item in raw.split(",") if item.strip()])
+            toggles[f"{list_field}_count"] = count
+
+        return toggles
+    except Exception as e:
+        logger.warning(
+            "Failed to read settings for bug report toggles: %s (%s)",
+            e,
+            type(e).__name__,
+        )
         return {}
-
-    toggles: dict[str, Any] = {}
-    for field in _CONFIG_TOGGLE_FIELDS:
-        value = getattr(s, field, None)
-        if value is None:
-            continue
-        toggles[field] = value
-
-    # Summarize list-shaped seeds rather than dumping the full strings, which
-    # may include private tool names or be very long.
-    for list_field in ("disabled_tools", "pinned_tools"):
-        raw = getattr(s, list_field, "") or ""
-        count = len([item for item in raw.split(",") if item.strip()])
-        toggles[f"{list_field}_count"] = count
-
-    return toggles
 
 
 def _extract_client_info(ctx: Context | None) -> dict[str, str]:
@@ -159,15 +165,23 @@ def _extract_client_info(ctx: Context | None) -> dict[str, str]:
 
     The MCP ``initialize`` handshake carries a ``clientInfo`` Implementation
     object (``name``/``version``/optional ``title``). FastMCP exposes the
-    underlying server session as ``ctx.session``, and the MCP server session
-    keeps the parsed initialize params on ``client_params``. This is the
-    ground truth for which application is talking to ha-mcp — we use it
-    instead of asking the LLM to self-report ``Client application``.
+    underlying server session as ``ctx.session``; the MCP SDK's
+    ``ServerSession`` keeps the parsed initialize params on ``client_params``.
+    The attribute name on the parsed Pydantic model is ``clientInfo`` in
+    ``mcp`` 1.24.x (the version this project pins) — we also fall back to
+    ``client_info`` to stay forward-compatible with SDK versions that switch
+    to snake_case.
 
-    Returns ``{"name": ..., "version": ..., "title": ...}`` with ``"unknown"``
-    for fields the client didn't send. Returns an empty dict if no context is
-    available (tool invoked outside an MCP request, e.g. unit tests) so the
-    bug-report path stays robust.
+    Returns ``{"name": ..., "version": ..., "title": ...}``. ``name`` and
+    ``version`` fall back to ``"unknown"`` when the client didn't send them;
+    ``title`` falls back to the empty string so callers can distinguish "not
+    sent" from a real title without false-positive aside rendering.
+
+    Returns an empty dict if no context is available (tool invoked outside an
+    MCP request, e.g. unit tests) so the bug-report path stays robust. The
+    log level is intentionally INFO, not DEBUG: this catch is the only signal
+    we'd get if FastMCP/MCP SDK shape drifts in a future release, and silent
+    drift would hide a regression for months.
     """
     if ctx is None:
         return {}
@@ -176,7 +190,13 @@ def _extract_client_info(ctx: Context | None) -> dict[str, str]:
         params = (
             getattr(session, "client_params", None) if session is not None else None
         )
-        client = getattr(params, "clientInfo", None) if params is not None else None
+        if params is None:
+            return {}
+        # Try the camelCase attribute (mcp 1.24.x) first, then snake_case so
+        # we keep working if the SDK switches the alias direction.
+        client = getattr(params, "clientInfo", None) or getattr(
+            params, "client_info", None
+        )
         if client is None:
             return {}
         return {
@@ -184,27 +204,32 @@ def _extract_client_info(ctx: Context | None) -> dict[str, str]:
             "version": getattr(client, "version", None) or "unknown",
             "title": getattr(client, "title", None) or "",
         }
-    except Exception as e:  # pragma: no cover — defensive guard
-        logger.debug("Failed to read MCP client info from context: %s", e)
+    except Exception as e:
+        logger.info(
+            "Failed to read MCP client info from context: %s (%s)",
+            e,
+            type(e).__name__,
+        )
         return {}
 
 
 def _format_client_info_for_template(info: dict[str, str]) -> str:
     """Render the MCP client identification as a single human-readable line.
 
-    Falls back to ``unknown (no client_info on context)`` when the handshake
-    didn't carry a ``clientInfo`` block — this happens for direct MCP clients
-    that skip the optional field, or when the bug report tool runs outside a
-    live request.
+    Falls back to ``unknown (client did not advertise itself)`` when no
+    client info was available — this happens for direct MCP clients that
+    skip the optional ``clientInfo`` field, or when the bug report tool
+    runs outside a live request. Phrasing is deliberately observable
+    rather than naming the underlying API field (which may be renamed).
     """
     if not info:
-        return "unknown (no client_info on context)"
+        return "unknown (client did not advertise itself)"
     name = info.get("name") or "unknown"
     version = info.get("version") or "unknown"
     title = info.get("title") or ""
     base = f"{name} {version}"
     if title and title != name:
-        return f"{base}  _(advertised title: {title})_"
+        return f"{base} _(advertised title: {title})_"
     return base
 
 
@@ -216,27 +241,35 @@ def _detect_mcp_transport() -> str:
     and well-known env hints. The result is informational — the bug template
     surfaces it as an auto-detect that the agent or user can override.
     """
-    # Entry-point script name (e.g. ``ha-mcp-web`` for HTTP).
+    # Entry-point script name (e.g. ``ha-mcp-web`` for HTTP, ``ha-mcp-sse``
+    # for SSE; pyproject.toml's [project.scripts] is the source of truth).
     argv0 = (sys.argv[0] if sys.argv else "").lower()
     basename = os.path.basename(argv0)
-    if basename.endswith("-web") or basename.endswith("-http"):
+    if basename.endswith("-web"):
         return "http"
     if basename.endswith("-sse"):
         return "sse"
 
-    # Env hints set by HTTP wrappers / supervisors.
+    # Env hints set by HTTP wrappers / supervisors. ``streamable-http`` is the
+    # documented FastMCP variant; collapse it to ``http`` since the
+    # distinction doesn't change triage decisions.
     transport_env = os.environ.get("FASTMCP_TRANSPORT", "").strip().lower()
     if transport_env in {"http", "stdio", "sse"}:
         return transport_env
+    if transport_env == "streamable-http":
+        return "http"
     if os.environ.get("MCP_HTTP_PORT") or os.environ.get("FASTMCP_PORT"):
         return "http"
 
-    # If stdin is a real TTY, ha-mcp wasn't launched by an MCP host pipe —
-    # it's almost certainly a manual run, not stdio MCP traffic.
+    # If stdin is piped (not a TTY), ha-mcp was launched by an MCP host on
+    # stdio. If it IS a TTY, this is a manual / interactive run with no
+    # other transport hints — fall through to ``unknown``.
     try:
         if not sys.stdin.isatty():
             return "stdio"
-    except Exception:  # pragma: no cover — sys.stdin can be None in tests
+    except (AttributeError, OSError, ValueError):
+        # ``sys.stdin`` can be None or detached (pythonw, daemonized
+        # contexts, certain test harnesses). Treat as no signal.
         pass
 
     return "unknown"
@@ -995,7 +1028,7 @@ def _generate_agent_behavior_template(
     # _extract_error_messages and recent_logs are unused in the agent template;
     # tool sequence already lives in log_summary. Kept in the signature so
     # callers don't have to remember which template needs which arg.
-    del recent_logs  # explicit: not used in agent template
+    del recent_logs
 
     return f"""## 🤖 Auto-Generated by `ha_report_issue` Tool
 

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -850,6 +850,12 @@ class TestGetConfigToggles:
 class TestDetectMcpTransport:
     """Tests for _detect_mcp_transport."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_transport_env(self, monkeypatch):
+        """Drop any env vars that could otherwise leak between tests."""
+        for var in ("FASTMCP_TRANSPORT", "MCP_HTTP_PORT", "FASTMCP_PORT"):
+            monkeypatch.delenv(var, raising=False)
+
     def test_http_argv0(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp-web"])
         assert _detect_mcp_transport() == "http"
@@ -858,16 +864,64 @@ class TestDetectMcpTransport:
         monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp-sse"])
         assert _detect_mcp_transport() == "sse"
 
-    def test_env_override_wins_over_argv0_default(self, monkeypatch):
+    def test_argv0_wins_over_env(self, monkeypatch):
+        # Real precedence test: argv0 ending in -web returns "http" early,
+        # before the FASTMCP_TRANSPORT env check would otherwise force "stdio".
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp-web"])
+        monkeypatch.setenv("FASTMCP_TRANSPORT", "stdio")
+        assert _detect_mcp_transport() == "http"
+
+    def test_env_picks_up_when_argv0_is_neutral(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
         monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
         assert _detect_mcp_transport() == "http"
 
+    def test_env_streamable_http_collapses_to_http(self, monkeypatch):
+        # FastMCP documents "streamable-http" as a valid transport literal.
+        # We collapse it to "http" — the distinction doesn't change triage.
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        monkeypatch.setenv("FASTMCP_TRANSPORT", "streamable-http")
+        assert _detect_mcp_transport() == "http"
+
     def test_env_port_implies_http(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
-        monkeypatch.delenv("FASTMCP_TRANSPORT", raising=False)
         monkeypatch.setenv("MCP_HTTP_PORT", "8086")
         assert _detect_mcp_transport() == "http"
+
+    def test_fastmcp_port_implies_http(self, monkeypatch):
+        # Cover the second half of the port-env clause that previously had no test.
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        monkeypatch.setenv("FASTMCP_PORT", "8086")
+        assert _detect_mcp_transport() == "http"
+
+    def test_piped_stdin_is_stdio(self, monkeypatch):
+        # The most common production deployment shape (Claude Desktop launching
+        # ha-mcp via stdio pipe). Without this test the stdio branch is dead
+        # from the suite — a regression there would silently mislabel every
+        # Desktop bug report's transport as "unknown".
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        fake_stdin = SimpleNamespace(isatty=lambda: False)
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        assert _detect_mcp_transport() == "stdio"
+
+    def test_tty_stdin_with_no_hints_returns_unknown(self, monkeypatch):
+        # Manual / interactive run with no transport hints whatsoever.
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        fake_stdin = SimpleNamespace(isatty=lambda: True)
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        assert _detect_mcp_transport() == "unknown"
+
+    def test_detached_stdin_falls_through_to_unknown(self, monkeypatch):
+        # ``sys.stdin.isatty()`` can raise OSError when stdin is detached
+        # (pythonw, daemonized contexts). The except clause must not let
+        # the helper crash.
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+
+        def boom():
+            raise OSError("stdin closed")
+
+        monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=boom))
+        assert _detect_mcp_transport() == "unknown"
 
 
 class TestFormatConfigTogglesForTemplate:
@@ -933,6 +987,36 @@ class TestExtractClientInfo:
         assert info["version"] == "0.42"
         assert info["title"] == ""
 
+    def test_missing_version_falls_back_to_unknown(self):
+        # Pin the docstring promise: name/version default to "unknown" when
+        # the client didn't send them. If the future SDK refactor stops
+        # sending `version`, the f"{name} {version}" downstream rendering
+        # must not produce "Cursor None".
+        client_info_obj = SimpleNamespace(name="Cursor", version=None, title=None)
+        ctx = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(clientInfo=client_info_obj)
+            )
+        )
+        info = _extract_client_info(ctx)
+        assert info == {"name": "Cursor", "version": "unknown", "title": ""}
+
+    def test_snake_case_client_info_attribute_is_picked_up(self):
+        # ha-mcp pins mcp 1.24.x where the attribute is `clientInfo`. Future
+        # SDK versions may switch to `client_info` (snake_case). The helper
+        # falls back to the snake_case attribute name so we keep working
+        # across the rename.
+        client_info_obj = SimpleNamespace(
+            name="Future Client", version="9.9.9", title=None
+        )
+        ctx = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(client_info=client_info_obj)
+            )
+        )
+        info = _extract_client_info(ctx)
+        assert info == {"name": "Future Client", "version": "9.9.9", "title": ""}
+
     def test_swallows_exceptions_and_returns_empty(self):
         # If the context shape is unexpected (future MCP / FastMCP API churn),
         # we'd rather degrade silently than fail the bug report.
@@ -949,7 +1033,9 @@ class TestFormatClientInfoForTemplate:
     def test_empty_renders_unknown_placeholder(self):
         rendered = _format_client_info_for_template({})
         assert "unknown" in rendered
-        assert "no client_info" in rendered
+        # Phrasing describes the observable, not the underlying API field name,
+        # so the message stays accurate if MCP renames the attribute.
+        assert "did not advertise" in rendered
 
     def test_name_and_version_render_as_single_line(self):
         rendered = _format_client_info_for_template(
@@ -1085,6 +1171,19 @@ class TestBugReportNewIdentityFields:
             # At least one known toggle ends up in the rendered section.
             assert "enable_tool_search" in template
 
+        # The plain-text formatted_report body (separate output from the
+        # markdown templates, returned to callers as a triage-readable
+        # summary) must mirror the new auto-detected rows. A future refactor
+        # that drops them from formatted_report while keeping the templates
+        # correct would silently regress the plain-text output.
+        report = result["formatted_report"]
+        assert "MCP Transport:" in report
+        assert "MCP Client:" in report
+        # Renamed from "Platform" to "Operating System" in this PR — pin it.
+        assert "Operating System:" in report
+        assert "=== ha-mcp Config Toggles ===" in report
+        assert "enable_tool_search" in report
+
         # The diagnostic dict carries the structured value too.
         toggles = result["diagnostic_info"]["config_toggles"]
         assert toggles["enable_tool_search"] is True
@@ -1102,6 +1201,13 @@ class TestBugReportNewIdentityFields:
         assert "&title=" in result["agent_behavior_submit_url"]
         assert result["runtime_bug_submit_url"].startswith(
             "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
+        )
+        # Verify the title is actually URL-encoded — a regression that drops
+        # the quote_plus call would leak raw spaces / brackets into the
+        # query, which GitHub mangles.
+        title_query = result["runtime_bug_submit_url"].split("&title=", 1)[1]
+        assert " " not in title_query, (
+            f"Title query must be URL-encoded; got raw space in {title_query!r}"
         )
         # The submit URL is the one printed inside the rendered template body.
         assert result["runtime_bug_submit_url"] in result["runtime_bug_template"]

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -1,5 +1,6 @@
 """Unit tests for the bug report tool (ha_report_issue)."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -7,9 +8,14 @@ import pytest
 
 from ha_mcp import __version__
 from ha_mcp.tools.tools_bug_report import (
+    _detect_mcp_transport,
+    _extract_client_info,
     _fetch_addon_logs,
+    _format_client_info_for_template,
+    _format_config_toggles_for_template,
     _format_logs_for_report,
     _format_startup_logs,
+    _get_config_toggles,
     _sanitize_log_text,
     register_bug_report_tools,
 )
@@ -120,7 +126,10 @@ class TestBugReportTool:
         assert "🔄 Steps to Reproduce" in runtime_template
         assert "✅ Expected vs ❌ Actual Behavior" in runtime_template
         assert "🔧 Environment" in runtime_template
-        assert "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml" in runtime_template
+        assert (
+            "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
+            in runtime_template
+        )
 
         # Check agent behavior template
         agent_template = result["agent_behavior_template"]
@@ -128,7 +137,10 @@ class TestBugReportTool:
         assert "🤖 What Did the AI Agent Do?" in agent_template
         assert "🎯 What Should the Agent Have Done?" in agent_template
         assert "🔧 Tool Calls Made" in agent_template
-        assert "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml" in agent_template
+        assert (
+            "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
+            in agent_template
+        )
 
         # Check anonymization guide
         anon_guide = result["anonymization_guide"]
@@ -201,8 +213,14 @@ class TestBugReportTool:
         result = await actual_func()
 
         # Check both templates have correct URLs
-        assert "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml" in result["runtime_bug_template"]
-        assert "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml" in result["agent_behavior_template"]
+        assert (
+            "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
+            in result["runtime_bug_template"]
+        )
+        assert (
+            "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=agent_behavior.yml"
+            in result["agent_behavior_template"]
+        )
 
     @pytest.mark.asyncio
     async def test_bug_report_no_timezone(self, registered_tools, mock_client):
@@ -239,9 +257,7 @@ class TestBugReportTool:
 
         # Mock get_recent_logs to verify it's called with correct max_entries
         # Formula: AVG_LOG_ENTRIES_PER_TOOL (3) * 2 * tool_call_count
-        with patch(
-            "ha_mcp.tools.tools_bug_report.get_recent_logs"
-        ) as mock_get_logs:
+        with patch("ha_mcp.tools.tools_bug_report.get_recent_logs") as mock_get_logs:
             mock_get_logs.return_value = [
                 {
                     "timestamp": "2024-12-01T10:00:00",
@@ -279,9 +295,7 @@ class TestBugReportTool:
         while hasattr(actual_func, "__wrapped__"):
             actual_func = actual_func.__wrapped__
 
-        with patch(
-            "ha_mcp.tools.tools_bug_report.get_recent_logs"
-        ) as mock_get_logs:
+        with patch("ha_mcp.tools.tools_bug_report.get_recent_logs") as mock_get_logs:
             mock_get_logs.return_value = [
                 {
                     "timestamp": "2024-12-01T10:00:00.123456",
@@ -340,9 +354,7 @@ class TestBugReportTool:
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
 
-        with patch(
-            "ha_mcp.tools.tools_bug_report.get_recent_logs"
-        ) as mock_get_logs:
+        with patch("ha_mcp.tools.tools_bug_report.get_recent_logs") as mock_get_logs:
             mock_get_logs.return_value = [
                 {
                     "timestamp": "2024-12-01T10:00:00",
@@ -372,9 +384,7 @@ class TestBugReportTool:
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
 
-        with patch(
-            "ha_mcp.tools.tools_bug_report.get_recent_logs"
-        ) as mock_get_logs:
+        with patch("ha_mcp.tools.tools_bug_report.get_recent_logs") as mock_get_logs:
             mock_get_logs.return_value = [
                 {
                     "timestamp": "2024-12-01T10:00:00",
@@ -394,14 +404,14 @@ class TestBugReportTool:
             assert len(title) <= 60
 
     @pytest.mark.asyncio
-    async def test_bug_report_duplicate_check_urls(self, ha_report_issue_func, mock_client):
+    async def test_bug_report_duplicate_check_urls(
+        self, ha_report_issue_func, mock_client
+    ):
         """Test that duplicate check URLs are generated with correct keywords."""
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
 
-        with patch(
-            "ha_mcp.tools.tools_bug_report.get_recent_logs"
-        ) as mock_get_logs:
+        with patch("ha_mcp.tools.tools_bug_report.get_recent_logs") as mock_get_logs:
             mock_get_logs.return_value = [
                 {
                     "timestamp": "2024-12-01T10:00:00",
@@ -801,3 +811,361 @@ class TestFormatStartupLogsSanitization:
 
         assert "eyJhbG" not in formatted
         assert "[REDACTED_JWT]" in formatted
+
+
+class TestGetConfigToggles:
+    """Tests for _get_config_toggles."""
+
+    def test_collects_known_toggles_from_settings(self):
+        # Use SimpleNamespace as a stand-in for Settings to avoid touching the
+        # real env-driven singleton. Only fields present on the namespace are
+        # collected; missing fields fall through (None).
+        fake = SimpleNamespace(
+            enable_websocket=True,
+            enable_dashboard_partial_tools=True,
+            enable_tool_search=False,
+            tool_search_max_results=5,
+            enable_yaml_config_editing=False,
+            enable_code_mode=False,
+            enabled_tool_modules="all",
+            disabled_tools="ha_foo,ha_bar",
+            pinned_tools="",
+        )
+        toggles = _get_config_toggles(fake)
+        assert toggles["enable_tool_search"] is False
+        assert toggles["tool_search_max_results"] == 5
+        assert toggles["enabled_tool_modules"] == "all"
+        # Lists are summarized, not dumped — count of comma-separated entries.
+        assert toggles["disabled_tools_count"] == 2
+        assert toggles["pinned_tools_count"] == 0
+
+    def test_returns_empty_dict_when_settings_construction_fails(self):
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_global_settings",
+            side_effect=RuntimeError("env missing"),
+        ):
+            assert _get_config_toggles() == {}
+
+
+class TestDetectMcpTransport:
+    """Tests for _detect_mcp_transport."""
+
+    def test_http_argv0(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp-web"])
+        assert _detect_mcp_transport() == "http"
+
+    def test_sse_argv0(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp-sse"])
+        assert _detect_mcp_transport() == "sse"
+
+    def test_env_override_wins_over_argv0_default(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        monkeypatch.setenv("FASTMCP_TRANSPORT", "http")
+        assert _detect_mcp_transport() == "http"
+
+    def test_env_port_implies_http(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["/usr/bin/ha-mcp"])
+        monkeypatch.delenv("FASTMCP_TRANSPORT", raising=False)
+        monkeypatch.setenv("MCP_HTTP_PORT", "8086")
+        assert _detect_mcp_transport() == "http"
+
+
+class TestFormatConfigTogglesForTemplate:
+    """Tests for _format_config_toggles_for_template."""
+
+    def test_empty_returns_placeholder(self):
+        assert (
+            _format_config_toggles_for_template({}) == "_(config toggles unavailable)_"
+        )
+
+    def test_renders_bullets_with_value(self):
+        rendered = _format_config_toggles_for_template(
+            {"enable_tool_search": False, "tool_search_max_results": 5}
+        )
+        assert "- **enable_tool_search:** `False`" in rendered
+        assert "- **tool_search_max_results:** `5`" in rendered
+
+
+class TestExtractClientInfo:
+    """Tests for _extract_client_info — pulls clientInfo off the MCP context."""
+
+    def test_returns_empty_when_ctx_is_none(self):
+        # Tool can be invoked outside an MCP request (unit tests, scripts).
+        # The bug-report path must not blow up — empty dict is the contract.
+        assert _extract_client_info(None) == {}
+
+    def test_returns_empty_when_session_has_no_client_params(self):
+        # Some transports / direct callers won't have completed an initialize
+        # handshake yet. _extract_client_info should treat that as "no info".
+        ctx = SimpleNamespace(session=SimpleNamespace(client_params=None))
+        assert _extract_client_info(ctx) == {}
+
+    def test_reads_name_version_title_off_initialize_params(self):
+        # Mirrors the shape of mcp.types.InitializeRequestParams.clientInfo
+        # (an Implementation: name + version, optional title) without pulling
+        # the real types into the test.
+        client_info_obj = SimpleNamespace(
+            name="Claude Desktop",
+            version="0.7.42",
+            title="Claude Desktop (claude.ai integration)",
+        )
+        ctx = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(clientInfo=client_info_obj)
+            )
+        )
+        info = _extract_client_info(ctx)
+        assert info == {
+            "name": "Claude Desktop",
+            "version": "0.7.42",
+            "title": "Claude Desktop (claude.ai integration)",
+        }
+
+    def test_missing_optional_title_falls_back_to_empty_string(self):
+        client_info_obj = SimpleNamespace(name="Cursor", version="0.42", title=None)
+        ctx = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(clientInfo=client_info_obj)
+            )
+        )
+        info = _extract_client_info(ctx)
+        assert info["name"] == "Cursor"
+        assert info["version"] == "0.42"
+        assert info["title"] == ""
+
+    def test_swallows_exceptions_and_returns_empty(self):
+        # If the context shape is unexpected (future MCP / FastMCP API churn),
+        # we'd rather degrade silently than fail the bug report.
+        class Boom:
+            def __getattr__(self, _name):
+                raise RuntimeError("unexpected ctx shape")
+
+        assert _extract_client_info(Boom()) == {}
+
+
+class TestFormatClientInfoForTemplate:
+    """Tests for _format_client_info_for_template."""
+
+    def test_empty_renders_unknown_placeholder(self):
+        rendered = _format_client_info_for_template({})
+        assert "unknown" in rendered
+        assert "no client_info" in rendered
+
+    def test_name_and_version_render_as_single_line(self):
+        rendered = _format_client_info_for_template(
+            {"name": "Claude Desktop", "version": "0.7.42", "title": ""}
+        )
+        assert rendered == "Claude Desktop 0.7.42"
+
+    def test_distinct_title_appears_as_aside(self):
+        rendered = _format_client_info_for_template(
+            {
+                "name": "ClaudeDesktop",
+                "version": "0.7.42",
+                "title": "Claude Desktop (claude.ai integration)",
+            }
+        )
+        assert "ClaudeDesktop 0.7.42" in rendered
+        assert "Claude Desktop (claude.ai integration)" in rendered
+
+    def test_title_matching_name_is_not_repeated(self):
+        # Many clients send title == name; don't print the same string twice.
+        rendered = _format_client_info_for_template(
+            {"name": "Cursor", "version": "0.42", "title": "Cursor"}
+        )
+        assert rendered == "Cursor 0.42"
+
+
+class TestBugReportNewIdentityFields:
+    """End-to-end checks that the new self-reported placeholders + auto fields
+    land in both templates and the response payload."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        mcp._tools = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                mcp._tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get_config = AsyncMock(return_value={"version": "2024.12.0"})
+        client.get_states = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def ha_report_issue_func(self, mock_mcp, mock_client):
+        register_bug_report_tools(mock_mcp, mock_client)
+        func = mock_mcp._tools["ha_report_issue"]
+        while hasattr(func, "__wrapped__"):
+            func = func.__wrapped__
+        return func
+
+    @pytest.mark.asyncio
+    async def test_self_reported_placeholders_in_runtime_template(
+        self, ha_report_issue_func
+    ):
+        result = await ha_report_issue_func()
+        runtime = result["runtime_bug_template"]
+        # All three self-report fields and the auto-detected transport row
+        # are present, with the "fill in" sentinel still visible — this is
+        # what the agent populates before showing it to the user.
+        # AI Model is collected, but as a bare label with no placeholder
+        # examples to bias the agent — the instructions block straight-up
+        # asks the agent to write its identity. Old multi-axis placeholders
+        # (Model family / Model version / Client application) are gone.
+        assert "**AI Model:**" in runtime
+        assert "**Model family:**" not in runtime
+        assert "**Model version:**" not in runtime
+        assert "**Client application:**" not in runtime
+        # No vendor enumeration in the template body — that's exactly the
+        # hallucination-bait we removed.
+        for vendor in ("Claude, Gemini", "Gemini, GPT", "GPT, Llama"):
+            assert vendor not in runtime
+        assert "**MCP Client:**" in runtime
+        assert "**MCP Transport:**" in runtime
+        assert "<fill in" in runtime
+        # Triggering prompt + tool call section is present and asks for the
+        # exact user message + tool call.
+        assert "Triggering Prompt & Tool Call" in runtime
+        assert "**User prompt:**" in runtime
+
+    @pytest.mark.asyncio
+    async def test_self_reported_placeholders_in_agent_template(
+        self, ha_report_issue_func
+    ):
+        result = await ha_report_issue_func()
+        agent = result["agent_behavior_template"]
+        assert "**AI Model:**" in agent
+        assert "**Model family:**" not in agent
+        assert "**Model version:**" not in agent
+        assert "**Client application:**" not in agent
+        for vendor in ("Claude, Gemini", "Gemini, GPT", "GPT, Llama"):
+            assert vendor not in agent
+        assert "**MCP Client:**" in agent
+        assert "**MCP Transport:**" in agent
+        assert "Triggering Prompt & Tool Call" in agent
+
+    @pytest.mark.asyncio
+    async def test_config_toggles_section_renders_in_templates(
+        self, ha_report_issue_func
+    ):
+        # Use a fake Settings so we don't depend on real env vars.
+        fake = SimpleNamespace(
+            enable_websocket=True,
+            enable_dashboard_partial_tools=True,
+            enable_tool_search=True,
+            tool_search_max_results=7,
+            enable_yaml_config_editing=False,
+            enable_code_mode=False,
+            enabled_tool_modules="all",
+            disabled_tools="",
+            pinned_tools="",
+        )
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_global_settings", return_value=fake
+        ):
+            result = await ha_report_issue_func()
+
+        for template in (
+            result["runtime_bug_template"],
+            result["agent_behavior_template"],
+        ):
+            # Section header surfaces the toggle block.
+            assert "ha-mcp Configuration" in template
+            # At least one known toggle ends up in the rendered section.
+            assert "enable_tool_search" in template
+
+        # The diagnostic dict carries the structured value too.
+        toggles = result["diagnostic_info"]["config_toggles"]
+        assert toggles["enable_tool_search"] is True
+        assert toggles["tool_search_max_results"] == 7
+
+    @pytest.mark.asyncio
+    async def test_submit_urls_include_prefilled_title(self, ha_report_issue_func):
+        # The runtime/agent submit URLs append &title=<urlencoded suggested_title>
+        # so GitHub auto-fills the issue title field. This addresses bare-`[BUG]`
+        # title submissions seen in #1095.
+        result = await ha_report_issue_func()
+        suggested = result["suggested_title"]
+        assert suggested  # always non-empty
+        assert "&title=" in result["runtime_bug_submit_url"]
+        assert "&title=" in result["agent_behavior_submit_url"]
+        assert result["runtime_bug_submit_url"].startswith(
+            "https://github.com/homeassistant-ai/ha-mcp/issues/new?template=runtime_bug.yml"
+        )
+        # The submit URL is the one printed inside the rendered template body.
+        assert result["runtime_bug_submit_url"] in result["runtime_bug_template"]
+        assert result["agent_behavior_submit_url"] in result["agent_behavior_template"]
+
+    @pytest.mark.asyncio
+    async def test_diagnostic_info_carries_transport_and_toggles(
+        self, ha_report_issue_func
+    ):
+        result = await ha_report_issue_func()
+        diag = result["diagnostic_info"]
+        # New top-level diagnostic fields requested by issue #1095.
+        assert "mcp_transport" in diag
+        assert "config_toggles" in diag
+        assert "mcp_client_info" in diag
+        assert isinstance(diag["config_toggles"], dict)
+        assert isinstance(diag["mcp_client_info"], dict)
+
+    @pytest.mark.asyncio
+    async def test_ctx_client_info_populates_mcp_client_row(self, ha_report_issue_func):
+        # When ha_report_issue is called from inside an MCP request, the
+        # FastMCP-injected Context exposes the initialize handshake's
+        # clientInfo. Verify the helper picks it up and the rendered template
+        # surfaces it on the `MCP Client:` row — no agent self-report needed.
+        client_info_obj = SimpleNamespace(
+            name="Claude Desktop",
+            version="0.7.42",
+            title=None,
+        )
+        ctx = SimpleNamespace(
+            session=SimpleNamespace(
+                client_params=SimpleNamespace(clientInfo=client_info_obj)
+            )
+        )
+        result = await ha_report_issue_func(ctx=ctx)
+
+        # Diagnostic dict carries the structured value.
+        assert result["diagnostic_info"]["mcp_client_info"] == {
+            "name": "Claude Desktop",
+            "version": "0.7.42",
+            "title": "",
+        }
+        # And both rendered templates show the formatted line on the
+        # `MCP Client:` row.
+        for key in ("runtime_bug_template", "agent_behavior_template"):
+            template = result[key]
+            assert "**MCP Client:** Claude Desktop 0.7.42" in template
+
+    @pytest.mark.asyncio
+    async def test_instructions_describe_all_self_report_fields(
+        self, ha_report_issue_func
+    ):
+        result = await ha_report_issue_func()
+        instructions = result["instructions"]
+        # The instructions block must straight-up ASK the agent for both
+        # self-reported fields (no enumerated options to pick from — that's
+        # what biases agents and invites hallucinations).
+        assert "**AI Model:**" in instructions
+        assert "**Triggering Prompt & Tool Call:**" in instructions
+        # The old multi-axis identity placeholders are gone.
+        assert "**Model family:**" not in instructions
+        assert "**Model version:**" not in instructions
+        assert "**Client application:**" not in instructions
+        # And the instructions must NOT enumerate vendor lists — that's the
+        # hallucination bait we removed.
+        for vendor in ("Claude, Gemini", "Gemini, GPT", "GPT, Llama"):
+            assert vendor not in instructions


### PR DESCRIPTION
## What does this PR do?

Closes #1095. Restructures the `ha_report_issue` payload + rendered
templates so triage doesn't have to ask "which client? which model? which
toggles? what prompt?" on every report.

### Tool-side changes (`src/ha_mcp/tools/tools_bug_report.py`)

- **Auto-detected `MCP Client`** row, read off the MCP `initialize`
  handshake via `ctx.session.client_params.clientInfo` (FastMCP exposes
  the server session on `Context`). Renders as `<name> <version>` with
  the advertised `title` as a parenthetical aside when distinct. Falls
  back to `unknown (no client_info on context)` when the handshake didn't
  carry one. Authoritative — no agent self-report.
- **`AI Model`** line in the Environment block: bare label, no placeholder
  examples. The instructions block straight-up asks the calling agent
  to write its own identity on this line — provider/family + the most
  specific version it knows, in whatever form it would describe itself.
  No vendor enumeration: there are too many models out there, and any
  list biases the agent / invites it to hallucinate a plausible-looking
  match instead of answering honestly.
- **Auto-collected `MCP Transport`** row (best-effort: argv0,
  `FASTMCP_TRANSPORT`, `MCP_HTTP_PORT` / `FASTMCP_PORT`, stdin TTY
  heuristic). Surfaced as `(auto-detected — correct if wrong)`.
- **Auto-collected `⚙️ ha-mcp Configuration` section** with toggle
  snapshot from `Settings`: `enable_tool_search`,
  `tool_search_max_results`, `enable_yaml_config_editing`,
  `enable_code_mode`, `enabled_tool_modules`, `disabled_tools_count`,
  `pinned_tools_count`, etc. These flags shape which tools the agent
  sees, so the same complaint can mean very different things.
- **`💬 Triggering Prompt & Tool Call` section** the agent fills with
  the verbatim user prompt + offending tool call — the highest-leverage
  signal for triage.
- **Pre-filled GitHub issue titles.** New return fields
  `runtime_bug_submit_url` / `agent_behavior_submit_url` append
  `&title=<urlencoded suggested_title>` to the existing template URLs,
  so clicking the link opens GitHub's new-issue form with the title
  field already populated. Addresses the bare-`[BUG]` titles pain point.
- Renamed `Platform` → `Operating System` inside the rendered template
  body so the new auto-detected rows don't collide with the existing
  OS row.

### Issue template changes (`.github/ISSUE_TEMPLATE/`)

- `runtime_bug.yml` + `agent_behavior.yml` gain a small "Title tip"
  banner reminding users not to leave bare `[BUG] ` / `[AGENT] ` titles
  and noting that the `ha_report_issue` link pre-fills the title field
  for them. No structural form-field changes.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

### Tests added
- `_get_config_toggles` — collects known toggles, summarizes
  `disabled_tools` / `pinned_tools` as counts, returns `{}` when
  settings construction fails.
- `_detect_mcp_transport` — argv0 suffix detection, env override,
  port-env implies HTTP.
- `_extract_client_info` — `None` ctx, missing `client_params`, full
  handshake, missing optional `title`, exception swallowing.
- `_format_client_info_for_template` — empty placeholder,
  name+version rendering, distinct-title aside, duplicate-title
  de-duplication.
- End-to-end: both templates contain `MCP Client` + `MCP Transport` +
  bare `AI Model` rows; neither contains old multi-axis placeholders
  (`Model family` / `Model version` / `Client application`) or vendor
  enumeration; submit URLs include `&title=`; instructions block
  straight-up asks the agent for AI Model + the triggering prompt
  without nudging via vendor lists; injecting a `ctx` with a
  `clientInfo` populates the rendered `MCP Client:` row.

## Checklist
- [x] I have updated documentation if needed — _none required; tool
      response and template body are self-documenting._