### PR TITLE
test(seed): add disabled seed automation for test_get_state_automation_entity

### DIFF
--- a/tests/initial_test_state/automations.yaml
+++ b/tests/initial_test_state/automations.yaml
@@ -1,1 +1,17 @@
-[]
+# E2E seed automations — referenced by tests that would otherwise skip with
+# "No automation entities available for testing" (test_state.py::test_get_state_automation_entity).
+# initial_state is false so the automation never fires during the test session.
+- id: e2e_test_automation_seed
+  alias: E2E Seed Automation
+  description: Seed automation for test_state.py::test_get_state_automation_entity. Disabled at startup to avoid runtime side effects.
+  trigger:
+    - platform: time
+      at: '03:00:00'
+  condition: []
+  action:
+    - service: persistent_notification.create
+      data:
+        title: E2E seed
+        message: This automation should never run during tests; initial_state is false.
+  initial_state: false
+  mode: single


### PR DESCRIPTION
## What does this PR do?

Fills a silently-skipped CI test by seeding an automation. From the #366 silent-skip audit: `tests/src/e2e/workflows/core/test_state.py::test_get_state_automation_entity` skipped on every CI run with `"No automation entities available for testing"` because `tests/initial_test_state/automations.yaml` was an empty list.

Adds one `e2e_test_automation_seed` automation with `initial_state: false` so it never fires during the test session. Trigger is a benign daily time pattern (03:00:00); action is a `persistent_notification.create` that wouldn't execute anyway because the automation is disabled.

Note: the diff renders as "Binary files differ" because `tests/initial_test_state/**` is `binary merge=ours` in `.gitattributes`. The actual content is:

```yaml
- id: e2e_test_automation_seed
  alias: E2E Seed Automation
  description: Seed automation for test_state.py::test_get_state_automation_entity. Disabled at startup to avoid runtime side effects.
  trigger:
    - platform: time
      at: '03:00:00'
  condition: []
  action:
    - service: persistent_notification.create
      data:
        title: E2E seed
        message: This automation should never run during tests; initial_state is false.
  initial_state: false
  mode: single
```

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified locally on `ghcr.io/home-assistant/home-assistant:2026.4.1`: previously `SKIPPED`, now `PASSED in 42.75s` (0.33s call — fetches state of `automation.e2e_seed_automation`).

## Future improvements

Two more silent-skip seed PRs from the same audit queued behind this one (history sensor + assertion fix, logbook fixture).

## Checklist

- [x] I have updated documentation if needed