### PR TITLE
test(e2e): surface readiness-gate elapsed times in CI logs (refs #366)

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -61,6 +61,25 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _log_readiness_timing(gate: str, elapsed_s: int, **extras: Any) -> None:
+    """Emit a fixture-side readiness-gate timing line that survives pytest-xdist capture.
+
+    The default ``logger.info`` path is captured by pytest-xdist on passing
+    runs, hiding fixture-side timing data even with ``log_cli=true``.
+    Writing directly to ``sys.stderr`` with an explicit flush bypasses the
+    per-worker capture buffer so the elapsed times surface in CI job logs,
+    enabling data-driven tightening of the 30s ``STABILIZATION_TIMEOUT`` /
+    ``ENTITY_STABILIZATION_TIMEOUT`` / ``SUN_WAIT`` budgets (refs #366,
+    follow-up to #1273 which lowered the only previously-measured gate
+    ``INPUT_BOOLEAN_WAIT`` from 30s to 10s based on a 1s observed-resolve).
+    """
+    parts = [f"gate={gate}", f"elapsed_s={elapsed_s}"]
+    for key, value in extras.items():
+        parts.append(f"{key}={value}")
+    sys.stderr.write("[READINESS_GATE_TIMING] " + " ".join(parts) + "\n")
+    sys.stderr.flush()
+
+
 def _is_missing_column_or_table_error(exc: sqlite3.OperationalError) -> bool:
     """Return True only for benign 'schema drift' errors (column/table missing).
 
@@ -1025,6 +1044,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                             f"✅ Home Assistant stabilized with {component_count} components "
                             f"after {elapsed}s"
                         )
+                        _log_readiness_timing(
+                            "components", elapsed, count=component_count
+                        )
                         break
                     if component_count != last_count:
                         logger.info(
@@ -1074,6 +1096,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                         logger.info(
                             f"✅ {entity_count} entities registered after {elapsed}s"
                         )
+                        _log_readiness_timing("entities", elapsed, count=entity_count)
                         break
                     if entity_count != last_entity_count:
                         logger.info(
@@ -1115,6 +1138,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     if "input_boolean" in domains:
                         elapsed = int(time.monotonic() - ib_start)
                         logger.info(f"✅ input_boolean service ready after {elapsed}s")
+                        _log_readiness_timing("input_boolean", elapsed)
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
                 logger.debug(f"Service check failed: {exc}")
@@ -1192,6 +1216,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     if sun_state != "unknown":
                         elapsed = int(time.monotonic() - sun_start)
                         logger.info(f"✅ sun.sun is '{sun_state}' after {elapsed}s")
+                        _log_readiness_timing("sun", elapsed, state=sun_state)
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
                 logger.debug(f"sun.sun check failed: {exc}")

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -72,7 +72,7 @@ _READINESS_TIMINGS: list[dict[str, Any]] = []
 _ALL_READINESS_TIMINGS: list[dict[str, Any]] = []
 
 
-def _log_readiness_timing(gate: str, elapsed_s: int, **extras: Any) -> None:
+def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     """Record a fixture-side readiness-gate timing data point.
 
     The data points are routed to the master process and rendered at
@@ -122,8 +122,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         return
     terminalreporter.section("Readiness gate timings")
     for point in timings:
-        rendered = " ".join(f"{key}={value}" for key, value in point.items())
-        terminalreporter.write_line(f"[READINESS_GATE_TIMING] {rendered}")
+        parts = []
+        for key, value in point.items():
+            if isinstance(value, float):
+                parts.append(f"{key}={value:.2f}")
+            else:
+                parts.append(f"{key}={value}")
+        terminalreporter.write_line("[READINESS_GATE_TIMING] " + " ".join(parts))
 
 
 def _is_missing_column_or_table_error(exc: sqlite3.OperationalError) -> bool:
@@ -1085,10 +1090,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if config_resp.status_code == 200:
                     component_count = len(config_resp.json().get("components", []))
                     if component_count >= MIN_COMPONENTS:
-                        elapsed = int(time.monotonic() - stabilize_start)
+                        elapsed = time.monotonic() - stabilize_start
                         logger.info(
                             f"✅ Home Assistant stabilized with {component_count} components "
-                            f"after {elapsed}s"
+                            f"after {elapsed:.1f}s"
                         )
                         _log_readiness_timing(
                             "components", elapsed, count=component_count
@@ -1138,9 +1143,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if states_resp.status_code == 200:
                     entity_count = len(states_resp.json())
                     if entity_count >= MIN_ENTITIES:
-                        elapsed = int(time.monotonic() - entity_start)
+                        elapsed = time.monotonic() - entity_start
                         logger.info(
-                            f"✅ {entity_count} entities registered after {elapsed}s"
+                            f"✅ {entity_count} entities registered after {elapsed:.1f}s"
                         )
                         _log_readiness_timing("entities", elapsed, count=entity_count)
                         break
@@ -1182,8 +1187,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if svc_resp.status_code == 200:
                     domains = {s.get("domain") for s in svc_resp.json()}
                     if "input_boolean" in domains:
-                        elapsed = int(time.monotonic() - ib_start)
-                        logger.info(f"✅ input_boolean service ready after {elapsed}s")
+                        elapsed = time.monotonic() - ib_start
+                        logger.info(
+                            f"✅ input_boolean service ready after {elapsed:.1f}s"
+                        )
                         _log_readiness_timing("input_boolean", elapsed)
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
@@ -1260,8 +1267,8 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if sun_resp.status_code == 200:
                     sun_state = sun_resp.json().get("state", "unknown")
                     if sun_state != "unknown":
-                        elapsed = int(time.monotonic() - sun_start)
-                        logger.info(f"✅ sun.sun is '{sun_state}' after {elapsed}s")
+                        elapsed = time.monotonic() - sun_start
+                        logger.info(f"✅ sun.sun is '{sun_state}' after {elapsed:.1f}s")
                         _log_readiness_timing("sun", elapsed, state=sun_state)
                         break
             except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -61,23 +61,69 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def _log_readiness_timing(gate: str, elapsed_s: int, **extras: Any) -> None:
-    """Emit a fixture-side readiness-gate timing line that survives pytest-xdist capture.
+# Module-level collection of readiness-gate timings, per process. Workers
+# write to ``_READINESS_TIMINGS``; pytest_sessionfinish hands their lists
+# to the master via xdist's ``workeroutput`` channel, and the master
+# aggregates into ``_ALL_READINESS_TIMINGS`` in pytest_testnodedown. The
+# pytest_terminal_summary hook then renders the aggregate to the
+# master's terminalreporter, which writes outside the pytest-xdist
+# capture buffer (refs #366).
+_READINESS_TIMINGS: list[dict[str, Any]] = []
+_ALL_READINESS_TIMINGS: list[dict[str, Any]] = []
 
-    The default ``logger.info`` path is captured by pytest-xdist on passing
-    runs, hiding fixture-side timing data even with ``log_cli=true``.
-    Writing directly to ``sys.stderr`` with an explicit flush bypasses the
-    per-worker capture buffer so the elapsed times surface in CI job logs,
-    enabling data-driven tightening of the 30s ``STABILIZATION_TIMEOUT`` /
-    ``ENTITY_STABILIZATION_TIMEOUT`` / ``SUN_WAIT`` budgets (refs #366,
-    follow-up to #1273 which lowered the only previously-measured gate
-    ``INPUT_BOOLEAN_WAIT`` from 30s to 10s based on a 1s observed-resolve).
+
+def _log_readiness_timing(gate: str, elapsed_s: int, **extras: Any) -> None:
+    """Record a fixture-side readiness-gate timing data point.
+
+    The data points are routed to the master process and rendered at
+    session end by ``pytest_terminal_summary``. Direct ``sys.stderr``
+    writes don't survive pytest-xdist's per-worker capture buffer, so
+    going through pytest's own reporting plumbing is the reliable path
+    (follow-up to #1273 which lowered the only previously-measured gate
+    ``INPUT_BOOLEAN_WAIT`` from 30s to 10s based on a 1s observed-resolve;
+    the remaining 30s ``STABILIZATION_TIMEOUT`` /
+    ``ENTITY_STABILIZATION_TIMEOUT`` / ``SUN_WAIT`` budgets need
+    empirical timings to scope a follow-up tightening PR).
     """
-    parts = [f"gate={gate}", f"elapsed_s={elapsed_s}"]
-    for key, value in extras.items():
-        parts.append(f"{key}={value}")
-    sys.stderr.write("[READINESS_GATE_TIMING] " + " ".join(parts) + "\n")
-    sys.stderr.flush()
+    _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """xdist worker hook: hand collected timings up to the master.
+
+    ``config.workeroutput`` only exists on workers; on the master (or
+    when running without xdist) the attribute is missing, and the local
+    list is read directly by ``pytest_terminal_summary`` instead.
+    """
+    workeroutput = getattr(session.config, "workeroutput", None)
+    if workeroutput is not None and _READINESS_TIMINGS:
+        workeroutput["readiness_timings"] = list(_READINESS_TIMINGS)
+
+
+def pytest_testnodedown(node, error):
+    """xdist master hook: collect a finished worker's timings.
+
+    Called once per worker as it shuts down. ``error`` is non-None when
+    the worker crashed — we still try to drain whatever it managed to
+    record.
+    """
+    timings = getattr(node, "workeroutput", {}).get("readiness_timings", [])
+    _ALL_READINESS_TIMINGS.extend(timings)
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Master-side hook: render collected timings as a terminal section.
+
+    Falls back to the local list when running without xdist (no
+    ``pytest_testnodedown`` fires in that mode, so ``_ALL_*`` stays empty).
+    """
+    timings = _ALL_READINESS_TIMINGS or _READINESS_TIMINGS
+    if not timings:
+        return
+    terminalreporter.section("Readiness gate timings")
+    for point in timings:
+        rendered = " ".join(f"{key}={value}" for key, value in point.items())
+        terminalreporter.write_line(f"[READINESS_GATE_TIMING] {rendered}")
 
 
 def _is_missing_column_or_table_error(exc: sqlite3.OperationalError) -> bool:


### PR DESCRIPTION
## What does this PR do?

Adds a small fixture-side helper `_log_readiness_timing` in `tests/src/e2e/conftest.py` and instruments the four polled success-paths (components, entities, input_boolean service, sun.sun state) to write their elapsed times to `sys.stderr` with an explicit flush.

The existing `logger.info(f"✅ ... after {elapsed}s")` lines are captured by pytest-xdist on passing runs and don't surface in CI job logs — even though `tests/pytest.ini` sets `log_cli=true, log_cli_level=INFO`. Writing directly to `sys.stderr` bypasses the per-worker capture buffer so the elapsed times appear in the job log, where they're greppable as:

```
[READINESS_GATE_TIMING] gate=components elapsed_s=2 count=82
[READINESS_GATE_TIMING] gate=entities elapsed_s=3 count=156
[READINESS_GATE_TIMING] gate=input_boolean elapsed_s=1
[READINESS_GATE_TIMING] gate=sun elapsed_s=4 state=below_horizon
```

This is the prerequisite measurement infrastructure for the broader **70+s session-init readiness gates audit** item from #366's [Still on the list](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4423440909). #1273 lowered the only previously-measured gate (`INPUT_BOOLEAN_WAIT` 30→10s) on a 1s observed-resolve; the remaining `STABILIZATION_TIMEOUT` and `ENTITY_STABILIZATION_TIMEOUT` budgets carry **fatal `pytest.fail`** branches and `SUN_WAIT` a **non-fatal `logger.warning`** — tightening them without an empirical anchor would risk regressing the suite.

After a few green runs land with this instrumentation, the typical elapsed times can be extracted from the CI job logs to scope the actual tightening as a follow-up PR.

**No tests are added** — this is pure measurement infrastructure. The four `logger.info` calls stay in place so the local-dev experience (with `-s` or otherwise uncaptured runs) is unchanged.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The instrumentation is fixture-side; the first CI run on this PR validates whether the `[READINESS_GATE_TIMING]` lines actually surface in the job log. If not, an alternative routing (pytest_terminal_summary hook, fixture-artifact upload, or `--capture=no` scoping) follows in a fix-commit.

## Future improvements

After 3-5 green runs land:
- Extract typical `elapsed_s` per gate from the CI logs
- Propose tightening PRs analogous to #1273, with a safety margin over observed median

Not in scope here: `ha_mcp_tools` readiness wait (180s budget) would also benefit from the same instrumentation, but the success path lives behind `_wait_for_ha_mcp_tools_services` — a follow-up could refactor that helper to return its elapsed time.

## Checklist
- [x] I have updated documentation if needed
