### PR TITLE
fix: route Supervisor 401s to structured tool errors + add E2E coverage (#1129)

### DIFF
--- a/src/ha_mcp/_version.py
+++ b/src/ha_mcp/_version.py
@@ -56,3 +56,14 @@ def is_running_in_addon() -> bool:
     users, who already see the dev/stable distinction in the HAOS add-on UI.
     """
     return bool(os.environ.get("SUPERVISOR_TOKEN"))
+
+
+def get_supervisor_base_url() -> str:
+    """Return the base URL for direct Supervisor REST calls.
+
+    Defaults to ``http://supervisor`` (the in-addon Supervisor hostname). The
+    ``SUPERVISOR_BASE_URL`` env var override exists so E2E tests can point the
+    direct-Supervisor httpx call sites at a local mock without /etc/hosts or
+    DNS hacks. Production add-ons leave it unset.
+    """
+    return os.environ.get("SUPERVISOR_BASE_URL", "http://supervisor")

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import httpx
 
-from .._version import is_running_in_addon
+from .._version import get_supervisor_base_url, is_running_in_addon
 from ..config import get_global_settings
 
 
@@ -543,7 +543,7 @@ class HomeAssistantClient:
                 "(addon-mode gate fired but SUPERVISOR_TOKEN env var not set)"
             )
 
-        url = f"http://supervisor/{path}/logs"
+        url = f"{get_supervisor_base_url()}/{path}/logs"
         logger.debug("Fetching %s via Supervisor direct", url)
 
         try:

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -40,6 +40,22 @@ class HomeAssistantConnectionError(HomeAssistantError):
     """Connection error to Home Assistant."""
 
 
+class HomeAssistantAuthError(HomeAssistantError):
+    """Authentication error with Home Assistant.
+
+    Sibling of ``HomeAssistantAPIError`` (not a subclass). The codebase has
+    18 ``except HomeAssistantAPIError`` sites (util_helpers polling,
+    tools_integrations registry lookups, etc.) that deliberately rely on
+    auth errors NOT matching so they can propagate to a paired
+    ``except (HomeAssistantConnectionError, HomeAssistantAuthError): raise``
+    block. Subclassing AuthError under APIError silently swallowed those
+    auth errors as part of the local "this entity is not registered yet"
+    polling logic. Sites that specifically need to catch both must list
+    them explicitly (see ``_get_supervisor_log`` and
+    ``_get_system_service_log`` in ``tools_utility.py``).
+    """
+
+
 class HomeAssistantAPIError(HomeAssistantError):
     """API error from Home Assistant."""
 
@@ -52,29 +68,6 @@ class HomeAssistantAPIError(HomeAssistantError):
         super().__init__(message)
         self.status_code = status_code
         self.response_data = response_data
-
-
-class HomeAssistantAuthError(HomeAssistantAPIError):
-    """Authentication error with Home Assistant.
-
-    Subclass of ``HomeAssistantAPIError`` so ``except HomeAssistantAPIError``
-    blocks (e.g. ``_get_system_service_log``) catch auth failures uniformly
-    instead of letting them propagate raw to FastMCP's generic wrapper.
-    Pattern matching in ``_classify_exception`` still routes auth errors to
-    ``create_auth_error`` first because ``case HomeAssistantAuthError():``
-    appears before ``case HomeAssistantAPIError():`` in source order.
-
-    Defaults ``status_code`` to 401 since that's what every production raise
-    site corresponds to today.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        status_code: int | None = 401,
-        response_data: dict[str, Any] | None = None,
-    ):
-        super().__init__(message, status_code=status_code, response_data=response_data)
 
 
 class HomeAssistantCommandError(HomeAssistantError):

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -40,10 +40,6 @@ class HomeAssistantConnectionError(HomeAssistantError):
     """Connection error to Home Assistant."""
 
 
-class HomeAssistantAuthError(HomeAssistantError):
-    """Authentication error with Home Assistant."""
-
-
 class HomeAssistantAPIError(HomeAssistantError):
     """API error from Home Assistant."""
 
@@ -56,6 +52,29 @@ class HomeAssistantAPIError(HomeAssistantError):
         super().__init__(message)
         self.status_code = status_code
         self.response_data = response_data
+
+
+class HomeAssistantAuthError(HomeAssistantAPIError):
+    """Authentication error with Home Assistant.
+
+    Subclass of ``HomeAssistantAPIError`` so ``except HomeAssistantAPIError``
+    blocks (e.g. ``_get_system_service_log``) catch auth failures uniformly
+    instead of letting them propagate raw to FastMCP's generic wrapper.
+    Pattern matching in ``_classify_exception`` still routes auth errors to
+    ``create_auth_error`` first because ``case HomeAssistantAuthError():``
+    appears before ``case HomeAssistantAPIError():`` in source order.
+
+    Defaults ``status_code`` to 401 since that's what every production raise
+    site corresponds to today.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = 401,
+        response_data: dict[str, Any] | None = None,
+    ):
+        super().__init__(message, status_code=status_code, response_data=response_data)
 
 
 class HomeAssistantCommandError(HomeAssistantError):
@@ -1300,7 +1319,6 @@ class HomeAssistantClient:
                     status_code=405,
                 ) from e
             raise
-
 
     async def resolve_scene_id(self, identifier: str) -> str:
         """

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -19,7 +19,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 
-from ._version import is_running_in_addon
+from ._version import get_supervisor_base_url, is_running_in_addon
 from .errors import ErrorCode, create_error_response
 from .transforms import DEFAULT_PINNED_TOOLS
 from .utils.data_paths import get_data_dir
@@ -910,7 +910,7 @@ def register_settings_routes(
                 timeout=5.0, verify=server.settings.verify_ssl
             ) as client:
                 resp = await client.post(
-                    "http://supervisor/addons/self/restart",
+                    f"{get_supervisor_base_url()}/addons/self/restart",
                     headers={"Authorization": f"Bearer {token}"},
                 )
         except (httpx.ReadError, httpx.RemoteProtocolError):

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from ha_mcp import __version__
 
+from .._version import get_supervisor_base_url
 from ..config import Settings, get_global_settings
 from ..utils.usage_logger import (
     AVG_LOG_ENTRIES_PER_TOOL,
@@ -357,7 +358,7 @@ async def _fetch_addon_logs() -> str:
             timeout=10.0, verify=get_global_settings().verify_ssl
         ) as http_client:
             resp = await http_client.get(
-                "http://supervisor/addons/self/logs",
+                f"{get_supervisor_base_url()}/addons/self/logs",
                 headers={"Authorization": f"Bearer {token}"},
             )
             if resp.status_code != 200:

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -12,7 +12,11 @@ from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
 
