### PR TITLE
fix(ci): switch Renovate to GitHub App token (unblocks workflow-file pushes)

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,9 +18,7 @@ on:
           - error
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   renovate:
@@ -30,11 +28,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # The default GITHUB_TOKEN cannot push commits that modify any file
+      # under .github/workflows/ — GitHub blocks workflow-file mutations
+      # from GITHUB_TOKEN for security reasons. Renovate needs to touch
+      # those files (the # renovate: annotations sit alongside image: pins
+      # in pr.yml, e2e-tests.yml, performance-tests.yml), so we mint a
+      # short-lived installation token from a dedicated GitHub App that
+      # has Workflows: write.
+      - name: Generate Renovate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v46.1.14
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^cat.*", "^echo.*", "^cut.*", "^sed.*", "^git add.*"]'


### PR DESCRIPTION
## What does this PR do?

Restores Renovate's ability to auto-create dependency-bump PRs.

Since #817 merged on 2026-03-24 (which added \`# renovate: ...\` annotations to \`.github/workflows/pr.yml\`), Renovate runs have silently failed for two months — the workflow ran on schedule but pushed no branches and opened no PRs. The push log under debug-level logging contained the real cause, verbatim:

> \`remote rejected (refusing to allow a GitHub App to create or update workflow .github/workflows/pr.yml without\` workflows \`permission)\`

The default \`GITHUB_TOKEN\` is hard-blocked by GitHub from creating commits that modify any file under \`.github/workflows/\`. This is a fixed server-side restriction — no \`permissions:\` block override exists. HA pins live in \`pr.yml\`, \`e2e-tests.yml\`, \`performance-tests.yml\`, and \`test_constants.py\`; uv pins live in pr.yml (5 occurrences) plus three Dockerfiles. Any Renovate branch touching a workflow file got silently rejected.

Fix: mint a short-lived installation token from a dedicated \`ha-mcp-renovate\` GitHub App (org-installed on \`homeassistant-ai\`) and feed that to the Renovate action instead of \`secrets.GITHUB_TOKEN\`. App-issued tokens with \`Workflows: write\` are exempt from the workflow-file push block. The workflow's job-level \`permissions:\` block is also tightened to \`contents: read\` since the Renovate step no longer relies on \`GITHUB_TOKEN\` for any write operation.

**Required secrets (already added):**
- \`RENOVATE_APP_ID\`
- \`RENOVATE_APP_PRIVATE_KEY\`

**Verified by one-shot real-mode dispatch** (run \`25680169263\`): Renovate pushed both branches and opened #1233 (uv 0.11.0 → 0.11.13) and #1236 (HA 2026.4.1 → 2026.5.1). The dedicated app also superseded the stale Dependency Dashboard #361 with #1237 (old one was closed today with a migration comment).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`)
- [ ] Code follows style guidelines (\`uv run ruff check\`)

**Verification done instead** (this is a CI-infrastructure change — no Python or test code modified): a one-shot real-mode workflow dispatch from this branch ran end-to-end and produced the two expected Renovate PRs (#1233, #1236). PR CI is fully green on this branch.

## Future improvements

- \`tests/addon/test_webhook_proxy.py::test_token_with_tampered_signature_rejected\` has a latent ~6% flake — it tampers the last base64-url char of an HMAC-SHA256 signature, but the 43rd char only encodes 4 of 6 useful bits, so when the sig ends in \`{A, B, C, D}\` the tampered char shares those 4 high bits and the decoded HMAC is byte-identical. Triggered on this PR's first CI run, passed on retry. Filed as #1238.

## Checklist
- [x] I have updated documentation if needed *(no docs apply — the only relevant guidance was already in the existing renovate.yml comments)*