### PR TITLE
refactor: remove ha_get_helper_schema (closes #1186)

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -548,7 +548,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "utility_meter, derivative, statistics, trend, threshold, "
             "filter, switch_as_x, etc.) cannot be listed through this "
             "tool — use ha_search_entities or ha_deep_search.\n\n"
-            "For per-type schemas, see ha_get_helper_schema and "
+            "For per-type schemas and decision guidance, see "
             "ha_get_skill_guide."
         ),
         "ha_config_set_helper": (
@@ -558,10 +558,10 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "flow-based types (template, group, utility_meter, "
             "derivative, statistics, trend, threshold, filter, "
             "switch_as_x, and others).\n\n"
-            "For per-type config schemas, call "
-            "ha_get_helper_schema(helper_type) first. For decision "
-            "matrix and worked examples (which helper type for which "
-            "use case), see ha_get_skill_guide."
+            "Field set is delivered as `data_schema` on the first "
+            "validation error — submit once and self-correct. For "
+            "decision matrix and worked examples (which helper type "
+            "for which use case), see ha_get_skill_guide."
         ),
         "ha_config_get_dashboard": (
             "Get Home Assistant dashboard info (list mode, search "

--- a/src/ha_mcp/tools/tools_config_entry_flow.py
+++ b/src/ha_mcp/tools/tools_config_entry_flow.py
@@ -244,24 +244,33 @@ def _parse_flow_api_error(
     }
 
 
-async def _fetch_data_schema_for_error_context(
+async def fetch_helper_flow_info(
     client: Any,
     helper_type: str | None,
-    menu_choice: str | None,
-) -> list[Any] | None:
-    """Best-effort fetch of the helper's data_schema for error context.
+    menu_choice: str | None = None,
+) -> dict[str, Any]:
+    """Best-effort introspection of a helper's config-entry flow.
 
-    Starts a fresh introspection flow (always aborted), and returns the
-    user step's ``data_schema`` so the LLM has something concrete to react
-    to when HA's error body is unstructured. Returns ``None`` on any
-    failure or when the helper is menu-based without a chosen branch.
+    Starts a fresh introspection flow (always aborted) and returns a dict
+    with optional keys ``"schema"`` and ``"menu_options"`` so a single HA
+    round-trip serves both the schema-attach path (used by
+    ``_raise_flow_api_error`` and the pre-flow validation gates in
+    ``_handle_flow_helper``) and the menu-sub-types path (used when a
+    menu-rooted helper has no branch chosen yet — issue #1186).
 
-    Public alias ``fetch_helper_data_schema`` is exported below for the
-    pre-flow validation gates in ``_handle_flow_helper`` (issue #1149) —
-    they need the same best-effort fetch but live in another module.
+    Behaviour:
+
+    - FORM at top: ``{"schema": [...]}``
+    - MENU at top with ``menu_choice``: submits and returns the branch
+      form schema as ``{"schema": [...]}`` (no ``menu_options`` since
+      the caller already picked a branch)
+    - MENU at top without ``menu_choice``: ``{"menu_options": [...]}``
+    - any failure or unparseable shape: ``{}`` (callers branch on
+      ``"schema" in info`` / ``"menu_options" in info``)
     """
+    info: dict[str, Any] = {}
     if not helper_type or client is None:
-        return None
+        return info
     intro_flow_id: str | None = None
     try:
         flow_result = await client.start_config_flow(helper_type)
@@ -270,72 +279,38 @@ async def _fetch_data_schema_for_error_context(
 
         if flow_type == _FlowType.FORM:
             schema = flow_result.get("data_schema")
-            return schema if isinstance(schema, list) else None
+            if isinstance(schema, list):
+                info["schema"] = schema
+            return info
 
-        if flow_type == _FlowType.MENU and menu_choice and intro_flow_id:
-            try:
-                step = await asyncio.wait_for(
-                    client.submit_config_flow_step(
-                        intro_flow_id, {"next_step_id": menu_choice}
-                    ),
-                    timeout=10.0,
-                )
-            except Exception:
-                return None
-            if step.get("type") == _FlowType.FORM:
-                schema = step.get("data_schema")
-                return schema if isinstance(schema, list) else None
-        return None
+        if flow_type == _FlowType.MENU:
+            if menu_choice and intro_flow_id:
+                try:
+                    step = await asyncio.wait_for(
+                        client.submit_config_flow_step(
+                            intro_flow_id, {"next_step_id": menu_choice}
+                        ),
+                        timeout=10.0,
+                    )
+                except Exception:
+                    return info
+                if step.get("type") == _FlowType.FORM:
+                    schema = step.get("data_schema")
+                    if isinstance(schema, list):
+                        info["schema"] = schema
+                return info
+
+            # MENU without a choice — surface the legal sub-types instead.
+            options = flow_result.get("menu_options")
+            if isinstance(options, list):
+                filtered = [opt for opt in options if isinstance(opt, str)]
+                if filtered:
+                    info["menu_options"] = filtered
+            return info
+
+        return info
     except Exception:
-        return None
-    finally:
-        if intro_flow_id:
-            try:
-                await asyncio.wait_for(
-                    client.abort_config_flow(intro_flow_id), timeout=5.0
-                )
-            except Exception as abort_err:
-                logger.debug(
-                    f"Failed to abort introspection flow {intro_flow_id}: {abort_err}"
-                )
-
-
-# Public alias for use by pre-flow validation gates in tools_config_helpers
-# (issue #1149). The underscore-prefixed original is kept to preserve the
-# call sites already in this module; the alias avoids importing a private
-# name across modules.
-fetch_helper_data_schema = _fetch_data_schema_for_error_context
-
-
-async def fetch_helper_menu_options(
-    client: Any, helper_type: str
-) -> list[str] | None:
-    """Best-effort fetch of ``menu_options`` for a menu-rooted helper.
-
-    Starts a fresh introspection flow, returns the top-step ``menu_options``
-    list if the flow is menu-rooted, then aborts. Returns ``None`` for
-    non-menu flows or on any failure.
-
-    Used by the pre-flow validation gates in ``_handle_flow_helper`` to
-    surface the available sub-types alongside the
-    ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker
-    (issue #1186), so a caller hitting the marker has the legal sub-type
-    list inline without a second discovery round-trip.
-    """
-    if not helper_type or client is None:
-        return None
-    intro_flow_id: str | None = None
-    try:
-        flow_result = await client.start_config_flow(helper_type)
-        intro_flow_id = flow_result.get("flow_id")
-        if flow_result.get("type") != _FlowType.MENU:
-            return None
-        options = flow_result.get("menu_options")
-        if not isinstance(options, list):
-            return None
-        return [opt for opt in options if isinstance(opt, str)]
-    except Exception:
-        return None
+        return info
     finally:
         if intro_flow_id:
             try:
@@ -389,6 +364,10 @@ async def _raise_flow_api_error(
     suggestions: list[str] = []
     message: str
 
+    # Single introspection round-trip — used by both branches below.
+    info = await fetch_helper_flow_info(client, helper_type, menu_choice)
+    schema = info.get("schema")
+
     if field_errors:
         # Structured field errors — tell the caller which fields failed.
         context["field_errors"] = field_errors
@@ -402,9 +381,6 @@ async def _raise_flow_api_error(
         # codes — symmetric with the unstructured-error branch below.
         # `field_errors` tells "what failed", `data_schema` tells "what's
         # accepted"; together they're enough for self-correction.
-        schema = await _fetch_data_schema_for_error_context(
-            client, helper_type, menu_choice
-        )
         if schema is not None:
             context["data_schema"] = schema
     else:
@@ -412,9 +388,6 @@ async def _raise_flow_api_error(
         message = (
             f"Home Assistant rejected the {helper_type or 'flow'} request "
             f"({status_code}): {parsed['message']}"
-        )
-        schema = await _fetch_data_schema_for_error_context(
-            client, helper_type, menu_choice
         )
         if schema is not None:
             context["data_schema"] = schema

--- a/src/ha_mcp/tools/tools_config_entry_flow.py
+++ b/src/ha_mcp/tools/tools_config_entry_flow.py
@@ -1,9 +1,9 @@
 """
-Config Entry Flow API tools for Home Assistant MCP server.
+Config Entry Flow API machinery for Home Assistant MCP server.
 
 This module provides the shared machinery for creating and updating
 config-entry-based helpers (template, group, utility_meter, etc.) via the
-Config Entry Flow API, plus the ha_get_helper_schema tool.
+Config Entry Flow API.
 
 The create/update entry point is the unified ha_config_set_helper tool in
 tools_config_helpers.py, which routes to create_flow_helper / update_flow_helper
@@ -13,20 +13,11 @@ for the 15 helper types listed in FLOW_HELPER_TYPES.
 import asyncio
 import logging
 from enum import StrEnum
-from typing import Annotated, Any, Literal
-
-from fastmcp.exceptions import ToolError
-from fastmcp.tools import tool
-from pydantic import Field
+from typing import Any, Literal
 
 from ..client.rest_client import HomeAssistantAPIError
 from ..errors import ErrorCode, create_error_response
-from .helpers import (
-    exception_to_structured_error,
-    log_tool_usage,
-    raise_tool_error,
-    register_tool_methods,
-)
+from .helpers import raise_tool_error
 
 logger = logging.getLogger(__name__)
 
@@ -69,41 +60,6 @@ FLOW_HELPER_TYPES: frozenset[str] = frozenset({
     "generic_hygrostat",
 })
 
-# Issue #1149: full set accepted by ha_get_helper_schema (15 flow + 12
-# simple). Simple types route to a static dict in tools_config_helpers
-# rather than starting an HA flow.
-ALL_HELPER_TYPES = Literal[
-    # Flow helpers (mirrors SUPPORTED_HELPERS above)
-    "template",
-    "group",
-    "utility_meter",
-    "derivative",
-    "min_max",
-    "threshold",
-    "integration",
-    "statistics",
-    "trend",
-    "random",
-    "filter",
-    "tod",
-    "generic_thermostat",
-    "switch_as_x",
-    "generic_hygrostat",
-    # Simple helpers (mirrors SIMPLE_HELPER_TYPES in tools_config_helpers)
-    "input_button",
-    "input_boolean",
-    "input_select",
-    "input_number",
-    "input_text",
-    "input_datetime",
-    "counter",
-    "timer",
-    "schedule",
-    "zone",
-    "person",
-    "tag",
-]
-
 # Keys used to specify a menu selection — stripped before submitting form data.
 _MENU_SELECTION_KEYS = frozenset({"group_type", "next_step_id", "menu_option"})
 
@@ -120,9 +76,8 @@ class _FlowType(StrEnum):
 # Module-level flow machinery
 #
 # These functions are shared by the unified ha_config_set_helper tool in
-# tools_config_helpers.py and by ha_get_helper_schema below. They take a
-# client instance as an explicit parameter so they can be called from either
-# a closure-registered tool or a class method.
+# tools_config_helpers.py. They take a client instance as an explicit
+# parameter so the same logic can be used from any caller.
 # ---------------------------------------------------------------------------
 
 
@@ -352,6 +307,47 @@ async def _fetch_data_schema_for_error_context(
 fetch_helper_data_schema = _fetch_data_schema_for_error_context
 
 
+async def fetch_helper_menu_options(
+    client: Any, helper_type: str
+) -> list[str] | None:
+    """Best-effort fetch of ``menu_options`` for a menu-rooted helper.
+
+    Starts a fresh introspection flow, returns the top-step ``menu_options``
+    list if the flow is menu-rooted, then aborts. Returns ``None`` for
+    non-menu flows or on any failure.
+
+    Used by the pre-flow validation gates in ``_handle_flow_helper`` to
+    surface the available sub-types alongside the
+    ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker
+    (issue #1186), so a caller hitting the marker has the legal sub-type
+    list inline without a second discovery round-trip.
+    """
+    if not helper_type or client is None:
+        return None
+    intro_flow_id: str | None = None
+    try:
+        flow_result = await client.start_config_flow(helper_type)
+        intro_flow_id = flow_result.get("flow_id")
+        if flow_result.get("type") != _FlowType.MENU:
+            return None
+        options = flow_result.get("menu_options")
+        if not isinstance(options, list):
+            return None
+        return [opt for opt in options if isinstance(opt, str)]
+    except Exception:
+        return None
+    finally:
+        if intro_flow_id:
+            try:
+                await asyncio.wait_for(
+                    client.abort_config_flow(intro_flow_id), timeout=5.0
+                )
+            except Exception as abort_err:
+                logger.debug(
+                    f"Failed to abort introspection flow {intro_flow_id}: {abort_err}"
+                )
+
+
 async def _raise_flow_api_error(
     api_error: HomeAssistantAPIError,
     *,
@@ -426,11 +422,6 @@ async def _raise_flow_api_error(
                 "Inspect 'data_schema' in this error to see the fields HA expects, "
                 "then retry with a corrected config."
             )
-        suggestions.append(
-            f"Call ha_get_helper_schema(helper_type='{helper_type}') for the "
-            f"full field list and selectors." if helper_type else
-            "Call ha_get_helper_schema for this helper to see required fields."
-        )
 
     raise_tool_error(create_error_response(
         ErrorCode.SERVICE_CALL_FAILED,
@@ -703,253 +694,3 @@ async def create_flow_helper(
         "message": f"{helper_type} helper created successfully",
     }
 
-
-# ---------------------------------------------------------------------------
-# Schema introspection tool (ha_get_helper_schema)
-# ---------------------------------------------------------------------------
-
-
-class ConfigEntryFlowTools:
-    """Schema introspection tool for Config Entry Flow helpers."""
-
-    def __init__(self, client: Any) -> None:
-        self._client = client
-
-    @tool(
-        name="ha_get_helper_schema",
-        tags={"Helper Entities"},
-        annotations={
-            "readOnlyHint": True,
-            "title": "Get Helper Schema"
-        }
-    )
-    @log_tool_usage
-    async def ha_get_helper_schema(
-        self,
-        helper_type: Annotated[ALL_HELPER_TYPES, Field(description="Helper type")],
-        menu_option: Annotated[
-            str | None,
-            Field(
-                description=(
-                    "For menu-based flow helpers (template, group): the sub-type to "
-                    "inspect (e.g. 'sensor' or 'binary_sensor' for template). Omit to "
-                    "see available menu options first. Ignored for simple helpers."
-                ),
-                default=None,
-            ),
-        ] = None,
-    ) -> dict[str, Any]:
-        """Get configuration schema for a helper type.
-
-        Returns the field list and types needed to create this helper. Use
-        before ha_config_set_helper when unsure of the required `config`
-        (flow helpers) or required typed parameters (simple helpers). The
-        same schema is also auto-attached to validation-error responses
-        from ha_config_set_helper, so an explicit pre-call is optional.
-
-        Three branches:
-
-        1. Simple helpers (input_*, counter, timer, schedule, zone, person,
-           tag): static schema returned from a built-in dict.
-              ha_get_helper_schema("input_select")
-              → {flow_type: "form", data_schema: [{name: "name", required: True, ...}, ...]}
-
-        2. Form-based flow helpers (min_max, utility_meter, statistics, ...):
-           starts a fresh HA flow, reads the schema, and aborts the flow.
-              ha_get_helper_schema("min_max")
-              → {flow_type: "form", data_schema: [...]}
-
-        3. Menu-based flow helpers (template, group): two-call workflow.
-              # Step 1 — discover sub-types:
-              ha_get_helper_schema("template")
-              → {flow_type: "menu", menu_options: ["sensor", "binary_sensor", ...]}
-
-              # Step 2 — inspect form fields for a sub-type:
-              ha_get_helper_schema("template", menu_option="sensor")
-              → {flow_type: "form", menu_option: "sensor", data_schema: [...]}
-        """
-        # Issue #1149: simple-helper dispatch — return a static schema
-        # without round-tripping HA. Lazy import keeps the existing
-        # tools_config_helpers ↔ tools_config_entry_flow boundary intact.
-        from .tools_config_helpers import (
-            SIMPLE_HELPER_TYPES,
-            get_simple_helper_schema,
-        )
-
-        if helper_type in SIMPLE_HELPER_TYPES:
-            schema = get_simple_helper_schema(helper_type)
-            # Invariant in tools_config_helpers asserts every simple type
-            # has a schema entry — None here would indicate a developer
-            # error that should fail loudly rather than mask as empty.
-            if schema is None:
-                raise_tool_error(create_error_response(
-                    ErrorCode.INTERNAL_UNEXPECTED,
-                    f"No simple-helper schema registered for '{helper_type}'",
-                    context={"helper_type": helper_type},
-                ))
-            if menu_option is not None:
-                # Simple helpers have no menu — flag the misuse rather than
-                # silently ignore the parameter.
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"menu_option is not applicable to simple helper "
-                    f"'{helper_type}' (only flow helpers like 'template' "
-                    f"and 'group' use menus).",
-                    suggestions=["Omit menu_option for simple helpers."],
-                    context={"helper_type": helper_type},
-                ))
-            return {
-                "success": True,
-                "helper_type": helper_type,
-                "flow_type": _FlowType.FORM,
-                "step_id": "user",
-                "data_schema": schema,
-                "description_placeholders": {},
-            }
-
-        flow_id = None  # Track flow_id for error context
-        try:
-            flow_result = await self._client.start_config_flow(helper_type)
-            flow_id = flow_result.get("flow_id")
-            flow_type = flow_result.get("type")
-
-            if flow_type == _FlowType.ABORT:
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Could not get schema, flow aborted: {flow_result.get('reason')}",
-                    context={"helper_type": helper_type, "details": flow_result},
-                ))
-
-            if not flow_id:
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    "Failed to start config flow — no flow_id returned",
-                    context={"helper_type": helper_type, "details": flow_result},
-                ))
-
-            if menu_option is not None:
-                return await self._get_schema_with_menu_option(
-                    helper_type, menu_option, flow_id, flow_result, flow_type,
-                )
-
-            return self._build_top_level_schema(helper_type, flow_result, flow_type)
-
-        except ToolError:
-            raise
-        except Exception as e:
-            logger.error(f"Error getting helper schema: {e}")
-            exception_to_structured_error(e, context={"helper_type": helper_type})
-        finally:
-            # Always abort the introspection flow to avoid leaking it in HA memory.
-            if flow_id:
-                try:
-                    await self._client.abort_config_flow(flow_id)
-                except Exception as abort_err:
-                    logger.warning(f"Failed to abort introspection flow {flow_id}: {abort_err}")
-
-    async def _get_schema_with_menu_option(
-        self,
-        helper_type: str,
-        menu_option: str,
-        flow_id: str,
-        flow_result: dict[str, Any],
-        flow_type: str | None,
-    ) -> dict[str, Any]:
-        """Submit a menu selection and return the resulting form schema.
-
-        Validates that the flow is a menu type, submits the menu option,
-        and returns the form schema for the selected sub-type.
-        """
-        if flow_type != _FlowType.MENU:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                f"menu_option is not applicable to '{helper_type}' "
-                f"(flow type is '{flow_type}', not 'menu')",
-                suggestions=["Omit menu_option for form-based helpers"],
-                context={"helper_type": helper_type, "flow_type": flow_type},
-            ))
-
-        step_result = await self._client.submit_config_flow_step(
-            flow_id, {"next_step_id": menu_option}
-        )
-        sub_flow_type = step_result.get("type")
-
-        if sub_flow_type == _FlowType.ABORT:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                f"menu_option '{menu_option}' is not valid for '{helper_type}': "
-                f"{step_result.get('reason')}",
-                suggestions=[f"Valid options: {flow_result.get('menu_options', [])}"],
-                context={
-                    "helper_type": helper_type,
-                    "menu_option": menu_option,
-                    "details": step_result,
-                },
-            ))
-
-        if sub_flow_type != _FlowType.FORM:
-            raise_tool_error(create_error_response(
-                ErrorCode.INTERNAL_UNEXPECTED,
-                f"Unexpected sub-flow type '{sub_flow_type}' after menu selection",
-                context={
-                    "helper_type": helper_type,
-                    "menu_option": menu_option,
-                    "details": step_result,
-                },
-            ))
-
-        return {
-            "success": True,
-            "helper_type": helper_type,
-            "flow_type": _FlowType.FORM,
-            "menu_option": menu_option,
-            "step_id": step_result.get("step_id"),
-            "data_schema": step_result.get("data_schema", []),
-            "description_placeholders": step_result.get("description_placeholders", {}),
-        }
-
-    @staticmethod
-    def _build_top_level_schema(
-        helper_type: str,
-        flow_result: dict[str, Any],
-        flow_type: str | None,
-    ) -> dict[str, Any]:
-        """Build the top-level schema response for a form or menu flow."""
-        if flow_type == _FlowType.FORM:
-            return {
-                "success": True,
-                "helper_type": helper_type,
-                "flow_type": _FlowType.FORM,
-                "step_id": flow_result.get("step_id"),
-                "data_schema": flow_result.get("data_schema", []),
-                "description_placeholders": flow_result.get(
-                    "description_placeholders", {}
-                ),
-            }
-        if flow_type == _FlowType.MENU:
-            return {
-                "success": True,
-                "helper_type": helper_type,
-                "flow_type": _FlowType.MENU,
-                "step_id": flow_result.get("step_id"),
-                "menu_options": flow_result.get("menu_options", []),
-                "description_placeholders": flow_result.get(
-                    "description_placeholders", {}
-                ),
-                "note": (
-                    "This helper requires selecting from a menu first. "
-                    "Include 'group_type' (or 'next_step_id') in your config "
-                    "when calling ha_config_set_helper. "
-                    "Call ha_get_helper_schema with menu_option=<sub-type> to inspect form fields."
-                ),
-            }
-        raise_tool_error(create_error_response(
-            ErrorCode.INTERNAL_UNEXPECTED,
-            f"Unexpected flow type: {flow_type}",
-            context={"helper_type": helper_type, "details": flow_result},
-        ))
-
-
-def register_config_entry_flow_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
-    """Register Config Entry Flow API tools with the MCP server."""
-    register_tool_methods(mcp, ConfigEntryFlowTools(client))

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -21,6 +21,7 @@ from .tools_config_entry_flow import (
     FLOW_HELPER_TYPES,
     create_flow_helper,
     fetch_helper_data_schema,
+    fetch_helper_menu_options,
     get_user_step_field_names,
     update_flow_helper,
 )
