### PR TITLE
feat: add fields= and attribute_keys= projection to ha_get_state

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -150,6 +150,27 @@ async def _exact_match_search(
     }
 
 
+def _project_entity(
+    record: dict[str, Any],
+    fields: list[str] | None,
+    attribute_keys: list[str] | None,
+) -> dict[str, Any]:
+    """Apply optional field projection to a HA entity record.
+
+    ``fields`` filters which top-level keys to keep (e.g. ["state", "attributes"]).
+    ``attribute_keys`` further filters the ``attributes`` sub-dict.
+    Both default None = full payload (no-op).
+    """
+    if fields is not None:
+        keep = set(fields)
+        record = {k: v for k, v in record.items() if k in keep}
+    if attribute_keys is not None:
+        attrs = record.get("attributes")
+        if isinstance(attrs, dict):
+            record = {**record, "attributes": {k: v for k, v in attrs.items() if k in attribute_keys}}
+    return record
+
+
 def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register search and discovery tools with the MCP server."""
     smart_tools = kwargs.get("smart_tools")
@@ -1144,6 +1165,32 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "(e.g., 'light.kitchen' or ['light.kitchen', 'sensor.temperature'])"
             ),
         ],
+        fields: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified top-level entity record keys to reduce "
+                    'response size (e.g. ["state", "attributes"]). '
+                    "None = full entity record (default). "
+                    "Available keys: entity_id, state, attributes, last_changed, "
+                    "last_reported, last_updated, context."
+                ),
+            ),
+        ] = None,
+        attribute_keys: Annotated[
+            list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified keys from each entity's attributes dict "
+                    '(e.g. ["brightness", "color_temp"] for lights). '
+                    "None = full attributes (default). "
+                    "Unknown keys are silently absent (matches HA's per-domain behavior). "
+                    'Requires "attributes" to be present in fields= (or fields=None).'
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Get current status, state, and attributes of one or more entities (lights, switches, sensors, climate, covers, locks, fans, etc.).
 
@@ -1159,11 +1206,14 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         EXAMPLES:
         - Single: ha_get_state("light.kitchen")
         - Multiple: ha_get_state(["light.kitchen", "light.living_room", "sensor.temperature"])
+        - State only: ha_get_state("light.kitchen", fields=["state"])
+        - Slim bulk: ha_get_state(["light.k", "sensor.t"], fields=["state", "attributes"], attribute_keys=["brightness"])
         """
         # Single entity path
         if isinstance(entity_id, str):
             try:
                 result = await client.get_entity_state(entity_id)
+                result = _project_entity(result, fields, attribute_keys)
                 return await add_timezone_metadata(client, result)
             except ToolError:
                 raise
@@ -1235,7 +1285,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
             for eid, result in zip(unique_ids, results, strict=True):
                 if result.get("success") is True and "state" in result:
-                    states[eid] = result["state"]
+                    states[eid] = _project_entity(result["state"], fields, attribute_keys)
                 else:
                     error_detail = result.get("error")
                     if error_detail is None:

