### PR TITLE
fix: allow str.replace in python_transform; hint at search mode on IndexError

### DIFF
--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1097,18 +1097,17 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     transformed_config = safe_execute(python_transform, current_config)
                 except PythonSandboxError as e:
                     message, suggestions = format_sandbox_error(e, python_transform)
-                    # Runtime IndexError/KeyError almost always means the agent
-                    # constructed a path that doesn't match the actual dashboard
-                    # shape (wrong view, missing sections wrapper, etc). Point
-                    # them at search mode so the next attempt uses a verified
-                    # jq_path instead of guessing indices.
-                    if isinstance(e, PythonSandboxExecutionError) and (
-                        "IndexError" in str(e) or "KeyError" in str(e)
+                    # A path-shape mismatch (IndexError/KeyError) is almost always
+                    # a hallucinated path; steer the retry toward search mode so
+                    # the next transform is built from a verified jq_path.
+                    if isinstance(e, PythonSandboxExecutionError) and isinstance(
+                        e.__cause__, (IndexError, KeyError)
                     ):
                         suggestions = [
-                            "Use ha_config_get_dashboard(url_path=..., card_type=...) "
-                            "or (entity_id=...) to get the verified jq_path, then "
-                            "build python_transform from that path",
+                            "Call ha_config_get_dashboard with card_type=..., "
+                            "entity_id=..., or heading=... to get the verified "
+                            "jq_path for the target card, then build "
+                            "python_transform from that path",
                             *suggestions,
                         ]
                     raise_tool_error(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -16,6 +16,7 @@ from ..errors import ErrorCode, create_error_response, create_resource_not_found
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
     PythonSandboxError,
+    PythonSandboxExecutionError,
     format_sandbox_error,
     get_security_documentation,
     safe_execute,
@@ -1096,6 +1097,20 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     transformed_config = safe_execute(python_transform, current_config)
                 except PythonSandboxError as e:
                     message, suggestions = format_sandbox_error(e, python_transform)
+                    # Runtime IndexError/KeyError almost always means the agent
+                    # constructed a path that doesn't match the actual dashboard
+                    # shape (wrong view, missing sections wrapper, etc). Point
+                    # them at search mode so the next attempt uses a verified
+                    # jq_path instead of guessing indices.
+                    if isinstance(e, PythonSandboxExecutionError) and (
+                        "IndexError" in str(e) or "KeyError" in str(e)
+                    ):
+                        suggestions = [
+                            "Use ha_config_get_dashboard(url_path=..., card_type=...) "
+                            "or (entity_id=...) to get the verified jq_path, then "
+                            "build python_transform from that path",
+                            *suggestions,
+                        ]
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -192,6 +192,7 @@ SAFE_METHODS = {
     "strip",
     "split",
     "join",
+    "replace",
 }
 
 # Blocked function names
@@ -514,7 +515,7 @@ PYTHON TRANSFORM SECURITY:
 - Dict unpacking (**) in calls and dict literals: {**d, 'k': v}
 - Keyword arguments: func(key=value)
 - Lambdas (e.g. for `key=`): sorted(items, key=lambda x: x['score'])
-- String methods: startswith, endswith, lower, upper, split, join
+- String methods: startswith, endswith, lower, upper, strip, split, join, replace
 - Safe builtins: isinstance, len, range, enumerate, zip, sorted, reversed,
   min, max, sum, abs, any, all, round, str, int, float, bool, list, dict,
   tuple, set

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -358,3 +358,92 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
 
     assert isinstance(read1["config_hash"], str) and len(read1["config_hash"]) == 16
     assert read1["config_hash"] == read2["config_hash"]
+
+
+@pytest.mark.asyncio
+async def test_python_transform_replace_string_method(mcp_client, ha_client):
+    """Issue #1279: str.replace() is allowed inside python_transform.
+
+    A weaker agent hit ``Forbidden method: replace`` while sanitizing a
+    markdown card. ``replace`` is now whitelisted alongside other pure
+    string methods (``split``/``join``/``strip``).
+    """
+    mcp = MCPAssertions(mcp_client)
+
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-replace",
+            "config": {
+                "views": [
+                    {
+                        "cards": [
+                            {"type": "markdown", "content": "a\\b\\c"},
+                        ]
+                    }
+                ]
+            },
+        },
+    )
+
+    get_result = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-python-replace"}
+    )
+
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-replace",
+            "config_hash": get_result["config_hash"],
+            "python_transform": (
+                "card = config['views'][0]['cards'][0]\n"
+                "card['content'] = card['content'].replace('\\\\', '')"
+            ),
+        },
+    )
+
+    verify = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-python-replace"}
+    )
+    assert verify["config"]["views"][0]["cards"][0]["content"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_python_transform_index_error_hints_at_search_mode(mcp_client, ha_client):
+    """Issue #1279: IndexError from a bad path nudges the agent toward search mode.
+
+    Weaker models hallucinate dashboard structure and construct paths like
+    ``config['views'][3]['sections'][0]...`` against a single-view dashboard.
+    The IndexError is correct tool behavior, but the failure message should
+    point the agent at ``ha_config_get_dashboard(card_type=...)`` so the
+    retry uses a verified jq_path.
+    """
+    mcp = MCPAssertions(mcp_client)
+
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-bad-index",
+            "config": {"views": [{"cards": [{"type": "markdown", "content": "x"}]}]},
+        },
+    )
+
+    get_result = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-python-bad-index"}
+    )
+
+    result = await mcp.call_tool_failure(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-bad-index",
+            "config_hash": get_result["config_hash"],
+            "python_transform": "config['views'][3]['cards'][0]['type'] = 'tile'",
+        },
+    )
+
+    error = result["error"] if isinstance(result["error"], dict) else {}
+    suggestions = error.get("suggestions", [])
+    joined = " ".join(suggestions)
+    assert "jq_path" in joined or "ha_config_get_dashboard" in joined, (
+        f"Expected dashboard search-mode hint in suggestions, got: {suggestions}"
+    )

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -362,12 +362,7 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
 
 @pytest.mark.asyncio
 async def test_python_transform_replace_string_method(mcp_client, ha_client):
