### PR TITLE
fix: align ha_config_set_dashboard with sibling re-fetch-after-save pattern (#1291)

### DIFF
--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -21,7 +21,12 @@ from ..utils.python_sandbox import (
     get_security_documentation,
     safe_execute,
 )
-from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
+from .helpers import (
+    exception_to_structured_error,
+    extract_tool_error_message,
+    log_tool_usage,
+    raise_tool_error,
+)
 from .util_helpers import parse_json_param
 
 logger = logging.getLogger(__name__)
@@ -1085,14 +1090,14 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 # specific UX suggestions so the caller learns this branch
                 # requires an existing dashboard.
                 try:
-                    current_config, current_hash = (
-                        await _get_dashboard_config_internal(client, url_path)
+                    current_config, current_hash = await _get_dashboard_config_internal(
+                        client, url_path
                     )
                 except ToolError as e:
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
-                            f"Dashboard not found or inaccessible: {e}",
+                            f"Dashboard not found or inaccessible: {extract_tool_error_message(e)}",
                             suggestions=[
                                 "python_transform requires an existing dashboard",
                                 "Use 'config' parameter to create a new dashboard",
@@ -1349,18 +1354,25 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     # skip of both the optimistic-locking check and the
                     # large-config soft warning, matching the prior
                     # silently-fall-through behaviour.
+                    # Distinct names from the python_transform branch's
+                    # ``current_config``/``current_hash`` so the optional
+                    # type here doesn't redefine the non-optional binding
+                    # mypy infers there.
+                    existing_config: dict[str, Any] | None = None
+                    existing_hash: str | None = None
                     try:
-                        current_config, current_hash = (
-                            await _get_dashboard_config_internal(client, url_path)
-                        )
+                        (
+                            existing_config,
+                            existing_hash,
+                        ) = await _get_dashboard_config_internal(client, url_path)
                     except ToolError:
-                        current_config, current_hash = None, None
+                        pass
 
-                    if isinstance(current_config, dict):
-                        existing_config_size = len(json.dumps(current_config))
+                    if isinstance(existing_config, dict):
+                        existing_config_size = len(json.dumps(existing_config))
 
                         # Optional config_hash validation for full replacement
-                        if config_hash is not None and current_hash != config_hash:
+                        if config_hash is not None and existing_hash != config_hash:
                             raise_tool_error(
                                 create_error_response(
                                     ErrorCode.SERVICE_CALL_FAILED,

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -27,6 +27,57 @@ from .util_helpers import parse_json_param
 logger = logging.getLogger(__name__)
 
 
+async def _get_dashboard_config_internal(
+    client: Any, url_path: str | None
+) -> tuple[dict[str, Any], str]:
+    """Fetch dashboard config from HA and compute its hash.
+
+    Returns ``(config, config_hash)`` tuple where ``config`` is the
+    authoritative Lovelace config dict returned by HA's ``lovelace/config``
+    WebSocket call (with ``force=True`` to bypass any cache) and
+    ``config_hash`` is computed from that config via ``compute_config_hash``.
+
+    Used internally to obtain the authoritative post-save hash and as the
+    fetch+hash building block for the optimistic-locking pre-read paths.
+    Mirrors the ``_get_<entity>_config_internal`` helpers in the sibling
+    files (``tools_config_scripts.py``, ``tools_config_automations.py``,
+    ``tools_config_scenes.py``).
+
+    Raises ``ToolError`` with ``ErrorCode.SERVICE_CALL_FAILED`` if the
+    WebSocket call reports failure or the response is not a dict; callers
+    can rely on the returned tuple being populated.
+    """
+    get_data: dict[str, Any] = {"type": "lovelace/config", "force": True}
+    if url_path:
+        get_data["url_path"] = url_path
+
+    response = await client.send_websocket_message(get_data)
+
+    if isinstance(response, dict) and not response.get("success", True):
+        error_msg = response.get("error", {})
+        if isinstance(error_msg, dict):
+            error_msg = error_msg.get("message", str(error_msg))
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                f"Dashboard fetch failed: {error_msg}",
+                context={"url_path": url_path},
+            )
+        )
+
+    config = response.get("result") if isinstance(response, dict) else response
+    if not isinstance(config, dict):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Dashboard config response was not a dict",
+                context={"url_path": url_path},
+            )
+        )
+
+    return cast(dict[str, Any], config), compute_config_hash(config)
+
+
 async def _verify_config_unchanged(
     client: Any,
     url_path: str,
@@ -1029,21 +1080,19 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                         )
                     )
 
