### PR TITLE
fix: HA Core proxy fallback for ha_get_logs(source=system_service) on non-addon installs

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -527,7 +527,7 @@ class HomeAssistantClient:
 
         - ``"addons/<slug>"`` for add-on container logs
         - ``"<service>"`` (where service ∈ {supervisor, host, core, dns, audio,
-          multicast, observer}) for system-service logs
+          cli, multicast, observer}) for system-service logs
 
         Bypasses ``HomeAssistantClient.httpx_client`` because the Supervisor
         endpoint uses a different base URL (``http://supervisor``) and a
@@ -647,11 +647,11 @@ class HomeAssistantClient:
     async def _get_system_service_logs(self, service: str) -> str:
         """Fetch HA system-service logs.
 
-        ``service`` must be one of the seven Supervisor-managed services:
-        ``supervisor``, ``host``, ``core``, ``dns``, ``audio``, ``multicast``,
-        ``observer``. Caller is responsible for validating ``service`` against
-        the allowed set; this helper does no validation and will raise
-        ``HomeAssistantAPIError`` on any unknown path (404).
+        ``service`` must be one of the eight Supervisor-managed services:
+        ``supervisor``, ``host``, ``core``, ``dns``, ``audio``, ``cli``,
+        ``multicast``, ``observer``. Caller is responsible for validating
+        ``service`` against the allowed set; this helper does no validation
+        and will raise ``HomeAssistantAPIError`` on any unknown path (404).
 
         Branch on ``is_running_in_addon()`` — mirror of ``get_addon_logs``:
         inside the addon container goes directly to Supervisor at

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -645,18 +645,42 @@ class HomeAssistantClient:
         return await self._supervisor_logs_get(f"addons/{slug}")
 
     async def _get_system_service_logs(self, service: str) -> str:
-        """Fetch HA system-service logs directly from Supervisor's REST API.
+        """Fetch HA system-service logs.
 
-        Hits ``http://supervisor/{service}/logs``. ``service`` must be one of
-        the seven Supervisor-managed services: ``supervisor``, ``host``,
-        ``core``, ``dns``, ``audio``, ``multicast``, ``observer``. Caller is
-        responsible for validating ``service`` against the allowed set; this
-        helper does no validation and will raise ``HomeAssistantAPIError`` on
-        any unknown path (404 from Supervisor).
+        ``service`` must be one of the seven Supervisor-managed services:
+        ``supervisor``, ``host``, ``core``, ``dns``, ``audio``, ``multicast``,
+        ``observer``. Caller is responsible for validating ``service`` against
+        the allowed set; this helper does no validation and will raise
+        ``HomeAssistantAPIError`` on any unknown path (404).
 
-        Requires ``hassio_role: manager`` like the addon-logs path.
+        Branch on ``is_running_in_addon()`` — mirror of ``get_addon_logs``:
+        inside the addon container goes directly to Supervisor at
+        ``http://supervisor/{service}/logs`` with the Supervisor token
+        (``hassio_role: manager`` required). On non-addon installs (Docker
+        without Supervisor, pyinstaller, pip pointing at a normal HA URL),
+        falls back to the HA Core proxy at ``/api/hassio/{service}/logs``.
+
+        All seven slugs are whitelisted in HA Core's hassio proxy
+        (``homeassistant/components/hassio/http.py`` — ``PATHS_ADMIN``), so
+        an admin LLA is sufficient to reach any of them from outside the
+        addon.
+
+        Closes #1260: pre-fix this method had only the addon-direct branch,
+        so non-addon installs (the Docker image, uvx ha-mcp, etc.) hit the
+        ``SUPERVISOR_TOKEN``-absent fail-fast in ``_supervisor_logs_get`` for
+        every service, while the sibling ``source="supervisor"`` (addon
+        logs) call kept working through its own Core-proxy fallback.
         """
-        return await self._supervisor_logs_get(service)
+        if is_running_in_addon():
+            return await self._supervisor_logs_get(service)
+
+        logger.debug(f"Fetching {service} logs via HA Core proxy")
+        response = await self._raw_request(
+            "GET",
+            f"/hassio/{service}/logs",
+            headers={"Accept": "text/plain"},
+        )
+        return response.text
 
     async def test_connection(self) -> tuple[bool, str | None]:
         """

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
 
+from .._version import is_running_in_addon
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
@@ -42,11 +43,12 @@ COMPACT_LOGBOOK_FIELDS = {
 }
 
 
-# Supervisor-managed system services exposed via /<slug>/logs. Stable set
-# in HA Core; if Supervisor adds e.g. /cli/logs in a future release, extend
-# here. See #1116.
+# Supervisor-managed system services exposed via /<slug>/logs. Set mirrors
+# HA Core's hassio HTTP proxy ``PATHS_ADMIN`` whitelist in
+# ``homeassistant/components/hassio/http.py``. See #1116 (original 7-service
+# scope) and #1260 (cli added — proxy supported it the whole time).
 SYSTEM_SERVICE_SLUGS = frozenset(
-    {"supervisor", "host", "core", "dns", "audio", "multicast", "observer"}
+    {"supervisor", "host", "core", "dns", "audio", "cli", "multicast", "observer"}
 )
 
 
@@ -145,7 +147,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - "error_log": Raw home-assistant.log text
         - "supervisor": Add-on container logs (requires slug = add-on slug)
         - "system_service": HA-Supervisor-managed system service logs (requires
-          slug ∈ {supervisor, host, core, dns, audio, multicast, observer})
+          slug ∈ {supervisor, host, core, dns, audio, cli, multicast, observer})
         - "logger": Effective log level per integration via logger/log_info (confirms logger.set_level changes took effect)
 
         **Shared params:** limit, search (keyword filter on entries/lines; matches integration domain for source='logger')
@@ -762,15 +764,29 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         except HomeAssistantAuthError as e:
             # Listed before HomeAssistantAPIError because AuthError is a sibling,
             # not a subclass — without this explicit clause the 401 from
-            # _supervisor_logs_get propagates raw to FastMCP and surfaces
-            # without a structured `code` field.
+            # _supervisor_logs_get / _raw_request propagates raw to FastMCP and
+            # surfaces without a structured `code` field.
+            #
+            # Suggestions branch on is_running_in_addon(): addon installs go
+            # direct to Supervisor (the failure mode is a missing/rotated
+            # SUPERVISOR_TOKEN), non-addon installs hit HA Core's hassio
+            # proxy with the user's LLA (the failure mode is a non-admin or
+            # expired LLA — SUPERVISOR_TOKEN doesn't even apply).
+            if is_running_in_addon():
+                suggestions = [
+                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
+                    "Reinstall the add-on if the token may have rotated",
+                ]
+            else:
+                suggestions = [
+                    "Verify HOMEASSISTANT_TOKEN is a valid admin Long-Lived "
+                    "Access Token (Settings → Profile → Long-Lived Access Tokens)",
+                    "Re-create the LLAT if it has expired or been revoked",
+                ]
             exception_to_structured_error(
                 e,
                 context={"source": "supervisor", "slug": slug},
-                suggestions=[
-                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
-                    "Reinstall the add-on if the token may have rotated",
-                ],
+                suggestions=suggestions,
             )
         except HomeAssistantAPIError as e:
             status = getattr(e, "status_code", None)
@@ -832,13 +848,15 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     ) -> dict[str, Any]:
         """Fetch HA system-service logs from Supervisor's per-service endpoint.
 
-        ``service`` ∈ {supervisor, host, core, dns, audio, multicast, observer}.
+        ``service`` ∈ ``SYSTEM_SERVICE_SLUGS`` (the eight Supervisor-managed
+        services: supervisor, host, core, dns, audio, cli, multicast, observer).
         Caller (``ha_get_logs(source='system_service')``) validates against
-        ``SYSTEM_SERVICE_SLUGS`` before dispatch. Hits
-        ``http://supervisor/<service>/logs`` directly via
-        ``HomeAssistantClient._get_system_service_logs`` — same direct-Supervisor
-        path #1116's add-on fix uses, just with a different URL prefix.
-        Requires ``hassio_role: manager`` in the addon manifest.
+        ``SYSTEM_SERVICE_SLUGS`` before dispatch. Routed through
+        ``HomeAssistantClient._get_system_service_logs`` which gates on
+        ``is_running_in_addon()``: addon installs hit Supervisor directly at
+        ``http://supervisor/<service>/logs`` (requires ``hassio_role: manager``
+        in the addon manifest), non-addon installs fall back to the HA Core
+        proxy at ``/api/hassio/<service>/logs`` (requires an admin LLA).
         """
         effective_limit = _coerce_limit(
             limit, default=DEFAULT_LOG_LIMIT, suggestion_example="100"
@@ -877,29 +895,53 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         except HomeAssistantAuthError as e:
             # Listed before HomeAssistantAPIError because AuthError is a sibling,
             # not a subclass — without this explicit clause the 401 from
-            # _supervisor_logs_get propagates raw to FastMCP and surfaces
-            # without a structured `code` field.
+            # _supervisor_logs_get / _raw_request propagates raw to FastMCP and
+            # surfaces without a structured `code` field.
+            #
+            # Suggestions branch on is_running_in_addon() (see _get_supervisor_log
+            # for the rationale): SUPERVISOR_TOKEN suggestions only make sense
+            # inside the addon container; non-addon installs need admin-LLA hints.
+            if is_running_in_addon():
+                suggestions = [
+                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
+                    "Reinstall the add-on if the token may have rotated",
+                ]
+            else:
+                suggestions = [
+                    "Verify HOMEASSISTANT_TOKEN is a valid admin Long-Lived "
+                    "Access Token (Settings → Profile → Long-Lived Access Tokens)",
+                    "Re-create the LLAT if it has expired or been revoked",
+                ]
             exception_to_structured_error(
                 e,
                 context={"source": "system_service", "slug": service},
-                suggestions=[
-                    "Verify SUPERVISOR_TOKEN is set correctly inside the add-on",
-                    "Reinstall the add-on if the token may have rotated",
-                ],
+                suggestions=suggestions,
             )
         except HomeAssistantAPIError as e:
             status = getattr(e, "status_code", None)
             if status == 403:
-                # Same role-too-low cause as the addon-logs branch.
-                exception_to_structured_error(
-                    e,
-                    context={"source": "system_service", "slug": service},
-                    suggestions=[
+                # In-addon: Supervisor returns 403 when the addon's hassio_role
+                # is below 'manager'. Non-addon: HA Core's hassio proxy returns
+                # 403 when the LLA's user lacks admin — completely different
+                # remediation. Branch on the gate accordingly.
+                if is_running_in_addon():
+                    suggestions = [
                         "Addon's hassio_role must be 'manager' or higher to "
                         "read /<service>/logs",
                         "Verify the addon was reinstalled after the role bump "
                         "took effect",
-                    ],
+                    ]
+                else:
+                    suggestions = [
+                        "The Long-Lived Access Token must belong to a user "
+                        "with admin privileges",
+                        "Generate a new LLAT under an admin account and set "
+                        "HOMEASSISTANT_TOKEN to it",
+                    ]
+                exception_to_structured_error(
+                    e,
+                    context={"source": "system_service", "slug": service},
+                    suggestions=suggestions,
                 )
             if status == 404:
                 exception_to_structured_error(

--- a/tests/src/e2e/utilities/supervisor_mock.py
+++ b/tests/src/e2e/utilities/supervisor_mock.py
@@ -20,7 +20,7 @@ the test event loop and can't deadlock against in-process MCP server work.
 Endpoints implemented (only what the code actually calls):
 
 - ``GET /{service}/logs`` for service ∈ {supervisor, host, core, dns, audio,
-  multicast, observer} — the seven Supervisor-managed system services
+  cli, multicast, observer} — the eight Supervisor-managed system services
 - ``GET /addons/{slug}/logs`` and ``GET /addons/self/logs`` — addon container logs
 - ``POST /addons/self/restart`` — addon self-restart (Supervisor envelope reply)
 
@@ -47,10 +47,10 @@ MOCK_SUPERVISOR_TOKEN = "test-supervisor-token"
 # need to exercise the role-mismatch branch added alongside #1116.
 MOCK_INSUFFICIENT_ROLE_TOKEN = "test-supervisor-token-low-role"
 
-# The seven Supervisor-managed system services exposed at /<service>/logs.
+# The eight Supervisor-managed system services exposed at /<service>/logs.
 # Mirrors SYSTEM_SERVICE_SLUGS in src/ha_mcp/tools/tools_utility.py.
 SYSTEM_SERVICES = frozenset(
-    {"supervisor", "host", "core", "dns", "audio", "multicast", "observer"}
+    {"supervisor", "host", "core", "dns", "audio", "cli", "multicast", "observer"}
 )
 
 _SERVICE_LOGS_RE = re.compile(r"^/([a-z]+)/logs$")

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -643,7 +643,9 @@ class TestGetSystemServiceLogsBranchSelection:
     Supervisor-direct branch, so non-addon installs (Docker image, uvx
     ha-mcp, etc.) fell straight through to the SUPERVISOR_TOKEN fail-fast
     in `_supervisor_logs_get` for every service slug. Pin both directions
-    so a future refactor of the gate doesn't silently regress either.
+    so a future refactor of the gate doesn't silently regress either,
+    plus a non-addon-branch error-path smoke test so the proxy delegation
+    doesn't accidentally swallow ``_raw_request``'s exception envelope.
     """
 
     @pytest.mark.parametrize(
@@ -659,6 +661,11 @@ class TestGetSystemServiceLogsBranchSelection:
         Supervisor service-log paths, so an admin LLA can reach any of them
         from outside the addon. Parametrize over the full set so a future
         proxy regression for a single slug surfaces here.
+
+        Also pins ``Accept: text/plain`` on the request: without it the HA
+        Core proxy negotiates ``application/json`` and the body stops being
+        raw log text — same silent-failure signature #950 describes one
+        layer up.
         """
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -670,8 +677,38 @@ class TestGetSystemServiceLogsBranchSelection:
 
         assert f"{service} via proxy" in result
         mock_client.httpx_client.request.assert_called_once()
-        args, _ = mock_client.httpx_client.request.call_args
+        args, kwargs = mock_client.httpx_client.request.call_args
         assert args[1] == f"/hassio/{service}/logs"
+        assert kwargs["headers"]["Accept"] == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_non_addon_install_404_raises_api_error_with_service_context(
+        self, mock_client
+    ):
+        """Proxy returns 404 → ``HomeAssistantAPIError(status_code=404)``.
+
+        Anchors the live "observer returned 404 on hubs that don't run it"
+        case from the #1260 end-to-end verification. ``_raw_request`` is
+        what raises (one layer down), but this test guards against a future
+        refactor wrapping the proxy call in a swallow-and-return-empty
+        try/except in ``_get_system_service_logs`` itself — which would
+        break the bug-report flow that depends on these exceptions.
+        Parallels ``TestGetAddonLogs.test_raises_api_error_on_404_with_slug_context``.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "service not available"
+        mock_response.json = MagicMock(side_effect=ValueError("not json"))
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("ha_mcp.client.rest_client.is_running_in_addon", return_value=False),
+            pytest.raises(HomeAssistantAPIError) as exc_info,
+        ):
+            await mock_client._get_system_service_logs("observer")
+
+        assert exc_info.value.status_code == 404
+        assert "service not available" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_addon_install_does_not_call_ha_core_proxy(self, mock_client):

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -7,10 +7,11 @@ Covers two REST-client paths and their tools_utility wrappers:
   `http://supervisor/addons/{slug}/logs` (the HA-Core proxy rejects the
   Supervisor token there — see #1116); otherwise falls back to
   `/api/hassio/addons/{slug}/logs` (returned as text/plain — see #950).
-- `HomeAssistantClient._get_system_service_logs()` — fetches HA-Supervisor
-  system-service logs at `http://supervisor/{service}/logs` for
-  service ∈ {supervisor, host, core, dns, audio, multicast, observer} (#1116
-  scope-add).
+- `HomeAssistantClient._get_system_service_logs()` — branches on
+  `is_running_in_addon()` like `get_addon_logs`: in-addon hits
+  `http://supervisor/{service}/logs`; non-addon falls back to the HA Core
+  proxy at `/api/hassio/{service}/logs` (#1260 fix on top of #1116 scope).
+  service ∈ {supervisor, host, core, dns, audio, cli, multicast, observer}.
 - The wrappers (`_get_supervisor_log`, `_get_system_service_log`) — response
   shape, tail slicing, search filter, slug-enum validation, and structured-
   error translation.
@@ -449,8 +450,8 @@ class TestGetAddonLogsViaSupervisor:
 
 class TestGetAddonLogsBranchSelection:
     """The branch decision is made via `is_running_in_addon()`. Pin both
-    directions so a future refactor of the gate (e.g. inlining the env-var
-    check) doesn't silently regress one branch.
+    directions so a future refactor of the gate (e.g. inlining the
+    ``SUPERVISOR_TOKEN`` env-var check) doesn't silently regress one branch.
     """
 
     @pytest.mark.asyncio
@@ -641,16 +642,17 @@ class TestGetSystemServiceLogsBranchSelection:
     """`_get_system_service_logs()` mirrors `get_addon_logs()`'s
     `is_running_in_addon()` branch. Pre-#1260 this method had only the
     Supervisor-direct branch, so non-addon installs (Docker image, uvx
-    ha-mcp, etc.) fell straight through to the SUPERVISOR_TOKEN fail-fast
-    in `_supervisor_logs_get` for every service slug. Pin both directions
-    so a future refactor of the gate doesn't silently regress either,
-    plus a non-addon-branch error-path smoke test so the proxy delegation
-    doesn't accidentally swallow ``_raw_request``'s exception envelope.
+    ``ha-mcp``, etc.) fell straight through to the ``SUPERVISOR_TOKEN``
+    fail-fast in ``_supervisor_logs_get`` for every service slug. Pin both
+    directions so a future refactor of the gate doesn't silently regress
+    either, plus a non-addon-branch error-path smoke test so the proxy
+    delegation doesn't accidentally swallow ``_raw_request``'s exception
+    envelope.
     """
 
     @pytest.mark.parametrize(
         "service",
-        ["supervisor", "host", "core", "dns", "audio", "multicast", "observer"],
+        ["supervisor", "host", "core", "dns", "audio", "cli", "multicast", "observer"],
     )
     @pytest.mark.asyncio
     async def test_non_addon_install_uses_ha_core_proxy(self, mock_client, service):
@@ -962,6 +964,60 @@ class TestGetSupervisorLogWrapper:
             f"Expected level/supervisor warning, got: {result['warnings']}"
         )
 
+    @pytest.mark.asyncio
+    async def test_auth_error_in_addon_suggests_supervisor_token(
+        self, client_with_logs
+    ):
+        """In-addon ``HomeAssistantAuthError`` on the addon-logs path → the
+        ``SUPERVISOR_TOKEN`` suggestion (the env var the Supervisor-direct
+        call site actually reads)."""
+        client_with_logs.get_addon_logs.side_effect = HomeAssistantAuthError(
+            "Invalid Supervisor token for /addons/core_mosquitto/logs"
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await tools["ha_get_logs"](source="supervisor", slug="core_mosquitto")
+
+        body = _parse_tool_error(exc_info)
+        suggestions = body["error"]["suggestions"]
+        assert any("SUPERVISOR_TOKEN" in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_auth_error_non_addon_suggests_admin_lla(
+        self, client_with_logs
+    ):
+        """Non-addon ``HomeAssistantAuthError`` on the addon-logs path
+        (Docker/uvx hitting ``/api/hassio/addons/{slug}/logs`` with a
+        bad/expired LLA) → admin-LLA suggestion, NOT the ``SUPERVISOR_TOKEN``
+        hint. Companion to the #1260 wrapper-message split on the
+        system_service source.
+        """
+        client_with_logs.get_addon_logs.side_effect = HomeAssistantAuthError(
+            "Invalid authentication token"
+        )
+        tools = _register_and_collect(client_with_logs)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=False,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await tools["ha_get_logs"](source="supervisor", slug="core_mosquitto")
+
+        body = _parse_tool_error(exc_info)
+        suggestions = body["error"]["suggestions"]
+        assert any("Long-Lived Access Token" in s for s in suggestions)
+        assert not any("SUPERVISOR_TOKEN" in s for s in suggestions)
+
 
 class TestSlugParameterIncompatibilityWarning:
     """`slug` only applies to `source='supervisor'` and `source='system_service'`.
@@ -1091,10 +1147,10 @@ class TestGetSystemServiceLogWrapper:
 
     @pytest.mark.parametrize(
         "service",
-        ["supervisor", "host", "core", "dns", "audio", "multicast", "observer"],
+        ["supervisor", "host", "core", "dns", "audio", "cli", "multicast", "observer"],
     )
     @pytest.mark.asyncio
-    async def test_all_seven_allowed_services_dispatch(
+    async def test_all_allowed_services_dispatch(
         self, client_with_system_logs, service
     ):
         """Every allowed service routes through to the client helper. Catches
@@ -1112,7 +1168,14 @@ class TestGetSystemServiceLogWrapper:
         )
 
     @pytest.mark.asyncio
-    async def test_403_role_hint_suggestion(self, client_with_system_logs):
+    async def test_403_in_addon_suggests_hassio_role(self, client_with_system_logs):
+        """In-addon branch (#1116): Supervisor returns 403 when ``hassio_role``
+        is below ``manager``. Suggestion must point at the role bump.
+
+        Mocks ``is_running_in_addon`` True explicitly — without the mock the
+        wrapper's branch defaults to the non-addon admin-LLA suggestion
+        (#1260's wrapper-message split) and this assertion would fail.
+        """
         client_with_system_logs._get_system_service_logs.side_effect = (
             HomeAssistantAPIError(
                 "Supervisor forbids /core/logs (403) — addon's hassio_role "
@@ -1123,12 +1186,104 @@ class TestGetSystemServiceLogWrapper:
         )
         tools = _register_and_collect(client_with_system_logs)
 
-        with pytest.raises(ToolError) as exc_info:
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
             await tools["ha_get_logs"](source="system_service", slug="core")
 
         body = _parse_tool_error(exc_info)
         suggestions = body["error"]["suggestions"]
         assert any("hassio_role" in s and "manager" in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_403_non_addon_suggests_admin_lla_privileges(
+        self, client_with_system_logs
+    ):
+        """Non-addon branch (#1260): HA Core's hassio proxy returns 403 when
+        the LLA's user lacks admin privileges — completely different
+        remediation from the addon's ``hassio_role`` case. Suggestion must
+        steer toward the admin-LLA fix, NOT the role bump.
+        """
+        client_with_system_logs._get_system_service_logs.side_effect = (
+            HomeAssistantAPIError(
+                "API error: 403 - Unauthorized",
+                status_code=403,
+                response_data={"message": "Unauthorized"},
+            )
+        )
+        tools = _register_and_collect(client_with_system_logs)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=False,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await tools["ha_get_logs"](source="system_service", slug="core")
+
+        body = _parse_tool_error(exc_info)
+        suggestions = body["error"]["suggestions"]
+        assert any("admin" in s.lower() for s in suggestions)
+        # Crucially: the role-bump suggestion that's appropriate inside the
+        # addon must NOT fire here — it would send a Docker/uvx user on a
+        # wild goose chase.
+        assert not any("hassio_role" in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_auth_error_in_addon_suggests_supervisor_token(
+        self, client_with_system_logs
+    ):
+        """In-addon AuthError → SUPERVISOR_TOKEN suggestion (the env var the
+        Supervisor-direct call site actually reads)."""
+        client_with_system_logs._get_system_service_logs.side_effect = (
+            HomeAssistantAuthError("Invalid Supervisor token for /core/logs")
+        )
+        tools = _register_and_collect(client_with_system_logs)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await tools["ha_get_logs"](source="system_service", slug="core")
+
+        body = _parse_tool_error(exc_info)
+        suggestions = body["error"]["suggestions"]
+        assert any("SUPERVISOR_TOKEN" in s for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_auth_error_non_addon_suggests_admin_lla(
+        self, client_with_system_logs
+    ):
+        """Non-addon AuthError (#1260) → admin-LLA suggestion. The
+        SUPERVISOR_TOKEN hint must NOT appear — Docker/uvx callers don't
+        have one, and pointing at it sends them looking in the wrong place.
+        """
+        client_with_system_logs._get_system_service_logs.side_effect = (
+            HomeAssistantAuthError("Invalid authentication token")
+        )
+        tools = _register_and_collect(client_with_system_logs)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_utility.is_running_in_addon",
+                return_value=False,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await tools["ha_get_logs"](source="system_service", slug="core")
+
+        body = _parse_tool_error(exc_info)
+        suggestions = body["error"]["suggestions"]
+        assert any("Long-Lived Access Token" in s for s in suggestions)
+        assert not any("SUPERVISOR_TOKEN" in s for s in suggestions)
 
     @pytest.mark.asyncio
     async def test_level_param_emits_warning_for_system_service_source(

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -637,6 +637,74 @@ class TestGetSystemServiceLogs:
         assert exc_info.value.status_code == 404
 
 
+class TestGetSystemServiceLogsBranchSelection:
+    """`_get_system_service_logs()` mirrors `get_addon_logs()`'s
+    `is_running_in_addon()` branch. Pre-#1260 this method had only the
+    Supervisor-direct branch, so non-addon installs (Docker image, uvx
+    ha-mcp, etc.) fell straight through to the SUPERVISOR_TOKEN fail-fast
+    in `_supervisor_logs_get` for every service slug. Pin both directions
+    so a future refactor of the gate doesn't silently regress either.
+    """
+
+    @pytest.mark.parametrize(
+        "service",
+        ["supervisor", "host", "core", "dns", "audio", "multicast", "observer"],
+    )
+    @pytest.mark.asyncio
+    async def test_non_addon_install_uses_ha_core_proxy(self, mock_client, service):
+        """`is_running_in_addon()` False → HA-Core-proxy path for every slug.
+
+        HA Core's hassio HTTP proxy (PATHS_ADMIN in
+        `homeassistant/components/hassio/http.py`) whitelists all seven
+        Supervisor service-log paths, so an admin LLA can reach any of them
+        from outside the addon. Parametrize over the full set so a future
+        proxy regression for a single slug surfaces here.
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = f"{service} via proxy\n"
+        mock_client.httpx_client.request = AsyncMock(return_value=mock_response)
+
+        with patch("ha_mcp.client.rest_client.is_running_in_addon", return_value=False):
+            result = await mock_client._get_system_service_logs(service)
+
+        assert f"{service} via proxy" in result
+        mock_client.httpx_client.request.assert_called_once()
+        args, _ = mock_client.httpx_client.request.call_args
+        assert args[1] == f"/hassio/{service}/logs"
+
+    @pytest.mark.asyncio
+    async def test_addon_install_does_not_call_ha_core_proxy(self, mock_client):
+        """`is_running_in_addon()` True → HA-Core-proxy path must be skipped.
+
+        URL/auth contract for the Supervisor-direct branch is pinned by
+        `TestGetSystemServiceLogs`; this test only verifies the gate
+        consultation.
+        """
+        inner_client = MagicMock()
+        inner_client.get = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+        inner_client.get.return_value = mock_response
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=inner_client)
+        cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "ha_mcp.client.rest_client.is_running_in_addon",
+                return_value=True,
+            ),
+            patch.dict("os.environ", {"SUPERVISOR_TOKEN": "supervisor-token-branch"}),
+            patch("httpx.AsyncClient", return_value=cm),
+        ):
+            await mock_client._get_system_service_logs("supervisor")
+
+        mock_client.httpx_client.request.assert_not_called()
+
+
 class TestRawRequestEmptyBodyFallback:
     """Error message must stay actionable even when the 4xx body is empty.
 


### PR DESCRIPTION
## What does this PR do?

Closes #1260. Adds the `is_running_in_addon()` gate plus HA Core proxy fallback to `_get_system_service_logs`, matching the pattern PR #1126 already established for `get_addon_logs` and (in round 3) `get_error_log`. Plus two follow-ons from the review pass that fix real behavior gaps the branch split exposes:

1. **Branch-aware error suggestions** in the tool-layer wrappers (`_get_supervisor_log`, `_get_system_service_log`). Pre-fix they always emitted "verify SUPERVISOR_TOKEN" / "hassio_role must be 'manager'" hints — useless advice on the new non-addon proxy path. The wrappers now gate on `is_running_in_addon()` and emit admin-LLA suggestions when the call came in via the HA Core proxy.
2. **Add `cli` to `SYSTEM_SERVICE_SLUGS`.** HA Core's hassio proxy already whitelists `cli/logs` in `PATHS_ADMIN`; ha-mcp's enum just didn't include it. Eight slugs total now.

### Background

Pre-#1126, `ha_get_logs(source="supervisor")` and `source="error_log"` both routed through HA Core's hassio proxy. #1126 added the `is_running_in_addon()` branch so addon installs go direct to Supervisor (`http://supervisor/...`), while non-addon installs (Docker image, `uvx ha-mcp`, pip-based) keep the Core-proxy fallback. The same PR introduced `source="system_service"` as a new scope but only wired up the addon-direct branch — `_get_system_service_logs` ended up a one-liner with no gate:

```python
async def _get_system_service_logs(self, service: str) -> str:
    return await self._supervisor_logs_get(service)
```

Result for non-addon installs: every `system_service` call (`supervisor`, `host`, `core`, `dns`, `audio`, `multicast`, `observer`) hit the `SUPERVISOR_TOKEN`-absent fail-fast inside `_supervisor_logs_get` with the misleading `(addon-mode gate fired but SUPERVISOR_TOKEN env var not set)` text — even though no addon-mode gate ever fired.

Reproduced on a `uvx ha-mcp` install pointed at a Supervisor-equipped HA: `source="supervisor"` slug=`core_mosquitto` succeeded; `source="system_service"` for `supervisor`/`core`/`host` all returned `AUTH_INVALID_TOKEN`. Identical to #1260's report.

### Fix

**1. Client-layer gate (`rest_client.py`):** Mirror `get_addon_logs`: gate on `is_running_in_addon()`, fall back to `/hassio/{service}/logs` via `_raw_request` (the same call shape `get_addon_logs` uses for `/hassio/addons/{slug}/logs`). All eight service slugs are reachable: HA Core's `homeassistant/components/hassio/http.py` lists `audio/logs`, `cli/logs`, `core/logs`, `dns/logs`, `host/logs`, `multicast/logs`, `observer/logs`, `supervisor/logs`, and `addons/{slug}/logs` in `PATHS_ADMIN`. Admin LLA is sufficient.

With the gate in place, the existing fail-fast string in `_supervisor_logs_get` is accurate again because the only callers landing there are addon-mode-confirmed.

**2. Branch-aware wrapper suggestions (`tools_utility.py`):** `_get_supervisor_log` and `_get_system_service_log` now check `is_running_in_addon()` on `HomeAssistantAuthError` (and on 403 for the system_service path) and pick suggestions matching the branch that produced the error:

| Branch | Error | Suggestions |
|---|---|---|
| In-addon | 401 | Verify `SUPERVISOR_TOKEN` / reinstall addon |
| Non-addon | 401 | Verify `HOMEASSISTANT_TOKEN` is a valid admin LLA / re-create if expired |
| In-addon | 403 (system_service) | Bump `hassio_role` to `manager` |
| Non-addon | 403 (system_service) | LLA must belong to an admin user / generate a new admin LLA |

This avoids steering Docker/uvx users toward `SUPERVISOR_TOKEN` or `hassio_role` — env-var and role concepts that don't apply outside the addon container.

**3. `cli` slug.** Added to `SYSTEM_SERVICE_SLUGS` (the in-addon validation set), to the supervisor-mock's mirrored set in `tests/src/e2e/utilities/supervisor_mock.py`, and to the dispatch and proxy-branch parametrized tests. Tool docstrings updated to mention the eight-slug set.

### Tests

`TestGetSystemServiceLogsBranchSelection` (new in this PR):

- `test_non_addon_install_uses_ha_core_proxy` — parametrized over all 8 slugs (post-cli-add), asserts the proxy URL is `/hassio/{service}/logs`, the `Accept: text/plain` header is passed (without it the proxy negotiates `application/json` and the body stops being raw log text — same silent-failure signature #950 describes one layer up), and the response text flows through.
- `test_non_addon_install_404_raises_api_error_with_service_context` — anchors the live "observer returns 404 on hubs that don't run it" case from the end-to-end verification. Guards against a future refactor wrapping the proxy call in a swallow-and-return-empty try/except in `_get_system_service_logs`. Parallels `TestGetAddonLogs.test_raises_api_error_on_404_with_slug_context`.
- `test_addon_install_does_not_call_ha_core_proxy` — gate-only assertion that addon installs skip the proxy path (URL/auth contract for the Supervisor-direct branch stays pinned by the existing `TestGetSystemServiceLogs` class).

Branch-aware-suggestion tests:

- `_get_supervisor_log`: `test_auth_error_in_addon_suggests_supervisor_token`, `test_auth_error_non_addon_suggests_admin_lla`
- `_get_system_service_log`: same two for AuthError, plus `test_403_in_addon_suggests_hassio_role` (renamed from `test_403_role_hint_suggestion` and now mocks the gate explicitly) and `test_403_non_addon_suggests_admin_lla_privileges`.

Existing `test_all_seven_allowed_services_dispatch` renamed to `test_all_allowed_services_dispatch` and extended over 8 slugs.

71 tests pass in `test_tools_utility_supervisor_logs.py` (was 63 pre-PR, 64 after first review-pass additions, 71 now). `uv run ruff check` clean on touched files.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature (`cli` added to `system_service` slug set)
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
  - Bug reproduced pre-fix on `uvx ha-mcp` (stable PyPI) pointed at a Supervisor-equipped HA: `source="system_service"` returned `AUTH_INVALID_TOKEN` for `supervisor`/`core`/`host` while `source="supervisor"` succeeded. Matches issue #1260's report exactly.
  - Post-fix verified end-to-end against the same hub via `uv run --with "git+...@fix/system-service-logs-non-addon-fallback" python <script>` calling `_get_system_service_logs` for seven of the eight slugs. Six return content (or expected-empty for `audio`/`multicast`); `observer` returns 404 — same 404 the in-addon Supervisor-direct path produces on the same hub, confirming code-path parity rather than a proxy gap. (`cli` not exercised live; its path is covered by the unit tests and HA Core's `PATHS_ADMIN` source.)
- [x] All automated tests pass (`uv run pytest tests/src/unit/test_tools_utility_supervisor_logs.py` — 71 passed. Full unit run on Windows shows only pre-existing OS-specific failures in `test_kill_signal_diagnostics.py`, `test_custom_component_filesystem.py`, `test_data_paths.py` that reproduce on clean master.)
- [x] Code follows style guidelines (`uv run ruff check` clean on touched files)

## Checklist
- [x] I have updated documentation if needed _(tool docstring + client docstring + e2e mock docstring updated to reflect the 8-slug set and the gate split; site/src/data/tools.json regeneration is owned by sync-tool-docs.yml on merge)_

Closes #1260
