### PR TITLE
feat: add fields= projection to ha_config_list_areas (#1199)

### DIFF
--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -6,7 +6,7 @@ Home Assistant areas and floors - essential organizational features for smart ho
 """
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -132,7 +132,21 @@ class AreaTools:
         annotations={"idempotentHint": True, "readOnlyHint": True, "title": "List Areas"},
     )
     @log_tool_usage
-    async def ha_config_list_areas(self) -> dict[str, Any]:
+    async def ha_config_list_areas(
+        self,
+        fields: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified top-level response keys to reduce "
+                    'response size (e.g. ["areas"]). '
+                    "None = full response (default). "
+                    "Available keys: success, count, areas, message."
+                ),
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
         """
         List all Home Assistant areas (rooms).
 
@@ -147,12 +161,16 @@ class AreaTools:
 
             if result.get("success"):
                 areas = result.get("result", [])
-                return {
+                response: dict[str, Any] = {
                     "success": True,
                     "count": len(areas),
                     "areas": areas,
                     "message": f"Found {len(areas)} area(s)",
                 }
+                if fields is not None:
+                    keep = set(fields) | {"success"}
+                    response = cast(dict[str, Any], {k: v for k, v in response.items() if k in keep})
+                return response
             else:
                 raise_tool_error(create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -6,7 +6,7 @@ Home Assistant areas and floors - essential organizational features for smart ho
 """
 
 import logging
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -169,7 +169,7 @@ class AreaTools:
                 }
                 if fields is not None:
                     keep = set(fields) | {"success"}
-                    response = cast(dict[str, Any], {k: v for k, v in response.items() if k in keep})
+                    response = {k: v for k, v in response.items() if k in keep}
                 return response
             else:
                 raise_tool_error(create_error_response(

--- a/tests/src/unit/test_tools_areas.py
+++ b/tests/src/unit/test_tools_areas.py
@@ -197,3 +197,42 @@ class TestSetAreaOrFloorCrossKindRejection:
         assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "non-empty" in error_data["error"]["message"]
         tools._client.send_websocket_message.assert_not_called()
+
+
+class TestHaConfigListAreasFieldsProjection:
+    """Unit tests for fields= projection in ha_config_list_areas."""
+
+    @pytest.fixture
+    def tools(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(return_value={
+            "success": True,
+            "result": [
+                {"area_id": "kitchen", "name": "Kitchen"},
+                {"area_id": "bedroom", "name": "Bedroom"},
+            ],
+        })
+        return AreaTools(client)
+
+    async def test_no_fields_returns_full_response(self, tools):
+        result = await tools.ha_config_list_areas()
+        assert set(result.keys()) == {"success", "count", "areas", "message"}
+
+    async def test_single_field_projects_to_that_key_plus_success(self, tools):
+        result = await tools.ha_config_list_areas(fields=["areas"])
+        assert set(result.keys()) == {"success", "areas"}
+        assert len(result["areas"]) == 2
+
+    async def test_multiple_fields_projects_correctly(self, tools):
+        result = await tools.ha_config_list_areas(fields=["count", "areas"])
+        assert set(result.keys()) == {"success", "count", "areas"}
+        assert result["count"] == 2
+
+    async def test_success_always_included_regardless_of_fields(self, tools):
+        result = await tools.ha_config_list_areas(fields=["count"])
+        assert "success" in result
+        assert result["success"] is True
+
+    async def test_unknown_field_silently_omitted(self, tools):
+        result = await tools.ha_config_list_areas(fields=["nonexistent_key"])
+        assert set(result.keys()) == {"success"}


### PR DESCRIPTION
Closes #1199 (partial — `ha_config_list_areas` slice)

## What

Adds an optional `fields` parameter to `ha_config_list_areas` that lets
callers request only the top-level response keys they need.

```python
# Return only the areas list — drops count and message
ha_config_list_areas(fields=["areas"])
```

`success` is always included regardless of the `fields` value.

## Why

`ha_config_list_areas` is a read-heavy tool called frequently by area-
scoped automations. Most callers only need `areas`; returning `count` and
`message` on every call adds unnecessary tokens.

## Changes

- `src/ha_mcp/tools/tools_areas.py`: add `fields: list[str] | None = None`
  parameter; apply `{k: v for k, v in response.items() if k in keep}`
  projection with `keep = set(fields) | {"success"}` before return.
- `tests/src/unit/test_tools_areas.py`: add `TestHaConfigListAreasFieldsProjection`
  with 5 unit tests (no projection, single key, multi key, success-always-present,
  unknown-key-silent).

## Available keys

`success`, `count`, `areas`, `message`