### PR TITLE
test(e2e): close ARM ha_mcp_tools readiness race under loadscope

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -266,7 +266,7 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
                     # Extract to temp location first; the context manager
                     # cleans up even if extractall or shutil.move raises.
                     temp_extract = Path(temp_dir_str)
-                    tar.extractall(temp_extract)
+                    tar.extractall(temp_extract, filter="data")
 
                     # Move the hacs_frontend subdirectory
                     extracted_frontend = (

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -197,54 +197,94 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
 
     HACS requires the frontend (~51MB) to be present to fully initialize.
     This is not committed to git to keep the repo size manageable.
+
+    Uses a directory-based atomic lock so concurrent xdist workers don't race
+    on ``shutil.move`` into the shared ``initial_test_state`` path. One worker
+    wins ``mkdir(exist_ok=False)`` and performs the download; the losers poll
+    on the lock and exit when the winner releases it.
     """
     import tarfile
     import urllib.request
 
     hacs_dir = initial_state_path / "custom_components" / "hacs"
     frontend_dir = hacs_dir / "hacs_frontend"
+    lock_dir = initial_state_path / ".hacs_frontend.lock"
 
-    # Check if HACS is installed and frontend is missing
-    if hacs_dir.exists() and not frontend_dir.exists():
-        logger.info("HACS frontend not found, downloading...")
+    # Fast path: HACS not installed (nothing to do), or frontend present
+    # AND no lock held. The lock-held check rules out the window where
+    # another worker's ``shutil.move`` is mid-flight — ``frontend_dir``
+    # exists then but its contents are partial. By the time the winner's
+    # ``finally`` runs ``rmdir``, the move has already committed in the
+    # inner ``try`` — the ``rmdir`` is the visible release signal that
+    # peers can observe.
+    if not hacs_dir.exists() or (frontend_dir.exists() and not lock_dir.exists()):
+        return
 
-        try:
-            # Get the latest frontend version from GitHub API
-            import json
+    # Cross-worker lock: atomic mkdir succeeds on exactly one xdist worker.
+    # The losers poll on the lock itself (released by the winner's finally
+    # block) so they wake immediately whether the winner finished, skipped
+    # the download, or raised — not only when ``frontend_dir`` appears. The
+    # 180s cap survives as a safety net for an ungraceful winner exit (e.g.
+    # SIGKILL) that never reaches the finally clause.
+    try:
+        lock_dir.mkdir(exist_ok=False)
+    except FileExistsError:
+        wait_start = time.monotonic()
+        while lock_dir.exists() and time.monotonic() - wait_start < 180:
+            time.sleep(2)
+        return
 
-            api_url = "https://api.github.com/repos/hacs/frontend/releases/latest"
-            with urllib.request.urlopen(api_url, timeout=30) as response:
-                release_data = json.loads(response.read())
-                tag_name = release_data["tag_name"]
+    # We own the lock. Outer try/finally guarantees release even when the
+    # download block is skipped (e.g. hacs_dir missing) or raises.
+    try:
+        # Check if HACS is installed and frontend is still missing.
+        if hacs_dir.exists() and not frontend_dir.exists():
+            logger.info("HACS frontend not found, downloading...")
 
-            # Download and extract the frontend
-            tarball_url = f"https://github.com/hacs/frontend/releases/download/{tag_name}/hacs_frontend-{tag_name}.tar.gz"
-            logger.info(f"Downloading HACS frontend {tag_name}...")
+            try:
+                # Get the latest frontend version from GitHub API
+                api_url = "https://api.github.com/repos/hacs/frontend/releases/latest"
+                with urllib.request.urlopen(api_url, timeout=30) as response:
+                    release_data = json.loads(response.read())
+                    tag_name = release_data["tag_name"]
 
-            with (
-                urllib.request.urlopen(tarball_url, timeout=120) as response,
-                tarfile.open(fileobj=response, mode="r:gz") as tar,
-            ):
-                # Extract to temp location first
-                temp_extract = Path(tempfile.mkdtemp())
-                tar.extractall(temp_extract)
+                # Download and extract the frontend
+                tarball_url = f"https://github.com/hacs/frontend/releases/download/{tag_name}/hacs_frontend-{tag_name}.tar.gz"
+                logger.info(f"Downloading HACS frontend {tag_name}...")
 
-                # Move the hacs_frontend subdirectory
-                extracted_frontend = (
-                    temp_extract / f"hacs_frontend-{tag_name}" / "hacs_frontend"
+                with (
+                    urllib.request.urlopen(tarball_url, timeout=120) as response,
+                    tarfile.open(fileobj=response, mode="r:gz") as tar,
+                    tempfile.TemporaryDirectory() as temp_dir_str,
+                ):
+                    # Extract to temp location first; the context manager
+                    # cleans up even if extractall or shutil.move raises.
+                    temp_extract = Path(temp_dir_str)
+                    tar.extractall(temp_extract)
+
+                    # Move the hacs_frontend subdirectory
+                    extracted_frontend = (
+                        temp_extract / f"hacs_frontend-{tag_name}" / "hacs_frontend"
+                    )
+                    if extracted_frontend.exists():
+                        shutil.move(str(extracted_frontend), str(frontend_dir))
+                        logger.info(f"HACS frontend installed at {frontend_dir}")
+                    else:
+                        logger.warning(
+                            f"Could not find hacs_frontend in downloaded archive for {tag_name}"
+                        )
+
+            except Exception as e:
+                logger.warning(
+                    f"Failed to download HACS frontend ({type(e).__name__}): {e}"
                 )
-                if extracted_frontend.exists():
-                    shutil.move(str(extracted_frontend), str(frontend_dir))
-                    logger.info(f"HACS frontend installed at {frontend_dir}")
-                else:
-                    logger.warning("Could not find hacs_frontend in downloaded archive")
-
-                # Cleanup temp
-                shutil.rmtree(temp_extract, ignore_errors=True)
-
-        except Exception as e:
-            logger.warning(f"Failed to download HACS frontend: {e}")
-            logger.warning("HACS tests may be skipped without the frontend")
+                logger.warning("HACS tests may be skipped without the frontend")
+    finally:
+        # Release the lock so waiting workers can proceed.
+        try:
+            lock_dir.rmdir()
+        except OSError:
+            pass
 
 
 def _install_custom_component(
@@ -689,8 +729,17 @@ def ha_container_with_fresh_config(_blueprint_http_server):
             )
 
         # Wait for ha_mcp_tools custom component services (installed above).
-        # The component is loaded after core services, so it needs its own check.
-        HA_MCP_TOOLS_WAIT = 30
+        # The component is loaded after core services, so it needs its own
+        # check. Bumped from 30s to 180s in two steps: 30→90 closed the
+        # silent-warn fake-pass against COMPONENT_NOT_INSTALLED; 90→180 added
+        # headroom after observation that on the 2-vCPU ARM runner with 4
+        # parallel HA containers, the pre-polling stages (boot + HACS install
+        # + custom-component install) can take ~48s, leaving the old 90s
+        # window starting too late to outlast registration. Timeout branch
+        # is ``pytest.fail`` so the failure mode is loud instead of letting
+        # tests advance into a guaranteed COMPONENT_NOT_INSTALLED on the
+        # first ha_mcp_tools call.
+        HA_MCP_TOOLS_WAIT = 180
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():
             logger.info("⏳ Waiting for ha_mcp_tools services to register...")
@@ -713,9 +762,11 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     logger.debug(f"ha_mcp_tools service check failed: {exc}")
                 time.sleep(1)
             else:
-                logger.warning(
-                    f"⚠️ ha_mcp_tools services not registered after {HA_MCP_TOOLS_WAIT}s "
-                    f"— yaml config tests may fail"
+                pytest.fail(
+                    f"ha_mcp_tools services not registered after {HA_MCP_TOOLS_WAIT}s. "
+                    "Required for filesystem and config-editing tests; a silent "
+                    "warning here would let those tests proceed into "
+                    "COMPONENT_NOT_INSTALLED on the first tool call."
                 )
 
         # Wait for sun.sun to leave the 'unknown' state.  During HA startup the

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -204,6 +204,7 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     on the lock and exit when the winner releases it.
     """
     import tarfile
+    import urllib.error
     import urllib.request
 
     hacs_dir = initial_state_path / "custom_components" / "hacs"
@@ -213,10 +214,12 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     # Fast path: HACS not installed (nothing to do), or frontend present
     # AND no lock held. The lock-held check rules out the window where
     # another worker's ``shutil.move`` is mid-flight — ``frontend_dir``
-    # exists then but its contents are partial. By the time the winner's
-    # ``finally`` runs ``rmdir``, the move has already committed in the
-    # inner ``try`` — the ``rmdir`` is the visible release signal that
-    # peers can observe.
+    # exists then but its contents are partial. On the success path the
+    # move commits in the inner ``try`` before the winner's ``finally``
+    # runs ``rmdir`` — waiters observing lock-gone-and-frontend-present
+    # see a complete frontend. On any failure path the finally still
+    # releases with ``frontend_dir`` absent; waiters re-enter the slow
+    # path and the download except-branch handles the skip.
     if not hacs_dir.exists() or (frontend_dir.exists() and not lock_dir.exists()):
         return
 
@@ -232,10 +235,21 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
         wait_start = time.monotonic()
         while lock_dir.exists():
             if time.monotonic() - wait_start >= 180:
+                # Asymmetric with ``HA_MCP_TOOLS_WAIT`` below (which is
+                # ``pytest.fail``): a stuck tool registration breaks
+                # every downstream test, while a stuck HACS download
+                # only breaks HACS-dependent tests — the rest of the
+                # session still produces useful signal. Clear the stale
+                # lock so a subsequent session does not also hit the
+                # 180s wait when the winner truly crashed.
                 logger.warning(
                     f"Timeout waiting for HACS frontend lock release at "
                     f"{lock_dir}; proceeding without verification."
                 )
+                try:
+                    lock_dir.rmdir()
+                except OSError as exc:
+                    logger.warning(f"Could not clear stale HACS lock dir: {exc}")
                 return
             time.sleep(2)
         return
@@ -280,17 +294,35 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
                             f"Could not find hacs_frontend in downloaded archive for {tag_name}"
                         )
 
