### PR TITLE
test(e2e): use time.monotonic() for duration polling (#1234)

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1123,9 +1123,9 @@ async def wait_for_state_change():
         client: Client, entity_id: str, expected_state: str, timeout: int = 5
     ) -> bool:
         """Wait for entity to reach expected state."""
-        start_time = time.time()
+        start_time = time.monotonic()
 
-        while time.time() - start_time < timeout:
+        while time.monotonic() - start_time < timeout:
             state_result = await client.call_tool(
                 "ha_get_state", {"entity_id": entity_id}
             )

--- a/tests/src/e2e/error_handling/test_network_errors.py
+++ b/tests/src/e2e/error_handling/test_network_errors.py
@@ -738,9 +738,9 @@ async def test_system_resilience_under_load(mcp_client):
         safe_overview_call() for _ in range(10)
     ]  # Reduced to 10 for stability
 
-    start_time = time.time()
+    start_time = time.monotonic()
     rapid_results = await asyncio.gather(*rapid_operations, return_exceptions=True)
-    end_time = time.time()
+    end_time = time.monotonic()
 
     successful_rapid = sum(
         1

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -131,8 +131,7 @@ def assert_mcp_success(result, operation_name: str = "operation"):
     ]
 
     if not any(success_indicators):
-        error_msg = data.get("error", "Unknown error"
-        )
+        error_msg = data.get("error", "Unknown error")
         suggestions = data.get("suggestions", [])
 
         failure_msg = f"{operation_name} failed: {error_msg}"