--- a/tests/src/unit/test_get_state_fields_projection.py
+++ b/tests/src/unit/test_get_state_fields_projection.py
@@ -1,0 +1,70 @@
+"""Unit tests for fields= and attribute_keys= projection in ha_get_state (issue #1199)."""
+
+from ha_mcp.tools.tools_search import _project_entity
+
+
+_ENTITY_RECORD = {
+    "entity_id": "light.kitchen",
+    "state": "on",
+    "attributes": {
+        "brightness": 200,
+        "color_temp": 3500,
+        "friendly_name": "Kitchen Light",
+    },
+    "last_changed": "2025-01-01T00:00:00+00:00",
+    "last_updated": "2025-01-01T00:00:00+00:00",
+    "context": {"id": "abc", "parent_id": None, "user_id": None},
+}
+
+
+class TestProjectEntity:
+    """Test _project_entity helper."""
+
+    def test_none_fields_and_none_attribute_keys_returns_unchanged(self):
+        result = _project_entity(dict(_ENTITY_RECORD), None, None)
+        assert set(result.keys()) == {"entity_id", "state", "attributes", "last_changed", "last_updated", "context"}
+
+    def test_fields_keeps_only_specified_keys(self):
+        result = _project_entity(dict(_ENTITY_RECORD), ["state"], None)
+        assert set(result.keys()) == {"state"}
+        assert result["state"] == "on"
+
+    def test_fields_multiple_keys(self):
+        result = _project_entity(dict(_ENTITY_RECORD), ["state", "entity_id"], None)
+        assert set(result.keys()) == {"state", "entity_id"}
+
+    def test_fields_unknown_key_silently_omitted(self):
+        result = _project_entity(dict(_ENTITY_RECORD), ["nonexistent"], None)
+        assert result == {}
+
+    def test_attribute_keys_filters_attributes_subdict(self):
+        result = _project_entity(dict(_ENTITY_RECORD), None, ["brightness"])
+        assert result["attributes"] == {"brightness": 200}
+        assert "color_temp" not in result["attributes"]
+        assert "friendly_name" not in result["attributes"]
+
+    def test_attribute_keys_unknown_silently_absent(self):
+        result = _project_entity(dict(_ENTITY_RECORD), None, ["nonexistent_attr"])
+        assert result["attributes"] == {}
+
+    def test_fields_and_attribute_keys_combined(self):
+        result = _project_entity(dict(_ENTITY_RECORD), ["state", "attributes"], ["brightness"])
+        assert set(result.keys()) == {"state", "attributes"}
+        assert result["attributes"] == {"brightness": 200}
+
+    def test_attribute_keys_no_effect_when_attributes_not_in_fields(self):
+        result = _project_entity(dict(_ENTITY_RECORD), ["state"], ["brightness"])
+        assert set(result.keys()) == {"state"}
+        assert "attributes" not in result
+
+    def test_attribute_keys_empty_list_returns_empty_attributes(self):
+        result = _project_entity(dict(_ENTITY_RECORD), None, [])
+        assert result["attributes"] == {}
+
+    def test_does_not_mutate_original(self):
+        original = dict(_ENTITY_RECORD)
+        _project_entity(original, ["state"], ["brightness"])
+        assert "last_changed" in original
+        assert original["attributes"]["color_temp"] == 3500
+
+


### PR DESCRIPTION
## Summary

Adds optional `fields=` and `attribute_keys=` parameters to `ha_get_state` as specified in #1199, delivering the highest-priority item in the issue's table (99% reduction for bulk calls).

- **`fields=`** — keep only the specified top-level entity record keys (e.g. `["state", "entity_id"]`)
- **`attribute_keys=`** — keep only the specified keys from each entity's `attributes` dict (e.g. `["brightness", "color_temp"]` for lights)

Both apply before `add_timezone_metadata` so the `{"data": ..., "metadata": ...}` outer wrapper shape is always preserved. Both default `None` = full payload (zero breaking change).

### Measured savings (7-entity bulk call, per #1199)

| Call | Size | Reduction |
|---|---|---|
| `ha_get_state(["e1"…"e7"])` | ~52,000 chars | baseline |
| `ha_get_state(["e1"…"e7"], fields=["state"])` | ~440 chars | **99%** |
| `ha_get_state("light.k", fields=["state"])` | ~40 chars | ~95% |

## Changes

- `src/ha_mcp/tools/tools_search.py` — adds `_project_entity` helper + `fields` / `attribute_keys` parameters to `ha_get_state` (both single-entity and bulk paths)
- `tests/src/unit/test_get_state_fields_projection.py` — 10 unit tests for `_project_entity`

## Test plan

- [x] `uv run pytest tests/src/unit/test_get_state_fields_projection.py` — 10/10 pass
- [x] `uv run mypy src/` — no issues
- [ ] CI (pr.yml — lint + type check)

Part of #1199 (alongside #1210 list-areas, #1211 history, #1212 search-entities)