### PR TITLE
test(e2e): module-scope bulk_automations + bulk_scripts fixtures (refs #366)

### DIFF
--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -78,9 +78,14 @@ def _script_config(index: int) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 async def bulk_automations(mcp_client):
-    """Create a batch of test automations and tear them down after the test."""
+    """Create a batch of test automations once per module and tear them down after the module.
+
+    Module-scoped because every test in this file is read-only against the
+    created automations (search/list only; no modify/remove), so a single
+    setup amortises ~20s of fixture overhead per consuming test (refs #366).
+    """
     created_ids = []
 
     for i in range(_AUTOMATION_COUNT):
@@ -127,9 +132,13 @@ async def bulk_automations(mcp_client):
     logger.info(f"Cleaned up {len(created_ids)} bulk test automations")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 async def bulk_scripts(mcp_client):
-    """Create a batch of test scripts and tear them down after the test."""
+    """Create a batch of test scripts once per module and tear them down after the module.
+
+    Module-scoped for the same reason as ``bulk_automations`` above: every
+    consuming test in this file is read-only against the created scripts.
+    """
     created_ids = []
 
     for i in range(_SCRIPT_COUNT):


### PR DESCRIPTION
## What does this PR do?

Convert `bulk_automations` and `bulk_scripts` fixtures in `tests/src/e2e/tools/test_deep_search_bulk_fetch.py` from default function-scope to **module-scope**. Addresses kingpanther13's "Module-scope the bulk_automations / bulk_scripts fixtures" item on #366 ([Still on the list](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4423440909)).

**Why module-scope is safe here:** every consuming test in the file is read-only against the created entities — only `ha_deep_search` / `ha_list_states` calls, no `ha_config_set_*` / `ha_config_remove_*` on the fixture-owned entities. State-pollution risk between tests within the module is zero, and module-scope teardown still removes every created automation and script.

**Empirical baseline** from the latest master E2E run (job 75763307274, 2026-05-13):

| Test | Setup time |
|---|---|
| `test_bulk_fetch_completes_within_timeout` (both fixtures) | 31.51s |
| `test_bulk_fetch_finds_automation_by_config_content` | 20.41s |
| `test_bulk_fetch_result_structure_integrity` | 20.39s |
| `test_bulk_fetch_populates_config_for_multiple_results` | 20.38s |
| (+ four more bulk_automations consumers — same ~20s class) | |

With module-scope, each fixture fires once per module instead of once per consuming test. Expected wall-clock reclaim: **~110-140s per E2E run** — KP13's "~120s" estimate empirically verified, slightly conservative.

**Precedent**: `tests/src/e2e/tools/test_create_custom_tool.py` already uses bare `@pytest.fixture(scope="module")` on an async fixture under the repo's `asyncio_mode = "auto"` setting, so no `loop_scope` kwarg or `@pytest_asyncio.fixture` decorator is needed.

**Scope-dependency safety**: `mcp_client` is already session-scoped at `tests/src/e2e/conftest.py:1280`, wider than module — module-scoped consumers are valid by pytest.

Refs #366.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

Carve-out from KP13's same-list bonus item: **`asyncio.gather` for the serial automation creates inside `bulk_automations`**. With module-scope already in place, the fixture fires once per module, so the additional ~15s win from parallelising the 10 sequential `ha_config_set_automation` calls is marginal compared to the race-risk of concurrent HA `.storage` writes against `automations.yaml`. To be raised as its own feature-request issue with a dedicated race-verification plan before any implementation.

## Checklist
- [x] I have updated documentation if needed