-            except Exception as e:
-                logger.warning(
-                    f"Failed to download HACS frontend ({type(e).__name__}): {e}"
-                )
+            except (
+                urllib.error.URLError,
+                json.JSONDecodeError,
+                KeyError,
+                tarfile.TarError,
+                OSError,
+            ):
+                # Narrow catch + ``logger.exception`` so the full
+                # traceback surfaces in CI logs, not just the exception
+                # type — KP13's "don't green-pass a failed download"
+                # principle. HACS-dependent tests will fail at first
+                # HACS call; other tests can still run.
+                logger.exception("Failed to download HACS frontend")
                 logger.warning("HACS tests may be skipped without the frontend")
     finally:
-        # Release the lock so waiting workers can proceed.
+        # Release the lock so waiting workers can proceed. A
+        # ``FileNotFoundError`` here means a timed-out waiter cleared
+        # the lock first — invariant broke but the session can
+        # continue; log so it's diagnosable. Other ``OSError`` classes
+        # (PermissionError, Errno-39 "Directory not empty" from a
+        # future sentinel/pidfile refactor) would wedge subsequent
+        # sessions into the 180s wait — let them surface.
         try:
             lock_dir.rmdir()
-        except OSError:
-            pass
+        except FileNotFoundError:
+            logger.warning(
+                f"HACS frontend lock dir {lock_dir} vanished before "
+                f"release — concurrent timeout-clear?"
+            )
 
 
 def _install_custom_component(
@@ -734,18 +766,13 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 f"— helper/automation tests may be flaky"
             )
 
