### PR TITLE
fix: filter dismissed repairs in overview and system_health (#1307)

### DIFF
--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -22,7 +22,9 @@ from .util_helpers import (
     build_pagination_metadata,
     coerce_bool_param,
     coerce_int_param,
+    filter_active_repairs,
     parse_string_list_param,
+    project_repair_fields,
     public_fields,
 )
 
@@ -852,6 +854,16 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 description="Include active persistent notifications (default: True). Set False to skip.",
             ),
         ] = True,
+        include_dismissed_repairs: Annotated[
+            bool | str | None,
+            Field(
+                default=False,
+                description=(
+                    "Include user-dismissed/ignored repairs (default: False). "
+                    "Matches the HA Repairs UI which hides dismissed items by default."
+                ),
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """Get AI-friendly system overview with intelligent categorization.
 
@@ -872,6 +884,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         )
         include_notifications_bool = coerce_bool_param(
             include_notifications, "include_notifications", default=True
+        )
+        include_dismissed_repairs_bool = bool(
+            coerce_bool_param(
+                include_dismissed_repairs,
+                "include_dismissed_repairs",
+                default=False,
+            )
         )
 
         # Parse domains filter
@@ -951,24 +970,29 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             except Exception as e:
                 logger.warning(f"Failed to fetch notifications for overview: {e}")
 
-        # Include active repair issues
+        # Include active repair issues. By default we filter out user-dismissed
+        # ("ignored") repairs to match the HA Repairs UI — surfacing them as
+        # actionable would send agents chasing problems the user already
+        # resolved. Set `include_dismissed_repairs=True` to get all repairs.
         result["repair_count"] = 0
         try:
             repairs_result = await client.send_websocket_message(
                 {"type": "repairs/list_issues"}
             )
             if repairs_result.get("success"):
-                issues = repairs_result.get("result", {}).get("issues", [])
-                result["repair_count"] = len(issues)
-                if issues:
+                all_issues = repairs_result.get("result", {}).get("issues", [])
+                visible_issues = filter_active_repairs(
+                    all_issues,
+                    include_dismissed=include_dismissed_repairs_bool,
+                )
+                result["repair_count"] = len(visible_issues)
+                if not include_dismissed_repairs_bool:
+                    dismissed_count = len(all_issues) - len(visible_issues)
+                    if dismissed_count:
+                        result["dismissed_repair_count"] = dismissed_count
+                if visible_issues:
                     result["repairs"] = [
-                        {
-                            "issue_id": r.get("issue_id"),
-                            "domain": r.get("domain"),
-                            "severity": r.get("severity"),
-                            "translation_key": r.get("translation_key"),
-                        }
-                        for r in issues
+                        project_repair_fields(r) for r in visible_issues
                     ]
         except Exception as e:
             logger.warning("Failed to fetch repairs for overview: %s", e)

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -970,10 +970,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             except Exception as e:
                 logger.warning(f"Failed to fetch notifications for overview: {e}")
 
-        # Include active repair issues. By default we filter out user-dismissed
-        # ("ignored") repairs to match the HA Repairs UI — surfacing them as
-        # actionable would send agents chasing problems the user already
-        # resolved. Set `include_dismissed_repairs=True` to get all repairs.
+        # Active repairs only by default — matches the HA Repairs UI so agents
+        # don't chase problems the user already dismissed.
         result["repair_count"] = 0
         try:
             repairs_result = await client.send_websocket_message(
@@ -994,6 +992,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     result["repairs"] = [
                         project_repair_fields(r) for r in visible_issues
                     ]
+            else:
+                err = repairs_result.get("error") or {}
+                err_msg = (
+                    err.get("message")
+                    if isinstance(err, dict)
+                    else str(err)
+                ) or "unknown error"
+                logger.warning(
+                    "repairs/list_issues returned success=false: %s", err_msg
+                )
+                result["repairs_error"] = f"Could not fetch repairs: {err_msg}"
         except Exception as e:
             logger.warning("Failed to fetch repairs for overview: %s", e)
             result["repairs_error"] = f"Could not fetch repairs: {e}"

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -491,6 +491,17 @@ class SystemTools:
                     dismissed_count = len(all_issues) - len(visible_issues)
                     if dismissed_count:
                         repairs["dismissed_count"] = dismissed_count
+            else:
+                err = repairs_result.get("error") or {}
+                err_msg = (
+                    err.get("message")
+                    if isinstance(err, dict)
+                    else str(err)
+                ) or "unknown error"
+                logger.warning(
+                    "repairs/list_issues returned success=false: %s", err_msg
+                )
+                repairs["error"] = f"Repairs data not available: {err_msg}"
         except Exception as e:
             logger.warning("Failed to fetch repairs: %s", e)
             repairs["error"] = f"Repairs data not available: {e}"

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -21,7 +21,7 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
-from .util_helpers import coerce_bool_param
+from .util_helpers import coerce_bool_param, filter_active_repairs
 
 logger = logging.getLogger(__name__)
 
@@ -339,6 +339,7 @@ class SystemTools:
     async def ha_get_system_health(
         self,
         include: str | None = None,
+        include_dismissed_repairs: bool | str | None = False,
     ) -> dict[str, Any]:
         """
         Get Home Assistant system health, including Zigbee (ZHA) and Z-Wave JS network diagnostics.
@@ -348,13 +349,21 @@ class SystemTools:
 
         **Parameters:**
         - include: Optional comma-separated list of additional data to include.
-          - "repairs": Repair items from Settings > System > Repairs
+          - "repairs": Repair items from Settings > System > Repairs (active only by default; pass `include_dismissed_repairs=True` for all)
           - "zha_network": ZHA Zigbee devices with radio signal summary (name, LQI, RSSI)
           - "zha_network_full": ZHA Zigbee devices with all device details (can be large on 100+ device networks; prefer "zha_network" for summary)
           - "zwave_network": Z-Wave JS network status and node summary (status, security, routing)
           - Example: include="repairs,zha_network,zwave_network"
+        - include_dismissed_repairs: Include user-dismissed/ignored repairs (default: False). Only meaningful when "repairs" is in `include`.
         """
         includes = self._parse_includes(include)
+        include_dismissed_repairs_bool = bool(
+            coerce_bool_param(
+                include_dismissed_repairs,
+                "include_dismissed_repairs",
+                default=False,
+            )
+        )
 
         ws_client = None
 
@@ -369,7 +378,10 @@ class SystemTools:
 
             # Fetch optional sections
             if "repairs" in includes:
-                result["repairs"] = await self._fetch_repairs(ws_client)
+                result["repairs"] = await self._fetch_repairs(
+                    ws_client,
+                    include_dismissed=include_dismissed_repairs_bool,
+                )
 
             zha_full = "zha_network_full" in includes
             zha_summary = "zha_network" in includes
@@ -454,17 +466,31 @@ class SystemTools:
 
 
     @staticmethod
-    async def _fetch_repairs(ws_client: Any) -> dict[str, Any]:
-        """Fetch repair issues from Home Assistant."""
+    async def _fetch_repairs(
+        ws_client: Any, *, include_dismissed: bool = False
+    ) -> dict[str, Any]:
+        """Fetch repair issues from Home Assistant.
+
+        Filters out user-dismissed ("ignored") repairs by default to match the
+        HA Repairs UI. Pass ``include_dismissed=True`` to return all issues
+        and report the dismissed count alongside the active count.
+        """
         repairs: dict[str, Any] = {"issues": [], "count": 0}
         try:
             repairs_result = await ws_client.send_command("repairs/list_issues")
             if repairs_result.get("success"):
-                repairs_list = repairs_result.get("result", {}).get("issues", [])
+                all_issues = repairs_result.get("result", {}).get("issues", [])
+                visible_issues = filter_active_repairs(
+                    all_issues, include_dismissed=include_dismissed
+                )
                 repairs = {
-                    "issues": repairs_list,
-                    "count": len(repairs_list),
+                    "issues": visible_issues,
+                    "count": len(visible_issues),
                 }
+                if not include_dismissed:
+                    dismissed_count = len(all_issues) - len(visible_issues)
+                    if dismissed_count:
+                        repairs["dismissed_count"] = dismissed_count
         except Exception as e:
             logger.warning("Failed to fetch repairs: %s", e)
             repairs["error"] = f"Repairs data not available: {e}"

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -315,6 +315,49 @@ def unwrap_service_response(result: dict[str, Any]) -> dict[str, Any]:
     return sr if isinstance(sr, dict) else result
 
 
+# Fields surfaced from each repair issue. Includes the dismissal-state fields
+# (`ignored`, `dismissed_version`) so callers can distinguish active vs.
+# user-dismissed repairs even when both are returned. `is_fixable` /
+# `breaks_in_ha_version` / `created` / `issue_domain` help agents triage.
+_REPAIR_PROJECTION_FIELDS = (
+    "issue_id",
+    "domain",
+    "severity",
+    "translation_key",
+    "ignored",
+    "dismissed_version",
+    "is_fixable",
+    "breaks_in_ha_version",
+    "created",
+    "issue_domain",
+)
+
+
+def filter_active_repairs(
+    issues: list[dict[str, Any]], *, include_dismissed: bool = False
+) -> list[dict[str, Any]]:
+    """Drop user-dismissed repairs unless ``include_dismissed`` is set.
+
+    HA's `repairs/list_issues` returns both active and ignored repairs (the
+    Repairs UI hides ignored ones by default). Mirror that UI default so
+    overview / system-health responses don't surface repairs the user has
+    already dismissed.
+    """
+    if include_dismissed:
+        return list(issues)
+    return [r for r in issues if not r.get("ignored")]
+
+
+def project_repair_fields(issue: dict[str, Any]) -> dict[str, Any]:
+    """Project a repair issue dict to the public-facing field subset.
+
+    Translation placeholders and `learn_more_url` are dropped to keep
+    overview payloads compact; agents can fetch them via the HA Repairs UI
+    or a direct `repairs/list_issues` call if needed.
+    """
+    return {k: issue[k] for k in _REPAIR_PROJECTION_FIELDS if k in issue}
+
+
 # Python logging numeric-level → canonical level name.
 # Mirrors the values in HA's LOGSEVERITY constant (components/logger/const.py).
 _LOG_LEVEL_NAMES: dict[int, str] = {

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -315,10 +315,9 @@ def unwrap_service_response(result: dict[str, Any]) -> dict[str, Any]:
     return sr if isinstance(sr, dict) else result
 
 
-# Fields surfaced from each repair issue. Includes the dismissal-state fields
-# (`ignored`, `dismissed_version`) so callers can distinguish active vs.
-# user-dismissed repairs even when both are returned. `is_fixable` /
-# `breaks_in_ha_version` / `created` / `issue_domain` help agents triage.
+# Fields surfaced from each repair issue. Includes `ignored` / `dismissed_version`
+# so callers can distinguish active vs. user-dismissed repairs when both are
+# returned (e.g., `include_dismissed_repairs=True`).
 _REPAIR_PROJECTION_FIELDS = (
     "issue_id",
     "domain",
@@ -351,9 +350,8 @@ def filter_active_repairs(
 def project_repair_fields(issue: dict[str, Any]) -> dict[str, Any]:
     """Project a repair issue dict to the public-facing field subset.
 
-    Translation placeholders and `learn_more_url` are dropped to keep
-    overview payloads compact; agents can fetch them via the HA Repairs UI
-    or a direct `repairs/list_issues` call if needed.
+    Drops verbose fields (`translation_placeholders`, `learn_more_url`) to
+    keep overview payloads compact.
     """
     return {k: issue[k] for k in _REPAIR_PROJECTION_FIELDS if k in issue}
 

--- a/tests/src/unit/test_overview_repairs.py
+++ b/tests/src/unit/test_overview_repairs.py
@@ -196,3 +196,76 @@ class TestHaGetOverviewRepairs:
         assert result["repair_count"] == 0
         assert "repairs" not in result
         assert result["dismissed_repair_count"] == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value,expected_count",
+        [("true", 2), ("True", 2), ("1", 2), ("false", 1), ("0", 1)],
+    )
+    async def test_include_dismissed_accepts_string_inputs(
+        self, mock_mcp, mock_smart_tools, value, expected_count
+    ):
+        """LLM clients send booleans as strings — coercion must apply."""
+        issues = [_active_issue("active"), _ignored_issue("dismissed")]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(
+            detail_level="minimal", include_dismissed_repairs=value
+        )
+
+        assert result["repair_count"] == expected_count
+
+    @pytest.mark.asyncio
+    async def test_repairs_ws_failure_does_not_break_overview(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """A websocket exception while fetching repairs leaves the overview
+        functional with a `repairs_error` message and repair_count=0.
+        """
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(return_value={})
+
+        async def fake_ws(msg):
+            if msg.get("type") == "repairs/list_issues":
+                raise RuntimeError("ws disconnect")
+            return {"success": True, "result": []}
+
+        client.send_websocket_message = AsyncMock(side_effect=fake_ws)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 0
+        assert "repairs" not in result
+        assert "repairs_error" in result
+        assert "ws disconnect" in result["repairs_error"]
+
+    @pytest.mark.asyncio
+    async def test_repairs_ws_success_false_surfaces_error(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """When HA responds `success: False`, surface the error message
+        instead of silently returning repair_count=0.
+        """
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(return_value={})
+
+        async def fake_ws(msg):
+            if msg.get("type") == "repairs/list_issues":
+                return {
+                    "success": False,
+                    "error": {"code": "unknown_error", "message": "boom"},
+                }
+            return {"success": True, "result": []}
+
+        client.send_websocket_message = AsyncMock(side_effect=fake_ws)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 0
+        assert "repairs" not in result
+        assert "boom" in result["repairs_error"]

--- a/tests/src/unit/test_overview_repairs.py
+++ b/tests/src/unit/test_overview_repairs.py
@@ -1,0 +1,198 @@
+"""Unit tests for ha_get_overview repairs filtering and projection.
+
+Regression coverage for issue #1307: dismissed repairs must be filtered by
+default (matching the HA Repairs UI), and the projection must surface the
+dismissal-state fields so callers that opt in can distinguish active vs.
+ignored repairs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ha_mcp.tools.tools_search import register_search_tools
+
+
+def _ws_response(issues: list[dict]) -> dict:
+    return {"success": True, "result": {"issues": issues}}
+
+
+def _active_issue(issue_id: str) -> dict:
+    return {
+        "issue_id": issue_id,
+        "domain": "demo",
+        "severity": "warning",
+        "translation_key": "demo_issue",
+        "ignored": False,
+        "dismissed_version": None,
+        "is_fixable": True,
+        "breaks_in_ha_version": None,
+        "created": "2026-05-01T00:00:00+00:00",
+        "issue_domain": "demo",
+    }
+
+
+def _ignored_issue(issue_id: str, dismissed_version: str = "2026.4.0") -> dict:
+    return {
+        "issue_id": issue_id,
+        "domain": "demo",
+        "severity": "warning",
+        "translation_key": "demo_issue",
+        "ignored": True,
+        "dismissed_version": dismissed_version,
+        "is_fixable": False,
+        "breaks_in_ha_version": None,
+        "created": "2026-04-01T00:00:00+00:00",
+        "issue_domain": "demo",
+    }
+
+
+class TestHaGetOverviewRepairs:
+    """ha_get_overview repairs filtering, count, and field projection."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    def _make_client(self, issues: list[dict]) -> MagicMock:
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(return_value={})
+
+        async def fake_ws(msg):
+            if msg.get("type") == "repairs/list_issues":
+                return _ws_response(issues)
+            # Persistent notifications fetch — return empty success
+            return {"success": True, "result": []}
+
+        client.send_websocket_message = AsyncMock(side_effect=fake_ws)
+        return client
+
+    @pytest.fixture
+    def mock_smart_tools(self):
+        smart = MagicMock()
+        smart.get_system_overview = AsyncMock(return_value={"success": True})
+        return smart
+
+    def _build_tool(self, mock_mcp, client, smart_tools):
+        register_search_tools(mock_mcp, client, smart_tools=smart_tools)
+        return self.registered_tools["ha_get_overview"]
+
+    @pytest.mark.asyncio
+    async def test_ignored_repairs_filtered_by_default(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """Default behavior: dismissed repairs do not appear in `repairs[]`
+        and are not counted in `repair_count`. Matches the HA Repairs UI.
+        """
+        issues = [
+            _active_issue("active_one"),
+            _ignored_issue("dismissed_one"),
+            _ignored_issue("dismissed_two", dismissed_version="2025.12.0"),
+        ]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 1
+        repair_ids = [r["issue_id"] for r in result["repairs"]]
+        assert repair_ids == ["active_one"]
+        # Surface dismissed count separately so agents can decide to opt in
+        assert result["dismissed_repair_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_include_dismissed_returns_all_repairs(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """With `include_dismissed_repairs=True`, all repairs surface and
+        the standalone dismissed counter is omitted.
+        """
+        issues = [_active_issue("active_one"), _ignored_issue("dismissed_one")]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(
+            detail_level="minimal", include_dismissed_repairs=True
+        )
+
+        assert result["repair_count"] == 2
+        assert "dismissed_repair_count" not in result
+        ids = {r["issue_id"] for r in result["repairs"]}
+        assert ids == {"active_one", "dismissed_one"}
+
+    @pytest.mark.asyncio
+    async def test_repair_projection_includes_dismissal_state(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """`ignored`, `dismissed_version`, `is_fixable`, etc. must be present
+        on each repair entry so callers can distinguish state.
+        """
+        issues = [_active_issue("active_one"), _ignored_issue("dismissed_one")]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(
+            detail_level="minimal", include_dismissed_repairs=True
+        )
+
+        for entry in result["repairs"]:
+            for field in (
+                "issue_id",
+                "domain",
+                "severity",
+                "translation_key",
+                "ignored",
+                "dismissed_version",
+                "is_fixable",
+            ):
+                assert field in entry, f"Missing field {field} in repair entry"
+
+        by_id = {r["issue_id"]: r for r in result["repairs"]}
+        assert by_id["active_one"]["ignored"] is False
+        assert by_id["dismissed_one"]["ignored"] is True
+        assert by_id["dismissed_one"]["dismissed_version"] == "2026.4.0"
+
+    @pytest.mark.asyncio
+    async def test_no_repairs_yields_zero_counts(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """Empty issue list keeps repair_count = 0 and omits the `repairs`
+        key (existing contract — don't regress).
+        """
+        client = self._make_client([])
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 0
+        assert "repairs" not in result
+        assert "dismissed_repair_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_only_dismissed_repairs_yields_zero_active(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """When every repair is dismissed, repair_count=0 (agents see clean
+        state) and `dismissed_repair_count` reports the hidden total.
+        """
+        issues = [_ignored_issue(f"dismissed_{i}") for i in range(3)]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 0
+        assert "repairs" not in result
+        assert result["dismissed_repair_count"] == 3

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -109,8 +109,9 @@ class TestFetchRepairs:
     @pytest.mark.asyncio
     async def test_repair_fields_pass_through_unmodified(self):
         """`_fetch_repairs` returns full payloads — fields like `ignored`,
-        `dismissed_version`, `is_fixable` must survive the filter so callers
-        can introspect them.
+        `dismissed_version`, `is_fixable`, and the verbose
+        `translation_placeholders` all survive (no projection at this layer,
+        unlike `ha_get_overview`'s compact view).
         """
         ws = _ws_client_with_issues(
             [
@@ -131,3 +132,31 @@ class TestFetchRepairs:
         assert entry["ignored"] is False
         assert entry["is_fixable"] is True
         assert entry["translation_placeholders"] == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_success_false_surfaces_error_message(self):
+        """When HA responds `success: False`, surface the error message
+        instead of silently returning an empty list.
+        """
+        ws = AsyncMock()
+        ws.send_command.return_value = {
+            "success": False,
+            "error": {"code": "unknown_error", "message": "boom"},
+        }
+
+        result = await SystemTools._fetch_repairs(ws)
+
+        assert result["count"] == 0
+        assert result["issues"] == []
+        assert "boom" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_ws_exception_captured_as_error(self):
+        """Exceptions during the WS call are caught and surfaced via `error`."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = RuntimeError("ws disconnect")
+
+        result = await SystemTools._fetch_repairs(ws)
+
+        assert result["count"] == 0
+        assert "ws disconnect" in result["error"]

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -48,3 +48,86 @@ class TestHaRestartErrorHandling:
 
         with pytest.raises(ToolError):
             await tools.ha_restart(confirm=True)
+
+
+def _ws_client_with_issues(issues):
+    """Mock ws_client whose send_command('repairs/list_issues') returns ``issues``."""
+    ws = AsyncMock()
+    ws.send_command.return_value = {
+        "success": True,
+        "result": {"issues": issues},
+    }
+    return ws
+
+
+class TestFetchRepairs:
+    """Regression coverage for #1307: dismissed repairs must be filtered by default."""
+
+    @pytest.mark.asyncio
+    async def test_default_filters_ignored_repairs(self):
+        ws = _ws_client_with_issues(
+            [
+                {"issue_id": "active", "ignored": False},
+                {"issue_id": "dismissed", "ignored": True, "dismissed_version": "2026.4.0"},
+            ]
+        )
+
+        result = await SystemTools._fetch_repairs(ws)
+
+        assert result["count"] == 1
+        assert [i["issue_id"] for i in result["issues"]] == ["active"]
+        assert result["dismissed_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_include_dismissed_returns_all(self):
+        ws = _ws_client_with_issues(
+            [
+                {"issue_id": "active", "ignored": False},
+                {"issue_id": "dismissed", "ignored": True},
+            ]
+        )
+
+        result = await SystemTools._fetch_repairs(ws, include_dismissed=True)
+
+        assert result["count"] == 2
+        assert "dismissed_count" not in result
+        ids = {i["issue_id"] for i in result["issues"]}
+        assert ids == {"active", "dismissed"}
+
+    @pytest.mark.asyncio
+    async def test_no_dismissed_omits_counter(self):
+        """When nothing is filtered, the `dismissed_count` key stays out."""
+        ws = _ws_client_with_issues(
+            [{"issue_id": "active", "ignored": False}]
+        )
+
+        result = await SystemTools._fetch_repairs(ws)
+
+        assert result["count"] == 1
+        assert "dismissed_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_repair_fields_pass_through_unmodified(self):
+        """`_fetch_repairs` returns full payloads — fields like `ignored`,
+        `dismissed_version`, `is_fixable` must survive the filter so callers
+        can introspect them.
+        """
+        ws = _ws_client_with_issues(
+            [
+                {
+                    "issue_id": "active",
+                    "ignored": False,
+                    "dismissed_version": None,
+                    "is_fixable": True,
+                    "severity": "warning",
+                    "translation_placeholders": {"foo": "bar"},
+                }
+            ]
+        )
+
+        result = await SystemTools._fetch_repairs(ws, include_dismissed=True)
+
+        entry = result["issues"][0]
+        assert entry["ignored"] is False
+        assert entry["is_fixable"] is True
+        assert entry["translation_placeholders"] == {"foo": "bar"}

--- a/tests/src/unit/test_util_helpers.py
+++ b/tests/src/unit/test_util_helpers.py
@@ -7,10 +7,12 @@ import pytest
 from ha_mcp.tools.util_helpers import (
     build_pagination_metadata,
     coerce_int_param,
+    filter_active_repairs,
     get_logger_levels,
     normalize_log_level,
     parse_json_param,
     parse_string_list_param,
+    project_repair_fields,
 )
 
 
@@ -392,3 +394,60 @@ class TestGetLoggerLevels:
             return_value={"success": True, "result": {"unexpected": "shape"}}
         )
         assert await get_logger_levels(client) == {}
+
+
+class TestFilterActiveRepairs:
+    """Default-filters user-dismissed repairs; opt-in returns the full set."""
+
+    def test_filters_ignored_by_default(self):
+        issues = [
+            {"issue_id": "a", "ignored": False},
+            {"issue_id": "b", "ignored": True},
+            {"issue_id": "c"},  # missing key — treated as not-ignored
+        ]
+        assert [r["issue_id"] for r in filter_active_repairs(issues)] == ["a", "c"]
+
+    def test_include_dismissed_returns_all(self):
+        issues = [
+            {"issue_id": "a", "ignored": False},
+            {"issue_id": "b", "ignored": True},
+        ]
+        out = filter_active_repairs(issues, include_dismissed=True)
+        assert [r["issue_id"] for r in out] == ["a", "b"]
+
+    def test_empty_input(self):
+        assert filter_active_repairs([]) == []
+        assert filter_active_repairs([], include_dismissed=True) == []
+
+
+class TestProjectRepairFields:
+    """Projection keeps dismissal-state fields and drops verbose ones."""
+
+    def test_includes_dismissal_state_fields(self):
+        issue = {
+            "issue_id": "x",
+            "domain": "demo",
+            "severity": "warning",
+            "translation_key": "demo_issue",
+            "ignored": True,
+            "dismissed_version": "2026.4.0",
+            "is_fixable": False,
+            "breaks_in_ha_version": None,
+            "created": "2026-04-01T00:00:00+00:00",
+            "issue_domain": "automation",
+            "translation_placeholders": {"x": "y"},
+            "learn_more_url": "https://example",
+        }
+        out = project_repair_fields(issue)
+        assert out["ignored"] is True
+        assert out["dismissed_version"] == "2026.4.0"
+        assert out["is_fixable"] is False
+        assert out["issue_domain"] == "automation"
+        # Verbose fields dropped to keep overview payloads compact
+        assert "translation_placeholders" not in out
+        assert "learn_more_url" not in out
+
+    def test_missing_fields_omitted_not_none(self):
+        """Only project fields that exist on the source dict."""
+        out = project_repair_fields({"issue_id": "x", "domain": "demo"})
+        assert out == {"issue_id": "x", "domain": "demo"}


### PR DESCRIPTION
## What does this PR do?

Closes #1307.

`ha_get_overview` and `ha_get_system_health(include="repairs")` both
returned every repair from HA's `repairs/list_issues` WebSocket API,
including ones the user had already dismissed via Settings → System →
Repairs. `ha_get_overview` additionally stripped the dismissal-state
fields (`ignored`, `dismissed_version`, `is_fixable`), so agents had no
way to distinguish active from dismissed repairs and would send users
chasing problems they had already resolved.

Both tools now:
- **Default-filter `ignored` repairs** to match the HA Repairs UI.
- Accept **`include_dismissed_repairs=True`** to opt back in.
- Report a separate `dismissed_repair_count` (overview) /
  `dismissed_count` (system_health) when there are hidden repairs, so
  agents can still surface that state if relevant.
- Pass through `ignored`, `dismissed_version`, `is_fixable`,
  `breaks_in_ha_version`, `created`, `issue_domain` on each repair so
  opt-in callers can introspect state.

Filtering and projection are centralized in `util_helpers`
(`filter_active_repairs`, `project_repair_fields`) so both call sites
stay in sync.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit tests cover both tools and the helper:
- `tests/src/unit/test_overview_repairs.py` — overview filtering, projection, opt-in, all-dismissed edge case
- `tests/src/unit/test_tools_system.py::TestFetchRepairs` — `_fetch_repairs` filtering, pass-through, dismissed counter
- `tests/src/unit/test_util_helpers.py` — `filter_active_repairs` + `project_repair_fields`

## Checklist
- [x] I have updated documentation if needed