### PR TITLE
docs: clarify setup wizard placeholders need braces removed

### DIFF
--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -657,7 +657,7 @@ const remoteOnlyClients = ['chatgpt', 'claude-ai'];
 
         <!-- Environment Variables -->
         <div class="bg-amber-900/20 border border-amber-700/50 rounded-xl p-4 mb-6">
-          <h3 class="font-medium text-amber-300 mb-2">Replace these values:</h3>
+          <h3 class="font-medium text-amber-300 mb-2">Replace these placeholders (delete the surrounding <code class="bg-amber-900/30 px-1 rounded">{{ }}</code> braces too):</h3>
           <ul class="text-sm text-amber-200/80 space-y-1" id="replace-hints">
             <!-- Filled by JS -->
           </ul>
@@ -2271,20 +2271,20 @@ Authorization = "Bearer YOUR_TOKEN"</pre>
     if (isStdio || derivedDeployment === 'uvx' || derivedDeployment === 'docker') {
       // Docker-specific URL hint
       if (isDocker) {
-        hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_URL}}</code> → Use <code>http://host.docker.internal:8123</code> if Home Assistant runs on your host machine</li>`);
+        hints.push(`<li>Replace <code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_URL}}</code> (braces and all) with <code>http://host.docker.internal:8123</code> if Home Assistant runs on your host machine</li>`);
       } else {
-        hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_URL}}</code> → Your Home Assistant URL (e.g., http://homeassistant.local:8123)</li>`);
+        hints.push(`<li>Replace <code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_URL}}</code> (braces and all) with your Home Assistant URL (e.g., <code>http://homeassistant.local:8123</code>)</li>`);
       }
-      hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_TOKEN}}</code> → Your long-lived access token</li>`);
+      hints.push(`<li>Replace <code class="bg-amber-900/30 px-1 rounded">{{HOMEASSISTANT_TOKEN}}</code> (braces and all) with your long-lived access token</li>`);
     }
     if (isRemote && (derivedDeployment === 'uvx' || derivedDeployment === 'docker') && state.proxy !== 'webhook-proxy') {
-      hints.push(`<li><code class="bg-red-900/30 px-1 rounded text-red-300">{{RANDOM_STRING}}</code> → A random secret string (e.g., <code>abc123xyz</code>) - <strong class="text-red-400">keep this private!</strong></li>`);
+      hints.push(`<li>Replace <code class="bg-red-900/30 px-1 rounded text-red-300">{{RANDOM_STRING}}</code> (braces and all) with a random secret string (e.g., <code>abc123xyz</code>) — <strong class="text-red-400">keep this private!</strong></li>`);
     }
     if (!isStdio) {
       const urlHint = state.proxy === 'webhook-proxy'
-        ? 'Your webhook proxy URL (from the webhook proxy add-on logs)'
-        : 'Your MCP server URL (from deployment step above)';
-      hints.push(`<li><code class="bg-amber-900/30 px-1 rounded">{{MCP_SERVER_URL}}</code> → ${urlHint}</li>`);
+        ? 'your webhook proxy URL (from the webhook proxy add-on logs)'
+        : 'your MCP server URL (from deployment step above)';
+      hints.push(`<li>Replace <code class="bg-amber-900/30 px-1 rounded">{{MCP_SERVER_URL}}</code> (braces and all) with ${urlHint}</li>`);
     }
     hintsEl.innerHTML = hints.join('');
 


### PR DESCRIPTION
## What does this PR do?

Updates the "Replace these placeholders" callout in the setup wizard (`site/src/pages/setup.astro`) to make it explicit that the surrounding `{{ }}` mustache braces must be deleted along with the placeholder text — not just the inner token. Both the section heading and each per-line hint now spell out "(braces and all)" so users don't end up pasting values like `{{http://192.168.1.111:8123/}}` into their config.

Closes #1284.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Future improvements

<!-- none -->

## Checklist
- [ ] I have updated documentation if needed