### PR TITLE
feat: detect duration math patterns and suggest native for: field

### DIFF
--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -77,6 +77,11 @@ _RE_SUN = re.compile(r"(?:is_state|state_attr|states)\s*\(\s*['\"]sun\.sun['\"]"
 _RE_STATE_IN = re.compile(r"states\s*\([^)]+\)\s+in\s+[\[(]")
 # Unsafe direct state access: states.sensor.x.state
 _RE_DIRECT_STATE = re.compile(r"\bstates\.\w+\.\w+\.state\b")
+# Duration/recency checks via last_changed or last_updated arithmetic
+_RE_DURATION_MATH = re.compile(
+    r"\bnow\(\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\b"
+    r"|\blast_(?:changed|updated)\s*<\s*now\(\)"
+)
 # Motion entity pattern
 _RE_MOTION = re.compile(r"binary_sensor\.\w*motion", re.IGNORECASE)
 # Any Jinja template marker — catch-all and target-field scan.
@@ -272,6 +277,16 @@ def _check_template_string(
             "errors if entity doesn't exist — use the `states('entity_id')` "
             "function instead (returns 'unknown' if missing rather than raising)."
             + _ref(skill_prefix, "template-guidelines.md#common-patterns")
+        )
+    if _RE_DURATION_MATH.search(template):
+        warnings.append(
+            f"{label} uses template for duration/recency check "
+            "(`now() - X.last_changed/last_updated`) — use the native `for:` field "
+            "on a `state` trigger or condition instead "
+            "(e.g., `platform: state, entity_id: binary_sensor.motion, to: 'off', "
+            "for: {minutes: 5}`). Native `for:` is event-driven and avoids repeated "
+            "template evaluation on every state change."
+            + _ref(skill_prefix, "automation-patterns.md#native-conditions")
         )
 
     # Generic fallback: any Jinja in this logic position that didn't match
@@ -495,6 +510,19 @@ def _check_triggers(
                         "Trigger uses template with `is_state()` — use "
                         "native `state` trigger instead "
                         "(e.g., `platform: state, entity_id: light.x, to: 'on'`)."
+                        + _ref(
+                            skill_prefix,
+                            "automation-patterns.md#trigger-types",
+                        )
+                    )
+                if _RE_DURATION_MATH.search(vt):
+                    warnings.append(
+                        "Trigger uses template for duration/recency check "
+                        "(`now() - X.last_changed/last_updated`) — use the native "
+                        "`for:` field on a `state` trigger instead "
+                        "(e.g., `platform: state, entity_id: binary_sensor.motion, "
+                        "to: 'off', for: {minutes: 5}`). Native `for:` is event-driven "
+                        "and doesn't re-evaluate on every state change."
                         + _ref(
                             skill_prefix,
                             "automation-patterns.md#trigger-types",

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -1311,3 +1311,81 @@ class TestSkillPrefixNoneNewDetectors:
             "action": [],
         }, skill_prefix=None)
         self._assert_clean(warnings)
+
+
+# ---------------------------------------------------------------------------
+# Duration math / for: field detector
+# ---------------------------------------------------------------------------
+
+
+class TestDurationMathDetector:
+    """Detects now() - X.last_changed patterns and suggests native for:."""
+
+    def test_condition_last_changed_math(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now() - states.binary_sensor.motion.last_changed > timedelta(minutes=5) }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_condition_last_updated_math(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now() - states.sensor.temp.last_updated > timedelta(minutes=10) }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_trigger_template_last_changed_math(self):
+        config = {
+            "trigger": [{
+                "platform": "template",
+                "value_template": "{{ now() - trigger.last_changed > timedelta(seconds=30) }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_state_trigger_with_for_field_no_warning(self):
+        config = {
+            "trigger": [{
+                "platform": "state",
+                "entity_id": "binary_sensor.motion",
+                "to": "off",
+                "for": {"minutes": 5},
+            }],
+            "action": [{"service": "light.turn_off", "target": {"entity_id": "light.hall"}}],
+        }
+        warnings = check_automation_config(config)
+        assert not _has_warning_containing(warnings, "last_changed", "for:")
+
+    def test_warning_contains_skill_ref(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now() - states.sensor.x.last_changed > timedelta(hours=1) }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config, skill_prefix=SKILL_PREFIX)
+        assert _has_warning_containing(warnings, "automation-patterns.md#native-conditions")
+
+    def test_no_generic_fallback_when_duration_fires(self):
+        config = {
+            "condition": [{
+                "condition": "template",
+                "value_template": "{{ now() - states.binary_sensor.door.last_changed > timedelta(minutes=1) }}",
+            }],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        generic_warnings = [w for w in warnings if "if this maps to a native option" in w]
+        assert not generic_warnings, "Generic fallback should not fire alongside specific detector"


### PR DESCRIPTION
Addresses part of #1157 (HA 2026.5 `for:` field).

## Summary

Adds a `_RE_DURATION_MATH` detector to `best_practice_checker.py` that fires when a condition or trigger template uses `now() - X.last_changed/last_updated` arithmetic for duration/recency checks. The warning directs agents to use the native `for:` field on a `state` trigger or condition instead — which is event-driven and avoids repeated template evaluation on every state change.

**Scope note:** This PR covers the best-practice checker update only (step 2 of #1157's investigation areas). The docstring example updates in `ha_config_set_automation` / `ha_config_set_script` and skill reference updates (`template-guidelines.md`, `automation-patterns.md` in the skills repo) are tracked as follow-up work in #1157.

## Changes

- `best_practice_checker.py`: Add `_RE_DURATION_MATH` regex and check in `_check_template_string` (conditions) and `_check_triggers` (template triggers)
- `tests/src/unit/test_best_practice_checker.py`: 6 new tests in `TestDurationMathDetector`

## Tests

- `test_condition_last_changed_math` — detects `now() - X.last_changed` in conditions
- `test_condition_last_updated_math` — detects `now() - X.last_updated` in conditions
- `test_trigger_template_last_changed_math` — detects in template trigger value_template
- `test_state_trigger_with_for_field_no_warning` — clean `for:` trigger doesn't fire
- `test_warning_contains_skill_ref` — skill reference present in message
- `test_no_generic_fallback_when_duration_fires` — specific detector suppresses generic fallback