### PR TITLE
test: use time.monotonic() in UAT runner and test_env_manager

### DIFF
--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -144,10 +144,10 @@ class HomeAssistantTestEnvironment:
         """Wait for Home Assistant to be ready."""
         logger.info("⏳ Waiting for Home Assistant to become ready...")
 
-        start_time = time.time()
+        start_time = time.monotonic()
         attempts = 0
 
-        while time.time() - start_time < timeout:
+        while time.monotonic() - start_time < timeout:
             attempts += 1
             try:
                 # Check frontend (no auth required) to see if HA is up

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -307,6 +307,10 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
     start = time.monotonic()
+    # Default for the response schema; both return paths re-assign before
+    # using the value, but the explicit init survives a future exit-path
+    # addition that would otherwise omit the field.
+    duration_ms = 0
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -382,13 +386,16 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
             result["raw_json"] = raw_json
         return result
     except TimeoutError:
+        # Capture the timeout-firing instant before the cleanup work so the
+        # reported duration reflects "wall-clock until the command timed out"
+        # rather than "wall-clock including the orphan-process teardown".
+        duration_ms = int((time.monotonic() - start) * 1000)
         # Terminate the orphaned process
         try:
             proc.terminate()
             await asyncio.wait_for(proc.wait(), timeout=5)
         except (TimeoutError, ProcessLookupError):
             proc.kill()
-        duration_ms = int((time.monotonic() - start) * 1000)
         return {
             "completed": False,
             "output": "",

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -306,7 +306,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
     # Strip CLAUDECODE env var to allow nested Claude CLI sessions
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
-    start = time.time()
+    start = time.monotonic()
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -318,7 +318,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             proc.communicate(), timeout=timeout
         )
-        duration_ms = int((time.time() - start) * 1000)
+        duration_ms = int((time.monotonic() - start) * 1000)
         stdout_text = stdout_bytes.decode("utf-8", errors="replace")
         stderr_text = stderr_bytes.decode("utf-8", errors="replace")
 
@@ -388,7 +388,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
             await asyncio.wait_for(proc.wait(), timeout=5)
         except (TimeoutError, ProcessLookupError):
             proc.kill()
