### PR TITLE
fix(ci): add --dist loadscope to E2E test command (#1196)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -178,6 +178,7 @@ jobs:
         echo "🚀 Running full E2E test suite with ${{ matrix.pytest_workers }} workers..."
         uv run pytest tests/src/e2e/ \
           -n${{ matrix.pytest_workers }} \
+          --dist loadscope \
           --tb=short \
           -v
         echo "✅ Full E2E test suite passed"


### PR DESCRIPTION
## What does this PR do?

Adds `--dist loadscope` to the E2E test pytest invocation in `pr.yml`, fixing the test-isolation race documented in #1196. Without the flag, same-class tests can land on different xdist workers (each worker has its own session-scoped HA testcontainer) **and** be scheduled out-of-order — both modes were observed on `TestYamlModeDashboardRegistration` arm runs (see #1196 for the per-run worker map). `--dist loadscope` groups same-class tests on the same worker and preserves collection order, fixing both modes.

Closes #1196.

The local invocation in `AGENTS.md` already uses `--dist loadscope`; this aligns CI with the documented local command.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Future improvements

<!-- Optional: things noticed during this PR that are out of scope but worth doing later.
     Small things fixable in a few lines should be fixed inline rather than listed here. -->

## Checklist
- [ ] I have updated documentation if needed
