### PR TITLE
feat: add ENABLE_LITE_DOCSTRINGS beta toggle

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -116,7 +116,11 @@ Reload the `Logger` integration (or restart HA) to apply.
 
 Replaces the docstrings on a handful of heavy ha-mcp tools (automations, scripts, scenes, helpers, dashboards, `ha_call_service`, `ha_config_set_yaml`) with shorter variants that defer schema and example detail to `ha_get_skill_home_assistant_best_practices` (or its `skill://` resource). This is a behaviour flag, not a new tool.
 
-**The trade-off.** This reduces idle tool-catalog token usage but relies on the LLM actually calling the skill tool (or reading the skill resource) when it needs detail. Some models will skip the extra tool call and produce worse output than they would have with the full docstrings in front of them. Pair this toggle with one of the following to mitigate:
+**The trade-off.** This reduces idle tool-catalog token usage but relies on the LLM actually calling the skill tool (or reading the skill resource) when it needs detail. Some models will skip the extra tool call and produce worse output than they would have with the full docstrings in front of them.
+
+**Search discoverability shrinks too.** Clients that BM25-search the tool catalog (claude.ai's native deferred-tool search, ha-mcp's own `enable_tool_search` index) see fewer tokens per lite-mapped tool, so natural-language queries that previously matched on words in the full docstring may rank lower or miss. ha-mcp's explicit `_SEARCH_KEYWORDS` boosts still apply on top of the lite text, but coverage outside those boosts will be thinner.
+
+Pair this toggle with one of the following to mitigate:
 
 - A client that supports MCP resources (the model can read `skill://` directly without an extra tool round-trip).
 - `enable_tool_search` — the search transform's description already nudges the LLM toward the skill resources.

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -13,6 +13,7 @@ Some ha-mcp tools are gated behind feature flags and available only in the **dev
 | `ha_delete_file` | `enable_filesystem_tools` (dev add-on) / `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (env var) | Delete files from allowed directories. Requires `ha_mcp_tools` custom component. |
 | `ha_install_mcp_tools` | `enable_custom_component_integration` (dev add-on) / `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` (env var) | Installs the `ha_mcp_tools` custom component via HACS. |
 | `ha_manage_custom_tool` | `enable_code_mode` (dev add-on) / `ENABLE_CODE_MODE=true` (env var) | Sandboxed Python "escape hatch" that lets AI assistants write, run, save, and delete custom tools when no built-in tool covers the request. Code runs in pydantic-monty (no filesystem, no network); sandbox can call the HA REST API (`api_get`/`api_post`), send WebSocket commands (`ws_send`), call registered MCP tools (`call_tool`), or delete a saved tool (`delete_saved_tool`). Saved tools persist to disk via `CODE_MODE_SAVED_TOOLS_PATH` (defaults to `/data/saved_tools.json` in the dev add-on). |
+| _(behaviour flag, no new tool)_ | `enable_lite_docstrings` (dev add-on) / `ENABLE_LITE_DOCSTRINGS=true` (env var) | Replaces the docstrings on a handful of heavy ha-mcp tools (automations, scripts, scenes, helpers, dashboards, `ha_call_service`, `ha_config_set_yaml`) with shorter variants that defer schema and example detail to `ha_get_skill_home_assistant_best_practices` (or its `skill://` resource). Reduces idle catalog token usage; relies on the LLM actually calling the skill tool/resource when it needs detail. See "Known limitations" below. |
 
 ## How to enable
 
@@ -24,7 +25,7 @@ Some ha-mcp tools are gated behind feature flags and available only in the **dev
 4. Enable the desired toggle (e.g., `enable_yaml_config_editing`, `enable_filesystem_tools`).
 5. Restart the add-on.
 
-`enable_yaml_config_editing`, `enable_filesystem_tools`, `enable_custom_component_integration`, and `enable_code_mode` are only available in the dev channel add-on. The stable add-on does not expose these beta toggles.
+`enable_yaml_config_editing`, `enable_filesystem_tools`, `enable_custom_component_integration`, `enable_code_mode`, and `enable_lite_docstrings` are only available in the dev channel add-on. The stable add-on does not expose these beta toggles.
 
 ### Option 2: Environment variable (non-add-on installs)
 
@@ -110,3 +111,21 @@ Reload the `Logger` integration (or restart HA) to apply.
 **Recommended prerequisites:**
 - You're comfortable with the AI authoring small Python snippets that wrap existing tools or HA REST endpoints
 - You have `destructiveHint=True` confirmation enabled on the MCP client and you actually read the prompts
+
+### `enable_lite_docstrings`
+
+Replaces the docstrings on a handful of heavy ha-mcp tools (automations, scripts, scenes, helpers, dashboards, `ha_call_service`, `ha_config_set_yaml`) with shorter variants that defer schema and example detail to `ha_get_skill_home_assistant_best_practices` (or its `skill://` resource). This is a behaviour flag, not a new tool.
+
+**The trade-off.** This reduces idle tool-catalog token usage but relies on the LLM actually calling the skill tool (or reading the skill resource) when it needs detail. Some models will skip the extra tool call and produce worse output than they would have with the full docstrings in front of them. Pair this toggle with one of the following to mitigate:
+
+- A client that supports MCP resources (the model can read `skill://` directly without an extra tool round-trip).
+- `enable_tool_search` — the search transform's description already nudges the LLM toward the skill resources.
+- A clear system prompt that instructs the LLM to consult `ha_get_skill_home_assistant_best_practices` before creating/editing automations, scripts, or helpers.
+
+**Startup warning.** When this flag is enabled via environment variable, a single WARNING line is emitted at startup so non-add-on users see the trade-off in their logs. The add-on UI surfaces the same warning in the toggle's description.
+
+**What is replaced.** Only the descriptions exposed via the MCP `list_tools` reply are swapped. The Python docstrings in `src/ha_mcp/tools/` are unchanged — the substitution happens via a FastMCP transform installed during server initialisation. Tools not in the lite mapping pass through with their original descriptions.
+
+**Recommended prerequisites:**
+- A client that lets you watch tool-call traces, so you can see whether the LLM is actually fetching the skill content before acting
+- Willingness to disable the flag if the model regresses on your prompts

--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -26,6 +26,7 @@ options:
   enable_tool_search: false
   enable_yaml_config_editing: false
   enable_code_mode: false
+  enable_lite_docstrings: false
   tool_search_max_results: 5
   disabled_tools: ""
   pinned_tools: ""
@@ -36,6 +37,7 @@ schema:
   enable_tool_search: bool?
   enable_yaml_config_editing: bool?
   enable_code_mode: bool?
