### PR TITLE
refactor(internal): extract _fetch_dashboards_list helper (#1193)

### DIFF
--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -267,7 +267,6 @@ def _should_lazy_resolve(error_msg: str) -> bool:
 
 async def _fetch_dashboards_list(
     client: Any,
-    log: logging.Logger,
 ) -> list[dict[str, Any]] | None:
     """Fetch and normalise the lovelace/dashboards/list WebSocket response.
 
@@ -280,11 +279,11 @@ async def _fetch_dashboards_list(
     propagate the failure).
     """
     result = await client.send_websocket_message({"type": "lovelace/dashboards/list"})
-    if isinstance(result, dict) and "result" in result:
+    if isinstance(result, dict) and isinstance(result.get("result"), list):
         return cast(list[dict[str, Any]], result["result"])
     if isinstance(result, list):
         return cast(list[dict[str, Any]], result)
-    log.warning(
+    logger.warning(
         "lovelace/dashboards/list returned an unexpected shape (type=%s); "
         "treating as no-match",
         type(result).__name__,
@@ -324,7 +323,7 @@ async def _resolve_dashboard(
       to the registry id before issuing the delete. Discards
       ``dashboards``.
     """
-    dashboards = await _fetch_dashboards_list(client, logger)
+    dashboards = await _fetch_dashboards_list(client)
     if dashboards is None:
         return None, None
 
@@ -541,7 +540,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         try:
             # List mode
             if list_only:
-                dashboards = await _fetch_dashboards_list(client, logger) or []
+                dashboards = await _fetch_dashboards_list(client) or []
                 return {
                     "success": True,
                     "action": "list",
@@ -1164,7 +1163,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 existing_dashboards = pre_fetched_dashboards
             else:
                 existing_dashboards = (
-                    await _fetch_dashboards_list(client, logger) or []
+                    await _fetch_dashboards_list(client) or []
                 )
             dashboard_exists = any(
                 d.get("url_path") == url_path for d in existing_dashboards

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -267,7 +267,7 @@ def _should_lazy_resolve(error_msg: str) -> bool:
 
 async def _fetch_dashboards_list(
     client: Any,
-    _logger: logging.Logger,
+    log: logging.Logger,
 ) -> list[dict[str, Any]] | None:
     """Fetch and normalise the lovelace/dashboards/list WebSocket response.
 
@@ -284,7 +284,7 @@ async def _fetch_dashboards_list(
         return cast(list[dict[str, Any]], result["result"])
     if isinstance(result, list):
         return cast(list[dict[str, Any]], result)
-    _logger.warning(
+    log.warning(
         "lovelace/dashboards/list returned an unexpected shape (type=%s); "
         "treating as no-match",
         type(result).__name__,

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -265,6 +265,33 @@ def _should_lazy_resolve(error_msg: str) -> bool:
     return _LAZY_RESOLVE_TRIGGER in error_msg
 
 
+async def _fetch_dashboards_list(
+    client: Any,
+    _logger: logging.Logger,
+) -> list[dict[str, Any]] | None:
+    """Fetch and normalise the lovelace/dashboards/list WebSocket response.
+
+    Returns the list of dashboard registry entries on success, or ``None``
+    when the response shape is unrecognised.  A warning is logged on
+    unexpected shapes so that future HA response-format changes surface at
+    every fetch site rather than silently degrading.
+
+    Callers decide how to handle ``None`` (e.g. fall through to ``[]`` or
+    propagate the failure).
+    """
+    result = await client.send_websocket_message({"type": "lovelace/dashboards/list"})
+    if isinstance(result, dict) and "result" in result:
+        return cast(list[dict[str, Any]], result["result"])
+    if isinstance(result, list):
+        return cast(list[dict[str, Any]], result)
+    _logger.warning(
+        "lovelace/dashboards/list returned an unexpected shape (type=%s); "
+        "treating as no-match",
+        type(result).__name__,
+    )
+    return None
+
+
 async def _resolve_dashboard(
     client: Any, identifier: str
 ) -> tuple[dict[str, str] | None, list[dict[str, Any]] | None]:
@@ -297,21 +324,8 @@ async def _resolve_dashboard(
       to the registry id before issuing the delete. Discards
       ``dashboards``.
     """
-    result = await client.send_websocket_message({"type": "lovelace/dashboards/list"})
-    if isinstance(result, dict) and "result" in result:
-        dashboards = result["result"]
-    elif isinstance(result, list):
-        dashboards = result
-    else:
-        # Neither dict-with-result nor list — either HA returned an error
-        # envelope (unknown shape) or the response format changed.
-        # Surface a warning so the next response-shape change isn't a
-        # silent "always no match" regression.
-        logger.warning(
-            "lovelace/dashboards/list returned an unexpected shape (type=%s); "
-            "treating as no-match",
-            type(result).__name__,
-        )
+    dashboards = await _fetch_dashboards_list(client, logger)
+    if dashboards is None:
         return None, None
 
     for d in dashboards:
@@ -527,16 +541,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         try:
             # List mode
             if list_only:
-                result = await client.send_websocket_message(
-                    {"type": "lovelace/dashboards/list"}
-                )
-                if isinstance(result, dict) and "result" in result:
-                    dashboards = result["result"]
-                elif isinstance(result, list):
-                    dashboards = result
-                else:
-                    dashboards = []
-
+                dashboards = await _fetch_dashboards_list(client, logger) or []
                 return {
                     "success": True,
                     "action": "list",
@@ -1158,24 +1163,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             if pre_fetched_dashboards is not None:
                 existing_dashboards = pre_fetched_dashboards
             else:
-                result = await client.send_websocket_message(
-                    {"type": "lovelace/dashboards/list"}
+                existing_dashboards = (
+                    await _fetch_dashboards_list(client, logger) or []
                 )
-                if isinstance(result, dict) and "result" in result:
-                    existing_dashboards = result["result"]
-                elif isinstance(result, list):
-                    existing_dashboards = result
-                else:
-                    # Mirror the warning emitted by ``_resolve_dashboard`` on
-                    # the same response-shape failure, so a future HA shape
-                    # change shows up at every fetch site rather than going
-                    # silent on this one.
-                    logger.warning(
-                        "lovelace/dashboards/list returned an unexpected shape "
-                        "(type=%s); treating as no-match",
-                        type(result).__name__,
-                    )
-                    existing_dashboards = []
             dashboard_exists = any(
                 d.get("url_path") == url_path for d in existing_dashboards
             )

--- a/tests/src/unit/test_config_get_dashboard_search_error.py
+++ b/tests/src/unit/test_config_get_dashboard_search_error.py
@@ -120,8 +120,8 @@ class TestGetDashboardListOnlyUnexpectedShape:
     fallback means the tool still returns a valid success response with an
     empty dashboards list. This test pins the behavior introduced when the
     inline fetch was extracted to the shared helper so that a silent ``[]``
-    return can no longer mask a future HA shape change at Site 2
-    (ha_config_get_dashboard list path).
+    return can no longer mask a future HA shape change at the
+    ``ha_config_get_dashboard`` list path (``list_only=True`` branch).
     """
 
     @pytest.fixture
@@ -164,6 +164,10 @@ class TestGetDashboardListOnlyUnexpectedShape:
         assert result["success"] is True
         assert result["dashboards"] == []
         assert result["count"] == 0
-        assert any("unexpected shape" in rec.message for rec in caplog.records), (
-            f"expected 'unexpected shape' warning; got {[r.message for r in caplog.records]}"
+        assert any(
+            "unexpected shape" in rec.message and "type=str" in rec.message
+            for rec in caplog.records
+        ), (
+            f"expected an 'unexpected shape' warning naming the response "
+            f"type; got {[rec.message for rec in caplog.records]}"
         )

--- a/tests/src/unit/test_config_get_dashboard_search_error.py
+++ b/tests/src/unit/test_config_get_dashboard_search_error.py
@@ -1,13 +1,17 @@
-"""Unit tests for ha_config_get_dashboard search mode error handling.
+"""Unit tests for ha_config_get_dashboard error handling.
 
-Validates that ha_config_get_dashboard in search mode uses structured error
-responses and does NOT leak internal Python type names or tracebacks.
+Covers two distinct failure axes:
+ - Search mode: structured error responses must not leak internal Python type
+   names or tracebacks.
+ - List mode (list_only=True): unexpected HA response shapes must emit a
+   warning and return an empty list, not a silent degradation.
 
 Replaces test_dashboard_find_card_error.py after ha_dashboard_find_card
 was merged into ha_config_get_dashboard (issue #901).
 """
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -107,3 +111,59 @@ class TestConfigGetDashboardSearchErrorHandling:
         result = json.loads(str(exc_info.value))
         assert result["success"] is False
         assert result["error"]["code"] == expected_code
+
+
+class TestGetDashboardListOnlyUnexpectedShape:
+    """list_only=True emits a warning (not a failure) on unexpected HA response shape.
+
+    _fetch_dashboards_list logs at WARNING and returns None; the ``or []``
+    fallback means the tool still returns a valid success response with an
+    empty dashboards list. This test pins the behavior introduced when the
+    inline fetch was extracted to the shared helper so that a silent ``[]``
+    return can no longer mask a future HA shape change at Site 2
+    (ha_config_get_dashboard list path).
+    """
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools: dict = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def get_dashboard_tool(self, mock_mcp, mock_client):
+        register_config_dashboard_tools(mock_mcp, mock_client)
+        return self.registered_tools["ha_config_get_dashboard"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_shape_logs_warning_and_returns_empty_list(
+        self, get_dashboard_tool, mock_client, caplog
+    ):
+        mock_client.send_websocket_message.return_value = "unexpected string"
+
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.tools_config_dashboards"
+        ):
+            result = await get_dashboard_tool(list_only=True)
+
+        assert result["success"] is True
+        assert result["dashboards"] == []
+        assert result["count"] == 0
+        assert any("unexpected shape" in rec.message for rec in caplog.records), (
+            f"expected 'unexpected shape' warning; got {[r.message for r in caplog.records]}"
+        )


### PR DESCRIPTION
Closes #1193

Three call sites in `tools_config_dashboards.py` duplicated the same
`lovelace/dashboards/list` fetch + shape-normalisation + warning logic.
This PR extracts a shared `_fetch_dashboards_list(client)` helper and
routes all three sites through it.

## What changed

**New private helper `_fetch_dashboards_list(client)`:**
- fetches via `send_websocket_message({"type": "lovelace/dashboards/list"})`
- normalises dict-with-`result` (guarded with `isinstance(..., list)`) vs bare-list response shapes
- emits one `logger.warning` on unexpected shapes (module-level logger; no extra parameter)
- returns `list[dict[str, Any]] | None` — `None` on shape failure

**Refactored call sites (all three preserve existing caller semantics):**
- `_resolve_dashboard`: `None` → `return None, None`
- `ha_config_get_dashboard` (`list_only=True`): `None` → fallback `[]`;
  **now emits the shape-change warning that was previously missing at this site**
- `ha_config_set_dashboard` existence-check: `None` → fallback `[]`;
  removes the inline warning duplication added in ac52f74

## Behaviour deltas (alongside the refactor)

Two small behavioural changes came in with the extraction — both intentional and strictly safer:

1. **Guard tightened at the dict branch** — from `"result" in result` to
   `isinstance(result.get("result"), list)`. Previously a response like
   `{"result": "string"}` or `{"result": None}` would take the happy path
   and blow up downstream on iteration; now it falls through to the warning path.

2. **`ha_config_get_dashboard(list_only=True)` now emits the unexpected-shape warning.**
   Before this PR, an unexpected HA response at the `list_only` path silently
   returned `[]` with no operator signal. After: same `[]` fallback, but the
   warning is emitted — consistent with the other two sites.

## Testing

- All existing dashboard unit tests pass (34 tests)
- **New unit test** `TestGetDashboardListOnlyUnexpectedShape` added to
  `test_config_get_dashboard_search_error.py`: pins the new warning
  behaviour at the `ha_config_get_dashboard` `list_only=True` path,
  which had no unexpected-shape coverage before this PR
- `ruff` and `mypy` both pass on the changed files