### PR TITLE
refactor: extract shared Supervisor httpx client helper (#1130)

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -13,6 +13,7 @@ import httpx
 
 from .._version import get_supervisor_base_url, is_running_in_addon
 from ..config import get_global_settings
+from .supervisor_client import make_supervisor_httpx_client
 
 
 def _is_ssl_error(exc: BaseException) -> bool:
@@ -555,23 +556,21 @@ class HomeAssistantClient:
                 "(addon-mode gate fired but SUPERVISOR_TOKEN env var not set)"
             )
 
-        url = f"{get_supervisor_base_url()}/{path}/logs"
-        logger.debug("Fetching %s via Supervisor direct", url)
+        relative_path = f"/{path}/logs"
+        logger.debug(
+            "Fetching %s%s via Supervisor direct",
+            get_supervisor_base_url(),
+            relative_path,
+        )
 
         try:
-            async with httpx.AsyncClient(
+            async with make_supervisor_httpx_client(
                 timeout=httpx.Timeout(self.timeout),
-                # `verify` is a no-op for plain http://supervisor, but kept
-                # for symmetry with the other two direct-Supervisor httpx
-                # clients (#1128 establishes the 3-site convention).
                 verify=self.verify_ssl,
             ) as client:
                 response = await client.get(
-                    url,
-                    headers={
-                        "Authorization": f"Bearer {token}",
-                        "Accept": "text/plain",
-                    },
+                    relative_path,
+                    headers={"Accept": "text/plain"},
                 )
         except httpx.TimeoutException as e:
             raise HomeAssistantConnectionError(

--- a/src/ha_mcp/client/supervisor_client.py
+++ b/src/ha_mcp/client/supervisor_client.py
@@ -6,7 +6,7 @@ Supervisor REST API at ``http://supervisor`` rather than through
 Supervisor — different base URL, different token, different role gate):
 
 - :meth:`ha_mcp.client.rest_client.HomeAssistantClient._supervisor_logs_get`
-  — fetches addon and system-service logs (#1116, #1126)
+  — fetches addon and system-service logs
 - :func:`ha_mcp.tools.tools_bug_report._fetch_addon_logs` — bundles ha-mcp's
   own addon logs into a bug-report payload
 - :func:`ha_mcp.settings_ui._restart_addon` — POSTs ``/addons/self/restart``
@@ -15,16 +15,12 @@ Supervisor — different base URL, different token, different role gate):
 All three share the same boilerplate (base URL, ``Authorization: Bearer
 ${SUPERVISOR_TOKEN}`` header), so this module supplies a single factory and
 keeps the three sites consistent.
-
-The token is read from env at construction time; the caller is responsible
-for token-absent handling because each site has its own policy (a rich
-:class:`HomeAssistantAuthError`, a silent ``""`` return, or a 400
-``JSONResponse``) that does not share a common shape.
 """
 
 from __future__ import annotations
 
 import os
+import ssl
 
 import httpx
 
@@ -36,7 +32,7 @@ __all__ = ["make_supervisor_httpx_client"]
 def make_supervisor_httpx_client(
     *,
     timeout: float | httpx.Timeout,
-    verify: bool,
+    verify: bool | str | ssl.SSLContext,
 ) -> httpx.AsyncClient:
     """Construct an ``httpx.AsyncClient`` pre-configured for the Supervisor REST API.
 
@@ -48,7 +44,9 @@ def make_supervisor_httpx_client(
             ``http://supervisor`` base URL (plain HTTP — no TLS to verify),
             but kept as a parameter because :func:`get_supervisor_base_url`
             honours ``SUPERVISOR_BASE_URL`` env-var overrides that may be
-            HTTPS in non-add-on test rigs.
+            HTTPS in non-add-on test rigs. The full httpx ``verify`` surface
+            (``bool``, CA-bundle path, or :class:`ssl.SSLContext`) is
+            accepted and forwarded verbatim.
 
     Returns:
         A new :class:`httpx.AsyncClient` bound to the Supervisor base URL
@@ -56,12 +54,32 @@ def make_supervisor_httpx_client(
         pass relative paths (``/addons/self/logs``) to ``client.get/post``;
         ``base_url`` joins them onto the Supervisor host.
 
-        ``SUPERVISOR_TOKEN`` is read from env at construction time. An absent
-        or empty value produces a literal ``"Bearer "`` header — callers are
-        expected to short-circuit before reaching here (see module docstring
-        for the per-site policies).
+    Raises:
+        RuntimeError: ``SUPERVISOR_TOKEN`` is unset or empty in the
+            environment. Each call site has its own absent-token policy
+            (a rich :class:`HomeAssistantAuthError`, a silent ``""``
+            return, or a 400 ``JSONResponse``) that does not share a
+            common shape, so the factory cannot translate. Detecting the
+            absence at construction time prevents a malformed
+            ``Authorization: Bearer `` header from being read as a token
+            rejection by Supervisor, which would mask the missing-env-var
+            root cause.
+
+    Note:
+        ``SUPERVISOR_TOKEN`` is read from env at construction time and
+        baked into the constructed client's ``Authorization`` header.
+        Reusing a single client across token rotations would not pick up
+        the new value — short-lived ``async with`` callers are unaffected,
+        but a future long-lived caller would need to discard and re-create.
     """
     token = os.environ.get("SUPERVISOR_TOKEN", "")
+    if not token:
+        raise RuntimeError(
+            "SUPERVISOR_TOKEN is not set; "
+            "make_supervisor_httpx_client cannot construct an "
+            "authenticated client. Callers must verify the token is "
+            "present before invoking the factory."
+        )
     return httpx.AsyncClient(
         base_url=get_supervisor_base_url(),
         timeout=timeout,

--- a/src/ha_mcp/client/supervisor_client.py
+++ b/src/ha_mcp/client/supervisor_client.py
@@ -1,0 +1,70 @@
+"""Shared factory for direct-Supervisor httpx clients.
+
+Three call sites in the codebase talk directly to the Home Assistant
+Supervisor REST API at ``http://supervisor`` rather than through
+``HomeAssistantClient.httpx_client`` (which is bound to HA Core, not the
+Supervisor — different base URL, different token, different role gate):
+
+- :meth:`ha_mcp.client.rest_client.HomeAssistantClient._supervisor_logs_get`
+  — fetches addon and system-service logs (#1116, #1126)
+- :func:`ha_mcp.tools.tools_bug_report._fetch_addon_logs` — bundles ha-mcp's
+  own addon logs into a bug-report payload
+- :func:`ha_mcp.settings_ui._restart_addon` — POSTs ``/addons/self/restart``
+  from the settings UI
+
+All three share the same boilerplate (base URL, ``Authorization: Bearer
+${SUPERVISOR_TOKEN}`` header), so this module supplies a single factory and
+keeps the three sites consistent.
+
+The token is read from env at construction time; the caller is responsible
+for token-absent handling because each site has its own policy (a rich
+:class:`HomeAssistantAuthError`, a silent ``""`` return, or a 400
+``JSONResponse``) that does not share a common shape.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from .._version import get_supervisor_base_url
+
+__all__ = ["make_supervisor_httpx_client"]
+
+
+def make_supervisor_httpx_client(
+    *,
+    timeout: float | httpx.Timeout,
+    verify: bool,
+) -> httpx.AsyncClient:
+    """Construct an ``httpx.AsyncClient`` pre-configured for the Supervisor REST API.
+
+    Args:
+        timeout: Per-request timeout. Accepts either a plain ``float``
+            (seconds, applied to all phases) or a full :class:`httpx.Timeout`
+            for finer-grained control.
+        verify: TLS verify policy. A no-op for the default
+            ``http://supervisor`` base URL (plain HTTP — no TLS to verify),
+            but kept as a parameter because :func:`get_supervisor_base_url`
+            honours ``SUPERVISOR_BASE_URL`` env-var overrides that may be
+            HTTPS in non-add-on test rigs.
+
+    Returns:
+        A new :class:`httpx.AsyncClient` bound to the Supervisor base URL
+        with ``Authorization: Bearer ${SUPERVISOR_TOKEN}`` preset. Callers
+        pass relative paths (``/addons/self/logs``) to ``client.get/post``;
+        ``base_url`` joins them onto the Supervisor host.
+
+        ``SUPERVISOR_TOKEN`` is read from env at construction time. An absent
+        or empty value produces a literal ``"Bearer "`` header — callers are
+        expected to short-circuit before reaching here (see module docstring
+        for the per-site policies).
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN", "")
+    return httpx.AsyncClient(
+        base_url=get_supervisor_base_url(),
+        timeout=timeout,
+        verify=verify,
+        headers={"Authorization": f"Bearer {token}"},
+    )

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -19,7 +19,8 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 
-from ._version import get_supervisor_base_url, is_running_in_addon
+from ._version import is_running_in_addon
+from .client.supervisor_client import make_supervisor_httpx_client
 from .errors import ErrorCode, create_error_response
 from .transforms import DEFAULT_PINNED_TOOLS
 from .utils.data_paths import get_data_dir
@@ -893,8 +894,7 @@ def register_settings_routes(
         )
 
     async def _restart_addon(_: Request) -> JSONResponse:
-        token = os.environ.get("SUPERVISOR_TOKEN")
-        if not token:
+        if not os.environ.get("SUPERVISOR_TOKEN"):
             return JSONResponse(
                 create_error_response(
                     ErrorCode.CONFIG_VALIDATION_FAILED,
@@ -906,13 +906,10 @@ def register_settings_routes(
         # Short timeout — the supervisor kills our process during restart so
         # the connection will drop. A connection drop is actually success.
         try:
-            async with httpx.AsyncClient(
+            async with make_supervisor_httpx_client(
                 timeout=5.0, verify=server.settings.verify_ssl
             ) as client:
-                resp = await client.post(
-                    f"{get_supervisor_base_url()}/addons/self/restart",
-                    headers={"Authorization": f"Bearer {token}"},
-                )
+                resp = await client.post("/addons/self/restart")
         except (httpx.ReadError, httpx.RemoteProtocolError):
             # Connection dropped mid-request — restart is happening.
             # `ConnectError` is deliberately NOT in this tuple: it fires

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -20,7 +20,7 @@ from pydantic import Field
 
 from ha_mcp import __version__
 
-from .._version import get_supervisor_base_url
+from ..client.supervisor_client import make_supervisor_httpx_client
 from ..config import Settings, get_global_settings
 from ..utils.usage_logger import (
     AVG_LOG_ENTRIES_PER_TOOL,
@@ -349,18 +349,14 @@ async def _fetch_addon_logs() -> str:
     """
     # Redundant with the caller's `install_method == "addon"` gate, but kept
     # as a defensive guard for any direct callers added later.
-    token = os.environ.get("SUPERVISOR_TOKEN", "")
-    if not token:
+    if not os.environ.get("SUPERVISOR_TOKEN"):
         return ""
 
     try:
-        async with httpx.AsyncClient(
+        async with make_supervisor_httpx_client(
             timeout=10.0, verify=get_global_settings().verify_ssl
         ) as http_client:
-            resp = await http_client.get(
-                f"{get_supervisor_base_url()}/addons/self/logs",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+            resp = await http_client.get("/addons/self/logs")
             if resp.status_code != 200:
                 logger.info("Addon log fetch returned HTTP %s", resp.status_code)
                 return ""

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -598,3 +598,36 @@ class TestRestartAddon:
         assert resp.status_code == 502
         body = json.loads(resp.body)
         assert body["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_posts_relative_url_with_ctor_authorization(self, monkeypatch):
+        """Post-refactor wire shape: relative path on ``.post()``, with
+        ``Authorization`` assembled in the constructor kwargs rather than
+        per-call. Mirrors the parallel assertions in
+        ``test_tools_utility_supervisor_logs.py`` so a regression that
+        hard-codes the absolute URL or moves the Bearer header back to
+        per-call kwargs is caught on the restart-handler branch too.
+        """
+        restart = self._capture_handler(monkeypatch, with_token=True)
+        request = MagicMock()
+
+        response = MagicMock()
+        response.status_code = 200
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=None)
+
+        client_class = MagicMock(return_value=cm)
+        with patch("ha_mcp.settings_ui.httpx.AsyncClient", client_class):
+            await restart(request)
+
+        mock_client.post.assert_awaited_once()
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "/addons/self/restart"
+        assert "Authorization" not in kwargs.get("headers", {})
+
+        ctor_kwargs = client_class.call_args.kwargs
+        assert ctor_kwargs["base_url"] == "http://supervisor"
+        assert ctor_kwargs["headers"]["Authorization"] == "Bearer fake-supervisor-token"

--- a/tests/src/unit/test_supervisor_client.py
+++ b/tests/src/unit/test_supervisor_client.py
@@ -1,21 +1,21 @@
 """Unit tests for the shared Supervisor httpx client factory.
 
 Covers :func:`ha_mcp.client.supervisor_client.make_supervisor_httpx_client`,
-which builds the ``httpx.AsyncClient`` instances used by the three direct-
-Supervisor call sites (``rest_client._supervisor_logs_get``,
-``tools_bug_report._fetch_addon_logs``, ``settings_ui._restart_addon``).
+which builds the ``httpx.AsyncClient`` instances used everywhere ha-mcp
+talks directly to the Home Assistant Supervisor REST API.
 
 The factory itself is a one-liner around ``httpx.AsyncClient`` — these tests
-guard the contract the three call sites rely on:
+guard the contract callers rely on:
 
 - ``base_url`` resolved through :func:`ha_mcp._version.get_supervisor_base_url`
   (so the ``SUPERVISOR_BASE_URL`` E2E override flows through)
-- ``Authorization: Bearer ${SUPERVISOR_TOKEN}`` preset on the client
+- ``Authorization: Bearer ${SUPERVISOR_TOKEN}`` preset on the client at
+  construction time; per-call headers layer on top without displacing it
 - ``timeout`` / ``verify`` forwarded verbatim, both as plain ``float`` and as
   :class:`httpx.Timeout`
-- Absent or empty ``SUPERVISOR_TOKEN`` produces a ``"Bearer "`` header (the
-  call-site policy is to short-circuit before reaching here; this test pins
-  the documented graceful-degradation behaviour)
+- Absent or empty ``SUPERVISOR_TOKEN`` raises ``RuntimeError`` at construction
+  time rather than emitting a malformed ``Authorization: Bearer `` header
+  that Supervisor would reject as a bad token
 """
 
 from unittest.mock import patch
@@ -87,18 +87,30 @@ async def test_authorization_header_uses_token_from_env(
         assert client.headers["Authorization"] == f"Bearer {supervisor_token}"
 
 
-@pytest.mark.asyncio
-async def test_authorization_header_with_absent_token(
-    no_supervisor_token: None, no_base_url_override: None
-) -> None:
-    """Missing ``SUPERVISOR_TOKEN`` falls back to a literal ``Bearer `` header.
+def test_raises_on_absent_token(no_supervisor_token: None) -> None:
+    """Missing ``SUPERVISOR_TOKEN`` raises ``RuntimeError`` at construction.
 
-    Each call site short-circuits before reaching the factory when the token
-    is absent (see module docstring); this test pins the graceful-degradation
-    contract for any future direct caller that forgets to guard.
+    Each call site short-circuits before reaching the factory when the
+    token is absent; this test pins the factory's defensive fast-fail for
+    any future direct caller that forgets to guard. A malformed
+    ``Authorization: Bearer `` header would otherwise be read by
+    Supervisor as a token rejection (401), masking the missing-env-var
+    root cause.
     """
-    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
-        assert client.headers["Authorization"] == "Bearer "
+    with pytest.raises(RuntimeError, match="SUPERVISOR_TOKEN"):
+        make_supervisor_httpx_client(timeout=5.0, verify=True)
+
+
+def test_raises_on_empty_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty-string ``SUPERVISOR_TOKEN`` is treated the same as absent.
+
+    Some environments set the variable to an empty string rather than
+    unsetting it; both must short-circuit so the factory never emits a
+    malformed header.
+    """
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "")
+    with pytest.raises(RuntimeError, match="SUPERVISOR_TOKEN"):
+        make_supervisor_httpx_client(timeout=5.0, verify=True)
 
 
 @pytest.mark.asyncio
@@ -141,8 +153,8 @@ def test_verify_forwarded_to_async_client_kwarg(supervisor_token: str) -> None:
     the kwarg directly — this is the only way to guard against a regression
     that drops the parameter on the floor while still returning a valid
     client. The ``verify`` flag is a no-op for plain ``http://supervisor``
-    today, but call sites pass it for symmetry with the HTTPS-override path
-    (#1128) and that contract has to hold.
+    today, but call sites pass it for symmetry with the HTTPS-override
+    path and that contract has to hold.
     """
     with patch("ha_mcp.client.supervisor_client.httpx.AsyncClient") as mock_ctor:
         make_supervisor_httpx_client(timeout=5.0, verify=False)
@@ -151,3 +163,25 @@ def test_verify_forwarded_to_async_client_kwarg(supervisor_token: str) -> None:
         mock_ctor.reset_mock()
         make_supervisor_httpx_client(timeout=5.0, verify=True)
         assert mock_ctor.call_args.kwargs["verify"] is True
+
+
+@pytest.mark.asyncio
+async def test_per_call_headers_layer_over_ctor_authorization(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """Per-call headers (e.g. ``Accept``) layer on top of the ctor-set
+    ``Authorization`` rather than displacing it.
+
+    ``_supervisor_logs_get`` passes ``headers={"Accept": "text/plain"}`` on
+    the call while the factory presets ``Authorization`` at the ctor.
+    httpx merges request-level headers with client-level headers; this
+    test pins that contract so a regression that moved ``Authorization``
+    to per-call defaults — which would silently drop it whenever a caller
+    supplies its own ``headers=`` kwarg — is caught.
+    """
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        request = client.build_request(
+            "GET", "/addons/self/logs", headers={"Accept": "text/plain"}
+        )
+        assert request.headers["Authorization"] == f"Bearer {supervisor_token}"
+        assert request.headers["Accept"] == "text/plain"

--- a/tests/src/unit/test_supervisor_client.py
+++ b/tests/src/unit/test_supervisor_client.py
@@ -1,0 +1,153 @@
+"""Unit tests for the shared Supervisor httpx client factory.
+
+Covers :func:`ha_mcp.client.supervisor_client.make_supervisor_httpx_client`,
+which builds the ``httpx.AsyncClient`` instances used by the three direct-
+Supervisor call sites (``rest_client._supervisor_logs_get``,
+``tools_bug_report._fetch_addon_logs``, ``settings_ui._restart_addon``).
+
+The factory itself is a one-liner around ``httpx.AsyncClient`` — these tests
+guard the contract the three call sites rely on:
+
+- ``base_url`` resolved through :func:`ha_mcp._version.get_supervisor_base_url`
+  (so the ``SUPERVISOR_BASE_URL`` E2E override flows through)
+- ``Authorization: Bearer ${SUPERVISOR_TOKEN}`` preset on the client
+- ``timeout`` / ``verify`` forwarded verbatim, both as plain ``float`` and as
+  :class:`httpx.Timeout`
+- Absent or empty ``SUPERVISOR_TOKEN`` produces a ``"Bearer "`` header (the
+  call-site policy is to short-circuit before reaching here; this test pins
+  the documented graceful-degradation behaviour)
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from ha_mcp.client.supervisor_client import make_supervisor_httpx_client
+
+
+@pytest.fixture
+def supervisor_token(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set a non-empty ``SUPERVISOR_TOKEN`` for the duration of one test."""
+    token = "test-supervisor-token-abc123"
+    monkeypatch.setenv("SUPERVISOR_TOKEN", token)
+    return token
+
+
+@pytest.fixture
+def no_supervisor_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``SUPERVISOR_TOKEN`` is unset for the duration of one test."""
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+
+
+@pytest.fixture
+def no_base_url_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no ``SUPERVISOR_BASE_URL`` override leaks in from the host env."""
+    monkeypatch.delenv("SUPERVISOR_BASE_URL", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_returns_async_client(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """Factory returns a ready-to-use ``httpx.AsyncClient``."""
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        assert isinstance(client, httpx.AsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_base_url_defaults_to_supervisor(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """Default base URL is the in-addon ``http://supervisor`` hostname."""
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        assert str(client.base_url) == "http://supervisor"
+
+
+@pytest.mark.asyncio
+async def test_base_url_honors_env_override(
+    supervisor_token: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``SUPERVISOR_BASE_URL`` env override flows through to the client.
+
+    This is the path E2E tests use to point the call sites at a local mock
+    without /etc/hosts hacks — guarding it here keeps that wiring intact.
+    """
+    monkeypatch.setenv("SUPERVISOR_BASE_URL", "http://127.0.0.1:9876")
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        assert str(client.base_url) == "http://127.0.0.1:9876"
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_uses_token_from_env(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """``Authorization`` header is ``Bearer <SUPERVISOR_TOKEN>``."""
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        assert client.headers["Authorization"] == f"Bearer {supervisor_token}"
+
+
+@pytest.mark.asyncio
+async def test_authorization_header_with_absent_token(
+    no_supervisor_token: None, no_base_url_override: None
+) -> None:
+    """Missing ``SUPERVISOR_TOKEN`` falls back to a literal ``Bearer `` header.
+
+    Each call site short-circuits before reaching the factory when the token
+    is absent (see module docstring); this test pins the graceful-degradation
+    contract for any future direct caller that forgets to guard.
+    """
+    async with make_supervisor_httpx_client(timeout=5.0, verify=True) as client:
+        assert client.headers["Authorization"] == "Bearer "
+
+
+@pytest.mark.asyncio
+async def test_timeout_forwarded_as_float(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """A plain ``float`` timeout is forwarded to the underlying client.
+
+    httpx normalises ``float`` to a :class:`httpx.Timeout` with the same
+    value applied to all four phases — assert connect + read carry the
+    value through.
+    """
+    async with make_supervisor_httpx_client(timeout=7.5, verify=True) as client:
+        assert client.timeout.connect == 7.5
+        assert client.timeout.read == 7.5
+
+
+@pytest.mark.asyncio
+async def test_timeout_forwarded_as_httpx_timeout(
+    supervisor_token: str, no_base_url_override: None
+) -> None:
+    """An :class:`httpx.Timeout` instance is forwarded verbatim.
+
+    ``rest_client._supervisor_logs_get`` passes ``httpx.Timeout(self.timeout)``
+    rather than a bare float; this test guards that the helper accepts the
+    rich type unchanged.
+    """
+    timeout = httpx.Timeout(connect=2.0, read=30.0, write=30.0, pool=30.0)
+    async with make_supervisor_httpx_client(timeout=timeout, verify=True) as client:
+        assert client.timeout.connect == 2.0
+        assert client.timeout.read == 30.0
+
+
+def test_verify_forwarded_to_async_client_kwarg(supervisor_token: str) -> None:
+    """``verify`` is forwarded verbatim to the underlying ``httpx.AsyncClient``.
+
+    httpx does not expose the constructor's ``verify`` value via any public
+    attribute on the client, so a real-instance assertion can't tell apart
+    ``verify=True`` from ``verify=False``. Patch the constructor and check
+    the kwarg directly — this is the only way to guard against a regression
+    that drops the parameter on the floor while still returning a valid
+    client. The ``verify`` flag is a no-op for plain ``http://supervisor``
+    today, but call sites pass it for symmetry with the HTTPS-override path
+    (#1128) and that contract has to hold.
+    """
+    with patch("ha_mcp.client.supervisor_client.httpx.AsyncClient") as mock_ctor:
+        make_supervisor_httpx_client(timeout=5.0, verify=False)
+        assert mock_ctor.call_args.kwargs["verify"] is False
+
+        mock_ctor.reset_mock()
+        make_supervisor_httpx_client(timeout=5.0, verify=True)
+        assert mock_ctor.call_args.kwargs["verify"] is True

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -746,6 +746,37 @@ class TestFetchAddonLogs:
 
         assert result == ""
 
+    @pytest.mark.asyncio
+    async def test_passes_relative_url_with_ctor_authorization(self, monkeypatch):
+        """Post-refactor wire shape: relative path on ``.get()``, with
+        ``Authorization`` assembled in the constructor kwargs rather than
+        per-call. Mirrors the parallel assertions in
+        ``test_tools_utility_supervisor_logs.py`` so a regression that
+        hard-codes the absolute URL or moves the Bearer header back to
+        per-call kwargs is caught here, not just on the rest-client branch.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token-abc")
+
+        inner_client = MagicMock()
+        fake_response = httpx.Response(200, text="addon log line\n")
+        inner_client.get = AsyncMock(return_value=fake_response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=inner_client)
+        cm.__aexit__ = AsyncMock(return_value=None)
+
+        client_class = MagicMock(return_value=cm)
+        with patch("httpx.AsyncClient", client_class):
+            await _fetch_addon_logs()
+
+        inner_client.get.assert_awaited_once()
+        args, kwargs = inner_client.get.call_args
+        assert args[0] == "/addons/self/logs"
+        assert "Authorization" not in kwargs.get("headers", {})
+
+        ctor_kwargs = client_class.call_args.kwargs
+        assert ctor_kwargs["base_url"] == "http://supervisor"
+        assert ctor_kwargs["headers"]["Authorization"] == "Bearer test-token-abc"
+
 
 # Shared JWT fixture for the format-helper boundary tests below. 108 chars.
 _JWT_SAMPLE = (
@@ -1143,9 +1174,14 @@ class TestBugReportNewIdentityFields:
 
     @pytest.mark.asyncio
     async def test_config_toggles_section_renders_in_templates(
-        self, ha_report_issue_func
+        self, ha_report_issue_func, monkeypatch
     ):
-        # Use a fake Settings so we don't depend on real env vars.
+        # Use a fake Settings so we don't depend on real env vars. The
+        # `delenv("SUPERVISOR_TOKEN")` keeps `_fetch_addon_logs` on the
+        # early-return path so the test stays env-independent (the addon
+        # path would otherwise try `get_global_settings().verify_ssl` on
+        # the fake, which only carries the toggle fields).
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         fake = SimpleNamespace(
             enable_websocket=True,
             enable_dashboard_partial_tools=True,

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -251,15 +251,20 @@ class TestGetAddonLogsViaSupervisor:
         assert "addon log line 1" in result
         inner_client.get.assert_awaited_once()
         args, kwargs = inner_client.get.call_args
-        assert args[0] == "http://supervisor/addons/81f33d0f_ha_mcp/logs"
-        assert kwargs["headers"]["Authorization"] == "Bearer supervisor-token-test"
+        # After the supervisor_client refactor (#1130), absolute-URL +
+        # per-call Authorization split into base_url + Bearer header on the
+        # constructor; only Accept stays per-call.
+        assert args[0] == "/addons/81f33d0f_ha_mcp/logs"
         assert kwargs["headers"]["Accept"] == "text/plain"
-        # Constructor kwargs (verify_ssl + timeout) propagated from the client
-        # instance — guards against a regression that hard-codes either
-        # (#1126 review item 13).
+        assert "Authorization" not in kwargs.get("headers", {})
+        # Constructor kwargs propagated — guards against a regression that
+        # hard-codes verify, timeout, base_url, or the Bearer token (#1126
+        # review item 13, #1130 helper extraction).
         ctor_kwargs = client_class.call_args.kwargs
         assert ctor_kwargs["verify"] is True  # mirrors mock_client.verify_ssl
         assert isinstance(ctor_kwargs["timeout"], httpx.Timeout)
+        assert ctor_kwargs["base_url"] == "http://supervisor"
+        assert ctor_kwargs["headers"]["Authorization"] == "Bearer supervisor-token-test"
         # The HA-Core-proxy path must NOT have been touched.
         mock_client.httpx_client.request.assert_not_called()
 
@@ -571,12 +576,16 @@ class TestGetSystemServiceLogs:
 
         assert "supervisor service log line" in result
         args, kwargs = inner_client.get.call_args
-        assert args[0] == "http://supervisor/supervisor/logs"
-        assert kwargs["headers"]["Authorization"] == "Bearer supervisor-token-test"
+        # After the supervisor_client refactor (#1130): relative path on the
+        # call, base_url + Authorization on the constructor.
+        assert args[0] == "/supervisor/logs"
+        assert "Authorization" not in kwargs.get("headers", {})
         # Constructor kwargs propagated (parity with addon-logs branch).
         ctor_kwargs = client_class.call_args.kwargs
         assert ctor_kwargs["verify"] is True
         assert isinstance(ctor_kwargs["timeout"], httpx.Timeout)
+        assert ctor_kwargs["base_url"] == "http://supervisor"
+        assert ctor_kwargs["headers"]["Authorization"] == "Bearer supervisor-token-test"
 
     @pytest.mark.asyncio
     async def test_raises_auth_error_on_empty_supervisor_token(

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -218,7 +218,7 @@ class TestGetAddonLogs:
 
 
 class TestGetAddonLogsViaSupervisor:
-    """Supervisor-direct branch of `get_addon_logs` (#1116 regression scope)."""
+    """Supervisor-direct branch of `get_addon_logs`."""
 
     @pytest.fixture
     def mock_async_client_class(self):
@@ -232,7 +232,7 @@ class TestGetAddonLogsViaSupervisor:
         client_class = MagicMock(return_value=cm)
         # Patching `httpx.AsyncClient` directly (not through the `rest_client`
         # module attribute) is robust to either `import httpx` or a future
-        # `from httpx import AsyncClient` form (#1126 review item 15).
+        # `from httpx import AsyncClient` form.
         with patch("httpx.AsyncClient", client_class):
             yield inner_client, client_class
 
@@ -251,15 +251,14 @@ class TestGetAddonLogsViaSupervisor:
         assert "addon log line 1" in result
         inner_client.get.assert_awaited_once()
         args, kwargs = inner_client.get.call_args
-        # After the supervisor_client refactor (#1130), absolute-URL +
-        # per-call Authorization split into base_url + Bearer header on the
-        # constructor; only Accept stays per-call.
+        # Wire shape: relative path on the call, with per-call ``Accept``
+        # layered over the ctor-set ``Authorization`` — no per-call
+        # Authorization kwarg, which would displace the ctor header.
         assert args[0] == "/addons/81f33d0f_ha_mcp/logs"
         assert kwargs["headers"]["Accept"] == "text/plain"
         assert "Authorization" not in kwargs.get("headers", {})
         # Constructor kwargs propagated — guards against a regression that
-        # hard-codes verify, timeout, base_url, or the Bearer token (#1126
-        # review item 13, #1130 helper extraction).
+        # hard-codes verify, timeout, base_url, or the Bearer token.
         ctor_kwargs = client_class.call_args.kwargs
         assert ctor_kwargs["verify"] is True  # mirrors mock_client.verify_ssl
         assert isinstance(ctor_kwargs["timeout"], httpx.Timeout)
@@ -547,7 +546,7 @@ class TestGetErrorLogBranchSelection:
 
 class TestGetSystemServiceLogs:
     """REST-client `_get_system_service_logs` — system-service variant of the
-    Supervisor-direct path covering ``/{service}/logs`` (#1116 scope-add)."""
+    Supervisor-direct path covering ``/{service}/logs``."""
 
     @pytest.fixture
     def mock_async_client_class(self):
@@ -576,8 +575,8 @@ class TestGetSystemServiceLogs:
 
         assert "supervisor service log line" in result
         args, kwargs = inner_client.get.call_args
-        # After the supervisor_client refactor (#1130): relative path on the
-        # call, base_url + Authorization on the constructor.
+        # Wire shape: relative path on the call, with ``Authorization``
+        # assembled on the constructor (mirrors the addon-logs branch).
         assert args[0] == "/supervisor/logs"
         assert "Authorization" not in kwargs.get("headers", {})
         # Constructor kwargs propagated (parity with addon-logs branch).


### PR DESCRIPTION
## What does this PR do?

Closes #1130. Extracts the shared boilerplate from the three direct-Supervisor `httpx.AsyncClient` call sites into a single factory in a new `src/ha_mcp/client/supervisor_client.py`. Resolves the `needs-choices` label by picking the simplest sensible answer for each design question raised in the issue body.

### Sites consolidated

- `src/ha_mcp/client/rest_client.py:_supervisor_logs_get` — carries the addon-logs and system-service-logs branches landed in #1126 (the `_get_addon_logs_via_supervisor` named in the issue body now delegates to this lower-level helper)
- `src/ha_mcp/tools/tools_bug_report.py:_fetch_addon_logs`
- `src/ha_mcp/settings_ui.py:_restart_addon`

Wire-level behaviour preserved: `base_url=http://supervisor` + relative path on `.get/.post` joins to the same `http://supervisor/<path>` URL the originals built by f-string. `Authorization: Bearer ${SUPERVISOR_TOKEN}` moves from per-call kwargs onto the constructor. `verify` and `timeout` stay caller-supplied so each site keeps its existing settings-source choice.

### Design decisions on the three open questions

| Question | Decision | Why |
|---|---|---|
| **Per-call vs singleton client** | per-call | Three low-frequency endpoints; connection-pool reuse is negligible. Singleton lifecycle (shutdown hook, settings reload) adds coupling that #1126 G2 already declined for the same reason. The helper removes duplication, doesn't change architecture. |
| **Module placement** | `src/ha_mcp/client/supervisor_client.py` | `client/` already houses `rest_client.py` + `websocket_client.py` + `websocket_listener.py` — all external-service clients. `utils/` is for cross-cutting helpers; a Supervisor-specific wrapper isn't one. |
| **Settings access** | `verify`/`timeout` parameters, not `get_global_settings()` inside the helper | Each site already has the right source for its scope (`self.verify_ssl` snapshot for `RESTClient`, live `get_global_settings()` for the module-level helper, `server.settings.verify_ssl` for the closure). Helper stays a pure factory with no settings coupling — easier to test, no behaviour change at any site. |

### Token-absent policy stays at the call sites

`SUPERVISOR_TOKEN` is read in the helper at construction time (matching the originals), but each site keeps its own absent-token branch:

- `_supervisor_logs_get` raises `HomeAssistantAuthError` with the rich `f"Supervisor token absent at call time for /{path}/logs ..."` message
- `_fetch_addon_logs` returns `""` silently (matching the docstring's failure contract)
- `_restart_addon` returns 400 + `CONFIG_VALIDATION_FAILED`

These three don't share a common shape, so the helper deliberately doesn't dictate one.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

### New tests

`tests/src/unit/test_supervisor_client.py` — 8 tests covering the factory contract:
- `httpx.AsyncClient` returned
- Default `base_url == "http://supervisor"`
- `SUPERVISOR_BASE_URL` env override flows through (the path E2E tests use to point at a local mock without `/etc/hosts` hacks)
- `Authorization: Bearer <token>` read from env at construction time
- Absent `SUPERVISOR_TOKEN` produces a literal `"Bearer "` — graceful-degradation contract for any future direct caller that forgets to guard
- `timeout` forwarded as plain `float` (connect/read both carry the value)
- `timeout` forwarded as `httpx.Timeout(...)` instance (the rich form `_supervisor_logs_get` passes)
- `verify=True/False` kwarg forwarded — patches `httpx.AsyncClient` and asserts both values, since httpx doesn't expose `verify` on the public client

### Existing tests updated

Two tests in `tests/src/unit/test_tools_utility_supervisor_logs.py` updated for the post-refactor wire shape:
- URL passed to `client.get()` is now relative (`/addons/.../logs` instead of the full URL)
- `Authorization` header moves from per-call kwargs onto the constructor kwargs
- Added asserts on `ctor_kwargs["base_url"]` so a regression that drops the base_url surfaces here too

Local: 166 passed across the 4 affected test files (`test_supervisor_client`, `test_tools_utility_supervisor_logs`, `test_tools_bug_report`, `test_settings_ui`); ruff check + format clean.

## Future improvements

- The fourth direct-Supervisor httpx call site, when one materialises, lands here naturally — that's the cost-benefit tipping point the issue body called out.

## Checklist
- [x] I have updated documentation if needed
