### PR TITLE
refactor: migrate tools_config_scenes inline empty-id guards to shared helper (closes #1314)

### DIFF
--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -32,6 +32,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
@@ -221,20 +222,20 @@ class ConfigSceneTools:
             # Issue #1168 R6 blocker 16: empty ``scene_id`` previously
             # surfaced as ``RESOURCE_NOT_FOUND`` with a misleading
             # `entities`-related suggestion. Pre-flight here so the caller
-            # gets the actual problem.
-            if not scene_id or not scene_id.strip():
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "scene_id must not be empty",
-                        suggestions=[
-                            "Pass a non-empty scene identifier (e.g. 'movie_night')",
-                            "Use ha_search_entities(domain_filter='scene') "
-                            "to find existing scene_ids",
-                        ],
-                        context={"scene_id": scene_id},
-                    )
-                )
+            # gets the actual problem. Migrated to the shared
+            # ``validate_identifier_not_empty`` helper (#1314) — message
+            # and ``context["scene_id"]`` key preserved for callers.
+            validate_identifier_not_empty(
+                scene_id,
+                "scene_id",
+                message="scene_id must not be empty",
+                suggestions=[
+                    "Pass a non-empty scene identifier (e.g. 'movie_night')",
+                    "Use ha_search_entities(domain_filter='scene') "
+                    "to find existing scene_ids",
+                ],
+                context={"scene_id": scene_id},
+            )
             # Issue #1168 R3 blockers 3 + 6: unwrap the rest-client envelope
             # so the response carries the scene body directly (no nested
             # `success`/`scene_id`/`config` chain), and use the storage key
@@ -520,19 +521,19 @@ class ConfigSceneTools:
             # Issue #1168 R6 blocker 16: empty ``scene_id`` pre-flight before
             # any config dispatch — keeps the error code/message aligned with
             # the actual problem rather than the misleading
-            # ``RESOURCE_NOT_FOUND`` from a downstream lookup.
-            if not scene_id or not scene_id.strip():
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "scene_id must not be empty",
-                        suggestions=[
-                            "Pass a non-empty scene identifier (e.g. 'movie_night')",
-                            "For a fresh create, use a name-derived slug",
-                        ],
-                        context={"scene_id": scene_id},
-                    )
-                )
+            # ``RESOURCE_NOT_FOUND`` from a downstream lookup. Migrated to
+            # the shared ``validate_identifier_not_empty`` helper (#1314) —
+            # message and ``context["scene_id"]`` key preserved for callers.
+            validate_identifier_not_empty(
+                scene_id,
+                "scene_id",
+                message="scene_id must not be empty",
+                suggestions=[
+                    "Pass a non-empty scene identifier (e.g. 'movie_night')",
+                    "For a fresh create, use a name-derived slug",
+                ],
+                context={"scene_id": scene_id},
+            )
             # Validate mutual exclusivity of config and python_transform
             if config is not None and python_transform is not None:
                 raise_tool_error(
@@ -942,20 +943,20 @@ class ConfigSceneTools:
         try:
             # Issue #1168 R6 blocker 16: empty ``scene_id`` pre-flight before
             # the resolver — keeps the error code/message aligned with the
-            # actual problem.
-            if not scene_id or not scene_id.strip():
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "scene_id must not be empty",
-                        suggestions=[
-                            "Pass a non-empty scene identifier (e.g. 'old_scene')",
-                            "Use ha_search_entities(domain_filter='scene') "
-                            "to find existing scene_ids",
-                        ],
-                        context={"scene_id": scene_id},
-                    )
-                )
+            # actual problem. Migrated to the shared
+            # ``validate_identifier_not_empty`` helper (#1314) — message
+            # and ``context["scene_id"]`` key preserved for callers.
+            validate_identifier_not_empty(
+                scene_id,
+                "scene_id",
+                message="scene_id must not be empty",
+                suggestions=[
+                    "Pass a non-empty scene identifier (e.g. 'old_scene')",
+                    "Use ha_search_entities(domain_filter='scene') "
+                    "to find existing scene_ids",
+                ],
+                context={"scene_id": scene_id},
+            )
             # Issue #1168 R3 blocker 6: resolve once up-front so every later
             # callsite (entity_id resolver, delete call, response) uses the
             # storage key consistently — outer ``scene_id`` matches the