@@ -141,11 +142,9 @@ class _HelperFieldSpec(_HelperFieldSpecBase, total=False):
 
 # Per-simple-type field schemas — list-of-dicts shape mirroring HA's flow
 # ``data_schema`` so callers can iterate one shape regardless of helper kind.
-# Consumed by:
-#   - ``ha_get_helper_schema`` (returned verbatim for simple types).
-#   - ``ha_config_set_helper`` validation errors (relevant entry attached to
-#     ``context["data_schema"]`` so the LLM sees field shape inline with the
-#     4xx that just blocked it).
+# Consumed by ``ha_config_set_helper`` validation errors (relevant entry
+# attached to ``context["data_schema"]`` so the LLM sees field shape inline
+# with the 4xx that just blocked it).
 #
 # Each field-spec dict carries:
 #   - ``name``        : argument key on ``ha_config_set_helper``.
@@ -571,10 +570,11 @@ def _simple_helper_error_context(
 # FORM — for these, ``fetch_helper_data_schema`` cannot return a ``data_schema``
 # without a menu choice (``next_step_id`` / ``group_type`` / ``menu_option``).
 # The pre-flow gates in ``_handle_flow_helper`` use this set to surface a
-# ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker so
-# the LLM gets a non-silent signal to call
-# ``ha_get_helper_schema(<type>, menu_option=...)``. Hint set — extending it
-# only sharpens the signal, missing entries fall back to silent ``None``.
+# ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker
+# alongside the legal sub-types under ``menu_options`` so the LLM can pick
+# a branch on the next try without a separate discovery round-trip. Hint
+# set — extending it only sharpens the signal, missing entries fall back
+# to silent ``None``.
 _MENU_ROOTED_FLOW_HELPER_TYPES: frozenset[str] = frozenset({"template", "group"})
 
 # Keys callers may pass inside ``config`` to select a menu branch — mirrors
@@ -625,9 +625,9 @@ async def _flow_helper_error_context(
     For menu-rooted helpers (``template``, ``group``) without a derivable
     ``menu_choice``, the schema can't be fetched without picking a branch;
     a ``data_schema_unavailable_reason: "menu_helper_requires_branch"``
-    marker is added instead so the LLM gets a non-silent signal to call
-    ``ha_get_helper_schema(<type>, menu_option=...)`` rather than reading
-    the absence of ``data_schema`` as "no schema exists".
+    marker is added instead, along with the legal sub-types under
+    ``menu_options`` (issue #1186), so the caller can pick a branch on
+    the next try without a separate discovery round-trip.
     """
     context: dict[str, Any] = {"helper_type": helper_type}
     try:
@@ -651,6 +651,9 @@ async def _flow_helper_error_context(
         context["data_schema"] = schema
     elif helper_type in _MENU_ROOTED_FLOW_HELPER_TYPES and not menu_choice:
         context["data_schema_unavailable_reason"] = "menu_helper_requires_branch"
+        menu_options = await fetch_helper_menu_options(client, helper_type)
+        if menu_options:
+            context["menu_options"] = menu_options
     context.update(extra)
     return context
 
@@ -723,7 +726,7 @@ def _validate_applicable_params(
     inapplicable.sort()
     if helper_type in FLOW_HELPER_TYPES:
         applicable_msg = (
-            "config (use ha_get_helper_schema to see fields), "
+            "config (see data_schema on a validation error for the field set), "
             "name, helper_id, area_id, labels, category, wait"
         )
     else:
@@ -747,8 +750,8 @@ def _validate_applicable_params(
     if helper_type in FLOW_HELPER_TYPES:
         suggestions.append(
             f"For flow-based helpers like {helper_type!r}, type-specific config "
-            "goes inside the `config` dict; the per-type fields are discoverable "
-            f"via ha_get_helper_schema(helper_type='{helper_type}')."
+            "goes inside the `config` dict; submit with the wrong shape once "
+            "and the validation error returns the `data_schema` for that helper."
         )
 
     raise_tool_error(
@@ -2226,7 +2229,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "integration, statistics, trend, random, filter, tod, "
                     "generic_thermostat, switch_as_x, generic_hygrostat). "
                     "Accepts JSON string or dict. Ignored for simple helper types. "
-                    "Use ha_get_helper_schema(helper_type) to discover required fields."
+                    "Field set is delivered as data_schema on the first validation error."
                 ),
                 default=None,
             ),
@@ -2277,13 +2280,14 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
           without it the tool falls back to the implicit `helper_id`-presence
           discriminator.
         - For flow-based helpers, config keys not declared by any step's
-          data_schema are silently ignored by HA; verify field names with
-          `ha_get_helper_schema` before relying on them.
+          data_schema are silently ignored by HA; submit once and the
+          validation error returns the `data_schema` for that helper so
+          subsequent calls use the correct field names.
         - Validation errors raised by this tool carry the helper's
-          `data_schema` in the response context so a follow-up call can
-          self-correct. Calling `ha_get_helper_schema(helper_type)` ahead of
-          time is therefore optional — the schema is delivered alongside the
-          first 4xx if you call without it.
+          `data_schema` in the response context (and `menu_options` for
+          menu-rooted helpers like `template`/`group` when no sub-type is
+          chosen yet) so a follow-up call can self-correct without a
+          separate schema-discovery round-trip.
 
         EXAMPLES (menu-based types + tod, where first-call payload is non-obvious):
         - template sensor:
@@ -2299,11 +2303,10 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ha_config_set_helper(helper_type="tod", name="Quiet Hours",
                 config={"after_time": "22:00:00", "before_time": "07:00:00"})
 
-        For complex schemas and per-type parameter details, use ha_get_helper_schema.
-        For broader helper-design guidance (when to pick which helper type, YAML
-        examples), use ha_get_skill_guide — the skill's
-        `helper-selection.md` reference covers the `input_*` family, `counter`,
-        `timer`, and `schedule` with worked examples and a decision matrix.
+        For helper-design guidance (when to pick which helper type, YAML
+        examples, per-type field tables), use ha_get_skill_guide — the
+        skill's `helper-selection.md` reference covers all 27 helper types
+        with worked examples and a decision matrix.
         """
         try:
             # Determine if this is a create or update — set early so the

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -20,8 +20,7 @@ from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_e
 from .tools_config_entry_flow import (
     FLOW_HELPER_TYPES,
     create_flow_helper,
-    fetch_helper_data_schema,
-    fetch_helper_menu_options,
+    fetch_helper_flow_info,
     get_user_step_field_names,
     update_flow_helper,
 )
@@ -540,7 +539,7 @@ def get_simple_helper_schema(helper_type: str) -> list[_HelperFieldSpec] | None:
     Callers attach the result to validation-error context as ``data_schema``
     so the LLM sees field shape inline with a 4xx response, matching the
     auto-attach pattern already in use for flow helpers (see
-    ``_fetch_data_schema_for_error_context`` in ``tools_config_entry_flow``).
+    ``fetch_helper_flow_info`` in ``tools_config_entry_flow``).
     Returns ``None`` for any helper_type not in ``SIMPLE_HELPER_SCHEMAS``,
     so callers can write a single uniform ``if schema is not None: …`` branch.
     """
@@ -567,7 +566,7 @@ def _simple_helper_error_context(
 
 
 # Flow helper types whose top-level config-flow step is a MENU rather than a
-# FORM — for these, ``fetch_helper_data_schema`` cannot return a ``data_schema``
+# FORM — for these, ``fetch_helper_flow_info`` cannot return a ``data_schema``
 # without a menu choice (``next_step_id`` / ``group_type`` / ``menu_option``).
 # The pre-flow gates in ``_handle_flow_helper`` use this set to surface a
 # ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker
@@ -631,7 +630,7 @@ async def _flow_helper_error_context(
     """
     context: dict[str, Any] = {"helper_type": helper_type}
     try:
-        schema = await fetch_helper_data_schema(
+        info = await fetch_helper_flow_info(
             client, helper_type, menu_choice=menu_choice
         )
     except Exception as e:
@@ -640,20 +639,19 @@ async def _flow_helper_error_context(
         # disappear silently — this PR raises the call rate by 5 sites
         # and the swallow needs an audit-trail entry.
         logger.debug(
-            "_flow_helper_error_context: schema fetch failed for "
+            "_flow_helper_error_context: flow-info fetch failed for "
             "helper_type=%r menu_choice=%r: %s",
             helper_type,
             menu_choice,
             e,
         )
-        schema = None
-    if schema is not None:
-        context["data_schema"] = schema
+        info = {}
+    if "schema" in info:
+        context["data_schema"] = info["schema"]
     elif helper_type in _MENU_ROOTED_FLOW_HELPER_TYPES and not menu_choice:
         context["data_schema_unavailable_reason"] = "menu_helper_requires_branch"
-        menu_options = await fetch_helper_menu_options(client, helper_type)
-        if menu_options:
-            context["menu_options"] = menu_options
+        if "menu_options" in info:
+            context["menu_options"] = info["menu_options"]
     context.update(extra)
     return context
 

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -2,10 +2,10 @@
 E2E tests for Config Entry Flow API.
 
 Covers:
-- Schema retrieval for form-based and menu-based helpers (ha_get_helper_schema)
 - Creating a form-only helper (min_max)
 - Creating a menu-based helper (group — menu then form)
-- Error feedback on missing menu selection
+- Error feedback on missing menu selection (data_schema_unavailable_reason
+  marker + menu_options inline on validation errors)
 - Deletion of config-entry-based helpers
 """
 
@@ -53,107 +53,6 @@ async def _create_config_entry_helper(
 @pytest.mark.slow
 class TestConfigEntryFlow:
     """Test Config Entry Flow helper creation."""
-
-    async def test_get_helper_schema_form_type(self, mcp_client):
-        """Schema for a form-based helper returns data_schema fields."""
-        result = await mcp_client.call_tool(
-            "ha_get_helper_schema", {"helper_type": "min_max"}
-        )
-        data = assert_mcp_success(result, "Get min_max schema")
-
-        assert data.get("helper_type") == "min_max"
-        assert data.get("flow_type") == "form"
-        assert "data_schema" in data
-        assert isinstance(data["data_schema"], list)
-        logger.info(f"min_max schema has {len(data['data_schema'])} fields")
-
-    async def test_get_helper_schema_menu_type(self, mcp_client):
-        """Schema for a menu-based helper (group) returns menu_options."""
-        result = await mcp_client.call_tool(
-            "ha_get_helper_schema", {"helper_type": "group"}
-        )
-        data = assert_mcp_success(result, "Get group schema")
-
-        assert data.get("helper_type") == "group"
-        assert "flow_type" in data
-
-        if data.get("flow_type") == "menu":
-            assert "menu_options" in data
-            assert isinstance(data["menu_options"], list)
-            assert len(data["menu_options"]) > 0, "Group should have at least one menu option"
-            logger.info(f"Group has {len(data['menu_options'])} menu options: {data['menu_options']}")
-        else:
-            # HA may change group to form-based in future versions
-            assert "data_schema" in data
-
-    async def test_get_helper_schema_template_menu_top(self, mcp_client):
-        """Template schema without menu_option returns top-level menu with sensor/binary_sensor."""
-        result = await mcp_client.call_tool(
-            "ha_get_helper_schema", {"helper_type": "template"}
-        )
-        data = assert_mcp_success(result, "Get template schema top-level")
-
-        assert data.get("helper_type") == "template"
-        assert data.get("flow_type") == "menu"
-        assert "menu_options" in data
-        assert "sensor" in data["menu_options"], f"Expected 'sensor' in {data['menu_options']}"
-        assert "binary_sensor" in data["menu_options"], f"Expected 'binary_sensor' in {data['menu_options']}"
-        logger.info(f"Template menu_options: {data['menu_options']}")
-
-    async def test_get_helper_schema_template_sensor(self, mcp_client):
-        """Template schema with menu_option='sensor' returns form fields including 'state'."""
-        result = await mcp_client.call_tool(
-            "ha_get_helper_schema",
-            {"helper_type": "template", "menu_option": "sensor"},
-        )
-        data = assert_mcp_success(result, "Get template sensor schema")
-
-        assert data.get("helper_type") == "template"
-        assert data.get("flow_type") == "form"
-        assert data.get("menu_option") == "sensor"
-        assert "data_schema" in data
-        field_names = [f.get("name") for f in data["data_schema"]]
-        assert "state" in field_names, f"Expected 'state' field, got: {field_names}"
-        logger.info(f"Template sensor fields: {field_names}")
-
-    async def test_get_helper_schema_menu_option_invalid_for_form_helper(self, mcp_client):
-        """Passing menu_option to a form-based helper returns a validation error."""
-        data = await safe_call_tool(
-            mcp_client,
-            "ha_get_helper_schema",
-            {"helper_type": "min_max", "menu_option": "sensor"},
-        )
-        assert data.get("success") is not True
-        error_str = str(data).lower()
-        assert any(
-            kw in error_str for kw in ("menu_option", "form", "not 'menu'", "not applicable")
-        ), f"Error should mention menu_option or flow type mismatch: {data}"
-
-    async def test_get_helper_schema_invalid_menu_option(self, mcp_client):
-        """Passing an invalid menu_option value returns a clear validation error."""
-        data = await safe_call_tool(
-            mcp_client,
-            "ha_get_helper_schema",
-            {"helper_type": "template", "menu_option": "nonexistent_type"},
-        )
-        assert data.get("success") is not True
-        error_str = str(data).lower()
-        assert any(
-            kw in error_str
-            for kw in ("valid options", "not valid", "menu_option", "400", "api error")
-        ), f"Error should mention valid options or invalid menu_option: {data}"
-
-    async def test_get_helper_schema_multiple_types(self, mcp_client):
-        """Schema retrieval works for all supported helper types."""
-        helper_types = ["utility_meter", "min_max"]
-
-        for helper_type in helper_types:
-            result = await mcp_client.call_tool(
-                "ha_get_helper_schema", {"helper_type": helper_type}
-            )
-            data = assert_mcp_success(result, f"Get {helper_type} schema")
-            assert data.get("helper_type") == helper_type
-            assert "flow_type" in data
 
     async def test_create_min_max_helper(self, mcp_client):
         """Create a min_max helper (single form step, no menu)."""
@@ -268,7 +167,9 @@ class TestConfigEntryFlow:
         logger.info(f"options_schema flow_type={schema['flow_type']} for {entry['domain']}")
 
     async def test_create_group_helper_missing_menu_selection(self, mcp_client):
-        """Creating a group helper without group_type returns a helpful error."""
+        """Creating a group helper without group_type returns a helpful error
+        with the legal sub-types inline as ``menu_options`` (issue #1186).
+        """
         config = {"name": "my_group", "entities": []}  # missing group_type
 
         data = await safe_call_tool(
@@ -283,3 +184,13 @@ class TestConfigEntryFlow:
             kw in error_str.lower()
             for kw in ("menu", "group_type", "next_step_id", "selection", "option")
         ), f"Error should mention menu selection: {error_str}"
+        # The error context must carry the legal sub-types inline so the
+        # caller can pick a branch on the next try without a discovery
+        # round-trip — see _handle_menu_step in tools_config_entry_flow.
+        menu_options = data.get("menu_options")
+        assert isinstance(menu_options, list) and menu_options, (
+            f"Error should carry menu_options list: {data}"
+        )
+        assert "light" in menu_options, (
+            f"Group menu_options should include 'light': {menu_options}"
+        )

--- a/tests/src/unit/test_helper_schema_inline.py
+++ b/tests/src/unit/test_helper_schema_inline.py
@@ -36,7 +36,7 @@ from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_config_entry_flow import (
     FLOW_HELPER_TYPES,
-    fetch_helper_menu_options,
+    fetch_helper_flow_info,
 )
 from ha_mcp.tools.tools_config_helpers import (
     SIMPLE_HELPER_SCHEMAS,
@@ -277,81 +277,195 @@ class TestFlowHelperErrorContext:
 
         assert ctx == {"helper_type": "filter"}
 
+    async def test_menu_rooted_marker_omits_menu_options_on_ha_failure(
+        self,
+    ) -> None:
+        # If ``fetch_helper_flow_info`` returns ``{}`` (HA failure on the
+        # introspection round-trip) for a menu-rooted helper without a
+        # choice, the marker is still set but ``menu_options`` is
+        # omitted rather than written as an empty / None value. The
+        # caller can rely on ``"menu_options" in ctx`` as the
+        # has-options test.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(side_effect=RuntimeError("offline"))
+
+        ctx = await _flow_helper_error_context(client, "template")
+
+        assert ctx == {
+            "helper_type": "template",
+            "data_schema_unavailable_reason": "menu_helper_requires_branch",
+        }
+        assert "menu_options" not in ctx
+
 
 # ---------------------------------------------------------------------------
-# 3. fetch_helper_menu_options (issue #1186)
+# 3. fetch_helper_flow_info (issue #1186)
 # ---------------------------------------------------------------------------
 
 
-class TestFetchHelperMenuOptions:
-    """``fetch_helper_menu_options`` returns the legal sub-type list for a
-    menu-rooted helper, ``None`` for non-menu flows, and ``None`` on any
-    HA failure — used by ``_flow_helper_error_context`` to populate
-    ``menu_options`` alongside the
-    ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker.
+class TestFetchHelperFlowInfo:
+    """``fetch_helper_flow_info`` introspects a helper's config flow in
+    a single HA round-trip and returns a dict with optional ``"schema"``
+    and ``"menu_options"`` keys. Replaces the prior two helpers
+    (``_fetch_data_schema_for_error_context`` + ``fetch_helper_menu_options``)
+    that did the same flow start twice for menu-rooted helpers without
+    a branch picked.
     """
 
-    async def test_returns_menu_options_for_menu_flow(self) -> None:
-        client = AsyncMock()
-        client.start_config_flow = AsyncMock(
-            return_value={
-                "type": "menu",
-                "flow_id": "intro-1",
-                "menu_options": ["sensor", "binary_sensor", "button"],
-            }
-        )
-        client.abort_config_flow = AsyncMock(return_value={})
-
-        options = await fetch_helper_menu_options(client, "template")
-
-        assert options == ["sensor", "binary_sensor", "button"]
-        # The introspection flow was aborted to avoid leaking it in HA.
-        client.abort_config_flow.assert_called_once_with("intro-1")
-
-    async def test_returns_none_for_form_flow(self) -> None:
-        # Non-menu-rooted helpers like ``filter`` start with a form step;
-        # there are no ``menu_options`` to surface.
+    async def test_form_flow_returns_schema(self) -> None:
+        # ``filter`` is non-menu — top step is a form whose data_schema
+        # is returned directly.
+        intro_schema = [{"name": "entity_id", "required": True}]
         client = AsyncMock()
         client.start_config_flow = AsyncMock(
             return_value={
                 "type": "form",
                 "flow_id": "intro-1",
-                "data_schema": [{"name": "entity_id", "required": True}],
+                "data_schema": intro_schema,
             }
         )
         client.abort_config_flow = AsyncMock(return_value={})
 
-        options = await fetch_helper_menu_options(client, "filter")
+        info = await fetch_helper_flow_info(client, "filter")
 
-        assert options is None
-        # Flow still aborted — leakage check is independent of return value.
+        assert info == {"schema": intro_schema}
         client.abort_config_flow.assert_called_once_with("intro-1")
 
-    async def test_returns_none_on_ha_failure(self) -> None:
-        client = AsyncMock()
-        client.start_config_flow = AsyncMock(side_effect=RuntimeError("offline"))
-
-        options = await fetch_helper_menu_options(client, "template")
-
-        assert options is None
-
-    async def test_filters_non_string_options(self) -> None:
-        # Defensive — if HA returns a non-string entry in menu_options
-        # (shouldn't happen, but the API isn't strictly typed), drop it
-        # rather than propagating type confusion to the caller.
+    async def test_menu_flow_with_choice_submits_and_returns_branch_schema(
+        self,
+    ) -> None:
+        # ``template`` with ``menu_choice="sensor"`` submits the menu
+        # selection and returns the sensor-branch form schema.
+        branch_schema = [{"name": "state", "required": True}]
         client = AsyncMock()
         client.start_config_flow = AsyncMock(
             return_value={
                 "type": "menu",
-                "flow_id": "intro-1",
+                "flow_id": "menu-1",
+                "menu_options": ["sensor", "binary_sensor"],
+            }
+        )
+        client.submit_config_flow_step = AsyncMock(
+            return_value={
+                "type": "form",
+                "flow_id": "menu-1",
+                "step_id": "sensor",
+                "data_schema": branch_schema,
+            }
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        info = await fetch_helper_flow_info(
+            client, "template", menu_choice="sensor"
+        )
+
+        # menu_options is intentionally NOT surfaced when a choice was
+        # picked — the caller already has it.
+        assert info == {"schema": branch_schema}
+
+    async def test_menu_flow_without_choice_returns_menu_options(self) -> None:
+        # ``template`` without a menu_choice can't be schema-fetched —
+        # surface the legal sub-types instead so the caller can pick a
+        # branch on the next try.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "menu-1",
+                "menu_options": ["sensor", "binary_sensor", "button"],
+            }
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        info = await fetch_helper_flow_info(client, "template")
+
+        assert info == {"menu_options": ["sensor", "binary_sensor", "button"]}
+        # No submit_config_flow_step call — single HA round-trip.
+        assert not hasattr(client.submit_config_flow_step, "called") or (
+            not client.submit_config_flow_step.called
+        )
+
+    async def test_returns_empty_on_ha_failure(self) -> None:
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(side_effect=RuntimeError("offline"))
+
+        info = await fetch_helper_flow_info(client, "template")
+
+        assert info == {}
+
+    async def test_filters_non_string_menu_options(self) -> None:
+        # Defensive — if HA returns a non-string entry, drop it rather
+        # than propagating type confusion to the caller.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "menu-1",
                 "menu_options": ["sensor", 42, None, "binary_sensor"],
             }
         )
         client.abort_config_flow = AsyncMock(return_value={})
 
-        options = await fetch_helper_menu_options(client, "template")
+        info = await fetch_helper_flow_info(client, "template")
 
-        assert options == ["sensor", "binary_sensor"]
+        assert info == {"menu_options": ["sensor", "binary_sensor"]}
+
+    async def test_menu_options_absent_when_key_missing(self) -> None:
+        # HA returning a menu dict without the ``menu_options`` key (or
+        # with a non-list value) yields ``{}`` rather than a broken
+        # ``{"menu_options": None}`` shape.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "menu-1",
+                # menu_options key intentionally absent
+            }
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        info = await fetch_helper_flow_info(client, "template")
+
+        assert info == {}
+
+    async def test_menu_options_absent_when_list_is_empty(self) -> None:
+        # An empty options list still drops the ``menu_options`` key so
+        # callers don't have to special-case empty-list-vs-missing.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "menu-1",
+                "menu_options": [],
+            }
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        info = await fetch_helper_flow_info(client, "template")
+
+        assert info == {}
+
+    async def test_submit_failure_keeps_empty_info(self) -> None:
+        # If submitting the menu choice raises, the helper returns
+        # ``{}`` rather than swallowing into a partially-populated dict.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "menu-1",
+                "menu_options": ["sensor"],
+            }
+        )
+        client.submit_config_flow_step = AsyncMock(
+            side_effect=RuntimeError("submit failed")
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        info = await fetch_helper_flow_info(
+            client, "template", menu_choice="sensor"
+        )
+
+        assert info == {}
 
 
 # ---------------------------------------------------------------------------
@@ -797,8 +911,8 @@ class TestPreFlowGateMenuChoiceThreading:
     ) -> None:
         # B5: the swallow in ``_flow_helper_error_context`` leaves a
         # DEBUG breadcrumb so a fetch-failure under raised call rate
