### PR TITLE
test(e2e): asyncio.gather bulk_*-fixture creates (refs #366)

### DIFF
--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -13,6 +13,7 @@ single-entity search correctness. These tests specifically validate:
   - Results include the config object (proving bulk fetch worked)
 """
 
+import asyncio
 import logging
 import time
 import uuid
@@ -88,11 +89,17 @@ async def bulk_automations(mcp_client):
     """
     created_ids = []
 
-    for i in range(_AUTOMATION_COUNT):
-        result = await mcp_client.call_tool(
+    # Parallelise the 10 sequential creates with asyncio.gather (refs #366).
+    # Order-preserving: gather returns results in submission order, so iterating
+    # with enumerate matches the i used to build each config.
+    results = await asyncio.gather(*[
+        mcp_client.call_tool(
             "ha_config_set_automation",
             {"config": _automation_config(i)},
         )
+        for i in range(_AUTOMATION_COUNT)
+    ])
+    for i, result in enumerate(results):
         data = assert_mcp_success(result, f"Create bulk automation {i}")
         # Use the actual entity_id returned by HA (handles conflicts with _2 suffix)
         entity_id = data.get("entity_id")
@@ -141,12 +148,18 @@ async def bulk_scripts(mcp_client):
     """
     created_ids = []
 
-    for i in range(_SCRIPT_COUNT):
-        script_id = f"{_MARKER}_script_{i}"
-        result = await mcp_client.call_tool(
+    # Parallelise the 5 sequential creates with asyncio.gather (refs #366).
+    # script_id is deterministic from i, so we can compute it inside the
+    # comprehension and re-derive in the post-loop iteration without race risk.
+    results = await asyncio.gather(*[
+        mcp_client.call_tool(
             "ha_config_set_script",
-            {"script_id": script_id, "config": _script_config(i)},
+            {"script_id": f"{_MARKER}_script_{i}", "config": _script_config(i)},
         )
+        for i in range(_SCRIPT_COUNT)
+    ])
+    for i, result in enumerate(results):
+        script_id = f"{_MARKER}_script_{i}"
         assert_mcp_success(result, f"Create bulk script {i}")
         created_ids.append(script_id)
         logger.info(f"Created script {i}/{_SCRIPT_COUNT}: {script_id}")

--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -33,6 +33,16 @@ _MARKER = f"bft{_RUN_ID}"
 _AUTOMATION_COUNT = 10
 _SCRIPT_COUNT = 5
 
+# Concurrency cap for the fixture-create gather (refs #366). Unbounded
+# asyncio.gather at _AUTOMATION_COUNT-wide reproducibly dropped 1-of-10
+# automations on both ubuntu-latest and ubuntu-24.04-arm (PR #1276 first
+# CI run, deterministic ``total_matches should be >= 10, got 9`` in
+# ``test_deep_search_pagination_basic``). Suspected HA-side
+# read-modify-write race on automation-config persistence — capping the
+# in-flight concurrency narrows the race window. N=2 is conservative;
+# if CI surfaces residual races at this level, fall back further.
+_CREATE_CONCURRENCY = 2
+
 
 def _automation_config(index: int) -> dict:
     """Build a test automation config with a unique, searchable token in the action."""
@@ -89,16 +99,20 @@ async def bulk_automations(mcp_client):
     """
     created_ids = []
 
-    # Parallelise the 10 sequential creates with asyncio.gather (refs #366).
-    # Order-preserving: gather returns results in submission order, so iterating
-    # with enumerate matches the i used to build each config.
-    results = await asyncio.gather(*[
-        mcp_client.call_tool(
-            "ha_config_set_automation",
-            {"config": _automation_config(i)},
-        )
-        for i in range(_AUTOMATION_COUNT)
-    ])
+    # Parallelise the 10 sequential creates with a Semaphore-bounded gather
+    # (refs #366). See ``_CREATE_CONCURRENCY`` above for the race rationale.
+    # Order-preserving: gather returns results in submission order, so
+    # iterating with enumerate matches the i used to build each config.
+    sem = asyncio.Semaphore(_CREATE_CONCURRENCY)
+
+    async def _create(i: int):
+        async with sem:
+            return await mcp_client.call_tool(
+                "ha_config_set_automation",
+                {"config": _automation_config(i)},
+            )
+
+    results = await asyncio.gather(*[_create(i) for i in range(_AUTOMATION_COUNT)])
     for i, result in enumerate(results):
         data = assert_mcp_success(result, f"Create bulk automation {i}")
         # Use the actual entity_id returned by HA (handles conflicts with _2 suffix)
@@ -148,16 +162,20 @@ async def bulk_scripts(mcp_client):
     """
     created_ids = []
 
-    # Parallelise the 5 sequential creates with asyncio.gather (refs #366).
-    # script_id is deterministic from i, so we can compute it inside the
-    # comprehension and re-derive in the post-loop iteration without race risk.
-    results = await asyncio.gather(*[
-        mcp_client.call_tool(
-            "ha_config_set_script",
-            {"script_id": f"{_MARKER}_script_{i}", "config": _script_config(i)},
-        )
-        for i in range(_SCRIPT_COUNT)
-    ])
+    # Parallelise the 5 sequential creates with a Semaphore-bounded gather
+    # (refs #366). Same race-mitigation as ``bulk_automations`` — see
+    # ``_CREATE_CONCURRENCY`` for the rationale. script_id is deterministic
+    # from i, so we re-derive it in the post-loop iteration.
+    sem = asyncio.Semaphore(_CREATE_CONCURRENCY)
+
+    async def _create(i: int):
+        async with sem:
+            return await mcp_client.call_tool(
+                "ha_config_set_script",
+                {"script_id": f"{_MARKER}_script_{i}", "config": _script_config(i)},
+            )
+
+    results = await asyncio.gather(*[_create(i) for i in range(_SCRIPT_COUNT)])
     for i, result in enumerate(results):
         script_id = f"{_MARKER}_script_{i}"
         assert_mcp_success(result, f"Create bulk script {i}")


### PR DESCRIPTION
## What does this PR do?

Replace the two sequential `for i in range(...): await mcp_client.call_tool(...)` create loops in `bulk_automations` (10 automations) and `bulk_scripts` (5 scripts) in `tests/src/e2e/tools/test_deep_search_bulk_fetch.py` with a single `asyncio.gather(*[...])` call each, followed by an order-preserving iteration over the results list.

This is the carve-out from #1275 — kingpanther13's bonus item on top of the module-scope landed there:

> "`asyncio.gather` for the serial automation creates inside `bulk_automations` (small additional win on top of the scope change)"
> — https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4423440909

**Correctness preservation:** `asyncio.gather` preserves submission order in its returned results list, so the post-create `enumerate(results)` iteration still matches the index `i` used to build each `_automation_config(i)` / `_script_config(i)` payload. The `_2`-suffix conflict-fallback (entity_id from HA's response over the predicted id) and per-result `assert_mcp_success` are preserved exactly as in the serial path.

**Race-surface honest disclosure:**

Concurrent `ha_config_set_automation` calls trigger concurrent HA-side `automations.yaml` writes and reload events. Whether HA's YAML-config writer serialises these internally (and whether 10-wide parallelism is safe in practice) is the empirical question left to CI on this PR:

- The downstream `wait_for_condition` in both fixtures already polls for all expected entities to be registered post-create. A partial race that drops an entity would surface as a fixture-setup timeout with the `condition_name` log line identifying the gap.
- Both `E2E Validation (ubuntu-latest)` and `E2E Validation (ubuntu-24.04-arm)` exercise the new path; passing both is the validation gate.
- If CI flakes, the fallback is `asyncio.Semaphore(N=3)` bounded gather (~80% of the win, much lower concurrency surface) — added as a follow-up commit on this PR rather than splitting it out.

Expected additional reclaim on top of #1275: ~15-18s per module setup (`bulk_automations` from ~20s to ~3-5s), translating to roughly the same number of seconds saved per E2E run since the fixture is now module-scoped.

Refs #366. Carve-out source: #1275 (squash-merged as `3cf008a`).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

If CI surfaces races at 10-wide parallelism, fall back to `asyncio.Semaphore(N=3)` bounded gather in the same PR before merge. Tracked against #366.

## Checklist
- [x] I have updated documentation if needed