### PR DESCRIPTION
## What does this PR do?

Migrates the three inline `if not scene_id or not scene_id.strip():` empty-id guards in `src/ha_mcp/tools/tools_config_scenes.py` to the shared `validate_identifier_not_empty` helper introduced in #1312. Pure refactor — zero behaviour change for callers.

The 3 sites migrated (call-line anchors):
- `tools_config_scenes.py:228` — `ha_config_get_scene` pre-flight
- `tools_config_scenes.py:527` — `ha_config_set_scene` pre-flight
- `tools_config_scenes.py:949` — `ha_config_remove_scene` pre-flight

### Behaviour-preservation notes

- **Error code**: `VALIDATION_INVALID_PARAMETER` unchanged.
- **Error message**: `"scene_id must not be empty"` preserved at each site via `message=` override (the helper's default message would have been `"scene_id must be a non-empty, non-whitespace string"`; preserving the existing wording keeps the `TestEmptySceneIdGuard` contract intact without test changes).
- **Error context shape**: `context["scene_id"]` key preserved at each site; the helper additionally merges its own `parameter` + `value` keys, so the resulting `context` is a backward-compatible superset (`{"scene_id": value, "parameter": "scene_id", "value": value}`). Grep across `tests/` and `src/` shows zero consumers of `context["scene_id"]` on a `VALIDATION_INVALID_PARAMETER` response from scenes tools — extension is safe.
- **`None` and whitespace handling**: original `if not scene_id or not scene_id.strip()` rejected `None`, `""`, and any pure-whitespace string. The helper's `if value is not None and value.strip()` check produces the same accept/reject set.
- **Backend-call ordering**: each guard fires before the first client call (`get_scene_config` at L244, `upsert_scene_config` at L710/837, `resolve_scene_id` / `delete_scene_config` at L965/L973), same as the original inline guards.

### Tests

No test changes. The existing `TestEmptySceneIdGuard` class (`tests/src/unit/test_tools_config_scenes.py:1341`) — including its 4-value whitespace parametrization at L1380 — continues to pass exactly as before. That's the strongest signal of true behavioural equivalence: the migration was contract-preserving enough that no test update was needed.

- ruff clean on `tools_config_scenes.py`
- mypy clean on `tools_config_scenes.py`
- Full local unit suite: **2615 passed, 1 skipped** (the skip is `test_numpy_version_constraint.py` — by-design on Alpine musl).

### Net LOC reality

Issue body estimated −17 LOC for the migration; actual diff is **+42 / −41 = +1 LOC**. The three new "Migrated to the shared helper (#1314)" comment paragraphs offset most of the inline-guard removal. Worth surfacing so the diff doesn't read as a no-op cleanup — the value is in deduplicating the pattern across CRUD families, not in line count.

### Dependency on #1312

This branch is stacked on `feature/issue-1294-validate-identifier-family` because `validate_identifier_not_empty` doesn't exist on `master` yet — it lands with #1312. When #1312 merges, this PR will rebase cleanly onto `master` and the helper-import resolves naturally; the diff narrows to just the 3 site-migrations (no helper-add overlap because the helper is shared infrastructure not duplicated here).

Until #1312 merges, the diff against `master` will appear to include both PRs' contents. Reviewing this PR as a stack-on-top-of-#1312 (or after #1312 merges) gives the accurate scope.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None planned for scenes specifically. The companion Tier-3 expansion — extending the helper to `tools_config_{automations,scripts,dashboards}` get/set/remove — is tracked under #1313 (also stacked on #1312).

## Checklist
- [x] I have updated documentation if needed — no doc updates required for a behaviour-preserving refactor; cross-references in `AGENTS.md`/skill content unchanged.

Closes #1314
