### PR TITLE
test(addon): fix base64 padding-bit flake in token tamper tests

### DIFF
--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -1224,13 +1224,17 @@ class TestOAuthProvider:
     def test_token_with_tampered_payload_rejected(self, provider):
         token = provider.issue_access_token()
         body, sig = token.rsplit(".", 1)
-        tampered_body = body[:-1] + ("A" if body[-1] != "A" else "B")
+        # Flip the first base64-url character (6 full data bits, no padding)
+        # to guarantee a different decoded byte regardless of key material.
+        tampered_body = ("A" if body[0] != "A" else "B") + body[1:]
         assert provider.validate_access_token(f"{tampered_body}.{sig}") is False
 
     def test_token_with_tampered_signature_rejected(self, provider):
         token = provider.issue_access_token()
         body, sig = token.rsplit(".", 1)
-        tampered_sig = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+        # Flip the first base64-url character (6 full data bits, no padding)
+        # to guarantee a different decoded byte regardless of key material.
+        tampered_sig = ("A" if sig[0] != "A" else "B") + sig[1:]
         assert provider.validate_access_token(f"{body}.{tampered_sig}") is False
 
     def test_expired_token_rejected(self, tmp_path):


### PR DESCRIPTION
Fixes #1238

## Root cause

The last character of a 43-char base64-url HMAC-SHA256 encoding only carries
4 meaningful bits (2 bits are zero-padding). Characters in the same 4-char
group (e.g. `A`/`B`/`C`/`D`) share identical first 4 bits, so flipping the
last character within that group produces a byte-identical decoded value.
`hmac.compare_digest` returns `True`, validation correctly passes, and the
test — which expects rejection — fails. Probability: 4/64 = 6.25%.

## Fix

Target the **first** base64-url character instead. The first character always
encodes 6 full data bits with no padding, so any change to it is guaranteed to
produce a different decoded byte.

No new imports needed — the fix is a one-character positional change in both
affected tests.

Applied to both `test_token_with_tampered_payload_rejected` and
`test_token_with_tampered_signature_rejected` as the same padding-bit
collision can occur in the payload encoding depending on JSON length.