### PR TITLE
fix(array_patch): tighten validation and surface silent failures

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1136,6 +1136,9 @@ def _apply_array_ops(
                     )
                 )
             if not patches:
+                # `target.update({})` is a no-op; reject so the caller learns
+                # their op was meaningless rather than seeing a silent
+                # `summary["patched"]` entry with `"fields": []`.
                 raise_tool_error(
                     create_validation_error(
                         f"array_patch patch op #{index} 'patches' cannot be empty "
@@ -1257,9 +1260,14 @@ def _apply_array_ops(
             entry: dict[str, Any] = {"field": field, "value": value, "count": removed}
             # Distinguish "value not present" from "field name unknown to any
             # item" — the latter is almost always a typo and would otherwise
-            # be a silent count=0.
-            if removed == 0 and not any(
-                isinstance(it, dict) and field in it for it in working
+            # be a silent count=0. Only warn when there are dict items to
+            # inspect; an empty array or all-non-dict array would `not any(...)`
+            # trivially and produce a misleading typo suggestion.
+            inspectable = [it for it in working if isinstance(it, dict)]
+            if (
+                removed == 0
+                and inspectable
+                and not any(field in it for it in inspectable)
             ):
                 entry["warning"] = (
                     f"field {field!r} is not present on any item — "

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1135,6 +1135,14 @@ def _apply_array_ops(
                         parameter=f"array_patch.operations[{index}].patches",
                     )
                 )
+            if not patches:
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch patch op #{index} 'patches' cannot be empty "
+                        "(no fields to update)",
+                        parameter=f"array_patch.operations[{index}].patches",
+                    )
+                )
             target = next(
                 (
                     it
@@ -1197,6 +1205,17 @@ def _apply_array_ops(
                     )
                 )
             new_id = new_item[id_field]
+            if new_id is None or new_id == "":
+                # Items missing the id field have `dict.get(id_field) == None`
+                # by default, so allowing None/"" ids would let later patch /
+                # delete ops match unrelated items.
+                raise_tool_error(
+                    create_validation_error(
+                        f"array_patch add op #{index} item {id_field!r} cannot be "
+                        "None or an empty string",
+                        parameter=f"array_patch.operations[{index}].item.{id_field}",
+                    )
+                )
             if any(
                 isinstance(it, dict) and it.get(id_field) == new_id for it in working
             ):
@@ -1235,9 +1254,18 @@ def _apply_array_ops(
                 if not (isinstance(it, dict) and it.get(field) == value)
             ]
             removed = before - len(working)
-            summary["deleted_where"].append(
-                {"field": field, "value": value, "count": removed}
-            )
+            entry: dict[str, Any] = {"field": field, "value": value, "count": removed}
+            # Distinguish "value not present" from "field name unknown to any
+            # item" — the latter is almost always a typo and would otherwise
+            # be a silent count=0.
+            if removed == 0 and not any(
+                isinstance(it, dict) and field in it for it in working
+            ):
+                entry["warning"] = (
+                    f"field {field!r} is not present on any item — "
+                    "check for a typo in the field name"
+                )
+            summary["deleted_where"].append(entry)
 
     return working, summary
 
@@ -1830,9 +1858,9 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                     "Proxy/array-patch mode: extra HTTP headers to send to the addon API. "
                     "Useful for addon-specific requirements such as Node-RED's "
                     "`Node-RED-Deployment-Type: full`. The proxy's internal framing "
-                    "(`X-Ingress-Path`, `X-Hass-Source`, `Content-Type`) is layered on "
-                    "top, so caller-supplied values for those keys are overridden. "
-                    "Not valid in config mode."
+                    "(`X-Ingress-Path`, `X-Hass-Source`, `Cookie`, `Content-Type`) is "
+                    "layered on top, so caller-supplied values for those keys are "
+                    "overridden. Not valid in config or websocket mode."
                 ),
                 default=None,
             ),
@@ -2048,6 +2076,19 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                         parameter="array_patch.operations",
                     )
                 )
