### PR TITLE
feat: add fields= projection to ha_list_services (#1199)

### DIFF
--- a/src/ha_mcp/tools/tools_services.py
+++ b/src/ha_mcp/tools/tools_services.py
@@ -19,7 +19,7 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
-from .util_helpers import build_pagination_metadata, coerce_int_param
+from .util_helpers import build_pagination_metadata, coerce_int_param, project_fields
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +68,19 @@ class ServiceDiscoveryTools:
                 ),
             ),
         ] = "summary",
+        fields: Annotated[
+            str | list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified top-level response keys to reduce "
+                    'response size (e.g. ["services"]). '
+                    "None = full response (default). "
+                    "Available keys: success, domains, services, total_count, count, "
+                    "offset, limit, has_more, next_offset, detail_level, filters_applied."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """List available Home Assistant services with optional pagination and detail control.
 
@@ -119,7 +132,7 @@ class ServiceDiscoveryTools:
                 detail_level=detail_level,
             )
 
-            return result
+            return project_fields(result, fields)
 
         except ToolError:
             raise

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -280,6 +280,22 @@ def parse_string_list_param(
     raise ValueError(f"{param_name} must be string, list, or None")
 
 
+def project_fields(
+    data: dict[str, Any],
+    fields: str | list[str] | None,
+) -> dict[str, Any]:
+    """Apply optional field projection to a response data dict.
+
+    Always retains ``success``. Unknown keys in *fields* are silently dropped.
+    Accepts a list or a CSV/JSON-array string for *fields*.
+    """
+    if fields is None:
+        return data
+    parsed = parse_string_list_param(fields, "fields", allow_csv=True) or []
+    keep = set(parsed) | {"success"}
+    return {k: v for k, v in data.items() if k in keep}
+
+
 def build_pagination_metadata(
     total_count: int, offset: int, limit: int, count: int
 ) -> dict[str, Any]:

--- a/tests/src/unit/test_list_services_fields_projection.py
+++ b/tests/src/unit/test_list_services_fields_projection.py
@@ -1,0 +1,64 @@
+"""Unit tests for fields= projection in ha_list_services (issue #1199)."""
+
+from ha_mcp.tools.util_helpers import project_fields
+
+_SERVICES_RESULT = {
+    "success": True,
+    "domains": ["light", "switch"],
+    "services": {
+        "light.turn_on": {"name": "Turn on", "description": "Turn on a light."},
+        "light.turn_off": {"name": "Turn off", "description": "Turn off a light."},
+    },
+    "total_count": 2,
+    "count": 2,
+    "offset": 0,
+    "limit": 50,
+    "has_more": False,
+    "next_offset": None,
+    "detail_level": "summary",
+    "filters_applied": {"domain": None, "query": None},
+}
+
+
+class TestListServicesProjection:
+    """Test fields= projection applied to ha_list_services responses."""
+
+    def test_none_fields_returns_full_response(self):
+        result = project_fields(dict(_SERVICES_RESULT), None)
+        assert set(result.keys()) == set(_SERVICES_RESULT.keys())
+
+    def test_single_field_services_only(self):
+        result = project_fields(dict(_SERVICES_RESULT), ["services"])
+        assert set(result.keys()) == {"success", "services"}
+        assert result["services"] == _SERVICES_RESULT["services"]
+
+    def test_multiple_fields_retained(self):
+        result = project_fields(dict(_SERVICES_RESULT), ["services", "domains"])
+        assert set(result.keys()) == {"success", "services", "domains"}
+
+    def test_success_always_retained(self):
+        result = project_fields(dict(_SERVICES_RESULT), ["domains"])
+        assert "success" in result
+        assert result["success"] is True
+
+    def test_unknown_field_silently_dropped(self):
+        result = project_fields(dict(_SERVICES_RESULT), ["nonexistent"])
+        assert result == {"success": True}
+
+    def test_csv_string_input(self):
+        result = project_fields(dict(_SERVICES_RESULT), "services,domains")
+        assert set(result.keys()) == {"success", "services", "domains"}
+
+    def test_json_array_string_input(self):
+        result = project_fields(dict(_SERVICES_RESULT), '["services"]')
+        assert set(result.keys()) == {"success", "services"}
+
+    def test_empty_list_returns_only_success(self):
+        result = project_fields(dict(_SERVICES_RESULT), [])
+        assert set(result.keys()) == {"success"}
+
+    def test_does_not_mutate_original(self):
+        original = dict(_SERVICES_RESULT)
+        project_fields(original, ["services"])
+        assert "domains" in original
+        assert "detail_level" in original


### PR DESCRIPTION
## Summary

Completes the final tool in the `fields=` projection work from issue #1199 — adds an optional `fields` parameter to `ha_list_services` so AI agents can request only the response keys they need.

## Changes

- **`src/ha_mcp/tools/util_helpers.py`**: Add `project_fields(data, fields)` as a shared public helper. Accepts `str | list[str] | None` (handles CSV and JSON-array strings via `parse_string_list_param`). Always retains `success`. Unknown keys silently dropped.
- **`src/ha_mcp/tools/tools_services.py`**: Add `fields: str | list[str] | None = None` parameter. Apply `project_fields(result, fields)` before returning.
- **`tests/src/unit/test_list_services_fields_projection.py`**: 9 unit tests covering list input, CSV string input, JSON-array string input, no-op (`None`), `success` always retained, unknown keys dropped, no-mutation.

## Context

This is the sixth and final PR in the `fields=` projection series from [#1199](https://github.com/homeassistant-ai/ha-mcp/issues/1199):

| PR | Tool | Reduction |
|---|---|---|
| #1210 | `ha_config_list_areas` | 75% |
| #1211 | `ha_get_history` | 91% |
| #1212 | `ha_search_entities` | 80% |
| #1209 | `ha_get_overview` | 94% |
| #1213 | `ha_get_state` | 99% (bulk) |
| This PR | `ha_list_services` | TBD |

Closes #1199 (when all six PRs merge).

## Test plan

- [ ] Unit tests pass: `cd tests && uv run pytest src/unit/test_list_services_fields_projection.py -v`
- [ ] mypy: `uv run mypy src/` — no new errors
- [ ] ruff: `uv run ruff check src/ tests/` — clean
- [ ] `fields=None` returns full response unchanged
- [ ] `fields=["services"]` returns only `success` + `services`
- [ ] `fields="services,domains"` (CSV string) works correctly