+  enable_lite_docstrings: bool?
   enable_filesystem_tools: bool?
   enable_custom_component_integration: bool?
   tool_search_max_results: int(2,10)?

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -45,6 +45,21 @@ configuration:
       Saved tools persist to /data/saved_tools.json by default so they
       survive add-on restarts. See docs/beta.md for known limitations.
       Requires restart to take effect.
+  enable_lite_docstrings:
+    name: Enable lite tool docstrings (beta)
+    description: >-
+      Beta feature — disabled by default. Replaces the docstrings on a
+      handful of heavy ha-mcp tools (automations, scripts, scenes, helpers,
+      dashboards, ha_call_service, ha_config_set_yaml) with shorter
+      variants that defer schema and example detail to the
+      ha_get_skill_home_assistant_best_practices tool (or its skill://
+      resource). WARNING: this reduces idle token usage, but may degrade
+      LLM performance — the trimmed descriptions rely on the LLM
+      actually calling the skill tool or reading the skill resource for
+      detail, which is not guaranteed (some models will skip the extra
+      tool call and end up with less guidance than they had before).
+      Best paired with a client that supports MCP resources or with
+      enable_tool_search. Requires restart to take effect.
   enable_filesystem_tools:
     name: Enable filesystem tools (beta)
     description: >-

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -217,6 +217,7 @@ def main() -> int:
     enable_filesystem_tools = False  # default
     enable_custom_component_integration = False  # default
     enable_code_mode = False  # default
+    enable_lite_docstrings = False  # default
     tool_search_max_results = 5  # default
     disabled_tools_raw = ""  # default
     pinned_tools_raw = ""  # default
@@ -239,6 +240,8 @@ def main() -> int:
             enable_custom_component_integration = raw_custom_component if isinstance(raw_custom_component, bool) else False
             raw_code_mode = config.get("enable_code_mode", False)
             enable_code_mode = raw_code_mode if isinstance(raw_code_mode, bool) else False
+            raw_lite_docstrings = config.get("enable_lite_docstrings", False)
+            enable_lite_docstrings = raw_lite_docstrings if isinstance(raw_lite_docstrings, bool) else False
             raw_max_results = config.get("tool_search_max_results", 5)
             tool_search_max_results = raw_max_results if isinstance(raw_max_results, int) else 5
             raw_disabled = config.get("disabled_tools", "")
@@ -278,6 +281,7 @@ def main() -> int:
     os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = str(enable_filesystem_tools).lower()
     os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = str(enable_custom_component_integration).lower()
     os.environ["ENABLE_CODE_MODE"] = str(enable_code_mode).lower()
+    os.environ["ENABLE_LITE_DOCSTRINGS"] = str(enable_lite_docstrings).lower()
     # Persist saved custom tools across addon restarts. /data is the
     # per-addon writable directory mapped by Supervisor and survives
     # add-on updates (but not uninstall/reinstall — users should copy

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -113,6 +113,15 @@ class Settings(BaseSettings):
     # supervisor UI rejects out-of-range values before they reach env vars.
     tool_search_max_results: int = Field(5, ge=2, le=10, alias="TOOL_SEARCH_MAX_RESULTS")
 
+    # Lite docstrings — replace selected heavy tool descriptions with
+    # shorter variants that defer detailed guidance to the
+    # ``ha_get_skill_home_assistant_best_practices`` skill tool/resource.
+    # Reduces idle catalog token usage at the cost of relying on the LLM
+    # to actually consult the skill when it needs detail. Beta feature
+    # (issue #1062); a startup WARNING is emitted when enabled so
+    # env-var users see the trade-off in their logs.
+    enable_lite_docstrings: bool = Field(False, alias="ENABLE_LITE_DOCSTRINGS")
+
     # Code Mode — sandboxed Python execution via pydantic-monty.
     # Provides an "escape hatch" tool (ha_manage_custom_tool) that lets LLMs write
     # custom one-off Python code when no existing tool covers the request.

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -542,20 +542,14 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         ),
     }
 
-    # Lite docstrings — beta opt-in (enable_lite_docstrings).
+    # Lite docstrings — beta opt-in (enable_lite_docstrings, #1062).
     # Each entry replaces the full docstring on a heavy tool with a
