### PR TITLE
test(e2e): instrument and retry ha_mcp_tools readiness wait

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -27,7 +27,27 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.helpers import config_validation as cv
-from ruamel.yaml import YAMLError
+
+# Defensive imports: ``ruamel.yaml`` is declared in ``manifest.json``
+# ``requirements``, but the requirement install can lag behind the first
+# ``importlib`` resolution of this module — observed on PR #1262's ARM
+# E2E run where the module loaded before Home Assistant had installed
+# ``ruamel.yaml``, surfacing as ``ModuleNotFoundError: No module named
+# 'ruamel'`` and leaving the integration in ``state=not_loaded``.
+#
+# Two defensive shapes:
+#   * ``YAMLError`` falls back to ``Exception`` so the module loads past
+#     the import. The four ``except YAMLError`` clauses below still
+#     catch the real ``ruamel.yaml.YAMLError`` at runtime via its
+#     ``Exception`` base class.
+#   * ``make_yaml`` / ``yaml_dumps`` move to a lazy import inside
+#     ``_build_edit_yaml_config_handler`` (the only caller). By the time
+#     that function runs in ``async_setup_entry`` the requirement
+#     install has completed and ``ruamel.yaml`` is importable.
+try:
+    from ruamel.yaml import YAMLError
+except ImportError:  # pragma: no cover - early-import path only
+    YAMLError = Exception  # type: ignore[misc, assignment]
 
 from .const import (
     ALLOWED_READ_DIRS,
@@ -40,7 +60,6 @@ from .const import (
     YAML_KEY_DEFAULT_POST_ACTION,
     YAML_KEY_POST_ACTIONS,
 )
-from .yaml_rt import make_yaml, yaml_dumps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -315,6 +334,13 @@ def _build_edit_yaml_config_handler(hass):
     Extracted to module level so it can be tested without registering
     the full integration.
     """
+    # Lazy import: see the ``ruamel.yaml`` defensive-import comment at
+    # the top of this module. ``_build_edit_yaml_config_handler`` is
+    # invoked from ``async_setup_entry``, by which point Home Assistant
+    # has installed the ``manifest.json`` requirements (``ruamel.yaml``
+    # among them), so the import here is reliable.
+    from .yaml_rt import make_yaml, yaml_dumps
+
     config_dir = Path(hass.config.config_dir)
 
     async def handle_edit_yaml_config(call: ServiceCall) -> dict[str, Any]:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -655,6 +655,30 @@ def _restart_ha_container_for_retry(container: DockerContainer) -> bool:
         return False
 
 
+def _reset_ha_in_process_caches() -> None:
+    """Clear in-process caches that reference the previous HA container.
+
+    Both the initial fixture setup (after first container start) and the
+    retry path (after ``_restart_ha_container_for_retry``) call this so
+    subsequent ``HomeAssistantClient`` lookups go through the new
+    container's URL instead of stale references to the prior container.
+
+    ``ha_mcp.config._settings`` caches the URL + token. ``WebSocketManager``
+    pools live connections keyed by URL: ``_clients`` (plural dict) and
+    ``_last_used`` are the real attribute names — a direct
+    ``websocket_manager._client = None`` (singular) would create a no-op
+    attribute on the singleton without clearing the connection pool, since
+    ``_client`` is not declared on the class.
+    """
+    import ha_mcp.config
+    from ha_mcp.client.websocket_client import websocket_manager
+
+    ha_mcp.config._settings = None
+    websocket_manager._clients.clear()
+    websocket_manager._last_used.clear()
+    websocket_manager._current_loop = None
+
+
 @pytest.fixture(scope="session")
 async def test_settings():
     """Get test configuration settings."""
@@ -874,23 +898,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         os.environ["HAMCP_ENABLE_FILESYSTEM_TOOLS"] = "true"
         os.environ["HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION"] = "true"
 
-        # Reset cached settings so WebSocket client picks up the dynamic URL
-        import ha_mcp.config
-
-        ha_mcp.config._settings = None
-
-        # Reset the WebSocket manager to ensure fresh connection with new URL.
-        # ``WebSocketManager`` stores connections in ``_clients`` (dict, plural)
-        # and tracks per-key freshness in ``_last_used``; ``._client`` (the
-        # singular form previously assigned here) was never an attribute of the
-        # class, so the prior assignment created a new no-op attribute on the
-        # singleton without clearing the actual connection cache. Use the real
-        # collection-clear methods.
-        from ha_mcp.client.websocket_client import websocket_manager
-
-        websocket_manager._clients.clear()
-        websocket_manager._last_used.clear()
-        websocket_manager._current_loop = None
+        # Reset cached settings + WebSocket pool so subsequent client
+        # lookups pick up the new container's URL.
+        _reset_ha_in_process_caches()
 
         logger.info(f"🚀 Home Assistant container started on {base_url}")
         logger.info(f"🐳 Container ID: {container.get_container_host_ip()}:{host_port}")
@@ -1087,20 +1097,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                         "COMPONENT_NOT_INSTALLED on the first tool call."
                     )
 
-                # In-process caches that hold references to the pre-restart
-                # HA instance must be cleared, matching the same resets the
-                # initial fixture setup performs (search for the first
-                # ``ha_mcp.config._settings = None`` assignment in this
-                # file).
-                ha_mcp.config._settings = None
-                from ha_mcp.client.websocket_client import websocket_manager
-
-                # Mirror the connection-cache reset from the initial fixture
-                # setup above (``_clients`` dict + ``_last_used`` dict, not the
-                # nonexistent ``_client`` singular attribute).
-                websocket_manager._clients.clear()
-                websocket_manager._last_used.clear()
-                websocket_manager._current_loop = None
+                # Mirror the initial-fixture-setup reset so the post-restart
+                # client lookups go through the new container URL.
+                _reset_ha_in_process_caches()
 
                 # Re-wait for the API to come back up after the restart; the
                 # post-restart ha_mcp_tools wait depends on it. The 60s

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -436,6 +436,216 @@ def _install_custom_component(
     return True
 
 
+def _wait_for_ha_api_ready(
+    base_url: str,
+    headers: dict[str, str],
+    timeout: int,
+) -> bool:
+    """Poll ``/api/`` for HTTP 200. Returns True on success, False on timeout.
+
+    Extracted so the post-restart retry path in the ``HA_MCP_TOOLS_WAIT`` branch
+    re-uses the same API-readiness contract as the initial wait in
+    ``ha_container_with_fresh_config`` (lines ~637-657) without duplicating the
+    polling loop.
+    """
+    import requests as _requests
+
+    for attempt in range(timeout):
+        try:
+            response = _requests.get(f"{base_url}/api/", timeout=5, headers=headers)
+            if response.status_code == 200:
+                logger.info(f"🏠 Home Assistant API ready after {attempt + 1} attempts")
+                return True
+        except _requests.exceptions.RequestException:
+            pass
+        time.sleep(1)
+    return False
+
+
+def _wait_for_ha_mcp_tools_services(
+    base_url: str,
+    headers: dict[str, str],
+    timeout: int,
+) -> bool:
+    """Poll ``/api/services`` for the ``ha_mcp_tools`` domain.
+
+    Returns True if the domain appears within ``timeout`` seconds, False on
+    timeout. Extracted from the inline loop at lines ~779-796 so the same wait
+    contract can be invoked twice on the restart-retry path.
+    """
+    import requests as _requests
+
+    for mcp_attempt in range(timeout):
+        try:
+            svc_resp = _requests.get(
+                f"{base_url}/api/services", timeout=5, headers=headers
+            )
+            if svc_resp.status_code == 200:
+                domains = {s.get("domain") for s in svc_resp.json()}
+                if "ha_mcp_tools" in domains:
+                    logger.info(
+                        f"✅ ha_mcp_tools services ready after {mcp_attempt + 1}s"
+                    )
+                    return True
+        except (
+            _requests.exceptions.RequestException,
+            json.JSONDecodeError,
+        ) as exc:
+            logger.debug(f"ha_mcp_tools service check failed: {exc}")
+        time.sleep(1)
+    return False
+
+
+def _dump_ha_mcp_tools_diagnostics(
+    container: DockerContainer,
+    base_url: str,
+    headers: dict[str, str],
+    label: str,
+) -> None:
+    """Emit HA-side diagnostics for the ``ha_mcp_tools`` readiness gap.
+
+    Called from the ``HA_MCP_TOOLS_WAIT`` timeout branch before each retry and
+    before the final ``pytest.fail`` so the CI artifact carries enough context
+    to disambiguate the root-cause class (import error / dependency-setup
+    delay / late event-driven registration / resource starvation) without
+    requiring a local reproduction of the flake.
+
+    Best-effort: each capture is wrapped in its own try/except so a single
+    failure (container already exited, HA API gone) does not lose the other
+    captures. Surfaced at WARNING level so CI logs keep the lines visible
+    even with default filtering.
+    """
+    import docker as _docker
+    import requests as _requests
+
+    logger.warning(f"📋 ha_mcp_tools diagnostics dump ({label}):")
+
+    # /api/services snapshot — distinguishes "domain absent" from
+    # "request errored at timeout edge".
+    try:
+        svc_resp = _requests.get(f"{base_url}/api/services", timeout=5, headers=headers)
+        if svc_resp.status_code == 200:
+            domains = sorted(
+                {s.get("domain") for s in svc_resp.json() if s.get("domain")}
+            )
+            ha_mcp_present = "ha_mcp_tools" in domains
+            logger.warning(
+                f"  /api/services: {len(domains)} domains; "
+                f"ha_mcp_tools={'present' if ha_mcp_present else 'absent'}"
+            )
+            if not ha_mcp_present:
+                # Surface adjacent domains so a reader can rule out a
+                # regex / casing / typo class mismatch.
+                logger.warning(f"  /api/services domains: {domains}")
+        else:
+            logger.warning(
+                f"  /api/services: HTTP {svc_resp.status_code} {svc_resp.text[:200]}"
+            )
+    except (
+        _requests.exceptions.RequestException,
+        json.JSONDecodeError,
+    ) as exc:
+        logger.warning(f"  /api/services: request failed: {type(exc).__name__}: {exc}")
+
+    # /api/config/config_entries/entry — surfaces the entry's state
+    # ('loaded' / 'setup_retry' / 'setup_error' / 'not_loaded' / etc.).
+    # Distinguishes "HA never imported the entry" from "HA imported but
+    # async_setup_entry raised".
+    try:
+        entries_resp = _requests.get(
+            f"{base_url}/api/config/config_entries/entry",
+            timeout=5,
+            headers=headers,
+        )
+        if entries_resp.status_code == 200:
+            ha_mcp_entries = [
+                e for e in entries_resp.json() if e.get("domain") == "ha_mcp_tools"
+            ]
+            if ha_mcp_entries:
+                for entry in ha_mcp_entries:
+                    logger.warning(
+                        f"  config_entry: id={entry.get('entry_id')} "
+                        f"state={entry.get('state')} "
+                        f"reason={entry.get('reason')} "
+                        f"source={entry.get('source')}"
+                    )
+            else:
+                logger.warning(
+                    "  config_entry: NO ha_mcp_tools entry visible in HA's "
+                    "config_entries — install step wrote to .storage but HA "
+                    "did not pick it up"
+                )
+        else:
+            logger.warning(
+                f"  /api/config/config_entries: HTTP {entries_resp.status_code}"
+            )
+    except (
+        _requests.exceptions.RequestException,
+        json.JSONDecodeError,
+    ) as exc:
+        logger.warning(
+            f"  /api/config/config_entries: request failed: {type(exc).__name__}: {exc}"
+        )
+
+    # docker logs --tail 100 + container state. The early ``tail=20`` grab
+    # at line ~625 fires immediately after container start and so does not
+    # cover the custom-component lifecycle that produces the symptom.
+    try:
+        docker_client = _docker.from_env()
+        docker_container = docker_client.containers.get(
+            container.get_wrapped_container().id
+        )
+        logger.warning(f"  container status: {docker_container.status}")
+        try:
+            state_attrs = docker_container.attrs.get("State", {})
+            logger.warning(
+                f"  container state: exit_code={state_attrs.get('ExitCode')} "
+                f"oom_killed={state_attrs.get('OOMKilled')} "
+                f"restart_count={state_attrs.get('RestartCount')}"
+            )
+        except (KeyError, AttributeError) as exc:
+            logger.warning(
+                f"  container state: introspect failed: {type(exc).__name__}: {exc}"
+            )
+        try:
+            logs = docker_container.logs(tail=100).decode("utf-8", errors="ignore")
+            logger.warning(f"  docker logs --tail 100:\n{logs}")
+        except _docker.errors.DockerException as exc:
+            logger.warning(f"  docker logs: failed: {type(exc).__name__}: {exc}")
+    except _docker.errors.DockerException as exc:
+        logger.warning(f"  docker client: failed: {type(exc).__name__}: {exc}")
+
+
+def _restart_ha_container_for_retry(container: DockerContainer) -> bool:
+    """Stop + start the HA container via the raw docker client.
+
+    Returns True on success (container reports ``status == "running"`` after
+    restart), False on any docker error.
+
+    Implementation note: ``docker stop`` + ``docker start`` preserve the
+    container's port-mapping configuration (unlike ``docker rm`` + ``docker
+    run``, which allocates new ports). This means ``base_url`` stays valid
+    across the restart and the existing port-binding does not need to be
+    re-plumbed through the fixture.
+    """
+    import docker as _docker
+
+    try:
+        docker_client = _docker.from_env()
+        docker_container = docker_client.containers.get(
+            container.get_wrapped_container().id
+        )
+        logger.warning("🔄 Restarting HA container for ha_mcp_tools recovery retry...")
+        docker_container.stop(timeout=10)
+        docker_container.start()
+        docker_container.reload()
+        logger.info(f"🐳 Container restarted; status={docker_container.status}")
+        return docker_container.status == "running"
+    except _docker.errors.DockerException as exc:
+        logger.warning(f"⚠️ Container restart failed: {type(exc).__name__}: {exc}")
+        return False
+
+
 @pytest.fixture(scope="session")
 async def test_settings():
     """Get test configuration settings."""
@@ -832,35 +1042,91 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # COMPONENT_NOT_INSTALLED on the first tool call — surfacing
         # the registration gap beats misattributing it to the calling
         # test.
+        #
+        # On timeout the branch does not fail immediately: it dumps HA-side
+        # diagnostics (``/api/services`` snapshot, ``/api/config/config_entries``
+        # entry state, ``docker logs --tail 100``, container state) and then
+        # restarts the container once. The retry covers non-deterministic
+        # startup variance (dependency-setup delays, late event-driven service
+        # registration, runner resource starvation); a deterministic import
+        # error in ``custom_components/ha_mcp_tools`` would still fail on the
+        # retry and be surfaced by the final post-retry dump.
         HA_MCP_TOOLS_WAIT = 180  # session-level cap; covers slow CI runners
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():
             logger.info("⏳ Waiting for ha_mcp_tools services to register...")
-            for mcp_attempt in range(HA_MCP_TOOLS_WAIT):
-                try:
-                    svc_resp = requests.get(
-                        f"{base_url}/api/services", timeout=5, headers=headers
-                    )
-                    if svc_resp.status_code == 200:
-                        domains = {s.get("domain") for s in svc_resp.json()}
-                        if "ha_mcp_tools" in domains:
-                            logger.info(
-                                f"✅ ha_mcp_tools services ready after {mcp_attempt + 1}s"
-                            )
-                            break
-                except (
-                    requests.exceptions.RequestException,
-                    json.JSONDecodeError,
-                ) as exc:
-                    logger.debug(f"ha_mcp_tools service check failed: {exc}")
-                time.sleep(1)
-            else:
-                pytest.fail(
-                    f"ha_mcp_tools services not registered after {HA_MCP_TOOLS_WAIT}s. "
-                    "Required for filesystem and config-editing tests; a silent "
-                    "warning here would let those tests proceed into "
-                    "COMPONENT_NOT_INSTALLED on the first tool call."
+            if not _wait_for_ha_mcp_tools_services(
+                base_url, headers, HA_MCP_TOOLS_WAIT
+            ):
+                # First wait expired. Diagnostic dump → container restart →
+                # one retry. See module-level docstrings on the helpers for
+                # the rationale.
+                _dump_ha_mcp_tools_diagnostics(
+                    container, base_url, headers, label="pre-retry"
                 )
+
+                if not _restart_ha_container_for_retry(container):
+                    pytest.fail(
+                        f"ha_mcp_tools services not registered after "
+                        f"{HA_MCP_TOOLS_WAIT}s and container restart failed. "
+                        "See pre-retry diagnostic dump above. Required for "
+                        "filesystem and config-editing tests; a silent "
+                        "warning here would let those tests proceed into "
+                        "COMPONENT_NOT_INSTALLED on the first tool call."
+                    )
+
+                # In-process caches that hold references to the pre-restart
+                # HA instance must be cleared, matching the same resets the
+                # initial fixture setup performs (search for the first
+                # ``ha_mcp.config._settings = None`` assignment in this
+                # file).
+                ha_mcp.config._settings = None
+                from ha_mcp.client.websocket_client import websocket_manager
+
+                websocket_manager._client = None
+                websocket_manager._current_loop = None
+
+                # Re-wait for the API to come back up after the restart; the
+                # post-restart ha_mcp_tools wait depends on it. The 60s
+                # budget matches the initial API-readiness wait earlier in
+                # this fixture.
+                if not _wait_for_ha_api_ready(base_url, headers, timeout=60):
+                    _dump_ha_mcp_tools_diagnostics(
+                        container,
+                        base_url,
+                        headers,
+                        label="post-retry-api-failed",
+                    )
+                    pytest.fail(
+                        "HA API did not recover within 60s after container "
+                        "restart on the ha_mcp_tools retry path. See "
+                        "pre-retry and post-retry-api-failed diagnostic "
+                        "dumps above."
+                    )
+
+                # Second ha_mcp_tools wait. Same 180s budget so the retry
+                # gets the same chance the first attempt had.
+                if _wait_for_ha_mcp_tools_services(
+                    base_url, headers, HA_MCP_TOOLS_WAIT
+                ):
+                    logger.warning(
+                        "✅ ha_mcp_tools recovered after container restart "
+                        "(see pre-retry diagnostics for the original "
+                        "failure context)"
+                    )
+                else:
+                    _dump_ha_mcp_tools_diagnostics(
+                        container, base_url, headers, label="post-retry"
+                    )
+                    pytest.fail(
+                        f"ha_mcp_tools services not registered after "
+                        f"{HA_MCP_TOOLS_WAIT}s + container restart + "
+                        f"{HA_MCP_TOOLS_WAIT}s. See pre-retry and "
+                        "post-retry diagnostic dumps above. Required for "
+                        "filesystem and config-editing tests; a silent "
+                        "warning here would let those tests proceed into "
+                        "COMPONENT_NOT_INSTALLED on the first tool call."
+                    )
 
         # Wait for sun.sun to leave the 'unknown' state.  During HA startup the
         # sun integration reports 'unknown' until it computes the first position.

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -649,7 +649,10 @@ def _restart_ha_container_for_retry(container: DockerContainer) -> bool:
         docker_container.start()
         docker_container.reload()
         logger.info(f"🐳 Container restarted; status={docker_container.status}")
-        return docker_container.status == "running"
+        # Explicit ``bool`` because ``docker_container.status`` is typed
+        # as ``Any`` (the docker SDK ships no stubs), and mypy would
+        # otherwise flag the comparison as ``no-any-return``.
+        return bool(docker_container.status == "running")
     except _docker.errors.DockerException as exc:
         logger.warning(f"⚠️ Container restart failed: {type(exc).__name__}: {exc}")
         return False

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -912,41 +912,18 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         except Exception as e:
             logger.warning(f"⚠️ Could not inspect container: {e}")
 
-        # Wait for API to be ready
+        # Wait for API to be ready. Use the module-level
+        # ``_wait_for_ha_api_ready`` helper so the initial-boot and the
+        # post-restart-retry paths share a single readiness contract — any
+        # future tweak to the polling semantics (timeout, sleep cadence,
+        # error handling) propagates to both call sites.
         import requests
-
-        api_ready = False
 
         # Use test token for API readiness checks
         headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
 
-        # Wall-clock-bound polling: ``range(60)`` would let a slow ``/api/``
-        # (5s HTTP timeout + 1s sleep ≈ up to 6s per iteration) stretch the
-        # 60-second budget to ~6 minutes. The monotonic-based cap enforces
-        # the declared 60-second window.
-        api_start = time.monotonic()
-        attempt = 0
-        while time.monotonic() - api_start < 60:
-            attempt += 1
-            try:
-                response = requests.get(f"{base_url}/api/", timeout=5, headers=headers)
-                if response.status_code == 200:
-                    elapsed = int(time.monotonic() - api_start)
-                    logger.info(
-                        f"🏠 Home Assistant API ready after {elapsed}s "
-                        f"({attempt} additional attempts)"
-                    )
-                    api_ready = True
-                    break
-            except requests.exceptions.RequestException:
-                if attempt == 1:
-                    logger.info("🔄 Waiting for Home Assistant API to become ready...")
-                if attempt > 1 and attempt % 15 == 0:
-                    elapsed = int(time.monotonic() - api_start)
-                    logger.info(f"⏳ Still waiting... {elapsed}s elapsed")
-                time.sleep(1)
-
-        if not api_ready:
+        logger.info("🔄 Waiting for Home Assistant API to become ready...")
+        if not _wait_for_ha_api_ready(base_url, headers, timeout=60):
             pytest.fail(
                 f"Home Assistant API at {base_url} did not become ready within 60 seconds.\n"
                 "The container may have failed to start. Check Docker logs for details."

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -870,10 +870,17 @@ def ha_container_with_fresh_config(_blueprint_http_server):
 
         ha_mcp.config._settings = None
 
-        # Reset the WebSocket manager to ensure fresh connection with new URL
+        # Reset the WebSocket manager to ensure fresh connection with new URL.
+        # ``WebSocketManager`` stores connections in ``_clients`` (dict, plural)
+        # and tracks per-key freshness in ``_last_used``; ``._client`` (the
+        # singular form previously assigned here) was never an attribute of the
+        # class, so the prior assignment created a new no-op attribute on the
+        # singleton without clearing the actual connection cache. Use the real
+        # collection-clear methods.
         from ha_mcp.client.websocket_client import websocket_manager
 
-        websocket_manager._client = None
+        websocket_manager._clients.clear()
+        websocket_manager._last_used.clear()
         websocket_manager._current_loop = None
 
         logger.info(f"🚀 Home Assistant container started on {base_url}")
@@ -1083,7 +1090,11 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 ha_mcp.config._settings = None
                 from ha_mcp.client.websocket_client import websocket_manager
 
-                websocket_manager._client = None
+                # Mirror the connection-cache reset from the initial fixture
+                # setup above (``_clients`` dict + ``_last_used`` dict, not the
+                # nonexistent ``_client`` singular attribute).
+                websocket_manager._clients.clear()
+                websocket_manager._last_used.clear()
                 websocket_manager._current_loop = None
 
                 # Re-wait for the API to come back up after the restart; the

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -450,11 +450,18 @@ def _wait_for_ha_api_ready(
     """
     import requests as _requests
 
