### PR TITLE
test(e2e): lower INPUT_BOOLEAN_WAIT from 30s to 10s (refs #366)

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1101,7 +1101,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # (sun is intentionally not polled here — it registers sun.sun as an
         # entity but never a service domain, so it would always time out.
         # sun.sun readiness is gated by the state check below.)
-        INPUT_BOOLEAN_WAIT = 30
+        INPUT_BOOLEAN_WAIT = 10
         logger.info("⏳ Waiting for input_boolean service domain to register...")
         # Wall-clock-bound polling — same rationale as the loops above.
         ib_start = time.monotonic()


### PR DESCRIPTION
## What does this PR do?

Lower `INPUT_BOOLEAN_WAIT` in `tests/src/e2e/conftest.py:1104` from 30s to 10s, addressing kingpanther13's "Lower SERVICE_WAIT from 30→10s" item on #366 ([Still on the list](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4423440909)).

**Symbol-name note:** the live constant is `INPUT_BOOLEAN_WAIT`, not `SERVICE_WAIT` (the colloquial label in the issue text). It was introduced after #1227 dropped `"sun"` from `REQUIRED_SERVICES`, leaving `input_boolean` as the only service-domain wait at this readiness gate.

10s preserves a 10× safety margin over the 1s observed-resolve KP13 cited. The timeout branch is **non-fatal** (`logger.warning` + `_dump_ha_readiness_diagnostics`, no `pytest.fail` at this gate), so a tighter budget cannot regress the suite: at worst a slow-boot run logs an earlier warning while downstream tests continue, and the `HA_MCP_TOOLS_WAIT` gate further down keeps its full 180s `pytest.fail`-backed budget for the surface that does block the run.

Sibling 30s constants in the same fixture are intentionally **not** touched:

* `STABILIZATION_TIMEOUT` (line 1007)
* `ENTITY_STABILIZATION_TIMEOUT` (line 1057)
* `SUN_WAIT` (line 1181) — state-readiness wait for the `sun.sun` entity, not a service-domain wait (different concern from the one KP13 scoped to SERVICE_WAIT).

Refs #366.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

KP13's same comment requests a broader **70+s session-init readiness gates audit** covering `MIN_COMPONENTS`, `MIN_ENTITIES`, `ENTITY_STABILIZATION_TIMEOUT`, etc. — kept out of scope here to keep this change reviewable as a single-constant tightening. Tracked as a follow-up against #366.

## Checklist
- [x] I have updated documentation if needed