-    """Issue #1279: str.replace() is allowed inside python_transform.
-
-    A weaker agent hit ``Forbidden method: replace`` while sanitizing a
-    markdown card. ``replace`` is now whitelisted alongside other pure
-    string methods (``split``/``join``/``strip``).
-    """
+    """``str.replace`` works inside ``python_transform``."""
     mcp = MCPAssertions(mcp_client)
 
     await mcp.call_tool_success(
@@ -408,16 +403,14 @@ async def test_python_transform_replace_string_method(mcp_client, ha_client):
     assert verify["config"]["views"][0]["cards"][0]["content"] == "abc"
 
 
+def _hint_suggestions(result: dict) -> list[str]:
+    error = result["error"] if isinstance(result["error"], dict) else {}
+    return list(error.get("suggestions", []))
+
+
 @pytest.mark.asyncio
 async def test_python_transform_index_error_hints_at_search_mode(mcp_client, ha_client):
-    """Issue #1279: IndexError from a bad path nudges the agent toward search mode.
-
-    Weaker models hallucinate dashboard structure and construct paths like
-    ``config['views'][3]['sections'][0]...`` against a single-view dashboard.
-    The IndexError is correct tool behavior, but the failure message should
-    point the agent at ``ha_config_get_dashboard(card_type=...)`` so the
-    retry uses a verified jq_path.
-    """
+    """IndexError from a bad path surfaces the search-mode hint first."""
     mcp = MCPAssertions(mcp_client)
 
     await mcp.call_tool_success(
@@ -441,9 +434,78 @@ async def test_python_transform_index_error_hints_at_search_mode(mcp_client, ha_
         },
     )
 
-    error = result["error"] if isinstance(result["error"], dict) else {}
-    suggestions = error.get("suggestions", [])
+    suggestions = _hint_suggestions(result)
+    assert suggestions, "expected suggestions in error response"
+    assert "card_type" in suggestions[0] and "jq_path" in suggestions[0], (
+        f"Expected search-mode hint as first suggestion, got: {suggestions}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_python_transform_key_error_hints_at_search_mode(mcp_client, ha_client):
+    """KeyError from a missing dict key also surfaces the search-mode hint."""
+    mcp = MCPAssertions(mcp_client)
+
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-bad-key",
+            "config": {"views": [{"cards": [{"type": "markdown", "content": "x"}]}]},
+        },
+    )
+
+    get_result = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-python-bad-key"}
+    )
+
+    result = await mcp.call_tool_failure(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-bad-key",
+            "config_hash": get_result["config_hash"],
+            # 'sections' doesn't exist on this view — KeyError, not IndexError.
+            "python_transform": "config['views'][0]['sections'][0]['cards'][0]['type'] = 'tile'",
+        },
+    )
+
+    suggestions = _hint_suggestions(result)
+    assert suggestions, "expected suggestions in error response"
+    assert "card_type" in suggestions[0] and "jq_path" in suggestions[0], (
+        f"Expected search-mode hint as first suggestion, got: {suggestions}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_python_transform_unrelated_runtime_error_no_search_hint(
+    mcp_client, ha_client
+):
+    """A non-path runtime error (TypeError) must not get the dashboard hint."""
+    mcp = MCPAssertions(mcp_client)
+
+    await mcp.call_tool_success(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-type-error",
+            "config": {"views": [{"cards": [{"type": "markdown", "content": "x"}]}]},
+        },
+    )
+
+    get_result = await mcp.call_tool_success(
+        "ha_config_get_dashboard", {"url_path": "test-python-type-error"}
+    )
+
+    result = await mcp.call_tool_failure(
+        "ha_config_set_dashboard",
+        {
+            "url_path": "test-python-type-error",
+            "config_hash": get_result["config_hash"],
+            # str + int is a TypeError at runtime.
+            "python_transform": "config['views'][0]['title'] = 'x' + 1",
+        },
+    )
+
+    suggestions = _hint_suggestions(result)
     joined = " ".join(suggestions)
