### PR TITLE
fix(ci): align pr.yml E2E with --dist loadscope (#1206)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -178,6 +178,7 @@ jobs:
         echo "🚀 Running full E2E test suite with ${{ matrix.pytest_workers }} workers..."
         uv run pytest tests/src/e2e/ \
           -n${{ matrix.pytest_workers }} \
+          --dist loadscope \
           --tb=short \
           -v
         echo "✅ Full E2E test suite passed"


### PR DESCRIPTION
## What does this PR do?

Closes #1206.

Adds `--dist loadscope` to the E2E pytest invocation in `.github/workflows/pr.yml`. This aligns PR validation with the post-merge / `workflow_dispatch` path in `e2e-tests.yml:90` and the local invocations documented in `CONTRIBUTING.md:10` + `AGENTS.md:380` — the `pr.yml` E2E job was the lone holdout among the full-E2E invocations running pytest's default `--dist load`. (`.github/workflows/performance-tests.yml:92` runs `pytest tests/src/e2e/performance/ -m performance` single-worker (no `-n` / `--dist`), so `--dist loadscope` has no effect there — no alignment change applicable.)

`loadscope` keeps same-class tests on a single worker. The underlying motivation is that any future test-class with shared state across methods (e.g. the class-isolation bug behind #1196 that #1201 fixed) is exposed under `load` but not `loadscope`. The PR-validation lane should match the post-merge lane on this so a future "works locally and on merge, breaks on PR" failure mode doesn't recur.

PR #1198 attempted exactly this change and surfaced #1205 (`COMPONENT_NOT_INSTALLED` on `gw1`, ARM only, under loadscope). #1208 has since closed #1205, so the blocker is gone.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

CI on this PR is the verification path — the change only affects how pytest distributes tests across xdist workers in the PR-validation lane.

## Checklist

- [x] I have updated documentation if needed (no docs needed — `CONTRIBUTING.md` / `AGENTS.md` already prescribe `--dist loadscope`; this PR makes the CI match them)