-                # Fetch current dashboard config
-                get_data: dict[str, Any] = {"type": "lovelace/config", "force": True}
-                if url_path:
-                    get_data["url_path"] = url_path
-
-                response = await client.send_websocket_message(get_data)
-
-                if isinstance(response, dict) and not response.get("success", True):
-                    error_msg = response.get("error", {})
-                    if isinstance(error_msg, dict):
-                        error_msg = error_msg.get("message", str(error_msg))
+                # Fetch current dashboard config + hash via the shared helper.
+                # Re-wrap helper's generic fetch error with python_transform-
+                # specific UX suggestions so the caller learns this branch
+                # requires an existing dashboard.
+                try:
+                    current_config, current_hash = (
+                        await _get_dashboard_config_internal(client, url_path)
+                    )
+                except ToolError as e:
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.SERVICE_CALL_FAILED,
-                            f"Dashboard not found or inaccessible: {error_msg}",
+                            f"Dashboard not found or inaccessible: {e}",
                             suggestions=[
                                 "python_transform requires an existing dashboard",
                                 "Use 'config' parameter to create a new dashboard",
@@ -1056,26 +1105,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                         )
                     )
 
-                current_config = (
-                    response.get("result") if isinstance(response, dict) else response
-                )
-                if not isinstance(current_config, dict):
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.SERVICE_CALL_FAILED,
-                            "Current dashboard config is invalid",
-                            suggestions=[
-                                "Initialize dashboard with 'config' parameter first"
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "url_path": url_path,
-                            },
-                        )
-                    )
-
                 # Validate config_hash for optimistic locking
-                current_hash = compute_config_hash(current_config)
                 if current_hash != config_hash:
                     raise_tool_error(
                         create_error_response(
@@ -1153,8 +1183,10 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                         )
                     )
 
