### PR TITLE
feat: add ha_get_diagnostics tool

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1058,6 +1058,31 @@ class HomeAssistantClient:
             )
         return found
 
+    async def get_diagnostics(
+        self,
+        config_entry_id: str,
+        device_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch diagnostics for a config entry or a specific device within it.
+
+        Args:
+            config_entry_id: Config entry ID to fetch diagnostics for.
+            device_id: Optional device ID for device-scoped diagnostics.
+
+        Returns:
+            Diagnostics dict provided by the integration.
+
+        Raises:
+            HomeAssistantAPIError: If the entry is not found, integration does not
+                support diagnostics, or the API returns an error status.
+        """
+        if device_id:
+            path = f"/diagnostics/config_entry/{config_entry_id}/device/{device_id}"
+        else:
+            path = f"/diagnostics/config_entry/{config_entry_id}"
+        logger.debug(f"Fetching diagnostics: {path}")
+        return await self._request("GET", path)
+
     async def delete_config_entry(self, entry_id: str) -> dict[str, Any]:
         """Delete a config entry via REST API.
 

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -1252,6 +1252,77 @@ class IntegrationTools:
                 ],
             )
 
+    @tool(
+        name="ha_get_diagnostics",
+        tags={"Integrations"},
+        annotations={
+            "readOnlyHint": True,
+            "idempotentHint": True,
+            "title": "Get Integration Diagnostics",
+        },
+    )
+    @log_tool_usage
+    async def ha_get_diagnostics(
+        self,
+        config_entry_id: Annotated[
+            str,
+            Field(description="Config entry ID. Use ha_get_integration() to find it."),
+        ],
+        device_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional device ID for device-scoped diagnostics. "
+                    "Omit to get full config-entry diagnostics."
+                ),
+                default=None,
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        """Get the diagnostics dump for a Home Assistant integration or one of its devices.
+
+        Returns the structured JSON diagnostics data that integrations expose for
+        debugging — the same data users download from Settings → Devices & Services
+        → [integration] → Download diagnostics.
+
+        When NOT to use: for listing integrations or their config, use ha_get_integration().
+        For system logs, use ha_get_error_log() or ha_get_system_health().
+
+        When to use: debugging a flaky integration when you need auth state, device
+        hierarchy, redacted config entries, or integration-internal library state
+        (e.g., before filing a bug report or calling ha_report_issue()).
+
+        Caveats: not all integrations implement diagnostics; returns a 404 if
+        unsupported. Content is integration-defined and often partially redacted
+        for privacy — structure varies between integrations.
+        """
+        try:
+            result = await self._client.get_diagnostics(config_entry_id, device_id)
+            response: dict[str, Any] = {
+                "success": True,
+                "config_entry_id": config_entry_id,
+                "diagnostics": result,
+            }
+            if device_id:
+                response["device_id"] = device_id
+            return response
+        except ToolError:
+            raise
+        except Exception as e:
+            context: dict[str, Any] = {"config_entry_id": config_entry_id}
+            if device_id:
+                context["device_id"] = device_id
+            exception_to_structured_error(
+                e,
+                context=context,
+                suggestions=[
+                    "Use ha_get_integration() to find a valid config_entry_id",
+                    "Verify the integration supports diagnostics (not all do)",
+                    "Check Home Assistant connection",
+                ],
+            )
+
+
 def register_integration_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register integration management tools with the MCP server."""
     register_tool_methods(mcp, IntegrationTools(client))

--- a/tests/src/unit/test_ha_get_diagnostics.py
+++ b/tests/src/unit/test_ha_get_diagnostics.py
@@ -1,0 +1,66 @@
+"""Unit tests for ha_get_diagnostics tool."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.client.rest_client import HomeAssistantAPIError, HomeAssistantConnectionError
+from ha_mcp.tools.tools_integrations import IntegrationTools
+
+
+def _make_tools(diagnostics_return: dict | Exception) -> IntegrationTools:
+    client = MagicMock()
+    if isinstance(diagnostics_return, Exception):
+        client.get_diagnostics = AsyncMock(side_effect=diagnostics_return)
+    else:
+        client.get_diagnostics = AsyncMock(return_value=diagnostics_return)
+    tools = IntegrationTools.__new__(IntegrationTools)
+    tools._client = client
+    return tools
+
+
+class TestHaGetDiagnostics:
+    async def test_returns_diagnostics_for_config_entry(self):
+        dump = {"home_assistant": {"version": "2026.5.0"}, "data": {"auth": "ok"}}
+        tools = _make_tools(dump)
+        result = await tools.ha_get_diagnostics("entry_abc")
+        assert result["success"] is True
+        assert result["config_entry_id"] == "entry_abc"
+        assert result["diagnostics"] == dump
+        assert "device_id" not in result
+        tools._client.get_diagnostics.assert_called_once_with("entry_abc", None)
+
+    async def test_passes_device_id_when_provided(self):
+        dump = {"device": "data"}
+        tools = _make_tools(dump)
+        result = await tools.ha_get_diagnostics("entry_abc", "device_xyz")
+        assert result["success"] is True
+        assert result["device_id"] == "device_xyz"
+        tools._client.get_diagnostics.assert_called_once_with("entry_abc", "device_xyz")
+
+    async def test_omits_device_id_key_when_not_provided(self):
+        tools = _make_tools({"data": "ok"})
+        result = await tools.ha_get_diagnostics("entry_abc")
+        assert "device_id" not in result
+
+    async def test_raises_tool_error_on_404(self):
+        tools = _make_tools(HomeAssistantAPIError("Not found", status_code=404))
+        with pytest.raises(ToolError):
+            await tools.ha_get_diagnostics("nonexistent")
+
+    async def test_raises_tool_error_on_connection_error(self):
+        tools = _make_tools(HomeAssistantConnectionError("HA unreachable"))
+        with pytest.raises(ToolError):
+            await tools.ha_get_diagnostics("entry_abc")
+
+    async def test_raises_tool_error_on_403(self):
+        tools = _make_tools(HomeAssistantAPIError("Forbidden", status_code=403))
+        with pytest.raises(ToolError):
+            await tools.ha_get_diagnostics("entry_abc")
+
+    async def test_diagnostics_payload_forwarded_unchanged(self):
+        nested = {"a": {"b": [1, 2, 3]}, "redacted": True}
+        tools = _make_tools(nested)
+        result = await tools.ha_get_diagnostics("entry_abc")
+        assert result["diagnostics"] is nested