-        # Wait for ha_mcp_tools custom component services (installed above).
-        # The component is loaded after core services, so it needs its own
-        # check. Bumped from 30s to 180s in two steps: 30→90 closed the
-        # silent-warn fake-pass against COMPONENT_NOT_INSTALLED; 90→180 added
-        # headroom after observation that on the 2-vCPU ARM runner with 4
-        # parallel HA containers, the pre-polling stages (boot + HACS install
-        # + custom-component install) can take ~48s, leaving the old 90s
-        # window starting too late to outlast registration. Timeout branch
-        # is ``pytest.fail`` so the failure mode is loud instead of letting
-        # tests advance into a guaranteed COMPONENT_NOT_INSTALLED on the
-        # first ha_mcp_tools call.
-        HA_MCP_TOOLS_WAIT = 180
+        # Loud failure (``pytest.fail`` rather than ``logger.warning``):
+        # filesystem and config-editing tests downstream require
+        # ha_mcp_tools, and a silent warn here lets them proceed into
+        # COMPONENT_NOT_INSTALLED on the first tool call — surfacing
+        # the registration gap beats misattributing it to the calling
+        # test.
+        HA_MCP_TOOLS_WAIT = 180  # session-level cap; covers slow CI runners
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():
             logger.info("⏳ Waiting for ha_mcp_tools services to register...")

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -230,7 +230,13 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
         lock_dir.mkdir(exist_ok=False)
     except FileExistsError:
         wait_start = time.monotonic()
