### PR TITLE
test(e2e): detect partial/corrupt hacs_frontend dir in fast-path guard

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -207,6 +207,18 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     import urllib.error
     import urllib.request
 
+    def _is_valid_frontend(path: Path) -> bool:
+        """Best-effort check that ``path`` holds a complete HACS frontend.
+
+        A SIGKILL or partial-failure during ``tar.extractall`` →
+        ``shutil.move`` can leave a populated but incomplete ``frontend_dir``
+        from a prior session. ``entrypoint.js`` is a top-level file in every
+        release tarball published at https://github.com/hacs/frontend/releases,
+        so its absence flags an interrupted prior session and forces a clean
+        re-download instead of letting HACS boot against a broken frontend.
+        """
+        return (path / "entrypoint.js").is_file()
+
     hacs_dir = initial_state_path / "custom_components" / "hacs"
     frontend_dir = hacs_dir / "hacs_frontend"
     lock_dir = initial_state_path / ".hacs_frontend.lock"
@@ -256,7 +268,9 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     # see a complete frontend. On any failure path the finally still
     # releases with ``frontend_dir`` absent; waiters re-enter the slow
     # path and the download except-branch handles the skip.
-    if not hacs_dir.exists() or (frontend_dir.exists() and not lock_dir.exists()):
+    if not hacs_dir.exists() or (
+        _is_valid_frontend(frontend_dir) and not lock_dir.exists()
+    ):
         return
 
     # Cross-worker lock: atomic mkdir succeeds on exactly one xdist worker.
@@ -293,8 +307,18 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     # We own the lock. Outer try/finally guarantees release even when the
     # download block is skipped (e.g. hacs_dir missing) or raises.
     try:
-        # Check if HACS is installed and frontend is still missing.
-        if hacs_dir.exists() and not frontend_dir.exists():
+        # Check if HACS is installed and frontend is missing or invalid.
+        if hacs_dir.exists() and not _is_valid_frontend(frontend_dir):
+            if frontend_dir.exists():
+                # Partial/corrupt directory from a prior interrupted
+                # session. Clear it so ``shutil.move`` below replaces it
+                # cleanly — moving onto an existing directory nests the
+                # fresh ``hacs_frontend/`` inside the stale one.
+                logger.warning(
+                    f"HACS frontend at {frontend_dir} is partial or corrupt; "
+                    f"removing before re-download."
+                )
+                shutil.rmtree(frontend_dir, ignore_errors=True)
             logger.info("HACS frontend not found, downloading...")
 
             try:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -318,7 +318,7 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
                     f"HACS frontend at {frontend_dir} is partial or corrupt; "
                     f"removing before re-download."
                 )
-                shutil.rmtree(frontend_dir, ignore_errors=True)
+                shutil.rmtree(frontend_dir)
             logger.info("HACS frontend not found, downloading...")
 
             try:


### PR DESCRIPTION
## What does this PR do?

Closes #1248.

KP13 flagged on PR #1208 review (item 6 on commit `83efdf7`) that the fast-path guard in `_ensure_hacs_frontend` short-circuits whenever `frontend_dir.exists()` is true. A SIGKILL or partial-failure during the prior session's `tar.extractall` → `shutil.move` can leave the directory populated but incomplete; HACS then boots against a broken frontend and downstream tests fail opaquely instead of producing the clean "frontend missing → re-download" loop the guard is meant to guarantee.

This PR adds a nested `_is_valid_frontend(path)` helper that probes for `entrypoint.js` — a top-level file in every HACS-frontend release tarball — and routes both the fast-path guard and the download-trigger condition through it. When the directory exists but the probe fails, `shutil.rmtree` it before re-download: `shutil.move` onto an existing directory nests the fresh `hacs_frontend/` inside the stale one instead of replacing it.

Key implementation notes:
- **Magic-file choice**: `entrypoint.js` is HACS-specific (not a generic Python marker), top-level (visible without recursion), and present in every release tarball — live-probed against `hacs/frontend@20250128065759` (2220 files total, with `entrypoint.js` next to `__init__.py` / `extra.js` / `frontend_es5/`).
- **Cross-worker correctness unchanged**: the lock-held check in the fast-path guard still rules out the legitimate mid-`shutil.move` window where the freshly-moved tree may briefly lack `entrypoint.js`.
- **Orthogonal to lock-orphan recovery**: this PR addresses corrupt `frontend_dir`. The orphan-lock counterpart is tracked in #1235 / PR #1252; both touch `_ensure_hacs_frontend` at different lines, so whichever merges first will require a small rebase on the other.
- **No unit test**: the validity probe is one `.is_file()` call and the cleanup is one `shutil.rmtree`. A purely-mocked test would have mock-to-logic > 1; the fast-path is already exercised in every HACS e2e session.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None.

## Checklist
- [x] I have updated documentation if needed