### PR DESCRIPTION
Closes #1148

## Summary

Adds `ha_get_diagnostics` to `IntegrationTools` for fetching the structured diagnostics dump that Home Assistant integrations expose.

**Design choice: Option B (dedicated tool)** — while Option A (extending `ha_get_integration` with `include="diagnostics"`) would avoid a new tool, `ha_get_diagnostics` is conceptually distinct (debug data, not config/state data) and the explicit surface makes it easier to discover. The `ha_get_integration` tool already has 8 parameters; adding more would increase its cognitive load. The issue author noted "leaning A unless implementation surfaces a reason to split" — the parameter-count argument and conceptual clarity are that reason.

**REST client:**
- `get_diagnostics(config_entry_id, device_id=None)` — calls `GET /api/diagnostics/config_entry/{id}` or the device-scoped variant `GET /api/diagnostics/config_entry/{id}/device/{device_id}`

**Tool:**
- `ha_get_diagnostics(config_entry_id, device_id=None)` in `IntegrationTools`
- Returns `{success, config_entry_id, diagnostics, [device_id]}`
- Raises `ToolError` on 404 (not found), 403 (no diagnostics support), connection errors

## Tests

7 unit tests in `tests/src/unit/test_ha_get_diagnostics.py`:
- Config-entry diagnostics (no device_id)
- Device-scoped diagnostics (device_id forwarded, key present in response)
- `device_id` key absent when not provided
- ToolError on 404
- ToolError on connection error
- ToolError on 403
- Diagnostics payload forwarded unchanged