### PR TITLE
test(e2e): unify dict-error message extraction across e2e tests (refs #366)

### DIFF
--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -14,10 +14,15 @@ from fastmcp.exceptions import ToolError
 logger = logging.getLogger(__name__)
 
 
-def _extract_error_message(data: dict[str, Any]) -> str:
-    """Extract error message string from a failure result dict.
+def extract_error_message(data: dict[str, Any]) -> str:
+    """Extract an error-message string from a parsed MCP failure result.
 
-    Handles both string errors and dict errors with a 'message' key.
+    Handles both string errors and the modern structured-error dict-form
+    (`{"error": {"code": ..., "message": ...}}`) returned by
+    `create_error_response` in `src/ha_mcp/errors.py`. Returns an empty
+    string when the result has no error key, so callers can chain
+    `.lower()` / `in` membership checks without needing a `isinstance`
+    guard at the call site (refs #366).
     """
     error_obj = data.get("error", "")
     if isinstance(error_obj, dict):
@@ -163,7 +168,7 @@ def assert_mcp_failure(
 
     # If expected error specified, check for it
     if expected_error:
-        error_msg = _extract_error_message(data)
+        error_msg = extract_error_message(data)
         if expected_error.lower() not in error_msg.lower():
             raise AssertionError(
                 f"{operation_name} failed but error message doesn't contain '{expected_error}'. "
@@ -345,7 +350,7 @@ class MCPAssertions:
                 ) from exc
             # Check expected error if specified
             if expected_error:
-                error_msg = _extract_error_message(data)
+                error_msg = extract_error_message(data)
                 if expected_error.lower() not in error_msg.lower():
                     raise AssertionError(
                         f"{operation_name} failed but error message doesn't contain "

--- a/tests/src/e2e/workflows/automation/test_python_transform.py
+++ b/tests/src/e2e/workflows/automation/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions
+from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -128,7 +128,7 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
             "python_transform": "config['action'] = []",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "config_hash" in error_msg.lower()
 
 
@@ -144,7 +144,7 @@ async def test_python_transform_requires_identifier(mcp_client, ha_client):
             "python_transform": "config['action'] = []",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "identifier" in error_msg.lower()
 
 
@@ -161,7 +161,7 @@ async def test_python_transform_mutual_exclusivity(mcp_client, ha_client):
             "python_transform": "config['action'] = []",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "cannot use both" in error_msg.lower()
 
 
@@ -207,7 +207,7 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "python_transform": "config['action'][0]['data'] = {'brightness': 100}",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()
 
 
@@ -241,7 +241,7 @@ async def test_python_transform_blocked_import(mcp_client, ha_client):
             "python_transform": "import os; os.system('echo pwned')",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "import" in error_msg.lower() or "forbidden" in error_msg.lower()
 
 
@@ -358,7 +358,7 @@ async def test_transform_invalid_config_rejected(mcp_client, ha_client):
             "python_transform": "del config['action']",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "action" in error_msg.lower() or "missing" in error_msg.lower()
 
 
@@ -520,7 +520,7 @@ async def test_full_config_update_with_stale_hash(mcp_client, ha_client):
             },
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()
 
 

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -15,7 +15,7 @@ import pytest
 
 from ...utilities.assertions import (
     MCPAssertions,
-    _extract_error_message,
+    extract_error_message,
     safe_call_tool,
     wait_for_automation,
 )
@@ -300,7 +300,7 @@ class TestBlueprintManagement:
                 logger.info("Blueprint appears in list after import")
             else:
                 # Only acceptable failure is "already exists"
-                error_msg = _extract_error_message(result)
+                error_msg = extract_error_message(result)
                 assert "already exists" in error_msg.lower(), \
                     f"Expected 'already exists' error, got: {result}"
                 logger.info("Blueprint already existed (prior test run), still valid")

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -11,7 +11,12 @@ import logging
 
 import pytest
 
-from ...utilities.assertions import assert_mcp_success, parse_mcp_result, safe_call_tool
+from ...utilities.assertions import (
+    assert_mcp_success,
+    extract_error_message,
+    parse_mcp_result,
+    safe_call_tool,
+)
 from ...utilities.wait_helpers import wait_for_condition, wait_for_entity_state
 
 logger = logging.getLogger(__name__)
@@ -708,7 +713,7 @@ class TestInputButtonCRUD:
         assert get_data.get("success", True) is False, (
             f"Entity still present in registry after delete: {get_data}"
         )
-        err_msg = (get_data.get("error", {}).get("message") or "").lower()
+        err_msg = extract_error_message(get_data).lower()
         assert "not found" in err_msg, (
             f"Expected 'not found' in error message, got: {get_data}"
         )

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions
+from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -135,7 +135,7 @@ async def test_python_transform_blocked_import(mcp_client, ha_client):
         },
     )
     # Verify error message mentions import or forbidden
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "import" in error_msg.lower() or "forbidden" in error_msg.lower()
 
 
@@ -154,7 +154,7 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
         {"url_path": "test-python-hash", "python_transform": "config['views'] = []"},
     )
     # Verify error message mentions config_hash
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "config_hash" in error_msg.lower()
 
 
@@ -173,7 +173,7 @@ async def test_python_transform_mutual_exclusivity(mcp_client, ha_client):
         },
     )
     # Verify error message mentions mutual exclusivity
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "cannot use both" in error_msg.lower() or "mutually exclusive" in error_msg.lower()
 
 
@@ -304,7 +304,7 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
         },
     )
     # Verify error message mentions conflict
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()
 
 

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -27,7 +27,11 @@ import uuid
 
 import pytest
 
-from ...utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.assertions import (
+    MCPAssertions,
+    extract_error_message,
+    safe_call_tool,
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -239,7 +243,8 @@ class TestListFiles:
 
         # Should fail with security error
         assert data.get("success") is False, f"Should have failed: {data}"
-        assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
+        error_msg = extract_error_message(data).lower()
+        assert "not allowed" in error_msg or "must be in" in error_msg, (
             f"Wrong error message: {data.get('error')}"
         )
         logger.info("Correctly rejected listing disallowed directory")
@@ -351,7 +356,8 @@ class TestReadFile:
         )
 
         assert data.get("success") is False, f"Should have failed: {data}"
-        assert "not exist" in data.get("error", "").lower() or "not allowed" in data.get("error", "").lower(), (
+        error_msg = extract_error_message(data).lower()
+        assert "not exist" in error_msg or "not allowed" in error_msg, (
             f"Wrong error: {data.get('error')}"
         )
         logger.info("Correctly handled nonexistent file")
@@ -442,7 +448,9 @@ class TestWriteFile:
         )
 
         assert data.get("success") is False, f"Should have failed without overwrite: {data}"
-        assert "exists" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
+        assert "exists" in extract_error_message(data).lower(), (
+            f"Wrong error: {data.get('error')}"
+        )
 
         logger.info("Correctly blocked overwrite without flag")
 
@@ -559,7 +567,9 @@ class TestDeleteFile:
         )
 
         assert data.get("success") is False, f"Should have failed: {data}"
-        assert "not exist" in data.get("error", "").lower(), f"Wrong error: {data.get('error')}"
+        assert "not exist" in extract_error_message(data).lower(), (
+            f"Wrong error: {data.get('error')}"
+        )
 
         logger.info("Correctly handled delete of nonexistent file")
 
@@ -580,7 +590,8 @@ class TestSecurityBoundaries:
         )
 
         assert data.get("success") is False, f"Should block writing to config: {data}"
-        assert "not allowed" in data.get("error", "").lower() or "must be in" in data.get("error", "").lower(), (
+        error_msg = extract_error_message(data).lower()
+        assert "not allowed" in error_msg or "must be in" in error_msg, (
             f"Wrong error message: {data.get('error')}"
         )
 
@@ -733,7 +744,8 @@ class TestFullCRUDWorkflow:
         )
 
         assert final_data.get("success") is False
-        assert "not exist" in final_data.get("error", "").lower() or "not allowed" in final_data.get("error", "").lower()
+        error_msg = extract_error_message(final_data).lower()
+        assert "not exist" in error_msg or "not allowed" in error_msg
         logger.info("   Deletion verified")
 
         logger.info("Complete CRUD lifecycle test PASSED")

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -21,7 +21,11 @@ import os
 
 import pytest
 
-from ...utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.assertions import (
+    MCPAssertions,
+    extract_error_message,
+    safe_call_tool,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -123,7 +127,7 @@ class TestYamlConfigSecurity:
         )
         inner = data
         assert inner.get("success") is False, f"Disallowed file should fail: {data}"
-        assert "not allowed" in inner.get("error", "").lower()
+        assert "not allowed" in extract_error_message(inner).lower()
         logger.info("Correctly rejected disallowed file")
 
     async def test_blocked_key_rejected(self, mcp_client_with_yaml_config):
@@ -142,7 +146,7 @@ class TestYamlConfigSecurity:
         )
         inner = data
         assert inner.get("success") is False, f"Blocked key should fail: {data}"
-        assert "not in the allowed list" in inner.get("error", "").lower()
+        assert "not in the allowed list" in extract_error_message(inner).lower()
         logger.info("Correctly rejected blocked key")
 
     async def test_helper_keys_not_allowed(self, mcp_client_with_yaml_config):
@@ -401,7 +405,7 @@ class TestYamlConfigOperations:
         )
         inner = data
         assert inner.get("success") is False, f"Type mismatch should error: {data}"
-        assert "type mismatch" in inner.get("error", "").lower()
+        assert "type mismatch" in extract_error_message(inner).lower()
         logger.info("Correctly errored on type mismatch")
 
 

--- a/tests/src/e2e/workflows/scripts/test_python_transform.py
+++ b/tests/src/e2e/workflows/scripts/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions
+from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
             "python_transform": "config['sequence'] = []",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "config_hash" in error_msg.lower()
 
 
@@ -94,7 +94,7 @@ async def test_python_transform_mutual_exclusivity(mcp_client, ha_client):
             "python_transform": "config['sequence'] = []",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "cannot use both" in error_msg.lower()
 
 
@@ -138,7 +138,7 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "python_transform": "config['sequence'][0]['data'] = {'brightness': 100}",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()
 
 
@@ -170,7 +170,7 @@ async def test_python_transform_blocked_import(mcp_client, ha_client):
             "python_transform": "import os; os.system('echo pwned')",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "import" in error_msg.lower() or "forbidden" in error_msg.lower()
 
 
@@ -319,7 +319,7 @@ async def test_transform_invalid_config_rejected(mcp_client, ha_client):
             "python_transform": "del config['sequence']",
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "sequence" in error_msg.lower() or "use_blueprint" in error_msg.lower()
 
 
@@ -402,5 +402,5 @@ async def test_full_config_update_with_stale_hash(mcp_client, ha_client):
             },
         },
     )
-    error_msg = result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]
+    error_msg = extract_error_message(result)
     assert "conflict" in error_msg.lower() or "modified" in error_msg.lower()


### PR DESCRIPTION
## What does this PR do?

Picks up the dict-error fragility item from #366's "Still on the list" per [KP13's 14:38 sanction](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4467150914) for a single PR.

Lifts the existing private `_extract_error_message` helper in `tests/src/e2e/utilities/assertions.py` to public `extract_error_message`, and adopts it across all e2e tests that previously hand-rolled string-vs-dict error-message extraction or applied `.lower()` / `in` on a raw `data.get("error", "")` (which silently `AttributeError`s when the tool returns the modern structured `{"error": {"code": ..., "message": ...}}` form from `create_error_response`).

**Changes:**

**Helper (`tests/src/e2e/utilities/assertions.py`):** rename `_extract_error_message` → public `extract_error_message`; docstring expanded to reference the structured-error contract from `src/ha_mcp/errors.py:create_error_response`. Two internal callers in the same file updated for the rename.

**Actually-fragile sites (10 in 3 files):**

| File | Sites | Pattern fixed |
|---|---|---|
| `tests/src/e2e/workflows/config/test_helper_crud.py` | 1 | `(get_data.get("error", {}).get("message") or "").lower()` — the inverse fragility KP13 flagged: `.get("message")` on a string-form error `AttributeError`s, and the `or ""` never fires |
| `tests/src/e2e/workflows/filesystem/test_yaml_config.py` | 3 | `inner.get("error", "").lower()` against `tools_yaml_config.py` (5 `create_error_response` callsites) |
| `tests/src/e2e/workflows/filesystem/test_file_operations.py` | 6 | `data.get("error", "").lower()` / `final_data.get("error", "").lower()` against `tools_filesystem.py` (7 `create_error_response` callsites) |

**DRY-cleanup sites (16 across 3 sibling files):** the inline ternary `result["error"].get("message", str(result["error"])) if isinstance(result["error"], dict) else result["error"]` collapsed into `extract_error_message(result)`.

| File | Sites |
|---|---|
| `tests/src/e2e/workflows/automation/test_python_transform.py` | 7 |
| `tests/src/e2e/workflows/scripts/test_python_transform.py` | 5 |
| `tests/src/e2e/workflows/dashboards/test_python_transform.py` | 4 |

**Existing public-import caller:** `tests/src/e2e/workflows/blueprints/test_blueprints.py` was already importing the previously-private name; updated import + 1 call-site for the rename.

**Net diff:** +67 / −41 LOC.

**Scope evolution since the #366 analysis:** the initial sweep in [the analysis comment](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4467125386) listed 17 sites in 4 files. A second sibling sweep before committing surfaced two more copies of `test_python_transform.py` under `workflows/scripts/` (5 sites) and `workflows/dashboards/` (4 sites) — identical pattern, identical extraction. Included here so the cleanup is consistent across the python_transform sibling-class. One remaining variant at `dashboards/test_python_transform.py:407` (`error = result["error"] if isinstance(result["error"], dict) else {}` for `.get("suggestions")`) is structurally different (returns the dict, not the message) and explicitly out of scope.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local `pytest --collect-only` collects all 149 tests in the eight modified test files with no import errors. CI gates the full E2E run, per [KP13's note](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4467150914): "CI passing should be the biggest tell on if the changes helped."

## Future improvements

`dashboards/test_python_transform.py:407` extracts the error **dict** for `.get("suggestions")` and uses a similar inline-ternary; deferred because adding a sibling `extract_error_dict(data) -> dict` for one site is overkill. Other `data.get("error")` patterns outside `.lower()` / `.get("message")` chains turned up nothing structurally fragile elsewhere in `tests/src/e2e/`.

## Checklist
- [x] I have updated documentation if needed