-        while lock_dir.exists() and time.monotonic() - wait_start < 180:
+        while lock_dir.exists():
+            if time.monotonic() - wait_start >= 180:
+                logger.warning(
+                    f"Timeout waiting for HACS frontend lock release at "
+                    f"{lock_dir}; proceeding without verification."
+                )
+                return
             time.sleep(2)
         return
 


### PR DESCRIPTION
## What does this PR do?

Closes #1205.

Two changes to `tests/src/e2e/conftest.py` that resolve the ARM-only `COMPONENT_NOT_INSTALLED` failure under `--dist loadscope`:

**1. Bump `HA_MCP_TOOLS_WAIT` 30 → 90 → 180s + warn→fail.** The 30s budget was consistently exceeded on ARM CI under loadscope when 4 HA containers start in parallel; the previous `else:` branch logged a warning and let tests proceed — directly producing the `COMPONENT_NOT_INSTALLED` failure at the first `ha_mcp_tools` call. First stage 30→90 closed the silent-warn fake-pass; CI on `3b41109` then showed `gw0` setup at 138s wall-clock (only ~48s pre-poll before the polling window opened), so a second bump 90→180 added headroom. `pytest.fail` in the timeout branch replaces silent slip with loud failure (matching the existing `pytest.fail(...)` precedent at the `ENTITY_STABILIZATION_TIMEOUT` site).

**2. Cross-worker lock for `_ensure_hacs_frontend`.** The HACS frontend download (~51MB) was racing across xdist workers — all four entering the download path simultaneously and calling `shutil.move` into the shared `initial_test_state` path. Introduces an atomic `mkdir(exist_ok=False)` lock at the function's outer scope so exactly one worker downloads while peers poll on the lock (released by the winner's `finally → rmdir`) and exit immediately when it disappears. Refinements through Gemini review waves:

- `time.monotonic()` instead of `time.time()` for the 180s polling cap — NTP-immune (G1).
- Waiters poll on `lock_dir.exists()` rather than `not frontend_dir.exists()` so they wake on lock release whether the winner finished, skipped, or raised (G2).
- Fast-path guard extended to `frontend_dir.exists() and not lock_dir.exists()` to prevent peer workers from consuming a partially populated `frontend_dir` while the winner is mid-`shutil.move` (G4).
- Extraction wrapped in `tempfile.TemporaryDirectory()` context manager so the temp dir is cleaned up even when `tar.extractall` or `shutil.move` raises (G5); `type(e).__name__` added to the failure warning for disambiguation (G3).

Scope held to the failure mode in #1205. Independent #1227 by `kingpanther13` since merged on the related session-readiness path.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`pytest src/e2e/ --collect-only` collects 809 tests cleanly post-edit. The ARM-only failure mode is not reproducible locally on x86 Alpine; CI on `ubuntu-24.04-arm` is the verification path.

## Future improvements

- **`time.monotonic()` sweep across `tests/src/e2e/utilities/wait_helpers.py`** — 26 further `time.time()` callsites in the same idiom; left untouched because they are the prevailing convention in the e2e test framework. Eligible as a follow-up if the same NTP-safety concern that motivated G1 applies broadly.
- **Orphan `.hacs_frontend.lock` recovery** — with the fast-path guard added in G4, a SIGKILL-leftover lock (with `frontend_dir` already populated from the prior run) forces peers into the 180s poll path before they can use the frontend, instead of returning instantly. Acceptable for the CI matrix (orphan locks are rare, 180s < typical session) but the recovery cost is non-zero; an explicit lock-staleness check could close this if needed.
- **Partial-`frontend_dir` validation in the fast-path guard** (`conftest.py:260`) — the current `if hacs_dir.exists() and not frontend_dir.exists()` treats any existing `frontend_dir` as good, so a SIGKILL'd or partially-failed prior run that left an empty/partial dir would skip the redownload and boot HACS against a broken frontend. Pre-existing (not introduced by this PR); flagged by `kingpanther13` in review on `83efdf7`. Could close with a small `_is_valid_frontend(path)` helper (file-count or magic-file probe).

## Checklist

- [x] I have updated documentation if needed (no docs needed for fixture-infra changes)

