### PR TITLE
feat: add fields= projection to ha_get_overview (#1199)

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -853,7 +853,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = True,
         fields: Annotated[
-            list[str] | None,
+            str | list[str] | None,
             Field(
                 default=None,
                 description=(
@@ -1019,7 +1019,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             }
 
         if fields is not None:
-            keep = set(fields) | {"success"}
+            parsed_fields = parse_string_list_param(fields, "fields", allow_csv=True) or []
+            keep = set(parsed_fields) | {"success"}
             result = cast(dict[str, Any], {k: v for k, v in result.items() if k in keep})
 
         return result

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -852,6 +852,21 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 description="Include active persistent notifications (default: True). Set False to skip.",
             ),
         ] = True,
+        fields: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified top-level response keys to reduce "
+                    "response size (e.g. [\"system_info\", \"domains\"]). "
+                    "None = full response (default). "
+                    "Available keys: success, system_info, domains, entity_summary, "
+                    "total_entities, count, offset, limit, total_matches, has_more, "
+                    "next_offset, notification_count, notifications, "
+                    "repair_count, repairs, tool_discovery."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Get AI-friendly system overview with intelligent categorization.
 
@@ -862,6 +877,9 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         are always complete regardless of entity pagination.
         Standard/full modes paginate entities (default 200 per page) — use offset
         to fetch more. Use 'domains' filter to narrow scope.
+
+        Use fields= to project the response to only the keys you need — up to 94%
+        token reduction when fetching a single sub-section (e.g. fields=["system_info"]).
         """
         # Coerce boolean parameters that may come as strings from XML-style calls
         include_state_bool = coerce_bool_param(
@@ -999,6 +1017,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     ]
                 ),
             }
+
+        if fields is not None:
+            keep = set(fields) | {"success"}
+            result = cast(dict[str, Any], {k: v for k, v in result.items() if k in keep})
 
         return result
 

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -753,3 +753,31 @@ class TestSystemToolsIntegration:
             assert not_found, "Test notification should be dismissed"
 
         logger.info("Notification lifecycle test completed successfully")
+
+    @pytest.mark.asyncio
+    async def test_overview_fields_projection(self, mcp_client):
+        """fields= returns only the requested top-level keys (plus success).
+
+        Validates the 94% token-reduction path from issue #1199: callers that
+        need only one section receive a projected response with all other
+        top-level keys absent.
+        """
+        logger.info("Testing ha_get_overview fields= projection")
+
+        result = await mcp_client.call_tool(
+            "ha_get_overview",
+            {"fields": ["system_info"]},
+        )
+        data = parse_mcp_result(result)
+
+        assert data.get("success") is True
+        assert "system_info" in data, "requested field must be present"
+        assert "version" in data["system_info"], "system_info must be populated"
+
+        # All unrequested top-level keys must be absent.
+        for absent_key in ("domains", "entity_summary", "total_entities", "repair_count"):
+            assert absent_key not in data, (
+                f"key {absent_key!r} should be projected out when fields=[\"system_info\"]"
+            )
+
+        logger.info("fields= projection test passed")

--- a/tests/src/unit/test_overview_system_info.py
+++ b/tests/src/unit/test_overview_system_info.py
@@ -1,4 +1,4 @@
-"""Unit tests for ha_get_overview system_info builder."""
+"""Unit tests for ha_get_overview system_info builder and fields= projection."""
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -94,3 +94,95 @@ class TestHaGetOverviewSystemInfo:
         result = await overview_tool(detail_level="minimal")
 
         assert "allowlist_external_dirs" not in result["system_info"]
+
+
+class TestHaGetOverviewFieldsProjection:
+    """fields= projects the response to the requested top-level keys.
+
+    Pins the contract from issue #1199: callers that only need one section
+    (e.g. system_info) can request it via fields= and receive a response
+    that omits all other top-level keys, reducing token usage by up to 94%.
+    """
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools: dict = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(
+            return_value={"version": "2026.5.0", "location_name": "Home"}
+        )
+        client.send_websocket_message = AsyncMock(return_value={"success": False})
+        return client
+
+    @pytest.fixture
+    def mock_smart_tools(self):
+        smart = MagicMock()
+        smart.get_system_overview = AsyncMock(
+            return_value={
+                "success": True,
+                "domains": {"light": {"count": 3}},
+                "entity_summary": [],
+                "total_entities": 3,
+            }
+        )
+        return smart
+
+    @pytest.fixture
+    def overview_tool(self, mock_mcp, mock_client, mock_smart_tools):
+        register_search_tools(mock_mcp, mock_client, smart_tools=mock_smart_tools)
+        return self.registered_tools["ha_get_overview"]
+
+    @pytest.mark.asyncio
+    async def test_fields_none_returns_full_response(self, overview_tool):
+        """fields=None (default) returns the full response — no projection."""
+        result = await overview_tool()
+        assert "success" in result
+        assert "system_info" in result
+        assert "domains" in result
+
+    @pytest.mark.asyncio
+    async def test_fields_single_key_projects_correctly(self, overview_tool):
+        """fields=["system_info"] keeps only system_info (+ success always)."""
+        result = await overview_tool(fields=["system_info"])
+        assert result["success"] is True
+        assert "system_info" in result
+        assert result["system_info"]["version"] == "2026.5.0"
+        # All other top-level keys must be absent.
+        for key in ("domains", "entity_summary", "total_entities", "repair_count"):
+            assert key not in result, f"unexpected key {key!r} survived projection"
+
+    @pytest.mark.asyncio
+    async def test_fields_multiple_keys(self, overview_tool):
+        """fields=["system_info", "domains"] keeps exactly those two (+ success)."""
+        result = await overview_tool(fields=["system_info", "domains"])
+        assert "system_info" in result
+        assert "domains" in result
+        assert "entity_summary" not in result
+
+    @pytest.mark.asyncio
+    async def test_fields_success_always_included(self, overview_tool):
+        """success is always present even when the caller omits it from fields."""
+        result = await overview_tool(fields=["domains"])
+        assert "success" in result
+
+    @pytest.mark.asyncio
+    async def test_fields_unknown_key_silently_absent(self, overview_tool):
+        """Requesting a non-existent key silently produces no entry — no error."""
+        result = await overview_tool(fields=["nonexistent_key"])
+        assert result["success"] is True
+        assert "nonexistent_key" not in result


### PR DESCRIPTION
Closes #1199 (first conversion: `ha_get_overview`)

## What changed

Added a `fields: list[str] | None = None` parameter to `ha_get_overview`. When the caller specifies a list of top-level response keys, the tool returns only those keys (projection applied after the full response is assembled). `success` is always included regardless of the `fields` list.

```python
# Before: full ~2,300-char response
ha_get_overview()

# After: ~145 chars — 94% reduction
ha_get_overview(fields=["system_info"])
```

Available keys: `success`, `system_info`, `domains`, `entity_summary`, `total_entities`, `count`, `offset`, `limit`, `total_matches`, `has_more`, `next_offset`, `notification_count`, `notifications`, `repair_count`, `repairs`, `tool_discovery`.

## Design choices

- **Projection after assembly** — all underlying WS/REST calls still fire; the projection is a response-shaping concern, not a fetch-skipping one. Fetch-skipping is a separate follow-up optimization.
- **`success` always present** — prevents callers from accidentally receiving a response without the envelope key they check first.
- **Silent absent keys** — unknown field names in `fields` produce no error; the key simply isn't in the response (matches HA's optional-per-domain behavior for attributes).
- **`cast()` on the projected dict** — required to satisfy mypy's `no-any-return` check on the comprehension result.

## Testing

- 5 new unit tests in `TestHaGetOverviewFieldsProjection` (no-op default, single-key, multi-key, success guarantee, unknown-key silent)
- 1 new E2E test `test_overview_fields_projection` against a live HA container

## Measurement

The issue table shows ~2,300 chars baseline → ~145 chars with `fields=["system_info"]` on a real instance. The projection eliminates `domains`, `entity_summary`, pagination metadata, notification counts, and repair data from the response.

## Future work (out of scope for this PR)

- Fetch-skipping: skip the notification/repair WS calls when those keys aren't in `fields` (reduces network round-trips, not just token output)
- Same `fields=` param on the other tools in the issue table (`ha_get_history`, `ha_search_entities`, `ha_config_list_areas`, `ha_get_state`)