### PR TITLE
test(e2e): centralize wait_for_entity_registration helper (refs #366)

### DIFF
--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -361,9 +361,12 @@ async def wait_for_entity_registration(
         # Check if 'data' key exists (not 'success' key)
         success = "data" in data and data["data"] is not None
 
-        # Log every attempt with full details
+        # Per-attempt details at debug level so transient misses don't
+        # clutter CI logs; sibling wait_for_entity_state follows the same
+        # convention. See .gemini/styleguide.md ("Exception Handling in
+        # Test Polling Loops").
         elapsed = time.monotonic() - start_time
-        logger.info(
+        logger.debug(
             f"[Attempt {attempt} @ {elapsed:.1f}s] Checking {entity_id}: "
             f"success={success}, data keys={list(data.keys())}"
         )
@@ -373,7 +376,7 @@ async def wait_for_entity_registration(
             logger.info(f"✅ Entity {entity_id} EXISTS with state='{state}'")
         else:
             error = data.get("error", "No error message")
-            logger.warning(f"❌ Entity {entity_id} check failed: {error}")
+            logger.debug(f"❌ Entity {entity_id} check failed: {error}")
 
         return success
 

--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -14,7 +14,7 @@ from typing import Any
 from fastmcp.exceptions import ClientError, FastMCPError
 from mcp import McpError
 
-from .assertions import parse_mcp_result
+from .assertions import parse_mcp_result, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -328,3 +328,55 @@ async def wait_for_tool_result(
                 f"{description}: timed out after {timeout}s (predicate not satisfied)"
             )
         await asyncio.sleep(poll_interval)
+
+
+async def wait_for_entity_registration(
+    mcp_client, entity_id: str, timeout: int = 20
+) -> bool:
+    """
+    Wait for entity to be registered and queryable via API.
+
+    Does not check for a specific state — only that the entity exists and is
+    visible to ``ha_get_state``. Useful after ``ha_config_set_helper`` or
+    ``ha_set_entity``, where the tool returns success before Home Assistant
+    finishes the async entity-registry update.
+
+    Args:
+        mcp_client: FastMCP client instance
+        entity_id: Entity to wait for
+        timeout: Maximum wait time in seconds
+
+    Returns:
+        True if entity becomes queryable within timeout, False otherwise.
+    """
+    start_time = time.monotonic()
+    attempt = 0
+
+    async def entity_exists():
+        nonlocal attempt
+        attempt += 1
+        data = await safe_call_tool(
+            mcp_client, "ha_get_state", {"entity_id": entity_id}
+        )
+        # Check if 'data' key exists (not 'success' key)
+        success = "data" in data and data["data"] is not None
+
+        # Log every attempt with full details
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            f"[Attempt {attempt} @ {elapsed:.1f}s] Checking {entity_id}: "
+            f"success={success}, data keys={list(data.keys())}"
+        )
+
+        if success:
+            state = data.get("data", {}).get("state", "N/A")
+            logger.info(f"✅ Entity {entity_id} EXISTS with state='{state}'")
+        else:
+            error = data.get("error", "No error message")
+            logger.warning(f"❌ Entity {entity_id} check failed: {error}")
+
+        return success
+
+    return await wait_for_condition(
+        entity_exists, timeout=timeout, condition_name=f"{entity_id} registration"
+    )

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -17,46 +17,13 @@ from ...utilities.assertions import (
     parse_mcp_result,
     safe_call_tool,
 )
-from ...utilities.wait_helpers import wait_for_condition, wait_for_entity_state
+from ...utilities.wait_helpers import (
+    wait_for_condition,
+    wait_for_entity_registration,
+    wait_for_entity_state,
+)
 
 logger = logging.getLogger(__name__)
-
-
-async def wait_for_entity_registration(mcp_client, entity_id: str, timeout: int = 20) -> bool:
-    """
-    Wait for entity to be registered and queryable via API.
-    Does not check for specific state, only that entity exists.
-    """
-    import time
-    start_time = time.monotonic()
-    attempt = 0
-
-    async def entity_exists():
-        nonlocal attempt
-        attempt += 1
-        data = await safe_call_tool(mcp_client, "ha_get_state", {"entity_id": entity_id})
-        # Check if 'data' key exists (not 'success' key)
-        success = 'data' in data and data['data'] is not None
-
-        # Log every attempt with full details
-        elapsed = time.monotonic() - start_time
-        logger.info(
-            f"[Attempt {attempt} @ {elapsed:.1f}s] Checking {entity_id}: "
-            f"success={success}, data keys={list(data.keys())}"
-        )
-
-        if success:
-            state = data.get("data", {}).get("state", "N/A")
-            logger.info(f"✅ Entity {entity_id} EXISTS with state='{state}'")
-        else:
-            error = data.get("error", "No error message")
-            logger.warning(f"❌ Entity {entity_id} check failed: {error}")
-
-        return success
-
-    return await wait_for_condition(
-        entity_exists, timeout=timeout, condition_name=f"{entity_id} registration"
-    )
 
 
 def get_entity_id_from_response(data: dict, helper_type: str) -> str | None:

--- a/tests/src/e2e/workflows/registry/test_entity_rename.py
+++ b/tests/src/e2e/workflows/registry/test_entity_rename.py
@@ -14,12 +14,12 @@ Key test scenarios:
 - Rename entity and device together (convenience wrapper)
 """
 
-import asyncio
 import logging
 
 import pytest
 
 from ...utilities.assertions import safe_call_tool
+from ...utilities.wait_helpers import wait_for_entity_registration
 
 logger = logging.getLogger(__name__)
 
@@ -57,21 +57,13 @@ class TestEntityRename:
         cleanup_tracker.track("input_boolean", new_entity_id)
         logger.info(f"Created helper: {original_entity_id}")
 
-        # Wait for entity to be registered (retry with backoff)
-        state_data = None
-        for attempt in range(10):
-            await asyncio.sleep(0.5)  # Wait before checking
-            state_data = await safe_call_tool(
-                mcp_client, "ha_get_state", {"entity_id": original_entity_id}
-            )
-            if "data" in state_data and state_data["data"].get("state"):
-                break
-            logger.info(f"Waiting for entity to register (attempt {attempt + 1}/10)...")
-
         # 2. VERIFY: Original entity exists
-        assert (
-            state_data and "data" in state_data and state_data["data"].get("state")
-        ), f"Original entity not found after waiting: {state_data}"
+        entity_ready = await wait_for_entity_registration(
+            mcp_client, original_entity_id
+        )
+        assert entity_ready, (
+            f"Original entity not found after waiting: {original_entity_id}"
+        )
         logger.info(f"Verified original entity exists: {original_entity_id}")
 
         # 3. RENAME: Change entity_id
@@ -89,23 +81,11 @@ class TestEntityRename:
         assert rename_data.get("entity_id") == new_entity_id
         logger.info(f"Renamed entity: {original_entity_id} -> {new_entity_id}")
 
-        # Wait for rename to propagate (retry with backoff)
-        new_state_data = None
-        for attempt in range(10):
-            await asyncio.sleep(0.5)
-            new_state_data = await safe_call_tool(
-                mcp_client, "ha_get_state", {"entity_id": new_entity_id}
-            )
-            if "data" in new_state_data and new_state_data["data"].get("state"):
-                break
-            logger.info(f"Waiting for renamed entity (attempt {attempt + 1}/10)...")
-
         # 4. VERIFY: New entity exists and works
-        assert (
-            new_state_data
-            and "data" in new_state_data
-            and new_state_data["data"].get("state")
-        ), f"New entity not accessible after waiting: {new_state_data}"
+        new_entity_ready = await wait_for_entity_registration(mcp_client, new_entity_id)
+        assert new_entity_ready, (
+            f"New entity not accessible after waiting: {new_entity_id}"
+        )
         logger.info(f"Verified new entity exists: {new_entity_id}")
 
         # 5. VERIFY: Old entity_id no longer exists
@@ -159,15 +139,7 @@ class TestEntityRename:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        # Wait for entity to be registered (retry with backoff)
-        for attempt in range(10):
-            await asyncio.sleep(0.5)
-            state_data = await safe_call_tool(
-                mcp_client, "ha_get_state", {"entity_id": original_entity_id}
-            )
-            if "data" in state_data and state_data["data"].get("state"):
-                break
-            logger.info(f"Waiting for entity to register (attempt {attempt + 1}/10)...")
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # 2. RENAME: With name and icon updates
         rename_data = await safe_call_tool(
@@ -184,10 +156,8 @@ class TestEntityRename:
         assert rename_data.get("success"), f"Failed to rename entity: {rename_data}"
         logger.info("Renamed entity with name and icon update")
 
-        # Wait for rename to propagate
-        await asyncio.sleep(0.5)
-
         # 3. VERIFY: New entity has updated attributes
+        await wait_for_entity_registration(mcp_client, new_entity_id)
         state_data = await safe_call_tool(
             mcp_client, "ha_get_state", {"entity_id": new_entity_id}
         )
@@ -329,8 +299,7 @@ async def test_rename_entity_basic(mcp_client, cleanup_tracker):
     new_id = "input_button.test_quick_renamed"
     cleanup_tracker.track("input_button", new_id)
 
-    # Wait for entity to be registered
-    await asyncio.sleep(1.0)
+    await wait_for_entity_registration(mcp_client, original_id)
 
     # Rename
     rename_data = await safe_call_tool(
@@ -343,8 +312,7 @@ async def test_rename_entity_basic(mcp_client, cleanup_tracker):
     )
     assert rename_data.get("success"), f"Failed to rename: {rename_data}"
 
-    # Wait for rename to propagate
-    await asyncio.sleep(0.5)
+    await wait_for_entity_registration(mcp_client, new_id)
 
     # Cleanup
     delete_data = await safe_call_tool(
@@ -398,8 +366,7 @@ class TestEntityRenameVoiceExposure:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        # Wait for entity to be registered
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # 2. EXPOSE: Entity to conversation assistant
         expose_data = await safe_call_tool(
@@ -424,8 +391,7 @@ class TestEntityRenameVoiceExposure:
         )
         assert rename_data.get("success"), f"Failed to rename entity: {rename_data}"
 
-        # Wait for rename to propagate
-        await asyncio.sleep(0.5)
+        await wait_for_entity_registration(mcp_client, new_entity_id)
 
         # 4. VERIFY: New entity still has exposure settings (preserved by HA Core)
         check_data = await safe_call_tool(
@@ -476,8 +442,7 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        # Wait for entity to be registered
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # 2. RENAME: Using convenience wrapper
         rename_data = await safe_call_tool(
@@ -501,8 +466,7 @@ class TestRenameEntityWithDevice:
         )
         logger.info(f"Device rename result: {device_result}")
 
-        # Wait for rename to propagate
-        await asyncio.sleep(0.5)
+        await wait_for_entity_registration(mcp_client, new_entity_id)
 
         # 3. VERIFY: New entity exists
         state_data = await safe_call_tool(
@@ -544,8 +508,7 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        # Wait for entity to be registered
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # 2. RENAME: Without new_device_name
         rename_data = await safe_call_tool(
@@ -594,8 +557,7 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        # Wait for entity to be registered
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # 2. RENAME: With new entity friendly name
         rename_data = await safe_call_tool(
@@ -643,8 +605,7 @@ async def test_rename_entity_with_device_basic(mcp_client, cleanup_tracker):
     new_id = "input_button.test_combo_quick_new"
     cleanup_tracker.track("input_button", new_id)
 
-    # Wait for entity to be registered
-    await asyncio.sleep(1.0)
+    await wait_for_entity_registration(mcp_client, original_id)
 
     # Rename using convenience wrapper
     rename_data = await safe_call_tool(
@@ -657,8 +618,7 @@ async def test_rename_entity_with_device_basic(mcp_client, cleanup_tracker):
     )
     assert rename_data.get("success"), f"Failed to rename: {rename_data}"
 
-    # Wait for rename to propagate
-    await asyncio.sleep(0.5)
+    await wait_for_entity_registration(mcp_client, new_id)
 
     # Cleanup
     delete_data = await safe_call_tool(

--- a/tests/src/e2e/workflows/registry/test_entity_rename.py
+++ b/tests/src/e2e/workflows/registry/test_entity_rename.py
@@ -139,8 +139,9 @@ class TestEntityRename:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # 2. RENAME: With name and icon updates
         rename_data = await safe_call_tool(
             mcp_client,
@@ -157,7 +158,9 @@ class TestEntityRename:
         logger.info("Renamed entity with name and icon update")
 
         # 3. VERIFY: New entity has updated attributes
-        await wait_for_entity_registration(mcp_client, new_entity_id)
+        assert await wait_for_entity_registration(mcp_client, new_entity_id), (
+            f"Entity not registered: {new_entity_id}"
+        )
         state_data = await safe_call_tool(
             mcp_client, "ha_get_state", {"entity_id": new_entity_id}
         )
@@ -299,8 +302,9 @@ async def test_rename_entity_basic(mcp_client, cleanup_tracker):
     new_id = "input_button.test_quick_renamed"
     cleanup_tracker.track("input_button", new_id)
 
-    await wait_for_entity_registration(mcp_client, original_id)
-
+    assert await wait_for_entity_registration(mcp_client, original_id), (
+        f"Entity not registered: {original_id}"
+    )
     # Rename
     rename_data = await safe_call_tool(
         mcp_client,
@@ -312,8 +316,9 @@ async def test_rename_entity_basic(mcp_client, cleanup_tracker):
     )
     assert rename_data.get("success"), f"Failed to rename: {rename_data}"
 
-    await wait_for_entity_registration(mcp_client, new_id)
-
+    assert await wait_for_entity_registration(mcp_client, new_id), (
+        f"Entity not registered: {new_id}"
+    )
     # Cleanup
     delete_data = await safe_call_tool(
         mcp_client,
@@ -366,8 +371,9 @@ class TestEntityRenameVoiceExposure:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # 2. EXPOSE: Entity to conversation assistant
         expose_data = await safe_call_tool(
             mcp_client,
@@ -391,8 +397,9 @@ class TestEntityRenameVoiceExposure:
         )
         assert rename_data.get("success"), f"Failed to rename entity: {rename_data}"
 
-        await wait_for_entity_registration(mcp_client, new_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, new_entity_id), (
+            f"Entity not registered: {new_entity_id}"
+        )
         # 4. VERIFY: New entity still has exposure settings (preserved by HA Core)
         check_data = await safe_call_tool(
             mcp_client,
@@ -442,8 +449,9 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # 2. RENAME: Using convenience wrapper
         rename_data = await safe_call_tool(
             mcp_client,
@@ -466,8 +474,9 @@ class TestRenameEntityWithDevice:
         )
         logger.info(f"Device rename result: {device_result}")
 
-        await wait_for_entity_registration(mcp_client, new_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, new_entity_id), (
+            f"Entity not registered: {new_entity_id}"
+        )
         # 3. VERIFY: New entity exists
         state_data = await safe_call_tool(
             mcp_client, "ha_get_state", {"entity_id": new_entity_id}
@@ -508,8 +517,9 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # 2. RENAME: Without new_device_name
         rename_data = await safe_call_tool(
             mcp_client,
@@ -557,8 +567,9 @@ class TestRenameEntityWithDevice:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # 2. RENAME: With new entity friendly name
         rename_data = await safe_call_tool(
             mcp_client,
@@ -605,8 +616,9 @@ async def test_rename_entity_with_device_basic(mcp_client, cleanup_tracker):
     new_id = "input_button.test_combo_quick_new"
     cleanup_tracker.track("input_button", new_id)
 
-    await wait_for_entity_registration(mcp_client, original_id)
-
+    assert await wait_for_entity_registration(mcp_client, original_id), (
+        f"Entity not registered: {original_id}"
+    )
     # Rename using convenience wrapper
     rename_data = await safe_call_tool(
         mcp_client,
@@ -618,8 +630,9 @@ async def test_rename_entity_with_device_basic(mcp_client, cleanup_tracker):
     )
     assert rename_data.get("success"), f"Failed to rename: {rename_data}"
 
-    await wait_for_entity_registration(mcp_client, new_id)
-
+    assert await wait_for_entity_registration(mcp_client, new_id), (
+        f"Entity not registered: {new_id}"
+    )
     # Cleanup
     delete_data = await safe_call_tool(
         mcp_client,

--- a/tests/src/e2e/workflows/registry/test_rename_consolidation.py
+++ b/tests/src/e2e/workflows/registry/test_rename_consolidation.py
@@ -5,12 +5,12 @@ Tests the new_device_name parameter behavior and response format
 differences between entity-only and entity+device rename paths.
 """
 
-import asyncio
 import logging
 
 import pytest
 
 from ...utilities.assertions import safe_call_tool
+from ...utilities.wait_helpers import wait_for_entity_registration
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # Rename without new_device_name
         rename_data = await safe_call_tool(
@@ -99,7 +99,7 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # Rename WITH new_device_name
         rename_data = await safe_call_tool(
@@ -159,7 +159,7 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await asyncio.sleep(1.0)
+        await wait_for_entity_registration(mcp_client, original_entity_id)
 
         # Rename with empty new_device_name — should be treated as None
         rename_data = await safe_call_tool(

--- a/tests/src/e2e/workflows/registry/test_rename_consolidation.py
+++ b/tests/src/e2e/workflows/registry/test_rename_consolidation.py
@@ -43,8 +43,9 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # Rename without new_device_name
         rename_data = await safe_call_tool(
             mcp_client,
@@ -99,8 +100,9 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # Rename WITH new_device_name
         rename_data = await safe_call_tool(
             mcp_client,
@@ -159,8 +161,9 @@ class TestRenameConsolidationEdgeCases:
         new_entity_id = f"input_boolean.{new_name}"
         cleanup_tracker.track("input_boolean", new_entity_id)
 
-        await wait_for_entity_registration(mcp_client, original_entity_id)
-
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
         # Rename with empty new_device_name — should be treated as None
         rename_data = await safe_call_tool(
             mcp_client,


### PR DESCRIPTION
## What does this PR do?

Centralises `wait_for_entity_registration` by lifting it from `test_helper_crud.py` (where it was a local function) into `tests/src/e2e/utilities/wait_helpers.py`, and adopts it in the entity-rename tests in place of ad-hoc `asyncio.sleep` waits.

Picks up the "convert fixed sleeps to polling in `test_entity_rename.py` (~18 `asyncio.sleep` sites) and `test_rename_consolidation.py` (3 sites)" item from #366's "Still on the list".

**Changes:**
- `tests/src/e2e/utilities/wait_helpers.py` — adds `wait_for_entity_registration(mcp_client, entity_id, timeout=20)`; lifted from the local copy in `test_helper_crud.py`, polls `ha_get_state` via `wait_for_condition` until the entity is queryable.
- `tests/src/e2e/workflows/config/test_helper_crud.py` — removes the local helper definition, imports the centralised one. Four call-sites unchanged.
- `tests/src/e2e/workflows/registry/test_entity_rename.py` — replaces 14 sleep sites (3 manual `for attempt in range(10)` poll loops + 11 naive `asyncio.sleep(0.5/1.0)` waits) with calls to the centralised helper.
- `tests/src/e2e/workflows/registry/test_rename_consolidation.py` — replaces 3 naive sleep sites.

**Net diff:** +85 / −106 LOC.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local `pytest --collect-only` succeeds on all three modified test files (63 tests collected, no import errors); the full E2E run is gated on CI.

Also live-verified against a production HA instance: `ha_config_set_helper` (with `wait=True` default) and `ha_set_entity` (rename) leave the entity queryable immediately, so the helper's first poll succeeds in the happy path. The polling covers slower CI paths and any race window the tool wait doesn't close.

## Future improvements

<!-- None in scope for this PR — other ad-hoc sleeps in workflows/automation/, workflows/scenes/, workflows/scripts/, workflows/todo/, and workflows/device_control/ serve different purposes (timer expiry, scene transitions) and would need separate analysis. -->

## Checklist
- [x] I have updated documentation if needed
