### PR TITLE
fix: triage all 10 ha_search_entities behaviors from #1170

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -21,6 +21,7 @@ from mcp.types import Icon
 
 from .config import _PACKAGE_VERSION, get_global_settings
 from .tools.enhanced import EnhancedToolsMixin
+from .tools.util_helpers import strip_internal_fields
 from .transforms import DEFAULT_PINNED_TOOLS
 
 if TYPE_CHECKING:
@@ -922,13 +923,19 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         return await self.client.call_service(domain, service, service_data)
 
     async def get_entities_by_area(self, area_name: str) -> dict[str, Any]:
-        """Bridge method to existing area functionality."""
-        return cast(
-            dict[str, Any],
-            await self.smart_tools.get_entities_by_area(
-                area_query=area_name, group_by_domain=True
-            ),
+        """Bridge method to existing area functionality.
+
+        ``smart_tools.get_entities_by_area`` enriches per-entity dicts
+        with leading-underscore internals (``_hidden_by`` etc.) so
+        downstream search branches can apply the score penalty without
+        a second registry lookup. Strip them here so this public bridge
+        doesn't leak internals to MCP clients.
+        """
+        result = await self.smart_tools.get_entities_by_area(
+            area_query=area_name, group_by_domain=True
         )
+        strip_internal_fields(result)
+        return cast(dict[str, Any], result)
 
     async def start(self) -> None:
         """Start the Smart MCP server with async compatibility."""

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -113,6 +113,7 @@ class SmartSearchTools:
         offset: int = 0,
         include_attributes: bool = False,
         domain_filter: str | None = None,
+        include_hidden: bool = False,
     ) -> dict[str, Any]:
         """
         Advanced entity search with fuzzy matching and typo tolerance.
@@ -123,16 +124,98 @@ class SmartSearchTools:
             offset: Number of results to skip for pagination
             include_attributes: Whether to include full entity attributes
             domain_filter: Optional domain to filter entities before search (e.g., "light", "sensor")
+            include_hidden: When False (default), entities with
+                ``hidden_by`` set in the entity registry are skipped before
+                fuzzy search runs (#1170 finding 9). Pass True to include
+                them — typically for diagnostics or service workflows.
 
         Returns:
             Dictionary with search results and metadata
         """
         try:
-            # Get all entities
-            entities = await self.client.get_states()
+            # Fetch states + entity registry list in parallel. The slim
+            # ``list`` view gives us ``hidden_by`` (used to filter
+            # UI-hidden entities by default; #1170 finding 9) and the
+            # entity_ids we need to feed into ``get_entries`` for the
+            # full-fidelity data (#1170 finding 8 / closes #1166).
+            entities_task = self.client.get_states()
+            entity_registry_task = self.client.send_websocket_message(
+                {"type": "config/entity_registry/list"}
+            )
+            results = await asyncio.gather(
+                entities_task, entity_registry_task, return_exceptions=True
+            )
+            entities = results[0] if not isinstance(results[0], Exception) else []
+
+            # Build entity_id -> slim registry entry map. We tolerate
+            # registry fetch failure: the search continues without alias /
+            # hidden awareness rather than failing the whole call.
+            registry_slim: dict[str, dict[str, Any]] = {}
+            if isinstance(results[1], dict) and results[1].get("success"):
+                for entry in results[1].get("result", []):
+                    eid = entry.get("entity_id")
+                    if eid:
+                        registry_slim[eid] = entry
+
+            # First pass: hidden filter + collect entity_ids for the
+            # alias batch fetch. Pre-filtering shrinks the get_entries
+            # payload on installations with thousands of entities.
+            survivor_ids: list[str] = []
+            survivor_states: list[dict[str, Any]] = []
+            for entity in entities:
+                eid = entity.get("entity_id", "")
+                if not eid:
+                    continue
+                slim = registry_slim.get(eid, {})
+                hidden_by = slim.get("hidden_by")
+                if hidden_by is not None and not include_hidden:
+                    continue
+                survivor_ids.append(eid)
+                survivor_states.append(entity)
+
+            # Second pass: batch-fetch full registry entries for aliases.
+            # ``config/entity_registry/list`` deliberately omits
+            # ``aliases``; ``get_entries`` includes them. One extra
+            # round-trip closes #1166 without N+1 fan-out.
+            aliases_map: dict[str, list[str]] = {}
+            if survivor_ids:
+                try:
+                    entries_resp = await self.client.send_websocket_message({
+                        "type": "config/entity_registry/get_entries",
+                        "entity_ids": survivor_ids,
+                    })
+                    if (
+                        isinstance(entries_resp, dict)
+                        and entries_resp.get("success")
+                    ):
+                        for eid, entry in (
+                            entries_resp.get("result", {}) or {}
+                        ).items():
+                            if isinstance(entry, dict):
+                                aliases_map[eid] = entry.get("aliases", []) or []
+                except Exception as alias_err:
+                    logger.warning(
+                        "config/entity_registry/get_entries failed; "
+                        "aliases will not be searchable: %s",
+                        alias_err,
+                    )
+
+            # Enrich entities with aliases + hidden_by for the fuzzy layer.
+            enriched: list[dict[str, Any]] = []
+            for entity, eid in zip(survivor_states, survivor_ids, strict=True):
+                slim = registry_slim.get(eid, {})
+                # Shallow copy + private-prefixed keys so downstream
+                # consumers that round-trip these dicts don't ship
+                # internal fields back to clients.
+                enriched.append({
+                    **entity,
+                    "_aliases": aliases_map.get(eid, []),
+                    "_hidden_by": slim.get("hidden_by"),
+                })
 
             # Filter by domain BEFORE fuzzy search if domain_filter provided
             # This ensures fuzzy search only looks at entities in the target domain
+            entities = enriched
             if domain_filter:
                 entities = [
                     e
@@ -213,18 +296,25 @@ class SmartSearchTools:
             )
 
     async def get_entities_by_area(
-        self, area_query: str, group_by_domain: bool = True
+        self,
+        area_query: str,
+        group_by_domain: bool = True,
+        include_hidden: bool = False,
     ) -> dict[str, Any]:
         """
         Get entities grouped by area/room using the HA registries for accurate area resolution.
 
         Uses entity registry, device registry, and area registry to determine
         which area each entity belongs to. Fuzzy matches the query against
-        area names/IDs to find the target area(s).
+        area names, IDs, and area-registry aliases to find the target area(s).
 
         Args:
-            area_query: Area/room name to search for
+            area_query: Area/room name (or alias) to search for
             group_by_domain: Whether to group results by domain within each area
+            include_hidden: When False (default), entities with
+                ``hidden_by`` set in the entity registry are excluded
+                from per-area results (#1170 finding 9). Pass True to
+                include them.
 
         Returns:
             Dictionary with area-grouped entities
@@ -260,7 +350,7 @@ class SmartSearchTools:
                     if area_id:
                         area_registry[area_id] = area
 
-            # Parse entity registry: entity_id -> {area_id, device_id}
+            # Parse entity registry: entity_id -> {area_id, device_id, hidden_by}
             entity_reg_map: dict[str, dict[str, str | None]] = {}
             if isinstance(results[2], dict) and results[2].get("success"):
                 for entry in results[2].get("result", []):
@@ -269,6 +359,7 @@ class SmartSearchTools:
                         entity_reg_map[entity_id] = {
                             "area_id": entry.get("area_id"),
                             "device_id": entry.get("device_id"),
+                            "hidden_by": entry.get("hidden_by"),
                         }
 
             # Parse device registry: device_id -> area_id
@@ -279,25 +370,42 @@ class SmartSearchTools:
                     if device_id:
                         device_area_map[device_id] = device.get("area_id")
 
-            # Fuzzy match area_query against known area names and IDs
+            # Fuzzy match area_query against known area names, IDs, and aliases.
+            # Aliases (set per-area in the area registry, used by HA voice
+            # config) were previously ignored — closing #1166 for areas in
+            # parallel with the entity-side fix in smart_entity_search.
             area_query_lower = area_query.lower().strip()
             matched_area_ids: set[str] = set()
 
             for area_id, area_info in area_registry.items():
                 area_name = area_info.get("name", "")
-                # Exact match on area_id or name (case-insensitive)
+                area_aliases = area_info.get("aliases", []) or []
+                # Exact match on area_id, name, or any alias (case-insensitive)
                 if (
                     area_query_lower == area_id.lower()
                     or area_query_lower == area_name.lower()
+                    or any(
+                        area_query_lower == a.lower()
+                        for a in area_aliases
+                        if isinstance(a, str)
+                    )
                 ):
                     matched_area_ids.add(area_id)
                     continue
-                # Fuzzy match on area name
+                # Fuzzy match on area name, id, or any alias
                 name_score = calculate_partial_ratio(
                     area_query_lower, area_name.lower()
                 )
                 id_score = calculate_partial_ratio(area_query_lower, area_id.lower())
-                best_score = max(name_score, id_score)
+                alias_score = max(
+                    (
+                        calculate_partial_ratio(area_query_lower, a.lower())
+                        for a in area_aliases
+                        if isinstance(a, str)
+                    ),
+                    default=0,
+                )
+                best_score = max(name_score, id_score, alias_score)
                 if best_score >= 80:
                     matched_area_ids.add(area_id)
 
@@ -313,10 +421,16 @@ class SmartSearchTools:
                     ],
                 }
 
-            # Build entity_id -> resolved area_id mapping
-            # Priority: entity direct area_id > device area_id
+            # Build entity_id -> resolved area_id mapping.
+            # Priority: entity direct area_id > device area_id.
+            # Hidden entities are skipped by default (#1170 finding 9).
             entity_area_resolved: dict[str, str] = {}
             for entity_id, reg_info in entity_reg_map.items():
+                if (
+                    not include_hidden
+                    and reg_info.get("hidden_by") is not None
+                ):
+                    continue
                 area_id = reg_info.get("area_id")
                 device_id = reg_info.get("device_id")
                 if not area_id and device_id:
@@ -330,6 +444,41 @@ class SmartSearchTools:
                 eid = entity.get("entity_id", "")
                 if eid:
                     state_map[eid] = entity
+
+            # Batch-fetch aliases for entities in matched areas. The slim
+            # entity_registry/list above does not return aliases; the
+            # get_entries endpoint does. Surface them as `_aliases` so the
+            # caller (tools_search.area_filtered_query branch) can fold
+            # them into its fuzzy haystack — closes #1166 for the
+            # area+query path. Fetch failure leaves _aliases empty.
+            area_entity_ids = sorted(
+                eid
+                for eid, resolved_area in entity_area_resolved.items()
+                if resolved_area in matched_area_ids
+            )
+            aliases_map: dict[str, list[str]] = {}
+            if area_entity_ids:
+                try:
+                    entries_resp = await self.client.send_websocket_message({
+                        "type": "config/entity_registry/get_entries",
+                        "entity_ids": area_entity_ids,
+                    })
+                    if (
+                        isinstance(entries_resp, dict)
+                        and entries_resp.get("success")
+                    ):
+                        for eid, entry in (
+                            entries_resp.get("result", {}) or {}
+                        ).items():
+                            if isinstance(entry, dict):
+                                aliases_map[eid] = entry.get("aliases", []) or []
+                except Exception as alias_err:
+                    logger.warning(
+                        "config/entity_registry/get_entries failed in area "
+                        "search; aliases will not be searchable for this "
+                        "result set: %s",
+                        alias_err,
+                    )
 
             # Collect entities belonging to matched areas
             formatted_areas: dict[str, dict[str, Any]] = {}
@@ -367,6 +516,7 @@ class SmartSearchTools:
                                     "friendly_name", entity_id
                                 ),
                                 "state": state_info.get("state", "unknown"),
+                                "_aliases": aliases_map.get(entity_id, []),
                             }
                         )
                     area_data["entities"] = domains
@@ -381,6 +531,7 @@ class SmartSearchTools:
                             .get("friendly_name", entity_id),
                             "domain": entity_id.split(".")[0],
                             "state": state_info.get("state", "unknown"),
+                            "_aliases": aliases_map.get(entity_id, []),
                         }
                         for entity_id in area_entities
                     ]

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -156,6 +156,11 @@ class SmartSearchTools:
             # bogus "zero matches" with success=True.
             if isinstance(results[0], BaseException):
                 raise results[0]
+            # CancelledError on the registry task must propagate too;
+            # gather captures it like any other exception when
+            # return_exceptions=True.
+            if isinstance(results[1], asyncio.CancelledError):
+                raise results[1]
             entities = results[0]
 
             # Build entity_id -> slim registry entry map. Registry-list

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -145,10 +145,15 @@ class SmartSearchTools:
             results = await asyncio.gather(
                 entities_task, entity_registry_task, return_exceptions=True
             )
-            entities = results[0] if not isinstance(results[0], Exception) else []
+            # States-fetch failure is fatal — auth/connection errors must
+            # propagate so the caller sees the real cause instead of a
+            # bogus "zero matches" with success=True (#1170).
+            if isinstance(results[0], BaseException):
+                raise results[0]
+            entities = results[0]
 
-            # Build entity_id -> slim registry entry map. We tolerate
-            # registry fetch failure: the search continues without alias /
+            # Build entity_id -> slim registry entry map. Registry-list
+            # failure is tolerated: search continues without alias /
             # hidden awareness rather than failing the whole call.
             registry_slim: dict[str, dict[str, Any]] = {}
             if isinstance(results[1], dict) and results[1].get("success"):
@@ -193,10 +198,10 @@ class SmartSearchTools:
                         ).items():
                             if isinstance(entry, dict):
                                 aliases_map[eid] = entry.get("aliases", []) or []
-                except Exception as alias_err:
+                except (KeyError, TypeError, AttributeError) as alias_err:
                     logger.warning(
-                        "config/entity_registry/get_entries failed; "
-                        "aliases will not be searchable: %s",
+                        "config/entity_registry/get_entries returned "
+                        "malformed payload; aliases unavailable: %s",
                         alias_err,
                     )
 
@@ -445,42 +450,12 @@ class SmartSearchTools:
                 if eid:
                     state_map[eid] = entity
 
-            # Batch-fetch aliases for entities in matched areas. The slim
-            # entity_registry/list above does not return aliases; the
-            # get_entries endpoint does. Surface them as `_aliases` so the
-            # caller (tools_search.area_filtered_query branch) can fold
-            # them into its fuzzy haystack — closes #1166 for the
-            # area+query path. Fetch failure leaves _aliases empty.
-            area_entity_ids = sorted(
-                eid
-                for eid, resolved_area in entity_area_resolved.items()
-                if resolved_area in matched_area_ids
-            )
-            aliases_map: dict[str, list[str]] = {}
-            if area_entity_ids:
-                try:
-                    entries_resp = await self.client.send_websocket_message({
-                        "type": "config/entity_registry/get_entries",
-                        "entity_ids": area_entity_ids,
-                    })
-                    if (
-                        isinstance(entries_resp, dict)
-                        and entries_resp.get("success")
-                    ):
-                        for eid, entry in (
-                            entries_resp.get("result", {}) or {}
-                        ).items():
-                            if isinstance(entry, dict):
-                                aliases_map[eid] = entry.get("aliases", []) or []
-                except Exception as alias_err:
-                    logger.warning(
-                        "config/entity_registry/get_entries failed in area "
-                        "search; aliases will not be searchable for this "
-                        "result set: %s",
-                        alias_err,
-                    )
-
-            # Collect entities belonging to matched areas
+            # Collect entities belonging to matched areas. Alias data is
+            # NOT enriched here — exposing private `_aliases` on a public
+            # method would leak through any caller that round-trips this
+            # response (e.g. server.py:get_entities_by_area). The
+            # area+query consumer in tools_search.py fetches aliases on
+            # its own when needed.
             formatted_areas: dict[str, dict[str, Any]] = {}
             total_entities = 0
 
@@ -516,7 +491,6 @@ class SmartSearchTools:
                                     "friendly_name", entity_id
                                 ),
                                 "state": state_info.get("state", "unknown"),
-                                "_aliases": aliases_map.get(entity_id, []),
                             }
                         )
                     area_data["entities"] = domains
@@ -531,7 +505,6 @@ class SmartSearchTools:
                             .get("friendly_name", entity_id),
                             "domain": entity_id.split(".")[0],
                             "state": state_info.get("state", "unknown"),
-                            "_aliases": aliases_map.get(entity_id, []),
                         }
                         for entity_id in area_entities
                     ]

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -113,7 +113,7 @@ class SmartSearchTools:
         offset: int = 0,
         include_attributes: bool = False,
         domain_filter: str | None = None,
-        include_hidden: bool = False,
+        include_hidden: bool = True,
     ) -> dict[str, Any]:
         """
         Search entities with fuzzy matching and typo tolerance.
@@ -124,10 +124,10 @@ class SmartSearchTools:
             offset: Number of results to skip for pagination
             include_attributes: Whether to include full entity attributes
             domain_filter: Optional domain to filter entities before search (e.g., "light", "sensor")
-            include_hidden: When False (default), entities with
-                ``hidden_by`` set in the entity registry are skipped before
-                fuzzy search runs. Pass True to include them — typically
-                for diagnostics or service workflows.
+            include_hidden: When True (default), entities with ``hidden_by``
+                set in the entity registry are still returned but receive
+                a score penalty so they sort below comparable visible
+                matches. Pass False to filter them out entirely.
 
         Returns:
             Dictionary with search results and metadata
@@ -315,7 +315,7 @@ class SmartSearchTools:
         self,
         area_query: str,
         group_by_domain: bool = True,
-        include_hidden: bool = False,
+        include_hidden: bool = True,
     ) -> dict[str, Any]:
         """
         Get entities grouped by area/room using the HA registries for accurate area resolution.
@@ -327,9 +327,10 @@ class SmartSearchTools:
         Args:
             area_query: Area/room name (or alias) to search for
             group_by_domain: Whether to group results by domain within each area
-            include_hidden: When False (default), entities with
-                ``hidden_by`` set in the entity registry are excluded
-                from per-area results. Pass True to include them.
+            include_hidden: When True (default), entities with ``hidden_by``
+                set in the entity registry are still grouped under their
+                area but receive a score penalty when ranked. Pass False
+                to filter them out entirely.
 
         Returns:
             Dictionary with area-grouped entities
@@ -438,14 +439,17 @@ class SmartSearchTools:
 
             # Build entity_id -> resolved area_id mapping.
             # Priority: entity direct area_id > device area_id.
-            # Hidden entities are skipped unless include_hidden is True.
+            # Hidden entities are filtered only when include_hidden is
+            # False; otherwise they pass through and downstream applies
+            # the score penalty so they sort below visible matches.
             entity_area_resolved: dict[str, str] = {}
+            hidden_entity_ids: set[str] = set()
             for entity_id, reg_info in entity_reg_map.items():
-                if (
-                    not include_hidden
-                    and reg_info.get("hidden_by") is not None
-                ):
+                is_hidden = reg_info.get("hidden_by") is not None
+                if is_hidden and not include_hidden:
                     continue
+                if is_hidden:
+                    hidden_entity_ids.add(entity_id)
                 area_id = reg_info.get("area_id")
                 device_id = reg_info.get("device_id")
                 if not area_id and device_id:
@@ -494,6 +498,9 @@ class SmartSearchTools:
                         state_info = state_map.get(entity_id, {})
                         if domain not in domains:
                             domains[domain] = []
+                        # Carry ``_hidden_by`` as a sentinel ("hidden" or
+                        # None) so downstream branches can apply the
+                        # score penalty without a second registry lookup.
                         domains[domain].append(
                             {
                                 "entity_id": entity_id,
@@ -501,6 +508,11 @@ class SmartSearchTools:
                                     "friendly_name", entity_id
                                 ),
                                 "state": state_info.get("state", "unknown"),
+                                "_hidden_by": (
+                                    "hidden"
+                                    if entity_id in hidden_entity_ids
+                                    else None
+                                ),
                             }
                         )
                     area_data["entities"] = domains
@@ -515,6 +527,11 @@ class SmartSearchTools:
                             .get("friendly_name", entity_id),
                             "domain": entity_id.split(".")[0],
                             "state": state_info.get("state", "unknown"),
+                            "_hidden_by": (
+                                "hidden"
+                                if entity_id in hidden_entity_ids
+                                else None
+                            ),
                         }
                         for entity_id in area_entities
                     ]

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -133,11 +133,12 @@ class SmartSearchTools:
             Dictionary with search results and metadata
         """
         try:
-            # HA domains are canonically lowercase; defend the service
-            # layer so internal callers get the same normalization the
-            # tool layer applies.
+            # HA domains are canonically lowercase and unpadded; defend
+            # the service layer so internal callers get the same
+            # normalization the tool layer applies (strip + lowercase
+            # before the prefix match downstream).
             if domain_filter:
-                domain_filter = domain_filter.lower()
+                domain_filter = domain_filter.strip().lower()
             # Fetch states + entity registry list in parallel. The slim
             # ``list`` view gives us ``hidden_by`` (used to filter
             # UI-hidden entities by default) and the entity_ids we need

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -116,7 +116,7 @@ class SmartSearchTools:
         include_hidden: bool = False,
     ) -> dict[str, Any]:
         """
-        Advanced entity search with fuzzy matching and typo tolerance.
+        Search entities with fuzzy matching and typo tolerance.
 
         Args:
             query: Search query (can be partial, with typos)

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -264,19 +264,12 @@ class SmartSearchTools:
 
                 if include_attributes:
                     result["attributes"] = match["attributes"]
-                else:
-                    # Include only essential attributes
-                    attrs = match["attributes"]
-                    essential_attrs = {}
-                    for key in [
-                        "unit_of_measurement",
-                        "device_class",
-                        "icon",
-                        "area_id",
-                    ]:
-                        if key in attrs:
-                            essential_attrs[key] = attrs[key]
-                    result["essential_attributes"] = essential_attrs
+                # No ``essential_attributes`` fallback — the other four
+                # search-type branches (exact_match, area_only,
+                # area_filtered_query, domain_listing) never emit it, so
+                # surfacing it only from fuzzy_search was a shape
+                # asymmetry. Callers needing full state should follow
+                # up with ``ha_get_state``.
 
                 results.append(result)
 
@@ -392,12 +385,18 @@ class SmartSearchTools:
                     if device_id:
                         device_area_map[device_id] = device.get("area_id")
 
-            # Fuzzy match area_query against known area names, IDs, and aliases.
-            # Aliases (set per-area in the area registry, used by HA voice
-            # config) are searched alongside name+id, mirroring the
-            # entity-side alias enrichment in smart_entity_search.
+            # Two-pass area resolution. Pass 1 collects exact id / name /
+            # alias matches; if any are found, fuzzy aggregation is
+            # skipped entirely. This makes ``area_filter`` honor a
+            # literal area_id from ``ha_config_list_areas`` — pre-fix a
+            # query like ``"bedroom_kids"`` would also fuzzy-match its
+            # parent ``"bedroom"`` (partial_ratio=100) and aggregate
+            # sibling areas' entities. Aliases (per-area registry, used
+            # by HA voice config) mirror the entity-side enrichment in
+            # smart_entity_search.
             area_query_lower = area_query.lower().strip()
-            matched_area_ids: set[str] = set()
+            exact_area_ids: set[str] = set()
+            fuzzy_area_ids: set[str] = set()
 
             for area_id, area_info in area_registry.items():
                 area_name = area_info.get("name", "")
@@ -412,7 +411,7 @@ class SmartSearchTools:
                         if isinstance(a, str)
                     )
                 ):
-                    matched_area_ids.add(area_id)
+                    exact_area_ids.add(area_id)
                     continue
                 # Fuzzy match on area name, id, or any alias
                 name_score = calculate_partial_ratio(
@@ -429,7 +428,11 @@ class SmartSearchTools:
                 )
                 best_score = max(name_score, id_score, alias_score)
                 if best_score >= 80:
-                    matched_area_ids.add(area_id)
+                    fuzzy_area_ids.add(area_id)
+
+            # Exact matches win — fuzzy aggregation only runs when no
+            # area_query_lower is itself an area_id / name / alias.
+            matched_area_ids = exact_area_ids or fuzzy_area_ids
 
             if not matched_area_ids:
                 return {

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -126,18 +126,23 @@ class SmartSearchTools:
             domain_filter: Optional domain to filter entities before search (e.g., "light", "sensor")
             include_hidden: When False (default), entities with
                 ``hidden_by`` set in the entity registry are skipped before
-                fuzzy search runs (#1170 finding 9). Pass True to include
-                them — typically for diagnostics or service workflows.
+                fuzzy search runs. Pass True to include them — typically
+                for diagnostics or service workflows.
 
         Returns:
             Dictionary with search results and metadata
         """
         try:
+            # HA domains are canonically lowercase; defend the service
+            # layer so internal callers get the same normalization the
+            # tool layer applies.
+            if domain_filter:
+                domain_filter = domain_filter.lower()
             # Fetch states + entity registry list in parallel. The slim
             # ``list`` view gives us ``hidden_by`` (used to filter
-            # UI-hidden entities by default; #1170 finding 9) and the
-            # entity_ids we need to feed into ``get_entries`` for the
-            # full-fidelity data (#1170 finding 8 / closes #1166).
+            # UI-hidden entities by default) and the entity_ids we need
+            # to feed into ``get_entries`` for the full-fidelity data
+            # (aliases live only in get_entries, not the slim list).
             entities_task = self.client.get_states()
             entity_registry_task = self.client.send_websocket_message(
                 {"type": "config/entity_registry/list"}
@@ -147,7 +152,7 @@ class SmartSearchTools:
             )
             # States-fetch failure is fatal — auth/connection errors must
             # propagate so the caller sees the real cause instead of a
-            # bogus "zero matches" with success=True (#1170).
+            # bogus "zero matches" with success=True.
             if isinstance(results[0], BaseException):
                 raise results[0]
             entities = results[0]
@@ -181,7 +186,7 @@ class SmartSearchTools:
             # Second pass: batch-fetch full registry entries for aliases.
             # ``config/entity_registry/list`` deliberately omits
             # ``aliases``; ``get_entries`` includes them. One extra
-            # round-trip closes #1166 without N+1 fan-out.
+            # round-trip enriches the survivor set without N+1 fan-out.
             aliases_map: dict[str, list[str]] = {}
             if survivor_ids:
                 try:
@@ -198,10 +203,18 @@ class SmartSearchTools:
                         ).items():
                             if isinstance(entry, dict):
                                 aliases_map[eid] = entry.get("aliases", []) or []
+                    else:
+                        logger.warning(
+                            "alias_enrichment_failed: get_entries returned "
+                            "non-success for %d entities (resp=%r)",
+                            len(survivor_ids),
+                            entries_resp,
+                        )
                 except (KeyError, TypeError, AttributeError) as alias_err:
                     logger.warning(
-                        "config/entity_registry/get_entries returned "
-                        "malformed payload; aliases unavailable: %s",
+                        "alias_enrichment_failed: malformed payload for "
+                        "%d entities (err=%r)",
+                        len(survivor_ids),
                         alias_err,
                     )
 
@@ -218,8 +231,6 @@ class SmartSearchTools:
                     "_hidden_by": slim.get("hidden_by"),
                 })
 
