### PR TITLE
docs: align label refs with live label set and fix triaged-removal trigger

### DIFF
--- a/.claude/skills/issue-analysis/SKILL.md
+++ b/.claude/skills/issue-analysis/SKILL.md
@@ -40,7 +40,7 @@ gh issue list --repo homeassistant-ai/ha-mcp --state open --json number,title,la
 
 | Situation | Label |
 |-----------|-------|
-| Multiple valid directions needing a decision | `needs-choice` |
+| Multiple valid directions needing a decision | `needs-choices` |
 | Clear implementation path | `ready-to-implement` |
 | Missing info from reporter | `needs-info` |
 
@@ -60,8 +60,7 @@ Once approved, apply labels and post the comment:
 
 ```bash
 gh issue edit "$ARGUMENTS" --repo homeassistant-ai/ha-mcp \
-  --add-label "issue-analyzed,<classification>,<priority>" \
-  --remove-label "triaged"
+  --add-label "issue-analyzed,<classification>,<priority>"
 
 gh issue comment "$ARGUMENTS" --repo homeassistant-ai/ha-mcp --body "$(cat <<'EOF'
 [approved comment text]

--- a/.github/ISSUE_TEMPLATE/runtime_bug.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_bug.yml
@@ -1,7 +1,7 @@
 name: "🐛 Runtime Bug"
 description: "Report a bug that occurs while ha-mcp is running (errors, crashes, incorrect behavior)"
 title: "[BUG] "
-labels: ["bug"]
+labels: ["bug", "runtime-bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/startup_bug.yml
+++ b/.github/ISSUE_TEMPLATE/startup_bug.yml
@@ -1,7 +1,7 @@
 name: "🚀 Startup/Installation Bug"
 description: "Report a bug preventing ha-mcp from starting, installing, or connecting"
 title: "[BUG] "
-labels: ["bug", "startup"]
+labels: ["bug", "startup-bug"]
 body:
   - type: markdown
     attributes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ When implementing features or debugging, consult these resources:
 | Label | Meaning |
 |-------|---------|
 | `ready-to-implement` | Clear path, no decisions needed |
-| `needs-choice` | Multiple approaches, needs stakeholder input |
+| `needs-choices` | Multiple approaches, needs stakeholder input |
 | `needs-info` | Awaiting clarification from reporter |
 | `priority: high/medium/low` | Relative priority |
 | `triaged` | Automated Gemini triage complete |


### PR DESCRIPTION
## What does this PR do?

Phase B of the Option A (Workflow-First) decision documented in #1296 — aligns the label references in docs / skill / issue templates with the live label set and the workflow's classification logic.

Five edits:

1. **`AGENTS.md:L112`** — `` `needs-choice` `` (singular) → `` `needs-choices` `` (plural). Skill-driven label-applies that included `needs-choice` were silently erroring out because the label doesn't exist under that name.

2. **`.claude/skills/issue-analysis/SKILL.md:L43`** — same typo fix.

3. **`.claude/skills/issue-analysis/SKILL.md:L60-64`** — drop the `--remove-label "triaged"` line. The `triaged` label is the circuit-breaker that `gemini-triage.yml:L70` reads to skip re-triage on subsequent comment events. Removing it after deep-analysis triggers an immediate re-run + duplicate triage comment, with the label back on the issue within seconds — net cost is one extra Gemini run and one duplicate timeline comment per `/issue-analysis` invocation, no end-state benefit. Verified live on #1294.

4. **`.github/ISSUE_TEMPLATE/runtime_bug.yml:L4`** — `["bug"]` → `["bug", "runtime-bug"]`. `gemini-triage.yml:L290` checks `labels.includes('runtime-bug')` for issue-type classification; the label-first path was dead because the label didn't exist. Dual-label keeps the `bug` umbrella for backward-compat filtering and adds the workflow-matched sub-class. `runtime-bug` label created admin-side via Phase A of #1296.

5. **`.github/ISSUE_TEMPLATE/startup_bug.yml:L4`** — `["bug", "startup"]` → `["bug", "startup-bug"]`. Same fix class: `gemini-triage.yml:L292` checks `startup-bug` (which now exists in the repo); the previous `startup` value was a label that didn't exist. The `bug` umbrella stays for cross-class filtering.

`.github/ISSUE_TEMPLATE/agent_behavior.yml` is unchanged — its existing `["agent-behavior"]` label became effective when Phase A created the `agent-behavior` label.

`issue-analyzed` references in `AGENTS.md` (L117, L122, L125) and the skill (L49, L63) stay — Phase A created that label.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — N/A, no Python code changes; ruff still clean on touched files
- [x] Code follows style guidelines (`uv run ruff check`)

No new tests added (pure label / template / docs change). The Phase A labels are live and verifiable via `gh label list --repo homeassistant-ai/ha-mcp` (filtering for `issue-analyzed`, `runtime-bug`, `startup-bug`, `agent-behavior`).

## Future improvements

- **Reverse-drift sweep** — eight labels exist live with no documentation reference (`addon`, `wontfix`, `blocked`, `docker`, `javascript`, `python-upgrade`, `to-merge`, `codex`) and varying usage. Out of scope here; can be raised as a separate consolidation issue if anyone wants to align AGENTS.md's Issue Labels table with the full live set.

## Checklist
- [x] I have updated documentation if needed

Closes #1296

