### PR TITLE
feat: reject empty/whitespace identifiers on registry-metadata writes (closes #1294)

### DIFF
--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -78,6 +78,72 @@ def extract_tool_error_message(te: ToolError) -> str:
         return str(te)
 
 
+def validate_identifier_not_empty(
+    value: str | None,
+    param_name: str,
+    *,
+    suggestions: list[str] | None = None,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """Reject ``None``, empty, or whitespace-only identifier values.
+
+    Centralises the pre-flight check first introduced in
+    ``tools_config_scenes.py`` (per PR #1168) so every CRUD-style tool in the
+    ``tools_config_*`` family — plus the registry-metadata tools
+    (``tools_labels.py``, ``tools_categories.py``, ``tools_areas.py``) — can
+    surface a structured ``VALIDATION_INVALID_PARAMETER`` response instead of
+    silently routing on Python falsy semantics or relying on Home Assistant
+    to translate a missing identifier into a generic ``RESOURCE_NOT_FOUND``.
+
+    The destructive class this protects against:
+    ``action = "update" if label_id else "create"`` — passing ``""`` as
+    ``label_id`` silently routes to ``create`` when the caller intended
+    ``update``. The whitespace class this protects against: ``" "`` is truthy
+    in Python so ``if not value:`` lets it through, but Home Assistant has
+    no entry with id ``" "``.
+
+    Args:
+        value: Identifier string supplied by the caller. ``None`` is also
+            treated as invalid because every consuming tool requires an
+            identifier when this helper is called.
+        param_name: Name of the parameter, used in the structured error
+            response's ``context`` and the human-readable message.
+        suggestions: Optional list of guidance strings for the response's
+            ``suggestions`` field. Defaults to a generic
+            "provide a non-empty value" hint.
+        context: Optional additional context fields merged into the error
+            response (e.g. ``{"action": "update"}``). The keys ``parameter``
+            and ``value`` are always set and take precedence.
+
+    Raises:
+        ToolError: When ``value`` is ``None``, empty, or whitespace-only —
+            carrying a structured ``VALIDATION_INVALID_PARAMETER`` response
+            with the parameter name, the offending value (for diagnostics),
+            and the suggestions.
+
+    Example:
+        >>> validate_identifier_not_empty(label_id, "label_id",
+        ...     suggestions=["Omit label_id to create a new label"])
+    """
+    if value is not None and value.strip():
+        return
+
+    final_context: dict[str, Any] = {}
+    if context:
+        final_context.update(context)
+    final_context["parameter"] = param_name
+    final_context["value"] = value
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"{param_name} must be a non-empty, non-whitespace string",
+            suggestions=suggestions
+            or [f"Provide a valid non-empty value for {param_name}"],
+            context=final_context,
+        )
+    )
+
+
 async def get_connected_ws_client(
     base_url: str, token: str, verify_ssl: bool | None = None
 ) -> tuple[HomeAssistantWebSocketClient | None, dict[str, Any] | None]:

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -82,18 +82,16 @@ def validate_identifier_not_empty(
     value: str | None,
     param_name: str,
     *,
+    message: str | None = None,
     suggestions: list[str] | None = None,
     context: dict[str, Any] | None = None,
-) -> None:
+) -> str:
     """Reject ``None``, empty, or whitespace-only identifier values.
 
-    Centralises the pre-flight check first introduced in
-    ``tools_config_scenes.py`` (per PR #1168) so every CRUD-style tool in the
-    ``tools_config_*`` family — plus the registry-metadata tools
-    (``tools_labels.py``, ``tools_categories.py``, ``tools_areas.py``) — can
-    surface a structured ``VALIDATION_INVALID_PARAMETER`` response instead of
-    silently routing on Python falsy semantics or relying on Home Assistant
-    to translate a missing identifier into a generic ``RESOURCE_NOT_FOUND``.
+    Surfaces a structured ``VALIDATION_INVALID_PARAMETER`` response so
+    CRUD-style tools fail loudly on missing identifiers instead of silently
+    routing on Python falsy semantics or relying on Home Assistant to
+    translate a missing identifier into a generic ``RESOURCE_NOT_FOUND``.
 
     The destructive class this protects against:
     ``action = "update" if label_id else "create"`` — passing ``""`` as
@@ -102,18 +100,38 @@ def validate_identifier_not_empty(
     in Python so ``if not value:`` lets it through, but Home Assistant has
     no entry with id ``" "``.
 
+    The value is checked but not normalised: ``" abc "`` (a real id wrapped
+    in spaces) is accepted as-is and returned untouched. Only purely empty or
+    purely whitespace strings are rejected.
+
+    ``None`` is also rejected by this helper. Callers for whom ``None`` is a
+    documented sentinel (e.g. ``label_id=None`` meaning "list all" or
+    "create new") must gate the call themselves with
+    ``if value is not None: validate_identifier_not_empty(value, ...)``.
+
+    Returning ``str`` (rather than ``None``) lets call sites use the helper
+    in narrowing position — ``name = validate_identifier_not_empty(name, …)``
+    re-binds ``name`` from ``str | None`` to ``str`` so mypy can prove later
+    uses are safe without a duplicate inline check.
+
     Args:
-        value: Identifier string supplied by the caller. ``None`` is also
-            treated as invalid because every consuming tool requires an
-            identifier when this helper is called.
+        value: Identifier string supplied by the caller. ``None`` is
+            rejected — see the ``None``-sentinel note above for the caller
+            pattern that permits the sentinel.
         param_name: Name of the parameter, used in the structured error
             response's ``context`` and the human-readable message.
+        message: Optional override for the human-readable error message.
+            Defaults to ``"{param_name} must be a non-empty, non-whitespace
+            string"`` when omitted.
         suggestions: Optional list of guidance strings for the response's
             ``suggestions`` field. Defaults to a generic
             "provide a non-empty value" hint.
         context: Optional additional context fields merged into the error
             response (e.g. ``{"action": "update"}``). The keys ``parameter``
             and ``value`` are always set and take precedence.
+
+    Returns:
+        The validated ``value`` unchanged (typed as ``str``).
 
     Raises:
         ToolError: When ``value`` is ``None``, empty, or whitespace-only —
@@ -126,7 +144,7 @@ def validate_identifier_not_empty(
         ...     suggestions=["Omit label_id to create a new label"])
     """
     if value is not None and value.strip():
-        return
+        return value
 
     final_context: dict[str, Any] = {}
     if context:
