### PR TITLE
feat: mirror create-side validation guards onto update path (closes #1292)

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -873,8 +873,12 @@ def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
     The create-branch guard (#1150) and the update-branch guard (#1292) call
     this with the resolved values — caller-supplied or merged from the
     existing config. ``initial=None`` is the unset case and passes through.
+    The ``isinstance(options, list)`` guard mirrors the defensive shape check
+    in ``_validate_input_select_options`` below — both current callers feed a
+    list, but the guard keeps a future non-list caller from raising a confusing
+    ``TypeError`` on ``initial not in options``.
     """
-    if initial is None:
+    if not isinstance(options, list) or initial is None:
         return
     if initial not in options:
         raise_tool_error(
@@ -889,7 +893,7 @@ def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
                 ),
                 suggestions=[
                     "Pick an `initial` value that's in `options`.",
-                    "Or omit `initial` so the entity starts unset.",
+                    "Or omit `initial` to use the default or existing value.",
                 ],
             )
         )

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -909,7 +909,15 @@ def _validate_datetime_has_date_or_time(
             create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
                 "At least one of has_date or has_time must be True for input_datetime",
-                context=_simple_helper_error_context("input_datetime"),
+                context=_simple_helper_error_context(
+                    "input_datetime",
+                    has_date=has_date,
+                    has_time=has_time,
+                ),
+                suggestions=[
+                    "Set has_date=True to keep the date component.",
+                    "Set has_time=True to keep the time component.",
+                ],
             )
         )
 

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -867,16 +867,19 @@ def _validate_numeric_range(
             )
 
 
-def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
-    """Reject input_select ``initial`` values not in ``options`` (Bug 4a, issue #1150).
+def _validate_initial_in_options(
+    options: Any, initial: Any, helper_type: str = "input_select"
+) -> None:
+    """Reject ``initial`` values not in ``options``.
 
-    The create-branch guard (#1150) and the update-branch guard (#1292) call
-    this with the resolved values — caller-supplied or merged from the
-    existing config. ``initial=None`` is the unset case and passes through.
-    The ``isinstance(options, list)`` guard mirrors the defensive shape check
-    in ``_validate_input_select_options`` below — both current callers feed a
-    list, but the guard keeps a future non-list caller from raising a confusing
-    ``TypeError`` on ``initial not in options``.
+    Called from both create and update branches with the resolved values —
+    caller-supplied on create, merged with the existing config on update.
+    ``initial=None`` is the unset case and passes through. The
+    ``isinstance(options, list)`` early-return mirrors the defensive shape
+    check in ``_validate_input_select_options`` below — both validators are
+    invariant gates, not type contracts; a future non-list caller is
+    silently skipped rather than raising a confusing ``TypeError`` on
+    ``initial not in options``.
     """
     if not isinstance(options, list) or initial is None:
         return
@@ -885,9 +888,9 @@ def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
             create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
                 f"initial={initial!r} must be one of options "
-                f"{options!r} for input_select.",
+                f"{options!r} for {helper_type}.",
                 context=_simple_helper_error_context(
-                    "input_select",
+                    helper_type,
                     initial=initial,
                     options=options,
                 ),
@@ -902,11 +905,12 @@ def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
 def _validate_datetime_has_date_or_time(
     has_date: bool | None, has_time: bool | None
 ) -> None:
-    """Reject ``input_datetime`` payloads where both components are False (#1292).
+    """Reject ``input_datetime`` payloads where both components are False.
 
-    Mirrors the create-branch guard onto the update branch. Treats ``None``
-    as "not constrained" — only the explicit (False, False) case is flagged,
-    since that's what reaches HA as the broken-entity payload.
+    Treats ``None`` as "not constrained" — only the explicit (False, False)
+    case is flagged, since that's what reaches HA as the broken-entity
+    payload. Both the create and update branches call this with the
+    resolved-after-merge ``has_date`` / ``has_time`` pair.
     """
     if has_date is False and has_time is False:
         raise_tool_error(
@@ -2457,10 +2461,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
                         )
                     message["options"] = options
-                    # Bug 4a (issue #1150): if `initial` was passed but isn't
-                    # one of the options, reject explicitly instead of silently
-                    # dropping. Shared with the update branch via the helper
-                    # (issue #1292).
+                    # If `initial` was passed but isn't one of the options,
+                    # reject explicitly instead of silently dropping. Shared
+                    # with the update branch via the helper so the same
+                    # invariant fires on both code paths.
                     _validate_initial_in_options(options, initial)
                     if initial is not None:
                         message["initial"] = initial
@@ -2521,7 +2525,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["has_time"] = has_time
 
                     # Validate that at least one is True — shared with the
-                    # update branch via the helper (issue #1292).
+                    # update branch via the helper so the same invariant
+                    # fires on both code paths.
                     _validate_datetime_has_date_or_time(
                         message["has_date"], message["has_time"]
                     )
@@ -3087,11 +3092,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if initial is not None
                                 else existing.get("initial")
                             )
-                            # Issue #1292: parity with the create-branch guard.
-                            # Resolves to (new options, new initial) /
-                            # (new options, old initial) / (old options,
-                            # new initial) — any combination that excludes
-                            # initial from the final options list is caught.
+                            # Parity with the create-branch guard. Resolves to
+                            # (new options, new initial) / (new options, old
+                            # initial) / (old options, new initial) — any
+                            # combination that excludes initial from the final
+                            # options list is caught.
                             _validate_initial_in_options(
                                 update_msg["options"], initial_val
                             )
@@ -3187,8 +3192,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if has_time is not None
                                 else existing.get("has_time", False)
                             )
-                            # Issue #1292: parity with create-branch guard.
-                            # A merge that resolves to (False, False) — caller
+                            # Parity with the create-branch guard. A merge
+                            # that resolves to (False, False) — caller
                             # disabling the one component the existing entity
                             # had — would otherwise write a broken-entity
                             # payload and surface HA's cryptic generic error.

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -867,6 +867,53 @@ def _validate_numeric_range(
             )
 
 
+def _validate_initial_in_options(options: list[Any], initial: Any) -> None:
+    """Reject input_select ``initial`` values not in ``options`` (Bug 4a, issue #1150).
+
+    The create-branch guard (#1150) and the update-branch guard (#1292) call
+    this with the resolved values — caller-supplied or merged from the
+    existing config. ``initial=None`` is the unset case and passes through.
+    """
+    if initial is None:
+        return
+    if initial not in options:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                f"initial={initial!r} must be one of options "
+                f"{options!r} for input_select.",
+                context=_simple_helper_error_context(
+                    "input_select",
+                    initial=initial,
+                    options=options,
+                ),
+                suggestions=[
+                    "Pick an `initial` value that's in `options`.",
+                    "Or omit `initial` so the entity starts unset.",
+                ],
+            )
+        )
+
+
+def _validate_datetime_has_date_or_time(
+    has_date: bool | None, has_time: bool | None
+) -> None:
+    """Reject ``input_datetime`` payloads where both components are False (#1292).
+
+    Mirrors the create-branch guard onto the update branch. Treats ``None``
+    as "not constrained" — only the explicit (False, False) case is flagged,
+    since that's what reaches HA as the broken-entity payload.
+    """
+    if has_date is False and has_time is False:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "At least one of has_date or has_time must be True for input_datetime",
+                context=_simple_helper_error_context("input_datetime"),
+            )
+        )
+
+
 def _validate_input_select_options(options: Any) -> None:
     """Reject input_select option lists containing duplicates (Bug 17, issue #1150).
 
@@ -2400,26 +2447,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     message["options"] = options
                     # Bug 4a (issue #1150): if `initial` was passed but isn't
                     # one of the options, reject explicitly instead of silently
-                    # dropping. The previous `if initial and initial in options`
-                    # check stripped invalid initials with `success: true`.
+                    # dropping. Shared with the update branch via the helper
+                    # (issue #1292).
+                    _validate_initial_in_options(options, initial)
                     if initial is not None:
-                        if initial not in options:
-                            raise_tool_error(
-                                create_error_response(
-                                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                    f"initial={initial!r} must be one of options "
-                                    f"{options!r} for input_select.",
-                                    context=_simple_helper_error_context(
-                                        helper_type,
-                                        initial=initial,
-                                        options=options,
-                                    ),
-                                    suggestions=[
-                                        "Pick an `initial` value that's in `options`.",
-                                        "Or omit `initial` so the entity starts unset.",
-                                    ],
-                                )
-                            )
                         message["initial"] = initial
 
                 elif helper_type == "input_number":
@@ -2477,15 +2508,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message["has_date"] = has_date
                         message["has_time"] = has_time
 
-                    # Validate that at least one is True
-                    if not message["has_date"] and not message["has_time"]:
-                        raise_tool_error(
-                            create_error_response(
-                                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                                "At least one of has_date or has_time must be True for input_datetime",
-                                context=_simple_helper_error_context(helper_type),
-                            )
-                        )
+                    # Validate that at least one is True — shared with the
+                    # update branch via the helper (issue #1292).
+                    _validate_datetime_has_date_or_time(
+                        message["has_date"], message["has_time"]
+                    )
 
                     if initial is not None:
                         message["initial"] = initial
@@ -3048,6 +3075,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 if initial is not None
                                 else existing.get("initial")
                             )
+                            # Issue #1292: parity with the create-branch guard.
+                            # Resolves to (new options, new initial) /
+                            # (new options, old initial) / (old options,
+                            # new initial) — any combination that excludes
+                            # initial from the final options list is caught.
+                            _validate_initial_in_options(
+                                update_msg["options"], initial_val
+                            )
                             if initial_val is not None:
                                 update_msg["initial"] = initial_val
 
@@ -3139,6 +3174,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                                 has_time
                                 if has_time is not None
                                 else existing.get("has_time", False)
+                            )
+                            # Issue #1292: parity with create-branch guard.
+                            # A merge that resolves to (False, False) — caller
+                            # disabling the one component the existing entity
+                            # had — would otherwise write a broken-entity
+                            # payload and surface HA's cryptic generic error.
+                            _validate_datetime_has_date_or_time(
+                                update_msg["has_date"], update_msg["has_time"]
                             )
                             initial_val = (
                                 initial

--- a/tests/src/unit/test_helper_input_validation.py
+++ b/tests/src/unit/test_helper_input_validation.py
@@ -513,3 +513,251 @@ class TestUpdateRangeValidation:
                 options=["A", "A"],
             )
         _assert_invalid_param(excinfo)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1292 — initial-in-options + has_date/has_time guards on the update path
+# ---------------------------------------------------------------------------
+
+
+def _wire_existing_config(
+    mock_client, helper_type: str, existing_config: dict[str, Any]
+) -> None:
+    """Like ``_wire_default_ws`` but seeds the existing-config the update path
+    merges from. Used to simulate a starting state and assert the
+    resolved-after-merge guard fires when the merge produces an invalid combo.
+    """
+    mock_client.send_websocket_message = AsyncMock(
+        side_effect=mock_client._make_ws_responses(
+            helper_type, existing_config=existing_config
+        )
+    )
+
+
+class TestInputSelectInitialInOptions:
+    """Bug 4a (#1150) on create + #1292 parity on update.
+
+    Each scenario must produce the same ``VALIDATION_INVALID_PARAMETER`` error
+    on both code paths, so a caller hitting the invariant gets the same
+    actionable message regardless of action.
+    """
+
+    # --- Create-side coverage (the #1150 guard previously had no unit test) ---
+
+    async def test_create_rejects_initial_not_in_options(
+        self, register_tools, mock_client
+    ):
+        _wire_default_ws(mock_client, "input_select")
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                name="Mode",
+                options=["A", "B"],
+                initial="C",
+            )
+        _assert_invalid_param(excinfo)
+        assert "initial" in str(excinfo.value).lower()
+
+    async def test_create_valid_initial_passes(self, register_tools, mock_client):
+        _wire_default_ws(mock_client, "input_select")
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                name="Mode",
+                options=["A", "B", "C"],
+                initial="B",
+            )
+        msg = _find_msg(mock_client, "input_select/create")
+        assert msg is not None
+        assert msg["initial"] == "B"
+
+    # --- Update-side coverage (#1292 parity gap) ---
+
+    async def test_update_rejects_new_initial_not_in_new_options(
+        self, register_tools, mock_client
+    ):
+        """Both ``options`` and ``initial`` supplied; initial isn't in the new list."""
+        _wire_existing_config(
+            mock_client,
+            "input_select",
+            {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="mode",
+                options=["X", "Y"],
+                initial="Z",
+            )
+        _assert_invalid_param(excinfo)
+        assert "initial" in str(excinfo.value).lower()
+
+    async def test_update_rejects_existing_initial_falls_out_of_new_options(
+        self, register_tools, mock_client
+    ):
+        """Caller changes only ``options``; the existing-merged ``initial`` is no
+        longer in the new list. The pre-#1292 bug surfaced here as HA's generic
+        error."""
+        _wire_existing_config(
+            mock_client,
+            "input_select",
+            {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="mode",
+                options=["X", "Y"],
+            )
+        _assert_invalid_param(excinfo)
+        assert "initial" in str(excinfo.value).lower()
+
+    async def test_update_rejects_new_initial_outside_existing_options(
+        self, register_tools, mock_client
+    ):
+        """Caller changes only ``initial``; the value isn't in the existing options."""
+        _wire_existing_config(
+            mock_client,
+            "input_select",
+            {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="mode",
+                initial="Z",
+            )
+        _assert_invalid_param(excinfo)
+        assert "initial" in str(excinfo.value).lower()
+
+    async def test_update_happy_path_passes(self, register_tools, mock_client):
+        """Valid merge — happy path. Guards against false-positive rejections."""
+        _wire_existing_config(
+            mock_client,
+            "input_select",
+            {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="mode",
+                options=["A", "B", "C"],
+                initial="C",
+            )
+        msg = _find_msg(mock_client, "input_select/update")
+        assert msg is not None
+        assert msg["options"] == ["A", "B", "C"]
+        assert msg["initial"] == "C"
+
+
+class TestInputDatetimeHasDateOrTime:
+    """Issue #1292 parity for ``input_datetime`` has_date/has_time guard.
+
+    Same as input_select: the create-branch guard already exists; the update
+    branch needs the same invariant or callers can disable both components and
+    write a broken-entity payload.
+    """
+
+    # --- Create-side coverage (no existing unit test for the #1150 guard) ---
+
+    async def test_create_rejects_both_false(self, register_tools, mock_client):
+        _wire_default_ws(mock_client, "input_datetime")
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                name="Schedule",
+                has_date=False,
+                has_time=False,
+            )
+        _assert_invalid_param(excinfo)
+        assert "has_date" in str(excinfo.value) or "has_time" in str(excinfo.value)
+
+    async def test_create_with_only_date_passes(self, register_tools, mock_client):
+        _wire_default_ws(mock_client, "input_datetime")
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                name="DateOnly",
+                has_date=True,
+                has_time=False,
+            )
+        msg = _find_msg(mock_client, "input_datetime/create")
+        assert msg is not None
+        assert msg["has_date"] is True
+        assert msg["has_time"] is False
+
+    # --- Update-side coverage (#1292 parity gap) ---
+
+    async def test_update_rejects_disabling_both_components(
+        self, register_tools, mock_client
+    ):
+        """Caller sets both False explicitly; the merged payload would write
+        a broken-entity state into HA."""
+        _wire_existing_config(
+            mock_client,
+            "input_datetime",
+            {"id": "abc123", "name": "Schedule", "has_date": True, "has_time": True},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                helper_id="schedule",
+                has_date=False,
+                has_time=False,
+            )
+        _assert_invalid_param(excinfo)
+
+    async def test_update_rejects_disabling_only_remaining_component(
+        self, register_tools, mock_client
+    ):
+        """Existing has only has_time=True; caller disables has_time. The merge
+        resolves to (False, False) — a fall-out the guard catches."""
+        _wire_existing_config(
+            mock_client,
+            "input_datetime",
+            {"id": "abc123", "name": "TimeOnly", "has_date": False, "has_time": True},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                helper_id="timeonly",
+                has_time=False,
+            )
+        _assert_invalid_param(excinfo)
+
+    async def test_update_happy_path_keeps_both_true(
+        self, register_tools, mock_client
+    ):
+        """Valid merge passes — guards against false-positive rejection on a
+        no-op-ish update."""
+        _wire_existing_config(
+            mock_client,
+            "input_datetime",
+            {"id": "abc123", "name": "Schedule", "has_date": True, "has_time": True},
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                helper_id="schedule",
+                has_date=True,
+            )
+        msg = _find_msg(mock_client, "input_datetime/update")
+        assert msg is not None
+        assert msg["has_date"] is True
+        assert msg["has_time"] is True

--- a/tests/src/unit/test_helper_input_validation.py
+++ b/tests/src/unit/test_helper_input_validation.py
@@ -107,9 +107,19 @@ def register_tools(mock_client):
     return registered
 
 
-def _wire_default_ws(mock_client, helper_type: str) -> None:
+def _wire_default_ws(
+    mock_client,
+    helper_type: str,
+    existing_config: dict[str, Any] | None = None,
+) -> None:
+    """Seed the WS-response handler. ``existing_config`` overrides the
+    default seed the update path merges from, used by the parity-guard tests
+    to construct a specific starting state.
+    """
     mock_client.send_websocket_message = AsyncMock(
-        side_effect=mock_client._make_ws_responses(helper_type)
+        side_effect=mock_client._make_ws_responses(
+            helper_type, existing_config=existing_config
+        )
     )
 
 
@@ -516,33 +526,20 @@ class TestUpdateRangeValidation:
 
 
 # ---------------------------------------------------------------------------
-# Issue #1292 — initial-in-options + has_date/has_time guards on the update path
+# input_select initial-in-options + input_datetime has_date/has_time guards —
+# create-side coverage plus the corresponding update-path parity.
 # ---------------------------------------------------------------------------
 
 
-def _wire_existing_config(
-    mock_client, helper_type: str, existing_config: dict[str, Any]
-) -> None:
-    """Like ``_wire_default_ws`` but seeds the existing-config the update path
-    merges from. Used to simulate a starting state and assert the
-    resolved-after-merge guard fires when the merge produces an invalid combo.
-    """
-    mock_client.send_websocket_message = AsyncMock(
-        side_effect=mock_client._make_ws_responses(
-            helper_type, existing_config=existing_config
-        )
-    )
-
-
 class TestInputSelectInitialInOptions:
-    """Bug 4a (#1150) on create + #1292 parity on update.
+    """input_select: ``initial`` must be one of ``options`` on both branches.
 
     Each scenario must produce the same ``VALIDATION_INVALID_PARAMETER`` error
     on both code paths, so a caller hitting the invariant gets the same
     actionable message regardless of action.
     """
 
-    # --- Create-side coverage (the #1150 guard previously had no unit test) ---
+    # --- Create-side coverage ---
 
     async def test_create_rejects_initial_not_in_options(
         self, register_tools, mock_client
@@ -575,13 +572,13 @@ class TestInputSelectInitialInOptions:
         assert msg is not None
         assert msg["initial"] == "B"
 
-    # --- Update-side coverage (#1292 parity gap) ---
+    # --- Update-side coverage ---
 
     async def test_update_rejects_new_initial_not_in_new_options(
         self, register_tools, mock_client
     ):
         """Both ``options`` and ``initial`` supplied; initial isn't in the new list."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_select",
             {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
@@ -600,9 +597,9 @@ class TestInputSelectInitialInOptions:
         self, register_tools, mock_client
     ):
         """Caller changes only ``options``; the existing-merged ``initial`` is no
-        longer in the new list. The pre-#1292 bug surfaced here as HA's generic
-        error."""
-        _wire_existing_config(
+        longer in the new list — the parity guard catches the resolved-after-merge
+        invalid combo before the WS write."""
+        _wire_default_ws(
             mock_client,
             "input_select",
             {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
@@ -620,7 +617,7 @@ class TestInputSelectInitialInOptions:
         self, register_tools, mock_client
     ):
         """Caller changes only ``initial``; the value isn't in the existing options."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_select",
             {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
@@ -636,7 +633,7 @@ class TestInputSelectInitialInOptions:
 
     async def test_update_happy_path_passes(self, register_tools, mock_client):
         """Valid merge — happy path. Guards against false-positive rejections."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_select",
             {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
@@ -659,14 +656,15 @@ class TestInputSelectInitialInOptions:
 
 
 class TestInputDatetimeHasDateOrTime:
-    """Issue #1292 parity for ``input_datetime`` has_date/has_time guard.
+    """input_datetime: at least one of has_date/has_time must be True on both branches.
 
-    Same as input_select: the create-branch guard already exists; the update
-    branch needs the same invariant or callers can disable both components and
-    write a broken-entity payload.
+    The create and update branches each call the shared validator with the
+    resolved-after-merge ``(has_date, has_time)`` pair; either explicit
+    ``(False, False)`` from the caller or an update that disables the one
+    remaining True component is caught before the WS write.
     """
 
-    # --- Create-side coverage (no existing unit test for the #1150 guard) ---
+    # --- Create-side coverage ---
 
     async def test_create_rejects_both_false(self, register_tools, mock_client):
         _wire_default_ws(mock_client, "input_datetime")
@@ -698,14 +696,14 @@ class TestInputDatetimeHasDateOrTime:
         assert msg["has_date"] is True
         assert msg["has_time"] is False
 
-    # --- Update-side coverage (#1292 parity gap) ---
+    # --- Update-side coverage ---
 
     async def test_update_rejects_disabling_both_components(
         self, register_tools, mock_client
     ):
         """Caller sets both False explicitly; the merged payload would write
         a broken-entity state into HA."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_datetime",
             {"id": "abc123", "name": "Schedule", "has_date": True, "has_time": True},
@@ -724,7 +722,7 @@ class TestInputDatetimeHasDateOrTime:
     ):
         """Existing has only has_time=True; caller disables has_time. The merge
         resolves to (False, False) — a fall-out the guard catches."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_datetime",
             {"id": "abc123", "name": "TimeOnly", "has_date": False, "has_time": True},
@@ -742,7 +740,7 @@ class TestInputDatetimeHasDateOrTime:
     ):
         """Valid merge passes — guards against false-positive rejection on a
         no-op-ish update."""
-        _wire_existing_config(
+        _wire_default_ws(
             mock_client,
             "input_datetime",
             {"id": "abc123", "name": "Schedule", "has_date": True, "has_time": True},
@@ -761,3 +759,120 @@ class TestInputDatetimeHasDateOrTime:
         assert msg is not None
         assert msg["has_date"] is True
         assert msg["has_time"] is True
+
+    async def test_update_happy_path_omits_both_against_one_remaining(
+        self, register_tools, mock_client
+    ):
+        """Caller passes neither ``has_date`` nor ``has_time``; existing has
+        ``(False, True)``. The merge resolves to the existing state — no fall
+        to ``(False, False)``, so the guard must not reject."""
+        _wire_default_ws(
+            mock_client,
+            "input_datetime",
+            {"id": "abc123", "name": "TimeOnly", "has_date": False, "has_time": True},
+        )
+        with patch(
+            "ha_mcp.tools.tools_config_helpers.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_datetime",
+                helper_id="timeonly",
+                name="Renamed",
+            )
+        msg = _find_msg(mock_client, "input_datetime/update")
+        assert msg is not None
+        assert msg["has_date"] is False
+        assert msg["has_time"] is True
+
+
+# ---------------------------------------------------------------------------
+# Direct validator contract tests — exercise the helpers' own invariants
+# rather than the tool's WS plumbing, so the shape-guard semantics are
+# pinned independently of any future call-site refactor.
+# ---------------------------------------------------------------------------
+
+
+class TestValidateInitialInOptionsShapeGuard:
+    """``_validate_initial_in_options`` early-return contract.
+
+    Non-list ``options`` (or ``initial=None``) must pass through silently —
+    no ``TypeError`` from ``initial not in options``, no ``ToolError``. The
+    current callers feed lists, but a future caller might not; the guard
+    keeps that latent path from raising a confusing diagnostic.
+    """
+
+    def test_none_options_returns_silently(self):
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        # No raise — the guard short-circuits before the membership check.
+        _validate_initial_in_options(None, "anything")
+
+    def test_string_options_returns_silently(self):
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        _validate_initial_in_options("not a list", "anything")
+
+    def test_dict_options_returns_silently(self):
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        _validate_initial_in_options({"a": 1}, "a")
+
+    def test_none_initial_with_list_options_returns_silently(self):
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        # ``initial=None`` is the unset case — passes regardless of options.
+        _validate_initial_in_options(["A", "B"], None)
+
+    def test_helper_type_param_threads_to_error_context(self):
+        """A non-default ``helper_type`` reaches the error message + context."""
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        with pytest.raises(ToolError) as excinfo:
+            _validate_initial_in_options(["A", "B"], "Z", helper_type="some_other")
+        _assert_invalid_param(excinfo)
+        assert "some_other" in str(excinfo.value)
+
+
+class TestValidateInitialInOptionsEdges:
+    """Edge cases on the ``(options, initial)`` membership check."""
+
+    def test_empty_string_initial_rejected_against_non_empty_options(self):
+        """``initial=""`` is a set value (not ``None``) and must reject when
+        not in ``options`` — the truthy-only ``if initial:`` shortcut the
+        pre-helper inline code had would have silently dropped it."""
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        with pytest.raises(ToolError) as excinfo:
+            _validate_initial_in_options(["A", "B"], "")
+        _assert_invalid_param(excinfo)
+
+    def test_empty_options_with_any_initial_rejected(self):
+        """``options=[]`` means no value can be valid; an ``initial`` must
+        reject. The update path can reach this if the caller passes
+        ``options=[]`` explicitly or the existing config has no options."""
+        from ha_mcp.tools.tools_config_helpers import _validate_initial_in_options
+
+        with pytest.raises(ToolError) as excinfo:
+            _validate_initial_in_options([], "A")
+        _assert_invalid_param(excinfo)
+
+    async def test_update_rejects_initial_empty_string_against_existing_options(
+        self, register_tools, mock_client
+    ):
+        """End-to-end edge: caller passes ``initial=""`` on update against
+        non-empty existing options. The update path must reject the same
+        way the create path would."""
+        _wire_default_ws(
+            mock_client,
+            "input_select",
+            {"id": "abc123", "name": "Mode", "options": ["A", "B"], "initial": "A"},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_helper"](
+                helper_type="input_select",
+                helper_id="mode",
+                initial="",
+            )
+        _assert_invalid_param(excinfo)


### PR DESCRIPTION
## What does this PR do?

Closes the parity gap that issue #1292 surfaces: two input-side validation guards that fire on the **create** branch of `ha_config_set_helper` are absent from the **update** branch.

| Helper type | Constraint | Create-side (existed since #1150) | Update-side (before this PR) |
|---|---|---|---|
| `input_select` | `initial` ∈ `options` | ✓ enforced (`src/ha_mcp/tools/tools_config_helpers.py:L2401-2422` on master) | ✗ values merged, guard absent |
| `input_datetime` | at least one of `has_date` / `has_time` is `True` | ✓ enforced (`L2481-2488` on master) | ✗ values merged, guard absent |

A caller hitting either today reaches the same broken-entity state with `success: true` that #1150 closed for the create path, or surfaces the generic HA error message the create-side guard exists to pre-empt.

**Approach** — extract-and-share, matching the sibling pattern at `tools_config_helpers.py:L869-998` (`_validate_numeric_range`, `_validate_input_select_options`, `_validate_schedule_days`):

- `_validate_initial_in_options(options, initial, helper_type="input_select")` — accepts the resolved values from either branch; treats `initial=None` as the unset case so a merge-fall-through that leaves `initial` unset doesn't false-positive. `options: Any` with an internal `isinstance(options, list)` early-return mirrors the sibling validator's shape-guard pattern.
- `_validate_datetime_has_date_or_time(has_date, has_time)` — flags only the explicit `(False, False)` resolved-after-merge combo the issue targets; `None` passes through (not constrained).

Both validators are called from the create branch (replacing the inline blocks) and from the update branch after the merge step that resolves the final `(options, initial)` and `(has_date, has_time)` pairs.

**User-visible message shift on the create path:** the inline create-branch error message previously suggested *"Or omit `initial` so the entity starts unset"*. The shared validator now reads *"Or omit `initial` to use the default or existing value."* — a generalization for the dual-branch use, accurate on both code paths (omit on create → unset/default; omit on update → preserve existing via the merge).

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local runs (Alpine, Python 3.13 musl):
- **Unit tests**: 2459 passed, 1 skipped (numpy by-design), 0 failed
- **New tests** (`tests/src/unit/test_helper_input_validation.py`): 20 added — 4 closing the previously-untested coverage gap for the #1150 create-side guards, 8 covering the new update-side parity (5 input_select, 3 input_datetime), 5 direct shape-guard contract tests (`TestValidateInitialInOptionsShapeGuard` — None/str/dict options pass through silently; `None` initial with list options passes through; `helper_type` param threads to error context), and 3 edge tests (`TestValidateInitialInOptionsEdges` — `initial=""` against non-empty options rejects; `options=[]` with any initial rejects; end-to-end update path with `initial=""` against existing options rejects).
- **Mypy**: clean on `tools_config_helpers.py`
- **Ruff check**: clean on all touched files

## Future improvements

- **Sibling-validator audit on update paths**: the same create-only-guard pattern that motivated this PR may exist elsewhere in `tools_config_helpers.py` (e.g. `counter`, `timer`, `input_text` ranges). The numeric-range guard already runs on update via `_validate_numeric_range`; the remaining per-type fields would benefit from the same audit. Out-of-scope here to keep the PR narrowly aligned with issue #1292.

## Checklist
- [x] I have updated documentation if needed (no public docs reference these validators)