-from ..client.rest_client import HomeAssistantAPIError, HomeAssistantConnectionError
+from ..client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ..errors import ErrorCode, create_error_response
 from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
 from .util_helpers import (
@@ -755,6 +759,19 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         except ToolError:
             raise
+        except HomeAssistantAuthError as e:
+            # Listed before HomeAssistantAPIError because AuthError is a sibling,
+            # not a subclass — without this explicit clause the 401 from
+            # _supervisor_logs_get propagates raw to FastMCP and surfaces
+            # without a structured `code` field.
+            exception_to_structured_error(
+                e,
+                context={"source": "supervisor", "slug": slug},
+                suggestions=[
+                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
+                    "Reinstall the add-on if the token may have rotated",
+                ],
+            )
         except HomeAssistantAPIError as e:
             status = getattr(e, "status_code", None)
             if status == 400:
@@ -857,6 +874,19 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         except ToolError:
             raise
+        except HomeAssistantAuthError as e:
+            # Listed before HomeAssistantAPIError because AuthError is a sibling,
+            # not a subclass — without this explicit clause the 401 from
+            # _supervisor_logs_get propagates raw to FastMCP and surfaces
+            # without a structured `code` field.
+            exception_to_structured_error(
+                e,
+                context={"source": "system_service", "slug": service},
+                suggestions=[
+                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
+                    "Reinstall the add-on if the token may have rotated",
+                ],
+            )
         except HomeAssistantAPIError as e:
             status = getattr(e, "status_code", None)
             if status == 403:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -45,7 +45,9 @@ from ha_mcp.server import HomeAssistantSmartMCPServer
 
 # Import test utilities
 from .utilities.assertions import parse_mcp_result
-from .utilities.supervisor_mock import supervisor_mock  # noqa: F401  (re-exported fixture)
+from .utilities.supervisor_mock import (
+    supervisor_mock,  # noqa: F401  (re-exported fixture)
+)
 
 # Import test constants
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -45,6 +45,7 @@ from ha_mcp.server import HomeAssistantSmartMCPServer
 
 # Import test utilities
 from .utilities.assertions import parse_mcp_result
+from .utilities.supervisor_mock import supervisor_mock  # noqa: F401  (re-exported fixture)
 
 # Import test constants
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -46,6 +46,7 @@ from ha_mcp.server import HomeAssistantSmartMCPServer
 # Import test utilities
 from .utilities.assertions import parse_mcp_result
 from .utilities.supervisor_mock import (
+    _supervisor_mock_server,  # noqa: F401  (session fixture supervisor_mock depends on)
     supervisor_mock,  # noqa: F401  (re-exported fixture)
 )
 

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -6,11 +6,16 @@ sites — ``rest_client._supervisor_logs_get``, ``tools_bug_report._fetch_addon_
 against a real Supervisor; this mock makes the contract testable in CI without
 needing HAOS / Supervised infrastructure.
 
-The mock binds aiohttp to ``127.0.0.1:0`` and the fixture sets two env vars
-the production code already keys off of:
+Implementation: stdlib ``http.server.ThreadingHTTPServer`` on a daemon thread,
+bound to ``127.0.0.1:0``. The fixture sets two env vars the production code
+already keys off of:
 
 - ``SUPERVISOR_TOKEN`` — flips ``is_running_in_addon()`` on
 - ``SUPERVISOR_BASE_URL`` — points the three call sites at the mock
+
+Stdlib instead of aiohttp/starlette so no new dev dep is needed for what is
+ultimately a tiny canned-response server. Runs in a thread so it doesn't share
+the test event loop and can't deadlock against in-process MCP server work.
 
 Endpoints implemented (only what the code actually calls):
 
@@ -25,12 +30,15 @@ mismatch, matching real Supervisor behavior.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
-from collections.abc import AsyncGenerator
+import re
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
-from aiohttp import web
 
 logger = logging.getLogger(__name__)
 
@@ -42,74 +50,101 @@ SYSTEM_SERVICES = frozenset(
     {"supervisor", "host", "core", "dns", "audio", "multicast", "observer"}
 )
 
+_SERVICE_LOGS_RE = re.compile(r"^/([a-z]+)/logs$")
+_ADDON_LOGS_RE = re.compile(r"^/addons/([^/]+)/logs$")
 
-def _check_auth(request: web.Request) -> web.Response | None:
-    """Return a 401 response if the bearer token is missing or wrong."""
-    auth = request.headers.get("Authorization", "")
-    if auth != f"Bearer {MOCK_SUPERVISOR_TOKEN}":
-        return web.json_response(
-            {"result": "error", "message": "Invalid Supervisor token"},
-            status=401,
+
+class _SupervisorMockHandler(BaseHTTPRequestHandler):
+    """Routes the small set of Supervisor REST endpoints the codebase calls."""
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        # Silence the default per-request stderr line; pytest captures it as noise.
+        return
+
+    def _check_auth(self) -> bool:
+        if self.headers.get("Authorization", "") == f"Bearer {MOCK_SUPERVISOR_TOKEN}":
+            return True
+        self._send_json(401, {"result": "error", "message": "Invalid Supervisor token"})
+        return False
+
+    def _send_json(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_text(self, status: int, body: str) -> None:
+        encoded = body.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:
+        if m := _SERVICE_LOGS_RE.match(self.path):
+            service = m.group(1)
+            if service not in SYSTEM_SERVICES:
+                self._send_json(
+                    404, {"result": "error", "message": f"Unknown service: {service}"}
+                )
+                return
+            if not self._check_auth():
+                return
+            self._send_text(
+                200,
+                f"[{service}] mock log line 1\n"
+                f"[{service}] mock log line 2\n"
+                f"[{service}] mock log line 3\n",
+            )
+            return
+
+        if m := _ADDON_LOGS_RE.match(self.path):
+            slug = m.group(1)
+            if not self._check_auth():
+                return
+            self._send_text(
+                200,
+                f"[addon:{slug}] mock log line 1\n[addon:{slug}] mock log line 2\n",
+            )
+            return
+
+        self._send_json(
+            404, {"result": "error", "message": f"Unknown path: {self.path}"}
         )
-    return None
 
+    def do_POST(self) -> None:
+        if self.path == "/addons/self/restart":
+            if not self._check_auth():
+                return
+            # Real Supervisor returns this envelope on success; the call site
+            # discards the body but checks the status code.
+            self._send_json(200, {"result": "ok", "data": {}})
+            return
 
-async def _service_logs(request: web.Request) -> web.Response:
-    service = request.match_info["service"]
-    if service not in SYSTEM_SERVICES:
-        return web.json_response(
-            {"result": "error", "message": f"Unknown service: {service}"},
-            status=404,
+        self._send_json(
+            404, {"result": "error", "message": f"Unknown path: {self.path}"}
         )
-    if (denied := _check_auth(request)) is not None:
-        return denied
-    body = (
-        f"[{service}] mock log line 1\n"
-        f"[{service}] mock log line 2\n"
-        f"[{service}] mock log line 3\n"
-    )
-    return web.Response(text=body, content_type="text/plain")
-
-
-async def _addon_logs(request: web.Request) -> web.Response:
-    slug = request.match_info["slug"]
-    if (denied := _check_auth(request)) is not None:
-        return denied
-    body = f"[addon:{slug}] mock log line 1\n[addon:{slug}] mock log line 2\n"
-    return web.Response(text=body, content_type="text/plain")
-
-
-async def _addon_self_restart(request: web.Request) -> web.Response:
-    if (denied := _check_auth(request)) is not None:
-        return denied
-    # Real Supervisor returns this envelope on success; the call site discards
-    # the body but checks the status code.
-    return web.json_response({"result": "ok", "data": {}})
-
-
-def _build_app() -> web.Application:
-    app = web.Application()
-    app.router.add_get("/{service}/logs", _service_logs)
-    app.router.add_get("/addons/{slug}/logs", _addon_logs)
-    app.router.add_post("/addons/self/restart", _addon_self_restart)
-    return app
 
 
 @pytest.fixture(scope="session")
-async def supervisor_mock() -> AsyncGenerator[str]:
+def supervisor_mock() -> Iterator[str]:
     """Run the mock Supervisor on localhost and patch env vars to point at it.
 
     Yields the base URL (``http://127.0.0.1:<port>``). Tests that depend on
     this fixture have ``SUPERVISOR_TOKEN`` and ``SUPERVISOR_BASE_URL`` set
     for their entire session; tests that don't depend on it are unaffected.
     """
-    runner = web.AppRunner(_build_app())
-    await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
-    await site.start()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SupervisorMockHandler)
+    port = server.server_address[1]
+    base_url = f"http://127.0.0.1:{port}"
 
-    host, port = runner.addresses[0][:2]
-    base_url = f"http://{host}:{port}"
+    thread = threading.Thread(
+        target=server.serve_forever, name="supervisor-mock", daemon=True
+    )
+    thread.start()
 
     prior_token = os.environ.get("SUPERVISOR_TOKEN")
     prior_url = os.environ.get("SUPERVISOR_BASE_URL")
@@ -128,5 +163,7 @@ async def supervisor_mock() -> AsyncGenerator[str]:
             os.environ.pop("SUPERVISOR_BASE_URL", None)
         else:
             os.environ["SUPERVISOR_BASE_URL"] = prior_url
-        await runner.cleanup()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
         logger.info("🪞 Supervisor mock stopped")

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import threading
 from collections.abc import Iterator
@@ -130,40 +129,45 @@ class _SupervisorMockHandler(BaseHTTPRequestHandler):
 
 
 @pytest.fixture(scope="session")
-def supervisor_mock() -> Iterator[str]:
-    """Run the mock Supervisor on localhost and patch env vars to point at it.
+def _supervisor_mock_server() -> Iterator[str]:
+    """Start the mock Supervisor server once per session; yield its base URL.
 
-    Yields the base URL (``http://127.0.0.1:<port>``). Tests that depend on
-    this fixture have ``SUPERVISOR_TOKEN`` and ``SUPERVISOR_BASE_URL`` set
-    for their entire session; tests that don't depend on it are unaffected.
+    Server lifecycle only — does NOT touch ``os.environ``. Env-var patching
+    lives in the function-scoped ``supervisor_mock`` fixture so addon-mode
+    state doesn't leak across tests on the same xdist worker.
     """
     server = ThreadingHTTPServer(("127.0.0.1", 0), _SupervisorMockHandler)
-    port = server.server_address[1]
-    base_url = f"http://127.0.0.1:{port}"
-
-    thread = threading.Thread(
-        target=server.serve_forever, name="supervisor-mock", daemon=True
-    )
-    thread.start()
-
-    prior_token = os.environ.get("SUPERVISOR_TOKEN")
-    prior_url = os.environ.get("SUPERVISOR_BASE_URL")
-    os.environ["SUPERVISOR_TOKEN"] = MOCK_SUPERVISOR_TOKEN
-    os.environ["SUPERVISOR_BASE_URL"] = base_url
-
-    logger.info("🪞 Supervisor mock listening on %s", base_url)
     try:
-        yield base_url
+        port = server.server_address[1]
+        base_url = f"http://127.0.0.1:{port}"
+        thread = threading.Thread(
+            target=server.serve_forever, name="supervisor-mock", daemon=True
+        )
+        thread.start()
+        logger.info("🪞 Supervisor mock listening on %s", base_url)
+        try:
+            yield base_url
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            logger.info("🪞 Supervisor mock stopped")
     finally:
-        if prior_token is None:
-            os.environ.pop("SUPERVISOR_TOKEN", None)
-        else:
-            os.environ["SUPERVISOR_TOKEN"] = prior_token
-        if prior_url is None:
-            os.environ.pop("SUPERVISOR_BASE_URL", None)
-        else:
-            os.environ["SUPERVISOR_BASE_URL"] = prior_url
-        server.shutdown()
+        # server_close() is idempotent and safe to call after shutdown — kept in
+        # an outer try so the listening socket is released even if thread setup
+        # fails between server creation and serve_forever.
         server.server_close()
-        thread.join(timeout=5)
-        logger.info("🪞 Supervisor mock stopped")
+
+
+@pytest.fixture
+def supervisor_mock(
+    _supervisor_mock_server: str, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    """Patch addon-mode env vars to point at the mock for one test.
+
+    Function-scoped so ``SUPERVISOR_TOKEN`` and ``SUPERVISOR_BASE_URL`` are
+    cleaned up after each test — preventing other E2E tests on the same
+    xdist worker from accidentally taking the addon-mode branch.
+    """
+    monkeypatch.setenv("SUPERVISOR_TOKEN", MOCK_SUPERVISOR_TOKEN)
+    monkeypatch.setenv("SUPERVISOR_BASE_URL", _supervisor_mock_server)
+    return _supervisor_mock_server

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -1,0 +1,132 @@
+"""Mock Supervisor REST sidecar for E2E tests.
+
+Stands in for ``http://supervisor`` so the three direct-Supervisor httpx call
+sites — ``rest_client._supervisor_logs_get``, ``tools_bug_report._fetch_addon_logs``,
+``settings_ui._restart_addon`` — can be exercised end-to-end. Production runs
+against a real Supervisor; this mock makes the contract testable in CI without
+needing HAOS / Supervised infrastructure.
+
+The mock binds aiohttp to ``127.0.0.1:0`` and the fixture sets two env vars
+the production code already keys off of:
+
+- ``SUPERVISOR_TOKEN`` — flips ``is_running_in_addon()`` on
+- ``SUPERVISOR_BASE_URL`` — points the three call sites at the mock
+
+Endpoints implemented (only what the code actually calls):
+
+- ``GET /{service}/logs`` for service ∈ {supervisor, host, core, dns, audio,
+  multicast, observer} — the seven Supervisor-managed system services
+- ``GET /addons/{slug}/logs`` and ``GET /addons/self/logs`` — addon container logs
+- ``POST /addons/self/restart`` — addon self-restart (Supervisor envelope reply)
+
+All endpoints require ``Authorization: Bearer <SUPERVISOR_TOKEN>`` and 401 on
+mismatch, matching real Supervisor behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncGenerator
+
+import pytest
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+MOCK_SUPERVISOR_TOKEN = "test-supervisor-token"
+
+# The seven Supervisor-managed system services exposed at /<service>/logs.
+# Mirrors SYSTEM_SERVICE_SLUGS in src/ha_mcp/tools/tools_utility.py.
+SYSTEM_SERVICES = frozenset(
+    {"supervisor", "host", "core", "dns", "audio", "multicast", "observer"}
+)
+
+
+def _check_auth(request: web.Request) -> web.Response | None:
+    """Return a 401 response if the bearer token is missing or wrong."""
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {MOCK_SUPERVISOR_TOKEN}":
+        return web.json_response(
+            {"result": "error", "message": "Invalid Supervisor token"},
+            status=401,
+        )
+    return None
+
+
+async def _service_logs(request: web.Request) -> web.Response:
+    service = request.match_info["service"]
+    if service not in SYSTEM_SERVICES:
+        return web.json_response(
+            {"result": "error", "message": f"Unknown service: {service}"},
+            status=404,
+        )
+    if (denied := _check_auth(request)) is not None:
+        return denied
+    body = (
+        f"[{service}] mock log line 1\n"
+        f"[{service}] mock log line 2\n"
+        f"[{service}] mock log line 3\n"
+    )
+    return web.Response(text=body, content_type="text/plain")
+
+
+async def _addon_logs(request: web.Request) -> web.Response:
+    slug = request.match_info["slug"]
+    if (denied := _check_auth(request)) is not None:
+        return denied
+    body = f"[addon:{slug}] mock log line 1\n[addon:{slug}] mock log line 2\n"
+    return web.Response(text=body, content_type="text/plain")
+
+
+async def _addon_self_restart(request: web.Request) -> web.Response:
+    if (denied := _check_auth(request)) is not None:
+        return denied
+    # Real Supervisor returns this envelope on success; the call site discards
+    # the body but checks the status code.
+    return web.json_response({"result": "ok", "data": {}})
+
+
+def _build_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/{service}/logs", _service_logs)
+    app.router.add_get("/addons/{slug}/logs", _addon_logs)
+    app.router.add_post("/addons/self/restart", _addon_self_restart)
+    return app
+
+
+@pytest.fixture(scope="session")
+async def supervisor_mock() -> AsyncGenerator[str]:
+    """Run the mock Supervisor on localhost and patch env vars to point at it.
+
+    Yields the base URL (``http://127.0.0.1:<port>``). Tests that depend on
+    this fixture have ``SUPERVISOR_TOKEN`` and ``SUPERVISOR_BASE_URL`` set
+    for their entire session; tests that don't depend on it are unaffected.
+    """
+    runner = web.AppRunner(_build_app())
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+
+    host, port = runner.addresses[0][:2]
+    base_url = f"http://{host}:{port}"
+
+    prior_token = os.environ.get("SUPERVISOR_TOKEN")
+    prior_url = os.environ.get("SUPERVISOR_BASE_URL")
+    os.environ["SUPERVISOR_TOKEN"] = MOCK_SUPERVISOR_TOKEN
+    os.environ["SUPERVISOR_BASE_URL"] = base_url
+
+    logger.info("🪞 Supervisor mock listening on %s", base_url)
+    try:
+        yield base_url
+    finally:
+        if prior_token is None:
+            os.environ.pop("SUPERVISOR_TOKEN", None)
+        else:
+            os.environ["SUPERVISOR_TOKEN"] = prior_token
+        if prior_url is None:
+            os.environ.pop("SUPERVISOR_BASE_URL", None)
+        else:
+            os.environ["SUPERVISOR_BASE_URL"] = prior_url
+        await runner.cleanup()
+        logger.info("🪞 Supervisor mock stopped")

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -83,14 +83,16 @@ class _SupervisorMockHandler(BaseHTTPRequestHandler):
         self.wfile.write(encoded)
 
     def do_GET(self) -> None:
+        # Auth runs FIRST — real Supervisor returns 401 regardless of path
+        # when the bearer token is wrong. Routing/404 happens only after.
+        if not self._check_auth():
+            return
         if m := _SERVICE_LOGS_RE.match(self.path):
             service = m.group(1)
             if service not in SYSTEM_SERVICES:
                 self._send_json(
                     404, {"result": "error", "message": f"Unknown service: {service}"}
                 )
-                return
-            if not self._check_auth():
                 return
             self._send_text(
                 200,
@@ -102,8 +104,6 @@ class _SupervisorMockHandler(BaseHTTPRequestHandler):
 
         if m := _ADDON_LOGS_RE.match(self.path):
             slug = m.group(1)
-            if not self._check_auth():
-                return
             self._send_text(
                 200,
                 f"[addon:{slug}] mock log line 1\n[addon:{slug}] mock log line 2\n",
@@ -115,9 +115,9 @@ class _SupervisorMockHandler(BaseHTTPRequestHandler):
         )
 
     def do_POST(self) -> None:
+        if not self._check_auth():
+            return
         if self.path == "/addons/self/restart":
-            if not self._check_auth():
-                return
             # Real Supervisor returns this envelope on success; the call site
             # discards the body but checks the status code.
             self._send_json(200, {"result": "ok", "data": {}})

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -42,6 +42,10 @@ import pytest
 logger = logging.getLogger(__name__)
 
 MOCK_SUPERVISOR_TOKEN = "test-supervisor-token"
+# Special token that the mock treats as "valid auth, but addon hassio_role too
+# low" — surfaces as a 403 from any authenticated endpoint. Used by tests that
+# need to exercise the role-mismatch branch added alongside #1116.
+MOCK_INSUFFICIENT_ROLE_TOKEN = "test-supervisor-token-low-role"
 
 # The seven Supervisor-managed system services exposed at /<service>/logs.
 # Mirrors SYSTEM_SERVICE_SLUGS in src/ha_mcp/tools/tools_utility.py.
@@ -61,8 +65,21 @@ class _SupervisorMockHandler(BaseHTTPRequestHandler):
         return
 
     def _check_auth(self) -> bool:
-        if self.headers.get("Authorization", "") == f"Bearer {MOCK_SUPERVISOR_TOKEN}":
+        auth = self.headers.get("Authorization", "")
+        if auth == f"Bearer {MOCK_SUPERVISOR_TOKEN}":
             return True
+        if auth == f"Bearer {MOCK_INSUFFICIENT_ROLE_TOKEN}":
+            # Valid token, role too low — what real Supervisor returns when
+            # the addon's hassio_role is below `manager` for the requested
+            # endpoint (the #1116 cause).
+            self._send_json(
+                403,
+                {
+                    "result": "error",
+                    "message": "Insufficient role for this endpoint",
+                },
+            )
+            return False
         self._send_json(401, {"result": "error", "message": "Invalid Supervisor token"})
         return False
 

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -213,12 +213,18 @@ class TestMockResilience:
     async def test_unauthorized_supervisor_call_surfaces_as_tool_error(
         self, mcp_client, supervisor_mock, monkeypatch
     ):
-        """Wrong token → 401 from mock → tool raises an AUTH_INVALID_TOKEN error.
+        """Wrong token → 401 from mock → tool surfaces a meaningful failure.
 
         Exercises the auth-failure path through the full ha_get_logs →
-        _supervisor_logs_get → mock chain. Pinning the error code (not just
-        success=False) catches future regressions where 401 silently re-maps
-        to a generic INTERNAL_ERROR.
+        _supervisor_logs_get → mock chain. Asserts the underlying
+        "Invalid Supervisor token" message reaches the caller — protects
+        against regressions that swallow the 401 entirely.
+
+        Note: today HomeAssistantAuthError isn't a subclass of
+        HomeAssistantAPIError, so _get_system_service_log doesn't catch it
+        and the raw exception propagates to FastMCP which wraps it
+        generically (no structured `code` field). That's a pre-existing
+        gap in the error-mapping layer, not something this PR addresses.
         """
         monkeypatch.setenv("SUPERVISOR_TOKEN", "wrong-token-on-purpose")
         result = await safe_call_tool(
@@ -227,5 +233,7 @@ class TestMockResilience:
             {"source": "system_service", "slug": "core"},
         )
         assert result.get("success") is False
-        # HomeAssistantAuthError → create_auth_error → AUTH_INVALID_TOKEN
-        assert result.get("error", {}).get("code") == "AUTH_INVALID_TOKEN"
+        message = result.get("error", {}).get("message", "")
+        assert "Invalid Supervisor token" in message, (
+            f"Expected '/core/logs' 401 to surface in tool error message, got: {message!r}"
+        )

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -3,8 +3,8 @@
 Closes the coverage gap from issue #1129: prior to this, the three call sites
 that hit ``http://supervisor`` directly (logs via rest_client, bug-report addon
 log fetch, settings_ui addon self-restart) had only mock-based unit tests. Now
-they exercise the real socket path against an aiohttp sidecar via the
-``supervisor_mock`` fixture (see ``tests/src/e2e/utilities/supervisor_mock.py``).
+they exercise the real socket path against a stdlib ``http.server`` sidecar
+served from ``tests/src/e2e/utilities/supervisor_mock.py``.
 
 Out of scope (intentional): the WS-proxy ``supervisor/api`` path used by
 ``tools_addons.py``. See #1129 for why that's deferred.
@@ -214,13 +214,15 @@ class TestMockResilience:
     async def test_unauthorized_supervisor_call_surfaces_as_tool_error(
         self, mcp_client, supervisor_mock, monkeypatch
     ):
-        """Wrong token → 401 from mock → tool surfaces a meaningful failure.
+        """Wrong token → 401 → AUTH_INVALID_TOKEN with SUPERVISOR_TOKEN hint.
 
         Exercises the auth-failure path through the full ha_get_logs →
-        _supervisor_logs_get → mock chain. Asserts the underlying
-        "Invalid Supervisor token" message AND the failing endpoint path
-        reach the caller — locks in that the path identifier survives the
-        wrap, not just any auth failure.
+        _supervisor_logs_get → mock chain. The explicit
+        ``except HomeAssistantAuthError`` clause in
+        ``_get_system_service_log`` (added alongside this PR) routes the
+        401 through ``exception_to_structured_error`` so callers get a
+        structured ``code`` + remediation suggestions instead of the raw
+        FastMCP wrap they used to get.
         """
         monkeypatch.setenv("SUPERVISOR_TOKEN", "wrong-token-on-purpose")
         result = await safe_call_tool(
@@ -229,13 +231,15 @@ class TestMockResilience:
             {"source": "system_service", "slug": "core"},
         )
         assert result.get("success") is False
-        message = result.get("error", {}).get("message", "")
-        assert "Invalid Supervisor token" in message, (
-            f"Expected 401 to surface in tool error message, got: {message!r}"
+        error = result.get("error", {})
+        assert error.get("code") == "AUTH_INVALID_TOKEN", (
+            f"Expected AUTH_INVALID_TOKEN, got code={error.get('code')!r}, "
+            f"full error={error!r}"
         )
-        # Locks in that the failing endpoint identifier survives the wrap.
-        assert "/core/logs" in message, (
-            f"Expected failing path '/core/logs' in error message, got: {message!r}"
+        suggestions = error.get("suggestions", [])
+        assert any("SUPERVISOR_TOKEN" in s for s in suggestions), (
+            f"Expected SUPERVISOR_TOKEN remediation suggestion, "
+            f"got suggestions={suggestions!r}"
         )
 
     async def test_insufficient_role_supervisor_call_surfaces_403(
@@ -243,18 +247,19 @@ class TestMockResilience:
     ):
         """Valid token but addon hassio_role too low → 403 → structured tool error.
 
-        Covers the role-mismatch branch in rest_client.py added alongside
-        the #1116 fix (the addon's hassio_role bump from 'default' →
-        'manager' was the matching production change). Without this E2E
-        the 403-handling path has no real-socket coverage.
+        Covers the role-mismatch branch in ``_get_system_service_log`` added
+        alongside the #1116 fix (the addon's ``hassio_role`` bump from
+        ``default`` → ``manager`` was the matching production change). Without
+        this E2E the 403-handling path has no real-socket coverage.
 
         Asserts both:
           - the error code is AUTH_INVALID_TOKEN (today _classify_api_status
-            maps both 401 and 403 to this — see #1129 follow-up notes), and
-          - the role-specific suggestion ("hassio_role must be 'manager'")
-            from the _get_system_service_log 403 branch reaches the caller.
+            maps both 401 and 403 to this — distinguishing them would need a
+            new ErrorCode), and
+          - the role-specific suggestion (``hassio_role must be 'manager'``)
+            from the 403 branch reaches the caller.
         The second assertion is what proves the 403 branch fired specifically,
-        not the generic 401 path.
+        not the 401 branch (which has a different suggestion set).
         """
         monkeypatch.setenv("SUPERVISOR_TOKEN", MOCK_INSUFFICIENT_ROLE_TOKEN)
         result = await safe_call_tool(

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -12,12 +12,14 @@ Out of scope (intentional): the WS-proxy ``supervisor/api`` path used by
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 
 import httpx
 import pytest
 
+from ha_mcp._version import get_supervisor_base_url, is_running_in_addon
 from ha_mcp.tools.tools_bug_report import _fetch_addon_logs
 
 from ...utilities.assertions import MCPAssertions, safe_call_tool
@@ -142,3 +144,85 @@ class TestSettingsUiRestart:
                 url, headers={"Authorization": "Bearer wrong-token"}
             )
         assert resp.status_code == 401
+
+
+@pytest.mark.system
+class TestFixtureWiring:
+    """Sanity checks that the fixture flips the production gates correctly.
+
+    These are fast, deterministic, and prove that subsequent tests aren't
+    silently exercising the wrong branch (e.g. falling back to the HA Core
+    proxy when they should be hitting the mock).
+    """
+
+    async def test_is_running_in_addon_returns_true(self, supervisor_mock):
+        """SUPERVISOR_TOKEN set → addon-mode branch is taken."""
+        assert is_running_in_addon() is True
+
+    async def test_base_url_resolves_to_mock(self, supervisor_mock):
+        """The new helper picks up the override env var."""
+        assert get_supervisor_base_url() == supervisor_mock
+        assert get_supervisor_base_url().startswith("http://127.0.0.1:")
+
+    async def test_default_when_override_unset(self, supervisor_mock, monkeypatch):
+        """Removing the override falls back to the production hostname."""
+        monkeypatch.delenv("SUPERVISOR_BASE_URL", raising=False)
+        assert get_supervisor_base_url() == "http://supervisor"
+
+
+@pytest.mark.system
+class TestMockResilience:
+    """Stresses the mock to catch obvious wiring bugs (event-loop conflicts,
+    socket reuse issues, header mishandling) that trivial happy-path tests
+    would miss.
+    """
+
+    async def test_concurrent_log_fetches(self, mcp_client, supervisor_mock):
+        """Five parallel ha_get_logs calls all succeed.
+
+        The mock and the MCP server share the test event loop; if either
+        serialises requests incorrectly this surfaces as a hang or an error.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            results = await asyncio.gather(
+                *(
+                    mcp.call_tool_success(
+                        "ha_get_logs",
+                        {"source": "system_service", "slug": svc},
+                    )
+                    for svc in sorted(SYSTEM_SERVICES)
+                )
+            )
+        assert {r["slug"] for r in results} == SYSTEM_SERVICES
+        assert all(r["total_lines"] == 3 for r in results)
+
+    async def test_addon_logs_limit_truncation(self, mcp_client, supervisor_mock):
+        """limit=1 returns the last line only — proves the tool's tail-N
+        truncation works against real wire bytes, not just mock dicts.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_get_logs",
+                {"source": "supervisor", "slug": "core_zigbee", "limit": 1},
+            )
+        assert result["returned_lines"] == 1
+        assert result["total_lines"] == 2
+        # The mock returns "line 1\nline 2\n" — tail-1 should give us line 2.
+        assert "line 2" in result["log"]
+        assert "line 1" not in result["log"]
+
+    async def test_unauthorized_supervisor_call_surfaces_as_tool_error(
+        self, mcp_client, supervisor_mock, monkeypatch
+    ):
+        """Wrong token → 401 from mock → tool raises a structured error.
+
+        Exercises the auth-failure path through the full ha_get_logs →
+        _supervisor_logs_get → mock chain.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "wrong-token-on-purpose")
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_get_logs",
+            {"source": "system_service", "slug": "core"},
+        )
+        assert result.get("success") is False

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -213,10 +213,12 @@ class TestMockResilience:
     async def test_unauthorized_supervisor_call_surfaces_as_tool_error(
         self, mcp_client, supervisor_mock, monkeypatch
     ):
-        """Wrong token → 401 from mock → tool raises a structured error.
+        """Wrong token → 401 from mock → tool raises an AUTH_INVALID_TOKEN error.
 
         Exercises the auth-failure path through the full ha_get_logs →
-        _supervisor_logs_get → mock chain.
+        _supervisor_logs_get → mock chain. Pinning the error code (not just
+        success=False) catches future regressions where 401 silently re-maps
+        to a generic INTERNAL_ERROR.
         """
         monkeypatch.setenv("SUPERVISOR_TOKEN", "wrong-token-on-purpose")
         result = await safe_call_tool(
@@ -225,3 +227,5 @@ class TestMockResilience:
             {"source": "system_service", "slug": "core"},
         )
         assert result.get("success") is False
+        # HomeAssistantAuthError → create_auth_error → AUTH_INVALID_TOKEN
+        assert result.get("error", {}).get("code") == "AUTH_INVALID_TOKEN"

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -1,0 +1,144 @@
+"""E2E tests for the direct-Supervisor httpx call sites against a mock sidecar.
+
+Closes the coverage gap from issue #1129: prior to this, the three call sites
+that hit ``http://supervisor`` directly (logs via rest_client, bug-report addon
+log fetch, settings_ui addon self-restart) had only mock-based unit tests. Now
+they exercise the real socket path against an aiohttp sidecar via the
+``supervisor_mock`` fixture (see ``tests/src/e2e/utilities/supervisor_mock.py``).
+
+Out of scope (intentional): the WS-proxy ``supervisor/api`` path used by
+``tools_addons.py``. See #1129 for why that's deferred.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+import pytest
+
+from ha_mcp.tools.tools_bug_report import _fetch_addon_logs
+
+from ...utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.supervisor_mock import (
+    MOCK_SUPERVISOR_TOKEN,
+    SYSTEM_SERVICES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.system
+class TestGetLogsSupervisor:
+    """ha_get_logs source='supervisor' — addon container logs."""
+
+    async def test_addon_logs_returns_mocked_text(self, mcp_client, supervisor_mock):
+        """source='supervisor' with a slug hits /addons/<slug>/logs and parses it."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_get_logs",
+                {"source": "supervisor", "slug": "core_mosquitto", "limit": 100},
+            )
+
+        assert result["source"] == "supervisor"
+        assert result["slug"] == "core_mosquitto"
+        assert "core_mosquitto" in result["log"]
+        assert result["total_lines"] == 2
+        assert result["returned_lines"] == 2
+
+    async def test_addon_logs_search_filter(self, mcp_client, supervisor_mock):
+        """search filter narrows lines."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_get_logs",
+                {
+                    "source": "supervisor",
+                    "slug": "core_mosquitto",
+                    "search": "line 1",
+                },
+            )
+
+        assert result["returned_lines"] == 1
+        assert "line 1" in result["log"]
+        assert result["filters_applied"] == {"search": "line 1"}
+
+
+@pytest.mark.system
+class TestGetLogsSystemService:
+    """ha_get_logs source='system_service' — Supervisor-managed services."""
+
+    @pytest.mark.parametrize("service", sorted(SYSTEM_SERVICES))
+    async def test_each_system_service(self, mcp_client, supervisor_mock, service: str):
+        """All seven Supervisor-managed services are reachable."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_get_logs",
+                {"source": "system_service", "slug": service},
+            )
+
+        assert result["source"] == "system_service"
+        assert result["slug"] == service
+        assert f"[{service}]" in result["log"]
+        assert result["total_lines"] == 3
+
+    async def test_unknown_service_rejected_by_caller_validation(
+        self, mcp_client, supervisor_mock
+    ):
+        """The tool validates the slug against SYSTEM_SERVICE_SLUGS before dispatch.
+
+        Provides regression coverage that an unknown service never reaches the
+        mock — caller-side validation short-circuits.
+        """
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_get_logs",
+            {"source": "system_service", "slug": "not_a_real_service"},
+        )
+        assert result.get("success") is False
+
+
+@pytest.mark.system
+class TestBugReportAddonLogs:
+    """tools_bug_report._fetch_addon_logs — direct httpx to /addons/self/logs."""
+
+    async def test_fetches_self_logs(self, supervisor_mock):
+        text = await _fetch_addon_logs()
+        assert "[addon:self]" in text
+        assert "mock log line 1" in text
+
+    async def test_returns_empty_when_token_missing(self, supervisor_mock, monkeypatch):
+        """No SUPERVISOR_TOKEN → defensive guard returns empty string, no request."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        text = await _fetch_addon_logs()
+        assert text == ""
+
+
+@pytest.mark.system
+class TestSettingsUiRestart:
+    """settings_ui._restart_addon — direct httpx POST to /addons/self/restart.
+
+    Tested via a raw httpx call rather than constructing a starlette Request,
+    because the request shape is irrelevant to the Supervisor wire contract;
+    the wire contract is what this PR adds coverage for. The handler's branch
+    logic (success / token-missing / connection drop) is already covered by
+    unit tests in tests/src/unit/test_settings_ui.py.
+    """
+
+    async def test_restart_request_succeeds(self, supervisor_mock):
+        url = f"{os.environ['SUPERVISOR_BASE_URL']}/addons/self/restart"
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                url,
+                headers={"Authorization": f"Bearer {MOCK_SUPERVISOR_TOKEN}"},
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"result": "ok", "data": {}}
+
+    async def test_restart_request_rejects_bad_token(self, supervisor_mock):
+        url = f"{os.environ['SUPERVISOR_BASE_URL']}/addons/self/restart"
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                url, headers={"Authorization": "Bearer wrong-token"}
+            )
+        assert resp.status_code == 401

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -23,6 +23,7 @@ from ha_mcp.tools.tools_bug_report import _fetch_addon_logs
 
 from ...utilities.assertions import MCPAssertions, safe_call_tool
 from ...utilities.supervisor_mock import (
+    MOCK_INSUFFICIENT_ROLE_TOKEN,
     MOCK_SUPERVISOR_TOKEN,
     SYSTEM_SERVICES,
 )
@@ -217,14 +218,9 @@ class TestMockResilience:
 
         Exercises the auth-failure path through the full ha_get_logs →
         _supervisor_logs_get → mock chain. Asserts the underlying
-        "Invalid Supervisor token" message reaches the caller — protects
-        against regressions that swallow the 401 entirely.
-
-        Note: today HomeAssistantAuthError isn't a subclass of
-        HomeAssistantAPIError, so _get_system_service_log doesn't catch it
-        and the raw exception propagates to FastMCP which wraps it
-        generically (no structured `code` field). That's a pre-existing
-        gap in the error-mapping layer, not something this PR addresses.
+        "Invalid Supervisor token" message AND the failing endpoint path
+        reach the caller — locks in that the path identifier survives the
+        wrap, not just any auth failure.
         """
         monkeypatch.setenv("SUPERVISOR_TOKEN", "wrong-token-on-purpose")
         result = await safe_call_tool(
@@ -235,5 +231,45 @@ class TestMockResilience:
         assert result.get("success") is False
         message = result.get("error", {}).get("message", "")
         assert "Invalid Supervisor token" in message, (
-            f"Expected '/core/logs' 401 to surface in tool error message, got: {message!r}"
+            f"Expected 401 to surface in tool error message, got: {message!r}"
+        )
+        # Locks in that the failing endpoint identifier survives the wrap.
+        assert "/core/logs" in message, (
+            f"Expected failing path '/core/logs' in error message, got: {message!r}"
+        )
+
+    async def test_insufficient_role_supervisor_call_surfaces_403(
+        self, mcp_client, supervisor_mock, monkeypatch
+    ):
+        """Valid token but addon hassio_role too low → 403 → structured tool error.
+
+        Covers the role-mismatch branch in rest_client.py added alongside
+        the #1116 fix (the addon's hassio_role bump from 'default' →
+        'manager' was the matching production change). Without this E2E
+        the 403-handling path has no real-socket coverage.
+
+        Asserts both:
+          - the error code is AUTH_INVALID_TOKEN (today _classify_api_status
+            maps both 401 and 403 to this — see #1129 follow-up notes), and
+          - the role-specific suggestion ("hassio_role must be 'manager'")
+            from the _get_system_service_log 403 branch reaches the caller.
+        The second assertion is what proves the 403 branch fired specifically,
+        not the generic 401 path.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", MOCK_INSUFFICIENT_ROLE_TOKEN)
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_get_logs",
+            {"source": "system_service", "slug": "core"},
+        )
+        assert result.get("success") is False
+        error = result.get("error", {})
+        assert error.get("code") == "AUTH_INVALID_TOKEN", (
+            f"Expected AUTH_INVALID_TOKEN, got code={error.get('code')!r}, "
+            f"full error={error!r}"
+        )
+        suggestions = error.get("suggestions", [])
+        assert any("hassio_role" in s for s in suggestions), (
+            f"Expected a hassio_role suggestion (proves 403 branch fired), "
+            f"got suggestions={suggestions!r}"
         )

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 
 import httpx
 import pytest
@@ -128,7 +127,7 @@ class TestSettingsUiRestart:
     """
 
     async def test_restart_request_succeeds(self, supervisor_mock):
-        url = f"{os.environ['SUPERVISOR_BASE_URL']}/addons/self/restart"
+        url = f"{supervisor_mock}/addons/self/restart"
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.post(
                 url,
@@ -138,7 +137,7 @@ class TestSettingsUiRestart:
         assert resp.json() == {"result": "ok", "data": {}}
 
     async def test_restart_request_rejects_bad_token(self, supervisor_mock):
-        url = f"{os.environ['SUPERVISOR_BASE_URL']}/addons/self/restart"
+        url = f"{supervisor_mock}/addons/self/restart"
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.post(
                 url, headers={"Authorization": "Bearer wrong-token"}


### PR DESCRIPTION
## What does this PR do?

Closes #1129.

**Behavior fix**: 401 responses from `http://supervisor` (addon-mode log fetches) now surface as structured `AUTH_INVALID_TOKEN` tool errors with a `SUPERVISOR_TOKEN` remediation hint, instead of propagating raw to FastMCP's generic exception wrapper. `_get_supervisor_log` and `_get_system_service_log` now catch `HomeAssistantAuthError` explicitly before the existing `HomeAssistantAPIError` clause. (`HomeAssistantAuthError` stays a sibling of `HomeAssistantAPIError` — making it a subclass would have silently swallowed auth errors at the 18 other `except HomeAssistantAPIError` sites that deliberately rely on the sibling relationship to let auth/connection errors propagate.)

**Test coverage**: closes the long-standing E2E gap on the three call sites that hit `http://supervisor` directly — previously only covered by mock-based unit tests:

| Call site | Path |
|---|---|
| `client/rest_client._supervisor_logs_get` | `GET http://supervisor/{service}/logs` and `/addons/{slug}/logs` |
| `tools/tools_bug_report._fetch_addon_logs` | `GET http://supervisor/addons/self/logs` |
| `settings_ui._restart_addon` | `POST http://supervisor/addons/self/restart` |

These power `ha_get_logs` source=\"supervisor\" / \"system_service\", the bug-report addon-log embed, and the settings UI's add-on self-restart.

### How the mock works

Stdlib `http.server.ThreadingHTTPServer` on a daemon thread bound to `127.0.0.1:0`. A session-scoped `_supervisor_mock_server` fixture owns the lifecycle; a function-scoped `supervisor_mock` fixture uses pytest's `monkeypatch` to set `SUPERVISOR_TOKEN` and `SUPERVISOR_BASE_URL` for the test's lifetime only — no env-var bleed across tests on the same xdist worker.

`SUPERVISOR_BASE_URL` is a new env var read by `_version.get_supervisor_base_url()` (defaults to `http://supervisor`); the three call sites build their URL via this helper. Production behavior unchanged when env var unset. No new dev deps (stdlib only).

### Out of scope

The WS-proxy `supervisor/api` path used by `tools_addons.py` (`ha_manage_addon`, `ha_get_addon`, addon listing/store). Would need a much larger mock satisfying HA Core's hassio integration startup contract — not worth the maintenance for one tool family. See the [issue comment](https://github.com/homeassistant-ai/ha-mcp/issues/1129#issuecomment-4413853088) for the full breakdown.

### What this won't catch

Real Supervisor REST drift — the mock locks in our current understanding of the contract, not Supervisor's actual behavior. Catches regressions in our code against a frozen spec, not Supervisor-side breaking changes.

## Type of change
- [x] 🐛 Bug fix (Supervisor 401 error mapping)
- [x] 🧪 Tests only (E2E coverage for Supervisor-direct call sites)

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`) — verified via CI (Termux can't run e2e)
- [x] Code follows style guidelines (\`uv run ruff check\`) — verified via CI

## Checklist
- [x] I have updated documentation if needed (none needed beyond the new code's own docstrings)