### PR TITLE
fix: exit on HA container death + daily reset before CI check

### DIFF
--- a/tests/lab-setup/README.md
+++ b/tests/lab-setup/README.md
@@ -37,7 +37,7 @@ The setup script is **idempotent** (safe to re-run) and performs:
 3. **Docker** — Via official get.docker.com script
 4. **uv** — Python package manager for running ha-mcp
 5. **ha-mcp repo** — Clones to `~/ha-mcp` (or pulls if it already exists)
-6. **Systemd service** — Creates `hamcp-demo.service` (starts on boot, restarts on failure) and `hamcp-demo-update.timer` (daily at 3am: git pull, docker image prune, service restart)
+6. **Systemd service** — Creates `hamcp-demo.service` (starts on boot, exits+restarts if HA container dies) and two timers: `hamcp-demo-reset.timer` (daily at 19:00 UTC: fresh HA restart, 2h before nightly CI check) and `hamcp-demo-update.timer` (daily at 03:00 UTC: git pull, docker image prune, service restart)
 7. **Caddy** — Reverse proxy with automatic Let's Encrypt TLS for your domain
 8. **Unattended upgrades** — Auto-updates OS packages, reboots at 4am if needed
 9. **Container cleanup** — Removes stale HA containers and any leaked processes
@@ -65,9 +65,13 @@ sudo systemctl restart hamcp-demo
 # Live logs
 sudo journalctl -u hamcp-demo -f
 
-# Weekly update timer — next run and last result
+# Daily update timer (03:00 UTC) — next run and last result
 sudo systemctl list-timers hamcp-demo-update.timer
 sudo journalctl -u hamcp-demo-update --no-pager -n 20
+
+# Daily reset timer (19:00 UTC) — next run and last result
+sudo systemctl list-timers hamcp-demo-reset.timer
+sudo journalctl -u hamcp-demo-reset --no-pager -n 10
 ```
 
 ## Logs

--- a/tests/lab-setup/setup-ha-mcp.sh
+++ b/tests/lab-setup/setup-ha-mcp.sh
@@ -129,11 +129,36 @@ SVCEOF
 
 cat > /etc/systemd/system/hamcp-demo-update.timer << SVCEOF
 [Unit]
-Description=HA-MCP Demo Weekly Update Timer
+Description=HA-MCP Demo Daily Update Timer
 
 [Timer]
-OnCalendar=*-*-* 03:00:00
+OnCalendar=*-*-* 03:00:00 UTC
 AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+SVCEOF
+
+# Daily reset at 19:00 UTC — 2 hours before the CI check-demo-env workflow (21:00 UTC).
+# Restarts the service so HA comes up fresh for the nightly health check.
+cat > /etc/systemd/system/hamcp-demo-reset.service << SVCEOF
+[Unit]
+Description=HA-MCP Demo Daily Reset
+After=hamcp-demo.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl restart hamcp-demo
+SVCEOF
+
+cat > /etc/systemd/system/hamcp-demo-reset.timer << SVCEOF
+[Unit]
+Description=HA-MCP Demo Daily Reset Timer
+
+[Timer]
+OnCalendar=*-*-* 19:00:00 UTC
+AccuracySec=5m
 Persistent=true
 
 [Install]
@@ -147,6 +172,8 @@ systemctl daemon-reload
 systemctl enable hamcp-demo.service
 systemctl enable hamcp-demo-update.timer
 systemctl start hamcp-demo-update.timer
+systemctl enable hamcp-demo-reset.timer
+systemctl start hamcp-demo-reset.timer
 
 #=============================================================================
 # 7. CADDY

--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -319,6 +319,9 @@ def main():
                             sys.exit(1)
             except KeyboardInterrupt:
                 logger.info("\n🛑 Received interrupt signal")
+            except (OSError, RuntimeError) as e:
+                logger.error(f"❌ Watchdog failure: {e}, exiting for restart...")
+                sys.exit(1)
         else:
             # Interactive menu loop
             while True:

--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -302,11 +302,21 @@ def main():
         env.print_status()
 
         if args.no_interactive:
-            # Non-interactive mode: just wait for interrupt
+            # Non-interactive mode: wait for interrupt, and exit if the container dies
+            # so systemd's Restart=on-failure kicks in with a fresh instance.
             logger.info("🔄 Running in non-interactive mode. Press Ctrl+C to stop.")
             try:
                 while True:
-                    time.sleep(1)
+                    time.sleep(30)
+                    if env.container:
+                        wrapped = env.container.get_wrapped_container()
+                        wrapped.reload()
+                        if wrapped.status not in ("running",):
+                            logger.error(
+                                f"❌ Container stopped unexpectedly "
+                                f"(status: {wrapped.status}), exiting for restart..."
+                            )
+                            sys.exit(1)
             except KeyboardInterrupt:
                 logger.info("\n🛑 Received interrupt signal")
         else:

--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -17,6 +17,7 @@ import sys
 import time
 from pathlib import Path
 
+import docker.errors
 import requests
 from testcontainers.core.container import DockerContainer
 
@@ -319,7 +320,7 @@ def main():
                             sys.exit(1)
             except KeyboardInterrupt:
                 logger.info("\n🛑 Received interrupt signal")
-            except (OSError, RuntimeError) as e:
+            except (OSError, RuntimeError, docker.errors.DockerException) as e:
                 logger.error(f"❌ Watchdog failure: {e}, exiting for restart...")
                 sys.exit(1)
         else:


### PR DESCRIPTION
## Summary

- **`test_env_manager.py`**: In `--no-interactive` mode, poll the container status every 30s. When the container exits unexpectedly, the process exits with code 1 so systemd's `Restart=on-failure` fires and brings up a fresh HA instance. Previously the Python process would keep running indefinitely after the container died, leaving the demo unreachable until a manual restart.

- **`setup-ha-mcp.sh`**: Add `hamcp-demo-reset.timer` — fires daily at **19:00 UTC** (2 hours before the `check-demo-env` CI workflow at 21:00 UTC) and restarts `hamcp-demo` with a clean HA image. The update timer (`hamcp-demo-update.timer`, git pull + prune) stays at **03:00 UTC**. Both timers now use explicit `UTC` in `OnCalendar=` to be timezone-unambiguous.

- **`README.md`**: Document the new reset timer and update the service description.

## Root cause of last outage (2026-05-14)

HA's demo `media_player` raised `NotImplementedError` on a `media_seek` call → HA restarted internally then exited cleanly (exit 0) at 20:19 UTC. `hamcp-test-env` had no container-death detection, so it kept sleeping. systemd saw the process alive and never restarted. Demo was down for ~3h until the CI failure was noticed.

## Test plan

- [ ] Deploy to demo server and verify `hamcp-demo-reset.timer` is enabled
- [ ] Verify `check-demo-env` CI passes at 21:00 UTC
- [ ] Manually stop the HA container and confirm `hamcp-test-env` exits → systemd restarts within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)