### PR TITLE
fix(backup): discover local agent at call time instead of hardcoding hassio.local

### DIFF
--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -89,19 +89,23 @@ async def _get_local_backup_agent_id(
             )
         )
 
-    local_agents = [a.get("agent_id") for a in agents if a.get("name") == "local"]
+    local_agents: list[str] = [
+        a["agent_id"]
+        for a in agents
+        if a.get("name") == "local" and a.get("agent_id")
+    ]
     # Prefer hassio.local (Supervisor) over backup.local (Core) when both exist
     for preferred in ("hassio.local", "backup.local"):
         if preferred in local_agents:
             return preferred
     if local_agents:
-        return cast(str, local_agents[0])
+        return local_agents[0]
 
     raise_tool_error(
         create_error_response(
             ErrorCode.SERVICE_CALL_FAILED,
             "No local backup agent found",
-            context={"available_agents": [a.get("agent_id") for a in agents]},
+            context={"available_agents": [a.get("agent_id") for a in agents if a.get("agent_id")]},
             suggestions=[
                 "Backup creation requires a local agent (hassio.local on "
                 "Supervised, backup.local on Core); none is registered",

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -52,6 +52,64 @@ def _get_backup_hint_text() -> str:
     return hints.get(hint, hints["normal"])
 
 
+async def _get_local_backup_agent_id(
+    ws_client: HomeAssistantWebSocketClient,
+) -> str:
+    """Discover the local backup agent_id at call time.
+
+    HA Supervised registers ``hassio.local`` and HA Core registers
+    ``backup.local`` — both have ``name: "local"``. Hardcoding either breaks
+    the other deployment. We probe ``backup/agents/info`` and pick the agent
+    whose name is exactly ``"local"`` (prefer Supervisor's ``hassio.local``
+    when both are present, since the Supervisor agent is the canonical local
+    target on Supervised installs).
+
+    Raises ToolError if no local agent is available.
+    """
+    response = await ws_client.send_command("backup/agents/info")
+    if not response.get("success"):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Failed to enumerate backup agents",
+                context={"details": response},
+            )
+        )
+
+    agents = response.get("result", {}).get("agents", [])
+    if not agents:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "No backup agents registered with Home Assistant",
+                suggestions=[
+                    "The HA backup integration may not be fully set up; "
+                    "check the backup panel in Home Assistant",
+                ],
+            )
+        )
+
+    local_agents = [a.get("agent_id") for a in agents if a.get("name") == "local"]
+    # Prefer hassio.local (Supervisor) over backup.local (Core) when both exist
+    for preferred in ("hassio.local", "backup.local"):
+        if preferred in local_agents:
+            return preferred
+    if local_agents:
+        return cast(str, local_agents[0])
+
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            "No local backup agent found",
+            context={"available_agents": [a.get("agent_id") for a in agents]},
+            suggestions=[
+                "Backup creation requires a local agent (hassio.local on "
+                "Supervised, backup.local on Core); none is registered",
+            ],
+        )
+    )
+
+
 async def _get_backup_password(
     ws_client: HomeAssistantWebSocketClient,
 ) -> str:
@@ -94,8 +152,13 @@ async def _poll_backup_completion(
     backup_job_id: str,
     max_wait_seconds: int,
     poll_interval: int,
+    agent_id: str,
 ) -> dict[str, Any]:
     """Poll backup/info until the named backup completes, fails, or times out.
+
+    ``agent_id`` is the local agent that owns this backup (e.g.
+    ``hassio.local`` on Supervised, ``backup.local`` on Core); used to look
+    up the per-agent size in the backup-info payload.
 
     Raises ToolError on backup failure or timeout.
     """