-            # Filter by domain BEFORE fuzzy search if domain_filter provided
-            # This ensures fuzzy search only looks at entities in the target domain
             entities = enriched
             if domain_filter:
                 entities = [
@@ -318,8 +329,7 @@ class SmartSearchTools:
             group_by_domain: Whether to group results by domain within each area
             include_hidden: When False (default), entities with
                 ``hidden_by`` set in the entity registry are excluded
-                from per-area results (#1170 finding 9). Pass True to
-                include them.
+                from per-area results. Pass True to include them.
 
         Returns:
             Dictionary with area-grouped entities
@@ -377,8 +387,8 @@ class SmartSearchTools:
 
             # Fuzzy match area_query against known area names, IDs, and aliases.
             # Aliases (set per-area in the area registry, used by HA voice
-            # config) were previously ignored — closing #1166 for areas in
-            # parallel with the entity-side fix in smart_entity_search.
+            # config) are searched alongside name+id, mirroring the
+            # entity-side alias enrichment in smart_entity_search.
             area_query_lower = area_query.lower().strip()
             matched_area_ids: set[str] = set()
 
@@ -428,7 +438,7 @@ class SmartSearchTools:
 
             # Build entity_id -> resolved area_id mapping.
             # Priority: entity direct area_id > device area_id.
-            # Hidden entities are skipped by default (#1170 finding 9).
+            # Hidden entities are skipped unless include_hidden is True.
             entity_area_resolved: dict[str, str] = {}
             for entity_id, reg_info in entity_reg_map.items():
                 if (

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -51,11 +51,13 @@ async def _exact_match_search(
     include_hidden: bool = False,
 ) -> dict[str, Any]:
     """
-    Substring search across entity_id + friendly_name; used both as the
-    ``exact_match=True`` primary path and as the fallback when fuzzy
-    search raises. In addition to ``client.get_states()``, also queries
-    the entity registry via WebSocket to honor ``include_hidden``
-    (#1170): when False, entities with ``hidden_by != null`` are skipped.
+    Search entities by substring on entity_id + friendly_name.
+
+    Used both as the ``exact_match=True`` primary path and as the
+    fallback when fuzzy search raises. In addition to ``client.get_states()``,
+    also queries the entity registry via WebSocket to honor
+    ``include_hidden`` (#1170): when False, entities with
+    ``hidden_by != null`` are skipped.
     """
     # Fetch states + entity registry in parallel. Registry-list failure
     # is tolerated (we just lose the hidden filter); states-fetch failure

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -504,6 +504,16 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         }
                         if domain_filter:
                             area_search_data["domain_filter"] = domain_filter
+                        # Mirror the empty-area branch's message when
+                        # the area resolved but a domain_filter wiped
+                        # out every entity in it — otherwise the caller
+                        # sees total_matches=0 with no hint as to which
+                        # filter caused it.
+                        if not all_results and domain_filter:
+                            area_search_data["message"] = (
+                                f"No {domain_filter} entities found in area: "
+                                f"{area_filter}"
+                            )
                         if group_by_domain_bool:
                             # Group the paginated slice (not all_results) so
                             # by_domain and results stay in sync.
@@ -731,6 +741,24 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         except ToolError:
             raise
+        except ValueError as e:
+            # coerce_bool_param / coerce_int_param raise ValueError on
+            # bad input. These are param-validation failures, not
+            # operational ones — surface them as VALIDATION_FAILED with
+            # the helper's own message and NO generic operational
+            # suggestions (those would just be misleading boilerplate
+            # next to an unrelated message like "limit must be at least
+            # 1, got 0").
+            raise_tool_error(
+                create_validation_error(
+                    str(e),
+                    context={
+                        "query": query,
+                        "domain_filter": domain_filter,
+                        "area_filter": area_filter,
+                    },
+                )
+            )
         except Exception as e:
             exception_to_structured_error(
                 e,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -56,8 +56,8 @@ async def _exact_match_search(
     Used both as the ``exact_match=True`` primary path and as the
     fallback when fuzzy search raises. In addition to ``client.get_states()``,
     also queries the entity registry via WebSocket to honor
-    ``include_hidden`` (#1170): when False, entities with
-    ``hidden_by != null`` are skipped.
+    ``include_hidden``: when False, entities with ``hidden_by != null``
+    are skipped.
     """
     # Fetch states + entity registry in parallel. Registry-list failure
     # is tolerated (we just lose the hidden filter); states-fetch failure
@@ -230,7 +230,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
         # HA domains are canonically lowercase; agents that capitalize from a
         # user phrase ("turn on the Lights") would otherwise hit a silent
-        # zero-result. Issue #1170 finding 1.
+        # zero-result.
         if domain_filter:
             domain_filter = domain_filter.lower()
         # Coerce boolean parameter that may come as string from XML-style calls
@@ -273,11 +273,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             for domain_entities in entities.values():
                                 all_area_entities.extend(domain_entities)
 
-                    # Batch-fetch aliases for the surviving entity_ids
-                    # so the fuzzy haystack includes them (#1170 closes
-                    # #1166). Aliases live only in get_entries (not the
-                    # slim list endpoint), so this is a single bounded
-                    # round-trip on top of get_entities_by_area's calls.
+                    # Batch-fetch aliases for the surviving entity_ids so
+                    # the fuzzy haystack includes them. Aliases live only
+                    # in get_entries (not the slim list endpoint), so
+                    # this is a single bounded round-trip on top of
+                    # get_entities_by_area's calls.
                     area_entity_ids = sorted(
                         e.get("entity_id", "")
                         for e in all_area_entities
@@ -301,11 +301,19 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                         aliases_map[eid] = (
                                             entry.get("aliases", []) or []
                                         )
+                            else:
+                                logger.warning(
+                                    "alias_enrichment_failed: get_entries "
+                                    "returned non-success for %d area "
+                                    "entities (resp=%r)",
+                                    len(area_entity_ids),
+                                    entries_resp,
+                                )
                         except (KeyError, TypeError, AttributeError) as alias_err:
                             logger.warning(
-                                "config/entity_registry/get_entries returned "
-                                "malformed payload; aliases unavailable for "
-                                "area+query result set: %s",
+                                "alias_enrichment_failed: malformed payload "
+                                "for %d area entities (err=%r)",
+                                len(area_entity_ids),
                                 alias_err,
                             )
 
@@ -314,9 +322,6 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                     fuzzy_searcher = create_fuzzy_searcher(threshold=80)
 
-                    # Convert to format expected by fuzzy searcher.
-                    # Inject `_aliases` so the fuzzy haystack includes
-                    # per-entity aliases.
                     entities_for_search = [
                         {
                             "entity_id": entity.get("entity_id", ""),
@@ -336,9 +341,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
 
                     # Format matches similar to smart_entity_search.
-                    # Top-level `area_filter` already carries this context for
-                    # the caller; per-result echo was redundant and
-                    # asymmetric vs the other branches (#1170 finding 4).
+                    # Top-level `area_filter` already carries this
+                    # context for the caller; per-result echo would be
+                    # redundant and asymmetric vs the other branches.
                     results = [
                         {
                             "entity_id": match["entity_id"],
@@ -384,9 +389,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         # area but one — a query like area_filter="bedroom"
                         # against ["bedroom","bedroom_kids"] would return
                         # only one area's entities and miss the user's
-                        # intended one entirely. The with-query branch
-                        # already iterated all matches, so the two paths
-                        # diverged. (#1170 finding 7.)
+                        # intended one entirely. Match the with-query
+                        # branch by iterating all matched areas.
                         all_results: list[dict[str, Any]] = []
                         area_names_matched: list[str] = []
                         # Sort area_id keys to make iteration deterministic;
@@ -404,13 +408,14 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                     continue
                                 # `{**entity, ...}` avoids mutating dicts
                                 # owned by the smart_search helper.
-                                # Add score+match_type so the response shape
-                                # matches the other four search-type
-                                # branches (#1170 finding 3). Score=100
-                                # because area membership is exact, not
-                                # fuzzy. Strip leading-underscore internal
-                                # fields (e.g. `_aliases`) so the response
-                                # only contains public-API fields.
+                                # Add score+match_type so the response
+                                # shape matches the other four
+                                # search-type branches. Score=100 because
+                                # area membership is exact, not fuzzy.
+                                # Strip leading-underscore internal
+                                # fields (e.g. `_aliases`) so the
+                                # response only contains public-API
+                                # fields.
                                 all_results.extend(
                                     {
                                         **{
@@ -438,7 +443,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             # `area_names` lists every matched area;
                             # `area_name` (singular) is kept for backward
                             # compatibility with existing callers — new
-                            # callers should read `area_names` (#1170).
+                            # callers should read `area_names`.
                             "area_names": area_names_matched,
                             "area_name": (
                                 area_names_matched[0]
@@ -459,10 +464,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             area_search_data["by_domain"] = paginated_by_domain
                         return await add_timezone_metadata(client, area_search_data)
                     else:
-                        # Empty match: still emit `area_names: []` so callers
-                        # don't KeyError when they read the field on a
-                        # zero-match response. Symmetry with the populated
-                        # branch (#1170 finding 7).
+                        # Empty match: still emit `area_names: []` so
+                        # callers don't KeyError when they read the
+                        # field on a zero-match response. Symmetry with
+                        # the populated branch.
                         empty_area_data: dict[str, Any] = {
                             "success": True,
                             "area_filter": area_filter,
@@ -485,7 +490,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 # failure is tolerated (we just lose the hidden filter);
                 # states-fetch failure is fatal — auth/connection errors
                 # must propagate so the agent sees the real cause instead
-                # of silently ranked-zero results (#1170).
+                # of silently ranked-zero results.
                 states_task = client.get_states()
                 registry_task = client.send_websocket_message(
                     {"type": "config/entity_registry/list"}
@@ -554,12 +559,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             # - exact_match=True: substring match
             # - exact_match=False: fuzzy first, fall back to substring on failure
             #
-            # The legacy `partial_listing` last-resort dump was removed
-            # (#1170 finding 6): it returned every entity at score=0 with
-            # `partial: True`, which masked the underlying error and gave
-            # the agent a noise pile that was strictly worse than a clean
-            # error. If both real strategies fail we now propagate the
-            # exception so callers see why.
+            # If both real strategies fail we propagate the exception so
+            # callers see why; we deliberately do NOT fall back to a
+            # zero-scored entity dump (a clean error is strictly more
+            # useful to an agent than a noise pile flagged
+            # `partial: True`).
 
             result: dict[str, Any]
             warning: str | None = None
@@ -590,6 +594,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
                     search_type = "fuzzy_search"
                 except asyncio.CancelledError:
+                    raise
+                except ToolError:
+                    # Auth/connection/structured failures must propagate; the
+                    # substring fallback below is for fuzzy-engine bugs only.
                     raise
                 except Exception as fuzzy_error:
                     logger.warning(

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -23,6 +23,7 @@ from .util_helpers import (
     coerce_bool_param,
     coerce_int_param,
     parse_string_list_param,
+    public_fields,
 )
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,16 @@ async def _exact_match_search(
                 eid = entry.get("entity_id")
                 if eid:
                     hidden_ids.add(eid)
+    else:
+        # Without the registry we can't tag hidden entities, so the
+        # score-penalty downgrade silently doesn't apply. Log so the
+        # operator can correlate "diagnostic entity ranking first" with
+        # this WS hiccup instead of a code regression.
+        logger.warning(
+            "hidden_filter_unavailable: registry/list returned %r — "
+            "hidden entities will rank without the score penalty",
+            registry_result,
+        )
 
     query_lower = query.lower().strip()
 
@@ -237,23 +248,31 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         # zero-result.
         if domain_filter:
             domain_filter = domain_filter.lower()
-        # Coerce boolean parameter that may come as string from XML-style calls
-        group_by_domain_bool = (
-            coerce_bool_param(group_by_domain, "group_by_domain", default=False)
-            or False
-        )
-        exact_match_bool = coerce_bool_param(exact_match, "exact_match", default=True)
-        # Default True: hidden entities are kept (with score penalty) unless
-        # the caller explicitly opts out by passing include_hidden=False.
-        coerced_hidden = coerce_bool_param(
-            include_hidden, "include_hidden", default=True
-        )
-        # coerce_bool_param returns the default when value is None; with
-        # default=True the result is a real bool, but the type system
-        # still admits None — coalesce defensively for static typing.
-        include_hidden_bool = coerced_hidden if coerced_hidden is not None else True
 
         try:
+            # Param coercion stays inside try/except so a malformed
+            # value (e.g. include_hidden="maybe") surfaces as a
+            # structured ToolError via exception_to_structured_error
+            # rather than escaping as INTERNAL_ERROR.
+            group_by_domain_bool = (
+                coerce_bool_param(group_by_domain, "group_by_domain", default=False)
+                or False
+            )
+            exact_match_bool = coerce_bool_param(
+                exact_match, "exact_match", default=True
+            )
+            # Default True: hidden entities are kept (with score penalty)
+            # unless the caller explicitly opts out by passing False.
+            coerced_hidden = coerce_bool_param(
+                include_hidden, "include_hidden", default=True
+            )
+            # coerce_bool_param returns the default when value is None;
+            # with default=True the result is a real bool, but the type
+            # system still admits None — coalesce defensively for static
+            # typing.
+            include_hidden_bool = (
+                coerced_hidden if coerced_hidden is not None else True
+            )
             offset = coerce_int_param(offset, "offset", default=0, min_value=0) or 0
             limit = coerce_int_param(limit, "limit", default=10, min_value=1)
 
@@ -350,7 +369,6 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         entities_for_search, query, limit, offset
                     )
 
-                    # Format matches similar to smart_entity_search.
                     # Top-level `area_filter` already carries this
                     # context for the caller; per-result echo would be
                     # redundant and asymmetric vs the other branches.
@@ -416,26 +434,19 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             for domain, entities in entities_data.items():
                                 if domain_filter and domain != domain_filter:
                                     continue
-                                # `{**entity, ...}` avoids mutating dicts
-                                # owned by the smart_search helper.
-                                # Add score+match_type so the response
-                                # shape matches the other four
-                                # search-type branches. Score=100 because
-                                # area membership is exact, not fuzzy;
-                                # hidden entities receive the standard
-                                # penalty so they sort below visible
-                                # peers within the same area. Strip
-                                # leading-underscore internal fields
-                                # (e.g. `_aliases`, `_hidden_by`) so the
-                                # response only contains public-API
-                                # fields.
+                                # ``public_fields`` strips internal
+                                # ``_aliases`` / ``_hidden_by`` enrichments
+                                # before the dict crosses the public-API
+                                # boundary; ``{**..., ...}`` avoids
+                                # mutating dicts owned by smart_search.
+                                # Score=100 baseline because area
+                                # membership is exact (not fuzzy); hidden
+                                # entities receive the standard penalty
+                                # so they sort below visible peers within
+                                # the same area.
                                 all_results.extend(
                                     {
-                                        **{
-                                            k: v
-                                            for k, v in entity.items()
-                                            if not k.startswith("_")
-                                        },
+                                        **public_fields(entity),
                                         "domain": domain,
                                         "score": apply_hidden_penalty(
                                             100, entity.get("_hidden_by")
@@ -529,6 +540,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             eid = entry.get("entity_id")
                             if eid:
                                 hidden_ids.add(eid)
+                else:
+                    logger.warning(
+                        "hidden_filter_unavailable: registry/list returned "
+                        "%r — hidden entities in domain_listing will rank "
+                        "without the score penalty",
+                        registry_result,
+                    )
 
                 # Filter by domain. Hidden entities are kept by default
                 # (with score penalty applied below); ``include_hidden=False``

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -51,14 +51,16 @@ async def _exact_match_search(
     include_hidden: bool = False,
 ) -> dict[str, Any]:
     """
-    Fallback exact match search when fuzzy search fails.
-
-    Performs simple substring matching on entity_id and friendly_name.
-    Honors ``include_hidden`` (#1170 finding 9) by consulting the entity
-    registry and skipping ``hidden_by != null`` entries when False.
+    Substring search across entity_id + friendly_name; used both as the
+    ``exact_match=True`` primary path and as the fallback when fuzzy
+    search raises. In addition to ``client.get_states()``, also queries
+    the entity registry via WebSocket to honor ``include_hidden``
+    (#1170): when False, entities with ``hidden_by != null`` are skipped.
     """
-    # Fetch states + entity registry in parallel; tolerate registry
-    # failure (we just lose the hidden filter, search still works).
+    # Fetch states + entity registry in parallel. Registry-list failure
+    # is tolerated (we just lose the hidden filter); states-fetch failure
+    # is fatal — auth/connection errors must propagate so the agent sees
+    # "your token is invalid" instead of "zero entities matched".
     entities_task = client.get_states()
     registry_task = client.send_websocket_message(
         {"type": "config/entity_registry/list"}
@@ -68,9 +70,9 @@ async def _exact_match_search(
     )
     state_result: Any = gather_results[0]
     registry_result: Any = gather_results[1]
-    all_entities = (
-        state_result if not isinstance(state_result, Exception) else []
-    )
+    if isinstance(state_result, BaseException):
+        raise state_result
+    all_entities = state_result
     hidden_ids: set[str] = set()
     if (
         not include_hidden
@@ -157,7 +159,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             str | None,
             Field(
                 default=None,
-                description="Limit to a single domain (e.g. 'light', 'sensor', 'calendar').",
+                description=(
+                    "Limit to a single domain (e.g. 'light', 'sensor', "
+                    "'calendar'). Case-insensitive — values are normalized "
+                    "to lowercase before matching."
+                ),
             ),
         ] = None,
         area_filter: Annotated[
@@ -253,9 +259,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # Collect entities from all matched areas, applying
                     # domain_filter if present. get_entities_by_area is called
                     # with group_by_domain=True above, so entities is always a
-                    # dict keyed by domain.
+                    # dict keyed by domain. Iterate sorted area_id keys so
+                    # the order matches the area_only branch.
                     all_area_entities = []
-                    for area_data in area_result.get("areas", {}).values():
+                    for area_id in sorted(area_result.get("areas", {})):
+                        area_data = area_result["areas"][area_id]
                         entities = area_data.get("entities") or {}
                         if domain_filter:
                             all_area_entities.extend(entities.get(domain_filter, []))
@@ -263,16 +271,50 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             for domain_entities in entities.values():
                                 all_area_entities.extend(domain_entities)
 
+                    # Batch-fetch aliases for the surviving entity_ids
+                    # so the fuzzy haystack includes them (#1170 closes
+                    # #1166). Aliases live only in get_entries (not the
+                    # slim list endpoint), so this is a single bounded
+                    # round-trip on top of get_entities_by_area's calls.
+                    area_entity_ids = sorted(
+                        e.get("entity_id", "")
+                        for e in all_area_entities
+                        if e.get("entity_id")
+                    )
+                    aliases_map: dict[str, list[str]] = {}
+                    if area_entity_ids:
+                        try:
+                            entries_resp = await client.send_websocket_message({
+                                "type": "config/entity_registry/get_entries",
+                                "entity_ids": area_entity_ids,
+                            })
+                            if (
+                                isinstance(entries_resp, dict)
+                                and entries_resp.get("success")
+                            ):
+                                for eid, entry in (
+                                    entries_resp.get("result", {}) or {}
+                                ).items():
+                                    if isinstance(entry, dict):
+                                        aliases_map[eid] = (
+                                            entry.get("aliases", []) or []
+                                        )
+                        except (KeyError, TypeError, AttributeError) as alias_err:
+                            logger.warning(
+                                "config/entity_registry/get_entries returned "
+                                "malformed payload; aliases unavailable for "
+                                "area+query result set: %s",
+                                alias_err,
+                            )
+
                     # Apply fuzzy search to area entities
                     from ..utils.fuzzy_search import create_fuzzy_searcher
 
                     fuzzy_searcher = create_fuzzy_searcher(threshold=80)
 
                     # Convert to format expected by fuzzy searcher.
-                    # Pass through `_aliases` (populated by
-                    # get_entities_by_area) so the fuzzy haystack
-                    # includes per-entity aliases — closes #1166 for
-                    # the area+query branch alongside the non-area path.
+                    # Inject `_aliases` so the fuzzy haystack includes
+                    # per-entity aliases.
                     entities_for_search = [
                         {
                             "entity_id": entity.get("entity_id", ""),
@@ -280,7 +322,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 "friendly_name": entity.get("friendly_name", "")
                             },
                             "state": entity.get("state", "unknown"),
-                            "_aliases": entity.get("_aliases", []),
+                            "_aliases": aliases_map.get(
+                                entity.get("entity_id", ""), []
+                            ),
                         }
                         for entity in all_area_entities
                     ]
@@ -389,11 +433,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             ),
                             "results": paginated,
                             "search_type": "area_only",
-                            # Public-API change: `area_names` is now a list
-                            # so callers can see when their filter matched
-                            # multiple areas (#1170 finding 7). The legacy
-                            # `area_name` is preserved as the first match
-                            # for one minor version to ease migration.
+                            # `area_names` lists every matched area;
+                            # `area_name` (singular) is kept for backward
+                            # compatibility with existing callers — new
+                            # callers should read `area_names` (#1170).
                             "area_names": area_names_matched,
                             "area_name": (
                                 area_names_matched[0]
@@ -414,12 +457,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             area_search_data["by_domain"] = paginated_by_domain
                         return await add_timezone_metadata(client, area_search_data)
                     else:
+                        # Empty match: still emit `area_names: []` so callers
+                        # don't KeyError when they read the field on a
+                        # zero-match response. Symmetry with the populated
+                        # branch (#1170 finding 7).
                         empty_area_data: dict[str, Any] = {
                             "success": True,
                             "area_filter": area_filter,
                             **_build_pagination_metadata(0, offset, limit, []),
                             "results": [],
                             "search_type": "area_only",
+                            "area_names": [],
                             "message": f"No entities found in area: {area_filter}",
                         }
                         if domain_filter:
@@ -431,9 +479,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             # Regular entity search (no area filter)
             # Handle empty query with domain_filter - list all entities of that domain
             if domain_filter and (not query or not query.strip()):
-                # Fetch states + registry list in parallel so we can drop
-                # hidden entities (#1170 finding 9). Registry failure is
-                # tolerated: we just lose the hidden filter.
+                # Fetch states + registry list in parallel. Registry-list
+                # failure is tolerated (we just lose the hidden filter);
+                # states-fetch failure is fatal — auth/connection errors
+                # must propagate so the agent sees the real cause instead
+                # of silently ranked-zero results (#1170).
                 states_task = client.get_states()
                 registry_task = client.send_websocket_message(
                     {"type": "config/entity_registry/list"}
@@ -443,11 +493,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 )
                 states_result: Any = gather_results[0]
                 registry_result: Any = gather_results[1]
-                all_entities = (
-                    states_result
-                    if not isinstance(states_result, Exception)
-                    else []
-                )
+                if isinstance(states_result, BaseException):
+                    raise states_result
+                all_entities = states_result
                 hidden_ids: set[str] = set()
                 if (
                     not include_hidden_bool

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -43,19 +43,53 @@ def _build_pagination_metadata(
 
 
 async def _exact_match_search(
-    client: Any, query: str, domain_filter: str | None, limit: int, offset: int = 0
+    client: Any,
+    query: str,
+    domain_filter: str | None,
+    limit: int,
+    offset: int = 0,
+    include_hidden: bool = False,
 ) -> dict[str, Any]:
     """
     Fallback exact match search when fuzzy search fails.
 
     Performs simple substring matching on entity_id and friendly_name.
+    Honors ``include_hidden`` (#1170 finding 9) by consulting the entity
+    registry and skipping ``hidden_by != null`` entries when False.
     """
-    all_entities = await client.get_states()
+    # Fetch states + entity registry in parallel; tolerate registry
+    # failure (we just lose the hidden filter, search still works).
+    entities_task = client.get_states()
+    registry_task = client.send_websocket_message(
+        {"type": "config/entity_registry/list"}
+    )
+    gather_results = await asyncio.gather(
+        entities_task, registry_task, return_exceptions=True
+    )
+    state_result: Any = gather_results[0]
+    registry_result: Any = gather_results[1]
+    all_entities = (
+        state_result if not isinstance(state_result, Exception) else []
+    )
+    hidden_ids: set[str] = set()
+    if (
+        not include_hidden
+        and isinstance(registry_result, dict)
+        and registry_result.get("success")
+    ):
+        for entry in registry_result.get("result", []):
+            if entry.get("hidden_by") is not None:
+                eid = entry.get("entity_id")
+                if eid:
+                    hidden_ids.add(eid)
+
     query_lower = query.lower().strip()
 
     results = []
     for entity in all_entities:
         entity_id = entity.get("entity_id", "")
+        if entity_id in hidden_ids:
+            continue
         attributes = entity.get("attributes", {})
         friendly_name = attributes.get("friendly_name", entity_id)
         domain = entity_id.split(".")[0] if "." in entity_id else ""
@@ -89,49 +123,6 @@ async def _exact_match_search(
         **_build_pagination_metadata(len(results), offset, limit, paginated),
         "results": paginated,
         "search_type": "exact_match",
-    }
-
-
-async def _partial_results_search(
-    client: Any, query: str, domain_filter: str | None, limit: int, offset: int = 0
-) -> dict[str, Any]:
-    """
-    Last resort fallback - return any entities that might be relevant.
-
-    Returns entities from the specified domain (if any) or a sample of all entities.
-    """
-    all_entities = await client.get_states()
-
-    results = []
-    for entity in all_entities:
-        entity_id = entity.get("entity_id", "")
-        attributes = entity.get("attributes", {})
-        friendly_name = attributes.get("friendly_name", entity_id)
-        domain = entity_id.split(".")[0] if "." in entity_id else ""
-
-        # Apply domain filter if provided
-        if domain_filter and domain != domain_filter:
-            continue
-
-        results.append(
-            {
-                "entity_id": entity_id,
-                "friendly_name": friendly_name,
-                "domain": domain,
-                "state": entity.get("state", "unknown"),
-                "score": 0,
-                "match_type": "partial_listing",
-            }
-        )
-
-    paginated = results[offset : offset + limit]
-    return {
-        "success": True,
-        "partial": True,
-        "query": query,
-        **_build_pagination_metadata(len(results), offset, limit, paginated),
-        "results": paginated,
-        "search_type": "partial_listing",
     }
 
 
@@ -196,6 +187,19 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ),
             ),
         ] = True,
+        include_hidden: Annotated[
+            bool | str,
+            Field(
+                default=False,
+                description=(
+                    "Include entities marked hidden_by in the entity registry "
+                    "(default: False). Hidden entities are typically integration "
+                    "diagnostics or user-suppressed entries that an agent acting "
+                    "on a user phrase shouldn't surface. Set to True to include "
+                    "them — useful for diagnostics or service workflows."
+                ),
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """Find or list entities (lights, sensors, switches, etc.) by name, domain, or area.
 
@@ -216,12 +220,21 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     parameter="query",
                 )
             )
+        # HA domains are canonically lowercase; agents that capitalize from a
+        # user phrase ("turn on the Lights") would otherwise hit a silent
+        # zero-result. Issue #1170 finding 1.
+        if domain_filter:
+            domain_filter = domain_filter.lower()
         # Coerce boolean parameter that may come as string from XML-style calls
         group_by_domain_bool = (
             coerce_bool_param(group_by_domain, "group_by_domain", default=False)
             or False
         )
         exact_match_bool = coerce_bool_param(exact_match, "exact_match", default=True)
+        include_hidden_bool = (
+            coerce_bool_param(include_hidden, "include_hidden", default=False)
+            or False
+        )
 
         try:
             offset = coerce_int_param(offset, "offset", default=0, min_value=0) or 0
@@ -230,7 +243,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             # If area_filter is provided, use area-based search
             if area_filter:
                 area_result = await smart_tools.get_entities_by_area(
-                    area_filter, group_by_domain=True
+                    area_filter,
+                    group_by_domain=True,
+                    include_hidden=include_hidden_bool,
                 )
 
                 # If we also have a query, filter the area results
@@ -253,7 +268,11 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                     fuzzy_searcher = create_fuzzy_searcher(threshold=80)
 
-                    # Convert to format expected by fuzzy searcher
+                    # Convert to format expected by fuzzy searcher.
+                    # Pass through `_aliases` (populated by
+                    # get_entities_by_area) so the fuzzy haystack
+                    # includes per-entity aliases — closes #1166 for
+                    # the area+query branch alongside the non-area path.
                     entities_for_search = [
                         {
                             "entity_id": entity.get("entity_id", ""),
@@ -261,6 +280,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 "friendly_name": entity.get("friendly_name", "")
                             },
                             "state": entity.get("state", "unknown"),
+                            "_aliases": entity.get("_aliases", []),
                         }
                         for entity in all_area_entities
                     ]
@@ -269,7 +289,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         entities_for_search, query, limit, offset
                     )
 
-                    # Format matches similar to smart_entity_search
+                    # Format matches similar to smart_entity_search.
+                    # Top-level `area_filter` already carries this context for
+                    # the caller; per-result echo was redundant and
+                    # asymmetric vs the other branches (#1170 finding 4).
                     results = [
                         {
                             "entity_id": match["entity_id"],
@@ -278,7 +301,6 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             "state": match["state"],
                             "score": match["score"],
                             "match_type": match["match_type"],
-                            "area_filter": area_filter,
                         }
                         for match in matches
                     ]
@@ -311,21 +333,51 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 else:
                     # Just area filter, return area results with enhanced format
                     if area_result.get("areas"):
-                        first_area = next(iter(area_result["areas"].values()))
-                        entities_data = first_area.get("entities")
-
-                        # Build a flat results list, applying domain_filter and
-                        # tagging each entity with its `domain` so the optional
-                        # by_domain rebuild below can group without re-parsing
-                        # entity_id. `{**entity, "domain": domain}` avoids
-                        # mutating dicts owned by the helper.
+                        # Iterate ALL fuzzy-matched areas, not just the first.
+                        # Pre-fix: `next(iter(...))` silently dropped every
+                        # area but one — a query like area_filter="bedroom"
+                        # against ["bedroom","bedroom_kids"] would return
+                        # only one area's entities and miss the user's
+                        # intended one entirely. The with-query branch
+                        # already iterated all matches, so the two paths
+                        # diverged. (#1170 finding 7.)
                         all_results: list[dict[str, Any]] = []
-                        for domain, entities in (entities_data or {}).items():
-                            if domain_filter and domain != domain_filter:
-                                continue
-                            all_results.extend(
-                                {**entity, "domain": domain} for entity in entities
+                        area_names_matched: list[str] = []
+                        # Sort area_id keys to make iteration deterministic;
+                        # the upstream `matched_area_ids` is a set, so
+                        # without sorting we'd be at the mercy of CPython
+                        # set-iteration order.
+                        for area_id in sorted(area_result["areas"]):
+                            area_data = area_result["areas"][area_id]
+                            area_names_matched.append(
+                                area_data.get("area_name", area_id)
                             )
+                            entities_data = area_data.get("entities") or {}
+                            for domain, entities in entities_data.items():
+                                if domain_filter and domain != domain_filter:
+                                    continue
+                                # `{**entity, ...}` avoids mutating dicts
+                                # owned by the smart_search helper.
+                                # Add score+match_type so the response shape
+                                # matches the other four search-type
+                                # branches (#1170 finding 3). Score=100
+                                # because area membership is exact, not
+                                # fuzzy. Strip leading-underscore internal
+                                # fields (e.g. `_aliases`) so the response
+                                # only contains public-API fields.
+                                all_results.extend(
+                                    {
+                                        **{
+                                            k: v
+                                            for k, v in entity.items()
+                                            if not k.startswith("_")
+                                        },
+                                        "domain": domain,
+                                        "score": 100,
+                                        "match_type": "area_match",
+                                    }
+                                    for entity in entities
+                                )
 
                         paginated = all_results[offset : offset + limit]
 
@@ -337,7 +389,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             ),
                             "results": paginated,
                             "search_type": "area_only",
-                            "area_name": first_area.get("area_name", area_filter),
+                            # Public-API change: `area_names` is now a list
+                            # so callers can see when their filter matched
+                            # multiple areas (#1170 finding 7). The legacy
+                            # `area_name` is preserved as the first match
+                            # for one minor version to ease migration.
+                            "area_names": area_names_matched,
+                            "area_name": (
+                                area_names_matched[0]
+                                if area_names_matched
+                                else area_filter
+                            ),
                         }
                         if domain_filter:
                             area_search_data["domain_filter"] = domain_filter
@@ -369,14 +431,41 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             # Regular entity search (no area filter)
             # Handle empty query with domain_filter - list all entities of that domain
             if domain_filter and (not query or not query.strip()):
-                # Get all entities directly from the client
-                all_entities = await client.get_states()
+                # Fetch states + registry list in parallel so we can drop
+                # hidden entities (#1170 finding 9). Registry failure is
+                # tolerated: we just lose the hidden filter.
+                states_task = client.get_states()
+                registry_task = client.send_websocket_message(
+                    {"type": "config/entity_registry/list"}
+                )
+                gather_results = await asyncio.gather(
+                    states_task, registry_task, return_exceptions=True
+                )
+                states_result: Any = gather_results[0]
+                registry_result: Any = gather_results[1]
+                all_entities = (
+                    states_result
+                    if not isinstance(states_result, Exception)
+                    else []
+                )
+                hidden_ids: set[str] = set()
+                if (
+                    not include_hidden_bool
+                    and isinstance(registry_result, dict)
+                    and registry_result.get("success")
+                ):
+                    for entry in registry_result.get("result", []):
+                        if entry.get("hidden_by") is not None:
+                            eid = entry.get("entity_id")
+                            if eid:
+                                hidden_ids.add(eid)
 
-                # Filter by domain
+                # Filter by domain (and hidden_by, when not opted in)
                 filtered_entities = [
                     e
                     for e in all_entities
                     if e.get("entity_id", "").startswith(f"{domain_filter}.")
+                    and e.get("entity_id") not in hidden_ids
                 ]
 
                 # Format results to match fuzzy search output
@@ -412,75 +501,61 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 return await add_timezone_metadata(client, domain_list_data)
 
             # Search strategy depends on exact_match setting:
-            # - exact_match=True: use exact substring matching directly
-            # - exact_match=False: try fuzzy first, fall back to exact, then partial
+            # - exact_match=True: substring match
+            # - exact_match=False: fuzzy first, fall back to substring on failure
+            #
+            # The legacy `partial_listing` last-resort dump was removed
+            # (#1170 finding 6): it returned every entity at score=0 with
+            # `partial: True`, which masked the underlying error and gave
+            # the agent a noise pile that was strictly worse than a clean
+            # error. If both real strategies fail we now propagate the
+            # exception so callers see why.
 
-            result: dict[str, Any] | None = None
+            result: dict[str, Any]
             warning: str | None = None
             search_type = "exact_match" if exact_match_bool else "fuzzy_search"
 
             if exact_match_bool:
-                # Exact match mode: skip fuzzy, go straight to substring matching
-                try:
-                    result = await _exact_match_search(
-                        client, query, domain_filter, limit, offset
-                    )
-                    search_type = "exact_match"
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exact_error:
-                    logger.warning(
-                        f"Exact match failed, trying partial results: {exact_error}"
-                    )
-                    try:
-                        result = await _partial_results_search(
-                            client, query, domain_filter, limit, offset
-                        )
-                        warning = "Search degraded, returning partial results"
-                        search_type = "partial_listing"
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as partial_error:
-                        logger.error(f"All search methods failed: {partial_error}")
-                        raise Exception("All search methods failed") from partial_error
+                # Exact match mode: substring matching only. No fallback —
+                # _exact_match_search only fails when client.get_states()
+                # itself fails, in which case any further retry is futile.
+                result = await _exact_match_search(
+                    client,
+                    query,
+                    domain_filter,
+                    limit,
+                    offset,
+                    include_hidden=include_hidden_bool,
+                )
+                search_type = "exact_match"
             else:
-                # Fuzzy mode: graceful degradation chain
+                # Fuzzy mode: BM25 → substring fallback on exception only.
                 try:
                     result = await smart_tools.smart_entity_search(
-                        query, limit, offset=offset, domain_filter=domain_filter
+                        query,
+                        limit,
+                        offset=offset,
+                        domain_filter=domain_filter,
+                        include_hidden=include_hidden_bool,
                     )
                     search_type = "fuzzy_search"
                 except asyncio.CancelledError:
                     raise
                 except Exception as fuzzy_error:
                     logger.warning(
-                        f"Fuzzy search failed, trying exact match: {fuzzy_error}"
+                        f"Fuzzy search failed, falling back to substring "
+                        f"match: {fuzzy_error}"
                     )
-                    try:
-                        result = await _exact_match_search(
-                            client, query, domain_filter, limit, offset
-                        )
-                        warning = "Fuzzy search unavailable, using exact match"
-                        search_type = "exact_match"
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as exact_error:
-                        logger.warning(
-                            f"Exact match failed, trying partial results: {exact_error}"
-                        )
-                        try:
-                            result = await _partial_results_search(
-                                client, query, domain_filter, limit, offset
-                            )
-                            warning = "Search degraded, returning partial results"
-                            search_type = "partial_listing"
-                        except asyncio.CancelledError:
-                            raise
-                        except Exception as partial_error:
-                            logger.error(f"All search methods failed: {partial_error}")
-                            raise Exception(
-                                "All search methods failed"
-                            ) from partial_error
+                    result = await _exact_match_search(
+                        client,
+                        query,
+                        domain_filter,
+                        limit,
+                        offset,
+                        include_hidden=include_hidden_bool,
+                    )
+                    warning = "Fuzzy search unavailable, using substring match"
+                    search_type = "exact_match"
 
             # Convert 'matches' to 'results' for backward compatibility
             if "matches" in result:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -15,6 +15,7 @@ from pydantic import Field
 from ..config import get_global_settings
 from ..errors import create_validation_error
 from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
+from ..utils.fuzzy_search import apply_hidden_penalty
 from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
 from .util_helpers import (
     add_timezone_metadata,
@@ -48,16 +49,17 @@ async def _exact_match_search(
     domain_filter: str | None,
     limit: int,
     offset: int = 0,
-    include_hidden: bool = False,
+    include_hidden: bool = True,
 ) -> dict[str, Any]:
     """
     Search entities by substring on entity_id + friendly_name.
 
     Used both as the ``exact_match=True`` primary path and as the
     fallback when fuzzy search raises. In addition to ``client.get_states()``,
-    also queries the entity registry via WebSocket to honor
-    ``include_hidden``: when False, entities with ``hidden_by != null``
-    are skipped.
+    also queries the entity registry via WebSocket to identify
+    ``hidden_by`` entities: by default they remain in results but
+    receive a score penalty so visible matches sort first; pass
+    ``include_hidden=False`` to filter them out entirely.
     """
     # Fetch states + entity registry in parallel. Registry-list failure
     # is tolerated (we just lose the hidden filter); states-fetch failure
@@ -76,11 +78,7 @@ async def _exact_match_search(
         raise state_result
     all_entities = state_result
     hidden_ids: set[str] = set()
-    if (
-        not include_hidden
-        and isinstance(registry_result, dict)
-        and registry_result.get("success")
-    ):
+    if isinstance(registry_result, dict) and registry_result.get("success"):
         for entry in registry_result.get("result", []):
             if entry.get("hidden_by") is not None:
                 eid = entry.get("entity_id")
@@ -92,7 +90,8 @@ async def _exact_match_search(
     results = []
     for entity in all_entities:
         entity_id = entity.get("entity_id", "")
-        if entity_id in hidden_ids:
+        is_hidden = entity_id in hidden_ids
+        if is_hidden and not include_hidden:
             continue
         attributes = entity.get("attributes", {})
         friendly_name = attributes.get("friendly_name", entity_id)
@@ -107,13 +106,16 @@ async def _exact_match_search(
             is_exact = (
                 query_lower == entity_id.lower() or query_lower == friendly_name.lower()
             )
+            score = 100 if is_exact else 80
+            if is_hidden:
+                score = apply_hidden_penalty(score, "_hidden")
             results.append(
                 {
                     "entity_id": entity_id,
                     "friendly_name": friendly_name,
                     "domain": domain,
                     "state": entity.get("state", "unknown"),
-                    "score": 100 if is_exact else 80,
+                    "score": score,
                     "match_type": "exact_match",
                 }
             )
@@ -198,16 +200,18 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         include_hidden: Annotated[
             bool | str,
             Field(
-                default=False,
+                default=True,
                 description=(
                     "Include entities marked hidden_by in the entity registry "
-                    "(default: False). Hidden entities are typically integration "
-                    "diagnostics or user-suppressed entries that an agent acting "
-                    "on a user phrase shouldn't surface. Set to True to include "
-                    "them — useful for diagnostics or service workflows."
+                    "(default: True). Hidden entities still appear in results "
+                    "but receive a score penalty so they sort below comparable "
+                    "visible matches — typically pulling integration "
+                    "diagnostics and user-suppressed entries to the bottom of "
+                    "the list rather than excluding them. Set to False to "
+                    "filter them out entirely."
                 ),
             ),
-        ] = False,
+        ] = True,
     ) -> dict[str, Any]:
         """Find or list entities (lights, sensors, switches, etc.) by name, domain, or area.
 
@@ -239,10 +243,15 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             or False
         )
         exact_match_bool = coerce_bool_param(exact_match, "exact_match", default=True)
-        include_hidden_bool = (
-            coerce_bool_param(include_hidden, "include_hidden", default=False)
-            or False
+        # Default True: hidden entities are kept (with score penalty) unless
+        # the caller explicitly opts out by passing include_hidden=False.
+        coerced_hidden = coerce_bool_param(
+            include_hidden, "include_hidden", default=True
         )
+        # coerce_bool_param returns the default when value is None; with
+        # default=True the result is a real bool, but the type system
+        # still admits None — coalesce defensively for static typing.
+        include_hidden_bool = coerced_hidden if coerced_hidden is not None else True
 
         try:
             offset = coerce_int_param(offset, "offset", default=0, min_value=0) or 0
@@ -332,6 +341,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             "_aliases": aliases_map.get(
                                 entity.get("entity_id", ""), []
                             ),
+                            "_hidden_by": entity.get("_hidden_by"),
                         }
                         for entity in all_area_entities
                     ]
@@ -411,9 +421,12 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 # Add score+match_type so the response
                                 # shape matches the other four
                                 # search-type branches. Score=100 because
-                                # area membership is exact, not fuzzy.
-                                # Strip leading-underscore internal
-                                # fields (e.g. `_aliases`) so the
+                                # area membership is exact, not fuzzy;
+                                # hidden entities receive the standard
+                                # penalty so they sort below visible
+                                # peers within the same area. Strip
+                                # leading-underscore internal fields
+                                # (e.g. `_aliases`, `_hidden_by`) so the
                                 # response only contains public-API
                                 # fields.
                                 all_results.extend(
@@ -424,12 +437,18 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                             if not k.startswith("_")
                                         },
                                         "domain": domain,
-                                        "score": 100,
+                                        "score": apply_hidden_penalty(
+                                            100, entity.get("_hidden_by")
+                                        ),
                                         "match_type": "area_match",
                                     }
                                     for entity in entities
                                 )
 
+                        # Re-sort so visible matches outrank penalised
+                        # hidden ones; iteration order alone doesn't
+                        # guarantee that for an area with mixed entities.
+                        all_results.sort(key=lambda x: x["score"], reverse=True)
                         paginated = all_results[offset : offset + limit]
 
                         area_search_data: dict[str, Any] = {
@@ -504,48 +523,53 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     raise states_result
                 all_entities = states_result
                 hidden_ids: set[str] = set()
-                if (
-                    not include_hidden_bool
-                    and isinstance(registry_result, dict)
-                    and registry_result.get("success")
-                ):
+                if isinstance(registry_result, dict) and registry_result.get("success"):
                     for entry in registry_result.get("result", []):
                         if entry.get("hidden_by") is not None:
                             eid = entry.get("entity_id")
                             if eid:
                                 hidden_ids.add(eid)
 
-                # Filter by domain (and hidden_by, when not opted in)
+                # Filter by domain. Hidden entities are kept by default
+                # (with score penalty applied below); ``include_hidden=False``
+                # filters them out entirely.
                 filtered_entities = [
                     e
                     for e in all_entities
                     if e.get("entity_id", "").startswith(f"{domain_filter}.")
-                    and e.get("entity_id") not in hidden_ids
+                    and (
+                        include_hidden_bool
+                        or e.get("entity_id") not in hidden_ids
+                    )
                 ]
 
-                # Format results to match fuzzy search output
-                paginated_entities = filtered_entities[offset : offset + limit]
-                results = []
-                for entity in paginated_entities:
+                # Score: 100 baseline for domain membership (exact, not
+                # fuzzy); penalised for hidden entries so they sort below
+                # visible peers within the same domain.
+                scored_entities = []
+                for entity in filtered_entities:
                     entity_id = entity.get("entity_id", "")
                     attributes = entity.get("attributes", {})
-                    results.append(
-                        {
-                            "entity_id": entity_id,
-                            "friendly_name": attributes.get("friendly_name", entity_id),
-                            "domain": domain_filter,
-                            "state": entity.get("state", "unknown"),
-                            "score": 100,  # Perfect match since we're listing by domain
-                            "match_type": "domain_listing",
-                        }
+                    score = apply_hidden_penalty(
+                        100, "_hidden" if entity_id in hidden_ids else None
                     )
+                    scored_entities.append({
+                        "entity_id": entity_id,
+                        "friendly_name": attributes.get("friendly_name", entity_id),
+                        "domain": domain_filter,
+                        "state": entity.get("state", "unknown"),
+                        "score": score,
+                        "match_type": "domain_listing",
+                    })
+                scored_entities.sort(key=lambda x: x["score"], reverse=True)
+                results = scored_entities[offset : offset + limit]
 
                 domain_list_data: dict[str, Any] = {
                     "success": True,
                     "query": query,
                     "domain_filter": domain_filter,
                     **_build_pagination_metadata(
-                        len(filtered_entities), offset, limit, results
+                        len(scored_entities), offset, limit, results
                     ),
                     "results": results,
                     "search_type": "domain_listing",

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -243,11 +243,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     parameter="query",
                 )
             )
-        # HA domains are canonically lowercase; agents that capitalize from a
-        # user phrase ("turn on the Lights") would otherwise hit a silent
-        # zero-result.
+        # HA domains are canonically lowercase, no whitespace; agents that
+        # capitalize ("Lights") or pad ("  light  ") would otherwise hit a
+        # silent zero-result against the prefix match downstream. Strip
+        # before lowercasing so the canonical value flows through the
+        # response echo and the operator-facing note message.
         if domain_filter:
-            domain_filter = domain_filter.lower()
+            domain_filter = domain_filter.strip().lower()
 
         try:
             # Param coercion stays inside try/except so a malformed

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -77,6 +77,11 @@ async def _exact_match_search(
     registry_result: Any = gather_results[1]
     if isinstance(state_result, BaseException):
         raise state_result
+    # CancelledError comes through gather as a captured exception even
+    # when return_exceptions=True; it has to propagate or the canceller
+    # waits forever.
+    if isinstance(registry_result, asyncio.CancelledError):
+        raise registry_result
     all_entities = state_result
     hidden_ids: set[str] = set()
     if isinstance(registry_result, dict) and registry_result.get("success"):
@@ -131,8 +136,10 @@ async def _exact_match_search(
                 }
             )
 
-    # Sort by score descending
-    results.sort(key=lambda x: x["score"], reverse=True)
+    # Sort by score descending, tie-break on entity_id for stable
+    # pagination when many results share a score (visible substring
+    # hits at 100, hidden ones at 80 etc).
+    results.sort(key=lambda x: (-x["score"], x["entity_id"]))
     paginated = results[offset : offset + limit]
     return {
         "success": True,
@@ -224,7 +231,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = True,
     ) -> dict[str, Any]:
-        """Find or list entities (lights, sensors, switches, etc.) by name, domain, or area.
+        """Search for entities (lights, sensors, switches, etc.) by name, domain, or area.
 
         When NOT to use: for searching inside automation, script, helper, or dashboard
         *configurations* (e.g. which automations call a service or reference an entity),
@@ -236,6 +243,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         """
         # Normalize omitted/None query to empty string so downstream logic is unchanged
         query = query or ""
+        # HA domains are canonically lowercase, no whitespace; agents
+        # that capitalize ("Lights") or pad ("  light  ") would
+        # otherwise hit a silent zero-result against the prefix match
+        # downstream. Strip-then-lowercase before validation so a
+        # whitespace-only filter ("   ") collapses to "" and fails the
+        # at-least-one-set check rather than passing it and falling
+        # through to a no-op fuzzy search.
+        if domain_filter:
+            domain_filter = domain_filter.strip().lower()
+        if area_filter:
+            area_filter = area_filter.strip()
         if not query.strip() and not domain_filter and not area_filter:
             raise_tool_error(
                 create_validation_error(
@@ -243,13 +261,6 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     parameter="query",
                 )
             )
-        # HA domains are canonically lowercase, no whitespace; agents that
-        # capitalize ("Lights") or pad ("  light  ") would otherwise hit a
-        # silent zero-result against the prefix match downstream. Strip
-        # before lowercasing so the canonical value flows through the
-        # response echo and the operator-facing note message.
-        if domain_filter:
-            domain_filter = domain_filter.strip().lower()
 
         try:
             # Param coercion stays inside try/except so a malformed
@@ -461,7 +472,15 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         # Re-sort so visible matches outrank penalised
                         # hidden ones; iteration order alone doesn't
                         # guarantee that for an area with mixed entities.
-                        all_results.sort(key=lambda x: x["score"], reverse=True)
+                        # Tie-break on entity_id so paginated requests
+                        # return a stable ordering when many results
+                        # share a score (every visible area_match is at
+                        # 100, every hidden one at 80 — without the
+                        # secondary key the page split would shift
+                        # between calls).
+                        all_results.sort(
+                            key=lambda x: (-x["score"], x["entity_id"])
+                        )
                         paginated = all_results[offset : offset + limit]
 
                         area_search_data: dict[str, Any] = {
@@ -534,6 +553,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 registry_result: Any = gather_results[1]
                 if isinstance(states_result, BaseException):
                     raise states_result
+                # CancelledError must propagate; gather captures it like
+                # any other exception when return_exceptions=True.
+                if isinstance(registry_result, asyncio.CancelledError):
+                    raise registry_result
                 all_entities = states_result
                 hidden_ids: set[str] = set()
                 if isinstance(registry_result, dict) and registry_result.get("success"):
@@ -581,7 +604,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "score": score,
                         "match_type": "domain_listing",
                     })
-                scored_entities.sort(key=lambda x: x["score"], reverse=True)
+                # Tie-break on entity_id for stable pagination — every
+                # visible domain entry scores 100 and every hidden one
+                # scores 80, so sorting by score alone leaves the
+                # within-tier ordering up to dict iteration.
+                scored_entities.sort(
+                    key=lambda x: (-x["score"], x["entity_id"])
+                )
                 results = scored_entities[offset : offset + limit]
 
                 domain_list_data: dict[str, Any] = {

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -23,6 +23,40 @@ logger = logging.getLogger(__name__)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 
+def strip_internal_fields(obj: Any) -> Any:
+    """Remove leading-underscore keys from ``obj`` and any nested dicts
+    or lists in place.
+
+    The ha-mcp tool layer enriches entity / area dicts with internal
+    fields like ``_hidden_by`` and ``_aliases`` so downstream branches
+    can rank without re-querying the entity registry. Those keys must
+    not leak through public tool returns: this helper centralises the
+    convention so individual call sites don't have to remember to strip.
+    """
+    if isinstance(obj, dict):
+        for key in [k for k in obj if isinstance(k, str) and k.startswith("_")]:
+            obj.pop(key, None)
+        for value in obj.values():
+            strip_internal_fields(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            strip_internal_fields(item)
+    return obj
+
+
+def public_fields(d: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of ``d`` with leading-underscore keys
+    removed. Non-mutating counterpart to :func:`strip_internal_fields`,
+    for the comprehension call-sites where in-place mutation is
+    awkward (e.g. building a new result dict from an enriched input).
+    """
+    return {
+        k: v
+        for k, v in d.items()
+        if not (isinstance(k, str) and k.startswith("_"))
+    }
+
+
 def coerce_bool_param(
     value: bool | str | None,
     param_name: str = "parameter",

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 
-def strip_internal_fields(obj: Any) -> Any:
+def strip_internal_fields(obj: Any, _seen: set[int] | None = None) -> Any:
     """Remove leading-underscore keys from ``obj`` and any nested dicts
     or lists in place.
 
@@ -32,23 +32,36 @@ def strip_internal_fields(obj: Any) -> Any:
     can rank without re-querying the entity registry. Those keys must
     not leak through public tool returns: this helper centralises the
     convention so individual call sites don't have to remember to strip.
+
+    Mutates in place and returns the same reference for chaining. Cycle
+    guard via ``_seen`` (id-tracked) keeps the recursion safe if a
+    future caller ever feeds it a non-tree structure — JSON payloads
+    don't, but the helper is now a generic utility (importable from
+    ``server.py``) so the protection is cheap insurance.
     """
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return obj
     if isinstance(obj, dict):
+        _seen.add(obj_id)
         for key in [k for k in obj if isinstance(k, str) and k.startswith("_")]:
             obj.pop(key, None)
         for value in obj.values():
-            strip_internal_fields(value)
+            strip_internal_fields(value, _seen)
     elif isinstance(obj, list):
+        _seen.add(obj_id)
         for item in obj:
-            strip_internal_fields(item)
+            strip_internal_fields(item, _seen)
     return obj
 
 
 def public_fields(d: dict[str, Any]) -> dict[str, Any]:
     """Return a shallow copy of ``d`` with leading-underscore keys
-    removed. Non-mutating counterpart to :func:`strip_internal_fields`,
-    for the comprehension call-sites where in-place mutation is
-    awkward (e.g. building a new result dict from an enriched input).
+    removed. Non-mutating counterpart to :func:`strip_internal_fields`.
+    Shallow only — list/dict values are shared with the source, so a
+    later mutation of those values would propagate.
     """
     return {
         k: v

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -32,7 +32,7 @@ def tokenize(text: str) -> list[str]:
 
 
 def _strip_separators(text: str) -> str:
-    """Lowercase ``text`` and remove `.`, `_`, `-`, whitespace.
+    """Strip ``.``, ``_``, ``-``, whitespace from *text* and lowercase.
 
     Used to add elided-separator forms to the BM25 corpus so queries
     like ``bedlight`` match tokens like ``bed_light`` (#1170).

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -39,10 +39,13 @@ def apply_hidden_penalty(score: int, hidden_by: Any) -> int:
     """Return ``score`` reduced by :data:`HIDDEN_SCORE_PENALTY` when
     ``hidden_by`` indicates a hidden entity. Used by every search
     branch that emits a ``score`` field so the ranking is consistent.
+    Coerces ``score`` to ``int`` so a stray float caller can't break
+    the result-dict's int contract for ``score``.
     """
+    s = int(score)
     if hidden_by is not None:
-        return max(0, score - HIDDEN_SCORE_PENALTY)
-    return score
+        return max(0, s - HIDDEN_SCORE_PENALTY)
+    return s
 
 
 def tokenize(text: str) -> list[str]:
@@ -269,10 +272,15 @@ class FuzzyEntitySearcher:
             for i, raw in enumerate(raw_scores):
                 if raw <= 0:
                     continue
-                score = min(100, round(raw / theoretical_max * 100))
-                score = apply_hidden_penalty(score, hidden_flags[i])
-                if score < self.threshold:
+                # Threshold gates the *raw* match quality so the option-c
+                # contract holds: a hidden entity that genuinely matches
+                # at threshold doesn't get penalised below it and silently
+                # disappear. Penalty is applied only after the gate, so it
+                # affects ranking but not visibility.
+                raw_score = min(100, round(raw / theoretical_max * 100))
+                if raw_score < self.threshold:
                     continue
+                score = apply_hidden_penalty(raw_score, hidden_flags[i])
                 eid, fname, domain, attrs, state = meta[i]
                 # If any query token matched only on the alias haystack,
                 # surface that to the caller via match_type — useful both
@@ -360,16 +368,17 @@ class FuzzyEntitySearcher:
             entity_hidden = (
                 hidden_flags[i] if hidden_flags is not None else None
             )
-            penalised = apply_hidden_penalty(best_token_score, entity_hidden)
-            if penalised < 75:  # mirror typo-fallback threshold
-                continue
+            # Apply the hidden penalty after the threshold gate above so
+            # borderline hidden matches still surface (option-c contract);
+            # the penalty only re-ranks them.
+            score = apply_hidden_penalty(best_token_score, entity_hidden)
             results.append({
                 "entity_id": eid,
                 "friendly_name": fname,
                 "domain": domain,
                 "state": state,
                 "attributes": attrs,
-                "score": penalised,
+                "score": score,
                 "match_type": "typo_fallback",
             })
         return results

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -35,7 +35,7 @@ def _strip_separators(text: str) -> str:
     """Strip ``.``, ``_``, ``-``, whitespace from *text* and lowercase.
 
     Used to add elided-separator forms to the BM25 corpus so queries
-    like ``bedlight`` match tokens like ``bed_light`` (#1170).
+    like ``bedlight`` match tokens like ``bed_light``.
     """
     return _SPLIT_RE.sub("", text.lower())
 
@@ -252,7 +252,7 @@ class FuzzyEntitySearcher:
                 # If any query token matched only on the alias haystack,
                 # surface that to the caller via match_type — useful both
                 # for telemetry and for the agent to know the friendly_name
-                # alone wouldn't have led it here. (#1170 finding 8.)
+                # alone wouldn't have led it here.
                 hit_alias_tokens = query_token_set & alias_hit[i]
                 if hit_alias_tokens:
                     match_type = "alias_match"
@@ -297,9 +297,9 @@ class FuzzyEntitySearcher:
         For multi-token queries, additionally requires coverage:
         at least half of the distinct query tokens must each have *some*
         doc token they ratio-match. Without this, a single-token
-        accidental hit (e.g. ``garbage`` ≈ ``garage``) was enough to
-        surface unrelated entities at score 92 from queries like
-        ``xyz_irrelevant_garbage``. (#1170 finding 5.)
+        accidental hit (e.g. ``garbage`` ≈ ``garage``) is enough to
+        surface unrelated entities at score 92 from a 3-token query
+        whose other two tokens have no doc relationship.
         """
         del query_lower  # parameter kept for API compatibility
         results: list[dict[str, Any]] = []

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -272,11 +272,11 @@ class FuzzyEntitySearcher:
             for i, raw in enumerate(raw_scores):
                 if raw <= 0:
                     continue
-                # Threshold gates the *raw* match quality so the option-c
-                # contract holds: a hidden entity that genuinely matches
-                # at threshold doesn't get penalised below it and silently
-                # disappear. Penalty is applied only after the gate, so it
-                # affects ranking but not visibility.
+                # Threshold gates the *raw* match quality: a hidden
+                # entity that genuinely matches at threshold shouldn't
+                # get penalised below it and silently disappear.
+                # Penalty is applied only after the gate, so it affects
+                # ranking but not visibility.
                 raw_score = min(100, round(raw / theoretical_max * 100))
                 if raw_score < self.threshold:
                     continue
@@ -311,10 +311,13 @@ class FuzzyEntitySearcher:
         bm25_found_any = any(raw > 0 for raw in raw_scores)
         if not matches and not bm25_found_any:
             matches = self._typo_fallback(
-                query_tokens, query_lower, docs, meta, hidden_flags
+                query_tokens, docs, meta, hidden_flags
             )
 
-        matches.sort(key=lambda x: x["score"], reverse=True)
+        # Tie-break on entity_id so paginated requests return stable
+        # ordering when several entities share a score (common with the
+        # hidden-penalty bands at 100/80 and BM25's coarse score buckets).
+        matches.sort(key=lambda x: (-x["score"], x["entity_id"]))
         total_matches = len(matches)
         return matches[offset:offset + limit], total_matches
 
@@ -323,7 +326,6 @@ class FuzzyEntitySearcher:
     def _typo_fallback(
         self,
         query_tokens: list[str],
-        query_lower: str,
         docs: list[list[str]],
         meta: list[tuple[str, str, str, dict[str, Any], str]],
         hidden_flags: list[Any] | None = None,
@@ -337,7 +339,6 @@ class FuzzyEntitySearcher:
         surface unrelated entities at score 92 from a 3-token query
         whose other two tokens have no doc relationship.
         """
-        del query_lower  # parameter kept for API compatibility
         results: list[dict[str, Any]] = []
         distinct_query_tokens = list(dict.fromkeys(query_tokens))
         n_distinct = len(distinct_query_tokens)
@@ -368,9 +369,9 @@ class FuzzyEntitySearcher:
             entity_hidden = (
                 hidden_flags[i] if hidden_flags is not None else None
             )
-            # Apply the hidden penalty after the threshold gate above so
-            # borderline hidden matches still surface (option-c contract);
-            # the penalty only re-ranks them.
+            # Apply the hidden penalty after the threshold gate above
+            # so borderline hidden matches still surface; the penalty
+            # only re-ranks them.
             score = apply_hidden_penalty(best_token_score, entity_hidden)
             results.append({
                 "entity_id": eid,

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -342,6 +342,16 @@ class FuzzyEntitySearcher:
         results: list[dict[str, Any]] = []
         distinct_query_tokens = list(dict.fromkeys(query_tokens))
         n_distinct = len(distinct_query_tokens)
+        # Single-token min-length gate: short queries like ``lit`` (3
+        # chars) match too generously via partial overlap (every
+        # ``*_lite*`` entity surfaces at score 85). The multi-token
+        # coverage gate above doesn't help here (n_distinct == 1).
+        # Suppress the fallback entirely for short single-token
+        # queries — they almost never represent a typo, and the BM25
+        # path above already serves substring intent at a higher
+        # score floor.
+        if n_distinct == 1 and len(query_tokens[0]) < 4:
+            return results
         for i, doc_tokens in enumerate(docs):
             best_token_score = 0
             for qt in query_tokens:

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -32,15 +32,10 @@ def tokenize(text: str) -> list[str]:
 
 
 def _strip_separators(text: str) -> str:
-    """Return *text* lowercased with all `._-\\s` removed.
+    """Lowercase ``text`` and remove `.`, `_`, `-`, whitespace.
 
-    Used to expose elided-separator forms in the BM25 corpus so a query
-    like `bedlight` can directly match the doc token built from
-    `light.bed_light`'s tail (`bed_light` → `bedlight`). Without this,
-    BM25 finds nothing and falls through to typo_fallback, which then
-    ties unrelated `*_lights` entities at the same score because each
-    of them has a single token (`light`) that fuzzy-matches part of
-    the query. (#1170 finding 2.)
+    Used to add elided-separator forms to the BM25 corpus so queries
+    like ``bedlight`` match tokens like ``bed_light`` (#1170).
     """
     return _SPLIT_RE.sub("", text.lower())
 
@@ -196,9 +191,7 @@ class FuzzyEntitySearcher:
             tokens = list(id_tokens + name_tokens)
 
             # Separator-stripped forms (concat tokens) so queries that
-            # elide separators match. We add the entity_id tail (after
-            # the first dot) and the friendly_name to handle the common
-            # `bedlight` → `light.bed_light` / `Bed Light` case.
+            # elide separators match — e.g. `bedlight` finds `light.bed_light`.
             tail = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
             tail_concat = _strip_separators(tail)
             if tail_concat:
@@ -208,20 +201,28 @@ class FuzzyEntitySearcher:
                 tokens.append(name_concat)
 
             # Aliases (entity registry). Each alias contributes both its
-            # tokenized form and its separator-stripped concat. Track the
-            # token set so we can label the result `alias_match` later
-            # without re-checking every alias against the query.
+            # tokenized form and its separator-stripped concat. We track
+            # only the alias tokens that *aren't* already in id+name —
+            # otherwise a query like `bed` would mislabel a friendly_name
+            # match as `alias_match` whenever the entity also has a
+            # `bed`-containing alias.
+            id_name_tokens = set(id_tokens) | set(name_tokens)
+            id_name_tokens.add(tail_concat)
+            id_name_tokens.add(name_concat)
             entity_alias_tokens: set[str] = set()
             for alias in entity.get("_aliases", []) or []:
                 if not isinstance(alias, str):
                     continue
                 a_tokens = tokenize(alias)
                 tokens.extend(a_tokens)
-                entity_alias_tokens.update(a_tokens)
+                for t in a_tokens:
+                    if t not in id_name_tokens:
+                        entity_alias_tokens.add(t)
                 a_concat = _strip_separators(alias)
                 if a_concat:
                     tokens.append(a_concat)
-                    entity_alias_tokens.add(a_concat)
+                    if a_concat not in id_name_tokens:
+                        entity_alias_tokens.add(a_concat)
 
             docs.append(tokens)
             meta.append((entity_id, friendly_name, domain, attributes, state))

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -25,6 +25,25 @@ logger = logging.getLogger(__name__)
 
 _SPLIT_RE = re.compile(r"[._\-\s]+")
 
+# Score subtraction for entities marked ``hidden_by`` in the entity
+# registry. Hidden entities still surface in results, but a 20-point
+# penalty pushes them below comparable visible matches when both are
+# emitted by the same search branch. Picked so that an exact id/name
+# hit on a hidden entity (raw 100 → 80) still ranks above a fuzzy
+# threshold-floor visible match (60-70), but loses to any visible
+# entity scoring 80+.
+HIDDEN_SCORE_PENALTY = 20
+
+
+def apply_hidden_penalty(score: int, hidden_by: Any) -> int:
+    """Return ``score`` reduced by :data:`HIDDEN_SCORE_PENALTY` when
+    ``hidden_by`` indicates a hidden entity. Used by every search
+    branch that emits a ``score`` field so the ranking is consistent.
+    """
+    if hidden_by is not None:
+        return max(0, score - HIDDEN_SCORE_PENALTY)
+    return score
+
 
 def tokenize(text: str) -> list[str]:
     """Split text on `.`, `_`, `-`, and whitespace, lowercase, drop empties."""
@@ -178,6 +197,10 @@ class FuzzyEntitySearcher:
         meta: list[tuple[str, str, str, dict[str, Any], str]] = []  # eid, name, domain, attrs, state
         # Track which entities matched on alias (for `match_type="alias_match"`).
         alias_hit: list[set[str]] = []
+        # Track ``hidden_by`` per entity so the score-penalty pass can
+        # depress hidden hits without filtering them. Callers enrich via
+        # the ``_hidden_by`` key — see smart_search.smart_entity_search.
+        hidden_flags: list[Any] = []
 
         for entity in entities:
             entity_id = entity.get("entity_id", "")
@@ -227,6 +250,7 @@ class FuzzyEntitySearcher:
             docs.append(tokens)
             meta.append((entity_id, friendly_name, domain, attributes, state))
             alias_hit.append(entity_alias_tokens)
+            hidden_flags.append(entity.get("_hidden_by"))
 
         # Fit BM25
         scorer = BM25Scorer()
@@ -246,6 +270,7 @@ class FuzzyEntitySearcher:
                 if raw <= 0:
                     continue
                 score = min(100, round(raw / theoretical_max * 100))
+                score = apply_hidden_penalty(score, hidden_flags[i])
                 if score < self.threshold:
                     continue
                 eid, fname, domain, attrs, state = meta[i]
@@ -277,7 +302,9 @@ class FuzzyEntitySearcher:
         # exactly the noise floor the new absolute normalization is fixing.
         bm25_found_any = any(raw > 0 for raw in raw_scores)
         if not matches and not bm25_found_any:
-            matches = self._typo_fallback(query_tokens, query_lower, docs, meta)
+            matches = self._typo_fallback(
+                query_tokens, query_lower, docs, meta, hidden_flags
+            )
 
         matches.sort(key=lambda x: x["score"], reverse=True)
         total_matches = len(matches)
@@ -291,6 +318,7 @@ class FuzzyEntitySearcher:
         query_lower: str,
         docs: list[list[str]],
         meta: list[tuple[str, str, str, dict[str, Any], str]],
+        hidden_flags: list[Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Token-level SequenceMatcher fallback for typo correction.
 
@@ -329,13 +357,19 @@ class FuzzyEntitySearcher:
                     continue
 
             eid, fname, domain, attrs, state = meta[i]
+            entity_hidden = (
+                hidden_flags[i] if hidden_flags is not None else None
+            )
+            penalised = apply_hidden_penalty(best_token_score, entity_hidden)
+            if penalised < 75:  # mirror typo-fallback threshold
+                continue
             results.append({
                 "entity_id": eid,
                 "friendly_name": fname,
                 "domain": domain,
                 "state": state,
                 "attributes": attrs,
-                "score": best_token_score,
+                "score": penalised,
                 "match_type": "typo_fallback",
             })
         return results

--- a/src/ha_mcp/utils/fuzzy_search.py
+++ b/src/ha_mcp/utils/fuzzy_search.py
@@ -31,6 +31,20 @@ def tokenize(text: str) -> list[str]:
     return [t for t in _SPLIT_RE.split(text.lower()) if t]
 
 
+def _strip_separators(text: str) -> str:
+    """Return *text* lowercased with all `._-\\s` removed.
+
+    Used to expose elided-separator forms in the BM25 corpus so a query
+    like `bedlight` can directly match the doc token built from
+    `light.bed_light`'s tail (`bed_light` → `bedlight`). Without this,
+    BM25 finds nothing and falls through to typo_fallback, which then
+    ties unrelated `*_lights` entities at the same score because each
+    of them has a single token (`light`) that fuzzy-matches part of
+    the query. (#1170 finding 2.)
+    """
+    return _SPLIT_RE.sub("", text.lower())
+
+
 # ---------------------------------------------------------------------------
 # BM25 scorer – lightweight, zero-dependency
 # ---------------------------------------------------------------------------
@@ -163,8 +177,12 @@ class FuzzyEntitySearcher:
             return [], 0
 
         # Build per-entity document: tokens from entity_id + friendly_name
+        # + entity registry aliases (when callers enrich entities with the
+        # ``_aliases`` key — see smart_search.smart_entity_search).
         docs: list[list[str]] = []
         meta: list[tuple[str, str, str, dict[str, Any], str]] = []  # eid, name, domain, attrs, state
+        # Track which entities matched on alias (for `match_type="alias_match"`).
+        alias_hit: list[set[str]] = []
 
         for entity in entities:
             entity_id = entity.get("entity_id", "")
@@ -173,9 +191,41 @@ class FuzzyEntitySearcher:
             domain = entity_id.split(".")[0] if "." in entity_id else ""
             state = entity.get("state", "unknown")
 
-            tokens = tokenize(entity_id) + tokenize(friendly_name)
+            id_tokens = tokenize(entity_id)
+            name_tokens = tokenize(friendly_name)
+            tokens = list(id_tokens + name_tokens)
+
+            # Separator-stripped forms (concat tokens) so queries that
+            # elide separators match. We add the entity_id tail (after
+            # the first dot) and the friendly_name to handle the common
+            # `bedlight` → `light.bed_light` / `Bed Light` case.
+            tail = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+            tail_concat = _strip_separators(tail)
+            if tail_concat:
+                tokens.append(tail_concat)
+            name_concat = _strip_separators(friendly_name)
+            if name_concat and name_concat != tail_concat:
+                tokens.append(name_concat)
+
+            # Aliases (entity registry). Each alias contributes both its
+            # tokenized form and its separator-stripped concat. Track the
+            # token set so we can label the result `alias_match` later
+            # without re-checking every alias against the query.
+            entity_alias_tokens: set[str] = set()
+            for alias in entity.get("_aliases", []) or []:
+                if not isinstance(alias, str):
+                    continue
+                a_tokens = tokenize(alias)
+                tokens.extend(a_tokens)
+                entity_alias_tokens.update(a_tokens)
+                a_concat = _strip_separators(alias)
+                if a_concat:
+                    tokens.append(a_concat)
+                    entity_alias_tokens.add(a_concat)
+
             docs.append(tokens)
             meta.append((entity_id, friendly_name, domain, attributes, state))
+            alias_hit.append(entity_alias_tokens)
 
         # Fit BM25
         scorer = BM25Scorer()
@@ -190,6 +240,7 @@ class FuzzyEntitySearcher:
         matches: list[dict[str, Any]] = []
 
         if theoretical_max > 0:
+            query_token_set = set(query_tokens)
             for i, raw in enumerate(raw_scores):
                 if raw <= 0:
                     continue
@@ -197,6 +248,17 @@ class FuzzyEntitySearcher:
                 if score < self.threshold:
                     continue
                 eid, fname, domain, attrs, state = meta[i]
+                # If any query token matched only on the alias haystack,
+                # surface that to the caller via match_type — useful both
+                # for telemetry and for the agent to know the friendly_name
+                # alone wouldn't have led it here. (#1170 finding 8.)
+                hit_alias_tokens = query_token_set & alias_hit[i]
+                if hit_alias_tokens:
+                    match_type = "alias_match"
+                else:
+                    match_type = self._get_match_type(
+                        eid, fname, domain, query_lower
+                    )
                 matches.append({
                     "entity_id": eid,
                     "friendly_name": fname,
@@ -204,7 +266,7 @@ class FuzzyEntitySearcher:
                     "state": state,
                     "attributes": attrs,
                     "score": score,
-                    "match_type": self._get_match_type(eid, fname, domain, query_lower),
+                    "match_type": match_type,
                 })
 
         # Tier-3 fallback: token-level SequenceMatcher only if BM25 scored
@@ -229,8 +291,19 @@ class FuzzyEntitySearcher:
         docs: list[list[str]],
         meta: list[tuple[str, str, str, dict[str, Any], str]],
     ) -> list[dict[str, Any]]:
-        """Token-level SequenceMatcher fallback for typo correction."""
+        """Token-level SequenceMatcher fallback for typo correction.
+
+        For multi-token queries, additionally requires coverage:
+        at least half of the distinct query tokens must each have *some*
+        doc token they ratio-match. Without this, a single-token
+        accidental hit (e.g. ``garbage`` ≈ ``garage``) was enough to
+        surface unrelated entities at score 92 from queries like
+        ``xyz_irrelevant_garbage``. (#1170 finding 5.)
+        """
+        del query_lower  # parameter kept for API compatibility
         results: list[dict[str, Any]] = []
+        distinct_query_tokens = list(dict.fromkeys(query_tokens))
+        n_distinct = len(distinct_query_tokens)
         for i, doc_tokens in enumerate(docs):
             best_token_score = 0
             for qt in query_tokens:
@@ -238,17 +311,32 @@ class FuzzyEntitySearcher:
                     ratio = calculate_ratio(qt, dt)
                     best_token_score = max(best_token_score, ratio)
 
-            if best_token_score >= 75:  # stricter threshold for typo fallback
-                eid, fname, domain, attrs, state = meta[i]
-                results.append({
-                    "entity_id": eid,
-                    "friendly_name": fname,
-                    "domain": domain,
-                    "state": state,
-                    "attributes": attrs,
-                    "score": best_token_score,
-                    "match_type": "typo_fallback",
-                })
+            if best_token_score < 75:  # stricter threshold for typo fallback
+                continue
+
+            # Multi-token coverage gate: how many distinct query tokens
+            # have any doc token within the typo-fallback threshold?
+            # A 3-token nonsense query that only one token explains
+            # (coverage 1/3) is rejected; a single-token query is always
+            # fully covered so unaffected.
+            if n_distinct > 1:
+                covered = 0
+                for qt in distinct_query_tokens:
+                    if any(calculate_ratio(qt, dt) >= 75 for dt in doc_tokens):
+                        covered += 1
+                if covered * 2 < n_distinct:  # < 50% coverage
+                    continue
+
+            eid, fname, domain, attrs, state = meta[i]
+            results.append({
+                "entity_id": eid,
+                "friendly_name": fname,
+                "domain": domain,
+                "state": state,
+                "attributes": attrs,
+                "score": best_token_score,
+                "match_type": "typo_fallback",
+            })
         return results
 
     def _calculate_entity_score(

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1013,8 +1013,8 @@ async def test_area_filter_fuzzy_multi_area_with_query(
 
 @pytest.mark.asyncio
 async def test_domain_filter_uppercase_normalized_issue_1170(mcp_client):
-    """domain_filter is lowercased so agents that capitalize from a user
-    phrase (e.g. ``"turn on the Lights"``) don't hit a silent zero-result.
+    """domain_filter is stripped + lowercased so agents that capitalize
+    or pad from a user phrase don't hit a silent zero-result.
     (#1170 finding 1.)"""
     lower = await mcp_client.call_tool(
         "ha_search_entities", {"domain_filter": "light", "limit": 50}
@@ -1033,6 +1033,60 @@ async def test_domain_filter_uppercase_normalized_issue_1170(mcp_client):
     )
     # Echoed in normalized form so callers can see the canonical value.
     assert upper_data["domain_filter"] == "light"
+
+
+@pytest.mark.parametrize(
+    "padded",
+    ["  light  ", "\tlight", "light\n", "  Light  ", " LIGHT\t"],
+    ids=["padded", "tab-prefix", "newline-suffix", "padded-mixed-case", "tab-and-upper"],
+)
+@pytest.mark.asyncio
+async def test_domain_filter_whitespace_normalized_issue_1170(mcp_client, padded):
+    """domain_filter strips whitespace AND lowercases before the prefix
+    match. Pre-stress-test, only ``.lower()`` was applied: a padded
+    value like ``"  LIGHT  "`` returned a silent 0-result because the
+    prefix match ran against the unstripped string. This regression
+    test pins the strip step so a future revert silently re-introduces
+    the bug."""
+    canonical = await mcp_client.call_tool(
+        "ha_search_entities", {"domain_filter": "light", "limit": 50}
+    )
+    padded_call = await mcp_client.call_tool(
+        "ha_search_entities", {"domain_filter": padded, "limit": 50}
+    )
+    canon_data = assert_mcp_success(canonical, "canonical").get("data", {})
+    padded_data = assert_mcp_success(padded_call, f"padded={padded!r}").get("data", {})
+    assert canon_data["total_matches"] > 0, (
+        f"baseline canonical should return results: {canon_data}"
+    )
+    assert padded_data["total_matches"] == canon_data["total_matches"], (
+        f"padded domain_filter must match canonical: "
+        f"padded={padded!r} ({padded_data}), canon={canon_data}"
+    )
+    assert padded_data["domain_filter"] == "light", (
+        f"padded domain_filter should be echoed canonicalized: {padded_data}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_domain_filter_whitespace_only_rejected_issue_1170(mcp_client):
+    """``domain_filter='   '`` (all whitespace, no other filters) must
+    fail validation rather than collapse to '' and fall through to a
+    silent zero-result fuzzy search. Pre-fix, the strip happened
+    *after* the at-least-one-set check, so a whitespace-only filter
+    passed as truthy and then normalised to an empty string
+    downstream."""
+    data = await safe_call_tool(
+        mcp_client, "ha_search_entities", {"domain_filter": "   ", "limit": 5}
+    )
+    inner = data.get("data", data)
+    assert inner.get("success") is False, (
+        f"whitespace-only domain_filter should fail validation: {inner}"
+    )
+    error = inner.get("error", {})
+    assert isinstance(error, dict) and error.get("code") == "VALIDATION_FAILED", (
+        f"whitespace-only filter should be VALIDATION_FAILED: {inner}"
+    )
 
 
 @pytest.fixture
@@ -1713,20 +1767,22 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
             "data", {}
         )
         ids = [r["entity_id"] for r in data["results"]]
-        if h_eid in ids and v_eid in ids:
-            visible = next(r for r in data["results"] if r["entity_id"] == v_eid)
-            hidden = next(r for r in data["results"] if r["entity_id"] == h_eid)
-            assert hidden["score"] < visible["score"], (
-                f"hidden should rank below visible in area+query: "
-                f"visible={visible}, hidden={hidden}"
-            )
-        else:
-            # If only the visible match surfaced (BM25 threshold +
-            # penalty interaction), at least the hidden one is allowed
-            # to be absent — but the visible one MUST be present.
-            assert v_eid in ids, (
-                f"visible area+query match disappeared: {ids}"
-            )
+        # With the distinctive token hitting BM25 at score 100 in both
+        # entity_id and friendly_name, both helpers must surface — the
+        # earlier "hidden may be absent" escape hatch was masking the
+        # threshold-edge regression that's now locked down separately.
+        assert v_eid in ids, (
+            f"visible area+query match disappeared: {ids}"
+        )
+        assert h_eid in ids, (
+            f"hidden area+query match should still surface (option-c): {ids}"
+        )
+        visible = next(r for r in data["results"] if r["entity_id"] == v_eid)
+        hidden = next(r for r in data["results"] if r["entity_id"] == h_eid)
+        assert hidden["score"] < visible["score"], (
+            f"hidden should rank below visible in area+query: "
+            f"visible={visible}, hidden={hidden}"
+        )
     finally:
         for eid in (v_eid, h_eid):
             try:

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1433,54 +1433,71 @@ async def hidden_helper(mcp_client):
 
 
 @pytest.mark.asyncio
-async def test_search_excludes_hidden_by_default_issue_1170(
+async def test_search_includes_hidden_with_penalty_by_default_issue_1170(
     mcp_client, hidden_helper
 ):
-    """Entities with ``hidden_by`` set are excluded from search by default.
-    (#1170 finding 9.)"""
+    """Hidden entities surface in default search results but receive a
+    score penalty so visible matches sort above them. The issue's
+    option (c) — keep them, rank them lower — preserves agent access
+    to integration/diagnostic entities without burying visible
+    user-facing entities under them."""
     fixture = hidden_helper
     res = await mcp_client.call_tool(
         "ha_search_entities",
         {"query": fixture["distinctive"], "exact_match": True, "limit": 5},
     )
-    data = assert_mcp_success(res, "default hidden exclusion").get("data", {})
+    data = assert_mcp_success(res, "default hidden included").get("data", {})
     entity_ids = [r["entity_id"] for r in data["results"]]
-    assert fixture["entity_id"] not in entity_ids, (
-        f"hidden entity surfaced under default include_hidden=False: {data}"
+    assert fixture["entity_id"] in entity_ids, (
+        f"hidden entity should be in default results (option c): {data}"
+    )
+    target = next(
+        r for r in data["results"] if r["entity_id"] == fixture["entity_id"]
+    )
+    # The hidden entity is the only match for a uuid-suffixed query, so
+    # its raw score would be 100 (exact substring) — minus the 20-point
+    # penalty → 80. Asserting ``< 100`` keeps the test robust to small
+    # tuning changes in the penalty constant.
+    assert target["score"] < 100, (
+        f"hidden entity should carry score penalty (got {target['score']}): "
+        f"{target}"
     )
 
 
 @pytest.mark.asyncio
-async def test_search_include_hidden_opt_in_issue_1170(mcp_client, hidden_helper):
-    """``include_hidden=True`` re-surfaces entities with ``hidden_by`` set.
-    (#1170 finding 9.)"""
+async def test_search_include_hidden_false_filters_issue_1170(
+    mcp_client, hidden_helper
+):
+    """``include_hidden=False`` filters hidden entities out of the
+    result set entirely — the explicit opt-out for callers that need
+    visible-only search."""
     fixture = hidden_helper
     res = await mcp_client.call_tool(
         "ha_search_entities",
         {
             "query": fixture["distinctive"],
             "exact_match": True,
-            "include_hidden": True,
+            "include_hidden": False,
             "limit": 5,
         },
     )
-    data = assert_mcp_success(res, "include_hidden=True").get("data", {})
+    data = assert_mcp_success(res, "include_hidden=False filters").get("data", {})
     entity_ids = [r["entity_id"] for r in data["results"]]
-    assert fixture["entity_id"] in entity_ids, (
-        f"include_hidden=True did not surface hidden entity: {data}"
+    assert fixture["entity_id"] not in entity_ids, (
+        f"include_hidden=False should filter hidden entity: {data}"
     )
 
 
 @pytest.mark.asyncio
-async def test_search_fuzzy_mode_excludes_hidden_issue_1170(
+async def test_search_fuzzy_mode_penalises_hidden_issue_1170(
     mcp_client, hidden_helper
 ):
-    """Fuzzy mode (``exact_match=False``) also honors the hidden filter.
+    """Fuzzy mode applies the same hidden-score penalty.
 
     Default-True ``exact_match`` and the fuzzy path are SEPARATE code
     paths in tools_search.py — substring matching vs ``smart_entity_search``
-    (BM25). Both must filter hidden entities or one path silently
-    regresses while the other test passes.
+    (BM25). Both must apply the penalty or one path silently regresses
+    while the other test passes.
     """
     fixture = hidden_helper
     res = await mcp_client.call_tool(
@@ -1491,20 +1508,44 @@ async def test_search_fuzzy_mode_excludes_hidden_issue_1170(
             "limit": 5,
         },
     )
-    data = assert_mcp_success(res, "fuzzy mode hidden filter").get("data", {})
+    data = assert_mcp_success(res, "fuzzy mode hidden penalty").get("data", {})
     entity_ids = [r["entity_id"] for r in data["results"]]
-    assert fixture["entity_id"] not in entity_ids, (
-        f"fuzzy mode leaked hidden entity: {data}"
+    assert fixture["entity_id"] in entity_ids, (
+        f"fuzzy mode should keep hidden entity (option c): {data}"
+    )
+    target = next(
+        r for r in data["results"] if r["entity_id"] == fixture["entity_id"]
+    )
+    assert target["score"] < 100, (
+        f"fuzzy mode hidden entity should carry penalty (got "
+        f"{target['score']}): {target}"
+    )
+
+    # And include_hidden=False filters it out entirely in fuzzy mode too.
+    res2 = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "query": fixture["distinctive"],
+            "exact_match": False,
+            "include_hidden": False,
+            "limit": 5,
+        },
+    )
+    data2 = assert_mcp_success(res2, "fuzzy include_hidden=False").get(
+        "data", {}
+    )
+    entity_ids2 = [r["entity_id"] for r in data2["results"]]
+    assert fixture["entity_id"] not in entity_ids2, (
+        f"fuzzy + include_hidden=False should filter hidden: {data2}"
     )
 
 
 @pytest.mark.asyncio
-async def test_search_area_only_excludes_hidden_issue_1170(mcp_client):
-    """Area branch (``area_filter`` only, no query) honors the hidden
-    filter. The area resolver uses the entity registry's ``area_id``;
-    we must skip ``hidden_by`` entries before composing the per-area
-    list. Otherwise a UI-hidden entity assigned to an area still
-    surfaces under ``area_filter=<that-area>``."""
+async def test_search_area_only_penalises_hidden_issue_1170(mcp_client):
+    """Area branch (``area_filter`` only, no query) keeps hidden entities
+    in the area's bucket but applies the score penalty so visible peers
+    sort above them. ``include_hidden=False`` filters them out entirely.
+    """
     suffix = uuid.uuid4().hex[:8]
     area_name = f"e2e_1170_areahidden_{suffix}"
 
@@ -1542,27 +1583,33 @@ async def test_search_area_only_excludes_hidden_issue_1170(mcp_client):
             "ha_set_entity", {"entity_id": eid, "hidden": True}
         )
 
-        # Default include_hidden=False
+        # Default include_hidden=True: hidden entity surfaces with penalty
         res = await mcp_client.call_tool(
             "ha_search_entities", {"area_filter": area_id, "limit": 10}
         )
         data = assert_mcp_success(res, "area_only default hidden").get("data", {})
         entity_ids = [r["entity_id"] for r in data["results"]]
-        assert eid not in entity_ids, (
-            f"area_only branch leaked hidden entity: {data}"
+        assert eid in entity_ids, (
+            f"area_only branch should keep hidden entity (option c): {data}"
+        )
+        target = next(r for r in data["results"] if r["entity_id"] == eid)
+        # area_only baseline score is 100; penalty drops it below 100.
+        assert target["score"] < 100, (
+            f"area_only hidden entity should carry penalty (got "
+            f"{target['score']}): {target}"
         )
 
-        # include_hidden=True surfaces it again
+        # include_hidden=False filters it out
         res2 = await mcp_client.call_tool(
             "ha_search_entities",
-            {"area_filter": area_id, "include_hidden": True, "limit": 10},
+            {"area_filter": area_id, "include_hidden": False, "limit": 10},
         )
-        data2 = assert_mcp_success(res2, "area_only include_hidden").get(
+        data2 = assert_mcp_success(res2, "area_only include_hidden=False").get(
             "data", {}
         )
         entity_ids2 = [r["entity_id"] for r in data2["results"]]
-        assert eid in entity_ids2, (
-            f"include_hidden=True did not surface hidden entity in area: {data2}"
+        assert eid not in entity_ids2, (
+            f"include_hidden=False should filter hidden entity in area: {data2}"
         )
     finally:
         # Cleanup

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1643,8 +1643,14 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
     )
     area_id = assert_mcp_success(area_res, "Create area")["area_id"]
 
-    visible_name = f"e2e1170afqvis{suffix}"
-    hidden_name = f"e2e1170afqhid{suffix}"
+    # Distinctive token that BM25 will hit directly. Using spaces in
+    # the name ensures HA tokenizes the helper name into separate
+    # tokens (entity_id is slugified to contain ``afqtoken<suffix>``
+    # as its own token), so a single-token fuzzy query lands on it
+    # at score 100.
+    distinctive = f"afqtoken{suffix}"
+    visible_name = f"{distinctive} visible"
+    hidden_name = f"{distinctive} hidden"
     v_res = await mcp_client.call_tool(
         "ha_config_set_helper",
         {
@@ -1653,7 +1659,11 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
             "area_id": area_id,
         },
     )
-    v_eid = assert_mcp_success(v_res, "create visible").get("entity_id")
+    v_data = assert_mcp_success(v_res, "create visible")
+    v_eid = (
+        v_data.get("entity_id")
+        or f"input_boolean.{v_data['helper_data']['id']}"
+    )
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
         {
@@ -1662,21 +1672,25 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
             "area_id": area_id,
         },
     )
-    h_eid = assert_mcp_success(h_res, "create hidden-target").get("entity_id")
+    h_data = assert_mcp_success(h_res, "create hidden-target")
+    h_eid = (
+        h_data.get("entity_id")
+        or f"input_boolean.{h_data['helper_data']['id']}"
+    )
 
     try:
         # Hide the second helper.
         await mcp_client.call_tool(
             "ha_set_entity", {"entity_id": h_eid, "hidden": True}
         )
-        # Both helpers share the prefix "e2e1170afq" — query on that
-        # prefix matches both within the same area.
+        # Both helpers share the distinctive token — query on it
+        # matches both within the same area.
         await wait_for_tool_result(
             mcp_client,
             tool_name="ha_search_entities",
             arguments={
                 "area_filter": area_id,
-                "query": "e2e1170afq",
+                "query": distinctive,
                 "exact_match": False,
                 "limit": 20,
             },
@@ -1690,7 +1704,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
             "ha_search_entities",
             {
                 "area_filter": area_id,
-                "query": "e2e1170afq",
+                "query": distinctive,
                 "exact_match": False,
                 "limit": 20,
             },
@@ -1748,12 +1762,20 @@ async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
         "ha_config_set_helper",
         {"helper_type": "input_boolean", "name": visible_name},
     )
-    v_eid = assert_mcp_success(v_res, "create visible dl").get("entity_id")
+    v_data = assert_mcp_success(v_res, "create visible dl")
+    v_eid = (
+        v_data.get("entity_id")
+        or f"input_boolean.{v_data['helper_data']['id']}"
+    )
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
         {"helper_type": "input_boolean", "name": hidden_name},
     )
-    h_eid = assert_mcp_success(h_res, "create hidden dl").get("entity_id")
+    h_data = assert_mcp_success(h_res, "create hidden dl")
+    h_eid = (
+        h_data.get("entity_id")
+        or f"input_boolean.{h_data['helper_data']['id']}"
+    )
 
     try:
         await mcp_client.call_tool(

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1357,6 +1357,142 @@ async def test_search_include_hidden_opt_in_issue_1170(mcp_client, hidden_helper
     )
 
 
+@pytest.mark.asyncio
+async def test_search_fuzzy_mode_excludes_hidden_issue_1170(
+    mcp_client, hidden_helper
+):
+    """Fuzzy mode (``exact_match=False``) also honors the hidden filter.
+
+    Default-True ``exact_match`` and the fuzzy path are SEPARATE code
+    paths in tools_search.py — substring matching vs ``smart_entity_search``
+    (BM25). Both must filter hidden entities or one path silently
+    regresses while the other test passes.
+    """
+    fixture = hidden_helper
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "query": fixture["distinctive"],
+            "exact_match": False,
+            "limit": 5,
+        },
+    )
+    data = assert_mcp_success(res, "fuzzy mode hidden filter").get("data", {})
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["entity_id"] not in entity_ids, (
+        f"fuzzy mode leaked hidden entity: {data}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_area_only_excludes_hidden_issue_1170(mcp_client):
+    """Area branch (``area_filter`` only, no query) honors the hidden
+    filter. The area resolver uses the entity registry's ``area_id``;
+    we must skip ``hidden_by`` entries before composing the per-area
+    list. Otherwise a UI-hidden entity assigned to an area still
+    surfaces under ``area_filter=<that-area>``."""
+    suffix = uuid.uuid4().hex[:8]
+    area_name = f"e2e_1170_areahidden_{suffix}"
+
+    # Create area + a helper assigned to it; then hide the helper.
+    area_res = await mcp_client.call_tool(
+        "ha_set_area_or_floor", {"kind": "area", "name": area_name}
+    )
+    area_data = assert_mcp_success(area_res, "Create area")
+    area_id = area_data["area_id"]
+
+    h_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": f"e2e 1170 areahidden {suffix}",
+            "area_id": area_id,
+        },
+    )
+    h_data = assert_mcp_success(h_res, "Create helper")
+    eid = h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+
+    try:
+        # Wait for helper to be visible in the area before hiding it.
+        await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_search_entities",
+            arguments={"area_filter": area_id, "limit": 10},
+            predicate=lambda d: any(
+                r.get("entity_id") == eid
+                for r in d.get("data", d).get("results", [])
+            ),
+            description="area entity visible before hide",
+        )
+        await mcp_client.call_tool(
+            "ha_set_entity", {"entity_id": eid, "hidden": True}
+        )
+
+        # Default include_hidden=False
+        res = await mcp_client.call_tool(
+            "ha_search_entities", {"area_filter": area_id, "limit": 10}
+        )
+        data = assert_mcp_success(res, "area_only default hidden").get("data", {})
+        entity_ids = [r["entity_id"] for r in data["results"]]
+        assert eid not in entity_ids, (
+            f"area_only branch leaked hidden entity: {data}"
+        )
+
+        # include_hidden=True surfaces it again
+        res2 = await mcp_client.call_tool(
+            "ha_search_entities",
+            {"area_filter": area_id, "include_hidden": True, "limit": 10},
+        )
+        data2 = assert_mcp_success(res2, "area_only include_hidden").get(
+            "data", {}
+        )
+        entity_ids2 = [r["entity_id"] for r in data2["results"]]
+        assert eid in entity_ids2, (
+            f"include_hidden=True did not surface hidden entity in area: {data2}"
+        )
+    finally:
+        # Cleanup
+        try:
+            await mcp_client.call_tool(
+                "ha_delete_helpers_integrations",
+                {"target": eid, "helper_type": "input_boolean", "confirm": True},
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of {eid} failed: {exc}")
+        try:
+            await mcp_client.call_tool(
+                "ha_remove_area_or_floor", {"kind": "area", "id": area_id}
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of area {area_id} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_only_total_matches_aggregates_issue_1170(
+    mcp_client, two_areas_with_shared_prefix
+):
+    """``total_matches`` in the area_only branch reflects the FULL
+    multi-area aggregate, not a single area's count. Locks down the
+    finding-7 fix at the pagination metadata layer — a future change
+    that paginated per-area instead of the flattened all_results would
+    silently drop the cross-area count."""
+    fixture = two_areas_with_shared_prefix
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": f"bedroom_{fixture['suffix']}", "limit": 50},
+    )
+    data = assert_mcp_success(res, "multi-area total").get("data", {})
+    # Each fixture area has exactly 1 helper; total_matches must be
+    # at least 2 (could be more if the seed Bedroom area also matched
+    # the prefix and has assigned entities, but never less).
+    assert data["total_matches"] >= 2, (
+        f"total_matches did not aggregate across matched areas: {data}"
+    )
+    assert data["count"] == data["total_matches"] or data["has_more"], (
+        f"count/has_more inconsistent with total_matches: {data}"
+    )
+
+
 # ============================================================================
 # Issue #1170 finding 10: e2e coverage at realistic seeded-area populations
 # ============================================================================

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1208,6 +1208,97 @@ async def test_fuzzy_rejects_low_coverage_garbage_issue_1170(mcp_client):
     )
 
 
+@pytest.mark.asyncio
+async def test_result_shape_consistent_across_branches(mcp_client):
+    """Every result dict, regardless of search_type, carries the same
+    base keys and NO ``essential_attributes`` field. Pre-fix
+    ``fuzzy_search`` alone surfaced ``essential_attributes`` while the
+    other four branches omitted it — a shape asymmetry that complicates
+    caller code."""
+    base_keys = {"entity_id", "friendly_name", "domain", "state", "score", "match_type"}
+    forbidden = {"essential_attributes"}
+    calls = [
+        ({"domain_filter": "light", "limit": 1}, "domain_listing"),
+        ({"query": "light", "exact_match": True, "limit": 1}, "exact_match"),
+        ({"query": "light", "exact_match": False, "limit": 1}, "fuzzy_search"),
+        ({"area_filter": "kitchen", "limit": 1}, "area_only"),
+        (
+            {"area_filter": "kitchen", "query": "light", "exact_match": False, "limit": 1},
+            "area_filtered_query",
+        ),
+    ]
+    for params, expected_type in calls:
+        res = await mcp_client.call_tool("ha_search_entities", params)
+        data = assert_mcp_success(res, f"shape check {expected_type}").get(
+            "data", {}
+        )
+        assert data["search_type"] == expected_type, (
+            f"unexpected search_type for {params}: {data}"
+        )
+        if not data["results"]:
+            continue
+        result_keys = set(data["results"][0].keys())
+        assert base_keys.issubset(result_keys), (
+            f"{expected_type} missing base keys: "
+            f"{base_keys - result_keys} (have {result_keys})"
+        )
+        assert not (forbidden & result_keys), (
+            f"{expected_type} surfaced forbidden keys: "
+            f"{forbidden & result_keys}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_validation_error_carries_no_generic_suggestions(mcp_client):
+    """``VALIDATION_FAILED`` from parameter coercion (e.g. limit=0)
+    must NOT carry generic operational suggestions like ``Check Home
+    Assistant connection`` — those are misleading boilerplate next to a
+    message like ``limit must be at least 1, got 0``."""
+    data = await safe_call_tool(
+        mcp_client, "ha_search_entities", {"query": "light", "limit": 0}
+    )
+    inner = data.get("data", data)
+    assert inner.get("success") is False, f"expected failure: {inner}"
+    error = inner.get("error", {})
+    assert error.get("code") == "VALIDATION_FAILED", f"expected VALIDATION_FAILED: {inner}"
+    # No misleading "Check Home Assistant connection" boilerplate.
+    suggestions = error.get("suggestions") or []
+    if isinstance(error.get("suggestion"), str):
+        suggestions = list(suggestions) + [error["suggestion"]]
+    leakers = {"Check Home Assistant connection", "Try simpler search terms"}
+    assert not (set(suggestions) & leakers), (
+        f"validation error leaked generic operational suggestions: {error}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_area_filter_with_domain_filter_zero_overlap_has_message(
+    mcp_client,
+):
+    """When ``area_filter`` resolves to areas with entities but
+    ``domain_filter`` filters them all out, the response carries an
+    explanatory ``message`` field. Pre-fix the empty-area branch had
+    one but this populated-but-domain-filtered-empty branch was silent
+    — leaving the caller to guess which filter wiped out the result."""
+    # Find an area that exists and a domain that doesn't intersect with it
+    # — use a real area name (kitchen) with a domain that's unlikely to
+    # be assigned to it (zone is global, never per-area).
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": "kitchen", "domain_filter": "zone", "limit": 5},
+    )
+    data = assert_mcp_success(res, "area+domain zero-overlap").get("data", {})
+    assert data["total_matches"] == 0, (
+        f"setup: area+domain combination should be empty: {data}"
+    )
+    assert "message" in data, (
+        f"empty populated+domain-filtered branch missing message: {data}"
+    )
+    assert data["message"].startswith("No zone entities found in area:"), (
+        f"message should call out the domain_filter: {data['message']}"
+    )
+
+
 @pytest.fixture
 async def two_areas_with_shared_prefix(mcp_client):
     """Create two areas sharing a prefix (``bedroom_X_*``, ``bedroom_Y_*``)
@@ -1261,6 +1352,37 @@ async def two_areas_with_shared_prefix(mcp_client):
             )
         except Exception as exc:  # pragma: no cover
             logger.warning(f"Cleanup of area {area} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_exact_area_id_short_circuits_fuzzy_aggregation(
+    mcp_client, two_areas_with_shared_prefix
+):
+    """When ``area_filter`` is a literal area_id from
+    ``ha_config_list_areas``, exact match wins — fuzzy aggregation of
+    sibling areas is suppressed. Pre-fix a query like
+    ``bedroom_y_<suffix>`` would also partial_ratio-match its sibling
+    ``bedroom_x_<suffix>`` (and the seeded ``bedroom`` area), surfacing
+    every sibling area's entities under the supposedly-specific id."""
+    fixture = two_areas_with_shared_prefix
+    target_area_id = fixture["areas"][0]
+    target_helper = fixture["helpers"][0]
+    sibling_helper = fixture["helpers"][1]
+    res = await mcp_client.call_tool(
+        "ha_search_entities", {"area_filter": target_area_id, "limit": 50}
+    )
+    data = assert_mcp_success(res, "exact area_id resolution").get("data", {})
+    entity_ids = {r["entity_id"] for r in data["results"]}
+    assert target_helper in entity_ids, (
+        f"target area's helper missing: {data}"
+    )
+    assert sibling_helper not in entity_ids, (
+        f"sibling area's helper leaked into exact-id resolution: {data}"
+    )
+    assert len(data["area_names"]) == 1, (
+        f"exact area_id should resolve to exactly one area, got "
+        f"{data['area_names']}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1629,6 +1629,190 @@ async def test_search_area_only_penalises_hidden_issue_1170(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client):
+    """area_filter + query exercises a SEPARATE code path from the
+    plain area_only branch — `_hidden_by` is plumbed through
+    ``get_entities_by_area`` → ``entities_for_search`` enrichment →
+    BM25 ``hidden_flags``. A regression in any of those hops would
+    silently drop the penalty without breaking the simpler tests.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    area_name = f"e2e_1170_areafq_{suffix}"
+    area_res = await mcp_client.call_tool(
+        "ha_set_area_or_floor", {"kind": "area", "name": area_name}
+    )
+    area_id = assert_mcp_success(area_res, "Create area")["area_id"]
+
+    visible_name = f"e2e1170afqvis{suffix}"
+    hidden_name = f"e2e1170afqhid{suffix}"
+    v_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": visible_name,
+            "area_id": area_id,
+        },
+    )
+    v_eid = assert_mcp_success(v_res, "create visible").get("entity_id")
+    h_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": hidden_name,
+            "area_id": area_id,
+        },
+    )
+    h_eid = assert_mcp_success(h_res, "create hidden-target").get("entity_id")
+
+    try:
+        # Hide the second helper.
+        await mcp_client.call_tool(
+            "ha_set_entity", {"entity_id": h_eid, "hidden": True}
+        )
+        # Both helpers share the prefix "e2e1170afq" — query on that
+        # prefix matches both within the same area.
+        await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_search_entities",
+            arguments={
+                "area_filter": area_id,
+                "query": "e2e1170afq",
+                "exact_match": False,
+                "limit": 20,
+            },
+            predicate=lambda d: any(
+                r.get("entity_id") == v_eid
+                for r in d.get("data", d).get("results", [])
+            ),
+            description="visible helper visible in area+query",
+        )
+        res = await mcp_client.call_tool(
+            "ha_search_entities",
+            {
+                "area_filter": area_id,
+                "query": "e2e1170afq",
+                "exact_match": False,
+                "limit": 20,
+            },
+        )
+        data = assert_mcp_success(res, "area+query hidden penalty").get(
+            "data", {}
+        )
+        ids = [r["entity_id"] for r in data["results"]]
+        if h_eid in ids and v_eid in ids:
+            visible = next(r for r in data["results"] if r["entity_id"] == v_eid)
+            hidden = next(r for r in data["results"] if r["entity_id"] == h_eid)
+            assert hidden["score"] < visible["score"], (
+                f"hidden should rank below visible in area+query: "
+                f"visible={visible}, hidden={hidden}"
+            )
+        else:
+            # If only the visible match surfaced (BM25 threshold +
+            # penalty interaction), at least the hidden one is allowed
+            # to be absent — but the visible one MUST be present.
+            assert v_eid in ids, (
+                f"visible area+query match disappeared: {ids}"
+            )
+    finally:
+        for eid in (v_eid, h_eid):
+            try:
+                await mcp_client.call_tool(
+                    "ha_delete_helpers_integrations",
+                    {
+                        "target": eid,
+                        "helper_type": "input_boolean",
+                        "confirm": True,
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning(f"Cleanup of {eid} failed: {exc}")
+        try:
+            await mcp_client.call_tool(
+                "ha_remove_area_or_floor", {"kind": "area", "id": area_id}
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of area {area_id} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
+    """Empty-query + domain_filter (the domain_listing branch) also
+    applies the hidden score penalty so visible domain entries sort
+    above hidden ones, and ``include_hidden=False`` filters them out.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    visible_name = f"e2e1170dlvis{suffix}"
+    hidden_name = f"e2e1170dlhid{suffix}"
+
+    v_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "input_boolean", "name": visible_name},
+    )
+    v_eid = assert_mcp_success(v_res, "create visible dl").get("entity_id")
+    h_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "input_boolean", "name": hidden_name},
+    )
+    h_eid = assert_mcp_success(h_res, "create hidden dl").get("entity_id")
+
+    try:
+        await mcp_client.call_tool(
+            "ha_set_entity", {"entity_id": h_eid, "hidden": True}
+        )
+
+        # Default include_hidden=True: hidden helper present, score < 100.
+        res = await mcp_client.call_tool(
+            "ha_search_entities",
+            {"domain_filter": "input_boolean", "limit": 200},
+        )
+        data = assert_mcp_success(res, "domain_listing default").get("data", {})
+        by_id = {r["entity_id"]: r for r in data["results"]}
+        assert h_eid in by_id, (
+            f"hidden helper should appear in domain_listing default: "
+            f"{list(by_id)[:5]}"
+        )
+        assert by_id[h_eid]["score"] < 100, (
+            f"hidden should carry penalty in domain_listing: "
+            f"{by_id[h_eid]}"
+        )
+        if v_eid in by_id:
+            assert by_id[v_eid]["score"] >= by_id[h_eid]["score"], (
+                f"visible should outrank hidden in domain_listing: "
+                f"visible={by_id[v_eid]}, hidden={by_id[h_eid]}"
+            )
+
+        # include_hidden=False: hidden helper filtered.
+        res2 = await mcp_client.call_tool(
+            "ha_search_entities",
+            {
+                "domain_filter": "input_boolean",
+                "include_hidden": False,
+                "limit": 200,
+            },
+        )
+        data2 = assert_mcp_success(res2, "domain_listing include_hidden=False").get(
+            "data", {}
+        )
+        ids2 = {r["entity_id"] for r in data2["results"]}
+        assert h_eid not in ids2, (
+            f"include_hidden=False should filter in domain_listing: {ids2}"
+        )
+    finally:
+        for eid in (v_eid, h_eid):
+            try:
+                await mcp_client.call_tool(
+                    "ha_delete_helpers_integrations",
+                    {
+                        "target": eid,
+                        "helper_type": "input_boolean",
+                        "confirm": True,
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning(f"Cleanup of {eid} failed: {exc}")
+
+
+@pytest.mark.asyncio
 async def test_area_only_total_matches_aggregates_issue_1170(
     mcp_client, two_areas_with_shared_prefix
 ):

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1244,6 +1244,20 @@ async def test_area_only_aggregates_all_matched_areas_issue_1170(
         f"{set(fixture['helpers']) - entity_ids}; got {entity_ids}"
     )
 
+    # Determinism: same query twice must yield the same area ordering.
+    # The pre-fix code iterated a `set` which left ordering at CPython's
+    # hash-randomization mercy. Asserting equality across two calls is
+    # the only way to lock in the sorted-iteration fix.
+    res2 = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": f"bedroom_{fixture['suffix']}", "limit": 50},
+    )
+    data2 = assert_mcp_success(res2, "two-area aggregation rerun").get("data", {})
+    assert data["area_names"] == data2["area_names"], (
+        f"area_names ordering must be deterministic across calls: "
+        f"{data['area_names']!r} vs {data2['area_names']!r}"
+    )
+
 
 @pytest.fixture
 async def helper_with_alias(mcp_client):
@@ -1271,6 +1285,106 @@ async def helper_with_alias(mcp_client):
         )
     except Exception as exc:  # pragma: no cover
         logger.warning(f"Cleanup of {eid} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_search_concat_token_elision_issue_1170(mcp_client):
+    """End-to-end pipeline preserves the BM25 concat-token enrichment so
+    a separator-elided query (``bedlight``) lands on its target
+    (``light.bed_light``). Unit coverage exists in
+    ``test_bm25_search.TestFuzzySearcherIssue1170::
+    test_finding_2_elided_separator_query_finds_target_uniquely``;
+    this E2E variant catches a regression where alias-batch enrichment
+    or the hidden-filter survivor pass strips the concat token between
+    layers."""
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"query": "bedlight", "exact_match": False, "limit": 10},
+    )
+    data = assert_mcp_success(res, "concat-token elision").get("data", {})
+    entity_ids = [r["entity_id"] for r in data.get("results", [])]
+    # `light.bed_light` is part of the initial_test_state seed.
+    assert "light.bed_light" in entity_ids, (
+        f"separator-elided query 'bedlight' should match light.bed_light: "
+        f"{entity_ids}"
+    )
+
+
+@pytest.fixture
+async def area_with_alias(mcp_client):
+    """Create an area with a unique alias plus a helper assigned to it."""
+    suffix = uuid.uuid4().hex[:8]
+    area_name = f"e2e_1170_areaalias_{suffix}"
+    area_alias = f"e2e1170areaalias{suffix}"
+    area_res = await mcp_client.call_tool(
+        "ha_set_area_or_floor",
+        {"kind": "area", "name": area_name, "aliases": [area_alias]},
+    )
+    area_data = assert_mcp_success(area_res, "Create area with alias")
+    area_id = area_data["area_id"]
+
+    h_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": f"e2e 1170 areaalias {suffix}",
+            "area_id": area_id,
+        },
+    )
+    h_data = assert_mcp_success(h_res, "Create helper in alias-area")
+    eid = h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+
+    try:
+        await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_search_entities",
+            arguments={"area_filter": area_id, "limit": 10},
+            predicate=lambda d: any(
+                r.get("entity_id") == eid
+                for r in d.get("data", d).get("results", [])
+            ),
+            description="helper visible in alias-area",
+        )
+        yield {
+            "area_id": area_id,
+            "alias": area_alias,
+            "entity_id": eid,
+        }
+    finally:
+        try:
+            await mcp_client.call_tool(
+                "ha_delete_helpers_integrations",
+                {"target": eid, "helper_type": "input_boolean", "confirm": True},
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of {eid} failed: {exc}")
+        try:
+            await mcp_client.call_tool(
+                "ha_remove_area_or_floor", {"kind": "area", "id": area_id}
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of area {area_id} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_filter_resolves_by_area_alias_issue_1170(
+    mcp_client, area_with_alias
+):
+    """Area-registry aliases are honoured by ``area_filter``. Without
+    this, an area whose primary identity is ``Primary Suite`` and whose
+    voice alias is ``Guest Quarters`` would resolve only via the primary
+    name, defeating the alias's purpose. Locks down the area-side half
+    of the fix that the entity-side alias test does not cover."""
+    fixture = area_with_alias
+    res = await mcp_client.call_tool(
+        "ha_search_entities", {"area_filter": fixture["alias"], "limit": 10}
+    )
+    data = assert_mcp_success(res, "search by area alias").get("data", {})
+    assert data["search_type"] == "area_only"
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["entity_id"] in entity_ids, (
+        f"area_filter by alias did not resolve to the aliased area: {data}"
+    )
 
 
 @pytest.mark.asyncio
@@ -1518,42 +1632,53 @@ class TestSearchEntitiesSeededAreasIssue1170:
     @pytest.fixture
     async def seeded_bedroom(self, mcp_client):
         """Assign 4 entities of 3 different domains to the seeded
-        ``bedroom`` area, then unassign on teardown."""
-        for eid, area_id in self.SEED_ASSIGNMENTS:
-            try:
-                await mcp_client.call_tool(
-                    "ha_set_entity", {"entity_id": eid, "area_id": area_id}
-                )
-            except Exception as exc:
-                pytest.skip(f"Seed entity {eid} unavailable: {exc}")
-        # Wait until all 4 are visible in the bedroom area
-        expected = {eid for eid, _ in self.SEED_ASSIGNMENTS}
-        await wait_for_tool_result(
-            mcp_client,
-            tool_name="ha_search_entities",
-            arguments={"area_filter": "bedroom", "limit": 50},
-            predicate=lambda d: expected.issubset(
-                {
-                    r.get("entity_id")
-                    for r in d.get("data", d).get("results", [])
-                }
-            ),
-            description="all seed assignments visible under bedroom",
-        )
-        yield {
-            "area_id": "bedroom",
-            "entity_ids": [eid for eid, _ in self.SEED_ASSIGNMENTS],
-        }
-        # Cleanup: clear area assignment. ha_set_entity requires at least
-        # one update field, so we set area_id to empty-string (which the
-        # tool maps to "no area") rather than None.
-        for eid, _ in self.SEED_ASSIGNMENTS:
-            try:
-                await mcp_client.call_tool(
-                    "ha_set_entity", {"entity_id": eid, "area_id": ""}
-                )
-            except Exception as exc:  # pragma: no cover — cleanup best-effort
-                logger.warning(f"Cleanup of area assignment for {eid} failed: {exc}")
+        ``bedroom`` area, then unassign on teardown.
+
+        Cleanup is wrapped in try/finally so an unexpected fixture-body
+        failure (e.g. wait_for_tool_result timing out) still unwinds the
+        seed-area assignments — otherwise subsequent tests inherit the
+        leaked assignment.
+        """
+        try:
+            for eid, area_id in self.SEED_ASSIGNMENTS:
+                try:
+                    await mcp_client.call_tool(
+                        "ha_set_entity", {"entity_id": eid, "area_id": area_id}
+                    )
+                except Exception as exc:
+                    pytest.skip(f"Seed entity {eid} unavailable: {exc}")
+            # Wait until all 4 are visible in the bedroom area
+            expected = {eid for eid, _ in self.SEED_ASSIGNMENTS}
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_search_entities",
+                arguments={"area_filter": "bedroom", "limit": 50},
+                predicate=lambda d: expected.issubset(
+                    {
+                        r.get("entity_id")
+                        for r in d.get("data", d).get("results", [])
+                    }
+                ),
+                description="all seed assignments visible under bedroom",
+            )
+            yield {
+                "area_id": "bedroom",
+                "entity_ids": [eid for eid, _ in self.SEED_ASSIGNMENTS],
+            }
+        finally:
+            # Cleanup runs even on pytest.skip or fixture-body exceptions.
+            # ha_set_entity requires at least one update field, so we set
+            # area_id to empty-string (which the tool maps to "no area")
+            # rather than None.
+            for eid, _ in self.SEED_ASSIGNMENTS:
+                try:
+                    await mcp_client.call_tool(
+                        "ha_set_entity", {"entity_id": eid, "area_id": ""}
+                    )
+                except Exception as exc:  # pragma: no cover — cleanup best-effort
+                    logger.warning(
+                        f"Cleanup of area assignment for {eid} failed: {exc}"
+                    )
 
     @pytest.mark.asyncio
     async def test_area_only_returns_all_assigned_domains(

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -357,12 +357,16 @@ async def test_search_entities_response_structure_issue_214(mcp_client):
     assert "search_type" in data, "Response must include 'search_type' field"
     assert isinstance(data["results"], list), "Results must be a list"
 
-    # search_type should be one of the expected values
+    # search_type should be one of the expected values.
+    # Note: `partial_listing` was removed in #1170 (finding 6) — its
+    # behavior was a useless score=0 entity dump that masked errors;
+    # exceptions now propagate to callers instead.
     valid_search_types = [
         "fuzzy_search",
         "exact_match",
-        "partial_listing",
         "domain_listing",
+        "area_only",
+        "area_filtered_query",
     ]
     assert data["search_type"] in valid_search_types, (
         f"search_type '{data['search_type']}' not in {valid_search_types}"
@@ -998,3 +1002,491 @@ async def test_area_filter_fuzzy_multi_area_with_query(
     assert data["total_matches"] == 2, (
         f"Both fuzzy-matched areas contribute one input_boolean each: {data}"
     )
+
+
+# ============================================================================
+# Issue #1170: ha_search_entities triage findings — regression tests
+# ============================================================================
+# Each test below locks in one of the 10 behaviors triaged in #1170.
+# All would fail against master HEAD prior to the fix-PR.
+
+
+@pytest.mark.asyncio
+async def test_domain_filter_uppercase_normalized_issue_1170(mcp_client):
+    """domain_filter is lowercased so agents that capitalize from a user
+    phrase (e.g. ``"turn on the Lights"``) don't hit a silent zero-result.
+    (#1170 finding 1.)"""
+    lower = await mcp_client.call_tool(
+        "ha_search_entities", {"domain_filter": "light", "limit": 50}
+    )
+    upper = await mcp_client.call_tool(
+        "ha_search_entities", {"domain_filter": "Light", "limit": 50}
+    )
+    lower_data = assert_mcp_success(lower, "domain_filter=light").get("data", {})
+    upper_data = assert_mcp_success(upper, "domain_filter=Light").get("data", {})
+    assert lower_data.get("total_matches", 0) > 0, (
+        f"baseline: lowercase should return results: {lower_data}"
+    )
+    assert upper_data["total_matches"] == lower_data["total_matches"], (
+        f"uppercase domain_filter must match lowercase result count: "
+        f"upper={upper_data}, lower={lower_data}"
+    )
+    # Echoed in normalized form so callers can see the canonical value.
+    assert upper_data["domain_filter"] == "light"
+
+
+@pytest.fixture
+async def populated_area_for_shape_test(mcp_client):
+    """Create an area with a single helper assigned, for response-shape checks."""
+    suffix = uuid.uuid4().hex[:8]
+    area_name = f"e2e_1170_shape_{suffix}"
+    area_result = await mcp_client.call_tool(
+        "ha_set_area_or_floor", {"kind": "area", "name": area_name}
+    )
+    area_data = assert_mcp_success(area_result, "Create shape-test area")
+    area_id = area_data["area_id"]
+    helper_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {
+            "helper_type": "input_boolean",
+            "name": f"e2e 1170 shape {suffix}",
+            "area_id": area_id,
+        },
+    )
+    helper_data = assert_mcp_success(helper_result, "Create shape-test helper")
+    boolean_id = (
+        helper_data.get("entity_id")
+        or f"input_boolean.{helper_data['helper_data']['id']}"
+    )
+    await wait_for_tool_result(
+        mcp_client,
+        tool_name="ha_search_entities",
+        arguments={"area_filter": area_id, "limit": 10},
+        predicate=lambda d: any(
+            r.get("entity_id") == boolean_id
+            for r in d.get("data", d).get("results", [])
+        ),
+        description="shape-test helper visible",
+    )
+    yield {"area_id": area_id, "boolean_id": boolean_id}
+    try:
+        await mcp_client.call_tool(
+            "ha_delete_helpers_integrations",
+            {"target": boolean_id, "helper_type": "input_boolean", "confirm": True},
+        )
+    except Exception as exc:  # pragma: no cover — cleanup best-effort
+        logger.warning(f"Cleanup of {boolean_id} failed: {exc}")
+    try:
+        await mcp_client.call_tool(
+            "ha_remove_area_or_floor", {"kind": "area", "id": area_id}
+        )
+    except Exception as exc:  # pragma: no cover — cleanup best-effort
+        logger.warning(f"Cleanup of area {area_id} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_only_results_have_score_and_match_type_issue_1170(
+    mcp_client, populated_area_for_shape_test
+):
+    """area_only branch results carry score+match_type, matching the other
+    four search-type branches. (#1170 finding 3.)"""
+    fixture = populated_area_for_shape_test
+    res = await mcp_client.call_tool(
+        "ha_search_entities", {"area_filter": fixture["area_id"], "limit": 50}
+    )
+    data = assert_mcp_success(res, "area_only shape").get("data", {})
+    assert data["search_type"] == "area_only"
+    assert data["results"], "fixture should yield at least one result"
+    for r in data["results"]:
+        assert r.get("score") == 100, f"score missing/wrong on area_only result: {r}"
+        assert r.get("match_type") == "area_match", (
+            f"match_type missing/wrong on area_only result: {r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_area_filtered_query_no_per_result_area_filter_issue_1170(
+    mcp_client, populated_area_for_shape_test
+):
+    """area_filtered_query: top-level ``area_filter`` only, not per-result.
+
+    The redundant per-result echo was the only branch emitting it — see
+    #1170 finding 4. Top-level field is still expected.
+    """
+    fixture = populated_area_for_shape_test
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "area_filter": fixture["area_id"],
+            "query": "1170",
+            "exact_match": False,
+            "limit": 50,
+        },
+    )
+    data = assert_mcp_success(res, "area_filtered_query shape").get("data", {})
+    assert data["search_type"] == "area_filtered_query"
+    assert data.get("area_filter") == fixture["area_id"], (
+        f"top-level area_filter should still echo: {data}"
+    )
+    for r in data["results"]:
+        assert "area_filter" not in r, (
+            f"per-result area_filter should be dropped: {r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_rejects_low_coverage_garbage_issue_1170(mcp_client):
+    """Multi-token nonsense queries don't surface entities that only one
+    token grazes. (#1170 finding 5.)
+
+    Pre-fix, ``query="xyz_irrelevant_garbage"`` returned ``cover.garage_door``
+    at score 92 via typo_fallback because the single token "garbage" matched
+    "garage" at SequenceMatcher ratio 92. The new multi-token coverage
+    gate rejects entities that only explain <50% of the query tokens.
+    """
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"query": "xyz_irrelevant_garbage", "exact_match": False, "limit": 5},
+    )
+    data = assert_mcp_success(res, "garbage query").get("data", {})
+    assert data["total_matches"] == 0, (
+        f"low-coverage garbage query must be rejected: {data}"
+    )
+
+
+@pytest.fixture
+async def two_areas_with_shared_prefix(mcp_client):
+    """Create two areas sharing a prefix (``bedroom_X_*``, ``bedroom_Y_*``)
+    each with a helper, so a single ``area_filter="bedroom_<suffix>"``
+    fuzzy-matches both."""
+    suffix = uuid.uuid4().hex[:8]
+    areas: list[str] = []
+    helpers: list[str] = []
+    for label in ("X", "Y"):
+        area_res = await mcp_client.call_tool(
+            "ha_set_area_or_floor",
+            {"kind": "area", "name": f"bedroom {label} {suffix}"},
+        )
+        area_data = assert_mcp_success(area_res, f"Create area {label}")
+        areas.append(area_data["area_id"])
+        h_res = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "input_boolean",
+                "name": f"e2e 1170 bedroom {label} {suffix}",
+                "area_id": area_data["area_id"],
+            },
+        )
+        h_data = assert_mcp_success(h_res, f"Create helper {label}")
+        helpers.append(
+            h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+        )
+    # Wait for both helpers to be visible under the shared prefix
+    await wait_for_tool_result(
+        mcp_client,
+        tool_name="ha_search_entities",
+        arguments={"area_filter": f"bedroom_{suffix}", "limit": 10},
+        predicate=lambda d: {
+            r.get("entity_id") for r in d.get("data", d).get("results", [])
+        }.issuperset(set(helpers)),
+        description="both shared-prefix areas' helpers visible",
+    )
+    yield {"areas": areas, "helpers": helpers, "suffix": suffix}
+    for h in helpers:
+        try:
+            await mcp_client.call_tool(
+                "ha_delete_helpers_integrations",
+                {"target": h, "helper_type": "input_boolean", "confirm": True},
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of {h} failed: {exc}")
+    for area in areas:
+        try:
+            await mcp_client.call_tool(
+                "ha_remove_area_or_floor", {"kind": "area", "id": area}
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(f"Cleanup of area {area} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_area_only_aggregates_all_matched_areas_issue_1170(
+    mcp_client, two_areas_with_shared_prefix
+):
+    """area_only branch returns entities from ALL fuzzy-matched areas, not
+    just the first. (#1170 finding 7 — the most user-visible bug in the
+    triage; pre-fix, the user's intended area was silently skipped when
+    another area had a similar prefix.)"""
+    fixture = two_areas_with_shared_prefix
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"area_filter": f"bedroom_{fixture['suffix']}", "limit": 50},
+    )
+    data = assert_mcp_success(res, "two-area aggregation").get("data", {})
+    assert data["search_type"] == "area_only"
+    # New plural field carries every matched area. The seeded `Bedroom`
+    # area also matches the `bedroom_<suffix>` prefix at partial_ratio
+    # 100 (the literal token "bedroom" is a substring of the query) and
+    # legitimately appears alongside the two fixture areas — that's the
+    # whole point of the fix: aggregate, don't drop. So we assert the
+    # two fixture-created area names are *both* present rather than
+    # asserting an exact count.
+    assert isinstance(data.get("area_names"), list), (
+        f"area_names must be a list: {data}"
+    )
+    assert len(data["area_names"]) >= 2, (
+        f"at least the two fixture areas should be reported "
+        f"in area_names: {data['area_names']}"
+    )
+    entity_ids = {r["entity_id"] for r in data["results"]}
+    assert set(fixture["helpers"]).issubset(entity_ids), (
+        f"both fixture areas' helpers should appear: missing "
+        f"{set(fixture['helpers']) - entity_ids}; got {entity_ids}"
+    )
+
+
+@pytest.fixture
+async def helper_with_alias(mcp_client):
+    """Create an input_boolean helper, then set an alias on it via
+    ``ha_set_entity``. The alias is what the search query targets."""
+    suffix = uuid.uuid4().hex[:8]
+    alias = f"e2e1170alias{suffix}"
+    helper_res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "input_boolean", "name": f"e2e 1170 alias src {suffix}"},
+    )
+    helper_data = assert_mcp_success(helper_res, "Create alias-target helper")
+    eid = (
+        helper_data.get("entity_id")
+        or f"input_boolean.{helper_data['helper_data']['id']}"
+    )
+    await mcp_client.call_tool(
+        "ha_set_entity", {"entity_id": eid, "aliases": [alias]}
+    )
+    yield {"entity_id": eid, "alias": alias}
+    try:
+        await mcp_client.call_tool(
+            "ha_delete_helpers_integrations",
+            {"target": eid, "helper_type": "input_boolean", "confirm": True},
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"Cleanup of {eid} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_search_finds_entity_by_alias_issue_1170(mcp_client, helper_with_alias):
+    """Entity registry aliases are honoured in fuzzy search and labelled
+    ``alias_match``. (#1170 finding 8 — closes #1166.)"""
+    fixture = helper_with_alias
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"query": fixture["alias"], "exact_match": False, "limit": 5},
+    )
+    data = assert_mcp_success(res, "search by alias").get("data", {})
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["entity_id"] in entity_ids, (
+        f"alias query did not surface target entity: {data}"
+    )
+    target = next(r for r in data["results"] if r["entity_id"] == fixture["entity_id"])
+    assert target["match_type"] == "alias_match", (
+        f"expected match_type=alias_match, got: {target}"
+    )
+
+
+@pytest.fixture
+async def hidden_helper(mcp_client):
+    """Create an input_boolean helper, then hide it via the entity registry."""
+    suffix = uuid.uuid4().hex[:8]
+    distinctive = f"e2e1170hidden{suffix}"
+    res = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "input_boolean", "name": f"e2e 1170 hidden {suffix}"},
+    )
+    data = assert_mcp_success(res, "Create hidden-target helper")
+    eid = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+    # Rename so the search query has a unique substring to grep on.
+    await mcp_client.call_tool(
+        "ha_set_entity", {"entity_id": eid, "name": distinctive, "hidden": True}
+    )
+    yield {"entity_id": eid, "distinctive": distinctive}
+    try:
+        await mcp_client.call_tool(
+            "ha_delete_helpers_integrations",
+            {"target": eid, "helper_type": "input_boolean", "confirm": True},
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.warning(f"Cleanup of {eid} failed: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_search_excludes_hidden_by_default_issue_1170(
+    mcp_client, hidden_helper
+):
+    """Entities with ``hidden_by`` set are excluded from search by default.
+    (#1170 finding 9.)"""
+    fixture = hidden_helper
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {"query": fixture["distinctive"], "exact_match": True, "limit": 5},
+    )
+    data = assert_mcp_success(res, "default hidden exclusion").get("data", {})
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["entity_id"] not in entity_ids, (
+        f"hidden entity surfaced under default include_hidden=False: {data}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_include_hidden_opt_in_issue_1170(mcp_client, hidden_helper):
+    """``include_hidden=True`` re-surfaces entities with ``hidden_by`` set.
+    (#1170 finding 9.)"""
+    fixture = hidden_helper
+    res = await mcp_client.call_tool(
+        "ha_search_entities",
+        {
+            "query": fixture["distinctive"],
+            "exact_match": True,
+            "include_hidden": True,
+            "limit": 5,
+        },
+    )
+    data = assert_mcp_success(res, "include_hidden=True").get("data", {})
+    entity_ids = [r["entity_id"] for r in data["results"]]
+    assert fixture["entity_id"] in entity_ids, (
+        f"include_hidden=True did not surface hidden entity: {data}"
+    )
+
+
+# ============================================================================
+# Issue #1170 finding 10: e2e coverage at realistic seeded-area populations
+# ============================================================================
+
+
+class TestSearchEntitiesSeededAreasIssue1170:
+    """E2E tests against a multi-domain populated area at the scale of the
+    initial_test_state seed.
+
+    Pre-fix coverage gap: existing area tests used ad-hoc fixtures with one
+    or two helpers per fresh area. None exercised the area_filter branches
+    against an area populated with multiple domains, which is the realistic
+    shape on a production HA install. (#1170 finding 10.)
+    """
+
+    SEED_ASSIGNMENTS = (
+        ("light.bed_light", "bedroom"),
+        ("light.ceiling_lights", "bedroom"),
+        ("switch.ac", "bedroom"),
+        ("cover.garage_door", "bedroom"),
+    )
+
+    @pytest.fixture
+    async def seeded_bedroom(self, mcp_client):
+        """Assign 4 entities of 3 different domains to the seeded
+        ``bedroom`` area, then unassign on teardown."""
+        for eid, area_id in self.SEED_ASSIGNMENTS:
+            try:
+                await mcp_client.call_tool(
+                    "ha_set_entity", {"entity_id": eid, "area_id": area_id}
+                )
+            except Exception as exc:
+                pytest.skip(f"Seed entity {eid} unavailable: {exc}")
+        # Wait until all 4 are visible in the bedroom area
+        expected = {eid for eid, _ in self.SEED_ASSIGNMENTS}
+        await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_search_entities",
+            arguments={"area_filter": "bedroom", "limit": 50},
+            predicate=lambda d: expected.issubset(
+                {
+                    r.get("entity_id")
+                    for r in d.get("data", d).get("results", [])
+                }
+            ),
+            description="all seed assignments visible under bedroom",
+        )
+        yield {
+            "area_id": "bedroom",
+            "entity_ids": [eid for eid, _ in self.SEED_ASSIGNMENTS],
+        }
+        # Cleanup: clear area assignment. ha_set_entity requires at least
+        # one update field, so we set area_id to empty-string (which the
+        # tool maps to "no area") rather than None.
+        for eid, _ in self.SEED_ASSIGNMENTS:
+            try:
+                await mcp_client.call_tool(
+                    "ha_set_entity", {"entity_id": eid, "area_id": ""}
+                )
+            except Exception as exc:  # pragma: no cover — cleanup best-effort
+                logger.warning(f"Cleanup of area assignment for {eid} failed: {exc}")
+
+    @pytest.mark.asyncio
+    async def test_area_only_returns_all_assigned_domains(
+        self, mcp_client, seeded_bedroom
+    ):
+        """area_only returns every assigned entity, spanning all domains."""
+        fixture = seeded_bedroom
+        res = await mcp_client.call_tool(
+            "ha_search_entities", {"area_filter": fixture["area_id"], "limit": 50}
+        )
+        data = assert_mcp_success(res, "populated area").get("data", {})
+        entity_ids = {r["entity_id"] for r in data["results"]}
+        assert set(fixture["entity_ids"]).issubset(entity_ids), (
+            f"all assigned entities should appear: missing "
+            f"{set(fixture['entity_ids']) - entity_ids}"
+        )
+        domains = {r["domain"] for r in data["results"]}
+        assert {"light", "switch", "cover"}.issubset(domains), (
+            f"all 3 assigned domains expected in results: {domains}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_area_with_query_filters_within_area(
+        self, mcp_client, seeded_bedroom
+    ):
+        """area_filter + query restricts to query matches inside the area."""
+        fixture = seeded_bedroom
+        res = await mcp_client.call_tool(
+            "ha_search_entities",
+            {
+                "area_filter": fixture["area_id"],
+                "query": "light",
+                "exact_match": False,
+                "limit": 50,
+            },
+        )
+        data = assert_mcp_success(res, "area + query").get("data", {})
+        entity_ids = [r["entity_id"] for r in data["results"]]
+        assert "light.bed_light" in entity_ids
+        assert "light.ceiling_lights" in entity_ids
+        assert "switch.ac" not in entity_ids, (
+            f"switch should not match query='light': {entity_ids}"
+        )
+        assert "cover.garage_door" not in entity_ids, (
+            f"cover should not match query='light': {entity_ids}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_area_only_pagination_realistic(
+        self, mcp_client, seeded_bedroom
+    ):
+        """Pagination works correctly at realistic populated-area scale."""
+        fixture = seeded_bedroom
+        res = await mcp_client.call_tool(
+            "ha_search_entities", {"area_filter": fixture["area_id"], "limit": 2}
+        )
+        data = assert_mcp_success(res, "limit=2 page 1").get("data", {})
+        assert len(data["results"]) == 2
+        assert data["has_more"] is True
+        assert data["next_offset"] == 2
+        res2 = await mcp_client.call_tool(
+            "ha_search_entities",
+            {
+                "area_filter": fixture["area_id"],
+                "limit": 50,
+                "offset": 2,
+            },
+        )
+        data2 = assert_mcp_success(res2, "offset=2").get("data", {})
+        assert len(data2["results"]) >= 2, (
+            f"page 2 should have at least the remaining entities: {data2}"
+        )

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -410,3 +410,29 @@ class TestFuzzySearcherIssue1170:
             lights_corpus, "lullaby", limit=10
         )
         assert total == 0, f"no alias data → no match: {results}"
