### PR TITLE
fix: improve ha_manage_addon discoverability (BM25 keywords + slug examples)

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -525,6 +525,14 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "binary_sensor command_line rest mqtt platform yaml-only "
             "config file modify add remove replace"
         ),
+        "ha_manage_addon": (
+            "manage addon add-on configure settings options port network boot "
+            "watchdog auto_update supervisor ingress proxy websocket api rest "
+            "esphome nodered node-red frigate mosquitto mqtt zigbee2mqtt zigbee "
+            "z-wave zwave appdaemon hacs studio code server file editor terminal "
+            "ssh samba grafana influxdb deconz motioneye compile validate upload "
+            "deploy firmware ota flash yaml device logs flows events stats"
+        ),
     }
 
     # Description overrides that REPLACE the original description for BM25.

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -507,7 +507,7 @@ async def get_addon_info(client: HomeAssistantClient, slug: str) -> dict[str, An
 
     Args:
         client: Home Assistant REST client
-        slug: Add-on slug (e.g., "a0d7b954_nodered")
+        slug: Add-on slug (e.g., "<prefix>_nodered")
 
     Returns:
         Dictionary with add-on details including ingress info, state, options, etc.
@@ -740,7 +740,7 @@ async def _call_addon_ws(
 
     Args:
         client: Home Assistant REST client
-        slug: Add-on slug (e.g., "5c53de3b_esphome")
+        slug: Add-on slug (e.g., "<prefix>_esphome")
         path: WebSocket endpoint path (e.g., "/compile", "/validate")
         body: Message to send after connecting (JSON-encoded if dict, raw if string)
         timeout: Max seconds to wait for messages (default 60)
@@ -1081,7 +1081,7 @@ async def _call_addon_api(
 
     Args:
         client: Home Assistant REST client
-        slug: Add-on slug (e.g., "a0d7b954_nodered")
+        slug: Add-on slug (e.g., "<prefix>_nodered")
         path: API path relative to add-on root (e.g., "/flows")
         method: HTTP method (GET, POST, PUT, DELETE, PATCH)
         body: Request body for POST/PUT/PATCH
@@ -1349,8 +1349,9 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         slug: Annotated[
             str | None,
             Field(
-                description="Add-on slug for detailed info (e.g., 'a0d7b954_nodered'). "
-                "Omit to list all add-ons.",
+                description="Add-on slug for detailed info (e.g., '<prefix>_nodered'). "
+                "Slug prefixes vary by add-on repository — omit to list all add-ons "
+                "and discover the actual installed slug.",
                 default=None,
             ),
         ] = None,
@@ -1402,7 +1403,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
 
         **Example Usage:**
         - List installed add-ons: ha_get_addon()
-        - Get Node-RED details: ha_get_addon(slug="a0d7b954_nodered")
+        - Get Node-RED details: ha_get_addon(slug="<prefix>_nodered")
         - List with resource usage: ha_get_addon(include_stats=True)
         - List available add-ons: ha_get_addon(source="available")
         - Search for MQTT: ha_get_addon(source="available", query="mqtt")
@@ -1448,8 +1449,9 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         slug: Annotated[
             str,
             Field(
-                description="Add-on slug (e.g., 'a0d7b954_nodered', 'ccab4aaf_frigate'). "
-                "Use ha_get_addon() to find installed add-on slugs.",
+                description="Add-on slug (e.g., '<prefix>_nodered', '<prefix>_frigate'). "
+                "Slug prefixes vary by add-on repository — call ha_get_addon() "
+                "to discover the actual installed slug.",
             ),
         ],
         path: Annotated[

--- a/tests/src/unit/test_categorized_search.py
+++ b/tests/src/unit/test_categorized_search.py
@@ -803,6 +803,7 @@ class TestApplySearchKeywordEnrichment:
             "ha_config_set_script",
             "ha_config_set_helper",
             "ha_search_entities",
+            "ha_manage_addon",
         ):
             assert tool_name in keywords, f"{tool_name} missing from _SEARCH_KEYWORDS"
 


### PR DESCRIPTION
## What does this PR do?

Three small changes addressing #1167 (ToolSearch users can't find
`ha_manage_addon` when asking about ESPHome):

1. **Add `_SEARCH_KEYWORDS` entry for `ha_manage_addon`** in `server.py`.
   BM25 retrieval (used by ToolSearch and claude.ai's native deferred-tool
   search) now matches addon-name queries (esphome, node-red, frigate,
   zigbee2mqtt, mosquitto, hacs, appdaemon, etc.) and addon operation
   verbs (compile, validate, supervisor, ingress, websocket, api, ota).

2. **Replace literal slug examples with `<prefix>_<name>` placeholders**
   in `tools_addons.py`. Slug prefixes (e.g., `a0d7b954_`, `5c53de3b_`,
   `ccab4aaf_`) are deterministic per add-on repository URL but differ
   between official and community repos — literal examples were
   misleading an LLM into hallucinating a slug instead of calling
   `ha_get_addon()` to discover the actual installed slug.

3. **Add `ha_manage_addon` to the keyword regression test**
   (`test_canonical_keywords_end_to_end_for_940_tools`). One-line
   addition matching the existing pattern; catches the original bug if
   a future edit drops the new entry.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Closes #1167