@@ -404,7 +403,7 @@ def assert_logbook_contains(
     if not logbook_data.get("success", False):
         raise AssertionError(f"Logbook query failed: {logbook_data.get('error')}")
 
-    entries = logbook_data.get("entries", [])
+    entries = logbook_data.get("data", {}).get("entries", [])
 
     if not entries:
         raise AssertionError("Logbook contains no entries")
@@ -540,9 +539,9 @@ async def wait_for_automation(
     import asyncio
     import time
 
-    start_time = time.time()
+    start_time = time.monotonic()
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         # Use safe_call_tool to handle ToolError exceptions
         parsed = await safe_call_tool(
             mcp_client,
@@ -552,13 +551,11 @@ async def wait_for_automation(
 
         if parsed.get("success"):
             logger.debug(
-                f"Automation {automation_id} found after {time.time() - start_time:.2f}s"
+                f"Automation {automation_id} found after {time.monotonic() - start_time:.2f}s"
             )
             return parsed.get("config")
 
         await asyncio.sleep(poll_interval)
 
-    logger.warning(
-        f"Automation {automation_id} not found after {timeout}s timeout"
-    )
+    logger.warning(f"Automation {automation_id} not found after {timeout}s timeout")
     return None

--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -36,13 +36,13 @@ async def wait_for_entity_state(
     Returns:
         True if state reached, False if timeout
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
     logger.info(
         f"⏳ Waiting for {entity_id} to reach state '{expected_state}' (timeout: {timeout}s)"
     )
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             state_result = await mcp_client.call_tool(
                 "ha_get_state", {"entity_id": entity_id}
@@ -50,12 +50,12 @@ async def wait_for_entity_state(
             state_data = parse_mcp_result(state_result)
 
             # Check if 'data' key exists (not 'success' key which doesn't exist in parse_mcp_result)
-            if 'data' in state_data and state_data['data'] is not None:
+            if "data" in state_data and state_data["data"] is not None:
                 current_state = state_data.get("data", {}).get("state")
                 logger.debug(f"🔍 {entity_id} current state: {current_state}")
 
                 if current_state == expected_state:
-                    elapsed = time.time() - start_time
+                    elapsed = time.monotonic() - start_time
                     logger.info(
                         f"✅ {entity_id} reached state '{expected_state}' after {elapsed:.1f}s"
                     )
@@ -94,13 +94,13 @@ async def wait_for_entity_attribute(
     Returns:
         True if value reached, False if timeout
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
     logger.info(
         f"⏳ Waiting for {entity_id}.{attribute_name} = {expected_value} (timeout: {timeout}s)"
     )
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             state_result = await mcp_client.call_tool(
                 "ha_get_state", {"entity_id": entity_id}
@@ -108,7 +108,7 @@ async def wait_for_entity_attribute(
             state_data = parse_mcp_result(state_result)
 
             # Check if 'data' key exists (not 'success' key which doesn't exist in parse_mcp_result)
-            if 'data' in state_data and state_data['data'] is not None:
+            if "data" in state_data and state_data["data"] is not None:
                 attributes = state_data.get("data", {}).get("attributes", {})
                 current_value = attributes.get(attribute_name)
 
@@ -117,7 +117,7 @@ async def wait_for_entity_attribute(
                 )
 
                 if current_value == expected_value:
-                    elapsed = time.time() - start_time
+                    elapsed = time.monotonic() - start_time
                     logger.info(
                         f"✅ {entity_id}.{attribute_name} = {expected_value} after {elapsed:.1f}s"
                     )
@@ -149,13 +149,13 @@ async def wait_for_operation_completion(
     Returns:
         Operation status data
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
     logger.info(
         f"⏳ Waiting for operation {operation_id} to complete (timeout: {timeout}s)"
     )
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             status_result = await mcp_client.call_tool(
                 "ha_get_operation_status",
@@ -172,7 +172,7 @@ async def wait_for_operation_completion(
 
             # Check for completion states
             if operation_status in ["completed", "failed", "timeout"]:
-                elapsed = time.time() - start_time
+                elapsed = time.monotonic() - start_time
                 logger.info(
                     f"✅ Operation {operation_id} finished with status '{operation_status}' after {elapsed:.1f}s"
                 )
@@ -205,7 +205,7 @@ async def wait_for_bulk_operations(
     Returns:
         Dictionary mapping operation_id to status data
     """
-    start_time = time.time()
+    start_time = time.monotonic()
     results = {}
     pending_operations = set(operation_ids)
 
@@ -213,7 +213,7 @@ async def wait_for_bulk_operations(
         f"⏳ Waiting for {len(operation_ids)} operations to complete (timeout: {timeout}s)"
     )
 
-    while pending_operations and time.time() - start_time < timeout:
+    while pending_operations and time.monotonic() - start_time < timeout:
         for op_id in list(pending_operations):
             try:
                 status_result = await mcp_client.call_tool(
@@ -246,7 +246,7 @@ async def wait_for_bulk_operations(
         }
 
     completed = len(results) - len(pending_operations)
-    elapsed = time.time() - start_time
+    elapsed = time.monotonic() - start_time
     logger.info(
         f"📊 {completed}/{len(operation_ids)} operations completed after {elapsed:.1f}s"
     )
@@ -274,13 +274,13 @@ async def wait_for_logbook_entry(
     Returns:
         True if entry found, False if timeout
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
     logger.info(
         f"⏳ Waiting for logbook entry containing '{search_text}' (timeout: {timeout}s)"
     )
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             logbook_result = await mcp_client.call_tool(
                 "ha_get_logs", {"hours_back": hours_back}
@@ -289,13 +289,13 @@ async def wait_for_logbook_entry(
             logbook_data = parse_mcp_result(logbook_result)
 
             # Check if 'data' key exists (not 'success' key which doesn't exist in parse_mcp_result)
-            if 'data' in logbook_data and logbook_data['data'] is not None:
-                entries = logbook_data.get("entries", [])
+            if "data" in logbook_data and logbook_data["data"] is not None:
+                entries = logbook_data["data"].get("entries", [])
 
                 for entry in entries:
                     entry_text = str(entry).lower()
                     if search_text.lower() in entry_text:
-                        elapsed = time.time() - start_time
+                        elapsed = time.monotonic() - start_time
                         logger.info(
                             f"✅ Found logbook entry with '{search_text}' after {elapsed:.1f}s"
                         )
@@ -330,18 +330,18 @@ async def wait_for_condition(
     Returns:
         True if condition met, False if timeout
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
     logger.info(f"⏳ Waiting for {condition_name} (timeout: {timeout}s)")
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             if (
                 await condition_func()
                 if asyncio.iscoroutinefunction(condition_func)
                 else condition_func()
             ):
-                elapsed = time.time() - start_time
+                elapsed = time.monotonic() - start_time
                 logger.info(f"✅ {condition_name} met after {elapsed:.1f}s")
                 return True
         except Exception as e:
@@ -376,7 +376,7 @@ async def wait_for_state_change(
         initial_data = parse_mcp_result(initial_result)
 
         # Check if 'data' key exists (not 'success' key which doesn't exist in parse_mcp_result)
-        if 'data' not in initial_data or initial_data['data'] is None:
+        if "data" not in initial_data or initial_data["data"] is None:
             logger.warning(f"⚠️ Could not get initial state for {entity_id}")
             return None
 
@@ -389,9 +389,9 @@ async def wait_for_state_change(
         logger.warning(f"⚠️ Error getting initial state for {entity_id}: {e}")
         return None
 
-    start_time = time.time()
+    start_time = time.monotonic()
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             state_result = await mcp_client.call_tool(
                 "ha_get_state", {"entity_id": entity_id}
@@ -399,11 +399,11 @@ async def wait_for_state_change(
             state_data = parse_mcp_result(state_result)
 
             # Check if 'data' key exists (not 'success' key which doesn't exist in parse_mcp_result)
-            if 'data' in state_data and state_data['data'] is not None:
+            if "data" in state_data and state_data["data"] is not None:
                 current_state = state_data.get("data", {}).get("state")
 
                 if current_state != initial_state:
-                    elapsed = time.time() - start_time
+                    elapsed = time.monotonic() - start_time
                     logger.info(
                         f"✅ {entity_id} changed: '{initial_state}' → '{current_state}' after {elapsed:.1f}s"
                     )
@@ -451,7 +451,7 @@ async def wait_for_tool_result(
     Raises:
         TimeoutError: If the predicate is not satisfied within the timeout.
     """
-    start_time = time.time()
+    start_time = time.monotonic()
     last_data: dict[str, Any] = {}
 
     logger.info(f"⏳ Waiting for {description} (timeout: {timeout}s)")
@@ -463,7 +463,7 @@ async def wait_for_tool_result(
             last_data = parse_mcp_result(result)
         except Exception as e:
             logger.debug(f"⚠️ Error calling {tool_name}: {e}")
-            if time.time() - start_time >= timeout:
+            if time.monotonic() - start_time >= timeout:
                 raise TimeoutError(
                     f"{description}: timed out after {timeout}s (last error: {e})"
                 ) from e
@@ -475,7 +475,7 @@ async def wait_for_tool_result(
             logger.debug(
                 f"⚠️ {tool_name} returned error: {last_data.get('error')}, retrying..."
             )
-            if time.time() - start_time >= timeout:
+            if time.monotonic() - start_time >= timeout:
                 raise TimeoutError(
                     f"{description}: timed out after {timeout}s "
                     f"(last MCP error: {last_data.get('error')})"
@@ -485,11 +485,11 @@ async def wait_for_tool_result(
 
         # Run predicate OUTSIDE try/except so bugs (TypeError, KeyError) propagate
         if predicate(last_data):
-            elapsed = time.time() - start_time
+            elapsed = time.monotonic() - start_time
             logger.info(f"✅ {description} satisfied after {elapsed:.1f}s")
             return last_data
 
-        if time.time() - start_time >= timeout:
+        if time.monotonic() - start_time >= timeout:
             raise TimeoutError(
                 f"{description}: timed out after {timeout}s (predicate not satisfied)"
             )


### PR DESCRIPTION
## What does this PR do?

Closes #1234.

Mechanical sweep replacing `time.time()` with `time.monotonic()` across the e2e test framework's duration-math callsites. `time.monotonic()` is NTP-immune (cannot step backward on clock-sync) and forward-only by definition — the textbook-correct primitive for measuring elapsed time. The HACS lock-poll in `conftest.py` adopted this in #1208 (G1); this PR brings the rest of the e2e polling helpers in line.

**Files touched (33 substitutions + 2 Boy-Scout fixes):**

- `tests/src/e2e/utilities/wait_helpers.py` (26 + 1 fix) — `wait_for_entity_state`, `wait_for_entity_attribute`, `wait_for_operation_completion`, `wait_for_bulk_operations`, `wait_for_logbook_entry`, `wait_for_condition`, `wait_for_state_change`, `wait_for_tool_result`. All `start_time = time.time(); while time.time() - start_time < timeout:` + elapsed-log pairs. Plus 1-line fix in `wait_for_logbook_entry` (see "Adopted G1" below).
- `tests/src/e2e/utilities/assertions.py` (3 + 1 fix) — `wait_for_automation` polling helper. Was not enumerated in the issue body; Boy-Scout add since it sits in the same `tests/src/e2e/utilities/` directory and uses the identical idiom (1-line edit, same scope). Plus a sibling-bug fix on `assert_logbook_contains` (see "Sibling-bug sweep" below).
- `tests/src/e2e/error_handling/test_network_errors.py` (2) — wraps an `asyncio.gather` call with `start_time` / `end_time` for duration assertion.
- `tests/src/e2e/conftest.py` (2) — `_wait_for_state` helper inside `ha_container_with_fresh_config`. **Deliberately leaves `conftest.py:136` untouched**: that callsite computes an absolute Unix-epoch target for SQL recorder-row aging (`target = time.time() - target_age_seconds`), where wall-clock semantics are required and `monotonic()` would be wrong.

**Adopted Gemini-Code-Assist G1** (high-severity, flagged on `3561e31`):

`wait_for_logbook_entry` at `wait_helpers.py:293` checked `logbook_data["data"]` exists but read `entries` from the top-level `logbook_data` — missing the nested-data structure that `ha_get_logs` actually returns (verified against `test_logbook.py`'s `_extract_logbook_data` helper and the `entries`-in-`data` assertion in the same file). Bug pre-existed since `fcec5b2` (Julien's initial release 2025-09-18). The test consumer at `test_lifecycle.py:189` was silent-skipping into a "verification timeout - automation trigger was successful" log on failure — silent-skip class issue. Fix routes through the nested data structure to match sibling helpers in the same file (`wait_for_entity_state`, `wait_for_entity_attribute`).

**Sibling-bug sweep** — same anti-pattern at `assertions.py:406`:

`assert_logbook_contains` carries the identical bug: reads `entries = logbook_data.get("entries", [])` at the top level after a `success`-check, missing the same `data` nesting that `ha_get_logs` produces. Currently **dead code** (zero callers verified via `grep -rn assert_logbook_contains tests/`), but fixed defensively to match the `wait_for_logbook_entry` pattern and prevent future regressions if the helper gets adopted. Used the safer `.get("data", {}).get("entries", [])` form since no outer `data` guard exists at this call site.

**Out of scope** (separate sweep candidates, different test frameworks):

- `tests/test_env_manager.py` (2 callsites) — unit-test framework
- `tests/uat/run_uat.py` + `tests/uat/stories/run_story.py` (9 callsites) — UAT framework

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

CI provides primary verification for the helpers that are actively used by e2e tests: `wait_for_entity_state`, `wait_for_condition`, `wait_for_state_change`, `wait_for_logbook_entry`, `wait_for_tool_result` (from `wait_helpers.py`) and `wait_for_automation` (from `assertions.py`). Three helpers in `wait_helpers.py` — `wait_for_entity_attribute`, `wait_for_operation_completion`, `wait_for_bulk_operations` — currently have zero e2e callsites; their correctness rests on the mechanical-substitution semantics (`time.monotonic()` and `time.time()` have identical return type and call signature for relative-duration math, only the absolute reference point changes). `ruff check` + `ruff format` clean locally.

## Future improvements

- **UAT framework sweep** — `tests/uat/run_uat.py` + `tests/uat/stories/run_story.py` carry 9 further `time.time()` callsites in the same idiom (`run_start = time.time(); duration_ms = int((time.time() - start) * 1000)`). Eligible as a separate small PR if the same NTP-safety concern applies to the UAT runner.
- **Unit-test framework sweep** — `tests/test_env_manager.py:147,150` carries 2 callsites in the same pattern.
- **Unused test-utility audit** — `wait_for_entity_attribute`, `wait_for_operation_completion`, `wait_for_bulk_operations` in `wait_helpers.py` and `assert_logbook_contains` in `assertions.py` have no current callsites (verified by grep on master post-merge). Worth a follow-up to decide whether they're useful primitives kept for future use or dead-code candidates for removal.

## Checklist

- [x] I have updated documentation if needed (no docs needed — sweep is mechanical; the 2 Boy-Scout fixes are 1-line nested-access corrections each)