+
+    def test_finding_8_alias_does_not_overshadow_name_match(self, lights_corpus):
+        """When a query token matches BOTH the friendly_name and an alias,
+        the result keeps a name-driven match_type rather than mislabeling
+        as ``alias_match``. A future code change that swapped the
+        precedence (or used a too-broad set intersection) would surface
+        as a confused match_type for queries that obviously matched on
+        the entity's primary identity. (#1170)"""
+        # alias contains "bed" (which also tokenizes from "Bed Light")
+        # plus a unique alias-only token "lullaby".
+        enriched = []
+        for e in lights_corpus:
+            e2 = dict(e)
+            if e2["entity_id"] == "light.bed_light":
+                e2["_aliases"] = ["bed lullaby"]
+            enriched.append(e2)
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(enriched, "bed", limit=10)
+        assert total >= 1
+        target = next(r for r in results if r["entity_id"] == "light.bed_light")
+        # "bed" is in id+name AND in alias — match_type should reflect
+        # the primary id/name match, not the alias overlap.
+        assert target["match_type"] != "alias_match", (
+            f"query token also in id/name should not be labeled alias_match: "
+            f"{target}"
+        )

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -378,8 +378,13 @@ class TestFuzzySearcherIssue1170:
         on single-token queries — that would be too aggressive)."""
         searcher = FuzzyEntitySearcher()
         results, total = searcher.search_entities(lights_corpus, "ligth", limit=10)
-        # Should still find at least the *_lights entities via typo_fallback.
+        # Should still find a real light.* entity via typo_fallback — not
+        # just *something*.
         assert total >= 1, f"single-token typo recall regressed: {results}"
+        assert any(r["entity_id"].startswith("light.") for r in results), (
+            f"coverage gate falsely rejected legitimate single-token typo: "
+            f"{[r['entity_id'] for r in results]}"
+        )
 
     def test_finding_8_alias_search_with_match_type_label(self, lights_corpus):
         """Aliases are searchable when the caller supplies them on the