-                # Compute new hash for potential chaining
-                new_config_hash = compute_config_hash(transformed_config)
+                # Re-fetch to get authoritative hash (HA may normalize after save)
+                _, new_config_hash = await _get_dashboard_config_internal(
+                    client, url_path
+                )
 
                 transform_result: dict[str, Any] = {
                     "success": True,
@@ -1309,38 +1341,37 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
 
                 # For existing dashboards, optionally validate config_hash and warn on large replacement
                 if dashboard_exists:
-                    # Fetch current config for validation/comparison
-                    get_data = {
-                        "type": "lovelace/config",
-                        "force": True,
-                    }
-                    if url_path:
-                        get_data["url_path"] = url_path
-                    current_response = await client.send_websocket_message(get_data)
-                    current_config = (
-                        current_response.get("result")
-                        if isinstance(current_response, dict)
-                        else current_response
-                    )
+                    # Fetch current config + hash via the shared helper.
+                    # Tolerate fetch failures here — full-config replacement
+                    # should still proceed even if the pre-read can't load
+                    # the current state (force-replace path). The strict
+                    # ``ToolError`` raised by the helper is downgraded to a
+                    # skip of both the optimistic-locking check and the
+                    # large-config soft warning, matching the prior
+                    # silently-fall-through behaviour.
+                    try:
+                        current_config, current_hash = (
+                            await _get_dashboard_config_internal(client, url_path)
+                        )
+                    except ToolError:
+                        current_config, current_hash = None, None
 
                     if isinstance(current_config, dict):
                         existing_config_size = len(json.dumps(current_config))
 
                         # Optional config_hash validation for full replacement
-                        if config_hash is not None:
-                            current_hash = compute_config_hash(current_config)
-                            if current_hash != config_hash:
-                                raise_tool_error(
-                                    create_error_response(
-                                        ErrorCode.SERVICE_CALL_FAILED,
-                                        "Dashboard modified since last read (conflict)",
-                                        suggestions=[
-                                            "Call ha_config_get_dashboard() again",
-                                            "Use the fresh config_hash, or omit config_hash to force replace",
-                                        ],
-                                        context={"action": "set", "url_path": url_path},
-                                    )
+                        if config_hash is not None and current_hash != config_hash:
+                            raise_tool_error(
+                                create_error_response(
+                                    ErrorCode.SERVICE_CALL_FAILED,
+                                    "Dashboard modified since last read (conflict)",
+                                    suggestions=[
+                                        "Call ha_config_get_dashboard() again",
+                                        "Use the fresh config_hash, or omit config_hash to force replace",
+                                    ],
+                                    context={"action": "set", "url_path": url_path},
                                 )
+                            )
 
                         # Soft warning for large config full replacement (10KB ≈ 2-3k tokens)
                         if existing_config_size >= 10000:

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -509,3 +509,101 @@ async def test_python_transform_unrelated_runtime_error_no_search_hint(
     assert "card_type" not in joined, (
         f"Unrelated TypeError should not get the search-mode hint, got: {suggestions}"
     )
+
+
+@pytest.mark.asyncio
+async def test_python_transform_returns_authoritative_post_save_hash(
+    mcp_client, ha_client
+):
+    """Regression for #1291: the hash returned by set(python_transform) must
+    equal the hash a subsequent get returns — i.e. the post-save authoritative
+    state, not the pre-save in-memory transformed dict.
+
+    Before the fix, ``new_config_hash = compute_config_hash(transformed_config)``
+    (tools_config_dashboards.py, around L1157) silently drifted whenever HA
+    normalised on save (key reorder, default injection, empty-container
+    stripping). A subsequent ``set(python_transform=..., config_hash=<returned>)``
+    would then trip ``Dashboard modified since last read`` even with no
+    concurrent writes. The fix re-fetches via ``_get_dashboard_config_internal``
+    to obtain the authoritative hash, matching the sibling pattern in
+    ``tools_config_scripts.py`` / ``tools_config_scenes.py`` /
+    ``tools_config_automations.py``.
+
+    Hash invariance is a pre-condition for chained python_transform calls and
+    for the styleguide's "Dashboard updates use content hashing, not session
+    tracking" contract.
+    """
+    mcp = MCPAssertions(mcp_client)
+    url_path = "test-1291-hash-auth"
+
+    try:
+        # Create dashboard
+        await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": url_path,
+                "config": {
+                    "views": [
+                        {
+                            "cards": [
+                                {"type": "markdown", "content": "v1"}
+                            ]
+                        }
+                    ]
+                },
+            },
+        )
+
+        get_initial = await mcp.call_tool_success(
+            "ha_config_get_dashboard", {"url_path": url_path}
+        )
+        initial_hash = get_initial["config_hash"]
+
+        # Apply python_transform; capture returned hash.
+        transform_result = await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": url_path,
+                "config_hash": initial_hash,
+                "python_transform": (
+                    "config['views'][0]['cards'][0]['content'] = 'transformed'"
+                ),
+            },
+        )
+        returned_hash = transform_result["config_hash"]
+
+        # Re-read to obtain HA's authoritative post-save hash.
+        verify_get = await mcp.call_tool_success(
+            "ha_config_get_dashboard", {"url_path": url_path}
+        )
+        post_save_hash = verify_get["config_hash"]
+
+        # Invariant: hash returned by set(python_transform) must equal a
+        # subsequent get's hash. Master computes it from the pre-save dict;
+        # the fix re-fetches and computes it from HA's authoritative response.
+        assert returned_hash == post_save_hash, (
+            "set(python_transform) returned a config_hash that does not match "
+            "the hash from a subsequent get — the optimistic-locking chain is "
+            "broken (next chained python_transform call would fail with "
+            "'Dashboard modified since last read'). "
+            f"returned={returned_hash!r} post_save={post_save_hash!r}"
+        )
+
+        # Chain a second python_transform using the returned hash — this is
+        # the user-visible scenario that breaks when the invariant fails.
+        chain_result = await mcp.call_tool_success(
+            "ha_config_set_dashboard",
+            {
+                "url_path": url_path,
+                "config_hash": returned_hash,
+                "python_transform": (
+                    "config['views'][0]['cards'][0]['content'] = 'chained'"
+                ),
+            },
+        )
+        assert chain_result["success"] is True
+        assert chain_result["action"] == "python_transform"
+    finally:
+        await mcp.call_tool_success(
+            "ha_config_delete_dashboard", {"url_path": url_path}
+        )


