### PR TITLE
docs: fix two stale ha_get_skill_guide references missed in #1289

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ An MCP server can create automations, helpers, and dashboards, but it has no opi
 
 ### Bundled Skills (built-in)
 
-Skills from `homeassistant-ai/skills` are bundled and served as [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) via `skill://` URIs. Any MCP client that supports resources can discover them automatically — no manual installation needed. For tool-only clients, the same skills are also exposed as `ha_list_resources` / `ha_read_resource` tools. Resources are not auto-injected into context — clients must explicitly request them, so idle context cost is just the metadata listing.
+Skills from `homeassistant-ai/skills` are bundled and served as [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) via `skill://` URIs. Any MCP client that supports resources can discover them automatically — no manual installation needed. For tool-only clients (claude.ai, etc.), the same skills are reachable through the polymorphic `ha_get_skill_guide` tool — call it with no args to list bundled skills, with a `skill` arg to list its files, or with `skill` + `file` to read content. Resources are not auto-injected into context — clients must explicitly request them, so idle context cost is just the metadata listing.
 
-If you want to hide either tool from the catalog, disable it from the web settings UI like any other tool.
+`ha_get_skill_guide` is mandatory-pinned: the catalog always exposes it so tool-only clients never see a silently missing skill surface.
 
 Skills can still be installed manually for clients that prefer local skill files — see the [skills repo](https://github.com/homeassistant-ai/skills) for instructions.
 

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -513,7 +513,7 @@ The add-on provides 89+ MCP tools for controlling Home Assistant:
 
 <!-- ADDON_TOOLS_END -->
 
-For domain-specific Home Assistant documentation, use the `ha_get_skill_home_assistant_best_practices` resource.
+For domain-specific Home Assistant documentation, use the `ha_get_skill_guide` tool (or read the `skill://` resources directly if your MCP client supports resources).
 
 See the [main repository](https://github.com/homeassistant-ai/ha-mcp) for detailed tool documentation and examples.
 


### PR DESCRIPTION
## What does this PR do?

Followup to PR #1289 (skill tool consolidation). Two stale user-facing references slipped past the rename sweep — Patch76 flagged both in his approving review.

- **`README.md`** "Bundled Skills" paragraph still described `ha_list_resources` / `ha_read_resource` and told users they could disable them via the settings UI. Both are wrong: the tools no longer exist, and the replacement `ha_get_skill_guide` is in `MANDATORY_TOOLS` so the UI strips it from any disable list.
- **`homeassistant-addon/DOCS.md:516`** still pointed at the old `ha_get_skill_home_assistant_best_practices` resource. The `homeassistant-addon-dev/DOCS.md` sibling was already updated in #1289 but this prod one wasn't.

I had originally skipped these expecting `sync-tool-docs.yml` to regenerate them, but verified post-merge: the workflow's `extract_tools.py` only touches `site/src/data/tools.json` in practice, and only regenerates the auto-generated tool-listing sections — not the surrounding hand-authored prose. My mistake.

Both replacements describe `ha_get_skill_guide` accurately and mention the mandatory-pin contract where relevant.

I also re-grepped the entire codebase. Every other remaining occurrence of the old tool names is intentional and verified:

- `src/ha_mcp/server.py` `_OLD_SKILL_TOOL_ALIASES` constant + `_SEARCH_KEYWORDS` entry — BM25 redirect aliases so agents trained on the prior catalog get routed to the replacement.
- Test assertions that either (a) lock the redirect-alias content in place, or (b) assert the old names DON'T appear in the live tool list (regression guards).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] Code follows style guidelines (\`uv run ruff check\`) — doc-only change, no Python touched
- [ ] I have tested these changes with a LLM agent — n/a, doc-only
- [ ] All automated tests pass (\`uv run pytest\`) — will verify via CI

## Future improvements

None — this PR is intentionally minimal in scope.