@@ -417,7 +422,7 @@ class TestFuzzySearcherIssue1170:
         as ``alias_match``. A future code change that swapped the
         precedence (or used a too-broad set intersection) would surface
         as a confused match_type for queries that obviously matched on
-        the entity's primary identity. (#1170)"""
+        the entity's primary identity."""
         # alias contains "bed" (which also tokenizes from "Bed Light")
         # plus a unique alias-only token "lullaby".
         enriched = []
@@ -430,9 +435,45 @@ class TestFuzzySearcherIssue1170:
         results, total = searcher.search_entities(enriched, "bed", limit=10)
         assert total >= 1
         target = next(r for r in results if r["entity_id"] == "light.bed_light")
-        # "bed" is in id+name AND in alias — match_type should reflect
-        # the primary id/name match, not the alias overlap.
-        assert target["match_type"] != "alias_match", (
-            f"query token also in id/name should not be labeled alias_match: "
-            f"{target}"
+        # "bed" is a substring of "light.bed_light", so _get_match_type
+        # returns "partial_id". Asserting the specific value (not just
+        # !="alias_match") locks in the precedence: id/name path wins
+        # over alias_match labeling whenever the query token has *any*
+        # primary-identity hit.
+        assert target["match_type"] == "partial_id", (
+            f"query 'bed' should be labeled partial_id (entity_id contains "
+            f"'bed'), got: {target}"
         )
+
+
+class TestSmartEntitySearchPropagation:
+    """Lock down the finding-6 fix at the service layer: a fatal
+    ``get_states`` failure must propagate as a ``ToolError`` rather
+    than being swallowed into a zero-result dump.
+
+    The pre-fix code masked auth/connection failures by emitting a
+    ``partial_listing`` of every entity at score 0 with
+    ``partial: True`` — agents that read ``success: True`` would
+    silently accept the noise pile. After the fix, the failure surfaces
+    as ``isError=true`` so the caller can act on it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_states_failure_propagates_as_tool_error(self):
+        from unittest.mock import AsyncMock
+
+        from fastmcp.exceptions import ToolError
+
+        from ha_mcp.tools.smart_search import SmartSearchTools
+
+        mock_client = AsyncMock()
+        mock_client.get_states = AsyncMock(
+            side_effect=RuntimeError("simulated transport failure")
+        )
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": {}}
+        )
+        smart_tools = SmartSearchTools(client=mock_client, fuzzy_threshold=60)
+
+        with pytest.raises(ToolError):
+            await smart_tools.smart_entity_search("anything", limit=5)

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -6,7 +6,13 @@ and the BM25 path in SmartSearchTools._search_in_dict.
 
 import pytest
 
-from ha_mcp.utils.fuzzy_search import BM25Scorer, FuzzyEntitySearcher, tokenize
+from ha_mcp.utils.fuzzy_search import (
+    HIDDEN_SCORE_PENALTY,
+    BM25Scorer,
+    FuzzyEntitySearcher,
+    apply_hidden_penalty,
+    tokenize,
+)
 
 # ---------------------------------------------------------------------------
 # tokenize()
@@ -477,3 +483,58 @@ class TestSmartEntitySearchPropagation:
 
         with pytest.raises(ToolError):
             await smart_tools.smart_entity_search("anything", limit=5)
+
+
+class TestHiddenScorePenalty:
+    """Lock down option (c) for finding 9: hidden entities stay in
+    results but receive a score penalty so visible matches sort
+    above them. Filtering remains available via
+    ``include_hidden=False``.
+    """
+
+    def test_apply_hidden_penalty_subtracts_for_hidden(self):
+        assert apply_hidden_penalty(100, "user") == 100 - HIDDEN_SCORE_PENALTY
+        assert apply_hidden_penalty(80, "integration") == 80 - HIDDEN_SCORE_PENALTY
+
+    def test_apply_hidden_penalty_passthrough_for_visible(self):
+        assert apply_hidden_penalty(100, None) == 100
+        assert apply_hidden_penalty(60, None) == 60
+
+    def test_apply_hidden_penalty_clamps_to_zero(self):
+        # A 10-score hidden entity shouldn't go negative after a 20-pt
+        # penalty.
+        assert apply_hidden_penalty(10, "user") == 0
+
+    def test_visible_outranks_hidden_on_same_query(self):
+        """When a visible entity and a hidden entity both match the
+        same query, the visible one ranks first thanks to the penalty.
+        """
+        entities = [
+            {
+                "entity_id": "light.kitchen_main",
+                "attributes": {"friendly_name": "Kitchen Main"},
+                "state": "on",
+                # No _hidden_by → visible.
+            },
+            {
+                "entity_id": "light.kitchen_diag",
+                "attributes": {"friendly_name": "Kitchen Diag"},
+                "state": "on",
+                "_hidden_by": "integration",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(entities, "kitchen", limit=10)
+        assert total >= 2, f"both entities should match 'kitchen': {results}"
+        # Visible match must come first.
+        assert results[0]["entity_id"] == "light.kitchen_main", (
+            f"visible match should rank above penalised hidden: {results}"
+        )
+        # And the hidden one's score is lower.
+        hidden = next(
+            r for r in results if r["entity_id"] == "light.kitchen_diag"
+        )
+        visible = results[0]
+        assert hidden["score"] < visible["score"], (
+            f"hidden score should be < visible: hidden={hidden}, visible={visible}"
+        )

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -613,3 +613,46 @@ class TestHiddenScorePenalty:
                 assert hidden["score"] < results[0]["score"], (
                     f"hidden typo-match score should be lower: {results}"
                 )
+
+    def test_hidden_borderline_raw_score_threshold_edge(self):
+        """Lock down the threshold-on-raw-score fix at the regression-
+        prone edge: a hidden entity whose raw BM25 score lands
+        EXACTLY at the threshold must still surface, even though
+        ``raw - HIDDEN_SCORE_PENALTY`` falls below threshold.
+
+        Pre-fix the order was:
+            score = round(raw / theoretical_max * 100)
+            score = apply_hidden_penalty(score, hidden)
+            if score < threshold: continue   # ← drops borderline hidden
+        Post-fix the threshold gates the raw score before the penalty
+        is applied. A future revert that recomposes those two lines
+        would break here.
+        """
+        # Build a 1-entity corpus with a single token. Query against
+        # that token: BM25 raw score for the single doc is exactly
+        # theoretical_max → score 100 → at threshold 100 (custom).
+        # Then drop a hidden flag in: penalised would be 80 < 100,
+        # but the gate runs on raw=100 first, so it surfaces.
+        entities = [
+            {
+                "entity_id": "sensor.borderline",
+                "attributes": {"friendly_name": "borderline"},
+                "state": "off",
+                "_hidden_by": "integration",
+            },
+        ]
+        # threshold=100 means only an exact-IDF max BM25 hit clears.
+        # The single-token single-doc case lands at exactly that.
+        searcher = FuzzyEntitySearcher(threshold=100)
+        results, total = searcher.search_entities(
+            entities, "borderline", limit=10
+        )
+        assert total == 1, (
+            f"raw-100 hidden match must clear threshold-100 gate "
+            f"despite the post-gate penalty: {results}"
+        )
+        # And the emitted score reflects the penalty.
+        assert results[0]["score"] == 80, (
+            f"penalty must still apply (100→80) to the surfaced hit: "
+            f"{results[0]}"
+        )

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -656,3 +656,59 @@ class TestHiddenScorePenalty:
             f"penalty must still apply (100→80) to the surfaced hit: "
             f"{results[0]}"
         )
+
+    def test_score_ties_break_on_entity_id_ascending(self):
+        """Locks down the tie-breaker on the BM25 search-result sort.
+        When two entities share a score (very common — visible@100,
+        hidden@80, BM25's coarse buckets), the paginated order must be
+        stable across calls. A regression that drops the secondary key
+        flips this assertion."""
+        # Three entities that all match a single-token query at the
+        # same raw BM25 score. With score-only sort their relative
+        # order would depend on dict iteration; with the (-score,
+        # entity_id) tie-breaker they sort ascending by entity_id.
+        entities = [
+            {
+                "entity_id": "light.tie_b",
+                "attributes": {"friendly_name": "match"},
+                "state": "on",
+            },
+            {
+                "entity_id": "light.tie_a",
+                "attributes": {"friendly_name": "match"},
+                "state": "on",
+            },
+            {
+                "entity_id": "light.tie_c",
+                "attributes": {"friendly_name": "match"},
+                "state": "on",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        results, _ = searcher.search_entities(entities, "match", limit=10)
+        ids = [r["entity_id"] for r in results if r["score"] == results[0]["score"]]
+        assert ids == sorted(ids), (
+            f"tied-score results should sort by entity_id ascending: {ids}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates_from_registry_gather(self):
+        """Pre-fix `asyncio.gather(return_exceptions=True)` captured
+        CancelledError on the registry task and the search continued
+        with `hidden_filter_unavailable:` logged. After the fix the
+        cancellation must propagate — otherwise the caller waits
+        forever for a task that was already cancelled."""
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from ha_mcp.tools.smart_search import SmartSearchTools
+
+        mock_client = AsyncMock()
+        mock_client.get_states = AsyncMock(return_value=[])
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=asyncio.CancelledError()
+        )
+        smart_tools = SmartSearchTools(client=mock_client, fuzzy_threshold=60)
+
+        with pytest.raises(asyncio.CancelledError):
+            await smart_tools.smart_entity_search("anything", limit=5)

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -538,3 +538,78 @@ class TestHiddenScorePenalty:
         assert hidden["score"] < visible["score"], (
             f"hidden score should be < visible: hidden={hidden}, visible={visible}"
         )
+
+    def test_hidden_borderline_match_still_surfaces(self):
+        """Threshold gates the *raw* score, so a hidden entity that
+        matches at-or-just-above threshold still surfaces (with the
+        penalty applied to the emitted score). Pre-fix, the penalty
+        was applied before the threshold check, silently dropping
+        borderline hidden matches and partially regressing to option
+        (b) for that score range.
+        """
+        # Keep the threshold low (60 default) so the search returns
+        # results at all; engineer a hidden entity whose token-overlap
+        # against the query lands just above threshold.
+        entities = [
+            # A long-friendly-name hidden entity. The unique alias-only
+            # token "diag" gets BM25 traction without dominating.
+            {
+                "entity_id": "switch.diag",
+                "attributes": {"friendly_name": "Diag"},
+                "state": "off",
+                "_hidden_by": "integration",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(entities, "diag", limit=10)
+        # Pre-fix the hidden match would have been raw 100 → penalised
+        # 80 → still ≥ threshold (60), so it would have surfaced. But
+        # at raw 60 → 40 it would have been dropped. We can't easily
+        # construct a raw-60 hit here without HA-side fixture data, so
+        # this test exercises the simpler case (hidden surfaces with
+        # penalty); the threshold-edge regression is locked down by
+        # asserting that ``apply_hidden_penalty`` is the LAST step
+        # before ranking, not before the threshold gate.
+        assert total >= 1, f"hidden borderline match was dropped: {results}"
+        assert results[0]["entity_id"] == "switch.diag"
+        assert results[0]["score"] < 100, (
+            f"penalty should still apply to surfaced hidden: {results[0]}"
+        )
+
+    def test_hidden_typo_fallback_penalised(self):
+        """typo_fallback path also applies the hidden penalty so a
+        single-token typo against a hidden entity surfaces but ranks
+        below a typo against a visible one."""
+        entities = [
+            {
+                "entity_id": "light.kitchen",
+                "attributes": {"friendly_name": "Kitchen"},
+                "state": "on",
+            },
+            {
+                "entity_id": "light.kitchne_diag",  # typo'd
+                "attributes": {"friendly_name": "Kitchne Diag"},
+                "state": "on",
+                "_hidden_by": "integration",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        # "kitchne" is a typo target; BM25 may miss it, falling through
+        # to typo_fallback for the misspelled entity. Either path must
+        # apply the penalty.
+        results, total = searcher.search_entities(entities, "kitchne", limit=10)
+        assert total >= 1, f"typo path returned nothing: {results}"
+        # If both surface, visible kitchen entity should rank above
+        # the penalised hidden one.
+        if total >= 2:
+            assert results[0]["entity_id"] == "light.kitchen", (
+                f"visible match should rank first: {results}"
+            )
+            hidden = next(
+                (r for r in results if r["entity_id"] == "light.kitchne_diag"),
+                None,
+            )
+            if hidden is not None:
+                assert hidden["score"] < results[0]["score"], (
+                    f"hidden typo-match score should be lower: {results}"
+                )

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -298,3 +298,115 @@ class TestSearchInDictBM25:
             config, "kitchen motion", exact_match=False
         )
         assert score > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #1170 — fuzzy_search.py algorithmic regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzySearcherIssue1170:
+    """Lock down the fuzzy-search behavior changes from #1170 findings 2/5/8."""
+
+    @pytest.fixture
+    def lights_corpus(self):
+        return [
+            {
+                "entity_id": "light.bed_light",
+                "attributes": {"friendly_name": "Bed Light"},
+                "state": "off",
+            },
+            {
+                "entity_id": "light.ceiling_lights",
+                "attributes": {"friendly_name": "Ceiling Lights"},
+                "state": "off",
+            },
+            {
+                "entity_id": "light.kitchen_lights",
+                "attributes": {"friendly_name": "Kitchen Lights"},
+                "state": "off",
+            },
+            {
+                "entity_id": "cover.garage_door",
+                "attributes": {"friendly_name": "Garage Door"},
+                "state": "closed",
+            },
+        ]
+
+    def test_finding_2_elided_separator_query_finds_target_uniquely(
+        self, lights_corpus
+    ):
+        """Query ``bedlight`` (no separator) matches only ``light.bed_light``,
+        not the entire 3-light tie cluster pre-fix saw at score 76.
+
+        Implementation: separator-stripped concat tokens are added to the
+        BM25 corpus so a single-token query can match a multi-word entity
+        name directly, with high IDF (rare token = strong signal).
+        """
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(lights_corpus, "bedlight", limit=10)
+        assert total == 1, (
+            f"bedlight should uniquely match bed_light, not tie-cluster: {results}"
+        )
+        assert results[0]["entity_id"] == "light.bed_light"
+        assert results[0]["score"] >= 75, (
+            f"score should remain useful after fix: {results[0]}"
+        )
+
+    def test_finding_5_multi_token_garbage_rejected(self, lights_corpus):
+        """A 3-token nonsense query where only one token grazes a doc token
+        does NOT surface that doc.
+
+        Pre-fix: ``xyz_irrelevant_garbage`` returned ``cover.garage_door`` at
+        score 92 because typo_fallback compared each query token against
+        each doc token and a single ``garbage~garage`` ratio of 92 was
+        enough.
+
+        Post-fix: typo_fallback requires multi-token coverage ≥50% on
+        multi-token queries.
+        """
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(
+            lights_corpus, "xyz_irrelevant_garbage", limit=10
+        )
+        assert total == 0, (
+            f"low-coverage garbage query must yield no matches: {results}"
+        )
+
+    def test_finding_5_single_token_typo_still_recalls(self, lights_corpus):
+        """Single-token typos like ``ligth`` still recall (no coverage gate
+        on single-token queries — that would be too aggressive)."""
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(lights_corpus, "ligth", limit=10)
+        # Should still find at least the *_lights entities via typo_fallback.
+        assert total >= 1, f"single-token typo recall regressed: {results}"
+
+    def test_finding_8_alias_search_with_match_type_label(self, lights_corpus):
+        """Aliases are searchable when the caller supplies them on the
+        entity dict via ``_aliases``. Matches surface as
+        ``match_type='alias_match'`` so callers can distinguish."""
+        # Add an alias ONLY known via the `_aliases` field — neither
+        # entity_id nor friendly_name contain "lullaby".
+        enriched = []
+        for e in lights_corpus:
+            e2 = dict(e)
+            if e2["entity_id"] == "light.bed_light":
+                e2["_aliases"] = ["lullaby lamp"]
+            enriched.append(e2)
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(enriched, "lullaby", limit=10)
+        assert total == 1, (
+            f"alias should be searchable as a query token: {results}"
+        )
+        assert results[0]["entity_id"] == "light.bed_light"
+        assert results[0]["match_type"] == "alias_match", (
+            f"alias-driven match should be labeled alias_match: {results[0]}"
+        )
+
+    def test_finding_8_no_alias_no_match(self, lights_corpus):
+        """Without ``_aliases``, an alias-only query yields no result."""
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(
+            lights_corpus, "lullaby", limit=10
+        )
+        assert total == 0, f"no alias data → no match: {results}"

--- a/tests/src/unit/test_bm25_search.py
+++ b/tests/src/unit/test_bm25_search.py
@@ -392,6 +392,54 @@ class TestFuzzySearcherIssue1170:
             f"{[r['entity_id'] for r in results]}"
         )
 
+    def test_typo_fallback_short_single_token_returns_empty(self):
+        """Locks down the single-token min-length gate. A 3-char single
+        token (``lit``) used to surface unrelated entities like
+        ``u7_lite_*`` and ``shopping_list`` via partial overlap at score
+        85. The coverage gate from finding 5 only handles multi-token
+        garbage — short single-token queries needed their own gate."""
+        entities = [
+            {
+                "entity_id": "button.u7_lite_restart",
+                "attributes": {"friendly_name": "U7 Lite Restart"},
+                "state": "off",
+            },
+            {
+                "entity_id": "light.u7_lite_led",
+                "attributes": {"friendly_name": "U7 Lite LED"},
+                "state": "on",
+            },
+            {
+                "entity_id": "todo.shopping_list",
+                "attributes": {"friendly_name": "Shopping List"},
+                "state": "1",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        results, total = searcher.search_entities(entities, "lit", limit=10)
+        assert total == 0, (
+            f"short single-token typo query should not surface sub-word "
+            f"noise: {results}"
+        )
+
+    def test_typo_fallback_four_char_single_token_still_fires(self):
+        """Boundary: 4-char single token still triggers typo_fallback so
+        common typos like ``ligth``→``light`` survive the new gate."""
+        entities = [
+            {
+                "entity_id": "light.kitchen",
+                "attributes": {"friendly_name": "Kitchen"},
+                "state": "on",
+            },
+        ]
+        searcher = FuzzyEntitySearcher()
+        # 5-char typo of "light" — the 4-char gate should not block this.
+        results, total = searcher.search_entities(entities, "ligth", limit=10)
+        assert total >= 1, (
+            f"4+ char single-token typo should still fire typo_fallback: "
+            f"{results}"
+        )
+
     def test_finding_8_alias_search_with_match_type_label(self, lights_corpus):
         """Aliases are searchable when the caller supplies them on the
         entity dict via ``_aliases``. Matches surface as

--- a/tests/src/unit/test_search_fallback.py
+++ b/tests/src/unit/test_search_fallback.py
@@ -138,8 +138,14 @@ class TestExactMatchSearch:
         assert scores == sorted(scores, reverse=True)
 
     @pytest.mark.asyncio
-    async def test_exact_match_excludes_hidden_by_default(self, sample_entities):
-        """Hidden entities are filtered out by default (#1170 finding 9)."""
+    async def test_exact_match_includes_hidden_with_penalty_by_default(
+        self, sample_entities
+    ):
+        """Hidden entities surface in default results with a score
+        penalty (option c from issue #1170 finding 9). The penalty
+        ensures visible matches sort above hidden ones without
+        excluding the hidden entries entirely.
+        """
 
         class HidingClient(MockClient):
             async def send_websocket_message(self, payload):
@@ -152,12 +158,30 @@ class TestExactMatchSearch:
 
         client = HidingClient(sample_entities)
         result = await _exact_match_search(client, "bedroom", None, 10)
-        entity_ids = [r["entity_id"] for r in result["results"]]
-        assert "light.bedroom" not in entity_ids
+        by_id = {r["entity_id"]: r for r in result["results"]}
+        assert "light.bedroom" in by_id, (
+            "hidden entity should be in default results (option c)"
+        )
+        assert by_id["light.bedroom"]["score"] < 100, (
+            f"hidden entity should carry penalty: {by_id['light.bedroom']}"
+        )
+        # If a visible "bedroom" match exists at score 100, it must outrank
+        # the penalised hidden entry.
+        visible_bedroom = next(
+            (
+                r for eid, r in by_id.items()
+                if eid != "light.bedroom" and "bedroom" in eid.lower()
+            ),
+            None,
+        )
+        if visible_bedroom is not None:
+            assert visible_bedroom["score"] >= by_id["light.bedroom"]["score"], (
+                f"visible match must rank ≥ hidden: {by_id}"
+            )
 
     @pytest.mark.asyncio
-    async def test_exact_match_include_hidden_opt_in(self, sample_entities):
-        """include_hidden=True surfaces hidden entities (#1170 finding 9)."""
+    async def test_exact_match_include_hidden_false_filters(self, sample_entities):
+        """``include_hidden=False`` filters hidden entities out entirely."""
 
         class HidingClient(MockClient):
             async def send_websocket_message(self, payload):
@@ -170,10 +194,10 @@ class TestExactMatchSearch:
 
         client = HidingClient(sample_entities)
         result = await _exact_match_search(
-            client, "bedroom", None, 10, include_hidden=True
+            client, "bedroom", None, 10, include_hidden=False
         )
         entity_ids = [r["entity_id"] for r in result["results"]]
-        assert "light.bedroom" in entity_ids
+        assert "light.bedroom" not in entity_ids
 
 
 class TestSearchFallbackResponse:

--- a/tests/src/unit/test_search_fallback.py
+++ b/tests/src/unit/test_search_fallback.py
@@ -220,3 +220,25 @@ class TestSearchFallbackResponse:
         assert "success" in result
         assert "results" in result
         assert result["success"] is True
+
+
+class TestExactMatchSearchCancelledPropagation:
+    """Lock down the CancelledError re-raise added to _exact_match_search
+    after asyncio.gather(return_exceptions=True). Pre-fix the captured
+    cancellation hit the `hidden_filter_unavailable:` log path and the
+    function continued — the canceller waited forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancelled_on_registry_task_propagates(self):
+        import asyncio
+
+        class CancellingClient:
+            async def get_states(self):
+                return []
+
+            async def send_websocket_message(self, payload):
+                raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _exact_match_search(CancellingClient(), "x", None, 10)

--- a/tests/src/unit/test_search_fallback.py
+++ b/tests/src/unit/test_search_fallback.py
@@ -1,24 +1,36 @@
 """Unit tests for search fallback functionality (issue #214).
 
-Tests the graceful degradation search methods:
+Tests the graceful degradation search method:
 - _exact_match_search: Fallback exact substring matching
-- _partial_results_search: Last resort entity listing
+
+The legacy ``_partial_results_search`` was removed in #1170 (finding 6).
+Its behavior was a useless score-0 entity dump that masked errors;
+exceptions now propagate to callers instead.
 """
 
 
 import pytest
 
-from ha_mcp.tools.tools_search import _exact_match_search, _partial_results_search
+from ha_mcp.tools.tools_search import _exact_match_search
 
 
 class MockClient:
-    """Mock Home Assistant client for testing."""
+    """Mock Home Assistant client for testing.
+
+    ``_exact_match_search`` now also calls ``send_websocket_message``
+    to fetch the entity registry for the hidden_by filter (#1170 finding
+    9). The mock returns an empty success response, which is treated as
+    "no entities are hidden" by the fallback.
+    """
 
     def __init__(self, entities: list[dict]):
         self.entities = entities
 
     async def get_states(self) -> list[dict]:
         return self.entities
+
+    async def send_websocket_message(self, payload: dict) -> dict:
+        return {"success": True, "result": []}
 
 
 class TestExactMatchSearch:
@@ -125,82 +137,43 @@ class TestExactMatchSearch:
         scores = [r["score"] for r in result["results"]]
         assert scores == sorted(scores, reverse=True)
 
+    @pytest.mark.asyncio
+    async def test_exact_match_excludes_hidden_by_default(self, sample_entities):
+        """Hidden entities are filtered out by default (#1170 finding 9)."""
 
-class TestPartialResultsSearch:
-    """Test _partial_results_search fallback function."""
+        class HidingClient(MockClient):
+            async def send_websocket_message(self, payload):
+                return {
+                    "success": True,
+                    "result": [
+                        {"entity_id": "light.bedroom", "hidden_by": "user"},
+                    ],
+                }
 
-    @pytest.fixture
-    def sample_entities(self):
-        """Sample entities for testing."""
-        return [
-            {
-                "entity_id": "light.living_room",
-                "attributes": {"friendly_name": "Living Room Light"},
-                "state": "on",
-            },
-            {
-                "entity_id": "switch.kitchen",
-                "attributes": {"friendly_name": "Kitchen Switch"},
-                "state": "on",
-            },
-            {
-                "entity_id": "sensor.temperature",
-                "attributes": {"friendly_name": "Temperature Sensor"},
-                "state": "22.5",
-            },
-        ]
+        client = HidingClient(sample_entities)
+        result = await _exact_match_search(client, "bedroom", None, 10)
+        entity_ids = [r["entity_id"] for r in result["results"]]
+        assert "light.bedroom" not in entity_ids
 
     @pytest.mark.asyncio
-    async def test_partial_results_returns_all_entities(self, sample_entities):
-        """Partial results returns all entities without filtering."""
-        client = MockClient(sample_entities)
-        result = await _partial_results_search(client, "anything", None, 100)
+    async def test_exact_match_include_hidden_opt_in(self, sample_entities):
+        """include_hidden=True surfaces hidden entities (#1170 finding 9)."""
 
-        assert result["success"] is True
-        assert result["partial"] is True
-        assert result["search_type"] == "partial_listing"
-        assert len(result["results"]) == 3
+        class HidingClient(MockClient):
+            async def send_websocket_message(self, payload):
+                return {
+                    "success": True,
+                    "result": [
+                        {"entity_id": "light.bedroom", "hidden_by": "user"},
+                    ],
+                }
 
-    @pytest.mark.asyncio
-    async def test_partial_results_with_domain_filter(self, sample_entities):
-        """Partial results respects domain_filter."""
-        client = MockClient(sample_entities)
-        result = await _partial_results_search(client, "anything", "light", 100)
-
-        assert result["success"] is True
-        assert result["partial"] is True
-        assert len(result["results"]) == 1
-        assert result["results"][0]["entity_id"] == "light.living_room"
-
-    @pytest.mark.asyncio
-    async def test_partial_results_respects_limit(self, sample_entities):
-        """Partial results respects the limit parameter."""
-        client = MockClient(sample_entities)
-        result = await _partial_results_search(client, "anything", None, 2)
-
-        assert result["success"] is True
-        assert len(result["results"]) == 2
-
-    @pytest.mark.asyncio
-    async def test_partial_results_has_zero_score(self, sample_entities):
-        """Partial results have zero score to indicate no match."""
-        client = MockClient(sample_entities)
-        result = await _partial_results_search(client, "anything", None, 10)
-
-        assert result["success"] is True
-        for entity in result["results"]:
-            assert entity["score"] == 0
-            assert entity["match_type"] == "partial_listing"
-
-    @pytest.mark.asyncio
-    async def test_partial_results_empty_domain(self, sample_entities):
-        """Partial results returns empty for non-existent domain."""
-        client = MockClient(sample_entities)
-        result = await _partial_results_search(client, "anything", "nonexistent", 10)
-
-        assert result["success"] is True
-        assert result["partial"] is True
-        assert len(result["results"]) == 0
+        client = HidingClient(sample_entities)
+        result = await _exact_match_search(
+            client, "bedroom", None, 10, include_hidden=True
+        )
+        entity_ids = [r["entity_id"] for r in result["results"]]
+        assert "light.bedroom" in entity_ids
 
 
 class TestSearchFallbackResponse:
@@ -223,21 +196,3 @@ class TestSearchFallbackResponse:
         assert "success" in result
         assert "results" in result
         assert result["success"] is True
-
-    @pytest.mark.asyncio
-    async def test_partial_results_response_format(self):
-        """Verify partial results response format matches issue #214."""
-        entities = [
-            {
-                "entity_id": "light.test",
-                "attributes": {"friendly_name": "Test Light"},
-                "state": "on",
-            }
-        ]
-        client = MockClient(entities)
-        result = await _partial_results_search(client, "test", None, 10)
-
-        # Verify expected fields from issue #214
-        assert result["success"] is True
-        assert result["partial"] is True
-        assert "results" in result

--- a/tests/src/unit/test_search_pagination.py
+++ b/tests/src/unit/test_search_pagination.py
@@ -3,12 +3,17 @@
 Tests that search functions correctly support offset-based pagination
 with standardized metadata: total_matches, offset, limit, count, has_more, next_offset.
 Also includes regression test for suggestions bug fix.
+
+Note: pagination tests for the legacy ``_partial_results_search`` were
+removed in #1170 (finding 6) — that fallback returned a useless
+score-0 entity dump and was deleted; exceptions now propagate to
+callers instead.
 """
 
 import pytest
 
 from ha_mcp.tools.smart_search import SmartSearchTools
-from ha_mcp.tools.tools_search import _exact_match_search, _partial_results_search
+from ha_mcp.tools.tools_search import _exact_match_search
 from ha_mcp.utils.fuzzy_search import (
     FuzzyEntitySearcher,
     calculate_partial_ratio,
@@ -18,13 +23,25 @@ from ha_mcp.utils.fuzzy_search import (
 
 
 class MockClient:
-    """Mock Home Assistant client for testing."""
+    """Mock Home Assistant client for testing.
+
+    The search code paths now also call ``send_websocket_message`` to
+    fetch entity / area registries (#1170 findings 8 and 9). The mock
+    returns empty success responses, which the search code treats as
+    "no aliases, nothing hidden".
+    """
 
     def __init__(self, entities: list[dict]):
         self.entities = entities
 
     async def get_states(self) -> list[dict]:
         return self.entities
+
+    async def send_websocket_message(self, payload: dict) -> dict:
+        msg_type = payload.get("type", "")
+        if msg_type == "config/entity_registry/get_entries":
+            return {"success": True, "result": {}}
+        return {"success": True, "result": []}
 
 
 def _make_entities(count: int) -> list[dict]:
@@ -153,48 +170,6 @@ class TestExactMatchSearchPagination:
         assert result["has_more"] is False
         assert result["next_offset"] is None
         assert result["total_matches"] == 10
-
-
-class TestPartialResultsSearchPagination:
-    """Test _partial_results_search offset pagination."""
-
-    @pytest.fixture
-    def many_entities(self):
-        return _make_entities(10)
-
-    @pytest.mark.asyncio
-    async def test_offset_skips_results(self, many_entities):
-        client = MockClient(many_entities)
-        page1 = await _partial_results_search(client, "anything", None, 3, offset=0)
-        page2 = await _partial_results_search(client, "anything", None, 3, offset=3)
-
-        assert page1["count"] == 3
-        assert page2["count"] == 3
-        ids1 = {r["entity_id"] for r in page1["results"]}
-        ids2 = {r["entity_id"] for r in page2["results"]}
-        assert ids1.isdisjoint(ids2)
-
-    @pytest.mark.asyncio
-    async def test_pagination_metadata(self, many_entities):
-        client = MockClient(many_entities)
-        result = await _partial_results_search(client, "anything", None, 3, offset=0)
-
-        assert result.keys() >= PAGINATION_FIELDS
-        assert result["total_matches"] == 10
-        assert result["offset"] == 0
-        assert result["limit"] == 3
-        assert result["count"] == 3
-        assert result["has_more"] is True
-        assert result["next_offset"] == 3
-
-    @pytest.mark.asyncio
-    async def test_last_page_has_more_false(self, many_entities):
-        client = MockClient(many_entities)
-        result = await _partial_results_search(client, "anything", None, 5, offset=5)
-
-        assert result["count"] == 5
-        assert result["has_more"] is False
-        assert result["next_offset"] is None
 
 
 class TestFuzzyScoreAccumulation:

--- a/tests/src/unit/test_server_bridge_strip.py
+++ b/tests/src/unit/test_server_bridge_strip.py
@@ -1,0 +1,84 @@
+"""Locks down the `server.HASmartMCPServer.get_entities_by_area`
+bridge's invocation of `strip_internal_fields` on its return value.
+
+The bridge is a public method that wraps `smart_tools.get_entities_by_area`
+(which enriches per-entity dicts with `_hidden_by` so downstream search
+branches can apply the score penalty without a second registry lookup).
+That helper output crosses the public-API boundary here — if a future
+refactor drops the strip call, internal fields leak directly to MCP
+clients with no signal in CI. This test pins the contract.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_entities_by_area_bridge_strips_internal_fields(monkeypatch):
+    # Stub the minimal HASmartMCPServer surface needed for the bridge:
+    # the bridge just delegates to `self.smart_tools.get_entities_by_area`
+    # and then strips internals.
+    fake_smart_tools = SimpleNamespace()
+    fake_smart_tools.get_entities_by_area = AsyncMock(
+        return_value={
+            "areas": {
+                "kitchen": {
+                    "area_name": "Kitchen",
+                    "entities": {
+                        "light": [
+                            {
+                                "entity_id": "light.kitchen_main",
+                                "_hidden_by": None,
+                                "_aliases": [],
+                                "state": "on",
+                            },
+                            {
+                                "entity_id": "light.kitchen_diag",
+                                "_hidden_by": "integration",
+                                "_aliases": [],
+                                "state": "off",
+                            },
+                        ]
+                    },
+                }
+            },
+            "total_entities": 2,
+        }
+    )
+
+    # Import after monkeypatch path setup — server.py pulls in fastmcp
+    # which is heavy but available in the test env.
+    from ha_mcp.server import HASmartMCPServer
+
+    # Construct without going through __init__ (heavy startup). The
+    # bridge only touches self.smart_tools.
+    instance = HASmartMCPServer.__new__(HASmartMCPServer)
+    instance.smart_tools = fake_smart_tools
+
+    result = await instance.get_entities_by_area("kitchen")
+
+    # No leading-underscore keys anywhere in the tree.
+    def _no_internals(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(k, str) and k.startswith("_"):
+                    return False
+                if not _no_internals(v):
+                    return False
+        elif isinstance(obj, list):
+            for item in obj:
+                if not _no_internals(item):
+                    return False
+        return True
+
+    assert _no_internals(result), (
+        f"bridge leaked internal fields to public output: {result}"
+    )
+
+    # And the public data is still there.
+    light_entries = result["areas"]["kitchen"]["entities"]["light"]
+    assert {e["entity_id"] for e in light_entries} == {
+        "light.kitchen_main",
+        "light.kitchen_diag",
+    }

--- a/tests/src/unit/test_server_bridge_strip.py
+++ b/tests/src/unit/test_server_bridge_strip.py
@@ -52,9 +52,11 @@ async def test_get_entities_by_area_bridge_strips_internal_fields():
     from ha_mcp.server import HomeAssistantSmartMCPServer
 
     # Construct without going through __init__ (heavy startup). The
-    # bridge only touches self.smart_tools.
+    # bridge only touches self.smart_tools, which is a lazy-init
+    # property backed by ``_smart_tools`` — set the backing field
+    # directly so the property short-circuits to our fake.
     instance = HomeAssistantSmartMCPServer.__new__(HomeAssistantSmartMCPServer)
-    instance.smart_tools = fake_smart_tools
+    instance._smart_tools = fake_smart_tools
 
     result = await instance.get_entities_by_area("kitchen")
 

--- a/tests/src/unit/test_server_bridge_strip.py
+++ b/tests/src/unit/test_server_bridge_strip.py
@@ -1,4 +1,4 @@
-"""Locks down the `server.HASmartMCPServer.get_entities_by_area`
+"""Locks down the `server.HomeAssistantSmartMCPServer.get_entities_by_area`
 bridge's invocation of `strip_internal_fields` on its return value.
 
 The bridge is a public method that wraps `smart_tools.get_entities_by_area`
@@ -15,8 +15,8 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_get_entities_by_area_bridge_strips_internal_fields(monkeypatch):
-    # Stub the minimal HASmartMCPServer surface needed for the bridge:
+async def test_get_entities_by_area_bridge_strips_internal_fields():
+    # Stub the minimal HomeAssistantSmartMCPServer surface needed for the bridge:
     # the bridge just delegates to `self.smart_tools.get_entities_by_area`
     # and then strips internals.
     fake_smart_tools = SimpleNamespace()
@@ -49,11 +49,11 @@ async def test_get_entities_by_area_bridge_strips_internal_fields(monkeypatch):
 
     # Import after monkeypatch path setup — server.py pulls in fastmcp
     # which is heavy but available in the test env.
-    from ha_mcp.server import HASmartMCPServer
+    from ha_mcp.server import HomeAssistantSmartMCPServer
 
     # Construct without going through __init__ (heavy startup). The
     # bridge only touches self.smart_tools.
-    instance = HASmartMCPServer.__new__(HASmartMCPServer)
+    instance = HomeAssistantSmartMCPServer.__new__(HomeAssistantSmartMCPServer)
     instance.smart_tools = fake_smart_tools
 
     result = await instance.get_entities_by_area("kitchen")

--- a/tests/src/unit/test_util_helpers_internal_strip.py
+++ b/tests/src/unit/test_util_helpers_internal_strip.py
@@ -1,0 +1,131 @@
+"""Unit tests for the leading-underscore strip helpers in util_helpers.
+
+These two helpers (`strip_internal_fields` and `public_fields`)
+centralise the convention that ha-mcp tool layers enrich entity / area
+dicts with internal fields like ``_hidden_by`` / ``_aliases`` so
+downstream branches can rank without re-querying the registry, and
+those fields must not leak through public tool returns.
+
+A regression that, e.g., stops recursing into nested lists or mishandles
+non-string keys would silently surface internal fields through every
+public tool that touches them — these tests pin the contract.
+"""
+from ha_mcp.tools.util_helpers import public_fields, strip_internal_fields
+
+
+class TestStripInternalFields:
+    """Locks down `strip_internal_fields` mutate-in-place contract."""
+
+    def test_removes_top_level_underscore_keys(self):
+        d = {"entity_id": "light.x", "_hidden_by": "user", "score": 100}
+        result = strip_internal_fields(d)
+        assert result is d, "should mutate and return same reference"
+        assert d == {"entity_id": "light.x", "score": 100}
+
+    def test_recurses_into_nested_dicts(self):
+        d = {
+            "outer": "v",
+            "nested": {
+                "entity_id": "x",
+                "_hidden_by": "integration",
+                "_aliases": ["a"],
+            },
+        }
+        strip_internal_fields(d)
+        assert d == {"outer": "v", "nested": {"entity_id": "x"}}
+
+    def test_recurses_into_lists_of_dicts(self):
+        d = {
+            "results": [
+                {"entity_id": "a", "_hidden_by": "user"},
+                {"entity_id": "b", "_aliases": []},
+            ]
+        }
+        strip_internal_fields(d)
+        assert d == {"results": [{"entity_id": "a"}, {"entity_id": "b"}]}
+
+    def test_does_not_remove_non_string_keys(self):
+        # int keys can never start with "_" — they must pass through
+        # untouched, not crash the helper.
+        d = {1: "one", 2: "two", "_hidden_by": "x"}
+        strip_internal_fields(d)
+        assert d == {1: "one", 2: "two"}
+
+    def test_handles_non_dict_non_list_input(self):
+        # A bare string / int / None should pass through unchanged.
+        assert strip_internal_fields("hello") == "hello"
+        assert strip_internal_fields(42) == 42
+        assert strip_internal_fields(None) is None
+
+    def test_cycle_guard_prevents_recursion_error(self):
+        # JSON payloads can't be cyclic, but the helper is now a public
+        # utility — defend against a future caller that constructs one.
+        a: dict = {"entity_id": "x"}
+        b: dict = {"_hidden_by": "user", "back": a}
+        a["nested"] = b
+        # Without the cycle guard this would RecursionError.
+        strip_internal_fields(a)
+        assert "_hidden_by" not in b
+        assert a["entity_id"] == "x"
+
+    def test_deep_underscore_strip_in_double_nested_list(self):
+        d = {
+            "areas": [
+                {
+                    "entities": [
+                        {"entity_id": "a", "_hidden_by": "user"},
+                        {"entity_id": "b"},
+                    ]
+                }
+            ]
+        }
+        strip_internal_fields(d)
+        assert d["areas"][0]["entities"][0] == {"entity_id": "a"}
+
+    def test_only_string_underscore_prefix_stripped(self):
+        d = {"_hidden_by": "user", "_": "x", "no_underscore_prefix": "y"}
+        strip_internal_fields(d)
+        # "_" alone (just an underscore) starts with "_" and is stripped.
+        assert d == {"no_underscore_prefix": "y"}
+
+
+class TestPublicFields:
+    """Locks down `public_fields` non-mutating shallow-copy contract."""
+
+    def test_returns_new_dict(self):
+        d = {"entity_id": "x", "_hidden_by": "user"}
+        result = public_fields(d)
+        assert result is not d, "must return new dict"
+
+    def test_does_not_mutate_source(self):
+        d = {"entity_id": "x", "_hidden_by": "user"}
+        public_fields(d)
+        # Source must still have the underscore key.
+        assert "_hidden_by" in d
+
+    def test_strips_underscore_keys(self):
+        d = {"a": 1, "_b": 2, "c": 3, "_aliases": ["x"]}
+        assert public_fields(d) == {"a": 1, "c": 3}
+
+    def test_shallow_only_list_values_shared(self):
+        # Documents the shallow-copy contract: list/dict values are
+        # shared, so a downstream mutation of the value would affect
+        # the source.
+        shared_list = ["a", "b"]
+        d = {"items": shared_list, "_hidden_by": "user"}
+        result = public_fields(d)
+        assert result["items"] is shared_list
+
+    def test_handles_int_keys(self):
+        d = {1: "one", "_hidden_by": "x", "name": "n"}
+        # int keys (can't startswith) pass through untouched.
+        assert public_fields(d) == {1: "one", "name": "n"}
+
+    def test_empty_dict(self):
+        assert public_fields({}) == {}
+
+    def test_no_underscore_keys(self):
+        d = {"a": 1, "b": 2}
+        result = public_fields(d)
+        assert result == d
+        assert result is not d  # still a copy


### PR DESCRIPTION
## What does this PR do?

Triage and fix every one of the 10 behaviors in ha_search_entities documented in #1170. Each finding is addressed with a targeted change plus regression tests; the alias work also closes #1166.

### The 10 findings

| # | Finding | Resolution |
|---|---------|-----------|
| 1 | `domain_filter` is case-sensitive (silent zero on `Light`) | normalize to `.strip().lower()` at both the tool and service-layer boundaries (and BEFORE the at-least-one-set validation, so a whitespace-only filter fails validation instead of falling through); the response echoes the canonical value |
| 2 | `bedlight` ties `light.bed_light` against five unrelated `*_lights` at score 76 | per-entity, the entity_id tail and friendly_name now contribute their separator-stripped concat as a high-IDF BM25 token |
| 3 | `area_only` results miss `score` + `match_type`; `essential_attributes` only on fuzzy_search | add `score=100`, `match_type="area_match"` so the shape matches the other four search-type branches; drop `essential_attributes` from fuzzy_search for full shape parity |
| 4 | `area_filtered_query` echoes `area_filter` per-result (asymmetric) | drop the redundant per-result echo (top-level `area_filter` still present) |
| 5 | Threshold lets `xyz_irrelevant_garbage` → `cover.garage_door` at score 92; `lit` surfaces 186 `*_lite*` entities at 85 | multi-token coverage gate (≥50% of distinct tokens must fuzzy-match a doc token) + single-token min-length gate (≥4 chars) in typo_fallback. Legitimate typos like `ligth` (5 chars) unaffected |
| 6 | `_partial_results_search` returned a useless score-0 entity dump | deleted; exceptions propagate so callers see the real cause instead of `partial: true` noise |
| 7 | `area_only` returns the first matched area only (and from a `set`, so non-deterministic) | aggregate all matched areas in deterministic order; new `area_names: list[str]` joins legacy `area_name`. Exact id/name/alias matches short-circuit fuzzy aggregation so a literal area_id no longer leaks sibling areas' entities |
| 8 | Entity / area aliases not searchable | fold `entity_registry.aliases` into the BM25 corpus via a single batched `get_entries` call; consult `area_registry.aliases` in the area resolver. Closes #1166. |
| 9 | Hidden entities (`hidden_by`) outrank visible peers under identical match conditions | option (c) from the issue: hidden entities still surface, but receive a 20-point score penalty so visible matches sort above them. New `include_hidden: bool = True` parameter is the explicit opt-out for filtering them entirely |
| 10 | E2E coverage gap on populated areas | new `TestSearchEntitiesSeededAreasIssue1170` test class against the `tests/initial_test_state` seed |

### Implementation notes

- **Concat-token elision (#2):** the new `_strip_separators` helper exposes elided forms (`bed_light` → `bedlight`) as BM25 tokens. Single-token queries that omit separators now hit a unique high-IDF token directly instead of falling through to typo_fallback's tie-cluster.
- **Coverage gate + single-token gate (#5):** in `_typo_fallback`, multi-token queries must have ≥50% of their distinct tokens fuzzy-match some doc token. Garbage queries with one accidental hit (`garbage~garage`) are rejected. Single-token queries shorter than 4 chars also skip the fallback (`"lit"` no longer surfaces every `*_lite*` entity at score 85); legitimate typos like `"ligth"` are unaffected.
- **Aliases plumbing (#8):** the slim `config/entity_registry/list` deliberately omits `aliases` — we now batch-fetch via `config/entity_registry/get_entries` after the hidden filter, so the extra round-trip stays bounded by the post-filter survivor set. Same approach in `get_entities_by_area` for area-resolved entities. Alias-driven matches surface as `match_type="alias_match"`.
- **Aggregate areas + exact-id short-circuit (#7):** the area_only branch was using `next(iter(area_result["areas"].values()))` against a `set` upstream — non-deterministic AND lossy. Now sorts by `area_id` and iterates all. `area_names: list[str]` is the new field; `area_name` (singular) is retained as the first match for one minor version of soft-compat. Exact id/name/alias matches now short-circuit fuzzy aggregation: `area_filter="bedroom_kids"` no longer fuzzy-matches its parent `"bedroom"` (partial_ratio=100) and aggregates sibling areas' entities.
- **Hidden-score penalty (#9):** new `apply_hidden_penalty(score, hidden_by)` helper in `fuzzy_search.py` subtracts a 20-point penalty whenever `hidden_by` is non-None. Wired through every branch that emits a `score` field — BM25, typo_fallback, exact_match, area_only, area_filtered_query, domain_listing — so the contract is uniform: a hidden exact-id match (raw 100 → 80) still ranks above a fuzzy threshold-floor visible match (60-70), but loses to any visible entity scoring 80+. The threshold gate runs on the *raw* score so a borderline hidden match doesn't silently disappear. `include_hidden=False` retains the explicit opt-out for callers that need visible-only results.
- **Error propagation (#6):** the fuzzy fallback wrapper now has an `except ToolError: raise` guard, so structured failures from `smart_entity_search` propagate instead of being retried via the substring fallback. Alias-enrichment warnings carry a structured `alias_enrichment_failed` prefix and the survivor count for log bucketing.
- **CancelledError propagation:** `asyncio.gather(return_exceptions=True)` captures `asyncio.CancelledError` like any other exception. Three call sites (`smart_entity_search`, `_exact_match_search`, the empty-query+domain branch) now explicitly re-raise it so the canceller doesn't wait forever.
- **Sort tie-breaker:** all four score-only sort sites (`fuzzy_search` main path, `_exact_match_search`, `area_only`, `domain_listing`) now tie-break on `entity_id` for stable pagination — the hidden-penalty banding (visible@100, hidden@80) made the within-tier reordering particularly likely without the secondary key.
- **Validation-order fix:** `domain_filter` / `area_filter` strip+lowercase now happens BEFORE the at-least-one-set validation. Previously a whitespace-only filter (`"   "`) passed validation truthy then collapsed to `""` and fell through to a silent zero-result fuzzy search.
- **Validation error suggestions:** `ValueError` from `coerce_bool_param` / `coerce_int_param` is now caught separately and surfaced via `create_validation_error` with the helper's own message and no boilerplate operational suggestions (previously `limit=0` returned `"Check Home Assistant connection"` next to `"limit must be at least 1, got 0"`).
- **Internal-field strip helpers:** `strip_internal_fields` (recursive, mutating, cycle-guarded) and `public_fields` (shallow, non-mutating) in `tools/util_helpers.py` centralise the leading-underscore convention so `_hidden_by` / `_aliases` enrichments don't leak through public tool returns. `server.py:get_entities_by_area` bridge now strips its delegate's output.
- **Zero-overlap message (area+domain):** when `area_filter` resolves to populated areas but `domain_filter` wipes out every entity, the response now carries `"No <domain> entities found in area: <area>"` — previously the empty-area branch had a message but the populated-but-domain-filtered-empty branch was silent.

### Public API impact

- **Adds**: `include_hidden` parameter (default `True`); `area_names: list[str]` on `area_only`; `match_type="alias_match"` result value.
- **Shape changes** (compatible upgrades for the 4 affected branches):
  - `area_only` results now include `score` + `match_type` (#3).
  - `area_filtered_query` no longer emits `area_filter` per-result (top-level still present) (#4).
  - `search_type="partial_listing"` no longer returned (#6) — failures now surface as `ToolError` instead of a zero-scored entity dump.
  - `fuzzy_search` no longer emits `essential_attributes` (matches the other four branches' shape).
  - `domain_filter` is `.strip().lower()` normalized before matching, and echoed in normalized form (#1).
- **Score change** (#9): hidden entities (`hidden_by != null`) now sort below comparable visible matches due to a 20-point score penalty. Default-True `include_hidden` keeps them in results — set `include_hidden=False` for the visible-only behavior. No callers have a smaller result set than before unless they explicitly opt out.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Test additions:
- `TestFuzzySearcherIssue1170` in `tests/src/unit/test_bm25_search.py`: concat-token elision, multi-token coverage gate, alias-match labeling, single-token typo recall, alias-vs-name precedence, **short single-token min-length gate** (`"lit"` returns empty; `"ligth"` still recalls).
- `TestSmartEntitySearchPropagation` — locks down the finding-6 contract that `get_states` failures surface as `ToolError`.
- `TestHiddenScorePenalty` — locks down the option-(c) ranking contract: helper math, visible-vs-hidden ordering on shared queries, zero-clamp boundary, **threshold-on-raw-score edge case** (raw-100 hidden surfaces at score 80 even when threshold=100), **typo_fallback penalty**, **CancelledError propagation**, **sort tie-breaker ordering**.
- `TestStripInternalFields` and `TestPublicFields` in `tests/src/unit/test_util_helpers_internal_strip.py` — full coverage of the leak-guard helpers (recursion, cycles, non-string keys, mutation semantics, shallow-copy contract).
- `TestExactMatchSearchCancelledPropagation` in `test_search_fallback.py` — `_exact_match_search` re-raises CancelledError from the registry task.
- `tests/src/unit/test_server_bridge_strip.py` — `server.py:get_entities_by_area` bridge actually invokes `strip_internal_fields`.
- E2E regression tests in `tests/src/e2e/tools/test_search_entities.py`: one per runtime-observable finding, plus area-alias resolution, concat-token elision through the full pipeline, **area_filtered_query + hidden penalty**, **domain_listing + hidden penalty**, **determinism of `area_names` ordering**, **exact area_id short-circuits fuzzy aggregation**, **shape consistency across all 5 search_types**, **validation error has no generic suggestions**, **area+domain zero-overlap message**, parametrised whitespace test for `domain_filter` (5 variants), whitespace-only filter rejected at validation, hidden-with-penalty / `include_hidden=False` pair across substring + fuzzy + area_only branches.
- `TestSearchEntitiesSeededAreasIssue1170` class with 3 test methods exercising area_filter branches at realistic seeded-area populations (#10).
- Existing unit tests in `test_search_fallback.py` rewritten for option (c) — assert hidden entities are present with reduced score, and assert `include_hidden=False` filters them out.
- `seeded_bedroom` fixture wrapped in try/finally so a fixture-body failure (or `pytest.skip`) doesn't leak the seed area assignments.

Test updates:
- `valid_search_types` in the response-structure regression test no longer accepts the deleted `partial_listing`.
- `test_search_fallback.py` and `test_search_pagination.py` updated to drop references to the deleted `_partial_results_search`.

## Future improvements

None tracked — every triage item from #1170, plus all findings surfaced during live stress testing on a real HA instance, is addressed in this PR.

## Checklist

- [x] I have updated documentation if needed (tool docstrings refreshed inline; no public docs needed updating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
