### PR TITLE
refactor: drop obsolete ha_mcp_tools defensive ruamel.yaml imports (post-#1268)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -27,27 +27,7 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.helpers import config_validation as cv
-
-# Defensive imports: ``ruamel.yaml`` is declared in ``manifest.json``
-# ``requirements``, but the requirement install can lag behind the first
-# ``importlib`` resolution of this module — observed on PR #1262's ARM
-# E2E run where the module loaded before Home Assistant had installed
-# ``ruamel.yaml``, surfacing as ``ModuleNotFoundError: No module named
-# 'ruamel'`` and leaving the integration in ``state=not_loaded``.
-#
-# Two defensive shapes:
-#   * ``YAMLError`` falls back to ``Exception`` so the module loads past
-#     the import. The four ``except YAMLError`` clauses below still
-#     catch the real ``ruamel.yaml.YAMLError`` at runtime via its
-#     ``Exception`` base class.
-#   * ``make_yaml`` / ``yaml_dumps`` move to a lazy import inside
-#     ``_build_edit_yaml_config_handler`` (the only caller). By the time
-#     that function runs in ``async_setup_entry`` the requirement
-#     install has completed and ``ruamel.yaml`` is importable.
-try:
-    from ruamel.yaml import YAMLError
-except ImportError:  # pragma: no cover - early-import path only
-    YAMLError = Exception  # type: ignore[misc, assignment]
+from ruamel.yaml import YAMLError
 
 from .const import (
     ALLOWED_READ_DIRS,
@@ -60,6 +40,7 @@ from .const import (
     YAML_KEY_DEFAULT_POST_ACTION,
     YAML_KEY_POST_ACTIONS,
 )
+from .yaml_rt import make_yaml, yaml_dumps
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -334,13 +315,6 @@ def _build_edit_yaml_config_handler(hass):
     Extracted to module level so it can be tested without registering
     the full integration.
     """
-    # Lazy import: see the ``ruamel.yaml`` defensive-import comment at
-    # the top of this module. ``_build_edit_yaml_config_handler`` is
-    # invoked from ``async_setup_entry``, by which point Home Assistant
-    # has installed the ``manifest.json`` requirements (``ruamel.yaml``
-    # among them), so the import here is reliable.
-    from .yaml_rt import make_yaml, yaml_dumps
-
     config_dir = Path(hass.config.config_dir)
 
     async def handle_edit_yaml_config(call: ServiceCall) -> dict[str, Any]:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1103,11 +1103,12 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # container-restart retry path that originally sat here added a
         # ~3-minute slow-failure penalty (matching the second readiness
         # sequence) for negligible recovery value once the underlying
-        # H_LOAD class — the only flake-class observed live — was fixed by
-        # the ``ruamel`` defensive imports in
-        # ``custom_components/ha_mcp_tools/__init__.py``. Reintroduce a
-        # bounded retry only if a future dump surfaces a recoverable class
-        # (H_DEPS / H_LISTEN / H_RESOURCE) in the wild.
+        # H_LOAD class — the only flake-class observed live — was fixed
+        # structurally by pre-installing manifest ``requirements`` in
+        # the container entrypoint above (see
+        # ``_collect_manifest_requirements`` call site). Reintroduce a
+        # bounded retry only if a future dump surfaces a recoverable
+        # class (H_DEPS / H_LISTEN / H_RESOURCE) in the wild.
         HA_MCP_TOOLS_WAIT = 180  # session-level cap; covers slow CI runners
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():


### PR DESCRIPTION
## What does this PR do?

Drops the now-redundant `ruamel.yaml` defensive-import layer from `custom_components/ha_mcp_tools/__init__.py` that PR #1262 added on the hypothesis that `async_setup_entry` runs after HA has installed manifest `requirements`.

PR #1268's first ARM E2E run ([job 75569367373](https://github.com/homeassistant-ai/ha-mcp/actions/runs/25734951371/job/75569367373)) disproved that hypothesis — HA does **not** reliably install manifest requirements when the config entry is pre-injected via `.storage/core.config_entries` (the path `_install_custom_component` takes in the e2e fixture). The deeper import chain (`__init__.py:1120 async_setup_entry` → `:342 _build_edit_yaml_config_handler` → `yaml_rt.py:8 from ruamel.yaml import YAML`) still hit `ModuleNotFoundError` at setup-entry time, leaving the integration in `state=setup_error`.

PR #1268 fixed it structurally by pre-installing manifest requirements in the HA container's entrypoint before HA boots (e2e fixture only). For non-fixture deployments — HACS installs, manual installs — Home Assistant's normal manifest-requirement-install pipeline covers `ruamel.yaml` before module load.

With the structural fix in place:

- The `try/except ImportError → YAMLError = Exception` fallback is no longer reachable in practice.
- The function-scope `from .yaml_rt import make_yaml, yaml_dumps` inside `_build_edit_yaml_config_handler` had no real lazy-benefit — the function is called from `async_setup_entry`, so the import always ran at setup-time.
- The 16-line defensive-import comment block actively misleads future contributors by asserting an install-timing guarantee that #1268 disproved.

This PR:

- Replaces the `try/except` block with a plain `from ruamel.yaml import YAMLError` at module top.
- Moves the function-scope `from .yaml_rt import make_yaml, yaml_dumps` back to module top.
- Removes the 16-line defensive-import comment block.
- Updates the post-#1268 retry-drop rationale comment in `tests/src/e2e/conftest.py` to attribute the H_LOAD fix to the structural pre-install (`_collect_manifest_requirements`) rather than the now-obsolete defensive imports.

Net: 2 files changed, +8 / −33 LOC.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Coverage stays via `tests/src/unit/test_yaml_config_tool.py`, `test_yaml_roundtrip.py`, `test_yaml_dashboards.py`, and the e2e workflow at `tests/src/e2e/workflows/filesystem/test_yaml_config.py`.

## Future improvements

None specific to this PR.

## Checklist
- [x] I have updated documentation if needed
