### PR TITLE
feat: pinpoint backslash-escape mistake in python_sandbox errors

### DIFF
--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -23,6 +23,7 @@ from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
     PythonSandboxError,
+    format_sandbox_error,
     get_security_documentation,
     safe_execute,
 )
@@ -572,16 +573,12 @@ class ConfigSceneTools:
                 try:
                     transformed_config = safe_execute(python_transform, actual_config)
                 except PythonSandboxError as e:
+                    message, suggestions = format_sandbox_error(e, python_transform)
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,
-                            str(e),
-                            suggestions=[
-                                "Check expression syntax",
-                                "Ensure only allowed operations are used",
-                                "See tool description for allowed operations",
-                                f"Expression: {python_transform[:100]}{'...' if len(python_transform) > 100 else ''}",
-                            ],
+                            message,
+                            suggestions=suggestions,
                             context={
                                 "action": "python_transform",
                                 "scene_id": resolved_id,
@@ -656,9 +653,9 @@ class ConfigSceneTools:
                 # is the in-place equivalent of ``del`` — normalise both
                 # by checking against ``(None, resolved_id)``, so only an
                 # explicit non-None mismatch triggers the reject.
-                if (
-                    "id" in transformed_config
-                    and transformed_config["id"] not in (None, resolved_id)
+                if "id" in transformed_config and transformed_config["id"] not in (
+                    None,
+                    resolved_id,
                 ):
                     raise_tool_error(
                         create_error_response(

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -472,6 +472,19 @@ def format_sandbox_error(
             "See tool description for allowed operations",
             f"Expression: {preview}",
         ]
+        # Issue #1197 — agents commonly emit ``\"`` (intending a JSON-style
+        # quote escape) inside transforms. Outside Python string literals
+        # this is a line-continuation token followed by an unexpected
+        # character. Pinpoint the actual mistake so the agent fixes it on
+        # the first retry instead of guessing at "syntax".
+        if "line continuation character" in str(error):
+            suggestions.insert(
+                0,
+                "Backslashes outside Python string literals are "
+                "line-continuation tokens, not quote escapes — the JSON "
+                "wire encoding already handles quote escaping; remove the "
+                "leading `\\` before quotes in your Python source.",
+            )
     if variable_name != "config":
         suggestions = [
             f"Operate on the `{variable_name}` variable (in-place or reassign)",

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -472,18 +472,16 @@ def format_sandbox_error(
             "See tool description for allowed operations",
             f"Expression: {preview}",
         ]
-        # Issue #1197 — agents commonly emit ``\"`` (intending a JSON-style
-        # quote escape) inside transforms. Outside Python string literals
-        # this is a line-continuation token followed by an unexpected
-        # character. Pinpoint the actual mistake so the agent fixes it on
-        # the first retry instead of guessing at "syntax".
+        # Agents commonly emit ``\"`` (intending a JSON-style quote escape)
+        # inside transforms. Outside Python string literals this is a
+        # line-continuation token followed by an unexpected character.
+        # Pinpoint the actual mistake so the agent fixes it on the first
+        # retry instead of guessing at "syntax".
         if "line continuation character" in str(error):
             suggestions.insert(
                 0,
-                "Backslashes outside Python string literals are "
-                "line-continuation tokens, not quote escapes — the JSON "
-                "wire encoding already handles quote escaping; remove the "
-                "leading `\\` before quotes in your Python source.",
+                'Remove the leading backslash before quotes — write "foo" '
+                'not \\"foo\\" in the Python source.',
             )
     if variable_name != "config":
         suggestions = [

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -682,6 +682,12 @@ class TestFormatSandboxError:
         assert message.startswith("Expression validation failed:")
         assert any("syntax" in s.lower() for s in suggestions)
         assert any("allowed operations" in s.lower() for s in suggestions)
+        # Negative: the backslash-escape hint must NOT surface on
+        # validation errors whose message lacks the line-continuation
+        # phrase — guards against a future substring broadening
+        # (e.g. ``"continuation"``) silently misfiring on unrelated
+        # syntax errors.
+        assert not any("backslash" in s.lower() for s in suggestions)
 
     def test_execution_error_suggestions_point_at_data(self):
         err = PythonSandboxExecutionError("KeyError: 'foo'")
@@ -729,20 +735,20 @@ class TestFormatSandboxError:
         )
 
     def test_line_continuation_error_gets_specific_hint(self):
-        """Issue #1197 — a backslash-escape mistake outside string literals
-        should produce a targeted hint that comes BEFORE the generic
-        'Check expression syntax' so the agent recovers on the first retry
-        instead of guessing."""
+        """A backslash-escape mistake outside string literals produces a
+        targeted hint that comes BEFORE the generic 'Check expression
+        syntax' so the agent recovers on the first retry instead of
+        guessing."""
         err = PythonSandboxValidationError(
             "Syntax error: unexpected character after line continuation "
             "character (<unknown>, line 1)"
         )
         _, suggestions = format_sandbox_error(err, 'config["k"] = \\"v\\"')
         # Hint must be present
-        assert any("line-continuation" in s.lower() for s in suggestions)
+        assert any("backslash" in s.lower() for s in suggestions)
         # ...and must come BEFORE the generic syntax suggestion
         hint_idx = next(
-            i for i, s in enumerate(suggestions) if "line-continuation" in s.lower()
+            i for i, s in enumerate(suggestions) if "backslash" in s.lower()
         )
         generic_idx = next(
             i
@@ -752,7 +758,7 @@ class TestFormatSandboxError:
         assert hint_idx < generic_idx
 
     def test_line_continuation_with_response_variable_orders_correctly(self):
-        """When BOTH the variable-name prepend AND the line-continuation hint
+        """When BOTH the variable-name prepend AND the backslash-escape hint
         fire (addon caller passes `response` and emits a backslash-escape),
         the variable-name hint must remain at index 0 — agents need the
         target-variable framing before the diagnostic."""
@@ -766,4 +772,4 @@ class TestFormatSandboxError:
         assert suggestions[0] == (
             "Operate on the `response` variable (in-place or reassign)"
         )
-        assert "line-continuation" in suggestions[1].lower()
+        assert "backslash" in suggestions[1].lower()

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -111,7 +111,9 @@ for view in config['views']:
 
     def test_generator_expression_executes(self):
         """`sum(x for x in ...)` validates AND runs."""
-        config = {"views": [{"cards": [{"type": "tile"}, {"type": "btn"}, {"type": "tile"}]}]}
+        config = {
+            "views": [{"cards": [{"type": "tile"}, {"type": "btn"}, {"type": "tile"}]}]
+        }
         expr = "config['count'] = sum(1 for c in config['views'][0]['cards'] if c.get('type') == 'tile')"
         result = safe_execute(expr, config)
         assert result["count"] == 2
@@ -523,9 +525,7 @@ class TestSafeExecuteExpression:
     def test_missing_result_key_raises(self):
         """If result_key is not in variables, raise PythonSandboxValidationError up front."""
         with pytest.raises(PythonSandboxValidationError, match="result_key"):
-            safe_execute_expression(
-                "response = 1", {"other": 1}, "response"
-            )
+            safe_execute_expression("response = 1", {"other": 1}, "response")
 
     def test_validation_failure_raises(self):
         """Invalid expressions raise PythonSandboxValidationError."""
@@ -559,18 +559,14 @@ class TestSafeExecuteExpression:
             "response = [m for m in response "
             "if isinstance(m, dict) and m.get('level') == 'ERROR']"
         )
-        result = safe_execute_expression(
-            expr, {"response": messages}, "response"
-        )
+        result = safe_execute_expression(expr, {"response": messages}, "response")
         assert result == [{"level": "ERROR", "text": "Boom"}]
 
     def test_str_coercion_available(self):
         """str() is in the safe builtins for text-content matching."""
         messages = [{"level": "ERROR"}, "plain string", 42]
         expr = "response = [m for m in response if 'ERROR' in str(m)]"
-        result = safe_execute_expression(
-            expr, {"response": messages}, "response"
-        )
+        result = safe_execute_expression(expr, {"response": messages}, "response")
         assert result == [{"level": "ERROR"}]
 
     def test_builtins_do_not_include_open(self):
@@ -673,9 +669,7 @@ class TestSandboxErrorSubclasses:
                 ),
                 pytest.raises(type(infra_exc)),
             ):
-                safe_execute_expression(
-                    "response = 1", {"response": 0}, "response"
-                )
+                safe_execute_expression("response = 1", {"response": 0}, "response")
 
 
 class TestFormatSandboxError:
@@ -720,9 +714,7 @@ class TestFormatSandboxError:
         """The default `config` callers don't get a redundant variable-name hint."""
         err = PythonSandboxValidationError("Forbidden node type: Try")
         _, suggestions = format_sandbox_error(err, "try: pass\nexcept: pass")
-        assert not any(
-            "Operate on the" in s and "variable" in s for s in suggestions
-        )
+        assert not any("Operate on the" in s and "variable" in s for s in suggestions)
 
     def test_non_default_variable_name_prepends_hint(self):
         """A non-`config` caller (e.g. addons with `response`) gets a leading
@@ -735,3 +727,43 @@ class TestFormatSandboxError:
         assert suggestions[0] == (
             "Operate on the `response` variable (in-place or reassign)"
         )
+
+    def test_line_continuation_error_gets_specific_hint(self):
+        """Issue #1197 — a backslash-escape mistake outside string literals
+        should produce a targeted hint that comes BEFORE the generic
+        'Check expression syntax' so the agent recovers on the first retry
+        instead of guessing."""
+        err = PythonSandboxValidationError(
+            "Syntax error: unexpected character after line continuation "
+            "character (<unknown>, line 1)"
+        )
+        _, suggestions = format_sandbox_error(err, 'config["k"] = \\"v\\"')
+        # Hint must be present
+        assert any("line-continuation" in s.lower() for s in suggestions)
+        # ...and must come BEFORE the generic syntax suggestion
+        hint_idx = next(
+            i for i, s in enumerate(suggestions) if "line-continuation" in s.lower()
+        )
+        generic_idx = next(
+            i
+            for i, s in enumerate(suggestions)
+            if "check expression syntax" in s.lower()
+        )
+        assert hint_idx < generic_idx
+
+    def test_line_continuation_with_response_variable_orders_correctly(self):
+        """When BOTH the variable-name prepend AND the line-continuation hint
+        fire (addon caller passes `response` and emits a backslash-escape),
+        the variable-name hint must remain at index 0 — agents need the
+        target-variable framing before the diagnostic."""
+        err = PythonSandboxValidationError(
+            "Syntax error: unexpected character after line continuation "
+            "character (<unknown>, line 1)"
+        )
+        _, suggestions = format_sandbox_error(
+            err, 'response["k"] = \\"v\\"', variable_name="response"
+        )
+        assert suggestions[0] == (
+            "Operate on the `response` variable (in-place or reassign)"
+        )
+        assert "line-continuation" in suggestions[1].lower()

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -424,6 +424,45 @@ class TestScenePythonTransform:
         assert error_data["success"] is False
         assert error_data["error"]["code"] == "VALIDATION_FAILED"
 
+    async def test_transform_backslash_escape_surfaces_specific_hint(
+        self, tools, mock_client
+    ):
+        """A python_transform with ``\\"`` outside a string literal trips
+        Python's "unexpected character after line continuation character"
+        parser error. The scene tool routes that through
+        ``format_sandbox_error``, so the response must carry the
+        backslash-specific hint (not just a generic "Check expression
+        syntax") and an ``ErrorCode.VALIDATION_FAILED``.
+        """
+        seed = {
+            "id": "test_scene",
+            "name": "S",
+            "entities": {"light.kitchen": {"state": "on"}},
+        }
+        mock_client.get_scene_config = AsyncMock(return_value=seed)
+
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        seed_hash = compute_config_hash(seed)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_scene(
+                scene_id="test_scene",
+                # The agent intended a JSON-style quote escape; outside a
+                # Python string literal the leading ``\`` is a
+                # line-continuation token followed by an unexpected char.
+                python_transform='config["entities"]["light.kitchen"] = \\"v\\"',
+                config_hash=seed_hash,
+            )
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["success"] is False
+        assert error_data["error"]["code"] == "VALIDATION_FAILED"
+        suggestions = error_data["error"].get("suggestions", [])
+        assert any("backslash" in s.lower() for s in suggestions), (
+            f"Expected a backslash-escape hint among suggestions, got {suggestions!r}"
+        )
+
 
 class TestResolveSceneEntityId:
     """Coverage for _resolve_scene_entity_id — the BAT-discovered fix.
@@ -1340,7 +1379,9 @@ class TestEmptySceneIdGuard:
 
     @pytest.mark.parametrize("whitespace_value", ["   ", "\t", "\n", " \t\n "])
     async def test_get_scene_rejects_whitespace_only_scene_id(
-        self, tools, whitespace_value: str,
+        self,
+        tools,
+        whitespace_value: str,
     ):
         """R7 blocker 23: whitespace-only ``scene_id`` slipped past the
         original ``if not scene_id`` and surfaced as ``RESOURCE_NOT_FOUND`` —
@@ -1353,7 +1394,9 @@ class TestEmptySceneIdGuard:
         assert "scene_id must not be empty" in body["error"]["message"]
 
     async def test_set_scene_rejects_whitespace_only_scene_id(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_config_set_scene(
@@ -1367,7 +1410,9 @@ class TestEmptySceneIdGuard:
         mock_client.upsert_scene_config.assert_not_called()
 
     async def test_remove_scene_rejects_whitespace_only_scene_id(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_config_remove_scene(scene_id="   ", wait=False)
@@ -1656,7 +1701,9 @@ class TestCategoryValidationGate:
     """
 
     async def test_no_category_at_all_skips_validation(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         """Neither user param nor config dict supplies a category — the
         validator must NOT fire. No WS round-trip for category_registry/list."""
@@ -1676,9 +1723,9 @@ class TestCategoryValidationGate:
         )
 
         category_list_calls = [
-            c for c in ws_calls
-            if isinstance(c, dict)
-            and c.get("type") == "config/category_registry/list"
+            c
+            for c in ws_calls
+            if isinstance(c, dict) and c.get("type") == "config/category_registry/list"
         ]
         assert not category_list_calls, (
             "_validate_category_id must NOT fire when no category is supplied "
@@ -1686,7 +1733,9 @@ class TestCategoryValidationGate:
         )
 
     async def test_user_passed_category_validates(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         """User passes a non-None ``category`` — validator must fire."""
         mock_client.send_websocket_message = AsyncMock(
@@ -1714,7 +1763,9 @@ class TestCategoryValidationGate:
         )
 
     async def test_dict_promoted_category_validates(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         """User passes ``category=None`` but config has top-level
         ``config["category"]`` — ``_validate_scene_config`` promotes it
@@ -1751,7 +1802,9 @@ class TestCategoryValidationGate:
         )
 
     async def test_dict_promoted_phantom_rejected_pre_upsert(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         """B25 regression — phantom category in top-level ``config["category"]``
         must be rejected pre-upsert. Live reproducer: caller sets
@@ -1793,7 +1846,9 @@ class TestPythonTransformIdNoneRebind:
     """
 
     async def test_transform_setting_id_to_none_passes_through(
-        self, tools, mock_client,
+        self,
+        tools,
+        mock_client,
     ):
         from ha_mcp.utils.config_hash import compute_config_hash
 
@@ -1886,9 +1941,7 @@ class TestSmartSearchSceneIdFallbackPaths:
 
         client.send_websocket_message = AsyncMock(side_effect=_ws_handler)
 
-        with _patch(
-            "ha_mcp.tools.smart_search.get_global_settings"
-        ) as mock_settings:
+        with _patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
             mock_settings.return_value.fuzzy_threshold = 60
             tools_obj = SmartSearchTools(client=client)
             result = await tools_obj.deep_search(
@@ -1909,7 +1962,8 @@ class TestSmartSearchSceneIdFallbackPaths:
         assert scenes[0]["entity_id"] == "scene.bat_distinct_friendly_name"
 
     async def test_scene_falls_back_to_slug_with_warning(
-        self, caplog,
+        self,
+        caplog,
     ) -> None:
         """When neither the bulk config nor the registry walk produced a
         storage key for a scene, the result-builder falls back to the
@@ -1944,9 +1998,7 @@ class TestSmartSearchSceneIdFallbackPaths:
 
         caplog.set_level(logging.WARNING, logger="ha_mcp.tools.smart_search")
 
-        with _patch(
-            "ha_mcp.tools.smart_search.get_global_settings"
-        ) as mock_settings:
+        with _patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
             mock_settings.return_value.fuzzy_threshold = 60
             tools_obj = SmartSearchTools(client=client)
             result = await tools_obj.deep_search(


### PR DESCRIPTION
## What does this PR do?

Closes #1197.

When an agent emits `\"` outside a Python string literal in a `python_transform`, Python's parser reports "unexpected character after line continuation character" — a message that doesn't pinpoint the actual mistake (backslash before quote). `format_sandbox_error` now detects that exact substring and prepends a specific recovery hint, so agents fix it on the first retry instead of guessing.

Same precedent as #1163 (`feat:` for python_transform error-UX).

`tools_config_scenes.py` previously built its own ad-hoc suggestions list instead of calling `format_sandbox_error`, so the new hint wouldn't reach `ha_config_set_scene` callers. Migrated to the shared helper in this PR — the user-visible fix is incomplete without it.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

<!-- Optional: things noticed during this PR that are out of scope but worth doing later.
     Small things fixable in a few lines should be fixed inline rather than listed here. -->

## Checklist
- [ ] I have updated documentation if needed