-    # shorter variant that defers schema/example detail to the
-    # ha_get_skill_home_assistant_best_practices tool (or its skill://
-    # resource). The intent is to reduce idle catalog token usage; the
-    # trade-off (LLMs that skip the skill tool get less guidance) is
-    # surfaced in the dev-addon toggle description, in docs/beta.md,
-    # and as a startup WARNING log when the flag is on.
-    #
-    # Keep these lite variants long enough to still convey the tool's
-    # mode/shape (e.g. python_transform vs config) but short enough to
-    # meaningfully trim the catalog. Each one preserves a pointer to
-    # ha_get_skill_home_assistant_best_practices so the LLM has a path
-    # to the full guidance even from inside the trimmed description.
+    # shorter variant that defers schema/example detail to
+    # ha_get_skill_home_assistant_best_practices. Every entry preserves
+    # a pointer to that skill so the LLM still has a path to the full
+    # guidance from inside the trimmed description. The trade-off
+    # (LLMs that skip the skill tool get less guidance) is surfaced in
+    # the dev-addon toggle, docs/beta.md, and a startup WARNING.
     _LITE_DOCSTRINGS: ClassVar[dict[str, str]] = {
         "ha_config_get_automation": (
             "Retrieve a Home Assistant automation configuration by "
@@ -611,23 +605,43 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_list_helpers": (
-            "List Home Assistant helpers of a given type (e.g., "
-            "input_boolean, input_number, counter, timer, schedule, "
-            "zone, person, tag). Returns storage-based helpers only "
-            "(those created via UI/API), not YAML-defined ones.\n\n"
-            "For the helper-type taxonomy and per-type schemas, see "
-            "ha_get_helper_schema and "
+            "List Home Assistant helpers of a given simple type. "
+            "Accepts the 12 storage-backed helper types only: "
+            "input_button, input_boolean, input_select, input_number, "
+            "input_text, input_datetime, counter, timer, schedule, "
+            "zone, person, tag. Flow-based helpers (template, group, "
+            "utility_meter, derivative, statistics, trend, threshold, "
+            "filter, switch_as_x, etc.) cannot be listed through this "
+            "tool — use ha_search_entities or ha_deep_search.\n\n"
+            "For per-type schemas, see ha_get_helper_schema and "
             "ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_set_helper": (
-            "Create or update a Home Assistant helper of any of the "
-            "27 supported types (input_*, counter, timer, schedule, "
-            "zone, person, tag, template, group, utility_meter, "
-            "derivative, statistics, trend, threshold, etc.).\n\n"
+            "Create or update a Home Assistant helper. Supports all "
+            "supported helper types: the simple types (input_*, "
+            "counter, timer, schedule, zone, person, tag) and the "
+            "flow-based types (template, group, utility_meter, "
+            "derivative, statistics, trend, threshold, filter, "
+            "switch_as_x, and others).\n\n"
             "For per-type config schemas, call "
             "ha_get_helper_schema(helper_type) first. For decision "
             "matrix and worked examples (which helper type for which "
             "use case), see ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_get_dashboard": (
+            "Inspect a Home Assistant dashboard.\n\n"
+            "Three modes: (1) list — `list_only=True` returns all "
+            "storage-mode dashboards with metadata. (2) search — pass "
+            "any of `entity_id`, `card_type`, `heading` to find cards "
+            "(and their `jq_path`) inside a specific dashboard; the "
+            "result includes a `config_hash` you can pair with "
+            "ha_config_set_dashboard(python_transform=...) to edit "
+            "matched cards surgically. (3) get — no search params "
+            "returns the full Lovelace config plus a stable "
+            "`config_hash`. Use `url_path='default'` for the main "
+            "dashboard.\n\n"
+            "For card-type taxonomy and search workflow examples, see "
+            "ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_set_dashboard": (
             "Create or update a Home Assistant dashboard.\n\n"
@@ -695,7 +709,9 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
 
         Emits a startup WARNING when enabled so non-addon users (Docker,
         uvx, pip) see the trade-off in their logs — the addon UI surfaces
-        the same warning via the toggle description.
+        the same warning via the toggle description. A second WARNING is
+        emitted if the transform install fails, so users don't silently
+        get full descriptions back after explicitly enabling the toggle.
 
         Runs before ``_apply_search_keyword_enrichment`` so BM25 keywords
         append to the lite text instead of the discarded full description.
@@ -717,20 +733,24 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             from .transforms import LiteDocstringsTransform
         except ImportError:
             logger.exception(
-                "LiteDocstringsTransform not available; full tool "
-                "descriptions will be exposed."
+                "LiteDocstringsTransform not importable — please file a "
+                "bug. ENABLE_LITE_DOCSTRINGS=true is in effect but full "
+                "tool descriptions will be exposed."
             )
             return
 
         try:
             self.mcp.add_transform(
-                LiteDocstringsTransform(
-                    enabled=True,
-                    replacements=self._LITE_DOCSTRINGS,
-                )
+                LiteDocstringsTransform(replacements=self._LITE_DOCSTRINGS)
             )
         except Exception:
             logger.exception("Failed to apply LiteDocstringsTransform")
+            logger.warning(
+                "ENABLE_LITE_DOCSTRINGS=true was set but the transform "
+                "failed to install — full tool descriptions remain in "
+                "effect. Catalog token usage will be unchanged from the "
+                "default."
+            )
 
     def _apply_search_keyword_enrichment(self) -> None:
         """Append BM25 keyword boosts to tool descriptions.

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -552,7 +552,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
     # the dev-addon toggle, docs/beta.md, and a startup WARNING.
     _LITE_DOCSTRINGS: ClassVar[dict[str, str]] = {
         "ha_config_get_automation": (
-            "Retrieve a Home Assistant automation configuration by "
+            "Get a Home Assistant automation configuration by "
             "entity_id or unique_id. Returns the full config "
             "(trigger, condition, action, mode) plus a stable "
             "config_hash for use with python_transform on "
@@ -571,7 +571,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "guidance, see ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_get_script": (
-            "Retrieve a Home Assistant script configuration by "
+            "Get a Home Assistant script configuration by "
             "script_id or entity_id. Returns the full config (sequence, "
             "mode, fields) plus a stable config_hash for use with "
             "python_transform on ha_config_set_script.\n\n"
@@ -589,7 +589,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_get_scene": (
-            "Retrieve a Home Assistant scene configuration by "
+            "Get a Home Assistant scene configuration by "
             "scene_id or entity_id. Returns the full config plus a "
             "stable config_hash for use with python_transform on "
             "ha_config_set_scene.\n\n"
@@ -629,7 +629,8 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "use case), see ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_get_dashboard": (
-            "Inspect a Home Assistant dashboard.\n\n"
+            "Get Home Assistant dashboard info (list mode, search "
+            "mode, or full config).\n\n"
             "Three modes: (1) list — `list_only=True` returns all "
             "storage-mode dashboards with metadata. (2) search — pass "
             "any of `entity_id`, `card_type`, `heading` to find cards "
@@ -665,8 +666,9 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "see ha_get_skill_home_assistant_best_practices."
         ),
         "ha_config_set_yaml": (
-            "Add, replace, or remove a top-level YAML key in "
-            "configuration.yaml or packages/*.yaml (LAST RESORT).\n\n"
+            "Update raw YAML in configuration.yaml or packages/*.yaml "
+            "via add / replace / remove on a single top-level key "
+            "(LAST RESORT).\n\n"
             "Dedicated tools (ha_config_set_automation, "
             "ha_config_set_script, ha_config_set_scene, "
             "ha_config_set_helper) cover almost every use case and "

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -263,6 +263,12 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         # search indexing too).
         self._apply_settings_visibility()
 
+        # Replace heavy tool descriptions with lite variants when
+        # ENABLE_LITE_DOCSTRINGS=true. Must come BEFORE keyword
+        # enrichment so BM25 keywords append to the lite text (instead
+        # of the full description we just discarded).
+        self._apply_lite_docstrings()
+
         # Enrich tool descriptions with BM25 keyword boosts. Runs
         # unconditionally so Claude's native deferred-tool search
         # (claude.ai) benefits even when ENABLE_TOOL_SEARCH is off.
@@ -536,6 +542,131 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         ),
     }
 
+    # Lite docstrings — beta opt-in (enable_lite_docstrings).
+    # Each entry replaces the full docstring on a heavy tool with a
+    # shorter variant that defers schema/example detail to the
+    # ha_get_skill_home_assistant_best_practices tool (or its skill://
+    # resource). The intent is to reduce idle catalog token usage; the
+    # trade-off (LLMs that skip the skill tool get less guidance) is
+    # surfaced in the dev-addon toggle description, in docs/beta.md,
+    # and as a startup WARNING log when the flag is on.
+    #
+    # Keep these lite variants long enough to still convey the tool's
+    # mode/shape (e.g. python_transform vs config) but short enough to
+    # meaningfully trim the catalog. Each one preserves a pointer to
+    # ha_get_skill_home_assistant_best_practices so the LLM has a path
+    # to the full guidance even from inside the trimmed description.
+    _LITE_DOCSTRINGS: ClassVar[dict[str, str]] = {
+        "ha_config_get_automation": (
+            "Retrieve a Home Assistant automation configuration by "
+            "entity_id or unique_id. Returns the full config "
+            "(trigger, condition, action, mode) plus a stable "
+            "config_hash for use with python_transform on "
+            "ha_config_set_automation.\n\n"
+            "For schema and field-level details, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_automation": (
+            "Create or update a Home Assistant automation.\n\n"
+            "Supports two modes: full `config` replacement, or surgical "
+            "`python_transform` on an existing automation (requires "
+            "`identifier` and `config_hash` from "
+            "ha_config_get_automation). Omit `identifier` to create a "
+            "new automation.\n\n"
+            "For schema details, examples, and native-vs-template "
+            "guidance, see ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_get_script": (
+            "Retrieve a Home Assistant script configuration by "
+            "script_id or entity_id. Returns the full config (sequence, "
+            "mode, fields) plus a stable config_hash for use with "
+            "python_transform on ha_config_set_script.\n\n"
+            "For schema details, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_script": (
+            "Create or update a Home Assistant script.\n\n"
+            "Supports two modes: full `config` replacement, or surgical "
+            "`python_transform` on an existing script (requires "
+            "`identifier` and `config_hash` from "
+            "ha_config_get_script). Omit `identifier` to create a new "
+            "script.\n\n"
+            "For schema details and examples, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_get_scene": (
+            "Retrieve a Home Assistant scene configuration by "
+            "scene_id or entity_id. Returns the full config plus a "
+            "stable config_hash for use with python_transform on "
+            "ha_config_set_scene.\n\n"
+            "For schema details, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_scene": (
+            "Create or update a Home Assistant scene.\n\n"
+            "Supports two modes: full `config` replacement, or surgical "
+            "`python_transform` on an existing scene (requires "
+            "`identifier` and `config_hash`).\n\n"
+            "For schema details and examples, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_list_helpers": (
+            "List Home Assistant helpers of a given type (e.g., "
+            "input_boolean, input_number, counter, timer, schedule, "
+            "zone, person, tag). Returns storage-based helpers only "
+            "(those created via UI/API), not YAML-defined ones.\n\n"
+            "For the helper-type taxonomy and per-type schemas, see "
+            "ha_get_helper_schema and "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_helper": (
+            "Create or update a Home Assistant helper of any of the "
+            "27 supported types (input_*, counter, timer, schedule, "
+            "zone, person, tag, template, group, utility_meter, "
+            "derivative, statistics, trend, threshold, etc.).\n\n"
+            "For per-type config schemas, call "
+            "ha_get_helper_schema(helper_type) first. For decision "
+            "matrix and worked examples (which helper type for which "
+            "use case), see ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_dashboard": (
+            "Create or update a Home Assistant dashboard.\n\n"
+            "Supports two modes: full `config` replacement (new "
+            "dashboards or full restructures), or surgical "
+            "`python_transform` on an existing dashboard (requires "
+            "`config_hash` from ha_config_get_dashboard; recommended "
+            "for edits). Use `url_path` of 'default' or 'lovelace' "
+            "to target the built-in dashboard.\n\n"
+            "For card types, layout patterns, and python_transform "
+            "security rules, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_call_service": (
+            "Execute a Home Assistant service to control entities or "
+            "trigger automations. Calls `<domain>.<service>` "
+            "(e.g., light.turn_on, climate.set_temperature). Use "
+            "ha_search_entities to find entity IDs and ha_get_state "
+            "to read current values before changing them.\n\n"
+            "For service-parameter details and per-domain guidance, "
+            "see ha_get_skill_home_assistant_best_practices."
+        ),
+        "ha_config_set_yaml": (
+            "Add, replace, or remove a top-level YAML key in "
+            "configuration.yaml or packages/*.yaml (LAST RESORT).\n\n"
+            "Dedicated tools (ha_config_set_automation, "
+            "ha_config_set_script, ha_config_set_scene, "
+            "ha_config_set_helper) cover almost every use case and "
+            "should be preferred. Use this only for YAML-only "
+            "integrations (command_line, rest, shell_command, notify) "
+            "or registering YAML-mode dashboards via "
+            "`lovelace.dashboards.<url_path>`. Most edits require a "
+            "full HA restart; template, mqtt, and group support "
+            "reload.\n\n"
+            "For routing guidance and the full allowlist, see "
+            "ha_get_skill_home_assistant_best_practices."
+        ),
+    }
+
     # Description overrides that REPLACE the original description for BM25.
     # Used to narrow overly broad tools so they stop matching generic queries
     # against ha-mcp's internal BM25 search tool. Only applied when
@@ -551,6 +682,55 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "NOT for finding entities or discovering tools."
         ),
     }
+
+    def _apply_lite_docstrings(self) -> None:
+        """Swap heavy tool descriptions for shorter variants if enabled.
+
+        Beta feature gated on ``settings.enable_lite_docstrings`` /
+        ``ENABLE_LITE_DOCSTRINGS=true``. Replaces the description on
+        each tool listed in ``_LITE_DOCSTRINGS`` with a shorter variant
+        that defers detail to
+        ``ha_get_skill_home_assistant_best_practices``. Tools not in the
+        mapping pass through unchanged.
+
+        Emits a startup WARNING when enabled so non-addon users (Docker,
+        uvx, pip) see the trade-off in their logs — the addon UI surfaces
+        the same warning via the toggle description.
+
+        Runs before ``_apply_search_keyword_enrichment`` so BM25 keywords
+        append to the lite text instead of the discarded full description.
+        """
+        if not self.settings.enable_lite_docstrings:
+            return
+
+        logger.warning(
+            "ENABLE_LITE_DOCSTRINGS=true: replacing %d tool descriptions "
+            "with shorter variants. This reduces idle catalog token usage "
+            "but may degrade LLM performance — the trimmed descriptions "
+            "rely on the LLM calling ha_get_skill_home_assistant_best_practices "
+            "(or reading skill:// resources) for detail, which is not "
+            "guaranteed. See docs/beta.md.",
+            len(self._LITE_DOCSTRINGS),
+        )
+
+        try:
+            from .transforms import LiteDocstringsTransform
+        except ImportError:
+            logger.exception(
+                "LiteDocstringsTransform not available; full tool "
+                "descriptions will be exposed."
+            )
+            return
+
+        try:
+            self.mcp.add_transform(
+                LiteDocstringsTransform(
+                    enabled=True,
+                    replacements=self._LITE_DOCSTRINGS,
+                )
+            )
+        except Exception:
+            logger.exception("Failed to apply LiteDocstringsTransform")
 
     def _apply_search_keyword_enrichment(self) -> None:
         """Append BM25 keyword boosts to tool descriptions.

--- a/src/ha_mcp/transforms/__init__.py
+++ b/src/ha_mcp/transforms/__init__.py
@@ -5,5 +5,11 @@ from .categorized_search import (
     CategorizedSearchTransform,
     SearchKeywordsTransform,
 )
+from .lite_docstrings import LiteDocstringsTransform
 
-__all__ = ["CategorizedSearchTransform", "DEFAULT_PINNED_TOOLS", "SearchKeywordsTransform"]
+__all__ = [
+    "CategorizedSearchTransform",
+    "DEFAULT_PINNED_TOOLS",
+    "LiteDocstringsTransform",
+    "SearchKeywordsTransform",
+]

--- a/src/ha_mcp/transforms/lite_docstrings.py
+++ b/src/ha_mcp/transforms/lite_docstrings.py
@@ -13,7 +13,6 @@ their existing descriptions without us having to enumerate them.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -23,8 +22,6 @@ from fastmcp.tools import Tool
 if TYPE_CHECKING:
     from fastmcp.server.transforms import GetToolNext
     from fastmcp.utilities.versions import VersionSpec
-
-logger = logging.getLogger(__name__)
 
 
 class LiteDocstringsTransform(Transform):

--- a/src/ha_mcp/transforms/lite_docstrings.py
+++ b/src/ha_mcp/transforms/lite_docstrings.py
@@ -6,17 +6,16 @@ Replaces the description on a configurable set of tools with a shorter,
 resource). Trades catalog token usage for the assumption that the LLM
 will read the skill when it needs more detail — see issue #1062.
 
-This transform is opt-in (``ENABLE_LITE_DOCSTRINGS`` / dev-addon
-``enable_lite_docstrings``) and beta. Tools NOT in the mapping pass
-through unchanged so smaller tools keep their existing one-line
-descriptions without us having to enumerate them.
+Opt-in via ``enable_lite_docstrings``; see ``docs/beta.md`` for trade-offs.
+Tools NOT in the mapping pass through unchanged, so smaller tools keep
+their existing descriptions without us having to enumerate them.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from fastmcp.server.transforms import Transform
 from fastmcp.tools import Tool
@@ -29,15 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 class LiteDocstringsTransform(Transform):
-    """Replace heavy tool descriptions with lighter variants when enabled.
+    """Replace heavy tool descriptions with shorter variants.
 
-    Behaviour:
-    - If ``enabled`` is False (default), every tool passes through
-      unchanged. The transform is effectively a no-op so installing it
-      unconditionally is safe.
-    - If ``enabled`` is True, any tool whose name appears in
-      ``replacements`` has its ``description`` replaced with the mapped
-      text. Tools not in the mapping are returned unchanged.
+    Mirrors ``SearchKeywordsTransform``: an empty mapping is a no-op,
+    so installing the transform unconditionally would be safe. The
+    caller (``server._apply_lite_docstrings``) only installs it when
+    the feature flag is on, but the empty-dict-as-no-op contract keeps
+    the transform self-contained.
 
     The transform deliberately does not auto-append a pointer to
     ``ha_get_skill_home_assistant_best_practices`` — the mapped lite
@@ -45,25 +42,17 @@ class LiteDocstringsTransform(Transform):
     natural.
     """
 
-    def __init__(
-        self,
-        *,
-        enabled: bool,
-        replacements: dict[str, str] | None = None,
-    ) -> None:
-        self._enabled = enabled
+    def __init__(self, replacements: dict[str, str] | None = None) -> None:
         self._replacements: dict[str, str] = replacements or {}
 
-    def _apply(self, tool: Tool) -> Tool:
-        if not self._enabled:
-            return tool
+    def _rewrite(self, tool: Tool) -> Tool:
         lite = self._replacements.get(tool.name)
         if lite is None:
             return tool
         return tool.model_copy(update={"description": lite})
 
     async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
-        return [self._apply(t) for t in tools]
+        return [self._rewrite(t) for t in tools]
 
     async def get_tool(
         self,
@@ -72,5 +61,5 @@ class LiteDocstringsTransform(Transform):
         *,
         version: VersionSpec | None = None,
     ) -> Tool | None:
-        tool: Any = await call_next(name, version=version)
-        return self._apply(tool) if tool else None
+        tool = await call_next(name, version=version)
+        return self._rewrite(tool) if tool else None

--- a/src/ha_mcp/transforms/lite_docstrings.py
+++ b/src/ha_mcp/transforms/lite_docstrings.py
@@ -1,0 +1,76 @@
+"""Lite docstrings transform for ha-mcp.
+
+Replaces the description on a configurable set of tools with a shorter,
+"lite" variant that defers detailed guidance to the
+``ha_get_skill_home_assistant_best_practices`` tool (or its skill://
+resource). Trades catalog token usage for the assumption that the LLM
+will read the skill when it needs more detail — see issue #1062.
+
+This transform is opt-in (``ENABLE_LITE_DOCSTRINGS`` / dev-addon
+``enable_lite_docstrings``) and beta. Tools NOT in the mapping pass
+through unchanged so smaller tools keep their existing one-line
+descriptions without us having to enumerate them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from fastmcp.server.transforms import Transform
+from fastmcp.tools import Tool
+
+if TYPE_CHECKING:
+    from fastmcp.server.transforms import GetToolNext
+    from fastmcp.utilities.versions import VersionSpec
+
+logger = logging.getLogger(__name__)
+
+
+class LiteDocstringsTransform(Transform):
+    """Replace heavy tool descriptions with lighter variants when enabled.
+
+    Behaviour:
+    - If ``enabled`` is False (default), every tool passes through
+      unchanged. The transform is effectively a no-op so installing it
+      unconditionally is safe.
+    - If ``enabled`` is True, any tool whose name appears in
+      ``replacements`` has its ``description`` replaced with the mapped
+      text. Tools not in the mapping are returned unchanged.
+
+    The transform deliberately does not auto-append a pointer to
+    ``ha_get_skill_home_assistant_best_practices`` — the mapped lite
+    description owns its own pointer text so per-tool wording can stay
+    natural.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        replacements: dict[str, str] | None = None,
+    ) -> None:
+        self._enabled = enabled
+        self._replacements: dict[str, str] = replacements or {}
+
+    def _apply(self, tool: Tool) -> Tool:
+        if not self._enabled:
+            return tool
+        lite = self._replacements.get(tool.name)
+        if lite is None:
+            return tool
+        return tool.model_copy(update={"description": lite})
+
+    async def list_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
+        return [self._apply(t) for t in tools]
+
+    async def get_tool(
+        self,
+        name: str,
+        call_next: GetToolNext,
+        *,
+        version: VersionSpec | None = None,
+    ) -> Tool | None:
+        tool: Any = await call_next(name, version=version)
+        return self._apply(tool) if tool else None

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -1,19 +1,24 @@
-"""Unit tests for LiteDocstringsTransform.
+"""Unit tests for LiteDocstringsTransform and the server-side wiring.
 
-Covers the three behaviours that the toggle promises:
+Covers three layers:
 
-1. Disabled -> every tool passes through unchanged.
-2. Enabled, name in mapping -> description replaced with the lite text.
-3. Enabled, name NOT in mapping -> description unchanged.
-
-Also exercises ``get_tool`` so the single-tool lookup path stays in sync
-with ``list_tools`` (this matters because FastMCP can call either one).
+1. ``LiteDocstringsTransform`` itself — empty-mapping no-op, mapped
+   replacement, unmapped passthrough, on both ``list_tools`` and
+   ``get_tool`` paths.
+2. ``HomeAssistantSmartMCPServer._apply_lite_docstrings`` — the gate,
+   the WARNING log, the import-error fallback, and the
+   ``add_transform`` failure path. Uses the ``MagicMock`` stub pattern
+   from ``test_categorized_search.TestApplySearchKeywordEnrichment``.
+3. The ``_LITE_DOCSTRINGS`` mapping invariant — every lite description
+   names ``ha_get_skill_home_assistant_best_practices`` (or
+   ``ha_get_helper_schema`` for the helper entries) so the LLM still
+   has a path to detailed guidance from inside the trimmed text.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.tools import Tool
@@ -60,12 +65,17 @@ def tools() -> Sequence[Tool]:
     ]
 
 
+# ---------------------------------------------------------------------------
+# Layer 1: the transform itself
+# ---------------------------------------------------------------------------
+
+
 class TestListTools:
     @pytest.mark.asyncio
-    async def test_disabled_passes_through(
-        self, tools: Sequence[Tool], replacements: dict[str, str]
+    async def test_empty_mapping_passes_through(
+        self, tools: Sequence[Tool]
     ) -> None:
-        transform = LiteDocstringsTransform(enabled=False, replacements=replacements)
+        transform = LiteDocstringsTransform(replacements={})
 
         result = list(await transform.list_tools(tools))
 
@@ -75,10 +85,24 @@ class TestListTools:
         ]
 
     @pytest.mark.asyncio
-    async def test_enabled_replaces_mapped_only(
+    async def test_none_mapping_passes_through(
+        self, tools: Sequence[Tool]
+    ) -> None:
+        """``None`` replacements coerces to ``{}`` — same as the empty case."""
+        transform = LiteDocstringsTransform(replacements=None)
+
+        result = list(await transform.list_tools(tools))
+
+        assert [t.description for t in result] == [
+            _FULL_AUTOMATION,
+            "Get a state.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_replaces_mapped_tools_only(
         self, tools: Sequence[Tool], replacements: dict[str, str]
     ) -> None:
-        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        transform = LiteDocstringsTransform(replacements=replacements)
 
         result = list(await transform.list_tools(tools))
 
@@ -86,26 +110,11 @@ class TestListTools:
         assert descriptions["ha_config_get_automation"] == _LITE_AUTOMATION
         assert descriptions["ha_get_state"] == "Get a state."
 
-    @pytest.mark.asyncio
-    async def test_enabled_with_empty_mapping_is_noop(
-        self, tools: Sequence[Tool]
-    ) -> None:
-        transform = LiteDocstringsTransform(enabled=True, replacements={})
-
-        result = list(await transform.list_tools(tools))
-
-        assert [t.description for t in result] == [
-            _FULL_AUTOMATION,
-            "Get a state.",
-        ]
-
 
 class TestGetTool:
     @pytest.mark.asyncio
-    async def test_get_tool_disabled_passes_through(
-        self, replacements: dict[str, str]
-    ) -> None:
-        transform = LiteDocstringsTransform(enabled=False, replacements=replacements)
+    async def test_get_tool_empty_mapping_passes_through(self) -> None:
+        transform = LiteDocstringsTransform(replacements={})
         original = _make_tool("ha_config_get_automation", description=_FULL_AUTOMATION)
         call_next = AsyncMock(return_value=original)
 
@@ -115,10 +124,10 @@ class TestGetTool:
         assert result.description == _FULL_AUTOMATION
 
     @pytest.mark.asyncio
-    async def test_get_tool_enabled_replaces_mapped(
+    async def test_get_tool_replaces_mapped(
         self, replacements: dict[str, str]
     ) -> None:
-        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        transform = LiteDocstringsTransform(replacements=replacements)
         original = _make_tool("ha_config_get_automation", description=_FULL_AUTOMATION)
         call_next = AsyncMock(return_value=original)
 
@@ -128,10 +137,10 @@ class TestGetTool:
         assert result.description == _LITE_AUTOMATION
 
     @pytest.mark.asyncio
-    async def test_get_tool_enabled_unmapped_passes_through(
+    async def test_get_tool_unmapped_passes_through(
         self, replacements: dict[str, str]
     ) -> None:
-        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        transform = LiteDocstringsTransform(replacements=replacements)
         original = _make_tool("ha_get_state", description="Get a state.")
         call_next = AsyncMock(return_value=original)
 
@@ -144,9 +153,148 @@ class TestGetTool:
     async def test_get_tool_missing_returns_none(
         self, replacements: dict[str, str]
     ) -> None:
-        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        transform = LiteDocstringsTransform(replacements=replacements)
         call_next = AsyncMock(return_value=None)
 
         result = await transform.get_tool("ha_does_not_exist", call_next)
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: server.py wiring — mirrors TestApplySearchKeywordEnrichment
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLiteDocstrings:
+    """Tests for the server-side ``_apply_lite_docstrings`` wiring."""
+
+    def _make_server_stub(self, *, enable_lite_docstrings: bool) -> MagicMock:
+        """Minimal stub exposing only the attributes the method touches."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = MagicMock()
+        stub._LITE_DOCSTRINGS = HomeAssistantSmartMCPServer._LITE_DOCSTRINGS
+        stub.settings = MagicMock(
+            enable_lite_docstrings=enable_lite_docstrings
+        )
+        stub.mcp = MagicMock()
+        return stub
+
+    def test_noop_when_flag_disabled(self) -> None:
+        """When the flag is off, no transform is installed and no log."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_lite_docstrings=False)
+        HomeAssistantSmartMCPServer._apply_lite_docstrings(stub)
+
+        stub.mcp.add_transform.assert_not_called()
+
+    def test_installs_transform_when_flag_enabled(self) -> None:
+        """When on, install a LiteDocstringsTransform with the real mapping."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_lite_docstrings=True)
+        HomeAssistantSmartMCPServer._apply_lite_docstrings(stub)
+
+        stub.mcp.add_transform.assert_called_once()
+        installed = stub.mcp.add_transform.call_args.args[0]
+        assert isinstance(installed, LiteDocstringsTransform)
+        assert installed._replacements is stub._LITE_DOCSTRINGS
+
+    def test_logs_warning_when_enabled(self, caplog) -> None:
+        """The trade-off WARNING must be emitted so env-var users see it."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_lite_docstrings=True)
+        with caplog.at_level("WARNING"):
+            HomeAssistantSmartMCPServer._apply_lite_docstrings(stub)
+
+        assert any(
+            "ENABLE_LITE_DOCSTRINGS=true" in rec.message
+            and "may degrade LLM performance" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_transform_failure_logs_second_warning(self, caplog) -> None:
+        """If add_transform fails, the user must know full descs remain."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        stub = self._make_server_stub(enable_lite_docstrings=True)
+        stub.mcp.add_transform.side_effect = RuntimeError("boom")
+
+        with caplog.at_level("WARNING"):
+            HomeAssistantSmartMCPServer._apply_lite_docstrings(stub)
+
+        assert any(
+            "failed to install" in rec.message
+            and "full tool descriptions remain in effect" in rec.message
+            for rec in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: the mapping invariant
+# ---------------------------------------------------------------------------
+
+
+class TestLiteDocstringsMappingInvariants:
+    """Guard-rails on the user-visible lite descriptions themselves."""
+
+    def test_every_lite_description_references_skill(self) -> None:
+        """The design promise: every lite description points at a skill tool.
+
+        Without this anchor, the user-facing behaviour of the toggle
+        regresses to "shorter descriptions, no guidance" the moment
+        someone trims an entry too aggressively.
+        """
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        # ha_get_helper_schema is an acceptable substitute pointer on
+        # the two helper entries since it serves the same role
+        # (deferred per-type schema lookup).
+        acceptable_pointers = (
+            "ha_get_skill_home_assistant_best_practices",
+            "ha_get_helper_schema",
+        )
+        offenders: list[str] = []
+        for name, lite in HomeAssistantSmartMCPServer._LITE_DOCSTRINGS.items():
+            if not any(pointer in lite for pointer in acceptable_pointers):
+                offenders.append(name)
+
+        assert not offenders, (
+            "Lite descriptions missing a skill-tool pointer "
+            f"(invariant from _LITE_DOCSTRINGS docstring): {offenders}"
+        )
+
+    def test_every_lite_description_starts_with_action_verb(self) -> None:
+        """AGENTS.md tool-docstring rule: first word is an action verb."""
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        # Accept the verbs AGENTS.md lists plus "Inspect" (used for the
+        # dashboard get tool which has list / search / get modes).
+        accepted = {
+            "Get",
+            "List",
+            "Search",
+            "Create",
+            "Update",
+            "Delete",
+            "Remove",
+            "Execute",
+            "Call",
+            "Manage",
+            "Retrieve",
+            "Inspect",
+            "Add,",
+        }
+        offenders: list[tuple[str, str]] = []
+        for name, lite in HomeAssistantSmartMCPServer._LITE_DOCSTRINGS.items():
+            first_word = lite.split(maxsplit=1)[0]
+            if first_word not in accepted:
+                offenders.append((name, first_word))
+
+        assert not offenders, (
+            "Lite descriptions not starting with an action verb: "
+            f"{offenders}"
+        )

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -42,12 +42,12 @@ def _make_tool(name: str, *, description: str = "") -> Tool:
 
 
 _FULL_AUTOMATION = (
-    "Retrieve Home Assistant automation configuration.\n\n"
+    "Get Home Assistant automation configuration.\n\n"
     "Returns the complete configuration including triggers, conditions, "
     "actions, and mode settings. (... many more paragraphs ...)"
 )
 _LITE_AUTOMATION = (
-    "Retrieve a Home Assistant automation. See "
+    "Get a Home Assistant automation. See "
     "ha_get_skill_home_assistant_best_practices for schema."
 )
 

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -1,0 +1,152 @@
+"""Unit tests for LiteDocstringsTransform.
+
+Covers the three behaviours that the toggle promises:
+
+1. Disabled -> every tool passes through unchanged.
+2. Enabled, name in mapping -> description replaced with the lite text.
+3. Enabled, name NOT in mapping -> description unchanged.
+
+Also exercises ``get_tool`` so the single-tool lookup path stays in sync
+with ``list_tools`` (this matters because FastMCP can call either one).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
+
+from ha_mcp.transforms import LiteDocstringsTransform
+
+
+def _make_tool(name: str, *, description: str = "") -> Tool:
+    """Create a minimal Tool for testing."""
+
+    async def noop() -> str:
+        return "ok"
+
+    return Tool.from_function(
+        fn=noop,
+        name=name,
+        description=description,
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+
+
+_FULL_AUTOMATION = (
+    "Retrieve Home Assistant automation configuration.\n\n"
+    "Returns the complete configuration including triggers, conditions, "
+    "actions, and mode settings. (... many more paragraphs ...)"
+)
+_LITE_AUTOMATION = (
+    "Retrieve a Home Assistant automation. See "
+    "ha_get_skill_home_assistant_best_practices for schema."
+)
+
+
+@pytest.fixture
+def replacements() -> dict[str, str]:
+    return {"ha_config_get_automation": _LITE_AUTOMATION}
+
+
+@pytest.fixture
+def tools() -> Sequence[Tool]:
+    return [
+        _make_tool("ha_config_get_automation", description=_FULL_AUTOMATION),
+        _make_tool("ha_get_state", description="Get a state."),
+    ]
+
+
+class TestListTools:
+    @pytest.mark.asyncio
+    async def test_disabled_passes_through(
+        self, tools: Sequence[Tool], replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=False, replacements=replacements)
+
+        result = list(await transform.list_tools(tools))
+
+        assert [t.description for t in result] == [
+            _FULL_AUTOMATION,
+            "Get a state.",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_enabled_replaces_mapped_only(
+        self, tools: Sequence[Tool], replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+
+        result = list(await transform.list_tools(tools))
+
+        descriptions = {t.name: t.description for t in result}
+        assert descriptions["ha_config_get_automation"] == _LITE_AUTOMATION
+        assert descriptions["ha_get_state"] == "Get a state."
+
+    @pytest.mark.asyncio
+    async def test_enabled_with_empty_mapping_is_noop(
+        self, tools: Sequence[Tool]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=True, replacements={})
+
+        result = list(await transform.list_tools(tools))
+
+        assert [t.description for t in result] == [
+            _FULL_AUTOMATION,
+            "Get a state.",
+        ]
+
+
+class TestGetTool:
+    @pytest.mark.asyncio
+    async def test_get_tool_disabled_passes_through(
+        self, replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=False, replacements=replacements)
+        original = _make_tool("ha_config_get_automation", description=_FULL_AUTOMATION)
+        call_next = AsyncMock(return_value=original)
+
+        result = await transform.get_tool("ha_config_get_automation", call_next)
+
+        assert result is not None
+        assert result.description == _FULL_AUTOMATION
+
+    @pytest.mark.asyncio
+    async def test_get_tool_enabled_replaces_mapped(
+        self, replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        original = _make_tool("ha_config_get_automation", description=_FULL_AUTOMATION)
+        call_next = AsyncMock(return_value=original)
+
+        result = await transform.get_tool("ha_config_get_automation", call_next)
+
+        assert result is not None
+        assert result.description == _LITE_AUTOMATION
+
+    @pytest.mark.asyncio
+    async def test_get_tool_enabled_unmapped_passes_through(
+        self, replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        original = _make_tool("ha_get_state", description="Get a state.")
+        call_next = AsyncMock(return_value=original)
+
+        result = await transform.get_tool("ha_get_state", call_next)
+
+        assert result is not None
+        assert result.description == "Get a state."
+
+    @pytest.mark.asyncio
+    async def test_get_tool_missing_returns_none(
+        self, replacements: dict[str, str]
+    ) -> None:
+        transform = LiteDocstringsTransform(enabled=True, replacements=replacements)
+        call_next = AsyncMock(return_value=None)
+
+        result = await transform.get_tool("ha_does_not_exist", call_next)
+
+        assert result is None

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -268,11 +268,14 @@ class TestLiteDocstringsMappingInvariants:
         )
 
     def test_every_lite_description_starts_with_action_verb(self) -> None:
-        """AGENTS.md tool-docstring rule: first word is an action verb."""
+        """AGENTS.md tool-docstring rule: first word is an action verb.
+
+        Verb list mirrors AGENTS.md > Tool Docstrings > Required for
+        every tool. ``Create`` covers ``Create or update`` openers used
+        on the consolidated set_* tools.
+        """
         from ha_mcp.server import HomeAssistantSmartMCPServer
 
-        # Accept the verbs AGENTS.md lists plus "Inspect" (used for the
-        # dashboard get tool which has list / search / get modes).
         accepted = {
             "Get",
             "List",
@@ -284,13 +287,14 @@ class TestLiteDocstringsMappingInvariants:
             "Execute",
             "Call",
             "Manage",
-            "Retrieve",
-            "Inspect",
-            "Add,",
         }
+        # Strip trailing punctuation so multi-action openers (e.g.,
+        # "Update, replace, or remove ...") still validate against the
+        # leading verb.
+        punctuation = ",.;:"
         offenders: list[tuple[str, str]] = []
         for name, lite in HomeAssistantSmartMCPServer._LITE_DOCSTRINGS.items():
-            first_word = lite.split(maxsplit=1)[0]
+            first_word = lite.split(maxsplit=1)[0].rstrip(punctuation)
             if first_word not in accepted:
                 offenders.append((name, first_word))
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in beta toggle (`enable_lite_docstrings` / `ENABLE_LITE_DOCSTRINGS=true`) that swaps the docstrings on 12 heavy tools for shorter variants that defer schema and example detail to `ha_get_skill_home_assistant_best_practices` (and its `skill://` resource).

Closes #1062.

### Behaviour

- Default OFF. When OFF, the transform is not installed at all — zero overhead.
- When ON, descriptions are replaced for: `ha_config_get_automation`, `ha_config_set_automation`, `ha_config_get_script`, `ha_config_set_script`, `ha_config_get_scene`, `ha_config_set_scene`, `ha_config_list_helpers`, `ha_config_set_helper`, `ha_config_get_dashboard`, `ha_config_set_dashboard`, `ha_call_service`, `ha_config_set_yaml`.
- Each lite variant still includes a pointer to `ha_get_skill_home_assistant_best_practices`, so the LLM is not starved of context even with the toggle on (per #1062 author's "can't completely trim out all data" note).
- Tools not in the mapping pass through unchanged.

### Trade-off (surfaced everywhere it can be surfaced)

This reduces idle catalog token usage but relies on the LLM actually consulting the skill when it needs detail. Some models will skip the extra tool call and produce worse output than they would have with the full docstrings in front of them. The trade-off is surfaced in three places:

1. **Add-on UI toggle description** — explicit warning that it "may degrade LLM performance" and that some models skip the extra tool call.
2. **Startup WARNING log** — emitted once when the flag is enabled, so env-var users (Docker / uvx / pip) see it in their logs.
3. **`docs/beta.md`** — table entry + dedicated "Known limitations" section with mitigations (resource-capable client / `enable_tool_search` / system-prompt nudge).

### Distribution

- Dev add-on only (matching `enable_code_mode` / `enable_yaml_config_editing`). Hidden under "Show unused optional configuration options" via the standard `bool?` pattern.
- Env var `ENABLE_LITE_DOCSTRINGS=true` for non-add-on installs (Docker, uvx, pip).
- Stable add-on intentionally not touched.

### Implementation notes

- New transform installs **before** `_apply_search_keyword_enrichment` so BM25 keywords append to the lite text instead of the discarded full description — preserves search behaviour.
- Shared `homeassistant-addon/start.py` reads the option for both stable and dev add-ons; stable add-on's `config.yaml` doesn't expose it so it defaults to False there.
- Python docstrings in `src/ha_mcp/tools/` are unchanged — the substitution happens entirely in the FastMCP transform pipeline.

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit tests added: `tests/src/unit/test_lite_docstrings.py` (7 cases across `list_tools`/`get_tool` × enabled/disabled × mapped/unmapped/empty-mapping). Ruff passes on `src/ tests/`.

## Future improvements

- Could be combined with #1182 (inline skill pointer in tool returns) so the LLM sees the pointer at call-result time, not just at description time.
- Lite-variant copy was hand-written based on the existing docstrings; a follow-up could measure tokens-out across baseline / lite + skill-tool-call / lite + skill-resource to quantify the savings and the regression risk per family of tools.

## Checklist
- [x] I have updated documentation if needed