@@ -136,7 +154,7 @@ def validate_identifier_not_empty(
     raise_tool_error(
         create_error_response(
             ErrorCode.VALIDATION_INVALID_PARAMETER,
-            f"{param_name} must be a non-empty, non-whitespace string",
+            message or f"{param_name} must be a non-empty, non-whitespace string",
             suggestions=suggestions
             or [f"Provide a valid non-empty value for {param_name}"],
             context=final_context,

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1208,14 +1208,16 @@ def _apply_array_ops(
                     )
                 )
             new_id = new_item[id_field]
-            if new_id is None or new_id == "":
+            if new_id is None or (isinstance(new_id, str) and not new_id.strip()):
                 # Items missing the id field have `dict.get(id_field) == None`
-                # by default, so allowing None/"" ids would let later patch /
-                # delete ops match unrelated items.
+                # by default, so allowing None/""/whitespace-only ids would
+                # let later patch / delete ops match unrelated items.
+                # Non-string ids (e.g. integers) stay valid by design — see
+                # ``test_add_with_integer_zero_id_is_accepted``.
                 raise_tool_error(
                     create_validation_error(
                         f"array_patch add op #{index} item {id_field!r} cannot be "
-                        "None or an empty string",
+                        "None, empty, or whitespace-only",
                         parameter=f"array_patch.operations[{index}].item.{id_field}",
                     )
                 )

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -38,6 +38,7 @@ from .helpers import (
     get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
+    validate_identifier_not_empty,
 )
 from .util_helpers import ANSI_ESCAPE_RE
 
@@ -1956,6 +1957,18 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
             ha_manage_addon(slug="...", path="/api/state",
                             request_headers={"Accept": "text/plain"})
         """
+        # Empty/whitespace slug would propagate to every dispatch arm
+        # (Supervisor API, ingress proxy, websocket bridge) and surface as a
+        # misleading "addon not found" or 404 from the Supervisor. Reject
+        # up-front so the caller learns the slug was unusable before any
+        # backend call.
+        validate_identifier_not_empty(
+            slug,
+            "slug",
+            suggestions=[
+                "Use ha_get_addon() to discover installed add-on slugs",
+            ],
+        )
         # Build config payload from provided config parameters
         config_data: dict[str, Any] = {}
         if options:

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -466,12 +466,9 @@ class AreaTools:
                     ],
                 ))
 
-            # Reject empty/whitespace-only id explicitly. `if id:` below
-            # treats them as falsy and would silently route to the create
-            # branch — destructive intent loss if the caller intended an
-            # update. Issue #1294 broadened the original ``id == ""`` guard
-            # (PR #1139) to also catch whitespace-only strings via the
-            # shared ``validate_identifier_not_empty`` helper.
+            # ``None`` stays the documented "create-new" sentinel; explicit
+            # empty/whitespace would silently route to the ``if id:`` create
+            # branch below and lose update intent.
             if id is not None:
                 validate_identifier_not_empty(
                     id,
@@ -490,19 +487,15 @@ class AreaTools:
                     )
                     operation = "update"
                 else:
-                    # Issue #1294: ``if not name`` lets whitespace-only
-                    # ``"   "`` through because ``bool(" ") is True``.
-                    # Kept inline (rather than using the shared
-                    # ``validate_identifier_not_empty`` helper) so mypy can
-                    # narrow ``name`` from ``str | None`` to ``str`` for
-                    # the build-message call below.
-                    if not name or not name.strip():
-                        raise_tool_error(create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "name is required when creating a new area",
-                            context={"operation": "create_area"},
-                            suggestions=["Provide a non-empty name for the new area"],
-                        ))
+                    # Reassignment narrows ``name`` from ``str | None`` to
+                    # ``str`` for the build-message call below.
+                    name = validate_identifier_not_empty(
+                        name,
+                        "name",
+                        message="name is required when creating a new area",
+                        context={"operation": "create_area"},
+                        suggestions=["Provide a non-empty name for the new area"],
+                    )
                     message = self._build_area_create_message(
                         name, floor_id, icon, parsed_aliases, picture,
                     )
@@ -516,15 +509,13 @@ class AreaTools:
                     )
                     operation = "update"
                 else:
-                    # Issue #1294: same whitespace-rejection upgrade as the
-                    # area-create branch above.
-                    if not name or not name.strip():
-                        raise_tool_error(create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "name is required when creating a new floor",
-                            context={"operation": "create_floor"},
-                            suggestions=["Provide a non-empty name for the new floor"],
-                        ))
+                    name = validate_identifier_not_empty(
+                        name,
+                        "name",
+                        message="name is required when creating a new floor",
+                        context={"operation": "create_floor"},
+                        suggestions=["Provide a non-empty name for the new floor"],
+                    )
                     message = self._build_floor_create_message(
                         name, level, icon, parsed_aliases,
                     )
@@ -602,8 +593,7 @@ class AreaTools:
         registry = "area_registry" if kind == "area" else "floor_registry"
         id_key = "area_id" if kind == "area" else "floor_id"
         try:
-            # Issue #1294: empty/whitespace ``id`` would propagate to HA
-            # and surface as a misleading delete-failure.
+            # Empty/whitespace would surface as a misleading HA delete-failure.
             validate_identifier_not_empty(
                 id,
                 "id",

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -18,6 +18,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .util_helpers import parse_string_list_param
 
@@ -465,19 +466,22 @@ class AreaTools:
                     ],
                 ))
 
-            # Reject empty-string id explicitly. `if id:` below treats it as
-            # falsy and would silently route to the create branch — destructive
-            # if the caller intended an update.
-            if id == "":
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "id must be a non-empty string when provided (omit to create)",
-                    context={"kind": kind},
+            # Reject empty/whitespace-only id explicitly. `if id:` below
+            # treats them as falsy and would silently route to the create
+            # branch — destructive intent loss if the caller intended an
+            # update. Issue #1294 broadened the original ``id == ""`` guard
+            # (PR #1139) to also catch whitespace-only strings via the
+            # shared ``validate_identifier_not_empty`` helper.
+            if id is not None:
+                validate_identifier_not_empty(
+                    id,
+                    "id",
                     suggestions=[
                         "Omit id entirely to create a new entry",
                         "Pass a real area_id/floor_id to update an existing entry",
                     ],
-                ))
+                    context={"kind": kind},
+                )
 
             if kind == "area":
                 if id:
@@ -486,12 +490,18 @@ class AreaTools:
                     )
                     operation = "update"
                 else:
-                    if not name:
+                    # Issue #1294: ``if not name`` lets whitespace-only
+                    # ``"   "`` through because ``bool(" ") is True``.
+                    # Kept inline (rather than using the shared
+                    # ``validate_identifier_not_empty`` helper) so mypy can
+                    # narrow ``name`` from ``str | None`` to ``str`` for
+                    # the build-message call below.
+                    if not name or not name.strip():
                         raise_tool_error(create_error_response(
-                            ErrorCode.VALIDATION_MISSING_PARAMETER,
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
                             "name is required when creating a new area",
                             context={"operation": "create_area"},
-                            suggestions=["Provide a name for the new area"],
+                            suggestions=["Provide a non-empty name for the new area"],
                         ))
                     message = self._build_area_create_message(
                         name, floor_id, icon, parsed_aliases, picture,
@@ -506,12 +516,14 @@ class AreaTools:
                     )
                     operation = "update"
                 else:
-                    if not name:
+                    # Issue #1294: same whitespace-rejection upgrade as the
+                    # area-create branch above.
+                    if not name or not name.strip():
                         raise_tool_error(create_error_response(
-                            ErrorCode.VALIDATION_MISSING_PARAMETER,
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
                             "name is required when creating a new floor",
                             context={"operation": "create_floor"},
-                            suggestions=["Provide a name for the new floor"],
+                            suggestions=["Provide a non-empty name for the new floor"],
                         ))
                     message = self._build_floor_create_message(
                         name, level, icon, parsed_aliases,
@@ -590,6 +602,16 @@ class AreaTools:
         registry = "area_registry" if kind == "area" else "floor_registry"
         id_key = "area_id" if kind == "area" else "floor_id"
         try:
+            # Issue #1294: empty/whitespace ``id`` would propagate to HA
+            # and surface as a misleading delete-failure.
+            validate_identifier_not_empty(
+                id,
+                "id",
+                suggestions=[
+                    f"Pass a valid {id_key} (use ha_list_floors_areas() to list)",
+                ],
+                context={"action": "remove", "kind": kind},
+            )
             message: dict[str, Any] = {
                 "type": f"config/{registry}/delete",
                 id_key: id,

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -21,6 +21,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -353,6 +354,18 @@ class CalendarTools:
                         "Calendar entity IDs start with 'calendar.' prefix",
                     ],
                 ))
+
+            # entity_id format-check above does not cover the ``uid`` parameter.
+            # Empty/whitespace uid would flow through to ``calendar.delete_event``
+            # and HA returns a misleading "event not found".
+            validate_identifier_not_empty(
+                uid,
+                "uid",
+                suggestions=[
+                    "Use ha_config_get_calendar_events() to list events and obtain valid UIDs",
+                ],
+                context={"entity_id": entity_id},
+            )
 
             # Build service data
             service_data: dict[str, Any] = {

--- a/src/ha_mcp/tools/tools_categories.py
+++ b/src/ha_mcp/tools/tools_categories.py
@@ -77,10 +77,8 @@ class CategoryTools:
         Use ha_set_entity(categories={"automation": "category_id"}) to assign categories to entities.
         """
         try:
-            # Issue #1294: an explicit empty/whitespace ``category_id`` should
-            # surface a structured validation error rather than fall through
-            # to a generic "Category not found:  " response. ``None`` is the
-            # documented "list all" sentinel and stays untouched.
+            # ``None`` stays the documented "list-all" sentinel; explicit
+            # empty/whitespace is rejected by ``validate_identifier_not_empty``.
             if category_id is not None:
                 validate_identifier_not_empty(
                     category_id,
@@ -209,9 +207,9 @@ class CategoryTools:
         After creating a category, use ha_set_entity(categories={"automation": "category_id"}) to assign it.
         """
         try:
-            # Issue #1294: empty/whitespace ``category_id`` previously routed
-            # silently to ``create`` via ``action = "update" if category_id ...``
-            # — destructive intent loss when an update was intended.
+            # ``None`` stays the documented "create-new" sentinel; explicit
+            # empty/whitespace is rejected so the create/update discriminator
+            # below cannot silently route an intended update to create.
             if category_id is not None:
                 validate_identifier_not_empty(
                     category_id,
@@ -310,8 +308,7 @@ class CategoryTools:
         This action cannot be undone.
         """
         try:
-            # Issue #1294: empty/whitespace ``category_id`` would propagate
-            # to the HA backend and surface as a misleading delete-failure.
+            # Empty/whitespace would surface as a misleading HA delete-failure.
             validate_identifier_not_empty(
                 category_id,
                 "category_id",

--- a/src/ha_mcp/tools/tools_categories.py
+++ b/src/ha_mcp/tools/tools_categories.py
@@ -21,6 +21,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,20 @@ class CategoryTools:
         Use ha_set_entity(categories={"automation": "category_id"}) to assign categories to entities.
         """
         try:
+            # Issue #1294: an explicit empty/whitespace ``category_id`` should
+            # surface a structured validation error rather than fall through
+            # to a generic "Category not found:  " response. ``None`` is the
+            # documented "list all" sentinel and stays untouched.
+            if category_id is not None:
+                validate_identifier_not_empty(
+                    category_id,
+                    "category_id",
+                    suggestions=[
+                        "Omit category_id to list all categories for the scope",
+                        "Pass a valid non-empty category_id",
+                    ],
+                    context={"action": "get", "scope": scope},
+                )
             message: dict[str, Any] = {
                 "type": "config/category_registry/list",
                 "scope": scope,
@@ -194,6 +209,19 @@ class CategoryTools:
         After creating a category, use ha_set_entity(categories={"automation": "category_id"}) to assign it.
         """
         try:
+            # Issue #1294: empty/whitespace ``category_id`` previously routed
+            # silently to ``create`` via ``action = "update" if category_id ...``
+            # — destructive intent loss when an update was intended.
+            if category_id is not None:
+                validate_identifier_not_empty(
+                    category_id,
+                    "category_id",
+                    suggestions=[
+                        "Omit category_id entirely to create a new category",
+                        "Pass a valid category_id to update an existing category",
+                    ],
+                    context={"action": "set", "scope": scope, "name": name},
+                )
             action = "update" if category_id else "create"
 
             message: dict[str, Any] = {
@@ -282,6 +310,16 @@ class CategoryTools:
         This action cannot be undone.
         """
         try:
+            # Issue #1294: empty/whitespace ``category_id`` would propagate
+            # to the HA backend and surface as a misleading delete-failure.
+            validate_identifier_not_empty(
+                category_id,
+                "category_id",
+                suggestions=[
+                    "Pass a valid category_id (use ha_config_get_category() to list)",
+                ],
+                context={"action": "remove", "scope": scope},
+            )
             message: dict[str, Any] = {
                 "type": "config/category_registry/delete",
                 "scope": scope,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -33,6 +33,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
@@ -965,6 +966,15 @@ class AutomationConfigTools:
         **WARNING:** Deleting an automation removes it permanently from your Home Assistant configuration.
         """
         try:
+            # Empty/whitespace would surface as a misleading HA delete-failure.
+            validate_identifier_not_empty(
+                identifier,
+                "identifier",
+                suggestions=[
+                    "Use ha_search_entities(domain_filter='automation') to find existing automations"
+                ],
+                context={"operation": "remove_automation"},
+            )
             # Resolve entity_id for wait verification (identifier may be a unique_id)
             entity_id_for_wait = await self._resolve_automation_entity_id(identifier)
             if not entity_id_for_wait:

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1222,11 +1222,12 @@ async def _check_name_collision(
     duplicate entity instead of updating the original. Detect and reject before
     we send the create message, pointing the caller at the existing helper_id.
 
-    Empty / missing `name` is left to the existing name-required check downstream
-    so the user sees the standard "name is required" error rather than a
-    spurious collision miss.
+    Empty / missing / whitespace-only `name` is left to the existing
+    name-required check downstream so the user sees the standard "name is
+    required" error rather than a spurious collision miss (or a wasted WS
+    round-trip on a name the validator is about to reject anyway).
     """
-    if not name:
+    if not name or not name.strip():
         return
 
     target_slug = _slugify_helper_name(name)
@@ -2495,7 +2496,11 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 )
 
             if action == "create":
-                if not name:
+                # Issue #1294: ``if not name`` lets whitespace-only ``"   "``
+                # through because ``bool(" ") is True`` — upgrade to a strip
+                # check so the rich validation message also catches that
+                # class without delegating to HA.
+                if not name or not name.strip():
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -2838,7 +2843,9 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
 
             elif action == "update":
-                if not helper_id:
+                # Issue #1294: same whitespace-upgrade as the create-name
+                # check above. ``if not helper_id`` lets ``"   "`` through.
+                if not helper_id or not helper_id.strip():
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_INVALID_PARAMETER,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2400,12 +2400,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                     )
                 # Explicit-action update path: helper_id was confirmed non-None
-                # above; close the whitespace gap before the FLOW dispatch at
-                # ``L2488`` returns. The simple-path twin inside the ``elif
-                # action == "update":`` branch fires too late for flow helpers
-                # because the FLOW dispatch returns first; without this guard,
-                # ``helper_id="   "`` would reach ``update_flow_helper`` and
-                # surface as a misleading "entry not found" from HA.
+                # above; close the whitespace gap before the FLOW dispatch
+                # below (``if helper_type in FLOW_HELPER_TYPES: return await
+                # _handle_flow_helper(...)``). The simple-path whitespace twin
+                # inside the ``elif action == "update":`` branch fires after
+                # the FLOW dispatch returns and so is unreachable for flow
+                # helpers; without this guard, ``helper_id="   "`` would reach
+                # ``update_flow_helper`` and surface as a misleading "entry
+                # not found" from HA.
                 if action == "update" and helper_id is not None:
                     validate_identifier_not_empty(
                         helper_id,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -16,7 +16,12 @@ from pydantic import AliasChoices, Field
 
 from ..client.rest_client import HomeAssistantAPIError
 from ..errors import ErrorCode, create_error_response
-from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    validate_identifier_not_empty,
+)
 from .tools_config_entry_flow import (
     FLOW_HELPER_TYPES,
     create_flow_helper,
@@ -1563,6 +1568,22 @@ async def _handle_flow_helper(
     is consistent has already happened upstream in ha_config_set_helper.
     """
     if action is None:
+        # Defence in depth: when reached via the legacy implicit-action
+        # path, an empty/whitespace ``helper_id`` would otherwise be falsy
+        # and silently route to ``create`` — same destructive intent-loss
+        # class as the registry-metadata twins. ``None`` stays the
+        # documented "create-new" sentinel.
+        if helper_id is not None:
+            validate_identifier_not_empty(
+                helper_id,
+                "helper_id",
+                suggestions=[
+                    "Omit helper_id entirely to create a new flow helper",
+                    "Pass a valid helper_id to update an existing one",
+                    "Or pass action='create' / action='update' explicitly",
+                ],
+                context={"helper_type": helper_type},
+            )
         action = "update" if helper_id else "create"
 
     # Normalize empty string to None, matching ha_config_set_helper's treatment
@@ -1618,7 +1639,7 @@ async def _handle_flow_helper(
     # caller-supplied `name` (you cannot rename a flow helper through its
     # options flow). Strip `name` from config_dict and emit a warning so the
     # caller learns their attempted rename was a no-op.
-    if action == "create" and name and "name" not in config_dict:
+    if action == "create" and name and name.strip() and "name" not in config_dict:
         schema_fields = await get_user_step_field_names(client, helper_type)
         if schema_fields is None or "name" in schema_fields:
             config_dict["name"] = name
@@ -1661,7 +1682,12 @@ async def _handle_flow_helper(
         # Some helpers (switch_as_x) deliberately don't have `name` injected into
         # config_dict because their schema rejects it — but the tool still
         # requires `name` to be supplied so callers fail fast and consistently.
-        if not (name or config_dict.get("name")):
+        # Reject whitespace-only too (``" "`` is truthy in Python) so the
+        # flow-helper create gate is coherent with the simple-helper twin.
+        config_name = config_dict.get("name")
+        config_name_ok = isinstance(config_name, str) and bool(config_name.strip())
+        name_ok = name is not None and bool(name.strip())
+        if not (name_ok or config_name_ok):
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -2376,6 +2402,23 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             else:
                 # Implicit discriminator (back-compat). Pass action='create'
                 # or action='update' explicitly to avoid the inference.
+                # Reject empty/whitespace helper_id up front: ``bool("")`` is
+                # False, so without this gate ``helper_id=""`` silently routes
+                # to ``create`` even when the caller's intent was ``update``,
+                # producing a destructive intent-loss class identical to the
+                # one closed for labels/categories. ``None`` stays the
+                # documented "create-new" sentinel.
+                if helper_id is not None:
+                    validate_identifier_not_empty(
+                        helper_id,
+                        "helper_id",
+                        suggestions=[
+                            "Omit helper_id entirely to create a new helper",
+                            "Pass a valid helper_id to update an existing helper",
+                            "Or pass action='create' / action='update' explicitly to declare intent",
+                        ],
+                        context={"helper_type": helper_type},
+                    )
                 action = "update" if helper_id else "create"
 
             # Bug 4b/7c/10/14 (issue #1150): reject typed params that don't apply
@@ -2496,10 +2539,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 )
 
             if action == "create":
-                # Issue #1294: ``if not name`` lets whitespace-only ``"   "``
-                # through because ``bool(" ") is True`` — upgrade to a strip
-                # check so the rich validation message also catches that
-                # class without delegating to HA.
+                # ``bool(" ")`` is True, so plain ``if not name`` would let
+                # whitespace-only names through to a downstream HA error.
                 if not name or not name.strip():
                     raise_tool_error(
                         create_error_response(
@@ -2843,8 +2884,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
 
             elif action == "update":
-                # Issue #1294: same whitespace-upgrade as the create-name
-                # check above. ``if not helper_id`` lets ``"   "`` through.
+                # Same whitespace-upgrade rationale as the create-name check
+                # above — ``if not helper_id`` would let ``"   "`` through.
                 if not helper_id or not helper_id.strip():
                     raise_tool_error(
                         create_error_response(

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2399,6 +2399,23 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             ],
                         )
                     )
+                # Explicit-action update path: helper_id was confirmed non-None
+                # above; close the whitespace gap before the FLOW dispatch at
+                # ``L2488`` returns. The simple-path twin inside the ``elif
+                # action == "update":`` branch fires too late for flow helpers
+                # because the FLOW dispatch returns first; without this guard,
+                # ``helper_id="   "`` would reach ``update_flow_helper`` and
+                # surface as a misleading "entry not found" from HA.
+                if action == "update" and helper_id is not None:
+                    validate_identifier_not_empty(
+                        helper_id,
+                        "helper_id",
+                        suggestions=[
+                            "Pass a valid helper_id to identify the helper to update",
+                            "Or omit helper_id and pass action='create' to create a new helper",
+                        ],
+                        context={"helper_type": helper_type, "action": action},
+                    )
             else:
                 # Implicit discriminator (back-compat). Pass action='create'
                 # or action='update' explicitly to avoid the inference.

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -28,6 +28,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
@@ -619,6 +620,15 @@ class ConfigScriptTools:
         **WARNING:** Deleting a script that is used by automations may cause those automations to fail.
         """
         try:
+            # Empty/whitespace would surface as a misleading HA delete-failure.
+            validate_identifier_not_empty(
+                script_id,
+                "script_id",
+                suggestions=[
+                    "Use ha_search_entities(domain_filter='script') to find existing script_ids"
+                ],
+                context={"operation": "remove_script"},
+            )
             result = await self._client.delete_script_config(script_id)
 
             # Wait for script to be removed

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -41,6 +41,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -1011,6 +1012,18 @@ class EnergyTools:
                     ],
                 )
             )
+        # Empty/whitespace stat_consumption would write a ``{"stat_consumption": ""}``
+        # entry to energy prefs storage — a phantom row keyed on an empty
+        # sensor reference. Same multi-modal-destructive class as
+        # ``ha_manage_addon`` slug guard.
+        validate_identifier_not_empty(
+            stat_consumption,
+            "stat_consumption",
+            suggestions=[
+                "Pass stat_consumption='sensor.<your_device_energy>'",
+            ],
+            context={"mode": "add_device"},
+        )
 
         target_key = "device_consumption_water" if water else "device_consumption"
 
@@ -1049,6 +1062,17 @@ class EnergyTools:
                     ],
                 )
             )
+        # Empty/whitespace stat_consumption would search the prefs storage for
+        # an empty match (always missing) and surface as a misleading
+        # "Device with stat_consumption='' not found".
+        validate_identifier_not_empty(
+            stat_consumption,
+            "stat_consumption",
+            suggestions=[
+                "Pass stat_consumption='sensor.<existing_device_energy>'",
+            ],
+            context={"mode": "remove_device"},
+        )
 
         target_key = "device_consumption_water" if water else "device_consumption"
 

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -795,6 +795,13 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
                 )
 
+            # Per-element empty/whitespace check — the list-empty check above
+            # rejects ``[]`` but not ``[""]``; without this guard, an empty
+            # entity_id would propagate to the entity-registry update WS call
+            # and surface as a misleading HA "entity not found".
+            for eid in entity_ids:
+                validate_identifier_not_empty(eid, "entity_id")
+
             # Validate: bulk operations only support categories, labels, and expose_to
             single_entity_params = {
                 "area_id": area_id,

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -18,6 +18,7 @@ from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
     raise_tool_error,
+    validate_identifier_not_empty,
 )
 from .tools_voice_assistant import KNOWN_ASSISTANTS
 from .util_helpers import coerce_bool_param, parse_json_param, parse_string_list_param
@@ -1334,6 +1335,15 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - ha_get_entity: Check entity details before removal
         """
         try:
+            # Empty/whitespace entity_id would reach the registry-remove WS
+            # command and surface as a misleading HA "entity not found".
+            validate_identifier_not_empty(
+                entity_id,
+                "entity_id",
+                suggestions=[
+                    "Use ha_search_entities() to find valid entity IDs",
+                ],
+            )
             result = await client.send_websocket_message(
                 {"type": "config/entity_registry/remove", "entity_id": entity_id}
             )

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -272,6 +272,20 @@ class GroupTools:
         **NOTE:** entities, add_entities, and remove_entities are mutually exclusive.
         """
         try:
+            # ``_validate_group_params`` only catches dots in object_id and
+            # entity-list issues; empty/whitespace object_id would slip
+            # through to ``call_service("group", "set", {"object_id": "", ...})``
+            # and surface as a misleading HA service-call failure. Symmetric
+            # with the ``ha_config_remove_group`` pre-flight added in this PR.
+            validate_identifier_not_empty(
+                object_id,
+                "object_id",
+                suggestions=[
+                    "Use ha_config_list_groups() to find existing group object_ids",
+                    "Or provide a fresh object_id (without 'group.' prefix) to create a new group",
+                ],
+                context={"operation": "set_group"},
+            )
             self._validate_group_params(object_id, entities, add_entities, remove_entities)
 
             service_data = self._build_group_service_data(
@@ -362,6 +376,9 @@ class GroupTools:
         """
         try:
             # Empty/whitespace would surface as a misleading service-call failure.
+            # Runs before the "." format check below so the empty/whitespace
+            # case is named first; the order is locked by the test in
+            # TestGroupsIdentifierValidation.
             validate_identifier_not_empty(
                 object_id,
                 "object_id",

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -18,6 +18,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .util_helpers import (
     coerce_bool_param,
@@ -360,7 +361,16 @@ class GroupTools:
         - This only removes old-style groups, not platform-specific groups.
         """
         try:
-            # Validate object_id
+            # Empty/whitespace would surface as a misleading service-call failure.
+            validate_identifier_not_empty(
+                object_id,
+                "object_id",
+                suggestions=[
+                    "Use ha_config_list_groups() to find existing group object_ids"
+                ],
+                context={"operation": "remove_group"},
+            )
+            # Validate object_id format
             if "." in object_id:
                 raise_tool_error(create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -21,6 +21,7 @@ from .helpers import (
     register_tool_methods,
     safe_info,
     safe_progress,
+    validate_identifier_not_empty,
 )
 from .util_helpers import add_timezone_metadata, coerce_bool_param, coerce_int_param
 
@@ -568,6 +569,21 @@ class HacsTools:
             Success status and installation details.
         """
         try:
+            # Empty/whitespace repository_id would either be passed straight
+            # into ``_resolve_hacs_repo_id`` (which has no empty-check and
+            # would fall through to a HACS lookup miss) or — for a numeric
+            # candidate — reach ``hacs/repository/download`` with an empty
+            # repository field. Same destructive-WS-call class as
+            # ``ha_manage_addon``: guard up-front so the caller learns the
+            # identifier was unusable before any backend call.
+            validate_identifier_not_empty(
+                repository_id,
+                "repository_id",
+                suggestions=[
+                    "Use ha_hacs_search() to find valid repository IDs",
+                    "Or pass a GitHub path like 'owner/repo' to install by name",
+                ],
+            )
             # Check if HACS is available
             await _assert_hacs_available()
 

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -24,6 +24,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .tools_config_entry_flow import FLOW_HELPER_TYPES
 from .tools_config_helpers import (
@@ -624,6 +625,15 @@ class IntegrationTools:
         Use ha_get_integration() to find entry IDs.
         """
         try:
+            # Empty/whitespace entry_id would surface as a misleading HA
+            # "config entry not found" from ``config_entries/disable``.
+            validate_identifier_not_empty(
+                entry_id,
+                "entry_id",
+                suggestions=[
+                    "Use ha_get_integration() to find valid config entry IDs",
+                ],
+            )
             enabled_bool = coerce_bool_param(enabled, "enabled")
 
             message = {
@@ -799,6 +809,25 @@ class IntegrationTools:
                     },
                 )
             )
+
+        # === Empty/whitespace target gate (uniform for all three paths) ===
+        # Empty/whitespace ``target`` would reach the destructive backend call
+        # on every path: Path 1 (simple-helper websocket delete), Path 2
+        # (flow-helper entity-resolution → entry_id delete), Path 3
+        # (_delete_direct_entry → client.delete_config_entry("")). Each path
+        # surfaces a different misleading error from HA. Reject up-front so
+        # the caller learns the identifier was unusable before any backend
+        # call.
+        validate_identifier_not_empty(
+            target,
+            "target",
+            suggestions=[
+                "Use ha_get_integration() to find valid entry_ids",
+                "For simple helpers, use ha_search_entities() to find the helper_id",
+                "For flow helpers, use ha_search_entities() to find an entity_id",
+            ],
+            context={"helper_type": helper_type},
+        )
 
         # default=True guarantees a non-None return; cast for mypy.
         wait_bool = cast(bool, coerce_bool_param(wait, "wait", default=True))

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -18,6 +18,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,20 @@ class LabelTools:
         Use ha_set_entity(labels=["label1", "label2"]) to assign labels to entities.
         """
         try:
+            # Issue #1294: an explicit empty/whitespace ``label_id`` should
+            # surface a structured validation error rather than fall through
+            # to a generic "Label not found:  " response. ``None`` is the
+            # documented "list all" sentinel and stays untouched.
+            if label_id is not None:
+                validate_identifier_not_empty(
+                    label_id,
+                    "label_id",
+                    suggestions=[
+                        "Omit label_id entirely to list all labels",
+                        "Pass a valid non-empty label_id",
+                    ],
+                    context={"action": "get"},
+                )
             message: dict[str, Any] = {
                 "type": "config/label_registry/list",
             }
@@ -171,6 +186,19 @@ class LabelTools:
         After creating a label, use ha_set_entity(labels=["label_id"]) to assign it to entities.
         """
         try:
+            # Issue #1294: empty/whitespace ``label_id`` previously routed
+            # silently to ``create`` via ``action = "update" if label_id ...``
+            # — destructive intent loss when an update was intended.
+            if label_id is not None:
+                validate_identifier_not_empty(
+                    label_id,
+                    "label_id",
+                    suggestions=[
+                        "Omit label_id entirely to create a new label",
+                        "Pass a valid label_id to update an existing label",
+                    ],
+                    context={"action": "set", "name": name},
+                )
             action = "update" if label_id else "create"
 
             message: dict[str, Any] = {
@@ -246,6 +274,16 @@ class LabelTools:
         This action cannot be undone.
         """
         try:
+            # Issue #1294: empty/whitespace ``label_id`` would propagate to
+            # the HA backend and surface as a misleading delete-failure.
+            validate_identifier_not_empty(
+                label_id,
+                "label_id",
+                suggestions=[
+                    "Pass a valid label_id (use ha_config_get_label() to list)",
+                ],
+                context={"action": "remove"},
+            )
             message: dict[str, Any] = {
                 "type": "config/label_registry/delete",
                 "label_id": label_id,

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -64,10 +64,8 @@ class LabelTools:
         Use ha_set_entity(labels=["label1", "label2"]) to assign labels to entities.
         """
         try:
-            # Issue #1294: an explicit empty/whitespace ``label_id`` should
-            # surface a structured validation error rather than fall through
-            # to a generic "Label not found:  " response. ``None`` is the
-            # documented "list all" sentinel and stays untouched.
+            # ``None`` stays the documented "list-all" sentinel; explicit
+            # empty/whitespace is rejected by ``validate_identifier_not_empty``.
             if label_id is not None:
                 validate_identifier_not_empty(
                     label_id,
@@ -186,9 +184,9 @@ class LabelTools:
         After creating a label, use ha_set_entity(labels=["label_id"]) to assign it to entities.
         """
         try:
-            # Issue #1294: empty/whitespace ``label_id`` previously routed
-            # silently to ``create`` via ``action = "update" if label_id ...``
-            # — destructive intent loss when an update was intended.
+            # ``None`` stays the documented "create-new" sentinel; explicit
+            # empty/whitespace is rejected so the create/update discriminator
+            # below cannot silently route an intended update to create.
             if label_id is not None:
                 validate_identifier_not_empty(
                     label_id,
@@ -274,8 +272,7 @@ class LabelTools:
         This action cannot be undone.
         """
         try:
-            # Issue #1294: empty/whitespace ``label_id`` would propagate to
-            # the HA backend and surface as a misleading delete-failure.
+            # Empty/whitespace would surface as a misleading HA delete-failure.
             validate_identifier_not_empty(
                 label_id,
                 "label_id",

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -18,6 +18,7 @@ from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
     raise_tool_error,
+    validate_identifier_not_empty,
 )
 from .util_helpers import (
     build_pagination_metadata,
@@ -701,6 +702,17 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ha_update_device(device_id="abc123", disabled_by="user")
         """
         try:
+            # Empty/whitespace device_id would slip past the local-filter check
+            # at L719 (``next((d for d in devices if d.get("id") == device_id)...)``)
+            # and surface as a generic "Device not found: " error after a wasted
+            # registry round-trip.
+            validate_identifier_not_empty(
+                device_id,
+                "device_id",
+                suggestions=[
+                    "Use ha_get_device() to find valid device IDs",
+                ],
+            )
             # First, get device details to find config entries
             list_message: dict[str, Any] = {"type": "config/device_registry/list"}
             list_result = await client.send_websocket_message(list_message)

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -660,6 +660,18 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     )
                 )
 
+        # Empty/whitespace device_id would reach the
+        # ``config/device_registry/update`` WS message inside
+        # ``_update_device_internal`` and surface as a misleading HA
+        # "device not found" — same destructive-WS-call class as the
+        # ``ha_remove_device`` guard added in this PR.
+        validate_identifier_not_empty(
+            device_id,
+            "device_id",
+            suggestions=[
+                "Use ha_get_device() to find valid device IDs",
+            ],
+        )
         # Delegate to internal implementation
         return await _update_device_internal(
             device_id=device_id,
@@ -702,10 +714,10 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ha_update_device(device_id="abc123", disabled_by="user")
         """
         try:
-            # Empty/whitespace device_id would slip past the local-filter check
-            # at L719 (``next((d for d in devices if d.get("id") == device_id)...)``)
-            # and surface as a generic "Device not found: " error after a wasted
-            # registry round-trip.
+            # Empty/whitespace device_id would slip past the local-filter
+            # ``next((d for d in devices if d.get("id") == device_id), None)``
+            # check below and surface as a generic "Device not found: " error
+            # after a wasted registry-list round-trip.
             validate_identifier_not_empty(
                 device_id,
                 "device_id",

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -22,6 +22,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -592,6 +593,20 @@ class ResourceTools:
         resource_type: str,
     ) -> tuple[dict[str, Any], str]:
         """Create or update a lovelace resource. Returns (result, action)."""
+        # ``None`` stays the documented "create-new" sentinel; explicit
+        # empty/whitespace ``resource_id`` would silently route to the
+        # ``else`` create branch below and lose update intent (destructive
+        # intent-loss class, same as the registry-metadata twins).
+        if resource_id is not None:
+            validate_identifier_not_empty(
+                resource_id,
+                "resource_id",
+                suggestions=[
+                    "Omit resource_id entirely to create a new resource",
+                    "Pass a valid resource_id to update an existing resource",
+                ],
+                context={"action": "set"},
+            )
         if resource_id:
             result = await self._client.send_websocket_message(
                 {
@@ -646,6 +661,15 @@ class ResourceTools:
         before deleting. Ensure no dashboards depend on the resource.
         """
         try:
+            # Empty/whitespace would surface as a misleading HA delete-failure.
+            validate_identifier_not_empty(
+                resource_id,
+                "resource_id",
+                suggestions=[
+                    "Pass a valid resource_id (use ha_config_list_dashboard_resources() to list)",
+                ],
+                context={"action": "delete"},
+            )
             result = await self._client.send_websocket_message(
                 {
                     "type": "lovelace/resources/delete",

--- a/src/ha_mcp/tools/tools_todo.py
+++ b/src/ha_mcp/tools/tools_todo.py
@@ -21,6 +21,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -302,6 +303,24 @@ class TodoTools:
                 )
             )
 
+        # ``item`` is the implicit create/update discriminator: ``None`` routes
+        # to create, anything else routes to update. Empty/whitespace ``item``
+        # is the destructive-routing class — it is non-None so passes the
+        # ``is None`` check below and reaches ``_update_item``, which calls
+        # ``todo.update_item`` with an empty ``item`` and surfaces as a
+        # misleading "item not found" from HA. Same shape as the helper
+        # implicit-discriminator gate this PR closes for ``ha_config_set_helper``.
+        if item is not None:
+            validate_identifier_not_empty(
+                item,
+                "item",
+                suggestions=[
+                    "Use ha_get_todo() to list items and obtain a valid UID or summary",
+                    "Omit the item parameter entirely to create a new todo item",
+                ],
+                context={"entity_id": entity_id, "action": "update"},
+            )
+
         # Route: create mode (no item) vs update mode (item provided)
         if item is None:
             return await self._create_item(
@@ -546,6 +565,18 @@ class TodoTools:
                     ],
                 )
             )
+
+        # entity_id format-check above does not cover the ``item`` parameter.
+        # Empty/whitespace item would flow through to ``todo.remove_item`` and
+        # HA returns a misleading "item not found".
+        validate_identifier_not_empty(
+            item,
+            "item",
+            suggestions=[
+                "Use ha_get_todo() to list items and obtain a valid UID or summary",
+            ],
+            context={"entity_id": entity_id},
+        )
 
         try:
             # Build service data

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -330,6 +330,13 @@ class ZoneTools:
         **NOTE:** The 'home' zone cannot be removed as it is typically defined in configuration.yaml.
         """
         try:
+            # Empty/whitespace would surface as a misleading HA delete-failure.
+            validate_identifier_not_empty(
+                zone_id,
+                "zone_id",
+                suggestions=["Use ha_get_zone() to find existing zone_ids"],
+                context={"operation": "remove_zone"},
+            )
             message: dict[str, Any] = {
                 "type": "zone/delete",
                 "zone_id": zone_id,

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -18,6 +18,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 
 logger = logging.getLogger(__name__)
@@ -210,6 +211,20 @@ class ZoneTools:
         """
         operation = "create"
         try:
+            # ``None`` stays the documented "create-new" sentinel; explicit
+            # empty/whitespace ``zone_id`` would silently route to the
+            # create branch below and surface "name, latitude, longitude
+            # required" instead of the actual cause (unusable ``zone_id``).
+            if zone_id is not None:
+                validate_identifier_not_empty(
+                    zone_id,
+                    "zone_id",
+                    suggestions=[
+                        "Omit zone_id entirely to create a new zone",
+                        "Pass a valid zone_id to update an existing zone",
+                    ],
+                    context={"action": "set"},
+                )
             if zone_id:
                 # UPDATE operation
                 operation = "update"

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1,17 +1,11 @@
-"""Unit tests for tool-side identifier validation policy (issue #1294).
-
-The maintainer signal on #1294 from kingpanther13 endorses a
-"belt and suspenders" approach with per-tool nuance: tool-side
-empty/whitespace identifier rejection is valuable for the destructive
-intent-loss class (``action = "update" if id else "create"`` on the
-registry-metadata tools) and for partial guards that miss whitespace-only
-strings on the simple-helper writes.
+"""Unit tests for tool-side identifier validation policy.
 
 Two layers of coverage live here:
 
 1. **Helper-level** — direct unit tests for
    ``ha_mcp.tools.helpers.validate_identifier_not_empty``: every reject
-   case (``None``, ``""``, ``"   "``, tab/newline-only) raises
+   case (``None``, ``""``, ``"   "``, tab/newline-only, carriage return,
+   vertical tab, non-breaking space, ideographic space) raises
    ``VALIDATION_INVALID_PARAMETER`` with the parameter name in
    ``context``; every accept case (``"abc"``, ``" abc "``) is a no-op.
 
@@ -24,11 +18,11 @@ Two layers of coverage live here:
    - the ``None`` "list-all" or "create-new" sentinel still works (the
      guard does not regress the documented routing).
 
-The destructive class this PR closes:
+The destructive class these tests pin down:
 
-  ``action = "update" if label_id else "create"`` previously routed an
-  empty-string ``label_id`` to ``create`` silently. After this PR, the
-  caller sees a structured validation error naming ``label_id`` instead.
+  ``action = "update" if label_id else "create"`` would route an
+  empty-string ``label_id`` silently to ``create``. The guard surfaces a
+  structured validation error naming ``label_id`` instead.
 """
 
 from typing import Any
@@ -47,7 +41,22 @@ from ha_mcp.tools.helpers import validate_identifier_not_empty
 class TestValidateIdentifierNotEmptyHelper:
     """Direct tests for the shared validator."""
 
-    @pytest.mark.parametrize("bad", [None, "", " ", "   ", "\t", "\n", " \t\n "])
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            None,
+            "",
+            " ",
+            "   ",
+            "\t",
+            "\n",
+            " \t\n ",
+            "\r",
+            "\v",
+            "\xa0",  # non-breaking space (U+00A0)
+            "　",  # ideographic space (U+3000)
+        ],
+    )
     def test_rejects_empty_or_whitespace(self, bad):
         with pytest.raises(ToolError) as excinfo:
             validate_identifier_not_empty(bad, "test_param")
@@ -57,8 +66,9 @@ class TestValidateIdentifierNotEmptyHelper:
 
     @pytest.mark.parametrize("good", ["abc", " abc ", "x", "scene.movie_night", "0"])
     def test_accepts_valid_identifier(self, good):
-        # Returns None — must not raise on legitimate values.
-        assert validate_identifier_not_empty(good, "test_param") is None
+        # Helper returns the validated value untouched so call sites can
+        # rebind to narrow ``str | None`` → ``str`` for mypy.
+        assert validate_identifier_not_empty(good, "test_param") == good
 
     def test_merges_caller_context_into_error(self):
         with pytest.raises(ToolError) as excinfo:
@@ -73,6 +83,21 @@ class TestValidateIdentifierNotEmptyHelper:
         assert "Omit label_id" in msg
         assert "action" in msg and "set" in msg
         assert "Critical" in msg
+
+    def test_message_override_replaces_default_text(self):
+        # The ``message`` override is used by call sites that want a tighter
+        # context-specific phrase (e.g. "name is required when creating a
+        # new area") while still routing through the shared helper.
+        with pytest.raises(ToolError) as excinfo:
+            validate_identifier_not_empty(
+                "",
+                "name",
+                message="name is required when creating a new area",
+            )
+        msg = str(excinfo.value)
+        assert "name is required when creating a new area" in msg
+        # Default phrasing must not also appear when an override is supplied.
+        assert "must be a non-empty, non-whitespace string" not in msg
 
     def test_caller_context_does_not_shadow_parameter_name(self):
         # The helper always records the canonical ``parameter`` and ``value``
@@ -252,6 +277,28 @@ class TestAreasIdentifierValidation:
         _assert_invalid_param(excinfo)
         tools._client.send_websocket_message.assert_not_called()
 
+    async def test_set_with_none_id_routes_to_create_for_area(self, tools):
+        # Control symmetry with the labels/categories twins: None remains the
+        # documented "create-new" sentinel and routes to area_registry/create.
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"area_id": "x", "name": "X"},
+        }
+        result = await tools.ha_set_area_or_floor(kind="area", name="X")
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "config/area_registry/create"
+
+    async def test_set_with_none_id_routes_to_create_for_floor(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"floor_id": "x", "name": "X"},
+        }
+        result = await tools.ha_set_area_or_floor(kind="floor", name="X")
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "config/floor_registry/create"
+
 
 # --- tools_config_helpers.py (partial-guard whitespace upgrade) -----------
 
@@ -300,4 +347,76 @@ class TestSetHelperWhitespaceUpgrade:
                 name="X",
             )
         _assert_invalid_param(excinfo)
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_implicit_action_with_empty_helper_id_rejects(
+        self, register_tools, mock_ws_client
+    ):
+        # Implicit-discriminator path: ``action`` omitted, ``helper_id=""``.
+        # Without the up-front guard, ``bool("")`` would be False so the
+        # discriminator below silently routes to ``create`` instead of
+        # ``update`` — destructive intent-loss class.
+        set_helper = register_tools["ha_config_set_helper"]
+        for bad in ("", "   "):
+            mock_ws_client.send_websocket_message.reset_mock()
+            with pytest.raises(ToolError) as excinfo:
+                await set_helper(
+                    helper_type="input_boolean", helper_id=bad, name="X"
+                )
+            _assert_invalid_param(excinfo)
+            mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_flow_helper_create_rejects_whitespace_name(
+        self, register_tools, mock_ws_client
+    ):
+        # Flow-helper create gate parity with the simple-helper twin: the
+        # top-level ``name`` arg must be non-whitespace, otherwise the
+        # downstream config-flow build proceeds with a name HA cannot use.
+        set_helper = register_tools["ha_config_set_helper"]
+        with pytest.raises(ToolError) as excinfo:
+            await set_helper(
+                helper_type="utility_meter", action="create", name="   "
+            )
+        _assert_invalid_param(excinfo)
+        # The pre-flow gate runs before any flow start — no WS round-trip.
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_flow_helper_create_rejects_whitespace_config_name(
+        self, register_tools, mock_ws_client
+    ):
+        # Coverage for the other half of the name-required gate: when the
+        # top-level ``name`` is None/empty, ``config_dict["name"]`` must also
+        # be non-whitespace.
+        set_helper = register_tools["ha_config_set_helper"]
+        with pytest.raises(ToolError) as excinfo:
+            await set_helper(
+                helper_type="utility_meter",
+                action="create",
+                config={"name": "   "},
+            )
+        _assert_invalid_param(excinfo)
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+
+class TestCheckNameCollisionWhitespaceSkip:
+    """Direct test for the ``_check_name_collision`` dedupe-skip at L1229.
+
+    The downstream name-required gate at the simple-helper create branch
+    will reject whitespace-only names, but the collision check runs first
+    and would otherwise burn a WebSocket round-trip on a name HA is about
+    to reject. Locks the early-return on whitespace-only ``name`` so the
+    optimisation is not regressed by a refactor.
+    """
+
+    @pytest.mark.parametrize("bad_name", [None, "", " ", "   ", "\t", "\n"])
+    async def test_skips_ws_call_on_empty_or_whitespace_name(
+        self, mock_ws_client, bad_name
+    ):
+        from ha_mcp.tools.tools_config_helpers import _check_name_collision
+
+        # The early-return runs before any WS message is constructed.
+        result = await _check_name_collision(
+            mock_ws_client, "input_boolean", bad_name
+        )
+        assert result is None
         mock_ws_client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -501,3 +501,141 @@ class TestZonesIdentifierValidation:
         assert result["success"] is True
         sent = tools._client.send_websocket_message.call_args[0][0]
         assert sent["type"] == "zone/create"
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_zone_id(self, tools, bad):
+        # Symmetric to ha_config_delete_dashboard_resource: empty/whitespace
+        # would propagate to ``zone/delete`` and surface as a misleading HA
+        # delete-failure instead of naming the unusable zone_id.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_remove_zone(zone_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_config_automations.py / tools_config_scripts.py / tools_groups.py
+# (Round-3 sibling sweep — remove-symmetry across destructive write tools) --
+
+
+class TestAutomationsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+
+        return AutomationConfigTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_identifier(self, tools, bad):
+        # Empty/whitespace identifier would propagate to delete_automation_config
+        # and surface as a misleading HA delete-failure.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_automation(identifier=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.delete_automation_config.assert_not_called()
+
+
+class TestScriptsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
+
+        return ConfigScriptTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_script_id(self, tools, bad):
+        # Empty/whitespace script_id would propagate to delete_script_config
+        # and surface as a misleading HA delete-failure.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_script(script_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.delete_script_config.assert_not_called()
+
+
+class TestGroupsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_groups import GroupTools
+
+        return GroupTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_object_id(self, tools, bad):
+        # Empty/whitespace object_id would propagate to the group.remove
+        # service call and surface as a misleading HA service-call failure.
+        # The pre-flight runs before the pre-existing "." format check so the
+        # error names the empty/whitespace problem first.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_group(object_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.call_service.assert_not_called()
+
+
+# --- _handle_flow_helper direct guard test --------------------------------
+#
+# The parametrize on TestSetHelperWhitespaceUpgrade.test_implicit_action_with_
+# empty_helper_id_rejects locks behavioural parity at the public-tool dispatch
+# level (both helper_types hit the dispatch-level guard inside
+# ha_config_set_helper). The direct test below bypasses the dispatch entry and
+# exercises the defence-in-depth guard inside ``_handle_flow_helper`` itself,
+# so a future refactor that drops the dispatch-level guard would still leave
+# this twin as the locked safety net.
+
+
+class TestFlowHelperDirectGuard:
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_handle_flow_helper_implicit_action_rejects_empty_helper_id(
+        self, mock_ws_client, bad
+    ):
+        from ha_mcp.tools.tools_config_helpers import _handle_flow_helper
+
+        with pytest.raises(ToolError) as excinfo:
+            await _handle_flow_helper(
+                client=mock_ws_client,
+                helper_type="utility_meter",
+                name="X",
+                helper_id=bad,
+                config=None,
+                area_id=None,
+                labels=None,
+                category=None,
+                wait=False,
+                action=None,  # implicit-discriminator path
+            )
+        _assert_invalid_param(excinfo)
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_handle_flow_helper_with_none_helper_id_does_not_raise_guard(
+        self, mock_ws_client
+    ):
+        # Control: ``helper_id=None`` is the documented "create-new" sentinel
+        # and must NOT trip the guard. The call may still raise downstream
+        # (no config / no entity_id) but it must not be VALIDATION_INVALID_
+        # PARAMETER from the implicit-action guard naming ``helper_id``.
+        from ha_mcp.tools.tools_config_helpers import _handle_flow_helper
+
+        mock_ws_client.send_websocket_message.return_value = {
+            "success": False,
+            "error": {"message": "some downstream error"},
+        }
+        try:
+            await _handle_flow_helper(
+                client=mock_ws_client,
+                helper_type="utility_meter",
+                name="My Meter",
+                helper_id=None,
+                config=None,
+                area_id=None,
+                labels=None,
+                category=None,
+                wait=False,
+                action=None,
+            )
+        except ToolError as exc:
+            msg = str(exc)
+            assert "helper_id" not in msg, (
+                "None helper_id must not be rejected by the implicit-action guard"
+            )
+        except Exception:
+            # Any non-ToolError downstream failure is fine — we only need to
+            # confirm the implicit-action guard does not trip on None.
+            pass

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -857,6 +857,47 @@ class TestEntitiesIdentifierValidation:
         )
         mock_ws_client.send_websocket_message.assert_not_called()
 
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_entity_rejects_empty_entity_id_str(
+        self, mock_ws_client, bad
+    ):
+        # ``ha_set_entity`` accepts ``entity_id: str | list[str]``. The
+        # existing list-empty check rejects ``[]`` but lets ``[""]``
+        # through; for the string input path, ``""`` was normalised to
+        # ``[""]`` and propagated to the entity-registry update WS call.
+        # The new per-element guard closes both paths.
+        captured = _register_entity_tools_and_capture(mock_ws_client)
+        ha_set_entity = captured["ha_set_entity"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_set_entity(entity_id=bad, name="New Name")
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "entity_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_entity_rejects_empty_entity_id_in_list(
+        self, mock_ws_client, bad
+    ):
+        # List-input path: ``[""]`` and ``["sensor.real", ""]`` must both
+        # be rejected per-element, not just rejected when the list itself
+        # is empty.
+        captured = _register_entity_tools_and_capture(mock_ws_client)
+        ha_set_entity = captured["ha_set_entity"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_set_entity(
+                entity_id=["sensor.real", bad],
+                categories={"automation": "cat_id"},
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "entity_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
 
 # --- tools_registry.py (Round-4 sibling sweep) ---------------------------
 
@@ -898,4 +939,65 @@ class TestRegistryIdentifierValidation:
         assert '"parameter": "device_id"' in str(excinfo.value), str(
             excinfo.value
         )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_update_device_rejects_empty_device_id(
+        self, mock_ws_client, bad
+    ):
+        # ``device_id`` is passed straight through ``ha_update_device`` to
+        # ``_update_device_internal`` which builds a
+        # ``config/device_registry/update`` WS message; without the new
+        # guard, ``device_id=""`` would surface as a misleading HA
+        # "device not found". Same destructive-WS-call class as
+        # ``ha_remove_device``.
+        captured = _register_registry_tools_and_capture(mock_ws_client)
+        ha_update_device = captured["ha_update_device"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_update_device(device_id=bad, name="New Name")
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "device_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+
+# --- tools_addons.py (Iter6 — ha_manage_addon slug) ----------------------
+
+
+def _register_addon_tools_and_capture(mock_client):
+    from ha_mcp.tools.tools_addons import register_addon_tools
+
+    mock_mcp = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def fake_tool(**kwargs):
+        def decorator(fn):
+            captured[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp.tool = fake_tool
+    register_addon_tools(mock_mcp, mock_client)
+    return captured
+
+
+class TestAddonsIdentifierValidation:
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_manage_addon_rejects_empty_slug(self, mock_ws_client, bad):
+        # ``ha_manage_addon`` is multi-modal (proxy / config / websocket);
+        # ``slug`` is required across all modes and propagates to the
+        # Supervisor API on every dispatch arm. Without the guard,
+        # ``slug=""`` would surface as a misleading "addon not found" /
+        # 404 from the Supervisor; the up-front guard names the offending
+        # parameter before any backend call.
+        captured = _register_addon_tools_and_capture(mock_ws_client)
+        ha_manage_addon = captured["ha_manage_addon"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_manage_addon(slug=bad, path="/api/health")
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "slug"' in str(excinfo.value), str(excinfo.value)
         mock_ws_client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -239,8 +239,8 @@ class TestAreasIdentifierValidation:
 
     @pytest.mark.parametrize("bad", ["", "   "])
     async def test_set_rejects_whitespace_id_for_area(self, tools, bad):
-        # Pre-#1294: ``id == ""`` was guarded but ``"   "`` slipped through
-        # the truthy ``if id:`` branch and routed silently to update with an
+        # Was guarded for ``id == ""`` but ``"   "`` slipped through the
+        # truthy ``if id:`` branch and routed silently to update with an
         # invalid id. This regression test locks the whitespace upgrade.
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_set_area_or_floor(kind="area", id=bad, name="X")
@@ -256,8 +256,8 @@ class TestAreasIdentifierValidation:
 
     @pytest.mark.parametrize("bad", ["", "   "])
     async def test_create_rejects_whitespace_name_for_area(self, tools, bad):
-        # Pre-#1294: ``if not name`` let ``"   "`` through into the create
-        # branch because ``bool(" ") is True``.
+        # ``if not name`` let ``"   "`` through into the create branch
+        # because ``bool(" ") is True``.
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_set_area_or_floor(kind="area", name=bad)
         _assert_invalid_param(excinfo)
@@ -332,7 +332,6 @@ class TestSetHelperWhitespaceUpgrade:
                 helper_type="input_boolean", action="create", name="   "
             )
         _assert_invalid_param(excinfo)
-        # Validation fires before the WS round-trip.
         mock_ws_client.send_websocket_message.assert_not_called()
 
     async def test_update_rejects_whitespace_helper_id(
@@ -349,19 +348,23 @@ class TestSetHelperWhitespaceUpgrade:
         _assert_invalid_param(excinfo)
         mock_ws_client.send_websocket_message.assert_not_called()
 
+    @pytest.mark.parametrize("helper_type", ["input_boolean", "utility_meter"])
     async def test_implicit_action_with_empty_helper_id_rejects(
-        self, register_tools, mock_ws_client
+        self, register_tools, mock_ws_client, helper_type
     ):
         # Implicit-discriminator path: ``action`` omitted, ``helper_id=""``.
         # Without the up-front guard, ``bool("")`` would be False so the
         # discriminator below silently routes to ``create`` instead of
         # ``update`` — destructive intent-loss class.
+        # Parametrized so both the simple-helper guard (``input_boolean``)
+        # and the flow-helper twin guard inside ``_handle_flow_helper``
+        # (``utility_meter``) are exercised.
         set_helper = register_tools["ha_config_set_helper"]
         for bad in ("", "   "):
             mock_ws_client.send_websocket_message.reset_mock()
             with pytest.raises(ToolError) as excinfo:
                 await set_helper(
-                    helper_type="input_boolean", helper_id=bad, name="X"
+                    helper_type=helper_type, helper_id=bad, name="X"
                 )
             _assert_invalid_param(excinfo)
             mock_ws_client.send_websocket_message.assert_not_called()
@@ -399,7 +402,7 @@ class TestSetHelperWhitespaceUpgrade:
 
 
 class TestCheckNameCollisionWhitespaceSkip:
-    """Direct test for the ``_check_name_collision`` dedupe-skip at L1229.
+    """Direct test for the ``_check_name_collision`` dedupe-skip.
 
     The downstream name-required gate at the simple-helper create branch
     will reject whitespace-only names, but the collision check runs first
@@ -420,3 +423,81 @@ class TestCheckNameCollisionWhitespaceSkip:
         )
         assert result is None
         mock_ws_client.send_websocket_message.assert_not_called()
+
+
+# --- tools_resources.py (Round-2 sibling sweep) --------------------------
+
+
+class TestResourcesIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_resources import ResourceTools
+
+        return ResourceTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_resource_id(self, tools, bad):
+        # ``_upsert_resource`` previously routed ``resource_id=""`` to the
+        # create branch via the truthy ``if resource_id:`` check, producing
+        # a phantom dashboard resource instead of the intended update.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_dashboard_resource(
+                url="/local/test.js", resource_type="module", resource_id=bad
+            )
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_set_with_none_resource_id_routes_to_create(self, tools):
+        # Control: None remains the documented "create-new" sentinel.
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"resource_id": "x"},
+        }
+        result = await tools.ha_config_set_dashboard_resource(
+            url="/local/test.js", resource_type="module"
+        )
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "lovelace/resources/create"
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_delete_rejects_empty_resource_id(self, tools, bad):
+        # Empty/whitespace would surface as a misleading HA delete-failure.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_delete_dashboard_resource(resource_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_zones.py (Round-2 sibling sweep) ------------------------------
+
+
+class TestZonesIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_zones import ZoneTools
+
+        return ZoneTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_zone_id(self, tools, bad):
+        # Without the guard, ``zone_id=""`` falls into the create branch and
+        # surfaces "name, latitude, longitude required" — misleading UX
+        # masking the real cause (unusable ``zone_id``).
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_zone(zone_id=bad, name="X")
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_set_with_none_zone_id_routes_to_create(self, tools):
+        # Control: None remains the documented "create-new" sentinel.
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"zone_id": "x"},
+        }
+        result = await tools.ha_set_zone(
+            name="Office", latitude=40.7128, longitude=-74.0060, radius=150
+        )
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "zone/create"

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1001,3 +1001,32 @@ class TestAddonsIdentifierValidation:
         _assert_invalid_param(excinfo)
         assert '"parameter": "slug"' in str(excinfo.value), str(excinfo.value)
         mock_ws_client.send_websocket_message.assert_not_called()
+
+
+# --- tools_hacs.py (Iter7 — ha_hacs_download repository_id) --------------
+
+
+class TestHacsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_hacs import HacsTools
+
+        return HacsTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_hacs_download_rejects_empty_repository_id(self, tools, bad):
+        # Empty/whitespace ``repository_id`` would either fall through
+        # ``_resolve_hacs_repo_id`` (no empty-check) into a HACS lookup
+        # miss, or — for a numeric-looking candidate — reach
+        # ``hacs/repository/download`` with an empty repository field.
+        # Same destructive-WS-call class as ``ha_manage_addon``; the
+        # guard fires before any backend call (including the HACS
+        # availability check) so neither the supervisor nor HACS sees
+        # the empty id.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_hacs_download(repository_id=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "repository_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        tools._client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -356,9 +356,11 @@ class TestSetHelperWhitespaceUpgrade:
         # Without the up-front guard, ``bool("")`` would be False so the
         # discriminator below silently routes to ``create`` instead of
         # ``update`` — destructive intent-loss class.
-        # Parametrized so both the simple-helper guard (``input_boolean``)
-        # and the flow-helper twin guard inside ``_handle_flow_helper``
-        # (``utility_meter``) are exercised.
+        # Parametrized across both helper-type families to lock that the
+        # dispatch-level guard at ``ha_config_set_helper`` fires uniformly
+        # regardless of which helper family the call would have routed to.
+        # The defence-in-depth guard inside ``_handle_flow_helper`` is
+        # exercised separately by ``TestFlowHelperDirectGuard``.
         set_helper = register_tools["ha_config_set_helper"]
         for bad in ("", "   "):
             mock_ws_client.send_websocket_message.reset_mock()
@@ -396,6 +398,26 @@ class TestSetHelperWhitespaceUpgrade:
                 helper_type="utility_meter",
                 action="create",
                 config={"name": "   "},
+            )
+        _assert_invalid_param(excinfo)
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_flow_explicit_update_rejects_empty_helper_id(
+        self, register_tools, mock_ws_client, bad
+    ):
+        # Explicit-action update on a FLOW helper with empty/whitespace
+        # helper_id. The L2378 ``helper_id is None`` guard does not catch
+        # this (value is a non-None empty string), and the simple-path
+        # whitespace twin inside ``elif action == "update":`` fires AFTER
+        # the FLOW dispatch returns. Without the new guard between L2401
+        # and the implicit-action branch, the value would reach
+        # ``update_flow_helper`` and HA returns a misleading "entry not
+        # found".
+        set_helper = register_tools["ha_config_set_helper"]
+        with pytest.raises(ToolError) as excinfo:
+            await set_helper(
+                helper_type="utility_meter", action="update", helper_id=bad
             )
         _assert_invalid_param(excinfo)
         mock_ws_client.send_websocket_message.assert_not_called()
@@ -563,10 +585,31 @@ class TestGroupsIdentifierValidation:
         # Empty/whitespace object_id would propagate to the group.remove
         # service call and surface as a misleading HA service-call failure.
         # The pre-flight runs before the pre-existing "." format check so the
-        # error names the empty/whitespace problem first.
+        # error names the empty/whitespace problem first. The
+        # ``"parameter": "object_id"`` substring discriminates the new
+        # validator's structured error from the ``.`` format check's error
+        # (which uses ``context={"object_id": ...}`` without a ``parameter``
+        # key) — a regression swapping the two guards' order would lose the
+        # ``parameter`` field and break this assertion.
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_config_remove_group(object_id=bad)
         _assert_invalid_param(excinfo)
+        assert '"parameter": "object_id"' in str(excinfo.value), str(excinfo.value)
+        tools._client.call_service.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_object_id(self, tools, bad):
+        # ``_validate_group_params`` only catches ``"." in object_id`` and
+        # mutex/empty-list issues; empty/whitespace ``object_id`` would slip
+        # through to ``call_service("group", "set", ...)`` and surface as a
+        # misleading HA service-call failure. Symmetric with the
+        # ``ha_config_remove_group`` pre-flight added in this PR.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_group(
+                object_id=bad, entities=["light.example"]
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "object_id"' in str(excinfo.value), str(excinfo.value)
         tools._client.call_service.assert_not_called()
 
 
@@ -605,20 +648,25 @@ class TestFlowHelperDirectGuard:
         mock_ws_client.send_websocket_message.assert_not_called()
 
     async def test_handle_flow_helper_with_none_helper_id_does_not_raise_guard(
-        self, mock_ws_client
+        self, mock_ws_client, monkeypatch
     ):
         # Control: ``helper_id=None`` is the documented "create-new" sentinel
-        # and must NOT trip the guard. The call may still raise downstream
-        # (no config / no entity_id) but it must not be VALIDATION_INVALID_
-        # PARAMETER from the implicit-action guard naming ``helper_id``.
-        from ha_mcp.tools.tools_config_helpers import _handle_flow_helper
+        # and must NOT trip the implicit-action guard. The previous
+        # ``"helper_id" not in msg`` assertion would silently pass on any
+        # guard-message rewording; tighten to positive proof — mock the
+        # validator and assert it was not invoked on the None path, which
+        # is independent of any downstream behaviour.
+        from ha_mcp.tools import tools_config_helpers
 
-        mock_ws_client.send_websocket_message.return_value = {
-            "success": False,
-            "error": {"message": "some downstream error"},
-        }
+        validator_mock = MagicMock()
+        monkeypatch.setattr(
+            tools_config_helpers,
+            "validate_identifier_not_empty",
+            validator_mock,
+        )
+
         try:
-            await _handle_flow_helper(
+            await tools_config_helpers._handle_flow_helper(
                 client=mock_ws_client,
                 helper_type="utility_meter",
                 name="My Meter",
@@ -630,12 +678,224 @@ class TestFlowHelperDirectGuard:
                 wait=False,
                 action=None,
             )
-        except ToolError as exc:
-            msg = str(exc)
-            assert "helper_id" not in msg, (
-                "None helper_id must not be rejected by the implicit-action guard"
-            )
         except Exception:
-            # Any non-ToolError downstream failure is fine — we only need to
-            # confirm the implicit-action guard does not trip on None.
+            # Downstream may raise (mocked client returns nothing useful);
+            # the guard-not-invoked assertion below is independent of that.
             pass
+        validator_mock.assert_not_called()
+
+
+# --- tools_integrations.py (Round-4 sibling sweep) -----------------------
+#
+# Two destructive-class siblings the round-3 audit missed:
+#   1. ``ha_delete_helpers_integrations`` — empty/whitespace ``target``
+#      would reach the destructive backend call on every routing path
+#      (simple-helper WS delete, flow-helper entry-resolution, direct
+#      config-entry delete). Single up-front guard closes all three.
+#   2. ``ha_set_integration_enabled`` — empty/whitespace ``entry_id`` would
+#      reach the ``config_entries/disable`` WS message and surface as a
+#      misleading HA "config entry not found".
+
+
+class TestIntegrationsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_integrations import IntegrationTools
+
+        return IntegrationTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    @pytest.mark.parametrize(
+        "helper_type",
+        [None, "input_boolean", "utility_meter"],
+        ids=["direct_entry", "simple_helper", "flow_helper"],
+    )
+    async def test_delete_helpers_integrations_rejects_empty_target(
+        self, tools, bad, helper_type
+    ):
+        # Parametrized across all three routing paths (None→direct entry,
+        # SIMPLE→ws delete, FLOW→entry-resolution) so the single up-front
+        # guard is locked against a regression that moves it inside any
+        # one path.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_delete_helpers_integrations(
+                target=bad, helper_type=helper_type, confirm=True
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "target"' in str(excinfo.value), str(excinfo.value)
+        # No backend call should fire — guard precedes every dispatch arm.
+        tools._client.send_websocket_message.assert_not_called()
+        tools._client.delete_config_entry.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_integration_enabled_rejects_empty_entry_id(
+        self, tools, bad
+    ):
+        # ``entry_id`` is passed straight into ``config_entries/disable``;
+        # without the guard, ``entry_id=""`` would surface as a misleading
+        # HA "config entry not found".
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_integration_enabled(entry_id=bad, enabled=False)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "entry_id"' in str(excinfo.value), str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_calendar.py (Round-4 sibling sweep) ---------------------------
+
+
+class TestCalendarIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_calendar import CalendarTools
+
+        return CalendarTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_event_rejects_empty_uid(self, tools, bad):
+        # The entity_id format-check at the top of the body does not cover
+        # ``uid``; without the new guard, ``uid=""`` would flow through to
+        # ``calendar.delete_event`` and surface as a misleading HA
+        # "event not found".
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_calendar_event(
+                entity_id="calendar.family", uid=bad
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "uid"' in str(excinfo.value), str(excinfo.value)
+        tools._client.call_service.assert_not_called()
+
+
+# --- tools_todo.py (Round-4 sibling sweep) -------------------------------
+
+
+class TestTodoIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_todo import TodoTools
+
+        return TodoTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_item_rejects_empty_item(self, tools, bad):
+        # ``item`` is passed straight into ``todo.remove_item``; without the
+        # new guard, ``item=""`` would surface as a misleading HA
+        # "item not found".
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_remove_todo_item(
+                entity_id="todo.shopping_list", item=bad
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "item"' in str(excinfo.value), str(excinfo.value)
+        tools._client.call_service.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_item_rejects_empty_item_on_implicit_update(
+        self, tools, bad
+    ):
+        # ``item`` is the implicit create/update discriminator: ``None``
+        # routes to create, non-None to update. Without the new guard,
+        # ``item=""`` would route to update (``"" is None`` is False) and
+        # call ``todo.update_item`` with an empty item — destructive
+        # silent-routing class identical to the helper implicit-discriminator
+        # gate this PR closes. ``status="completed"`` is supplied so the
+        # update-mode "at least one update field" gate doesn't fire first.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_todo_item(
+                entity_id="todo.shopping_list",
+                item=bad,
+                status="completed",
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "item"' in str(excinfo.value), str(excinfo.value)
+        tools._client.call_service.assert_not_called()
+
+
+# --- tools_entities.py (Round-4 sibling sweep) ---------------------------
+#
+# ``ha_remove_entity`` is registered via the module-level
+# ``register_entity_tools`` function rather than a Tools class. The
+# ``_register_and_capture`` helper mirrors the pattern in
+# ``test_device_enrichment.py``.
+
+
+def _register_entity_tools_and_capture(mock_client):
+    from ha_mcp.tools.tools_entities import register_entity_tools
+
+    mock_mcp = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def fake_tool(**kwargs):
+        def decorator(fn):
+            captured[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp.tool = fake_tool
+    register_entity_tools(mock_mcp, mock_client)
+    return captured
+
+
+class TestEntitiesIdentifierValidation:
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_entity_rejects_empty_entity_id(
+        self, mock_ws_client, bad
+    ):
+        # ``entity_id`` is passed straight into the
+        # ``config/entity_registry/remove`` WS message; without the new
+        # guard, ``entity_id=""`` surfaces as a misleading HA
+        # "entity not found".
+        captured = _register_entity_tools_and_capture(mock_ws_client)
+        ha_remove_entity = captured["ha_remove_entity"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_remove_entity(entity_id=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "entity_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+
+# --- tools_registry.py (Round-4 sibling sweep) ---------------------------
+
+
+def _register_registry_tools_and_capture(mock_client):
+    from ha_mcp.tools.tools_registry import register_registry_tools
+
+    mock_mcp = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def fake_tool(**kwargs):
+        def decorator(fn):
+            captured[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp.tool = fake_tool
+    register_registry_tools(mock_mcp, mock_client)
+    return captured
+
+
+class TestRegistryIdentifierValidation:
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_device_rejects_empty_device_id(
+        self, mock_ws_client, bad
+    ):
+        # Empty/whitespace ``device_id`` would slip past the local-filter
+        # check (``next((d for d in devices if d.get("id") == device_id)...)``)
+        # after wasting a ``config/device_registry/list`` round-trip, and
+        # surface as a generic "Device not found: " error. Guard fires
+        # before the list WS call.
+        captured = _register_registry_tools_and_capture(mock_ws_client)
+        ha_remove_device = captured["ha_remove_device"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_remove_device(device_id=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "device_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1003,6 +1003,45 @@ class TestAddonsIdentifierValidation:
         mock_ws_client.send_websocket_message.assert_not_called()
 
 
+# --- tools_energy.py (Iter8 — ha_manage_energy_prefs stat_consumption) ---
+
+
+class TestEnergyPrefsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_energy import EnergyTools
+
+        # add an AsyncMock for save_prefs (used by _mutate_atomic) so the
+        # downstream path is reachable in principle — the guard must fire
+        # before we get there.
+        mock_ws_client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"prefs": {}},
+        }
+        return EnergyTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    @pytest.mark.parametrize(
+        "mode", ["add_device", "remove_device"], ids=["add", "remove"]
+    )
+    async def test_manage_energy_prefs_rejects_empty_stat_consumption(
+        self, tools, bad, mode
+    ):
+        # Both ``add_device`` and ``remove_device`` modes require
+        # ``stat_consumption`` and pass it to the prefs storage. Without
+        # the guard, ``add_device`` would write a ``{"stat_consumption": ""}``
+        # phantom entry, and ``remove_device`` would search for an empty
+        # match (always missing) and surface as a misleading
+        # "Device with stat_consumption='' not found".
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_energy_prefs(mode=mode, stat_consumption=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "stat_consumption"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        tools._client.send_websocket_message.assert_not_called()
+
+
 # --- tools_hacs.py (Iter7 — ha_hacs_download repository_id) --------------
 
 

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1,0 +1,303 @@
+"""Unit tests for tool-side identifier validation policy (issue #1294).
+
+The maintainer signal on #1294 from kingpanther13 endorses a
+"belt and suspenders" approach with per-tool nuance: tool-side
+empty/whitespace identifier rejection is valuable for the destructive
+intent-loss class (``action = "update" if id else "create"`` on the
+registry-metadata tools) and for partial guards that miss whitespace-only
+strings on the simple-helper writes.
+
+Two layers of coverage live here:
+
+1. **Helper-level** — direct unit tests for
+   ``ha_mcp.tools.helpers.validate_identifier_not_empty``: every reject
+   case (``None``, ``""``, ``"   "``, tab/newline-only) raises
+   ``VALIDATION_INVALID_PARAMETER`` with the parameter name in
+   ``context``; every accept case (``"abc"``, ``" abc "``) is a no-op.
+
+2. **Call-site-level** — one rejection test per affected entry point in
+   ``tools_labels.py``, ``tools_categories.py``, ``tools_areas.py``, and
+   ``tools_config_helpers.py``, asserting:
+
+   - empty / whitespace identifier surfaces ``VALIDATION_INVALID_PARAMETER``
+     (no WS message sent), and
+   - the ``None`` "list-all" or "create-new" sentinel still works (the
+     guard does not regress the documented routing).
+
+The destructive class this PR closes:
+
+  ``action = "update" if label_id else "create"`` previously routed an
+  empty-string ``label_id`` to ``create`` silently. After this PR, the
+  caller sees a structured validation error naming ``label_id`` instead.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.helpers import validate_identifier_not_empty
+
+# ---------------------------------------------------------------------------
+# Layer 1 — helper unit tests (no tool-class plumbing involved).
+# ---------------------------------------------------------------------------
+
+
+class TestValidateIdentifierNotEmptyHelper:
+    """Direct tests for the shared validator."""
+
+    @pytest.mark.parametrize("bad", [None, "", " ", "   ", "\t", "\n", " \t\n "])
+    def test_rejects_empty_or_whitespace(self, bad):
+        with pytest.raises(ToolError) as excinfo:
+            validate_identifier_not_empty(bad, "test_param")
+        msg = str(excinfo.value)
+        assert "VALIDATION_INVALID_PARAMETER" in msg
+        assert "test_param" in msg
+
+    @pytest.mark.parametrize("good", ["abc", " abc ", "x", "scene.movie_night", "0"])
+    def test_accepts_valid_identifier(self, good):
+        # Returns None — must not raise on legitimate values.
+        assert validate_identifier_not_empty(good, "test_param") is None
+
+    def test_merges_caller_context_into_error(self):
+        with pytest.raises(ToolError) as excinfo:
+            validate_identifier_not_empty(
+                "  ",
+                "label_id",
+                suggestions=["Omit label_id to create a new label"],
+                context={"action": "set", "name": "Critical"},
+            )
+        msg = str(excinfo.value)
+        assert "label_id" in msg
+        assert "Omit label_id" in msg
+        assert "action" in msg and "set" in msg
+        assert "Critical" in msg
+
+    def test_caller_context_does_not_shadow_parameter_name(self):
+        # The helper always records the canonical ``parameter`` and ``value``
+        # keys regardless of what the caller passed in ``context``.
+        with pytest.raises(ToolError) as excinfo:
+            validate_identifier_not_empty(
+                "",
+                "label_id",
+                context={"parameter": "imposter", "value": "imposter"},
+            )
+        msg = str(excinfo.value)
+        # Canonical name wins over caller-supplied "imposter" so downstream
+        # diagnostics can trust the recorded parameter.
+        assert '"parameter": "label_id"' in msg
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — call-site rejection tests per affected module.
+# ---------------------------------------------------------------------------
+
+
+def _assert_invalid_param(excinfo: pytest.ExceptionInfo[ToolError]) -> None:
+    msg = str(excinfo.value)
+    assert "VALIDATION_INVALID_PARAMETER" in msg, msg
+
+
+@pytest.fixture
+def mock_ws_client():
+    """Mock client whose ``send_websocket_message`` records every call.
+
+    Tests that expect validation rejection assert the mock was *not* called
+    (the guard fires before any WS round-trip); tests that exercise the
+    legitimate "list-all"/"create-new" path provide a single success
+    response so the body completes.
+    """
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock()
+    return client
+
+
+# --- tools_labels.py ------------------------------------------------------
+
+
+class TestLabelsIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_labels import LabelTools
+
+        return LabelTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_label_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_label(name="X", label_id=bad)
+        _assert_invalid_param(excinfo)
+        # Guard fires before WS — never reaches send.
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_set_with_none_label_id_routes_to_create(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"label_id": "x"},
+        }
+        result = await tools.ha_config_set_label(name="X")
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "config/label_registry/create"
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_get_rejects_empty_label_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_get_label(label_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_label_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_label(label_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_categories.py --------------------------------------------------
+
+
+class TestCategoriesIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_categories import CategoryTools
+
+        return CategoryTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_category_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_category(
+                name="X", scope="automation", category_id=bad
+            )
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_set_with_none_routes_to_create(self, tools):
+        tools._client.send_websocket_message.return_value = {
+            "success": True,
+            "result": {"category_id": "x"},
+        }
+        result = await tools.ha_config_set_category(name="X", scope="automation")
+        assert result["success"] is True
+        sent = tools._client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "config/category_registry/create"
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_get_rejects_empty_category_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_get_category(scope="automation", category_id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_empty_category_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_remove_category(
+                scope="automation", category_id=bad
+            )
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_areas.py -------------------------------------------------------
+
+
+class TestAreasIdentifierValidation:
+    @pytest.fixture
+    def tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_areas import AreaTools
+
+        return AreaTools(mock_ws_client)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_whitespace_id_for_area(self, tools, bad):
+        # Pre-#1294: ``id == ""`` was guarded but ``"   "`` slipped through
+        # the truthy ``if id:`` branch and routed silently to update with an
+        # invalid id. This regression test locks the whitespace upgrade.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_area_or_floor(kind="area", id=bad, name="X")
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_whitespace_id_for_floor(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_area_or_floor(kind="floor", id=bad, name="X")
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_create_rejects_whitespace_name_for_area(self, tools, bad):
+        # Pre-#1294: ``if not name`` let ``"   "`` through into the create
+        # branch because ``bool(" ") is True``.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_area_or_floor(kind="area", name=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_create_rejects_whitespace_name_for_floor(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_area_or_floor(kind="floor", name=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_remove_rejects_whitespace_id(self, tools, bad):
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_remove_area_or_floor(kind="area", id=bad)
+        _assert_invalid_param(excinfo)
+        tools._client.send_websocket_message.assert_not_called()
+
+
+# --- tools_config_helpers.py (partial-guard whitespace upgrade) -----------
+
+
+class TestSetHelperWhitespaceUpgrade:
+    """Locks the .strip()-aware upgrade on the two pre-existing partial
+    guards in ``ha_config_set_helper`` (create-name, update-helper_id)."""
+
+    @pytest.fixture
+    def register_tools(self, mock_ws_client):
+        from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+        registered: dict[str, Any] = {}
+
+        def capture_tool(**kwargs):
+            def decorator(fn):
+                registered[fn.__name__] = fn
+                return fn
+
+            return decorator
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool = capture_tool
+        register_config_helper_tools(mock_mcp, mock_ws_client)
+        return registered
+
+    async def test_create_rejects_whitespace_name(self, register_tools, mock_ws_client):
+        set_helper = register_tools["ha_config_set_helper"]
+        with pytest.raises(ToolError) as excinfo:
+            await set_helper(
+                helper_type="input_boolean", action="create", name="   "
+            )
+        _assert_invalid_param(excinfo)
+        # Validation fires before the WS round-trip.
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_update_rejects_whitespace_helper_id(
+        self, register_tools, mock_ws_client
+    ):
+        set_helper = register_tools["ha_config_set_helper"]
+        with pytest.raises(ToolError) as excinfo:
+            await set_helper(
+                helper_type="input_boolean",
+                action="update",
+                helper_id="   ",
+                name="X",
+            )
+        _assert_invalid_param(excinfo)
+        mock_ws_client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -294,14 +294,28 @@ class TestApplyArrayOpsValidation:
         assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
 
     def test_add_with_integer_zero_id_is_accepted(self):
-        """The check uses `is None or == ""` (not `not new_id`) so falsy
-        but valid ids like 0 / 0.0 / False are accepted. Pin this down so
+        """The check rejects `None` and whitespace-only strings only — non-string
+        falsy ids like 0 / 0.0 / False stay valid by design. Pin this down so
         a future refactor to `if not new_id:` doesn't silently regress."""
         new, summary = _apply_array_ops(
             [], [{"op": "add", "item": {"id": 0, "type": "x"}}], id_field="id"
         )
         assert summary["added"] == [{"id": 0}]
         assert new == [{"id": 0, "type": "x"}]
+
+    @pytest.mark.parametrize("bad_id", [" ", "   ", "\t", "\n", " \t\n "])
+    def test_add_with_whitespace_only_id_raises(self, bad_id):
+        """Whitespace-only string ids would let later patch/delete ops match
+        unrelated items (the same cross-contamination risk as the
+        empty-string class). The guard catches the whole class via
+        ``str.strip()``."""
+        with pytest.raises(ToolError) as exc:
+            _apply_array_ops(
+                [],
+                [{"op": "add", "item": {"id": bad_id, "type": "x"}}],
+                id_field="id",
+            )
+        assert _parse_tool_error(exc)["error"]["code"] == "VALIDATION_FAILED"
 
     def test_patch_with_empty_patches_raises(self):
         """Empty `patches` is a silent no-op — reject up-front so the caller


### PR DESCRIPTION
## What does this PR do?

Adopts tool-side empty/whitespace identifier rejection across the destructive class of tools per the maintainer signal on #1294 (kingpanther13: belt-and-suspenders, per-tool nuance). Three failure modes are closed:

1. **Destructive intent loss** — `action = "update" if id else "create"` previously routed an empty-string `label_id` / `category_id` / area `id` / `helper_id` / `item` silently to `create` (or `update`, in the `ha_set_todo_item` case) when the caller intended the other. Now surfaces a structured `VALIDATION_INVALID_PARAMETER` error naming the offending parameter instead.

2. **Whitespace gap on partial guards** — existing `if not name` / `if not helper_id` / `if x is None` checks on `ha_config_set_helper` (simple + flow create branches), `ha_set_area_or_floor` (area + floor create branches), and `ha_manage_energy_prefs` (`stat_consumption` on add_device/remove_device) were truthy-true for `"   "` because `bool(" ") is True`. Upgraded to also reject whitespace-only strings.

3. **Misleading delete/service-call errors** — destructive remove/delete/disable/update/install tools that passed identifier parameters straight to the backend would surface as misleading HA-side "not found" or service-call errors when the identifier was empty/whitespace. Each is now guarded with a pre-flight that names the offending parameter.

A new shared helper `validate_identifier_not_empty()` in `src/ha_mcp/tools/helpers.py` centralises the empty/whitespace pre-flight check. It returns the validated value (typed `str`) so call sites can rebind to narrow `str | None → str` for mypy without a duplicate inline check, and accepts a `message` override for context-specific phrasing. `None` stays rejected by the helper — callers permitting the documented "list-all" / "create-new" sentinel gate with `if value is not None:` first.

**Tier 1 — destructive intent-loss class (silent-failure):**
- `tools_labels.py:70, 191, 276` — `action = "update" if label_id else "create"` falsy-routing fix; guard added to `set_label`, `get_label`, `remove_label` for symmetry
- `tools_categories.py:83, 214, 312` — same falsy-routing pattern; guard added to all three CRUD entry points
- `tools_areas.py:473, 597` — `id == ""` guard upgraded to also reject whitespace-only `"   "`; same upgrade applied to `remove_area_or_floor`
- `tools_config_helpers.py:2412` — `ha_config_set_helper`'s explicit-action update path for FLOW helper types: `helper_id="   "` with `action="update"` previously bypassed both the L2378 None-check and the simple-path twin inside the `elif action == "update":` branch (the FLOW dispatch below returns before that branch runs). New guard between the explicit-update raise and the implicit-action `else:` closes the gap.
- `tools_config_helpers.py:2431` — `ha_config_set_helper`'s implicit-discriminator path: `helper_id=""` with `action` omitted no longer routes silently to `create`
- `tools_config_helpers.py:1577` — `_handle_flow_helper`'s implicit-discriminator twin guarded for defence in depth
- `tools_resources.py:601` — `_upsert_resource` (called from `ha_config_set_dashboard_resource`): `resource_id=""` previously routed silently to the create branch, producing a phantom dashboard resource
- `tools_resources.py:665` — `ha_config_delete_dashboard_resource` symmetric guard so empty/whitespace `resource_id` surfaces a structured validation error instead of a misleading HA delete-failure
- `tools_zones.py:219` — `ha_set_zone`: `zone_id="   "` previously fell into the create branch and surfaced "name, latitude, longitude required" instead of naming the unusable `zone_id`
- `tools_zones.py:334` — `ha_remove_zone` symmetric guard so empty/whitespace `zone_id` surfaces a structured validation error instead of a misleading HA delete-failure
- `tools_config_automations.py:970` — `ha_config_remove_automation` symmetric guard on `identifier` (same misleading-delete-failure class)
- `tools_config_scripts.py:624` — `ha_config_remove_script` symmetric guard on `script_id`
- `tools_groups.py:280` — `ha_config_set_group` symmetric guard on `object_id`: `_validate_group_params` only catches `"." in object_id` and entity-list issues; empty/whitespace `object_id` previously reached `call_service("group", "set", ...)`
- `tools_groups.py:382` — `ha_config_remove_group` symmetric guard on `object_id`, fires before the pre-existing `"." in object_id` format check so the empty case is named first
- `tools_integrations.py:630` — `ha_set_integration_enabled` guard on `entry_id` (would otherwise reach `config_entries/disable` WS message with an empty id; same destructive-WS-call class as `ha_remove_entity`/`ha_remove_device`)
- `tools_integrations.py:821` — `ha_delete_helpers_integrations` guard on `target`: single up-front guard after the confirm gate, before any of the 3 routing paths (Path 1 simple-helper WS delete, Path 2 flow-helper entry-resolution, Path 3 `_delete_direct_entry`)
- `tools_calendar.py:361` — `ha_config_remove_calendar_event` guard on `uid` (the `entity_id` format-check above the body does not cover the `uid` parameter; empty `uid` would flow through to `calendar.delete_event` and surface as misleading "event not found")
- `tools_todo.py:314` — `ha_set_todo_item` guard on `item` (implicit create/update discriminator: `item=""` is non-None so passes the `is None` check and silently routes to update, then reaches `todo.update_item` with empty id; same destructive-routing class as the helper implicit-discriminator gate)
- `tools_todo.py:572` — `ha_remove_todo_item` guard on `item` (entity_id format-check above does not cover the `item` parameter)
- `tools_entities.py:803` — `ha_set_entity` per-string guard on each `entity_id` (list-empty check above rejects `[]` but not `[""]`; for string input, `""` was normalised to `[""]` and propagated to the entity-registry update WS call)
- `tools_entities.py:1347` — `ha_remove_entity` guard on `entity_id` (would otherwise reach `config/entity_registry/remove` WS message)
- `tools_registry.py:668` — `ha_update_device` guard on `device_id` (passed straight through to `_update_device_internal` which builds `config/device_registry/update` WS message; same destructive-WS-call class as `ha_remove_device`)
- `tools_registry.py:721` — `ha_remove_device` guard on `device_id` (would otherwise slip past the local-filter check and surface as generic "Device not found: " after a wasted registry-list round-trip)
- `tools_addons.py:1965` — `ha_manage_addon` guard on `slug` (multi-modal tool; `slug` is required across all dispatch arms — Supervisor API, ingress proxy, websocket bridge — and would otherwise propagate to a misleading "addon not found" / 404 from the Supervisor)
- `tools_hacs.py:579` — `ha_hacs_download` guard on `repository_id` (would otherwise either fall through `_resolve_hacs_repo_id` into a HACS lookup miss or — for a numeric candidate — reach `hacs/repository/download` with an empty repository field; same destructive-WS-call class as `ha_manage_addon`)
- `tools_energy.py:1019` — `ha_manage_energy_prefs` `add_device` mode guard on `stat_consumption` (would otherwise write a `{"stat_consumption": ""}` phantom entry into energy prefs storage; same multi-modal-destructive class as `ha_manage_addon`)
- `tools_energy.py:1068` — `ha_manage_energy_prefs` `remove_device` mode guard on `stat_consumption` (would otherwise search prefs storage for an empty match and surface as misleading "Device with stat_consumption='' not found")

**Tier 2 — partial-guard whitespace upgrades:**
- `tools_config_helpers.py:1235` — `_check_name_collision` dedupe-skip now also returns early on whitespace-only `name`, avoiding a wasted WS list-call before the downstream validator rejects
- `tools_config_helpers.py:2563` — `if not name` upgraded for simple-helper `action="create"`
- `tools_config_helpers.py:2908` — `if not helper_id` upgraded for simple-helper `action="update"`
- `tools_config_helpers.py:1642, 1689` — flow-helper `name` injection + create-gate now reject whitespace-only, in parity with the simple-helper twin
- `tools_areas.py:492, 512` — area + floor create branches migrated to the shared helper via `name = validate_identifier_not_empty(name, …)` reassignment so mypy still narrows `str | None → str`

**Sibling-bug sweep (graphify + grep + per-round broader audit):**
- `tools_addons.py:1212` (`array_patch` add-op id validation) used `is None or == ""` which let whitespace-only ids through — same cross-contamination class the inline comment already named for `None` / `""`. Upgraded to also reject whitespace-only strings; non-string ids (eg integer `0`) stay valid by design (`test_add_with_integer_zero_id_is_accepted` continues to pass).
- Round 3+4 remove-symmetry sweep: four destructive remove tools needed the symmetric guard — `ha_remove_zone` (KP13-named in round 3), plus `ha_config_remove_automation` / `ha_config_remove_script` / `ha_config_remove_group` from the widened audit.
- Round 4 destructive-call sweep: five tools surfaced via KP13's named set — `ha_delete_helpers_integrations` (single up-front guard closes all 3 routing paths), `ha_config_remove_calendar_event` (uid), `ha_remove_todo_item` (item), `ha_remove_entity` (entity_id), `ha_remove_device` (device_id). Anchors in Tier 1 above.
- Round 4 set-tool sweep (broader audit beyond KP13's named set): `ha_set_integration_enabled` (entry_id), `ha_set_todo_item` (item discriminator), `ha_config_set_group` (object_id). Anchors in Tier 1 above.
- Iter6 destructive-update sweep (gap surfaced after iter5 publish): `ha_set_entity` (per-string entity_id — list-empty check above didn't cover `[""]`), `ha_update_device` (device_id reaches `config/device_registry/update` via `_update_device_internal`), `ha_manage_addon` (slug across all dispatch arms). All Tier 1 above.
- Iter7 install-tool sweep (HACS family): `ha_hacs_download` (repository_id reaches `hacs/repository/download`). Tier 1 above.
- Iter8 multi-modal sweep (`ha_manage_*` tools re-enumerated for destructive modes with identifier parameters): `ha_manage_energy_prefs` add_device + remove_device modes take `stat_consumption` (same class as `ha_manage_addon` slug). Tier 1 above.

**Out of scope (Tier 3) and other explicit rule-outs:**

Blanket pre-flight on `tools_config_{automations,scripts,dashboards}` get/set/remove was considered but deliberately omitted. KP13's "depends on the tool and how complicated and/or destructive it can be" framing reserves the validation cost for the destructive / silent-failure class — not blanket family-wide. The simple-get tools fall through to HA's `RESOURCE_NOT_FOUND` response which is already informative enough. If a future signal endorses the blanket expansion, the helper introduced here is the natural extension point.

Additional rule-outs (different class, not destructive identifier-routing):

- `ha_config_remove_scene`: already inline-guarded; helper migration tracked under #1314
- `ha_delete_file`: feature-flagged (`HAMCP_ENABLE_FILESYSTEM_TOOLS=true`) with custom-component dependency; path validation is server-side allowed-dirs/path-traversal check, not tool-side identifier routing
- `ha_config_set_calendar_event`: `entity_id` is format-validated upstream (must start with `calendar.`); no separate identifier slot in the same class
- `ha_import_blueprint`: URL parameter, not an identifier (already has URL format validation)
- `ha_install_mcp_tools`: install action, not identifier-routing
- `ha_hacs_add_repository`: empty `repository` is already rejected by the pre-existing `if "/" not in repository:` format check at `tools_hacs.py:450`. The error class is slightly different (`"Invalid repository format. Must be 'owner/repo'"` rather than a structured empty-id error), but the destructive `hacs/repositories/add` WS call is never reached for an empty value. Replacing the format-check with the shared helper would be a pure-refactor with no behavioural change; deferred to keep the scope of this PR coherent.
- `ha_hacs_repository_info`: `readOnlyHint=True`. Per KP13's "depends on how destructive" framing, read-only tools fall outside the destructive class addressed here — an empty `repository_id` surfaces as a HACS lookup miss, not a destructive misroute.
- `ha_get_addon`, `ha_hacs_search`: read-only inspect/search tools, same out-of-scope reason as `ha_hacs_repository_info`.
- `ha_manage_energy_prefs` `get` / `set` / `add_source` modes: `get` is read-only; `set` is a full-replace by-key, not identifier-routing; `add_source` takes a free-form name not an identifier slot — only `add_device` / `remove_device` are guarded above.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit/test_identifier_validation_family.py` (112 tests across 20 classes):
- **Layer 1** — direct helper tests for `validate_identifier_not_empty`: every reject case (`None`, `""`, `"   "`, `"\t"`, `"\n"`, `" \t\n "`, `"\r"`, `"\v"`, NBSP `"\xa0"`, ideographic space `"　"`) raises with the parameter name in the structured response's `context`; every accept case (including `" abc "` — leading/trailing whitespace is *not* stripped, only purely-whitespace strings are rejected) returns the value unchanged. The `message` override is locked by `test_message_override_replaces_default_text`.
- **Layer 2** — call-site rejection tests per affected entry point. Each test asserts `VALIDATION_INVALID_PARAMETER` *and* that the underlying client method is not called — the guard fires before any WS / service round-trip. Control tests (`test_set_with_none_*_routes_to_create`) lock that the `None` "list-all" / "create-new" sentinel still works for `set_label`, `set_category`, `set_area_or_floor` (area + floor), `ha_config_set_dashboard_resource`, and `ha_set_zone`. The implicit-discriminator regression (`helper_id=""` without explicit `action`) is pinned by `test_implicit_action_with_empty_helper_id_rejects`, parametrized over `helper_type in ("input_boolean", "utility_meter")` to lock behavioural parity across helper types at the dispatch-level guard. The explicit-action FLOW whitespace gap (round-2 carry-over) is pinned by `test_flow_explicit_update_rejects_empty_helper_id`.
- **Direct flow-helper guard test** — `TestFlowHelperDirectGuard` calls `_handle_flow_helper` directly with `action=None` to exercise the L1577 defence-in-depth guard, bypassing the dispatch-level guard inside `ha_config_set_helper`. A future refactor that drops the dispatch-level guard would still leave this twin as the locked safety net. The None-control test patches `validate_identifier_not_empty` and asserts not invoked, per the round-4 review.
- **Remove-symmetry classes** — `TestAutomationsIdentifierValidation` / `TestScriptsIdentifierValidation` / `TestGroupsIdentifierValidation` / `TestZonesIdentifierValidation` / `TestIntegrationsIdentifierValidation` / `TestCalendarIdentifierValidation` / `TestTodoIdentifierValidation` / `TestEntitiesIdentifierValidation` / `TestRegistryIdentifierValidation` / `TestAddonsIdentifierValidation` / `TestHacsIdentifierValidation` / `TestEnergyPrefsIdentifierValidation`. Each parametrized over `("", "   ")`. `TestIntegrationsIdentifierValidation.test_delete_helpers_integrations_rejects_empty_target` is parametrized over the 3 routing paths (direct entry, simple helper, flow helper) to lock that the single up-front guard pre-empts every dispatch arm. `TestEnergyPrefsIdentifierValidation.test_manage_energy_prefs_rejects_empty_stat_consumption` is parametrized over both destructive modes (add_device, remove_device).
- **Set/update-class siblings** — `TestGroupsIdentifierValidation.test_set_rejects_empty_object_id`, `TestIntegrationsIdentifierValidation.test_set_integration_enabled_rejects_empty_entry_id`, `TestTodoIdentifierValidation.test_set_item_rejects_empty_item_on_implicit_update`, `TestEntitiesIdentifierValidation.test_set_entity_rejects_empty_entity_id_str` + `test_set_entity_rejects_empty_entity_id_in_list` (string and list paths), `TestRegistryIdentifierValidation.test_update_device_rejects_empty_device_id`, `TestAddonsIdentifierValidation.test_manage_addon_rejects_empty_slug`, `TestHacsIdentifierValidation.test_hacs_download_rejects_empty_repository_id`. Each asserts `"parameter": "<name>"` in the structured error context to discriminate the new guard from any pre-existing validation in the same function.
- **`_check_name_collision` direct test** — `TestCheckNameCollisionWhitespaceSkip` parametrises over `[None, "", " ", "   ", "\t", "\n"]` and asserts `send_websocket_message.call_count == 0`, locking the dedupe-skip optimisation against a future refactor.
- **Sibling test in `test_tools_addons_array_patch.py`** — `test_add_with_whitespace_only_id_raises` parametrises over `[" ", "   ", "\t", "\n", " \t\n "]`.

Full local pytest run: **2615 passed, 1 skipped** (the skip is `test_numpy_version_constraint.py` — by-design on Alpine musl without numpy). mypy clean across the modified source files. ruff `check` clean across `src/` + `tests/`.

## Future improvements

- **Tier 3 follow-up**: a separate PR can extend the helper to `tools_config_{automations,scripts,dashboards}` get/set/remove if a maintainer signal endorses the blanket expansion. The helper is ready; only call-site additions would be needed.
- **Scenes consolidation (DRY)**: `tools_config_scenes.py:225, L524, L946` currently inline the same `if not scene_id or not scene_id.strip()` pattern that the new helper replaces. A pure-refactor PR can migrate those three sites to `validate_identifier_not_empty()` with zero behaviour change (tracked under #1314).
- **`ha_hacs_add_repository` consolidation (DRY)**: the existing `if "/" not in repository:` format check already rejects empty input but returns a less-specific error than the shared helper. Migrating to `validate_identifier_not_empty(repository, "repository", ...)` followed by the format check would unify the error shape across the HACS family without changing behaviour.
- **`ha_delete_file`**: feature-flagged + custom-component-dependent file deletion. The current path validation is server-side allowed-dirs / path-traversal — not in the identifier-routing class addressed here, but an empty/whitespace `path` would still surface as a less-than-ideal server error. A small tool-side `path.strip()` check would improve the UX for the (currently small) population of users with the filesystem feature flag enabled.

Closes #1294
