### PR TITLE
test(e2e): narrow except clauses in e2e polling helpers (closes #1266)

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -38,6 +38,18 @@ Use best judgement - not all changes require new tests, but the overall feature/
 - E2E tests (preferred for tools): `tests/src/e2e/`
 - Unit tests (utilities): `tests/src/unit/`
 
+## Exception Handling in Test Polling Loops
+
+Boot-phase verification helpers and async polling loops in `tests/src/e2e/` use **narrow `except (Specific1, Specific2, ...)` clauses + debug-level logging** for expected transient failures. Catch only the exception classes the polling target legitimately raises — e.g. `(requests.exceptions.RequestException, json.JSONDecodeError)` for direct HTTP polling, or the `_POLLING_TRANSIENT_ERRORS` tuple in `tests/src/e2e/utilities/wait_helpers.py` for MCP-client polling.
+
+Bugs — `TypeError`, `AttributeError`, `KeyError`, `AssertionError`, etc. — **must propagate** out of polling loops so they surface as clear test failures instead of being swallowed and retried until timeout.
+
+**Do NOT flag:**
+- Narrow `except (SpecificException, ...)` in polling/retry loops paired with `logger.debug(...)` — this is the intentional convention.
+- Broad `except Exception` at top-level setup/teardown handlers or cleanup loops marked `# pragma: no cover - cleanup best-effort`, where recovery is the same regardless of error class.
+
+See issue #1266.
+
 ## Security Patterns
 
 **Critical security checks (flag HIGH/CRITICAL severity):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -749,6 +749,8 @@ data = await wait_for_tool_result(
 ```
 Other available helpers: `wait_for_entity_state()`, `wait_for_condition()`, `wait_for_state_change()`. See `wait_helpers.py` for the full set.
 
+**Exception handling in polling helpers.** `wait_helpers.py` catches a narrow `_POLLING_TRANSIENT_ERRORS` tuple (MCP / transport / runtime classes) inside retry loops; bugs like `TypeError` / `AttributeError` / `KeyError` propagate so they fail tests immediately with a clear stack trace. Don't broaden these to `except Exception` — see `.gemini/styleguide.md` → *Exception Handling in Test Polling Loops*.
+
 ## Release Process
 
 Uses [semantic-release](https://python-semantic-release.readthedocs.io/) with conventional commits.

--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -11,9 +11,25 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from fastmcp.exceptions import ClientError, FastMCPError
+from mcp import McpError
+
 from .assertions import parse_mcp_result
 
 logger = logging.getLogger(__name__)
+
+# Transient errors expected during async polling of MCP tools or HTTP endpoints.
+# Bugs (TypeError, AttributeError, KeyError, AssertionError, ...) MUST propagate
+# out of polling loops so they fail tests with a clear stack trace instead of
+# being swallowed and retried until timeout. See issue #1266.
+_POLLING_TRANSIENT_ERRORS = (
+    McpError,
+    FastMCPError,
+    ClientError,
+    RuntimeError,
+    OSError,
+    TimeoutError,
+)
 
 
 async def wait_for_entity_state(
@@ -61,7 +77,7 @@ async def wait_for_entity_state(
                     )
                     return True
 
-        except Exception as e:
+        except _POLLING_TRANSIENT_ERRORS as e:
             logger.debug(f"⚠️ Error checking state for {entity_id}: {e}")
 
         await asyncio.sleep(poll_interval)
@@ -119,7 +135,7 @@ async def wait_for_logbook_entry(
                         )
                         return True
 
-        except Exception as e:
+        except _POLLING_TRANSIENT_ERRORS as e:
             logger.debug(f"⚠️ Error checking logbook: {e}")
 
         await asyncio.sleep(poll_interval)
@@ -162,7 +178,7 @@ async def wait_for_condition(
                 elapsed = time.monotonic() - start_time
                 logger.info(f"✅ {condition_name} met after {elapsed:.1f}s")
                 return True
-        except Exception as e:
+        except _POLLING_TRANSIENT_ERRORS as e:
             logger.debug(f"⚠️ Error checking {condition_name}: {e}")
 
         await asyncio.sleep(poll_interval)
@@ -227,7 +243,7 @@ async def wait_for_state_change(
                     )
                     return current_state
 
-        except Exception as e:
+        except _POLLING_TRANSIENT_ERRORS as e:
             logger.debug(f"⚠️ Error checking state change for {entity_id}: {e}")
 
         await asyncio.sleep(poll_interval)
@@ -279,7 +295,7 @@ async def wait_for_tool_result(
         try:
             result = await mcp_client.call_tool(tool_name, arguments)
             last_data = parse_mcp_result(result)
-        except Exception as e:
+        except _POLLING_TRANSIENT_ERRORS as e:
             logger.debug(f"⚠️ Error calling {tool_name}: {e}")
             if time.monotonic() - start_time >= timeout:
                 raise TimeoutError(


### PR DESCRIPTION
## What does this PR do?

Resolves #1266 (part of the #366 e2e-quality train) by codifying the exception-handling convention for boot-phase polling loops in `tests/src/e2e/` and bringing `wait_helpers.py` into compliance with that convention.

- **`.gemini/styleguide.md`** — new section *Exception Handling in Test Polling Loops*. Documents narrow `except (SpecificException, ...)` + debug-level logging as the intentional convention for polling/retry helpers; tells Gemini Code Assist not to flag this on future PRs. Explicitly allows broad `except Exception` at top-level setup/teardown handlers and `# pragma: no cover - cleanup best-effort` cleanup loops.
- **`AGENTS.md`** — short cross-reference from the *Test Patterns* section pointing at the styleguide rule.
- **`tests/src/e2e/utilities/wait_helpers.py`** — converts the broad `except Exception` in 5 async polling loops to a narrow `_POLLING_TRANSIENT_ERRORS` tuple: `(McpError, FastMCPError, ClientError, RuntimeError, OSError, TimeoutError)`. Bugs (`TypeError`, `AttributeError`, `KeyError`, `AssertionError`, …) now propagate as clear test failures rather than being swallowed by the polling loop and retried until timeout. The initial-state-fetch handler in `wait_for_state_change` (single call, outside the polling loop) keeps its broad-except.

**Why `RuntimeError`/`OSError` are in the transient tuple:** FastMCP `Client.call_tool` raises `RuntimeError` for session-/transport-closed states (`fastmcp/client/client.py`); `OSError` covers the underlying socket/IO failures during async polling. Both are retry-eligible.

**Note on framing:** Issue #1266 lists Option A (document status quo) and Option B (broaden uniformly). This PR is Option A faithfully implemented — the styleguide codifies the narrow convention, and `wait_helpers.py` is brought into line with it. The issue body assumed `wait_helpers.py` already followed the narrow pattern; it did not, so the code change here is the compliance step that makes Option A's status-quo claim actually true.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local validation: 2382 unit tests pass, 1 skipped (`test_numpy_version_constraint.py` — numpy not installed on Alpine, by-design). `ruff check` clean on the changed file and on the full repo. Import-smoke confirms `_POLLING_TRANSIENT_ERRORS` resolves to six `BaseException` subclasses and all five `wait_for_*` helpers still load. E2E suite will run in CI.

## Future improvements

- `tests/src/e2e/workflows/scenes/test_lifecycle.py` has the same broad-except-in-polling-loop anti-pattern inside a `while time.monotonic() < timeout:` block. Same shape, different concern — a workflow test rather than a boot-phase fixture/helper. Out of scope for this PR; worth a follow-up sweep when next touching that file.

## Checklist
- [x] I have updated documentation if needed

