### PR TITLE
fix: harden scene category validation gate (B25 follow-up to #1168)

### DIFF
--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -795,13 +795,19 @@ class ConfigSceneTools:
             # the python_transform branch — a phantom category must not
             # rewrite the scene before erroring.
             #
-            # Issue #1168 R7 blocker 22: gate on the user-facing ``category``
-            # param, not ``effective_category``. ``_validate_scene_config``
-            # promotes a metadata-embedded category into ``effective_category``
-            # when the user passed ``category=None``; validating that on
-            # every call costs a category-registry round-trip even when the
-            # user wasn't trying to change the category at all.
-            if category is not None and effective_category:
+            # Issue #1168 R8 (post-merge follow-up): gate on
+            # ``effective_category`` truthy, not on the user-facing
+            # ``category`` param. ``_validate_scene_config`` promotes a
+            # top-level ``config["category"]`` into ``effective_category``
+            # when the user passed ``category=None``; the R7 fix gated on
+            # ``category is not None`` to skip the WS round-trip when no
+            # category was supplied, but that left the dict-promoted path
+            # uncovered — a phantom category in ``config["category"]``
+            # would skip validation and reach ``apply_entity_category``,
+            # which attaches the phantom ID to the entity registry without
+            # checking it exists. Truthy check covers both sources and
+            # still skips the WS call when neither produces a category.
+            if effective_category:
                 await self._validate_category_id(effective_category)
 
             # Issue #1168 R3 blocker 7: when caller passes ``config_hash``,

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -1642,24 +1642,24 @@ class TestResolverRetriedFlag:
 
 
 class TestCategoryValidationGate:
-    """R7 blocker 22 — gate ``_validate_category_id`` on the user-facing
-    ``category`` param, not on ``effective_category``.
+    """R8 follow-up — gate ``_validate_category_id`` on
+    ``effective_category`` truthy, covering BOTH sources (user param and
+    ``_validate_scene_config``-promoted top-level ``config["category"]``).
 
-    ``_validate_scene_config`` promotes a metadata-embedded category into
-    ``effective_category`` when the caller passed ``category=None``. The
-    R6 fix ran the validator on every call where ``effective_category``
-    was truthy, costing a category-registry round-trip even when the user
-    wasn't trying to change the category at all.
+    The R7 fix gated on ``category is not None`` to skip the WS
+    round-trip when no category was supplied, but that left the
+    dict-promoted path uncovered: a phantom category in
+    ``config["category"]`` would skip validation and reach
+    ``apply_entity_category``, which attaches the phantom ID to the
+    entity registry without checking it exists. R8 widens the gate so
+    any non-None ``effective_category`` validates, regardless of source.
     """
 
-    async def test_metadata_promoted_category_does_not_validate(
+    async def test_no_category_at_all_skips_validation(
         self, tools, mock_client,
     ):
-        """User passes ``category=None``, config has a metadata category
-        (e.g. preserved from a previous get → set round-trip). The
-        validator must NOT fire — no WS round-trip for ``category_registry/list``.
-        """
-        # Track whether _validate_category_id was called via WS payload.
+        """Neither user param nor config dict supplies a category — the
+        validator must NOT fire. No WS round-trip for category_registry/list."""
         ws_calls: list[dict] = []
 
         async def _ws_handler(message):
@@ -1670,12 +1670,8 @@ class TestCategoryValidationGate:
 
         await tools.ha_config_set_scene(
             scene_id="test_scene",
-            config={
-                "name": "X",
-                "entities": {"light.x": {"state": "on"}},
-                "metadata": {"category": "lighting"},  # promoted to effective_category
-            },
-            category=None,  # user didn't pass — promotion fires
+            config={"name": "X", "entities": {"light.x": {"state": "on"}}},
+            category=None,
             wait=False,
         )
 
@@ -1685,18 +1681,14 @@ class TestCategoryValidationGate:
             and c.get("type") == "config/category_registry/list"
         ]
         assert not category_list_calls, (
-            "_validate_category_id must NOT fire when the user passed "
-            "category=None — the metadata-promoted value is preserved-state, "
-            "not a user-driven category change. "
-            f"Got payloads: {category_list_calls}"
+            "_validate_category_id must NOT fire when no category is supplied "
+            f"from either source. Got payloads: {category_list_calls}"
         )
 
-    async def test_user_passed_category_still_validates(
+    async def test_user_passed_category_validates(
         self, tools, mock_client,
     ):
-        """User passes a non-None ``category`` — the validator MUST fire
-        regardless of metadata-promotion. The R7 gate is about excluding
-        the promotion-only case, not breaking the user-driven path."""
+        """User passes a non-None ``category`` — validator must fire."""
         mock_client.send_websocket_message = AsyncMock(
             return_value={
                 "success": True,
@@ -1720,6 +1712,76 @@ class TestCategoryValidationGate:
         assert category_list_calls, (
             "_validate_category_id must fire when the user passes a category"
         )
+
+    async def test_dict_promoted_category_validates(
+        self, tools, mock_client,
+    ):
+        """User passes ``category=None`` but config has top-level
+        ``config["category"]`` — ``_validate_scene_config`` promotes it
+        to ``effective_category`` and the validator MUST fire so phantom
+        IDs are caught before they reach ``apply_entity_category``."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [{"category_id": "lighting"}],
+            }
+        )
+
+        await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            config={
+                "name": "X",
+                "category": "lighting",  # top-level → promoted
+                "entities": {"light.x": {"state": "on"}},
+            },
+            category=None,  # user didn't pass — promotion fires
+            wait=False,
+        )
+
+        category_list_calls = [
+            call.args[0]
+            for call in mock_client.send_websocket_message.call_args_list
+            if isinstance(call.args[0], dict)
+            and call.args[0].get("type") == "config/category_registry/list"
+        ]
+        assert category_list_calls, (
+            "_validate_category_id must fire when the config dict supplies "
+            "a top-level category — phantom IDs in this path were attached "
+            "to the entity registry without validation in R7."
+        )
+
+    async def test_dict_promoted_phantom_rejected_pre_upsert(
+        self, tools, mock_client,
+    ):
+        """B25 regression — phantom category in top-level ``config["category"]``
+        must be rejected pre-upsert. Live reproducer: caller sets
+        ``config={"category": "phantom_id", ...}`` with no ``category=`` param;
+        the R7 gate skipped validation, the upsert committed, and the phantom
+        ID was attached to the entity registry. R8 widens the gate so this
+        path validates and rejects before any state mutation."""
+        # Registry returns no matching category — phantom rejected.
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_scene(
+                scene_id="test_scene",
+                config={
+                    "name": "X",
+                    "category": "phantom_via_config_dict",
+                    "entities": {"light.x": {"state": "on"}},
+                },
+                category=None,
+                wait=False,
+            )
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["success"] is False
+        assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "phantom_via_config_dict" in error_data["error"]["message"]
+        # The whole point: no upsert reached HA.
+        mock_client.upsert_scene_config.assert_not_called()
 
 
 class TestPythonTransformIdNoneRebind:
@@ -1894,17 +1956,21 @@ class TestSmartSearchSceneIdFallbackPaths:
             )
 
         scenes = result.get("scenes", [])
-        if scenes:
-            # Tier 3 fallback — slug stays as scene_id.
-            assert scenes[0]["scene_id"] == "orphaned"
-            # WARNING log fired so the silent path becomes observable.
-            warn_records = [
-                r
-                for r in caplog.records
-                if "fell back to entity-id slug" in r.message
-                and r.levelno == logging.WARNING
-            ]
-            assert warn_records, (
-                "tier-3 slug-fallback must emit a WARNING; got "
-                f"{[(r.levelname, r.message) for r in caplog.records]}"
-            )
+        assert scenes, (
+            "tier-3 must yield a result for the matched scene, not drop it. "
+            "A regression that silently omits orphaned entries would produce "
+            f"empty scenes; got {scenes!r}"
+        )
+        # Tier 3 fallback — slug stays as scene_id.
+        assert scenes[0]["scene_id"] == "orphaned"
+        # WARNING log fired so the silent path becomes observable.
+        warn_records = [
+            r
+            for r in caplog.records
+            if "fell back to entity-id slug" in r.message
+            and r.levelno == logging.WARNING
+        ]
+        assert warn_records, (
+            "tier-3 slug-fallback must emit a WARNING; got "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )


### PR DESCRIPTION
## What does this PR do?

Follow-up to PR #1168. The R7 gate at `tools_config_scenes.py:804` for `_validate_category_id`:

```python
if category is not None and effective_category:
    await self._validate_category_id(effective_category)
```

skipped validation when the caller passed `category=None` but the config dict contained a top-level `category` field. `_validate_scene_config` promotes that dict value into `effective_category`, which then reached `apply_entity_category` and attached the phantom ID to the entity registry without checking it exists — reopening the partial-state contract that B9/B15 was supposed to close.

**Live reproducer (verified in BAT testing on #1168 round 8):**

```python
ha_config_set_scene(
    scene_id="bat_b25_repro",
    config={"name": "v", "category": "phantom_id", "entities": {"light.d1": {"state": "on"}}},
)
# Before: scene created, entity registry has categories: {"scene": "phantom_id"}
# After:  VALIDATION_INVALID_PARAMETER, no scene created, no registry mutation
```

Cross-verified with `ha_config_get_category(scope="scene")` — phantom IDs are NOT auto-created; they were just attached as orphan references to the entity registry.

**Fix:** widen the gate to `if effective_category:`. Covers both sources (user param and dict-promoted) and still skips the WS round-trip when neither produces a category.

## Changes

- **`src/ha_mcp/tools/tools_config_scenes.py`** — one-line gate change at `:804` from `if category is not None and effective_category:` → `if effective_category:`.
- **`tests/src/unit/test_tools_config_scenes.py`** — `TestCategoryValidationGate` rewritten to match the widened contract:
  - `test_no_category_at_all_skips_validation` — preserves R7's no-WS-roundtrip-without-category property.
  - `test_user_passed_category_validates` — kept, tightened name.
  - `test_dict_promoted_category_validates` — **new**, proves the widened gate fires for the dict path.
  - `test_dict_promoted_phantom_rejected_pre_upsert` — **B25 regression test** with `upsert_scene_config.assert_not_called()` so a future re-narrowing of the gate fails loud.
  - `test_metadata_promoted_category_does_not_validate` removed: it used a `metadata={"category": ...}` shape that never triggered promotion (only top-level `config["category"]` is popped), so the test passed for the wrong reason and didn't discriminate the R7 gate from this fix.
- **`tests/src/unit/test_tools_config_scenes.py`** — `test_scene_falls_back_to_slug_with_warning` weak `if scenes:` guard replaced with unconditional `assert scenes`, so a regression that silently drops orphaned entries fails loud rather than green-passing.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [x] All automated tests pass (verified locally)
- [x] Code follows style guidelines (`ruff check` clean on touched files)
- [x] Live-verified the fix on a real HA install before opening this PR — phantom rejected pre-upsert, no entity-registry mutation; legitimate paths (param=valid, dict=valid, neither) still work.

## Checklist

- [x] I have updated documentation if needed (inline comment at the gate updated to explain the widening)