### PR TITLE
feat: unify ha_config_set_helper response shape (closes #1293)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -640,11 +640,13 @@ Only use `raise_error=False` on `exception_to_structured_error` when you need to
 
 ### Return Values
 ```python
-{"success": True, "data": result}                    # Success
-{"success": True, "partial": True, "warning": "..."}  # Degraded
-raise ToolError(json.dumps({...}))                   # Tool-level failure (isError=true)
-{"success": False, "error": {...}}                   # Batch item failure only (in results list)
+{"success": True, "data": result}                     # Success
+{"success": True, "data": result, "warnings": [...]}  # Degraded (top-level list[str], omit when empty)
+raise ToolError(json.dumps({...}))                    # Tool-level failure (isError=true)
+{"success": False, "error": {...}}                    # Batch item failure only (in results list)
 ```
+
+`warnings` is always a top-level `list[str]`, never nested inside `data` and never a singular `"warning": "..."` string. See `tools_config_helpers.py::HelperResponse` / `_helper_response` for the canonical shape and `tests/src/unit/test_helper_response_shape.py` for the contract assertions.
 
 ### Tool Consolidation
 When a tool's functionality is fully covered by another tool, **remove** the redundant tool rather than deprecating it. Fewer tools reduces cognitive load for AI agents and improves decision-making. Do not add deprecation notices or shims — just delete the tool and update any docstring references to point to the replacement.

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2674,16 +2674,25 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 f"Helper created but entity registry update failed: {error_msg}"
                             )
 
-                    # Apply category via shared helper (consistent with automations/scripts)
+                    # Apply category via shared helper (consistent with automations/scripts).
+                    # Issue #1293: route the success/failure through ``cat_result`` so any
+                    # ``category_warning`` lands in the top-level ``warnings`` list instead
+                    # of leaking nested into ``helper_data``. Mirrors the precedent in
+                    # ``_handle_flow_helper`` (lines 1395-1407).
                     if category and entity_id:
+                        cat_result: dict[str, Any] = {}
                         await apply_entity_category(
                             client,
                             entity_id,
                             category,
                             "helpers",
-                            helper_data,
+                            cat_result,
                             "helper",
                         )
+                        if "category" in cat_result:
+                            helper_data["category"] = cat_result["category"]
+                        elif "category_warning" in cat_result:
+                            warnings.append(cat_result["category_warning"])
 
                     response: dict[str, Any] = {
                         "success": True,
@@ -3257,7 +3266,17 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         reg_result = await client.send_websocket_message(
                             registry_update
                         )
-                        if not reg_result.get("success"):
+                        if reg_result.get("success"):
+                            # Issue #1293: mirror the create branch by propagating the
+                            # registry writes into ``updated_data`` so the response's
+                            # ``data`` reflects the post-update state. Icon is
+                            # intentionally left out to match the create-branch's
+                            # current behavior (tracked as a separate consistency item).
+                            if area_id is not None:
+                                updated_data["area_id"] = area_id if area_id else None
+                            if labels is not None:
+                                updated_data["labels"] = labels
+                        else:
                             error_detail = reg_result.get("error", {})
                             error_msg = (
                                 error_detail.get("message", "Unknown error")
@@ -3271,16 +3290,23 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 f"Config updated but entity registry update failed: {error_msg}"
                             )
 
-                    # Apply category via shared helper
+                    # Apply category via shared helper. Issue #1293: route through
+                    # ``cat_result`` so any ``category_warning`` lands in the top-level
+                    # ``warnings`` list instead of nested in ``updated_data``.
                     if category:
+                        cat_result = {}
                         await apply_entity_category(
                             client,
                             entity_id,
                             category,
                             "helpers",
-                            updated_data,
+                            cat_result,
                             "helper",
                         )
+                        if "category" in cat_result:
+                            updated_data["category"] = cat_result["category"]
+                        elif "category_warning" in cat_result:
+                            warnings.append(cat_result["category_warning"])
 
                 else:
                     # Fallback for unknown/future helper types: entity registry update only
@@ -3314,16 +3340,22 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
                         )
 
-                    # Apply category via shared helper
+                    # Apply category via shared helper. Issue #1293: same temp-dict
+                    # routing as the simple-helper branch above.
                     if category:
+                        cat_result = {}
                         await apply_entity_category(
                             client,
                             entity_id,
                             category,
                             "helpers",
-                            updated_data,
+                            cat_result,
                             "helper",
                         )
+                        if "category" in cat_result:
+                            updated_data["category"] = cat_result["category"]
+                        elif "category_warning" in cat_result:
+                            warnings.append(cat_result["category_warning"])
 
                 # Wait for entity to reflect the update
                 wait_bool = coerce_bool_param(wait, "wait", default=True)

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1563,6 +1563,11 @@ async def _handle_flow_helper(
         )
 
     entry_id = flow_result.get("entry_id")
+    # ``data`` mirrors the HA flow_result payload for cross-action uniformity
+    # with the create/update branches (issue #1293). ``entry_id`` and ``title``
+    # also stay flat as convenience accessors — they are the primary identifiers
+    # callers reach for, and remain heavily used by per-action metadata
+    # consumers throughout the codebase.
     result: dict[str, Any] = {
         "success": True,
         "action": action,
@@ -1570,6 +1575,7 @@ async def _handle_flow_helper(
         "method": "config_flow",
         "entry_id": entry_id,
         "title": flow_result.get("title"),
+        "data": {"entry_id": entry_id, "title": flow_result.get("title")},
         "message": flow_result.get("message"),
     }
     if action == "update":
@@ -2616,6 +2622,12 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     if not entity_id and helper_data.get("id"):
                         entity_id = f"{helper_type}.{helper_data['id']}"
 
+                    # Issue #1293: collect warnings in a top-level list rather
+                    # than nest them in the payload dict. Aligns this branch
+                    # with the flow-helper path and lets callers do
+                    # ``result.get("warnings", [])`` uniformly.
+                    warnings: list[str] = []
+
                     # Wait for entity to be properly registered before proceeding
                     wait_bool = coerce_bool_param(wait, "wait", default=True)
                     if wait_bool and entity_id:
@@ -2624,11 +2636,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 client, entity_id
                             )
                             if not registered:
