### PR TITLE
test(seed): add a writable scene for test_call_service_scene_turn_on

### DIFF
--- a/tests/initial_test_state/scenes.yaml
+++ b/tests/initial_test_state/scenes.yaml
@@ -1,0 +1,8 @@
+# E2E seed scenes — referenced by tests that would otherwise skip with
+# "No scene entities available for testing" (test_service.py::test_call_service_scene_turn_on).
+# Keep entries minimal and side-effect-free.
+- id: e2e_test_scene_seed
+  name: E2E Test Seed Scene
+  entities:
+    light.bed_light:
+      state: 'off'


### PR DESCRIPTION
## What does this PR do?

Fills a silently-skipped CI test by seeding a scene. From the #366 silent-skip audit: `tests/src/e2e/workflows/core/test_service.py::TestCallService::test_call_service_scene_turn_on` skipped on every CI run with `"No scene entities available for testing"` because `tests/initial_test_state/scenes.yaml` was an empty list.

Adds one minimal scene entry (`e2e_test_scene_seed`, sets `light.bed_light` to `'off'`) so the test finds a callable target. The scene is idempotent and side-effect-free.

Note: the diff renders as "Binary files differ" because `tests/initial_test_state/**` is `binary merge=ours` in `.gitattributes`. The actual content of the new `scenes.yaml` is:

```yaml
# E2E seed scenes — referenced by tests that would otherwise skip with
# "No scene entities available for testing" (test_service.py::test_call_service_scene_turn_on).
# Keep entries minimal and side-effect-free.
- id: e2e_test_scene_seed
  name: E2E Test Seed Scene
  entities:
    light.bed_light:
      state: 'off'
```

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified locally on `ghcr.io/home-assistant/home-assistant:2026.4.1`: previously `SKIPPED`, now `PASSED in 55.43s` (10.39s call — exercises `scene.turn_on` and verifies state).

## Future improvements

Three more silent-skip seed PRs from the same audit queued behind this one (automation, history sensor, logbook fixture).

## Checklist

- [x] I have updated documentation if needed