+
+        # request_headers applies only to HTTP / array_patch mode.
+        # _call_addon_ws does not accept caller headers — reject the combo
+        # rather than silently dropping them (matches the fail-loud-on-misroute
+        # pattern used for message_limit / message_offset / summarize on HTTP).
+        if request_headers is not None and websocket:
+            raise_tool_error(
+                create_validation_error(
+                    "request_headers applies only to HTTP and array_patch modes; "
+                    "remove it or set websocket=False",
+                    parameter="request_headers",
+                )
+            )
 
         # Config mode: update Supervisor settings
         if config_data:

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -145,6 +145,34 @@ class TestApplyArrayOps:
         assert entry["count"] == 0
         assert "warning" not in entry
 
+    def test_delete_where_against_empty_array_no_warning(self):
+        """Empty input array is not a typo signal — there are no items to
+        check. Without this guard, `any(... for [])` is False and the typo
+        warning would fire unconditionally."""
+        new, summary = _apply_array_ops(
+            [],
+            [{"op": "delete_where", "field": "z", "value": "tab1"}],
+            id_field="id",
+        )
+        assert new == []
+        entry = summary["deleted_where"][0]
+        assert entry["count"] == 0
+        assert "warning" not in entry
+
+    def test_delete_where_against_non_dict_items_no_warning(self):
+        """Arrays of scalars (or other non-dict items) are not a typo signal
+        either — `field in it` is meaningless for non-dicts, so suggesting
+        a typo would be misleading."""
+        new, summary = _apply_array_ops(
+            [1, 2, "x"],
+            [{"op": "delete_where", "field": "z", "value": "tab1"}],
+            id_field="id",
+        )
+        assert new == [1, 2, "x"]
+        entry = summary["deleted_where"][0]
+        assert entry["count"] == 0
+        assert "warning" not in entry
+
     def test_delete_where_zero_matches_is_not_an_error(self):
         items = self._flows_fixture()
         new, summary = _apply_array_ops(
@@ -264,6 +292,16 @@ class TestApplyArrayOpsValidation:
                 [], [{"op": "add", "item": {"id": None, "type": "x"}}], id_field="id"
             )
         assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_add_with_integer_zero_id_is_accepted(self):