@@ -134,7 +197,7 @@ async def _poll_backup_completion(
                         "name": name,
                         "date": created_backup.get("date"),
                         "size_bytes": created_backup.get("agents", {})
-                        .get("hassio.local", {})
+                        .get(agent_id, {})
                         .get("size"),
                         "status": "Backup completed successfully",
                         "duration_seconds": waited,
@@ -192,19 +255,30 @@ async def create_backup(
         # Get backup password (raises ToolError on failure)
         password = await _get_backup_password(ws_client)
 
+        # Discover the local backup agent at call time. HA Core registers
+        # `backup.local`; HA Supervised registers `hassio.local`. Hardcoding
+        # either breaks the other deployment (#366 silent-skip audit
+        # surfaced this — test_backup_create_with_auto_name was failing on
+        # Core test containers with "available agents: ['backup.local']").
+        local_agent = await _get_local_backup_agent_id(ws_client)
+
         # Generate backup name if not provided
         if not name:
             now = datetime.now()
             name = f"MCP_Backup_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
 
-        # Create backup request
+        # Create backup request. Addons + addon folders are Supervisor
+        # concepts — HA Core errors with "Addons and folders are not
+        # supported by core backup" if we ask for them. Toggle off when we
+        # detect the Core local agent.
+        is_supervised = local_agent == "hassio.local"
         backup_params = {
             "name": name,
             "password": password,
-            "agent_ids": ["hassio.local"],  # Local only
+            "agent_ids": [local_agent],
             "include_homeassistant": True,
             "include_database": False,  # Fast backup
-            "include_all_addons": True,
+            "include_all_addons": is_supervised,
         }
 
         # Send backup request
@@ -225,6 +299,7 @@ async def create_backup(
             backup_job_id,
             max_wait_seconds=_BACKUP_MAX_WAIT_S,
             poll_interval=_BACKUP_POLL_INTERVAL_S,
+            agent_id=local_agent,
         )
 
     except ToolError:
@@ -248,8 +323,12 @@ async def create_backup(
 async def _create_safety_backup(
     ws_client: HomeAssistantWebSocketClient,
     password: str | None,
+    agent_id: str,
 ) -> str | None:
     """Create a pre-restore safety backup.
+
+    ``agent_id`` is the local backup agent (Supervisor's ``hassio.local`` or
+    Core's ``backup.local``) discovered by the caller.
 
     Returns the safety backup ID, or None when password is None (backup intentionally
     skipped). Raises ToolError if backup creation fails.
@@ -260,14 +339,16 @@ async def _create_safety_backup(
     now = datetime.now()
     safety_backup_name = f"PreRestore_Safety_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
 
+    # include_all_addons is a Supervisor concept; HA Core rejects it.
+    is_supervised = agent_id == "hassio.local"
     safety_backup = await ws_client.send_command(
         "backup/generate",
         name=safety_backup_name,
         password=password,
-        agent_ids=["hassio.local"],
+        agent_ids=[agent_id],
         include_homeassistant=True,
         include_database=True,
-        include_all_addons=True,
+        include_all_addons=is_supervised,
     )
 
     if not safety_backup.get("success"):
@@ -330,6 +411,11 @@ async def restore_backup(
                 suggestions=["Use ha_backup_list() to see available backups"],
             ))
 
+        # Discover the local backup agent (Supervisor's hassio.local on
+        # Supervised, backup.local on Core). Used for both the safety backup
+        # and the restore call below.
+        local_agent = await _get_local_backup_agent_id(ws_client)
+
         # Create safety backup BEFORE restoring
         logger.info("Creating safety backup before restore...")
         try:
@@ -339,12 +425,12 @@ async def restore_backup(
             logger.warning("No default password - proceeding without safety backup")
             password = None
 
-        safety_backup_id = await _create_safety_backup(ws_client, password)
+        safety_backup_id = await _create_safety_backup(ws_client, password, local_agent)
 
         # Perform restore
         restore_params = {
             "backup_id": backup_id,
-            "agent_id": "hassio.local",
+            "agent_id": local_agent,
             "restore_database": restore_database,
             "restore_homeassistant": True,
             "restore_addons": [],  # Restore all addons from backup
@@ -409,7 +495,7 @@ def register_backup_tools(mcp: "FastMCP", client: HomeAssistantClient, **kwargs:
 
 **Password:** Uses Home Assistant's default backup password (if configured)
 
-**Storage:** Local only (hassio.local agent)
+**Storage:** Local only (the local backup agent — `hassio.local` on HA Supervised, `backup.local` on HA Core)
 
 **Duration:** Typically takes several seconds to complete (without database)
 

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -60,9 +60,8 @@ async def _get_local_backup_agent_id(
     HA Supervised registers ``hassio.local`` and HA Core registers
     ``backup.local`` — both have ``name: "local"``. Hardcoding either breaks
     the other deployment. We probe ``backup/agents/info`` and pick the agent
-    whose name is exactly ``"local"`` (prefer Supervisor's ``hassio.local``
-    when both are present, since the Supervisor agent is the canonical local
-    target on Supervised installs).
+    whose name is exactly ``"local"``, preferring ``hassio.local`` if both
+    happen to be registered.
 
     Raises ToolError if no local agent is available.
     """
@@ -261,9 +260,7 @@ async def create_backup(
 
         # Discover the local backup agent at call time. HA Core registers
         # `backup.local`; HA Supervised registers `hassio.local`. Hardcoding
-        # either breaks the other deployment (#366 silent-skip audit
-        # surfaced this — test_backup_create_with_auto_name was failing on
-        # Core test containers with "available agents: ['backup.local']").
+        # either breaks the other deployment.
         local_agent = await _get_local_backup_agent_id(ws_client)
 
         # Generate backup name if not provided
@@ -271,11 +268,14 @@ async def create_backup(
             now = datetime.now()
             name = f"MCP_Backup_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
 
-        # Create backup request. Addons + addon folders are Supervisor
-        # concepts — HA Core errors with "Addons and folders are not
-        # supported by core backup" if we ask for them. Toggle off when we
-        # detect the Core local agent.
+        # Addons + addon folders are Supervisor concepts — HA Core errors
+        # with "Addons and folders are not supported by core backup" if we
+        # ask for them. Toggle off when we detect the Core local agent.
         is_supervised = local_agent == "hassio.local"
+        logger.info(
+            f"Detected {'Supervised' if is_supervised else 'Core'} install "
+            f"via backup agent '{local_agent}'"
+        )
         backup_params = {
             "name": name,
             "password": password,

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -64,7 +64,7 @@ class TestGetLocalBackupAgentId:
             await _get_local_backup_agent_id(ws)
         error = json.loads(str(exc_info.value))
         assert "No local backup agent found" in error["error"]["message"]
-        assert error["error"]["context"]["available_agents"] == ["google_drive.cloud"]
+        assert error["available_agents"] == ["google_drive.cloud"]
 
     @pytest.mark.asyncio
     async def test_empty_agent_list_raises(self):

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -1,0 +1,111 @@
+"""Unit tests for `_get_local_backup_agent_id` in the backup tools module.
+
+Regression coverage for the hardcoded `hassio.local` bug that broke `ha_backup_*`
+tools on HA Core installs (which only register `backup.local`).
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.backup import _get_local_backup_agent_id
+
+
+def _ws_client(agents_payload: dict) -> AsyncMock:
+    """Build a mock WS client whose `send_command("backup/agents/info")` returns the given payload."""
+    ws = AsyncMock()
+    ws.send_command.return_value = agents_payload
+    return ws
+
+
+class TestGetLocalBackupAgentId:
+    @pytest.mark.asyncio
+    async def test_core_only_returns_backup_local(self):
+        """HA Core install (only `backup.local` registered) returns `backup.local`."""
+        ws = _ws_client({
+            "success": True,
+            "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]},
+        })
+        assert await _get_local_backup_agent_id(ws) == "backup.local"
+
+    @pytest.mark.asyncio
+    async def test_supervised_only_returns_hassio_local(self):
+        """HA Supervised install (only `hassio.local` registered) returns `hassio.local`."""
+        ws = _ws_client({
+            "success": True,
+            "result": {"agents": [{"agent_id": "hassio.local", "name": "local"}]},
+        })
+        assert await _get_local_backup_agent_id(ws) == "hassio.local"
+
+    @pytest.mark.asyncio
+    async def test_both_present_prefers_hassio_local(self):
+        """When both agents are registered, prefer `hassio.local` (Supervisor)."""
+        ws = _ws_client({
+            "success": True,
+            "result": {
+                "agents": [
+                    {"agent_id": "backup.local", "name": "local"},
+                    {"agent_id": "hassio.local", "name": "local"},
+                ],
+            },
+        })
+        assert await _get_local_backup_agent_id(ws) == "hassio.local"
+
+    @pytest.mark.asyncio
+    async def test_only_remote_agents_raises(self):
+        """No agent named `local` raises `ToolError` listing the available agents."""
+        ws = _ws_client({
+            "success": True,
+            "result": {"agents": [{"agent_id": "google_drive.cloud", "name": "Google Drive"}]},
+        })
+        with pytest.raises(ToolError) as exc_info:
+            await _get_local_backup_agent_id(ws)
+        error = json.loads(str(exc_info.value))
+        assert "No local backup agent found" in error["error"]["message"]
+        assert error["error"]["context"]["available_agents"] == ["google_drive.cloud"]
+
+    @pytest.mark.asyncio
+    async def test_empty_agent_list_raises(self):
+        """Empty agent list raises `ToolError` with an actionable suggestion."""
+        ws = _ws_client({"success": True, "result": {"agents": []}})
+        with pytest.raises(ToolError) as exc_info:
+            await _get_local_backup_agent_id(ws)
+        error = json.loads(str(exc_info.value))
+        assert "No backup agents registered" in error["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_send_command_failure_raises(self):
+        """A `success=False` response from HA raises `ToolError`."""
+        ws = _ws_client({"success": False, "error": "WS error"})
+        with pytest.raises(ToolError) as exc_info:
+            await _get_local_backup_agent_id(ws)
+        error = json.loads(str(exc_info.value))
+        assert "Failed to enumerate backup agents" in error["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_local_entry_filtered_out(self):
+        """An agent with `name=local` but missing `agent_id` is filtered, not returned as None."""
+        ws = _ws_client({
+            "success": True,
+            "result": {
+                "agents": [
+                    {"name": "local"},  # malformed — no agent_id
+                    {"agent_id": "backup.local", "name": "local"},
+                ],
+            },
+        })
+        assert await _get_local_backup_agent_id(ws) == "backup.local"
+
+    @pytest.mark.asyncio
+    async def test_only_malformed_local_entry_raises(self):
+        """If the only `name=local` entry is malformed, raise rather than return None."""
+        ws = _ws_client({
+            "success": True,
+            "result": {"agents": [{"name": "local"}]},
+        })
+        with pytest.raises(ToolError) as exc_info:
+            await _get_local_backup_agent_id(ws)
+        error = json.loads(str(exc_info.value))
+        assert "No local backup agent found" in error["error"]["message"]


### PR DESCRIPTION
## What does this PR do?

`src/ha_mcp/tools/backup.py` hardcoded `agent_ids: ["hassio.local"]` in four places (the create-backup path, the safety-backup path, the restore path, and the post-completion per-agent size lookup). `hassio.local` is the Supervisor-registered backup agent — HA Core only registers `backup.local`. Every `ha_backup_*` tool call on a HA-Core install therefore failed with:

> Command failed: At least one available backup agent must be selected, got ['hassio.local']

Two changes:

1. **New `_get_local_backup_agent_id()` helper** probes `backup/agents/info` at call time and picks the agent whose `name` is exactly `"local"`. Prefers `hassio.local` over `backup.local` when both are present, so Supervised installs keep the canonical Supervisor agent. Raises a structured tool error if no local agent is registered.
2. **Gates `include_all_addons` on whether we're on Supervised** (i.e. the discovered local agent is `hassio.local`). HA Core rejects `backup/generate` with `"Addons and folders are not supported by core backup"` if `include_all_addons: True` is set, since addons are a Supervisor concept.

The companion e2e skip (`test_backup.py::TestBackupTools::test_backup_*` ×3 in the #366 silent-skip audit) still skips on CI because real backups take 100+ seconds — too slow for the e2e suite even with the tool working. That's a test-strategy concern outside this PR's scope.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified locally against `ghcr.io/home-assistant/home-assistant:2026.5.1` (HA Core, no Supervisor):

- `uv run ruff check src/ha_mcp/tools/backup.py` → All checks passed
- `uv run mypy src/ha_mcp/tools/backup.py` → No issues
- `dev_harness call ha_backup_create` — previously `Command failed: ...got ['hassio.local']`, now `success: true, backup_id: 1d95f0f8, size_bytes: 19425280` (50s on the long-running dev container)
- `pytest src/e2e/workflows/convenience/test_backup.py::TestBackupTools::test_backup_create_with_auto_name` with a manually-seeded default password: previously `SKIPPED`, then `FAILED` post-password-seed with `available agents: ['backup.local']`, now `PASSED in 114s`

## Future improvements

- The e2e `test_backup.py` skip-on-missing-default-password is acting as a coincidental "don't run slow backup tests in CI" gate. A cleaner design would mark these tests with `@pytest.mark.slow` (or similar) and let CI opt in/out explicitly — out of scope here.

## Checklist

- [x] I have updated documentation if needed