### PR TITLE
test(e2e): use time.monotonic() in workflow polling loops

### DIFF
--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -23,7 +23,7 @@ async def wait_for_entity_registration(mcp_client, entity_id: str, timeout: int 
     Does not check for specific state, only that entity exists.
     """
     import time
-    start_time = time.time()
+    start_time = time.monotonic()
     attempt = 0
 
     async def entity_exists():
@@ -34,7 +34,7 @@ async def wait_for_entity_registration(mcp_client, entity_id: str, timeout: int 
         success = 'data' in data and data['data'] is not None
 
         # Log every attempt with full details
-        elapsed = time.time() - start_time
+        elapsed = time.monotonic() - start_time
         logger.info(
             f"[Attempt {attempt} @ {elapsed:.1f}s] Checking {entity_id}: "
             f"success={success}, data keys={list(data.keys())}"

--- a/tests/src/e2e/workflows/device_control/test_lights.py
+++ b/tests/src/e2e/workflows/device_control/test_lights.py
@@ -72,9 +72,9 @@ async def wait_for_entity_state(
     """
     import time
 
-    start_time = time.time()
+    start_time = time.monotonic()
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             state_result = await mcp_client.call_tool(
                 "ha_get_state", {"entity_id": entity_id}

--- a/tests/src/e2e/workflows/scenes/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scenes/test_lifecycle.py
@@ -44,9 +44,9 @@ async def _wait_for_scene_registered(
     mcp_client, scene_id: str, timeout: int = 15, poll_interval: float = 1.0
 ) -> bool:
     """Poll until the scene is queryable via the management API or state API."""
-    start_time = time.time()
+    start_time = time.monotonic()
     scene_entity = f"scene.{scene_id}"
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             get_data = await safe_call_tool(
                 mcp_client, "ha_config_get_scene", {"scene_id": scene_id}
@@ -72,8 +72,8 @@ async def _wait_for_scene_removed(
     mcp_client, scene_id: str, timeout: int = 15, poll_interval: float = 1.0
 ) -> bool:
     """Poll until the scene is no longer queryable."""
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
         try:
             get_data = await safe_call_tool(
                 mcp_client, "ha_config_get_scene", {"scene_id": scene_id}

--- a/tests/src/e2e/workflows/scripts/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scripts/test_lifecycle.py
@@ -123,14 +123,14 @@ async def verify_script_exists_and_registered(
     This function addresses timing issues where scripts are created but not
     immediately discoverable through the management API or entity registry.
     """
-    start_time = time.time()
+    start_time = time.monotonic()
     script_entity = f"script.{script_id}"
 
     logger.info(
         f"⏳ Waiting for script {script_entity} to be registered (timeout: {timeout}s)"
     )
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             # Method 1: Try to get script config via management API
             get_result = await mcp_client.call_tool(
@@ -171,7 +171,7 @@ async def verify_script_exists_and_registered(
         except Exception as e:
             logger.debug(f"Script registration check failed: {e}")
 
-        elapsed = time.time() - start_time
+        elapsed = time.monotonic() - start_time
         logger.debug(
             f"🔍 Script {script_entity} not yet registered (elapsed: {elapsed:.1f}s)"
         )
@@ -187,11 +187,11 @@ async def verify_script_execution_state(
     timeout: int = 15,  # Increased from 10s to 15s
 ) -> dict[str, Any]:
     """Verify script execution by checking state changes with retry logic."""
-    start_time = time.time()
+    start_time = time.monotonic()
     consecutive_failures = 0
     max_consecutive_failures = 3
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             state_result = await mcp_client.call_tool(
                 "ha_get_state", {"entity_id": script_entity}

--- a/tests/src/e2e/workflows/todo/test_lifecycle.py
+++ b/tests/src/e2e/workflows/todo/test_lifecycle.py
@@ -74,9 +74,9 @@ async def wait_for_item_in_list(
     This function handles timing issues where items are added but not
     immediately visible through the API.
     """
-    start_time = time.time()
+    start_time = time.monotonic()
 
-    while time.time() - start_time < timeout:
+    while time.monotonic() - start_time < timeout:
         try:
             result = await mcp_client.call_tool("ha_get_todo", {"entity_id": entity_id})
             data = enhanced_parse_mcp_result(result)


### PR DESCRIPTION
## What does this PR do?

Closes #1255.

Continuation of the `time.time()` → `time.monotonic()` sweep started in PR #1249 (e2e framework: `wait_helpers.py`, `assertions.py`, `test_network_errors.py`, `conftest.py`) and PR #1254 (UAT runner + `test_env_manager.py`). This PR addresses the 5 e2e workflow test files that roll their own polling loops instead of using `wait_helpers.py`.

`time.monotonic()` is NTP-immune and forward-only — the textbook-correct primitive for measuring elapsed time. Same motivation as #1234 / #1249 / #1250 / #1254. Risk is low: `time.monotonic()` has the same return type and call signature as `time.time()` for relative-duration math; only the absolute reference point changes.

**Scope: 15 mechanical substitutions across 5 files** — every callsite is duration math (`start_time = time.time(); while time.time() - start_time < timeout` or `elapsed = time.time() - start_time`):

- `tests/src/e2e/workflows/scenes/test_lifecycle.py` — 4 callsites
- `tests/src/e2e/workflows/scripts/test_lifecycle.py` — 5 callsites
- `tests/src/e2e/workflows/device_control/test_lights.py` — 2 callsites
- `tests/src/e2e/workflows/todo/test_lifecycle.py` — 2 callsites
- `tests/src/e2e/workflows/config/test_helper_crud.py` — 2 callsites

**Untouched (absolute-timing exceptions):** `int(time.time())` callsites in the same files (`todo/test_lifecycle.py:183, 411, 454, 455, 523`) are wall-clock-derived unique-ID generators and must stay absolute-timing — exactly the same class as the documented exceptions in PR #1249 (e.g. `conftest.py:136` recorder-timestamp metric). The substitution was applied with a placeholder-protect pattern (`int(time.time())` → placeholder → substitute → restore) to guarantee these stay untouched.

Issue #1255 enumerated 3 of these unique-ID callsites; live audit on the touched files found 6 in total (the 5 listed above plus `tests/src/e2e/workflows/convenience/test_backup.py:97`, which is in a different file and not touched by this PR). The expanded count is informational — all 6 are the same class and intentionally out of sweep scope.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

**Pre-existing ruff-format debt** on 4 of the 5 touched files (~681 lines of line-length reflow on lines outside this PR's edit anchors). Confirmed pre-existing master state via `ruff format --check` against master directly. Including the reflow would 45× the diff and break the "Large/unrelated → many files" brake from `AGENTS.md` → Handling Discovered Improvements. Kept out of scope; worth a separate `chore: ruff format tests/src/e2e/workflows` sweep if any maintainer wants it.

**Higher-leverage alternative** (noted in the parent issue #1255 already, repeating here for the PR reviewer's awareness): the proper fix to the underlying duplication would be to refactor these workflow tests to use the shared `wait_helpers.py` helpers (`wait_for_entity_state`, `wait_for_condition`, etc.) instead of rolling their own polling loops. That eliminates the duplication at the source rather than just hardening it. Larger scope, per-test design review needed; tracked in #1255 as the alternative path if any maintainer prefers the bigger refactor.

## Checklist
- [x] I have updated documentation if needed