-    assert "jq_path" in joined or "ha_config_get_dashboard" in joined, (
-        f"Expected dashboard search-mode hint in suggestions, got: {suggestions}"
+    assert "card_type" not in joined, (
+        f"Unrelated TypeError should not get the search-mode hint, got: {suggestions}"
     )

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -431,6 +431,33 @@ class TestBlockedOperations:
         assert "Call" in error
 
 
+class TestStringMethods1279:
+    """Regression tests for issue #1279 — str.replace() missing from whitelist.
+
+    A weaker agent (Gemini flash) hit ``Forbidden method: replace`` while
+    sanitizing a markdown card. ``replace`` is a pure, side-effect-free
+    string method on par with ``split``/``join``/``strip`` (already
+    allowed), so its omission was an oversight rather than a deliberate
+    block. These pin the gap shut.
+    """
+
+    def test_replace_validates(self):
+        valid, error = validate_expression(
+            "config['views'][0]['cards'][0]['content'] = "
+            "config['views'][0]['cards'][0]['content'].replace('\\\\', '')"
+        )
+        assert valid is True, error
+
+    def test_replace_executes(self):
+        config = {"views": [{"cards": [{"content": "a\\b\\c"}]}]}
+        expr = (
+            "config['views'][0]['cards'][0]['content'] = "
+            "config['views'][0]['cards'][0]['content'].replace('\\\\', '')"
+        )
+        result = safe_execute(expr, config)
+        assert result["views"][0]["cards"][0]["content"] == "abc"
+
+
 class TestSafeExecute:
     """Test safe execution of expressions."""
 

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -431,15 +431,8 @@ class TestBlockedOperations:
         assert "Call" in error
 
 
-class TestStringMethods1279:
-    """Regression tests for issue #1279 — str.replace() missing from whitelist.
-
-    A weaker agent (Gemini flash) hit ``Forbidden method: replace`` while
-    sanitizing a markdown card. ``replace`` is a pure, side-effect-free
-    string method on par with ``split``/``join``/``strip`` (already
-    allowed), so its omission was an oversight rather than a deliberate
-    block. These pin the gap shut.
-    """
+class TestReplaceMethod:
+    """``str.replace`` is in the safe whitelist — pure, side-effect-free."""
 
     def test_replace_validates(self):
         valid, error = validate_expression(


### PR DESCRIPTION
## What does this PR do?

Fixes #1279 (both reported errors):

1. **Allow `str.replace()` in `python_transform`.** It was missing from the
   sandbox method whitelist alongside `split`/`join`/`strip`/`lower` (all pure
   string methods, same category). Agents hit `Forbidden method: replace`
   trying to do basic string sanitization on card content — the reporter's
   exact failure.

2. **Nudge agents toward search mode when a transform raises IndexError /
   KeyError.** The underlying exception is correct — the agent built a path
   (`config['views'][3]['sections'][0]...`) that doesn't match the actual
   dashboard shape. Weaker models retry blindly. The new suggestion points
   them at `ha_config_get_dashboard(card_type=..., entity_id=...)` so the
   next attempt uses a verified `jq_path` instead of guessing indices.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None.

## Checklist
- [x] I have updated documentation if needed