-        # doesn't disappear silently. ``fetch_helper_data_schema`` has its
-        # own internal swallow (returns None on any HA-side error), so
+        # doesn't disappear silently. ``fetch_helper_flow_info`` has its
+        # own internal swallow (returns ``{}`` on any HA-side error), so
         # the outer swallow only fires on programming bugs — patch it to
         # raise so the breadcrumb path is exercised.
         import logging
@@ -810,7 +924,7 @@ class TestPreFlowGateMenuChoiceThreading:
 
         monkeypatch.setattr(
             helpers_mod,
-            "fetch_helper_data_schema",
+            "fetch_helper_flow_info",
             _raises,
         )
 
@@ -824,7 +938,7 @@ class TestPreFlowGateMenuChoiceThreading:
         debug_records = [
             r
             for r in caplog.records
-            if "schema fetch failed" in r.message and r.levelno == logging.DEBUG
+            if "flow-info fetch failed" in r.message and r.levelno == logging.DEBUG
         ]
         assert debug_records, (
             "fetch-swallow must log at DEBUG; got "

--- a/tests/src/unit/test_helper_schema_inline.py
+++ b/tests/src/unit/test_helper_schema_inline.py
@@ -1,9 +1,12 @@
 """Unit tests for inline helper-schema attach in ``ha_config_set_helper``.
 
-``ha_get_helper_schema`` covers simple-helper types alongside flow types,
-and every reachable validation-error path in ``ha_config_set_helper``
-attaches the helper's ``data_schema`` to the response context so an LLM
-can self-correct from a 4xx without a separate discovery round-trip.
+Every reachable validation-error path in ``ha_config_set_helper`` attaches
+the helper's ``data_schema`` to the response context so an LLM can
+self-correct from a 4xx without a separate discovery round-trip. For
+menu-rooted helpers (``template``/``group``) where no sub-type has been
+picked yet, the context carries a
+``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker
+plus the legal sub-types under ``menu_options`` (issue #1186).
 
 Tests in this module:
 
@@ -11,18 +14,15 @@ Tests in this module:
    schema entry, every entry has a uniform ``{name, required, selector}``
    shape, ``name`` is required for every simple type, the import-time
    drift guard matches the ``SIMPLE_HELPER_TYPES`` set.
-2. ``ha_get_helper_schema`` simple-type dispatch — returns the static dict
-   without any HA round-trip; flow-types still drive the introspection
-   flow; ``menu_option`` is rejected for simple types.
-3. Simple-helper validation errors carry the schema — ``name``-required,
+2. Simple-helper validation errors carry the schema — ``name``-required,
    ``options``-required, ``latitude``/``longitude``-required, etc., all
    surface ``data_schema`` in the response context.
-4. Flow pre-flow validation gates carry the schema — the gates in
+3. Flow pre-flow validation gates carry the schema — the gates in
    ``_handle_flow_helper`` (``name``-required for create, malformed
    ``config``, etc.) attach the data_schema fetched via the introspection
    flow, with menu-rooted types surfacing a
-   ``data_schema_unavailable_reason`` marker when no menu choice can be
-   inferred.
+   ``data_schema_unavailable_reason`` marker + ``menu_options`` list when
+   no menu choice can be inferred.
 """
 
 from __future__ import annotations
@@ -35,11 +35,8 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_config_entry_flow import (
-    ALL_HELPER_TYPES,
     FLOW_HELPER_TYPES,
-    SUPPORTED_HELPERS,
-    ConfigEntryFlowTools,
-    _FlowType,
+    fetch_helper_menu_options,
 )
 from ha_mcp.tools.tools_config_helpers import (
     SIMPLE_HELPER_SCHEMAS,
@@ -153,9 +150,9 @@ class TestSimpleHelperSchemasInvariants:
 
 
 class TestGetSimpleHelperSchema:
-    """get_simple_helper_schema is the single accessor used by both
-    ``ha_get_helper_schema`` (dispatch path) and the validation-error-attach
-    path; behaviour must stay consistent."""
+    """get_simple_helper_schema is the accessor used by the
+    validation-error-attach path so a 4xx carries the helper's field
+    shape inline."""
 
     def test_returns_schema_for_each_simple_type(self) -> None:
         for helper_type in SIMPLE_HELPER_TYPES:
@@ -246,8 +243,9 @@ class TestFlowHelperErrorContext:
     ) -> None:
         # A menu-rooted flow type (``template``, ``group``) without a
         # derivable menu_choice can't be schema-fetched without picking a
-        # branch — surface the marker so the LLM has a non-silent signal to
-        # call ``ha_get_helper_schema(template, menu_option=...)``.
+        # branch — surface the marker so the caller has a non-silent
+        # signal, plus the legal sub-types inline as ``menu_options``
+        # so they can pick a branch on the next try (issue #1186).
         client = AsyncMock()
         client.start_config_flow = AsyncMock(
             return_value={
@@ -263,6 +261,7 @@ class TestFlowHelperErrorContext:
         assert ctx == {
             "helper_type": "template",
             "data_schema_unavailable_reason": "menu_helper_requires_branch",
+            "menu_options": ["sensor", "binary_sensor"],
         }
 
     async def test_non_menu_helper_returns_helper_type_only_on_no_schema(
@@ -280,85 +279,79 @@ class TestFlowHelperErrorContext:
 
 
 # ---------------------------------------------------------------------------
-# 3. ha_get_helper_schema simple-type dispatch
+# 3. fetch_helper_menu_options (issue #1186)
 # ---------------------------------------------------------------------------
 
 
-class TestHaGetHelperSchemaSimpleDispatch:
-    """ha_get_helper_schema for simple types returns the static dict
-    without any HA round-trip; ALL_HELPER_TYPES Literal accepts both
-    flow and simple types."""
+class TestFetchHelperMenuOptions:
+    """``fetch_helper_menu_options`` returns the legal sub-type list for a
+    menu-rooted helper, ``None`` for non-menu flows, and ``None`` on any
+    HA failure — used by ``_flow_helper_error_context`` to populate
+    ``menu_options`` alongside the
+    ``data_schema_unavailable_reason: "menu_helper_requires_branch"`` marker.
+    """
 
-    def test_all_helper_types_literal_covers_27_types(self) -> None:
-        import typing
-
-        all_types = set(typing.get_args(ALL_HELPER_TYPES))
-        flow_types = set(typing.get_args(SUPPORTED_HELPERS))
-        assert all_types == flow_types | SIMPLE_HELPER_TYPES
-        assert len(all_types) == 27
-
-    async def test_simple_type_returns_static_schema_without_ha_call(self) -> None:
+    async def test_returns_menu_options_for_menu_flow(self) -> None:
         client = AsyncMock()
-        # If anything in the simple branch reaches HA, fail loudly.
         client.start_config_flow = AsyncMock(
-            side_effect=AssertionError("simple types must not call HA"),
+            return_value={
+                "type": "menu",
+                "flow_id": "intro-1",
+                "menu_options": ["sensor", "binary_sensor", "button"],
+            }
         )
+        client.abort_config_flow = AsyncMock(return_value={})
 
-        tool_obj = ConfigEntryFlowTools(client)
-        result = await tool_obj.ha_get_helper_schema(helper_type="input_select")
+        options = await fetch_helper_menu_options(client, "template")
 
-        assert result["success"] is True
-        assert result["helper_type"] == "input_select"
-        assert result["flow_type"] == _FlowType.FORM
-        assert result["step_id"] == "user"
-        assert result["data_schema"] == SIMPLE_HELPER_SCHEMAS["input_select"]
-        assert result["description_placeholders"] == {}
-        client.start_config_flow.assert_not_called()
+        assert options == ["sensor", "binary_sensor", "button"]
+        # The introspection flow was aborted to avoid leaking it in HA.
+        client.abort_config_flow.assert_called_once_with("intro-1")
 
-    @pytest.mark.parametrize(
-        "helper_type",
-        ["counter", "input_select", "schedule", "zone", "person"],
-    )
-    async def test_simple_type_with_menu_option_rejects(
-        self,
-        helper_type: str,
-    ) -> None:
-        client = AsyncMock()
-        tool_obj = ConfigEntryFlowTools(client)
-
-        with pytest.raises(ToolError) as exc_info:
-            await tool_obj.ha_get_helper_schema(
-                helper_type=helper_type,
-                menu_option="sensor",
-            )
-
-        body = _parse_tool_error(exc_info.value)
-        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
-        assert "menu_option" in body["error"]["message"]
-        assert body["helper_type"] == helper_type
-
-    async def test_flow_type_still_drives_introspection_flow(self) -> None:
-        # Existing behaviour for flow types must remain intact.
-        intro_schema = [{"name": "entity_id", "required": True}]
+    async def test_returns_none_for_form_flow(self) -> None:
+        # Non-menu-rooted helpers like ``filter`` start with a form step;
+        # there are no ``menu_options`` to surface.
         client = AsyncMock()
         client.start_config_flow = AsyncMock(
             return_value={
                 "type": "form",
                 "flow_id": "intro-1",
-                "step_id": "user",
-                "data_schema": intro_schema,
+                "data_schema": [{"name": "entity_id", "required": True}],
             }
         )
         client.abort_config_flow = AsyncMock(return_value={})
 
-        tool_obj = ConfigEntryFlowTools(client)
-        result = await tool_obj.ha_get_helper_schema(helper_type="filter")
+        options = await fetch_helper_menu_options(client, "filter")
 
-        assert result["success"] is True
-        assert result["data_schema"] == intro_schema
-        client.start_config_flow.assert_called_once_with("filter")
-        # The introspection flow was aborted to avoid leaking it in HA.
+        assert options is None
+        # Flow still aborted — leakage check is independent of return value.
         client.abort_config_flow.assert_called_once_with("intro-1")
+
+    async def test_returns_none_on_ha_failure(self) -> None:
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(side_effect=RuntimeError("offline"))
+
+        options = await fetch_helper_menu_options(client, "template")
+
+        assert options is None
+
+    async def test_filters_non_string_options(self) -> None:
+        # Defensive — if HA returns a non-string entry in menu_options
+        # (shouldn't happen, but the API isn't strictly typed), drop it
+        # rather than propagating type confusion to the caller.
+        client = AsyncMock()
+        client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "menu",
+                "flow_id": "intro-1",
+                "menu_options": ["sensor", 42, None, "binary_sensor"],
+            }
+        )
+        client.abort_config_flow = AsyncMock(return_value={})
+
+        options = await fetch_helper_menu_options(client, "template")
+
+        assert options == ["sensor", "binary_sensor"]
 
 
 # ---------------------------------------------------------------------------
@@ -761,8 +754,9 @@ class TestPreFlowGateMenuChoiceThreading:
     async def test_template_without_menu_key_surfaces_marker(self) -> None:
         # ``template`` is menu-rooted but the config has no menu key.
         # The schema can't be fetched without picking a branch; the gate
-        # must surface ``data_schema_unavailable_reason`` so the LLM gets
-        # a non-silent signal to call ``ha_get_helper_schema``.
+        # must surface ``data_schema_unavailable_reason`` plus the legal
+        # sub-types under ``menu_options`` so the caller can pick a branch
+        # on the next try (issue #1186).
         from ha_mcp.tools.tools_config_helpers import _handle_flow_helper
 
         client = AsyncMock()
@@ -794,6 +788,7 @@ class TestPreFlowGateMenuChoiceThreading:
         assert body.get("data_schema_unavailable_reason") == (
             "menu_helper_requires_branch"
         )
+        assert body.get("menu_options") == ["sensor", "binary_sensor"]
 
     async def test_pre_flow_gate_logs_debug_on_fetch_failure(
         self,

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -10,9 +10,8 @@ Covers three layers:
    ``add_transform`` failure path. Uses the ``MagicMock`` stub pattern
    from ``test_categorized_search.TestApplySearchKeywordEnrichment``.
 3. The ``_LITE_DOCSTRINGS`` mapping invariant — every lite description
-   names ``ha_get_skill_guide`` (or
-   ``ha_get_helper_schema`` for the helper entries) so the LLM still
-   has a path to detailed guidance from inside the trimmed text.
+   names ``ha_get_skill_guide`` so the LLM still has a path to
+   detailed guidance from inside the trimmed text.
 """
 
 from __future__ import annotations
@@ -250,20 +249,13 @@ class TestLiteDocstringsMappingInvariants:
         """
         from ha_mcp.server import HomeAssistantSmartMCPServer
 
-        # ha_get_helper_schema is an acceptable substitute pointer on
-        # the two helper entries since it serves the same role
-        # (deferred per-type schema lookup).
-        acceptable_pointers = (
-            "ha_get_skill_guide",
-            "ha_get_helper_schema",
-        )
         offenders: list[str] = []
         for name, lite in HomeAssistantSmartMCPServer._LITE_DOCSTRINGS.items():
-            if not any(pointer in lite for pointer in acceptable_pointers):
+            if "ha_get_skill_guide" not in lite:
                 offenders.append(name)
 
         assert not offenders, (
-            "Lite descriptions missing a skill-tool pointer "
+            "Lite descriptions missing a ha_get_skill_guide pointer "
             f"(invariant from _LITE_DOCSTRINGS docstring): {offenders}"
         )
 


### PR DESCRIPTION
## What does this PR do?

Removes `ha_get_helper_schema` per #1186. The standalone introspection tool became redundant when #1179 added auto-attached `data_schema` to `ha_config_set_helper` validation errors — agents can self-correct from the first 4xx without a separate discovery round-trip.

For menu-rooted helpers (`template`, `group`) where no sub-type has been picked yet, the validation-error context now also carries `menu_options` inline (step 2a from the issue), so the caller can pick a branch on the next try without a separate discovery round-trip.

Per-type schema reference content lives in the `home-assistant-best-practices` skill — see [homeassistant-ai/skills#47](https://github.com/homeassistant-ai/skills/pull/47).

Per AGENTS.md "Tool Consolidation", removing a tool whose functionality is preserved through an alternative path is **not** a breaking change.

### Removed
- `ha_get_helper_schema` tool + `ConfigEntryFlowTools` class + `ALL_HELPER_TYPES` Literal in `tools_config_entry_flow.py`
- `"Call ha_get_helper_schema"` suggestions from `_raise_flow_api_error`
- `ha_get_helper_schema` cross-references from `ha_config_set_helper` and `ha_config_list_helpers` docstrings + `server.py` lite docstrings

### Added
- `fetch_helper_menu_options()` helper — best-effort menu_options fetcher for use by error-context builders
- `menu_options` in `_flow_helper_error_context` for menu-rooted pre-flow validation errors (issue #1186 step 2a)

### Tests
- Deleted `ha_get_helper_schema` e2e tests (no longer applicable)
- Deleted `TestHaGetHelperSchemaSimpleDispatch` unit test class
- Updated `test_menu_rooted_without_choice_surfaces_unavailable_reason` and `test_template_without_menu_key_surfaces_marker` to assert `menu_options` in context
- Added `TestFetchHelperMenuOptions` covering the new helper (4 cases: menu flow, form flow, HA failure, non-string filter)
- Updated `test_create_group_helper_missing_menu_selection` e2e to assert `menu_options` inline on the error

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`) — ruff passes locally

## Future improvements

None planned.

## Checklist
- [x] I have updated documentation if needed — docstring references updated; `tools.json`/`README.md`/`DOCS.md` will auto-regen via `sync-tool-docs.yml` on merge.