-        duration_ms = int((time.time() - start) * 1000)
+        duration_ms = int((time.monotonic() - start) * 1000)
         return {
             "completed": False,
             "output": "",

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -804,7 +804,10 @@ async def run_stories(
                     await _run_mcp_steps(shared_mcp, setup_steps, "setup")
 
                 logger.info(f"[{agent}/{sid}] Running test prompt...")
-                prompt_start = time.monotonic()
+                # ``prompt_start`` is compared to file ``st_mtime`` in
+                # ``_find_latest_session_file`` below, so it MUST be a
+                # wall-clock Unix epoch (not ``time.monotonic()``).
+                prompt_start = time.time()
                 summary: dict | None
                 if use_inline:
                     assert (

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -391,7 +391,7 @@ async def _run_test_prompt_inline(
     from uat.openai_agent import DEFAULT_MAX_TOKENS, run_scenario_inline
 
     tool_trace: list[str] = []
-    start = time.time()
+    start = time.monotonic()
     try:
         result = await run_scenario_inline(
             openai_client,
@@ -406,7 +406,7 @@ async def _run_test_prompt_inline(
     except Exception as e:
         logger.exception(f"  [{agent_name}] inline run failed")
         tb = traceback.format_exc()
-        duration_ms = int((time.time() - start) * 1000)
+        duration_ms = int((time.monotonic() - start) * 1000)
         return 1, _inline_failure_summary(
             agent_name,
             error_msg=f"{type(e).__name__}: {e}",
@@ -415,7 +415,7 @@ async def _run_test_prompt_inline(
             tool_trace=tool_trace,
         )
 
-    duration_ms = int((time.time() - start) * 1000)
+    duration_ms = int((time.monotonic() - start) * 1000)
     exit_code = 1 if result.get("hit_iteration_limit") else 0
 
     # Match the summary shape produced by run_uat.make_summary.
@@ -664,7 +664,7 @@ async def run_stories(
     For each agent: start container -> run all stories -> stop container.
     When --ha-url is provided, all agents share the external instance.
     """
-    run_start = time.time()
+    run_start = time.monotonic()
     sha, describe = get_git_info()
     agent_list = [a.strip() for a in args.agents.split(",")]
     using_external_ha = bool(args.ha_url)
@@ -804,7 +804,7 @@ async def run_stories(
                     await _run_mcp_steps(shared_mcp, setup_steps, "setup")
 
                 logger.info(f"[{agent}/{sid}] Running test prompt...")
-                prompt_start = time.time()
+                prompt_start = time.monotonic()
                 summary: dict | None
                 if use_inline:
                     assert (
@@ -909,7 +909,7 @@ async def run_stories(
         session_info = f" (session: {session_file})" if session_file else ""
         logger.info(f"  [{status}] {agent}/{sid}: {story['title']}{session_info}")
 
-    elapsed = time.time() - run_start
+    elapsed = time.monotonic() - run_start
     mins, secs = divmod(int(elapsed), 60)
     logger.info(f"\nTotal time: {mins}m {secs}s")
     logger.info(f"Results appended to {args.results_file}")


### PR DESCRIPTION
## What does this PR do?

Closes #1250.

Apply the `time.time()` → `time.monotonic()` sweep to the two test frameworks left out-of-scope in PR #1249 (which closed #1234 and adopted `time.monotonic()` across `wait_helpers.py`, `assertions.py`, `test_network_errors.py`, and `conftest.py` in the e2e framework).

`time.monotonic()` is NTP-immune and forward-only — the textbook-correct primitive for measuring elapsed time. Same motivation as #1234 / #1249. Risk is low: `time.monotonic()` is a drop-in for `time.time()` in relative-duration math; only the absolute reference point changes.

**Scope: 10 mechanical substitutions + 1 wall-clock carve-out + 1 Boy-Scout metric fix across 3 files:**

- `tests/uat/run_uat.py` — 3 substitutions (subprocess timing) + Boy-Scout `duration_ms` refactor (schema-init + move-before-cleanup in `TimeoutError` handler, commit `c24789b`).
- `tests/uat/stories/run_story.py` — 5 substitutions (story + per-prompt timing) + 1 wall-clock carve-out: `prompt_start` (commit `61f55d0`) reverts to `time.time()` because it is passed as `after=prompt_start` to `_find_latest_session_file`, which compares against `p.stat().st_mtime`. Monotonic-vs-epoch comparison breaks the "files modified after this point" semantic. Inline carve-out comment names the consuming function so a future mechanical sweep does not re-introduce the substitution.
- `tests/test_env_manager.py` — 2 substitutions (readiness polling loop).

The other documented absolute-timing exception from PR #1249 — `tests/src/e2e/conftest.py:136` (recorder-timestamp metric shift) — is outside this PR's scope and is intentionally untouched.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None remaining. The pre-push sibling-bug audit on this PR surfaced ~15 additional `time.time()` duration-polling callsites in the e2e workflows directory; those were filed as #1255 and have already shipped as PR #1258 (merged 2026-05-12). The Gemini iter-3 finding on the `duration_ms` placement in `run_uat.py:run_cli`'s `TimeoutError` handler was initially mis-categorised as out-of-scope and filed as #1263, then re-adopted in-scope per the Boy-Scout rule (commit `c24789b`); #1263 is closed as superseded.

The remaining `int(time.time())` callsites in `tests/src/e2e/workflows/convenience/test_backup.py` and `tests/src/e2e/workflows/todo/test_lifecycle.py:183,411,454,455,523` are intentional absolute-timing uses (unique-ID generation from epoch) and remain untouched.

## Checklist
- [x] I have updated documentation if needed