### PR DESCRIPTION
Closes #1291.

## What does this PR do?

Aligns `ha_config_set_dashboard` with the sibling re-fetch-after-save pattern
used by `tools_config_scripts.py`, `tools_config_scenes.py`, and
`tools_config_automations.py` after every upsert.

**Bug-site fix** (`src/ha_mcp/tools/tools_config_dashboards.py`, L1157 on
master):

Before:
```python
# Compute new hash for potential chaining
new_config_hash = compute_config_hash(transformed_config)
```

After:
```python
# Re-fetch to get authoritative hash (HA may normalize after save)
_, new_config_hash = await _get_dashboard_config_internal(client, url_path)
```

The pre-save in-memory hash silently drifts whenever HA normalises on save
(key reorder, default injection, empty-container stripping, etc.). A
subsequent chained `set_dashboard(python_transform=..., config_hash=<returned>)`
would then trip `Dashboard modified since last read` even with no concurrent
writes. The three sibling files all explicitly re-fetch after `upsert_*` and
hash the returned value, with the comment `HA may normalize after save`;
dashboards was the outlier.

**New module-level helper** `_get_dashboard_config_internal(client, url_path)
-> tuple[dict, str]` (closure-pattern-adapted, mirroring
`_get_<entity>_config_internal` in the three sibling files) — single
fetch+hash building block via the `lovelace/config` WebSocket call with
`force=True`.

**Boy-Scout (same PR):** the same helper is applied at two further fetch+hash
sites in `ha_config_set_dashboard`:

1. **python_transform pre-read.** A `try/except ToolError` wrap preserves the
   python_transform-specific UX suggestions (`python_transform requires an
   existing dashboard` / `Use 'config' parameter to create a new dashboard` /
   `Verify dashboard exists with ha_config_get_dashboard(list_only=True)`) on
   fetch-failure.

2. **Full-config compare.** A `try/except ToolError` wrap preserves the prior
   silently-fall-through semantics that let force-replace proceed even when
   the pre-read can't load current state.

Two other `compute_config_hash` call-sites in the file (search-mode and
get-mode) plus `_verify_config_unchanged` itself are intentionally **not**
touched — they have lazy-resolver retry / nullable-hash / different
fall-through semantics and aren't fetch+hash patterns; substituting the
helper there would change behaviour rather than dedupe it.

**Live probe against current HA (RBO).** Three transforms on a freshly-created
dashboard, each comparing the hash returned by `set(python_transform)` against
the hash from an immediate `get`:

| Transform | returned == post-save? |
|---|---|
| Set markdown card content `v1` → `transformed` | ✓ |
| Append card with `theme: None` field | ✓ |
| Set `cards: []` and `badges: []` | ✓ |

Current HA preserves dashboard config exactly across save in all three cases —
the bug is **structurally present** (the code path hashes the pre-save
in-memory dict) but does **not** currently manifest as a user-visible
conflict. The fix is sibling-consistency + structural defense against future
HA normalisation changes, exactly the rationale the three sibling tools
document with their `HA may normalize after save` comment.

**E2E regression test**
(`tests/src/e2e/workflows/dashboards/test_python_transform.py::test_python_transform_returns_authoritative_post_save_hash`):
creates a dashboard, captures `initial_hash` from `get`, calls
`set(python_transform=...)` with that hash, asserts the returned hash equals a
subsequent `get`'s hash, and chains a second `python_transform` with the
returned hash to validate the user-visible scenario. Cleans up via
try/finally.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

- **#1294** — the issue body raised one further sibling-gap as undecided:
  `tools_config_scenes.py` is the only file in the family that guards
  empty/whitespace identifiers proactively; the four siblings let them pass
  to HA. The maintainer decision (add the guard family-wide, or remove it
  from scenes for consistency with `.gemini/styleguide.md` "Validation
  delegation") is already tracked in #1294. Adopting the chosen direction
  post-decision will likely touch the fetch paths in this file alongside the
  rest of the family. Intentionally **not** bundled here — picking one
  direction is a multi-file decision deserving its own scoped change.

## Checklist
- [ ] I have updated documentation if needed
