### PR TITLE
test(e2e): clear stale .hacs_frontend.lock from prior crashed runs

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -245,7 +245,7 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
             # Best-effort: if cleanup fails (e.g., non-empty dir from a
             # future sentinel/pidfile refactor, or permission denied), the
             # existing 180s polling timeout still catches the orphan.
-            logger.debug(f"Stale-lock cleanup failed at {lock_dir}: {exc}")
+            logger.warning(f"Stale-lock cleanup failed at {lock_dir}: {exc}")
 
     # Fast path: HACS not installed (nothing to do), or frontend present
     # AND no lock held. The lock-held check rules out the window where

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -211,6 +211,42 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     frontend_dir = hacs_dir / "hacs_frontend"
     lock_dir = initial_state_path / ".hacs_frontend.lock"
 
+    # Staleness check: a SIGKILL during the winner's critical section (e.g.
+    # a developer hard-kills pytest mid-download) leaves an orphan
+    # ``lock_dir`` that would force every peer in the next session into the
+    # 180s polling wait below. If the lock predates any plausible download
+    # duration, clear it before the fast-path so peers recover instantly.
+    # CI tolerates the 180s wait because containers are torn down between
+    # runs; local developer iterations under a debugger don't.
+    #
+    # The 5-minute threshold is a conservative ceiling for any plausible
+    # download; legitimate winners finish well within this window.
+    #
+    # NB: ``stat().st_mtime`` is wall-clock (epoch seconds), so the age math
+    # uses ``time.time()`` — ``time.monotonic()`` measures elapsed-from-
+    # arbitrary-origin and cannot be compared to ``st_mtime``.
+    stale_lock_threshold_s = 300
+    if lock_dir.exists():
+        try:
+            lock_age_s = time.time() - lock_dir.stat().st_mtime
+            if lock_age_s > stale_lock_threshold_s:
+                logger.warning(
+                    f"Removing stale HACS frontend lock at {lock_dir} "
+                    f"(age {lock_age_s:.0f}s > {stale_lock_threshold_s}s "
+                    f"threshold — likely orphaned by a crashed prior run)."
+                )
+                lock_dir.rmdir()
+        except FileNotFoundError:
+            # Race: a peer cleared the lock between ``exists()`` and
+            # ``stat`` / ``rmdir``. The fast-path or lock-acquire below
+            # will handle whatever state remains.
+            pass
+        except OSError as exc:
+            # Best-effort: if cleanup fails (e.g., non-empty dir from a
+            # future sentinel/pidfile refactor, or permission denied), the
+            # existing 180s polling timeout still catches the orphan.
+            logger.debug(f"Stale-lock cleanup failed at {lock_dir}: {exc}")
+
     # Fast path: HACS not installed (nothing to do), or frontend present
     # AND no lock held. The lock-held check rules out the window where
     # another worker's ``shutil.move`` is mid-flight — ``frontend_dir``


### PR DESCRIPTION
## What does this PR do?

Closes #1235.

After PR #1208 introduced the cross-worker lock to serialize the 51MB HACS-frontend download, a SIGKILL during the winner's critical section (e.g. a developer hard-killing pytest mid-download) leaves an orphan `.hacs_frontend.lock` directory that forces every peer in the next session into the 180s polling wait before the lock-acquire path's timeout-clear catches it. CI tolerates the wait because containers are torn down between runs; local developer iterations under a debugger don't.

This PR adds an mtime-based staleness check at the entry of `_ensure_hacs_frontend` — before the fast-path guard — that clears any `lock_dir` older than the 5-minute conservative ceiling. Behaviour is unchanged when the lock is fresh (winner still in progress) or absent (no orphan to clean up).

Key implementation notes:
- `stat().st_mtime` is wall-clock (epoch seconds), so the age math uses `time.time()` — not `time.monotonic()`. PR #1249 just swept the rest of the polling code to `time.monotonic()` for duration math; this site is one of the documented absolute-timing exceptions.
- Race-handling: `FileNotFoundError` between `exists()` and `stat`/`rmdir` is benign (peer cleared the lock first); other `OSError` is logged at debug and falls through to the existing 180s timeout safety net.
- No unit test: the staleness path is ~10 LOC of `stat`/`rmdir`; a purely-mocked test would have mock-to-logic > 1 with limited regression value. The fast-path and lock-acquire paths are already exercised in every HACS e2e session.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None.

## Checklist
- [x] I have updated documentation if needed