+        """The check uses `is None or == ""` (not `not new_id`) so falsy
+        but valid ids like 0 / 0.0 / False are accepted. Pin this down so
+        a future refactor to `if not new_id:` doesn't silently regress."""
+        new, summary = _apply_array_ops(
+            [], [{"op": "add", "item": {"id": 0, "type": "x"}}], id_field="id"
+        )
+        assert summary["added"] == [{"id": 0}]
+        assert new == [{"id": 0, "type": "x"}]
 
     def test_patch_with_empty_patches_raises(self):
         """Empty `patches` is a silent no-op — reject up-front so the caller

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -114,6 +114,37 @@ class TestApplyArrayOps:
         assert {it["id"] for it in new} == {"tab1", "tab2", "n3"}
         assert summary["deleted_where"] == [{"field": "z", "value": "tab1", "count": 2}]
 
+    def test_delete_where_field_absent_on_all_items_emits_warning(self):
+        """count=0 with a misspelled or unknown field is the silent-failure
+        case — distinguish it from "field exists, value didn't match" by
+        attaching a warning to the summary entry. Doesn't raise (preserves
+        the deliberate best-effort semantics of delete_where)."""
+        items = [{"id": "a"}, {"id": "b"}]
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "delete_where", "field": "zzz_misspelled", "value": "tab1"}],
+            id_field="id",
+        )
+        assert new == items
+        entry = summary["deleted_where"][0]
+        assert entry["count"] == 0
+        assert "warning" in entry
+        assert "zzz_misspelled" in entry["warning"]
+
+    def test_delete_where_field_present_but_no_match_no_warning(self):
+        """count=0 when the field exists on items but no value matched is
+        not the silent-failure case — no warning, just count=0."""
+        items = [{"id": "a", "z": "tab9"}, {"id": "b", "z": "tab9"}]
+        new, summary = _apply_array_ops(
+            items,
+            [{"op": "delete_where", "field": "z", "value": "tab1"}],
+            id_field="id",
+        )
+        assert new == items
+        entry = summary["deleted_where"][0]
+        assert entry["count"] == 0
+        assert "warning" not in entry
+
     def test_delete_where_zero_matches_is_not_an_error(self):
         items = self._flows_fixture()
         new, summary = _apply_array_ops(
@@ -214,6 +245,35 @@ class TestApplyArrayOpsValidation:
     def test_add_missing_id_field_raises(self):
         with pytest.raises(ToolError) as exc:
             _apply_array_ops([], [{"op": "add", "item": {"type": "x"}}], id_field="id")
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_add_with_empty_string_id_raises(self):
+        """`id_field not in item` only checks key presence, not value validity.
+        Empty-string ids enable cross-contamination with items that legitimately
+        lack the id field (`dict.get(id_field)` returns `None`/`""`)."""
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [], [{"op": "add", "item": {"id": "", "type": "x"}}], id_field="id"
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_add_with_none_id_raises(self):
+        """Same rationale as empty-string: `id` cannot be None."""
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [], [{"op": "add", "item": {"id": None, "type": "x"}}], id_field="id"
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
+
+    def test_patch_with_empty_patches_raises(self):
+        """Empty `patches` is a silent no-op — reject up-front so the caller
+        knows their op was meaningless."""
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [{"id": "a"}],
+                [{"op": "patch", "id": "a", "patches": {}}],
+                id_field="id",
+            )
         assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
 
     def test_delete_where_with_explicit_none_value_is_allowed(self):
@@ -588,6 +648,22 @@ class TestHaManageAddonRequestHeaders:
         assert len(captured_headers) == 2
         assert captured_headers[0] == {"Node-RED-Deployment-Type": "full"}
         assert captured_headers[1] == {"Node-RED-Deployment-Type": "full"}
+
+    @pytest.mark.asyncio
+    async def test_request_headers_rejected_with_websocket(self, _registered_tool):
+        """`_call_addon_ws` doesn't accept caller headers. Without an explicit
+        rejection, request_headers would be silently dropped in WebSocket mode
+        — inconsistent with the existing fail-loud-on-misroute pattern (e.g.
+        message_limit rejection on HTTP)."""
+        with pytest.raises(ToolError) as exc:
+            await _registered_tool(
+                slug="a0d7b954_nodered",
+                path="/logs",
+                websocket=True,
+                request_headers={"X-Custom": "v"},
+            )
+        err = _parse_tool_error(exc)
+        assert err["error"]["code"] == "VALIDATION_FAILED"
 
     @pytest.mark.asyncio
     async def test_request_headers_rejected_in_config_mode(self, _registered_tool):


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1063. Addresses five polish items found during live-testing of the new `array_patch` mode against Node-RED `/flows`.

**Validation tightening in `_apply_array_ops`:**

1. `add` op rejects items whose id field is `None` or empty string. Only key-presence was checked previously; allowing `None`/`""` ids enables silent cross-contamination because `dict.get(id_field)` returns `None` for items that legitimately lack the field, so a later `patch id=None` could match the wrong item.

2. `patch` op rejects empty `patches: {}`. Previously a silent no-op (summary showed `"fields": []` but no error).

**Better signal on `delete_where`:**

3. `delete_where` with `count: 0` now attaches a `warning` to the summary entry when the field is not present on any item — distinguishes a typo from "value didn't match." Best-effort semantics preserved (still success, no exception). I confirmed the silent-typo case live during PR #1063 testing.

**Dispatcher:**

4. `request_headers` is rejected when combined with `websocket=True`. `_call_addon_ws` doesn't accept caller headers; previously dropped silently. Matches the existing fail-loud pattern for `message_limit` / `message_offset` / `summarize` on HTTP.

**Documentation:**

5. The `request_headers` Field description now includes `Cookie` in the framing-overrides list (implementation already overrides it via the ingress-session merge).

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] Code follows style guidelines (`uv run ruff check`)

6 new unit tests in `test_tools_addons_array_patch.py`. Existing `test_delete_where_zero_matches_is_not_an_error` continues to pass — the new warning attaches to the summary entry; the success/count=0 contract is unchanged.

## Future improvements

None — all 5 items addressed in this PR.