-    for attempt in range(timeout):
+    # Wall-clock-bound polling: ``for attempt in range(timeout)`` would let a
+    # single slow request (5s HTTP timeout) plus the 1s sleep stretch each
+    # iteration to ~6s, so a hung server could keep the loop running for up
+    # to ``6 * timeout`` seconds instead of ``timeout``. The monotonic-based
+    # cap enforces the budget the caller asked for.
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
         try:
             response = _requests.get(f"{base_url}/api/", timeout=5, headers=headers)
             if response.status_code == 200:
-                logger.info(f"🏠 Home Assistant API ready after {attempt + 1} attempts")
+                elapsed = int(time.monotonic() - start_time)
+                logger.info(f"🏠 Home Assistant API ready after {elapsed}s")
                 return True
         except _requests.exceptions.RequestException:
             pass
@@ -475,7 +482,10 @@ def _wait_for_ha_mcp_tools_services(
     """
     import requests as _requests
 
-    for mcp_attempt in range(timeout):
+    # Wall-clock-bound (see ``_wait_for_ha_api_ready`` for the rationale on
+    # why ``range(timeout)`` would understate the actual budget).
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
         try:
             svc_resp = _requests.get(
                 f"{base_url}/api/services", timeout=5, headers=headers
@@ -483,9 +493,8 @@ def _wait_for_ha_mcp_tools_services(
             if svc_resp.status_code == 200:
                 domains = {s.get("domain") for s in svc_resp.json()}
                 if "ha_mcp_tools" in domains:
-                    logger.info(
-                        f"✅ ha_mcp_tools services ready after {mcp_attempt + 1}s"
-                    )
+                    elapsed = int(time.monotonic() - start_time)
+                    logger.info(f"✅ ha_mcp_tools services ready after {elapsed}s")
                     return True
         except (
             _requests.exceptions.RequestException,
@@ -911,20 +920,30 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # Use test token for API readiness checks
         headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
 
-        for attempt in range(60):  # Up to 60 seconds additional wait
+        # Wall-clock-bound polling: ``range(60)`` would let a slow ``/api/``
+        # (5s HTTP timeout + 1s sleep ≈ up to 6s per iteration) stretch the
+        # 60-second budget to ~6 minutes. The monotonic-based cap enforces
+        # the declared 60-second window.
+        api_start = time.monotonic()
+        attempt = 0
+        while time.monotonic() - api_start < 60:
+            attempt += 1
             try:
                 response = requests.get(f"{base_url}/api/", timeout=5, headers=headers)
                 if response.status_code == 200:
+                    elapsed = int(time.monotonic() - api_start)
                     logger.info(
-                        f"🏠 Home Assistant API ready after {attempt + 1} additional attempts"
+                        f"🏠 Home Assistant API ready after {elapsed}s "
+                        f"({attempt} additional attempts)"
                     )
                     api_ready = True
                     break
             except requests.exceptions.RequestException:
-                if attempt == 0:
+                if attempt == 1:
                     logger.info("🔄 Waiting for Home Assistant API to become ready...")
-                if attempt % 15 == 0 and attempt > 0:
-                    logger.info(f"⏳ Still waiting... {attempt}/60 attempts")
+                if attempt > 1 and attempt % 15 == 0:
+                    elapsed = int(time.monotonic() - api_start)
+                    logger.info(f"⏳ Still waiting... {elapsed}s elapsed")
                 time.sleep(1)
 
         if not api_ready:
@@ -941,7 +960,11 @@ def ha_container_with_fresh_config(_blueprint_http_server):
 
         logger.info("⏳ Waiting for Home Assistant components to stabilize...")
         last_count = 0
-        for stabilize_attempt in range(STABILIZATION_TIMEOUT):
+        # Wall-clock-bound polling: ``range(STABILIZATION_TIMEOUT)`` would let
+        # a slow ``/api/config`` (2s HTTP timeout + 1s sleep ≈ up to 3s per
+        # iteration) stretch the effective wait to ~3× the declared budget.
+        stabilize_start = time.monotonic()
+        while time.monotonic() - stabilize_start < STABILIZATION_TIMEOUT:
             try:
                 config_resp = requests.get(
                     f"{base_url}/api/config", timeout=2, headers=headers
@@ -949,9 +972,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if config_resp.status_code == 200:
                     component_count = len(config_resp.json().get("components", []))
                     if component_count >= MIN_COMPONENTS:
+                        elapsed = int(time.monotonic() - stabilize_start)
                         logger.info(
                             f"✅ Home Assistant stabilized with {component_count} components "
-                            f"after {stabilize_attempt + 1}s"
+                            f"after {elapsed}s"
                         )
                         break
                     if component_count != last_count:
@@ -982,7 +1006,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         ENTITY_STABILIZATION_TIMEOUT = 30
         logger.info("⏳ Waiting for entities to register...")
         last_entity_count = 0
-        for entity_attempt in range(ENTITY_STABILIZATION_TIMEOUT):
+        # Wall-clock-bound polling — same rationale as the component-
+        # stabilization loop above.
+        entity_start = time.monotonic()
+        while time.monotonic() - entity_start < ENTITY_STABILIZATION_TIMEOUT:
             try:
                 states_resp = requests.get(
                     f"{base_url}/api/states",
@@ -992,9 +1019,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if states_resp.status_code == 200:
                     entity_count = len(states_resp.json())
                     if entity_count >= MIN_ENTITIES:
+                        elapsed = int(time.monotonic() - entity_start)
                         logger.info(
-                            f"✅ {entity_count} entities registered "
-                            f"after {entity_attempt + 1}s"
+                            f"✅ {entity_count} entities registered after {elapsed}s"
                         )
                         break
                     if entity_count != last_entity_count:
@@ -1022,7 +1049,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # sun.sun readiness is gated by the state check below.)
         INPUT_BOOLEAN_WAIT = 30
         logger.info("⏳ Waiting for input_boolean service domain to register...")
-        for svc_attempt in range(INPUT_BOOLEAN_WAIT):
+        # Wall-clock-bound polling — same rationale as the loops above.
+        ib_start = time.monotonic()
+        while time.monotonic() - ib_start < INPUT_BOOLEAN_WAIT:
             try:
                 svc_resp = requests.get(
                     f"{base_url}/api/services", timeout=5, headers=headers
@@ -1030,9 +1059,8 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if svc_resp.status_code == 200:
                     domains = {s.get("domain") for s in svc_resp.json()}
                     if "input_boolean" in domains:
-                        logger.info(
-                            f"✅ input_boolean service ready after {svc_attempt + 1}s"
-                        )
+                        elapsed = int(time.monotonic() - ib_start)
+                        logger.info(f"✅ input_boolean service ready after {elapsed}s")
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
                 logger.debug(f"Service check failed: {exc}")
@@ -1145,7 +1173,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # before the sun integration finishes its first calculation.
         SUN_WAIT = 30
         logger.info("⏳ Waiting for sun.sun to reach a known state...")
-        for sun_attempt in range(SUN_WAIT):
+        # Wall-clock-bound polling — same rationale as the loops above.
+        sun_start = time.monotonic()
+        while time.monotonic() - sun_start < SUN_WAIT:
             try:
                 sun_resp = requests.get(
                     f"{base_url}/api/states/sun.sun", timeout=5, headers=headers
@@ -1153,9 +1183,8 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if sun_resp.status_code == 200:
                     sun_state = sun_resp.json().get("state", "unknown")
                     if sun_state != "unknown":
-                        logger.info(
-                            f"✅ sun.sun is '{sun_state}' after {sun_attempt + 1}s"
-                        )
+                        elapsed = int(time.monotonic() - sun_start)
+                        logger.info(f"✅ sun.sun is '{sun_state}' after {elapsed}s")
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
                 logger.debug(f"sun.sun check failed: {exc}")

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -541,10 +541,12 @@ def _dump_ha_mcp_tools_diagnostics(
             logger.warning(
                 f"  /api/services: HTTP {svc_resp.status_code} {svc_resp.text[:200]}"
             )
-    except (
-        _requests.exceptions.RequestException,
-        json.JSONDecodeError,
-    ) as exc:
+    except Exception as exc:
+        # Broad catch by design: this is a diagnostic dump, and an
+        # unexpected exception class (e.g. SSL error subclass, unicode
+        # decode of an HTML 5xx body) should not abort the remaining
+        # captures below. The per-capture try/except scope ensures any
+        # single failure is logged without losing the others.
         logger.warning(f"  /api/services: request failed: {type(exc).__name__}: {exc}")
 
     # /api/config/config_entries/entry — surfaces the entry's state
@@ -579,10 +581,8 @@ def _dump_ha_mcp_tools_diagnostics(
             logger.warning(
                 f"  /api/config/config_entries: HTTP {entries_resp.status_code}"
             )
-    except (
-        _requests.exceptions.RequestException,
-        json.JSONDecodeError,
-    ) as exc:
+    except Exception as exc:
+        # Same broad-catch rationale as the /api/services dump above.
         logger.warning(
             f"  /api/config/config_entries: request failed: {type(exc).__name__}: {exc}"
         )


### PR DESCRIPTION
## What does this PR do?

Adds HA-side diagnostic dump + single-shot container-restart retry to the `HA_MCP_TOOLS_WAIT` timeout branch in `ha_container_with_fresh_config` (`tests/src/e2e/conftest.py`). Addresses the gap reported in #366 between #1208's silent-slip fix and the underlying ARM-flake it surfaces but does not mitigate. Design discussed in [#366 comment](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4428564451).

### Failure being addressed

- Run [25702631800](https://github.com/homeassistant-ai/ha-mcp/actions/runs/25702631800), attempt 1 (job [75465893019](https://github.com/homeassistant-ai/ha-mcp/actions/runs/25702631800/job/75465893019)) failed on `gw0` (PR #1259, ARM E2E) with `ha_mcp_tools services not registered after 180s`. Attempt 2 of the same run passed without any code change.
- 1 of the 20 most recent PR Validation runs (≈10 h window) needed a retry — the run above. Single observation; enough to characterise the failure as non-deterministic.
- The failure is exactly what the previous `pytest.fail` was designed to surface; the gap is that it was non-diagnosable (no HA-side context captured) and non-mitigated.

### Changes

Four new helpers in `conftest.py` plus a rewritten timeout branch:

- `_wait_for_ha_api_ready` and `_wait_for_ha_mcp_tools_services` extract the existing inline polling loops so the same wait contract can run twice on the retry path.
- `_dump_ha_mcp_tools_diagnostics` performs best-effort capture of `/api/services` (was `ha_mcp_tools` close to ready, or completely absent?), `/api/config/config_entries` entry state (`loaded` / `setup_retry` / `setup_error` / `not_loaded`), `docker logs --tail 100`, and container `exit_code` / `oom_killed` / `restart_count`. Logged at WARNING so CI artifacts keep the lines visible. Each capture has its own try/except so a single failure does not lose the others.
- `_restart_ha_container_for_retry` performs `docker stop` + `docker start` via the raw docker client. Port bindings survive stop+start (unlike `rm` + `run`), so `base_url` stays valid and testcontainers state does not need to be rebuilt.

Modified flow at the timeout branch:

1. First `_wait_for_ha_mcp_tools_services` (180s) expires.
2. `_dump_ha_mcp_tools_diagnostics(label="pre-retry")` runs.
3. `_restart_ha_container_for_retry` — fail-loud if the docker stop/start errors.
4. Reset in-process `ha_mcp.config._settings` and `websocket_manager._clients/._last_used/._current_loop` to clear stale references (matches the initial fixture setup; see Boy-Scout fix #1 below).
5. `_wait_for_ha_api_ready(60s)` — fail-loud with `post-retry-api-failed` dump if the API never returns.
6. Second `_wait_for_ha_mcp_tools_services` (180s, same budget as the first attempt).
7. Success → log `✅ ha_mcp_tools recovered after container restart` and continue. Failure → `_dump_ha_mcp_tools_diagnostics(label="post-retry")` → `pytest.fail` with both dumps referenced.

### Boy-Scout sweeps (Gemini-Code-Assist findings + dump-evidence-driven)

Substantive Gemini iterations and the diagnostic dump itself surfaced reachable cleanups. Boy-Scout-expanded each to the master-pre-existing siblings sharing the same defect class:

1. **`websocket_manager._client = None` is a no-op** (`3b83945`). The `WebSocketManager` class stores connections in `_clients: dict` and `_last_used: dict`; the singular `_client` attribute was never declared, so the prior assignment created a no-op attribute on the singleton without clearing the connection pool. Stale clients pointing at the pre-restart container URL would survive into the retry path. Fix: use `_clients.clear() + _last_used.clear() + _current_loop = None`. Applied at both sites — this PR's new retry-path reset and the master-pre-existing initial-fixture-setup reset that my code had mirrored when authoring.

2. **Broadened `_dump_ha_mcp_tools_diagnostics` HTTP catches to `except Exception`** (`0ad3474`). The function's docstring promises "each capture wrapped in its own try/except so a single failure does not lose the others"; the narrower `(RequestException, JSONDecodeError)` catch undercut that promise (e.g. SSL error subclass, unicode decode of HTML 5xx). The other catches in the function stay narrow: `(KeyError, AttributeError)` for dict introspect and the two `docker.errors.DockerException` catches are intentionally specific to the operation they wrap.

3. **All 7 polling loops in `conftest.py` converted from `range(TIMEOUT)` to wall-clock-bound** (`b3dce97`). `for X in range(TIMEOUT_CONSTANT)` lets a slow request (HTTP timeout 5s + sleep 1s ≈ several seconds per iteration) stretch the effective wait to a multiple of the declared budget — for `HA_MCP_TOOLS_WAIT = 180` the actual wait could reach ~18 minutes instead of 3. Seven sites converted: two of this PR's new helpers + five pre-existing master siblings (`STABILIZATION_TIMEOUT`, `ENTITY_STABILIZATION_TIMEOUT`, `INPUT_BOOLEAN_WAIT`, the inline API-ready loop in the fixture, `SUN_WAIT`).

4. **Inline API-ready loop replaced with `_wait_for_ha_api_ready` helper call** (`fefb7ce`). The new helper added by this PR was duplicating the existing inline loop; collapsing to a single call site removes 23 LOC and ensures initial-boot and post-restart-retry share one readiness contract.

5. **`_reset_ha_in_process_caches()` helper extracted** (`f85d597`). The `ha_mcp.config._settings = None` + `websocket_manager._clients.clear()` + `_last_used.clear()` + `_current_loop = None` sequence was duplicated at two sites (initial fixture setup + retry path); consolidated into one helper called from both. The class-attribute-correctness comment moves into the helper docstring instead of being duplicated.

6. **Defensive `ruamel.yaml` imports in `ha_mcp_tools/__init__.py`** (`cdcd4c2`). The diagnostic dump from this PR's first ARM E2E run surfaced exactly the `H_LOAD` hypothesis below as the real cause: the integration module imported `ruamel.yaml` unconditionally at module load time, even though `ruamel.yaml` is declared as a `manifest.json` requirement that Home Assistant installs only as part of the setup pipeline. On the ARM run the install lagged behind the first `importlib` resolution and `state=not_loaded` resulted. Two fixes applied: `YAMLError` import wrapped in `try/except ImportError` with `Exception` fallback (the four runtime `except YAMLError` clauses still catch correctly via the base class); and `from .yaml_rt import make_yaml, yaml_dumps` moved from module level into `_build_edit_yaml_config_handler` (invoked from `async_setup_entry`, by which time the install has reliably completed).

### Hypothesised root-cause classes the dump distinguishes

The PR does not diagnose the underlying flake — only puts the next CI artifact in a position to. Four plausible classes:

- **Import error in `custom_components/ha_mcp_tools`** — surfaces as a traceback in `docker logs --tail 100`. Deterministic; the retry will fail too with the second dump pinpointing the error.
- **Dependency-setup delay (e.g., `mcp_proxy`)** — surfaces as `state="setup_retry"` on the config entry + dependency-wait log lines. Non-deterministic; the retry will likely succeed.
- **Late event-driven registration** — surfaces as `state="loaded"` but `domains` missing `ha_mcp_tools` (entry up but service registration deferred to an event that did not fire). Non-deterministic; the retry will likely succeed.
- **Runner resource starvation** — surfaces as long gaps in `docker logs` timestamps + restart-retry succeeding on different timing. Non-deterministic.

### Trade-offs (accepted in #366 design discussion)

- **Slow-failure penalty:** when the timeout is truly unrecoverable, the test spends ~3 extra minutes on the second readiness sequence before failing.
- **Mitigation can mask deterministic bugs by greening flakes.** Bounded to a single retry; both dumps preserve the evidence trail.
- Does not change the 180s wait budget.
- No change on the success path — the new helpers replace inline loops with zero behavior change when the first wait succeeds.

### Testing approach

No unit tests in this PR. The helpers orchestrate Docker + HA together; the meaningful validation is end-to-end. Mock-based unit tests would only verify the mock-call contract — the same mocks I'd write are the ones the test would pass against. CI on ARM E2E is the natural validator:

- Success path is exercised by every existing E2E run on this PR (the new helpers replace inline loops 1:1 on the success path).
- Retry path will be exercised by the next ARM flake; the diagnostic dump will then either point to a deterministic cause or confirm the retry recovers.

The observed ARM flake rate (1 of 20 recent runs) gives this PR's own CI a non-trivial chance of triggering the retry path on its validation runs.

## Type of change
- [x] 🧪 Tests only

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit tests deliberately omitted — see "Testing approach" above. ruff check + format pass on `tests/src/e2e/conftest.py`. mypy on the file reports no new errors.

## Future improvements

Two follow-up issues filed from this PR:

- **#1266** — Project-level decision on exception-clause width in verification helpers. Surfaced by the broad-`except` re-pitches Gemini raised across six iterations on this PR; the resolution belongs at project level (style note or uniform sweep), not in this PR.
- **#1267** — Generalize `_dump_ha_mcp_tools_diagnostics` for the other readiness gates in `ha_container_with_fresh_config`. The diagnostic helper this PR introduces covers `ha_mcp_tools` only; the same diagnostic-poverty problem exists at `MIN_COMPONENTS` / `MIN_ENTITIES` / `INPUT_BOOLEAN_WAIT` / `SUN_WAIT` plus the API-readiness `pytest.fail`.

Conditional follow-ups (deferred until evidence from a CI dump arrives):

- Diagnose the underlying flake once the dump fires in CI. Follow-up issue or PR depending on which root-cause class is identified.
- WebSocket-based config-entry-state probe as an alternative to the REST `/api/services` poll. Worth investigating if the dumps show the REST endpoint reports the entry as `loaded` while the service is still missing.

## Checklist
- [x] I have updated documentation if needed