-                                helper_data["warning"] = (
+                                warnings.append(
                                     f"Helper created but {entity_id} not yet queryable. It may take a moment to become available."
                                 )
                         except Exception as e:
-                            helper_data["warning"] = (
+                            warnings.append(
                                 f"Helper created but verification failed: {e}"
                             )
 
@@ -2658,7 +2670,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if isinstance(error_detail, dict)
                                 else str(error_detail)
                             )
-                            helper_data["warning"] = (
+                            warnings.append(
                                 f"Helper created but entity registry update failed: {error_msg}"
                             )
 
@@ -2673,14 +2685,17 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             "helper",
                         )
 
-                    return {
+                    response: dict[str, Any] = {
                         "success": True,
                         "action": "create",
                         "helper_type": helper_type,
-                        "helper_data": helper_data,
+                        "data": helper_data,
                         "entity_id": entity_id,
                         "message": f"Successfully created {helper_type}: {name}",
                     }
+                    if warnings:
+                        response["warnings"] = warnings
+                    return response
                 else:
                     raise_tool_error(
                         create_error_response(
@@ -2728,6 +2743,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 }
 
                 updated_data: dict[str, Any] = {}
+                # Issue #1293: collect warnings in a top-level list for the
+                # update path too, mirroring create + flow-helper branches.
+                # (No re-annotation — the create branch above already defined
+                # ``warnings: list[str]``; mypy treats this as the same binding.)
+                warnings = []
 
                 if helper_type == "tag":
                     # Tags use their own registry — no entity registry entries.
@@ -2762,12 +2782,13 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                     # Tags don't have entity registry entries, so return directly
                     # without wait_for_entity_registered (they're not entities).
+                    # Issue #1293: ``data`` wrapper key + top-level ``warnings`` list.
                     return {
                         "success": True,
                         "action": "update",
                         "helper_type": helper_type,
                         "entity_id": entity_id,
-                        "updated_data": updated_data,
+                        "data": updated_data,
                         "message": f"Successfully updated {helper_type}: {entity_id}",
                     }
 
@@ -3240,7 +3261,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             logger.warning(
                                 f"Entity registry update failed for {entity_id}: {error_msg}"
                             )
-                            updated_data["warning"] = (
+                            warnings.append(
                                 f"Config updated but entity registry update failed: {error_msg}"
                             )
 
@@ -3300,25 +3321,29 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                 # Wait for entity to reflect the update
                 wait_bool = coerce_bool_param(wait, "wait", default=True)
-                response: dict[str, Any] = {
-                    "success": True,
-                    "action": "update",
-                    "helper_type": helper_type,
-                    "entity_id": entity_id,
-                    "updated_data": updated_data,
-                    "message": f"Successfully updated {helper_type}: {entity_id}",
-                }
                 if wait_bool:
                     try:
                         registered = await wait_for_entity_registered(client, entity_id)
                         if not registered:
-                            response["warning"] = (
+                            warnings.append(
                                 f"Update applied but {entity_id} not yet queryable."
                             )
                     except Exception as e:
-                        response["warning"] = (
-                            f"Update applied but verification failed: {e}"
-                        )
+                        warnings.append(f"Update applied but verification failed: {e}")
+
+                # Issue #1293: ``data`` wrapper key + top-level ``warnings`` list.
+                # (No re-annotation — the create branch above already defined
+                # ``response: dict[str, Any]``; mypy treats this as the same binding.)
+                response = {
+                    "success": True,
+                    "action": "update",
+                    "helper_type": helper_type,
+                    "entity_id": entity_id,
+                    "data": updated_data,
+                    "message": f"Successfully updated {helper_type}: {entity_id}",
+                }
+                if warnings:
+                    response["warnings"] = warnings
                 return response
 
             # This should never be reached since action is either "create" or "update"

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1409,6 +1409,69 @@ async def _apply_registry_updates_to_entity(
     return applied
 
 
+class HelperResponse(TypedDict, total=False):
+    """Uniform response contract for ``ha_config_set_helper`` (issue #1293).
+
+    Documents the legal key set across all three branches (create, update,
+    flow). ``total=False`` because per-branch fields (entity_id, flow extras,
+    warnings) are conditional. Consumed by ``_helper_response`` below — all
+    return literals in this module funnel through that builder so the shape
+    has a single point of construction.
+    """
+
+    success: bool
+    action: str  # "create" | "update"
+    helper_type: str
+    data: dict[str, Any]
+    entity_id: str  # absent on flow branch (use entity_ids[] for multi-entity)
+    message: str | None
+    warnings: list[str]  # omitted when empty
+    # Flow-helper convenience accessors (only set on the flow branch).
+    method: str
+    entry_id: str | None
+    title: str | None
+    updated: bool
+    entity_ids: list[str]
+    area_id: str | None
+    labels: list[str]
+    category: str
+    applied: list[dict[str, Any]]
+
+
+def _helper_response(
+    action: str,
+    helper_type: str,
+    *,
+    data: dict[str, Any],
+    entity_id: str | None = None,
+    message: str | None = None,
+    warnings: list[str] | None = None,
+    **extras: Any,
+) -> dict[str, Any]:
+    """Single construction point for the ``ha_config_set_helper`` response.
+
+    Enforces the uniform shape from issue #1293: ``success`` → ``action`` →
+    ``helper_type`` → ``data`` → ``entity_id`` (when present) → ``message`` →
+    flow-helper extras → ``warnings`` (only when non-empty). Returning
+    ``dict[str, Any]`` rather than ``HelperResponse`` keeps the call sites
+    free of mypy gymnastics around the dynamic ``**extras`` keys; the
+    TypedDict serves as the readable contract anchor instead.
+    """
+    resp: dict[str, Any] = {
+        "success": True,
+        "action": action,
+        "helper_type": helper_type,
+        "data": data,
+    }
+    if entity_id is not None:
+        resp["entity_id"] = entity_id
+    resp["message"] = message
+    resp.update(extras)
+    if warnings:
+        resp["warnings"] = warnings
+    return resp
+
+
 async def _handle_flow_helper(
     client: Any,
     helper_type: str,
@@ -1562,24 +1625,15 @@ async def _handle_flow_helper(
             helper_id,  # type: ignore[arg-type]
         )
 
+    # Cache the flow_result keys read multiple times below (issue #1293
+    # follow-up: reduces three .get() lookups for entry_id and two for title
+    # to one each, and makes the post-flow logic readable as a sequence of
+    # named values rather than repeated dict access). ``.get()`` is kept —
+    # ``create_flow_helper`` propagates HA's optional entry_id via ``.get()``
+    # too (tools_config_entry_flow.py:L700), so a missing key must surface as
+    # None for the ``if entry_id:`` guard below, not raise KeyError.
     entry_id = flow_result.get("entry_id")
-    # ``data`` mirrors the HA flow_result payload for cross-action uniformity
-    # with the create/update branches (issue #1293). ``entry_id`` and ``title``
-    # also stay flat as convenience accessors — they are the primary identifiers
-    # callers reach for, and remain heavily used by per-action metadata
-    # consumers throughout the codebase.
-    result: dict[str, Any] = {
-        "success": True,
-        "action": action,
-        "helper_type": helper_type,
-        "method": "config_flow",
-        "entry_id": entry_id,
-        "title": flow_result.get("title"),
-        "data": {"entry_id": entry_id, "title": flow_result.get("title")},
-        "message": flow_result.get("message"),
-    }
-    if action == "update":
-        result["updated"] = True
+    title = flow_result.get("title")
 
     # Resolve all entities for this config entry (multi-entity helpers handled naturally).
     # For create with wait=True, poll briefly for at least one entity to appear —
@@ -1623,7 +1677,22 @@ async def _handle_flow_helper(
         else:
             entities = await _get_entities_for_config_entry(client, entry_id, warnings)
     entity_ids = [e["entity_id"] for e in entities if e.get("entity_id")]
-    result["entity_ids"] = entity_ids
+
+    # ``data`` mirrors the HA flow_result payload for cross-action uniformity
+    # with the create/update branches (issue #1293). ``entry_id`` and ``title``
+    # also stay flat as convenience accessors — they are the primary identifiers
+    # callers reach for, and remain heavily used by per-action metadata
+    # consumers throughout the codebase. Per-entity registry-write outcomes
+    # live in the ``applied`` flat array, not nested in ``data``, because one
+    # flow can yield N entities with different per-entity results.
+    extras: dict[str, Any] = {
+        "method": "config_flow",
+        "entry_id": entry_id,
+        "title": title,
+        "entity_ids": entity_ids,
+    }
+    if action == "update":
+        extras["updated"] = True
 
     # Apply registry updates (area_id / labels / category) to every entity.
     # Use `is not None` so an explicit empty value (area_id="" or labels=[])
@@ -1646,17 +1715,21 @@ async def _handle_flow_helper(
             )
         )
         if area_id is not None:
-            result["area_id"] = area_id if area_id else None
+            extras["area_id"] = area_id if area_id else None
         if labels_list is not None:
-            result["labels"] = labels_list
+            extras["labels"] = labels_list
         if category:
-            result["category"] = category
-        result["applied"] = applied_per_entity
+            extras["category"] = category
+        extras["applied"] = applied_per_entity
 
-    if warnings:
-        result["warnings"] = warnings
-
-    return result
+    return _helper_response(
+        action,
+        helper_type,
+        data={"entry_id": entry_id, "title": title},
+        message=flow_result.get("message"),
+        warnings=warnings,
+        **extras,
+    )
 
 
 def _format_schedule_days(
@@ -2678,7 +2751,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # Issue #1293: route the success/failure through ``cat_result`` so any
                     # ``category_warning`` lands in the top-level ``warnings`` list instead
                     # of leaking nested into ``helper_data``. Mirrors the precedent in
-                    # ``_handle_flow_helper`` (lines 1395-1407).
+                    # ``_handle_flow_helper`` (the ``cat_result`` block near the end of
+                    # ``_apply_registry_updates_to_entity``).
                     if category and entity_id:
                         cat_result: dict[str, Any] = {}
                         await apply_entity_category(
@@ -2694,17 +2768,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         elif "category_warning" in cat_result:
                             warnings.append(cat_result["category_warning"])
 
-                    response: dict[str, Any] = {
-                        "success": True,
-                        "action": "create",
-                        "helper_type": helper_type,
-                        "data": helper_data,
-                        "entity_id": entity_id,
-                        "message": f"Successfully created {helper_type}: {name}",
-                    }
-                    if warnings:
-                        response["warnings"] = warnings
-                    return response
+                    return _helper_response(
+                        "create",
+                        helper_type,
+                        data=helper_data,
+                        entity_id=entity_id,
+                        message=f"Successfully created {helper_type}: {name}",
+                        warnings=warnings,
+                    )
                 else:
                     raise_tool_error(
                         create_error_response(
@@ -2791,21 +2862,19 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                     # Tags don't have entity registry entries, so return directly
                     # without wait_for_entity_registered (they're not entities).
-                    # Issue #1293: ``data`` wrapper key + top-level ``warnings`` list.
-                    # No producer appends to ``warnings`` on the tag path today,
-                    # but the conditional mirrors the sibling create/update
-                    # branches so future warnings flow through the same contract.
-                    response = {
-                        "success": True,
-                        "action": "update",
-                        "helper_type": helper_type,
-                        "entity_id": entity_id,
-                        "data": updated_data,
-                        "message": f"Successfully updated {helper_type}: {entity_id}",
-                    }
-                    if warnings:
-                        response["warnings"] = warnings
-                    return response
+                    # Issue #1293: same uniform builder as the sibling create/update
+                    # branches. No producer appends to ``warnings`` on the tag path
+                    # today, but ``_helper_response`` already omits the key when the
+                    # list is empty — future warnings flow through the same contract
+                    # without further plumbing.
+                    return _helper_response(
+                        "update",
+                        helper_type,
+                        data=updated_data,
+                        entity_id=entity_id,
+                        message=f"Successfully updated {helper_type}: {entity_id}",
+                        warnings=warnings,
+                    )
 
                 elif helper_type in config_store_types:
                     # Person and zone: look up unique_id from entity registry
@@ -3269,9 +3338,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         if reg_result.get("success"):
                             # Issue #1293: mirror the create branch by propagating the
                             # registry writes into ``updated_data`` so the response's
-                            # ``data`` reflects the post-update state. Icon is
-                            # intentionally left out to match the create-branch's
-                            # current behavior (tracked as a separate consistency item).
+                            # ``data`` reflects the post-update state.
+                            if icon is not None:
+                                updated_data["icon"] = icon if icon else None
                             if area_id is not None:
                                 updated_data["area_id"] = area_id if area_id else None
                             if labels is not None:
@@ -3283,9 +3352,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if isinstance(error_detail, dict)
                                 else str(error_detail)
                             )
-                            logger.warning(
-                                f"Entity registry update failed for {entity_id}: {error_msg}"
-                            )
+                            # No ``logger.warning`` here — the create-branch and
+                            # flow-helper registry-update failure paths surface this
+                            # via ``warnings.append`` only, and the response carries
+                            # the message to the caller in the top-level ``warnings``
+                            # list. Logging again would double-report.
                             warnings.append(
                                 f"Config updated but entity registry update failed: {error_msg}"
                             )
@@ -3369,20 +3440,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     except Exception as e:
                         warnings.append(f"Update applied but verification failed: {e}")
 
-                # Issue #1293: ``data`` wrapper key + top-level ``warnings`` list.
-                # (No re-annotation — the create branch above already defined
-                # ``response: dict[str, Any]``; mypy treats this as the same binding.)
-                response = {
-                    "success": True,
-                    "action": "update",
-                    "helper_type": helper_type,
-                    "entity_id": entity_id,
-                    "data": updated_data,
-                    "message": f"Successfully updated {helper_type}: {entity_id}",
-                }
-                if warnings:
-                    response["warnings"] = warnings
-                return response
+                return _helper_response(
+                    "update",
+                    helper_type,
+                    data=updated_data,
+                    entity_id=entity_id,
+                    message=f"Successfully updated {helper_type}: {entity_id}",
+                    warnings=warnings,
+                )
 
             # This should never be reached since action is either "create" or "update"
             raise_tool_error(

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2783,7 +2783,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     # Tags don't have entity registry entries, so return directly
                     # without wait_for_entity_registered (they're not entities).
                     # Issue #1293: ``data`` wrapper key + top-level ``warnings`` list.
-                    return {
+                    # No producer appends to ``warnings`` on the tag path today,
+                    # but the conditional mirrors the sibling create/update
+                    # branches so future warnings flow through the same contract.
+                    response = {
                         "success": True,
                         "action": "update",
                         "helper_type": helper_type,
@@ -2791,6 +2794,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "data": updated_data,
                         "message": f"Successfully updated {helper_type}: {entity_id}",
                     }
+                    if warnings:
+                        response["warnings"] = warnings
+                    return response
 
                 elif helper_type in config_store_types:
                     # Person and zone: look up unique_id from entity registry

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2732,6 +2732,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             update_message
                         )
                         if update_result.get("success"):
+                            # Mirror the update branch's icon propagation
+                            # (line ~3343) so the create response's ``data``
+                            # carries the same registry-write echo set.
+                            if icon is not None:
+                                helper_data["icon"] = icon if icon else None
                             if area_id is not None:
                                 helper_data["area_id"] = area_id if area_id else None
                             if labels is not None:

--- a/tests/src/e2e/tools/test_ha_call_event.py
+++ b/tests/src/e2e/tools/test_ha_call_event.py
@@ -85,7 +85,7 @@ async def test_call_event_delivery_verified(mcp_client):
     boolean_data = assert_mcp_success(boolean_result, "Create input_boolean flag")
     boolean_id = (
         boolean_data.get("entity_id")
-        or f"input_boolean.{boolean_data['helper_data']['id']}"
+        or f"input_boolean.{boolean_data['data']['id']}"
     )
     logger.info("Created flag entity: %s", boolean_id)
 

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -602,7 +602,7 @@ async def area_with_mixed_domains(mcp_client):
     boolean_data = assert_mcp_success(boolean_result, "Create input_boolean")
     boolean_id = (
         boolean_data.get("entity_id")
-        or f"input_boolean.{boolean_data['helper_data']['id']}"
+        or f"input_boolean.{boolean_data['data']['id']}"
     )
 
     number_result = await mcp_client.call_tool(
@@ -619,7 +619,7 @@ async def area_with_mixed_domains(mcp_client):
     number_data = assert_mcp_success(number_result, "Create input_number")
     number_id = (
         number_data.get("entity_id")
-        or f"input_number.{number_data['helper_data']['id']}"
+        or f"input_number.{number_data['data']['id']}"
     )
 
     # Wait until both entities are visible under this area in the registries
@@ -925,7 +925,7 @@ async def two_areas_fuzzy_match(mcp_client):
         bool_data = assert_mcp_success(bool_result, f"Create boolean {tag}")
         bool_id = (
             bool_data.get("entity_id")
-            or f"input_boolean.{bool_data['helper_data']['id']}"
+            or f"input_boolean.{bool_data['data']['id']}"
         )
         created.append(("input_boolean", bool_id))
         helpers.append({"area_id": area_id, "boolean_id": bool_id, "tag": tag})
@@ -1110,7 +1110,7 @@ async def populated_area_for_shape_test(mcp_client):
     helper_data = assert_mcp_success(helper_result, "Create shape-test helper")
     boolean_id = (
         helper_data.get("entity_id")
-        or f"input_boolean.{helper_data['helper_data']['id']}"
+        or f"input_boolean.{helper_data['data']['id']}"
     )
     await wait_for_tool_result(
         mcp_client,
@@ -1324,7 +1324,7 @@ async def two_areas_with_shared_prefix(mcp_client):
         )
         h_data = assert_mcp_success(h_res, f"Create helper {label}")
         helpers.append(
-            h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+            h_data.get("entity_id") or f"input_boolean.{h_data['data']['id']}"
         )
     # Wait for both helpers to be visible under the shared prefix
     await wait_for_tool_result(
@@ -1448,7 +1448,7 @@ async def helper_with_alias(mcp_client):
     helper_data = assert_mcp_success(helper_res, "Create alias-target helper")
     eid = (
         helper_data.get("entity_id")
-        or f"input_boolean.{helper_data['helper_data']['id']}"
+        or f"input_boolean.{helper_data['data']['id']}"
     )
     await mcp_client.call_tool(
         "ha_set_entity", {"entity_id": eid, "aliases": [alias]}
@@ -1508,7 +1508,7 @@ async def area_with_alias(mcp_client):
         },
     )
     h_data = assert_mcp_success(h_res, "Create helper in alias-area")
-    eid = h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+    eid = h_data.get("entity_id") or f"input_boolean.{h_data['data']['id']}"
 
     try:
         await wait_for_tool_result(
@@ -1593,7 +1593,7 @@ async def hidden_helper(mcp_client):
         {"helper_type": "input_boolean", "name": f"e2e 1170 hidden {suffix}"},
     )
     data = assert_mcp_success(res, "Create hidden-target helper")
-    eid = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+    eid = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
     # Rename so the search query has a unique substring to grep on.
     await mcp_client.call_tool(
         "ha_set_entity", {"entity_id": eid, "name": distinctive, "hidden": True}
@@ -1741,7 +1741,7 @@ async def test_search_area_only_penalises_hidden_issue_1170(mcp_client):
         },
     )
     h_data = assert_mcp_success(h_res, "Create helper")
-    eid = h_data.get("entity_id") or f"input_boolean.{h_data['helper_data']['id']}"
+    eid = h_data.get("entity_id") or f"input_boolean.{h_data['data']['id']}"
 
     try:
         # Wait for helper to be visible in the area before hiding it.
@@ -1838,7 +1838,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
     v_data = assert_mcp_success(v_res, "create visible")
     v_eid = (
         v_data.get("entity_id")
-        or f"input_boolean.{v_data['helper_data']['id']}"
+        or f"input_boolean.{v_data['data']['id']}"
     )
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
@@ -1851,7 +1851,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
     h_data = assert_mcp_success(h_res, "create hidden-target")
     h_eid = (
         h_data.get("entity_id")
-        or f"input_boolean.{h_data['helper_data']['id']}"
+        or f"input_boolean.{h_data['data']['id']}"
     )
 
     try:
@@ -1943,7 +1943,7 @@ async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
     v_data = assert_mcp_success(v_res, "create visible dl")
     v_eid = (
         v_data.get("entity_id")
-        or f"input_boolean.{v_data['helper_data']['id']}"
+        or f"input_boolean.{v_data['data']['id']}"
     )
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
@@ -1952,7 +1952,7 @@ async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
     h_data = assert_mcp_success(h_res, "create hidden dl")
     h_eid = (
         h_data.get("entity_id")
-        or f"input_boolean.{h_data['helper_data']['id']}"
+        or f"input_boolean.{h_data['data']['id']}"
     )
 
     try:

--- a/tests/src/e2e/workflows/categories/test_config_tool_categories.py
+++ b/tests/src/e2e/workflows/categories/test_config_tool_categories.py
@@ -365,19 +365,19 @@ class TestConfigToolCategories:
                 "category": category_id,
             },
         )
-        helper_data = assert_mcp_success(helper_result, "Create helper with category")
-        # entity_id may be None for some helper types — derive from helper_data.id
-        entity_id = helper_data.get("entity_id")
-        inner_data = helper_data.get("helper_data", {})
+        helper_response = assert_mcp_success(helper_result, "Create helper with category")
+        # entity_id may be None for some helper types — derive from data.id
+        entity_id = helper_response.get("entity_id")
+        inner_data = helper_response.get("data", {})
         helper_id = inner_data.get("id")
         if not entity_id and helper_id:
             entity_id = f"input_boolean.{helper_id}"
-        assert entity_id, f"Missing entity_id and helper_data.id: {helper_data}"
+        assert entity_id, f"Missing entity_id and data.id: {helper_response}"
         cleanup_tracker.track("input_boolean", entity_id)
 
-        # Check category was applied (in helper_data sub-dict)
+        # Check category was applied (in data sub-dict)
         assert inner_data.get("category") == category_id, (
-            f"Category not set in helper response: {helper_data}"
+            f"Category not set in helper response: {helper_response}"
         )
         logger.info(f"Created helper {entity_id} with category {category_id}")
 

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -58,11 +58,11 @@ def get_entity_id_from_response(data: dict, helper_type: str) -> str | None:
     """Extract entity_id from helper create response.
 
     The API may return entity_id directly or we may need to construct it
-    from helper_data.id.
+    from data.id (issue #1293 renamed the wrapper key from helper_data).
     """
     entity_id = data.get("entity_id")
     if not entity_id:
-        helper_id = data.get("helper_data", {}).get("id")
+        helper_id = data.get("data", {}).get("id")
         if helper_id:
             entity_id = f"{helper_type}.{helper_id}"
     return entity_id
@@ -1070,8 +1070,8 @@ class TestScheduleCRUD:
         cleanup_tracker.track("schedule", entity_id)
         logger.info(f"Created schedule with data: {entity_id}")
 
-        # Verify the helper_data includes the data field in time blocks
-        helper_data = create_data.get("helper_data", {})
+        # Verify the response data includes the schedule day blocks
+        helper_data = create_data.get("data", {})
         monday_blocks = helper_data.get("monday", [])
         assert len(monday_blocks) == 2, f"Expected 2 Monday blocks, got {len(monday_blocks)}"
 
@@ -1465,8 +1465,8 @@ class TestPersonCRUD:
         logger.info(f"Person updated: {update_data.get('message')}")
 
         # VERIFY the update succeeded and returned person config (not entity registry entry)
-        updated = update_data.get("updated_data", {})
-        assert updated, f"No updated_data in response: {update_data}"
+        updated = update_data.get("data", {})
+        assert updated, f"No data field in response: {update_data}"
         # person/update response includes the person config with 'name' and 'id'
         assert updated.get("name") == "E2E Person Update Test Renamed", (
             f"Name not updated in config store response — got: {updated.get('name')}. "
@@ -1522,7 +1522,7 @@ class TestTagCRUD:
         create_data = assert_mcp_success(create_result, "Create tag")
         entity_id = get_entity_id_from_response(create_data, "tag")
         # Tag may not return entity_id in same format
-        tag_id = create_data.get("helper_data", {}).get("id") or test_tag_id
+        tag_id = create_data.get("data", {}).get("id") or test_tag_id
         cleanup_tracker.track("tag", tag_id)
         logger.info(f"Created tag: {tag_id}")
 
@@ -1564,7 +1564,7 @@ class TestTagCRUD:
             },
         )
         create_data = assert_mcp_success(create_result, "Create tag for update test")
-        tag_id = create_data.get("helper_data", {}).get("id") or test_tag_id
+        tag_id = create_data.get("data", {}).get("id") or test_tag_id
         cleanup_tracker.track("tag", tag_id)
         logger.info(f"Created tag: {tag_id}")
 

--- a/tests/src/e2e/workflows/config/test_helper_field_persistence.py
+++ b/tests/src/e2e/workflows/config/test_helper_field_persistence.py
@@ -67,7 +67,7 @@ def _entity_id_from_create(data: dict, helper_type: str) -> str | None:
     """Extract entity_id from the ``ha_config_set_helper`` create response."""
     entity_id = data.get("entity_id")
     if not entity_id:
-        helper_id = data.get("helper_data", {}).get("id")
+        helper_id = data.get("data", {}).get("id")
         if helper_id:
             entity_id = f"{helper_type}.{helper_id}"
     return entity_id

--- a/tests/src/e2e/workflows/core/test_bulk.py
+++ b/tests/src/e2e/workflows/core/test_bulk.py
@@ -415,7 +415,7 @@ async def test_bulk_control_with_input_booleans(mcp_client, cleanup_tracker):
     def get_entity_id(data: dict) -> str | None:
         entity_id = data.get("entity_id")
         if not entity_id:
-            helper_id = data.get("helper_data", {}).get("id")
+            helper_id = data.get("data", {}).get("id")
             if helper_id:
                 entity_id = f"input_boolean.{helper_id}"
         return entity_id

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -352,8 +352,8 @@ def get_entity_id_from_response(data: dict, helper_type: str) -> str | None:
     """Extract entity_id from helper create response."""
     entity_id = data.get("entity_id")
     if not entity_id:
-        # Try to get from helper_data.id
-        helper_id = data.get("helper_data", {}).get("id")
+        # Try to get from data.id (issue #1293 renamed wrapper key from helper_data)
+        helper_id = data.get("data", {}).get("id")
         if helper_id:
             entity_id = f"{helper_type}.{helper_id}"
     return entity_id

--- a/tests/src/e2e/workflows/entities/test_entity_management.py
+++ b/tests/src/e2e/workflows/entities/test_entity_management.py
@@ -33,7 +33,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         logger.info(f"Created test entity: {entity_id}")
@@ -81,7 +81,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Create and assign to area
@@ -131,7 +131,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Update name and icon
@@ -197,7 +197,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Set aliases
@@ -255,7 +255,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Disable entity using enabled=False
@@ -299,7 +299,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Hide entity using hidden=True
@@ -343,7 +343,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id)
 
         # Create a test area
@@ -437,7 +437,7 @@ class TestEntityManagement:
             },
         )
         data1 = assert_mcp_success(create_result1, "Create first test entity")
-        entity_id1 = data1.get("entity_id") or f"input_boolean.{data1['helper_data']['id']}"
+        entity_id1 = data1.get("entity_id") or f"input_boolean.{data1['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id1)
 
         # Create second test helper
@@ -450,7 +450,7 @@ class TestEntityManagement:
             },
         )
         data2 = assert_mcp_success(create_result2, "Create second test entity")
-        entity_id2 = data2.get("entity_id") or f"input_boolean.{data2['helper_data']['id']}"
+        entity_id2 = data2.get("entity_id") or f"input_boolean.{data2['data']['id']}"
         cleaner.track_entity("input_boolean", entity_id2)
 
         # Call ha_get_entity with list of 2 entity_ids
@@ -533,7 +533,7 @@ class TestEntityManagement:
             },
         )
         data = assert_mcp_success(create_result, "Create test entity")
-        valid_entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        valid_entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         cleaner.track_entity("input_boolean", valid_entity_id)
 
         nonexistent_entity_id = "sensor.nonexistent_partial_test"

--- a/tests/src/e2e/workflows/entities/test_entity_remove.py
+++ b/tests/src/e2e/workflows/entities/test_entity_remove.py
@@ -26,7 +26,7 @@ class TestEntityRemove:
             },
         )
         data = assert_mcp_success(create_result, "Create test helper")
-        entity_id = data.get("entity_id") or f"input_boolean.{data['helper_data']['id']}"
+        entity_id = data.get("entity_id") or f"input_boolean.{data['data']['id']}"
         logger.info(f"Created test entity: {entity_id}")
 
         # Remove the entity

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -242,6 +242,124 @@ class TestUniformResponseShape:
         _assert_uniform_shape(result, expect_warnings=True)
         assert any("verification failed" in w for w in result["warnings"])
 
+    async def test_create_failed_registry_update_surfaces_top_level_warning(
+        self, register_tools, mock_client
+    ):
+        """Failed ``config/entity_registry/update`` on create → warning at top level, not nested in data.
+
+        Locks the create-branch registry-write failure path
+        (``warnings.append("Helper created but entity registry update failed: ...")``).
+        A regression that re-nests this string under ``data``, or drops the
+        ``warnings.append`` entirely, would slip past the category test —
+        this fills that gap. The ``area.kitchen`` is registered (so the
+        upstream ``_validate_registry_ids`` lookup passes) and the failure
+        happens at the post-create registry-update step itself.
+        """
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/area_registry/list":
+                return {
+                    "success": True,
+                    "result": [{"area_id": "area.kitchen", "name": "Kitchen"}],
+                }
+            if msg_type == "config/entity_registry/update":
+                return {
+                    "success": False,
+                    "error": {"message": "registry write rejected"},
+                }
+            return {
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+                area_id="area.kitchen",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        # Warning must surface at top level — never nested under ``data``.
+        assert "warning" not in result["data"]
+        assert "warnings" not in result["data"]
+        assert any(
+            "entity registry update failed" in w for w in result["warnings"]
+        )
+        assert any("registry write rejected" in w for w in result["warnings"])
+        # Successful registry-write would have propagated area_id into data;
+        # the failure must not silently mark data as if it succeeded.
+        assert "area_id" not in result["data"]
+
+    async def test_update_failed_registry_update_surfaces_top_level_warning(
+        self, register_tools, mock_client
+    ):
+        """Failed ``config/entity_registry/update`` on update → warning at top level, not nested in data.
+
+        Mirror of the create-side test on the simple-update branch.
+        ``logger.warning`` was previously emitted alongside the
+        ``warnings.append`` here (create-side never logged); the post-#1303
+        contract is ``warnings.append`` only, with the message carried to
+        the caller via the response. ``area.kitchen`` is registered so
+        upstream validation passes and the failure occurs at the registry
+        write itself.
+        """
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/get":
+                return {
+                    "success": True,
+                    "result": {
+                        "entity_id": msg["entity_id"],
+                        "unique_id": "abc123",
+                        "platform": "input_boolean",
+                    },
+                }
+            if msg_type == "config/area_registry/list":
+                return {
+                    "success": True,
+                    "result": [{"area_id": "area.kitchen", "name": "Kitchen"}],
+                }
+            if msg_type == "config/entity_registry/update":
+                return {
+                    "success": False,
+                    "error": {"message": "registry write rejected"},
+                }
+            if msg_type.endswith("/list"):
+                return {
+                    "success": True,
+                    "result": [{"id": "abc123", "name": "Existing"}],
+                }
+            if msg_type.endswith("/update"):
+                return {"success": True, "result": {"id": "abc123"}}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                helper_id="input_boolean.existing",
+                area_id="area.kitchen",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        assert "warning" not in result["data"]
+        assert "warnings" not in result["data"]
+        assert any(
+            "entity registry update failed" in w for w in result["warnings"]
+        )
+        assert any("registry write rejected" in w for w in result["warnings"])
+        assert "area_id" not in result["data"]
+
     async def test_create_failed_category_apply_surfaces_top_level_warning(
         self, register_tools, mock_client
     ):
@@ -251,7 +369,8 @@ class TestUniformResponseShape:
         into ``helper_data`` because ``apply_entity_category`` mutates its
         target dict in-place. The fix routes through a temp dict and lifts the
         warning to the top-level ``warnings`` list (mirrors the precedent in
-        ``_handle_flow_helper`` at lines 1395-1407).
+        ``_handle_flow_helper``'s ``cat_result`` block in
+        ``_apply_registry_updates_to_entity``).
         """
 
         async def ws_handler(msg: dict) -> dict:

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -242,6 +242,132 @@ class TestUniformResponseShape:
         _assert_uniform_shape(result, expect_warnings=True)
         assert any("verification failed" in w for w in result["warnings"])
 
+    async def test_create_failed_category_apply_surfaces_top_level_warning(
+        self, register_tools, mock_client
+    ):
+        """Failed ``apply_entity_category`` on create → warning at top level, not nested in data.
+
+        Issue #1293 close-out: the helper used to leak a ``category_warning`` key
+        into ``helper_data`` because ``apply_entity_category`` mutates its
+        target dict in-place. The fix routes through a temp dict and lifts the
+        warning to the top-level ``warnings`` list (mirrors the precedent in
+        ``_handle_flow_helper`` at lines 1395-1407).
+        """
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/category_registry/list":
+                return {
+                    "success": True,
+                    "result": [{"category_id": "cat-123", "name": "Test Cat"}],
+                }
+            return {
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+
+        async def fake_apply(
+            client, entity_id, category, scope, result_dict, entity_type
+        ):
+            result_dict["category_warning"] = (
+                "Helper saved but failed to set category: forced failure"
+            )
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "ha_mcp.tools.tools_config_helpers.apply_entity_category",
+                side_effect=fake_apply,
+            ),
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+                category="cat-123",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        assert "category_warning" not in result["data"], (
+            "category_warning leaked into data payload"
+        )
+        assert "category" not in result["data"], (
+            "category should not be set in data when apply failed"
+        )
+        assert any("failed to set category" in w for w in result["warnings"])
+
+    async def test_update_failed_category_apply_surfaces_top_level_warning(
+        self, register_tools, mock_client
+    ):
+        """Failed ``apply_entity_category`` on update → warning at top level, not nested in data.
+
+        Mirror of the create-side test on the simple/registry update branch.
+        """
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/get":
+                return {
+                    "success": True,
+                    "result": {
+                        "entity_id": msg["entity_id"],
+                        "unique_id": "abc123",
+                        "platform": "input_boolean",
+                    },
+                }
+            if msg_type == "config/category_registry/list":
+                return {
+                    "success": True,
+                    "result": [{"category_id": "cat-123", "name": "Test Cat"}],
+                }
+            if msg_type.endswith("/list"):
+                return {
+                    "success": True,
+                    "result": [{"id": "abc123", "name": "Existing"}],
+                }
+            if msg_type.endswith("/update"):
+                return {"success": True, "result": {"id": "abc123"}}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+
+        async def fake_apply(
+            client, entity_id, category, scope, result_dict, entity_type
+        ):
+            result_dict["category_warning"] = (
+                "Helper saved but failed to set category: forced failure"
+            )
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "ha_mcp.tools.tools_config_helpers.apply_entity_category",
+                side_effect=fake_apply,
+            ),
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                helper_id="input_boolean.existing",
+                name="Renamed",
+                category="cat-123",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        assert "category_warning" not in result["data"], (
+            "category_warning leaked into data payload"
+        )
+        assert "category" not in result["data"], (
+            "category should not be set in data when apply failed"
+        )
+        assert any("failed to set category" in w for w in result["warnings"])
+
     async def test_no_singular_warning_key_at_top_level_or_nested(
         self, register_tools, mock_client
     ):

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -288,13 +288,59 @@ class TestUniformResponseShape:
         # Warning must surface at top level — never nested under ``data``.
         assert "warning" not in result["data"]
         assert "warnings" not in result["data"]
-        assert any(
-            "entity registry update failed" in w for w in result["warnings"]
-        )
+        assert any("entity registry update failed" in w for w in result["warnings"])
         assert any("registry write rejected" in w for w in result["warnings"])
         # Successful registry-write would have propagated area_id into data;
         # the failure must not silently mark data as if it succeeded.
         assert "area_id" not in result["data"]
+
+    async def test_create_propagates_icon_into_data_after_registry_update(
+        self, register_tools, mock_client
+    ):
+        """Successful create-path registry write echoes ``icon`` into ``data``.
+
+        Locks the icon-propagation symmetry with the update branch
+        (``tools_config_helpers.py:3343``). Previously the create-side
+        success branch echoed ``area_id`` and ``labels`` into
+        ``helper_data`` but skipped ``icon`` — a silent asymmetry now
+        closed. The WS create response intentionally omits ``icon`` so
+        the assertion fails closed if the propagation line ever gets
+        dropped or moved out of the success branch.
+        """
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/area_registry/list":
+                return {
+                    "success": True,
+                    "result": [{"area_id": "area.kitchen", "name": "Kitchen"}],
+                }
+            if msg_type == "config/entity_registry/update":
+                return {"success": True, "result": {}}
+            # Helper create — deliberately omit ``icon`` from the result so the
+            # only way it lands in ``data`` is via the post-registry-write
+            # propagation we're locking here.
+            return {
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+                icon="mdi:toggle-switch",
+                area_id="area.kitchen",
+            )
+        _assert_uniform_shape(result, expect_warnings=False)
+        assert result["action"] == "create"
+        assert result["data"]["icon"] == "mdi:toggle-switch"
+        assert result["data"]["area_id"] == "area.kitchen"
 
     async def test_update_failed_registry_update_surfaces_top_level_warning(
         self, register_tools, mock_client
@@ -354,9 +400,7 @@ class TestUniformResponseShape:
         _assert_uniform_shape(result, expect_warnings=True)
         assert "warning" not in result["data"]
         assert "warnings" not in result["data"]
-        assert any(
-            "entity registry update failed" in w for w in result["warnings"]
-        )
+        assert any("entity registry update failed" in w for w in result["warnings"])
         assert any("registry write rejected" in w for w in result["warnings"])
         assert "area_id" not in result["data"]
 

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -1,0 +1,273 @@
+"""Unit tests for issue #1293 — uniform response shape across helper actions.
+
+Lock the contract for ``ha_config_set_helper`` so create / update / flow-helper
+branches return the same wrapper key (``data``) and the same warning shape
+(``warnings`` — top-level list of strings). The pre-#1293 file exposed four
+distinct shapes: nested ``helper_data["warning"]`` (create), top-level
+``response["warning"]`` (update), nested ``updated_data["warning"]`` (update
+registry path), top-level ``result["warnings"]`` plural list (flow). Callers
+doing ``result.get("warning")`` or ``result.get("helper_data")`` uniformly used
+to miss data on at least one branch.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import HomeAssistantConnectionError
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    return client
+
+
+@pytest.fixture
+def register_tools(mock_client):
+    from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+    registered: dict[str, Any] = {}
+
+    def capture_tool(**kwargs):
+        def decorator(fn):
+            registered[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = capture_tool
+    register_config_helper_tools(mock_mcp, mock_client)
+    return registered
+
+
+def _assert_uniform_shape(result: dict[str, Any], *, expect_warnings: bool) -> None:
+    """Common contract for all three branches.
+
+    - ``data`` is always the wrapper key for the post-write payload.
+    - ``warnings``, when present, is a list of strings (never a singular string).
+    - Legacy keys must not leak.
+    """
+    assert result["success"] is True
+    assert "data" in result, f"missing 'data' key: {result.keys()}"
+    assert isinstance(result["data"], dict)
+    # Legacy keys must be gone everywhere — pure rename per #1293.
+    assert "helper_data" not in result, "legacy 'helper_data' wrapper still present"
+    assert "updated_data" not in result, "legacy 'updated_data' wrapper still present"
+    # ``data`` itself must not nest a singular ``warning`` string anymore.
+    assert "warning" not in result["data"], (
+        f"warning leaked into data payload: {result['data']}"
+    )
+    if expect_warnings:
+        assert isinstance(result.get("warnings"), list)
+        assert all(isinstance(w, str) for w in result["warnings"])
+        assert result["warnings"], "warnings list present but empty"
+    else:
+        # Either absent or an empty list — both acceptable.
+        assert "warnings" not in result or result["warnings"] == []
+
+
+class TestUniformResponseShape:
+    """Issue #1293: create / update / flow paths return the same wrapper shape."""
+
+    async def test_create_simple_helper_uses_data_wrapper(
+        self, register_tools, mock_client
+    ):
+        """Simple WS create returns ``data`` wrapper, no ``helper_data``."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+            )
+        _assert_uniform_shape(result, expect_warnings=False)
+        assert result["action"] == "create"
+        assert result["data"]["id"] == "abc123"
+
+    async def test_update_simple_helper_uses_data_wrapper(
+        self, register_tools, mock_client
+    ):
+        """Simple WS update returns ``data`` wrapper, no ``updated_data``."""
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/get":
+                return {
+                    "success": True,
+                    "result": {
+                        "entity_id": msg["entity_id"],
+                        "unique_id": "abc123",
+                        "platform": "input_select",
+                    },
+                }
+            if msg_type.endswith("/list"):
+                return {
+                    "success": True,
+                    "result": [
+                        {"id": "abc123", "name": "Existing", "options": ["a", "b"]}
+                    ],
+                }
+            if msg_type.endswith("/update"):
+                return {
+                    "success": True,
+                    "result": {"id": "abc123", "options": ["x", "y"]},
+                }
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="input_select.existing",
+                options=["x", "y"],
+            )
+        _assert_uniform_shape(result, expect_warnings=False)
+        assert result["action"] == "update"
+
+    async def test_flow_helper_create_uses_data_wrapper(
+        self, register_tools, mock_client
+    ):
+        """Flow-helper create returns ``data`` wrapper with entry_id/title.
+
+        Flat ``entry_id`` / ``title`` are also preserved as convenience
+        accessors — they're the primary identifiers callers reach for.
+        """
+        mock_client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-1",
+                "result": {
+                    "entry_id": "entry-1",
+                    "title": "avg_temp",
+                    "domain": "min_max",
+                },
+            }
+        )
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {"entity_id": "sensor.avg_temp", "config_entry_id": "entry-1"}
+                ],
+            }
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="min_max",
+            name="avg_temp",
+            config={"entity_ids": ["sensor.a", "sensor.b"], "type": "mean"},
+            wait=False,
+        )
+        _assert_uniform_shape(result, expect_warnings=False)
+        assert result["data"]["entry_id"] == "entry-1"
+        assert result["data"]["title"] == "avg_temp"
+        # Flat accessors remain (per-action metadata, not wrapper keys).
+        assert result["entry_id"] == "entry-1"
+        assert result["title"] == "avg_temp"
+        assert result["entity_ids"] == ["sensor.avg_temp"]
+
+    async def test_create_wait_failure_surfaces_top_level_warnings_list(
+        self, register_tools, mock_client
+    ):
+        """A wait exception lands in top-level ``warnings`` list, never nested."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("network down"),
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_update_wait_failure_surfaces_top_level_warnings_list(
+        self, register_tools, mock_client
+    ):
+        """Update wait exception lands in top-level ``warnings`` list, never nested."""
+
+        async def ws_handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/get":
+                return {
+                    "success": True,
+                    "result": {
+                        "entity_id": msg["entity_id"],
+                        "unique_id": "abc123",
+                        "platform": "input_boolean",
+                    },
+                }
+            if msg_type.endswith("/list"):
+                return {
+                    "success": True,
+                    "result": [{"id": "abc123", "name": "Existing"}],
+                }
+            if msg_type.endswith("/update"):
+                return {"success": True, "result": {"id": "abc123"}}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=ws_handler)
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("net glitch"),
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                helper_id="input_boolean.existing",
+                name="Renamed",
+            )
+        _assert_uniform_shape(result, expect_warnings=True)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_no_singular_warning_key_at_top_level_or_nested(
+        self, register_tools, mock_client
+    ):
+        """``warning`` (singular string) must never appear — neither flat nor nested."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {"id": "abc123", "name": "Test Switch"},
+            }
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=False,  # not registered → triggers warning code path
+        ):
+            result = await register_tools["ha_config_set_helper"](
+                helper_type="input_boolean",
+                name="Test Switch",
+            )
+        # The pre-#1293 contract wrote ``helper_data["warning"]``; the new
+        # contract writes ``result["warnings"][i]``.
+        assert "warning" not in result, (
+            "singular 'warning' key must not appear at top level"
+        )
+        assert "warning" not in result["data"], (
+            "singular 'warning' key must not appear inside data wrapper"
+        )
+        assert isinstance(result.get("warnings"), list)
+        assert any("not yet queryable" in w for w in result["warnings"])

--- a/tests/src/unit/test_wait_parameter.py
+++ b/tests/src/unit/test_wait_parameter.py
@@ -457,7 +457,9 @@ class TestHelperWaitParameter:
                 name="Test Switch",
             )
             assert result["success"] is True
-            assert "warning" in result.get("helper_data", {})
+            # Issue #1293: warnings are now a top-level list, not nested in data.
+            assert result.get("warnings"), f"Expected warnings list, got: {result}"
+            assert any("verification failed" in w for w in result["warnings"])
 
 
 class TestServiceCallWaitParameter:
@@ -499,9 +501,7 @@ class TestServiceCallWaitParameter:
             assert result.get("verified_state") == "on"
             mock_wait.assert_called_once()
 
-    async def test_call_service_wait_false_skips_verification(
-        self, tools, mock_client
-    ):
+    async def test_call_service_wait_false_skips_verification(self, tools, mock_client):
         """wait=False skips state verification."""
         with patch(
             "ha_mcp.tools.tools_service.wait_for_state_change", new_callable=AsyncMock
@@ -575,9 +575,7 @@ class TestServiceCallWaitParameter:
                 or call_kwargs[0][2] is None
             )
 
-    async def test_call_service_wait_exception_still_succeeds(
-        self, tools, mock_client
-    ):
+    async def test_call_service_wait_exception_still_succeeds(self, tools, mock_client):
         """Wait exception doesn't collapse the successful service call."""
         with patch(
             "ha_mcp.tools.tools_service.wait_for_state_change", new_callable=AsyncMock


### PR DESCRIPTION
## What does this PR do?

Converges the four distinct response shapes that `ha_config_set_helper` exposed across `create` / `update` / `_handle_flow_helper` onto a single uniform contract.

**Before** (issue #1293 finding):

| Action | Wrapper key | Warning placement |
|---|---|---|
| Create (simple) | `"helper_data": {...}` | nested `helper_data["warning"]` (singular string) |
| Update (simple/tag/fallback) | `"updated_data": {...}` | top-level `response["warning"]` (singular string) |
| Update (registry path) | `"updated_data": {...}` | nested `updated_data["warning"]` (singular string) |
| Flow helper | _none — flat fields_ | top-level `result["warnings"]` (plural list) |

A caller doing `result.get("warning")` found it on update (top-level singular) but missed every other case. A caller doing `result.get("helper_data")` missed update + flow.

**After**:

```python
{
    "success": True,
    "action": "create" | "update",
    "helper_type": "...",
    "data": { ... },              # was helper_data / updated_data
    "entity_id": "...",
    "message": "...",
    "warnings": ["..."],          # always top-level list; omitted when empty
}
```

- **`data`** is the single wrapper key for the post-write payload across all three branches. Flow-helper's `data` contains `{entry_id, title}` (its HA flow_result payload); flat `entry_id` / `title` / `entity_ids` / `applied` etc. remain as convenience accessors — they're per-action metadata, not wrapper keys, and are heavily used by callers throughout the test suite.
- **`warnings`** is always a top-level `list[str]`, omitted when empty. The four nested/singular shapes are gone.
- **`HelperResponse` TypedDict + `_helper_response()` builder** at the top of `tools_config_helpers.py` are the single construction point for the contract — all four return sites funnel through the builder, so a fifth literal can't accrete and drift.

Per `.gemini/styleguide.md` (lines 172-179): _"Return value restructuring (as long as data still accessible) is NOT a breaking change — these are improvements - encourage them."_ Every previous value remains reachable at the new key.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local runs (Alpine, Python 3.13 musl):
- **Unit tests**: 2449 passed, 1 skipped (numpy by-design), 0 failed
- **Contract test** `tests/src/unit/test_helper_response_shape.py`: 10/10 passed — locks the uniform shape across create + update + flow-helper, asserts `warnings` is always a list, asserts the legacy singular `warning` and the `helper_data` / `updated_data` wrappers are gone everywhere, and asserts both failed `apply_entity_category` and failed `entity_registry/update` surface the warning at the top level (never nested inside `data`)
- **Mypy**: clean on `tools_config_helpers.py`
- **Ruff check**: clean on all touched files

E2E tests (run in CI): 34 mechanical key-renames across 9 e2e test files updated to read from the new `data` key; flow-helper-flat-field accessors (`entry_id`, `entity_ids`, etc.) unchanged.

## Future improvements

- **Sibling-bug sweep (separate PR).** The same `result["warning"] = "..."` singular-string anti-pattern lives in `tools_config_scripts.py`, `tools_config_automations.py`, `tools_config_scenes.py`, `tools_groups.py`, `tools_service.py`, `tools_integrations.py`, `tools_energy.py`, `tools_system.py`, `tools_addons.py`, `tools_entities.py`, `tools_search.py`, `backup.py`. The nested `category_warning` leak from `apply_entity_category` likewise still affects `tools_config_scripts.py`, `tools_config_automations.py`, `tools_config_scenes.py`. Issue #1293 scopes only `ha_config_set_helper`; sweeping the rest belongs in a follow-up so the diff stays tractable.
- **`tests/src/e2e/` pre-existing ruff-format debt.** The e2e test files I touched would reformat ~423 lines total under `ruff format`; this is master-state, not introduced by this PR. CI enforces only `ruff check` (verified in `.github/workflows/pr.yml:45-46`), so the debt is non-blocking and stays out-of-scope here.

## Checklist
- [x] I have updated documentation if needed (`AGENTS.md` Return Values section updated to plural-list contract; no public docs reference `helper_data` / `updated_data` as response key names — verified via grep on `docs/`, `README.md`, `.gemini/styleguide.md`)
