### PR TITLE
refactor: extend validate_identifier_not_empty to automations/scripts/dashboards CRUD (closes #1313)

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -287,6 +287,21 @@ class AutomationConfigTools:
         For comprehensive automation documentation, use ha_get_skill_guide.
         """
         try:
+            # Empty/whitespace identifier would propagate to the internal
+            # config lookup and surface as a misleading
+            # ``RESOURCE_NOT_FOUND``. Structured ``VALIDATION_INVALID_PARAMETER``
+            # naming the parameter is cleaner — extension of the #1312
+            # validate_identifier_not_empty pattern to the automations
+            # family per #1313.
+            validate_identifier_not_empty(
+                identifier,
+                "identifier",
+                suggestions=[
+                    "Pass an automation entity_id (e.g. 'automation.morning_routine')",
+                    "Or pass the unique_id of an existing automation",
+                    "Use ha_search_entities(domain_filter='automation') to list automations",
+                ],
+            )
             normalized_config, config_hash = await self._get_automation_config_internal(identifier)
 
             # Resolve entity_id and fetch category from entity registry
@@ -539,6 +554,23 @@ class AutomationConfigTools:
         """
         bp_warnings: list[str] = []
         try:
+            # ``identifier`` is optional (omit → create new with generated
+            # unique_id; pass → update existing). When provided, reject
+            # empty/whitespace up-front so the caller gets a structured
+            # parameter error instead of a misleading ``RESOURCE_NOT_FOUND``
+            # from the downstream lookup. The ``not identifier`` check
+            # further down the python_transform branch still handles the
+            # explicit ``identifier is None`` case for that mode.
+            if identifier is not None:
+                validate_identifier_not_empty(
+                    identifier,
+                    "identifier",
+                    suggestions=[
+                        "Omit identifier to create a new automation",
+                        "Or pass a valid automation entity_id / unique_id to update",
+                    ],
+                    context={"action": "set"},
+                )
             # Validate mutual exclusivity of config and python_transform
             if config is not None and python_transform is not None:
                 raise_tool_error(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -26,6 +26,7 @@ from .helpers import (
     extract_tool_error_message,
     log_tool_usage,
     raise_tool_error,
+    validate_identifier_not_empty,
 )
 from .util_helpers import parse_json_param
 
@@ -605,6 +606,25 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     "count": len(dashboards),
                 }
 
+            # ``url_path`` is optional in this tool (omitted with
+            # ``list_only=True`` lists all dashboards — handled above; omitted
+            # without ``list_only`` falls back to the default dashboard via
+            # the resolver below). When provided, reject empty/whitespace
+            # up-front so the caller gets a structured parameter error
+            # instead of a misleading ``RESOURCE_NOT_FOUND``. Extension of
+            # the #1312 validate_identifier_not_empty pattern to the
+            # dashboards family per #1313.
+            if url_path is not None:
+                validate_identifier_not_empty(
+                    url_path,
+                    "url_path",
+                    suggestions=[
+                        "Pass a dashboard URL path (e.g. 'lovelace-home')",
+                        "Omit url_path and pass list_only=True to list dashboards",
+                        "Use 'default' to target the default dashboard",
+                    ],
+                )
+
             # Search mode — find cards, badges, or header cards
             if search_mode:
                 get_data: dict[str, Any] = {"type": "lovelace/config", "force": True}
@@ -996,6 +1016,22 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         are also updated if explicitly provided alongside (or instead of) a config change.
         """
         try:
+            # ``url_path`` is required (always non-None). Reject empty/
+            # whitespace up-front so the caller gets a structured parameter
+            # error instead of a misleading downstream failure (the
+            # subsequent "default" alias, pre-resolver, and hyphen check
+            # all assume a usable string). Extension of the #1312
+            # validate_identifier_not_empty pattern to the dashboards
+            # family per #1313.
+            validate_identifier_not_empty(
+                url_path,
+                "url_path",
+                suggestions=[
+                    "Pass a dashboard URL path (e.g. 'my-dashboard')",
+                    "Use 'default' or 'lovelace' for the default dashboard",
+                ],
+                context={"action": "set"},
+            )
             # Handle "default" as alias for the default dashboard
             # (matches ha_config_get_dashboard behavior)
             if url_path == "default":
@@ -1490,6 +1526,20 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         Note: The default dashboard cannot be deleted via this method.
         """
         try:
+            # ``url_path`` is required. Reject empty/whitespace up-front so
+            # the caller gets a structured parameter error instead of a
+            # misleading "no dashboard found" from the resolver below.
+            # Extension of the #1312 validate_identifier_not_empty pattern
+            # to the dashboards family per #1313.
+            validate_identifier_not_empty(
+                url_path,
+                "url_path",
+                suggestions=[
+                    "Pass a dashboard URL path or internal ID (e.g. 'my-dashboard')",
+                    "Use ha_config_get_dashboard(list_only=True) to list dashboards",
+                ],
+                context={"action": "delete"},
+            )
             resolved, _ = await _resolve_dashboard(client, url_path)
             if resolved is None:
                 raise_tool_error(

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -103,6 +103,19 @@ class ConfigScriptTools:
         For detailed script configuration help, use ha_get_skill_guide.
         """
         try:
+            # Empty/whitespace script_id would propagate to
+            # ``get_script_config`` and surface as a misleading
+            # ``RESOURCE_NOT_FOUND``. Extension of the #1312
+            # validate_identifier_not_empty pattern to the scripts
+            # family per #1313.
+            validate_identifier_not_empty(
+                script_id,
+                "script_id",
+                suggestions=[
+                    "Pass a script identifier (e.g. 'morning_routine')",
+                    "Use ha_search_entities(domain_filter='script') to list scripts",
+                ],
+            )
             config_result = await self._client.get_script_config(script_id)
             # Extract actual script config body and compute hash before category injection
             actual_config = config_result.get("config", config_result)
@@ -412,6 +425,21 @@ class ConfigScriptTools:
         """
         bp_warnings: list[str] = []
         try:
+            # ``script_id`` is required (always non-None). Reject empty/
+            # whitespace up-front so the caller gets a structured parameter
+            # error instead of a misleading ``RESOURCE_NOT_FOUND`` from
+            # the downstream upsert/fetch. Extension of the #1312
+            # validate_identifier_not_empty pattern to the scripts family
+            # per #1313.
+            validate_identifier_not_empty(
+                script_id,
+                "script_id",
+                suggestions=[
+                    "Pass a script identifier (e.g. 'morning_routine')",
+                    "Use ha_search_entities(domain_filter='script') to list scripts",
+                ],
+                context={"action": "set"},
+            )
             # Validate mutual exclusivity of config and python_transform
             if config is not None and python_transform is not None:
                 raise_tool_error(

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -567,8 +567,7 @@ class TestAutomationsIdentifierValidation:
         )
         tools._client.send_websocket_message.assert_not_called()
         # Also no REST GET on the automation config.
-        if hasattr(tools._client, "get_automation_config"):
-            tools._client.get_automation_config.assert_not_called()
+        tools._client.get_automation_config.assert_not_called()
 
     @pytest.mark.parametrize("bad", ["", "   "])
     async def test_set_rejects_empty_identifier_on_update(self, tools, bad):
@@ -577,6 +576,7 @@ class TestAutomationsIdentifierValidation:
         # ``if not identifier`` python_transform-mode guard for the
         # config-update path. New guard rejects empty/whitespace whenever
         # identifier is non-None, regardless of mode.
+        tools._client.upsert_automation_config = AsyncMock()
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_config_set_automation(
                 config={"alias": "x", "trigger": [], "action": []},
@@ -587,8 +587,31 @@ class TestAutomationsIdentifierValidation:
             excinfo.value
         )
         # Guard fires before any upsert / WS round-trip.
-        if hasattr(tools._client, "upsert_automation_config"):
-            tools._client.upsert_automation_config.assert_not_called()
+        tools._client.upsert_automation_config.assert_not_called()
+
+    async def test_set_with_none_identifier_routes_to_create(self, tools):
+        # Control: ``identifier=None`` is the documented "create-new" sentinel
+        # and must NOT trip the conditional guard. Mirrors the labels (L158),
+        # categories (L202), and areas (L279) None-routing controls; without
+        # this, a regression tightening ``if identifier is not None:`` to
+        # ``if identifier is None or not identifier.strip():`` would silently
+        # break the documented create-mode and no test in the file would
+        # catch it.
+        tools._client.upsert_automation_config = AsyncMock(
+            return_value={"success": True, "entity_id": "automation.new_one"}
+        )
+        result = await tools.ha_config_set_automation(
+            config={"alias": "x", "trigger": [], "action": []},
+            wait=False,
+        )
+        assert result["success"] is True
+        # Positive proof: upsert was called with identifier=None
+        # (signature: upsert_automation_config(config_dict, identifier)).
+        tools._client.upsert_automation_config.assert_called_once()
+        call_args = tools._client.upsert_automation_config.call_args
+        assert call_args[0][1] is None, (
+            f"identifier should be None for create routing, got {call_args[0][1]!r}"
+        )
 
 
 class TestScriptsIdentifierValidation:
@@ -618,8 +641,7 @@ class TestScriptsIdentifierValidation:
         assert '"parameter": "script_id"' in str(excinfo.value), str(
             excinfo.value
         )
-        if hasattr(tools._client, "get_script_config"):
-            tools._client.get_script_config.assert_not_called()
+        tools._client.get_script_config.assert_not_called()
 
     @pytest.mark.parametrize("bad", ["", "   "])
     async def test_set_rejects_empty_script_id(self, tools, bad):
@@ -635,8 +657,7 @@ class TestScriptsIdentifierValidation:
         assert '"parameter": "script_id"' in str(excinfo.value), str(
             excinfo.value
         )
-        if hasattr(tools._client, "upsert_script_config"):
-            tools._client.upsert_script_config.assert_not_called()
+        tools._client.upsert_script_config.assert_not_called()
 
 
 # --- tools_config_dashboards.py (#1313) ---------------------------------
@@ -695,14 +716,51 @@ class TestDashboardsIdentifierValidation:
         captured = _register_dashboard_tools_and_capture(mock_ws_client)
         ha_config_get_dashboard = captured["ha_config_get_dashboard"]
 
+        # Narrow exception tuple: only the unstructured-mock noise
+        # (AttributeError / KeyError / TypeError from list-mode body
+        # touching missing keys on the bare MagicMock response) is
+        # swallowed. A guard-regression ``ToolError`` must propagate so
+        # the assertion below cannot pass by accident.
         try:
             await ha_config_get_dashboard(list_only=True)
-        except Exception:
+        except (AttributeError, KeyError, TypeError):
             pass
         # Positive proof: at least one WS message was attempted (the
         # list-dashboards fetch). Guard would have raised before that.
         assert mock_ws_client.send_websocket_message.call_count > 0, (
             "list_only=True must not trip the url_path guard"
+        )
+
+    async def test_get_dashboard_with_none_url_path_routes_to_default(
+        self, mock_ws_client
+    ):
+        # Control: ``url_path=None`` without ``list_only`` is the
+        # documented "default dashboard" fallback per
+        # ``tools_config_dashboards.py`` L569-571 ("defaulting to the
+        # main dashboard if url_path is omitted"). The
+        # ``if url_path and url_path != "default":`` gate at L734 must
+        # NOT add a ``url_path`` key to the WebSocket payload — HA
+        # returns the default dashboard when the key is absent. Without
+        # this control, a regression flipping the conditional guard at
+        # L617 to unconditional, or normalising ``None`` to ``""``
+        # before the gate, would silently break the documented
+        # default-dashboard path.
+        mock_ws_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": {"views": []}}
+        )
+        captured = _register_dashboard_tools_and_capture(mock_ws_client)
+        ha_config_get_dashboard = captured["ha_config_get_dashboard"]
+
+        result = await ha_config_get_dashboard()
+        assert result["success"] is True
+        assert result["action"] == "get"
+        # Positive proof: get-mode WS payload omits ``url_path``
+        # (HA treats absence as default-dashboard request).
+        assert mock_ws_client.send_websocket_message.call_count == 1
+        sent = mock_ws_client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "lovelace/config"
+        assert "url_path" not in sent, (
+            f"url_path must be absent for default routing, got {sent!r}"
         )
 
     @pytest.mark.parametrize("bad", ["", "   "])

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -554,6 +554,42 @@ class TestAutomationsIdentifierValidation:
         _assert_invalid_param(excinfo)
         tools._client.delete_automation_config.assert_not_called()
 
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_get_rejects_empty_identifier(self, tools, bad):
+        # Empty/whitespace identifier would propagate to
+        # ``_get_automation_config_internal`` and surface as misleading
+        # ``RESOURCE_NOT_FOUND``. #1313 extension.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_get_automation(identifier=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "identifier"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        tools._client.send_websocket_message.assert_not_called()
+        # Also no REST GET on the automation config.
+        if hasattr(tools._client, "get_automation_config"):
+            tools._client.get_automation_config.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_identifier_on_update(self, tools, bad):
+        # ``identifier`` is optional on set_automation: None → create,
+        # non-None → update. Empty/whitespace would slip past the
+        # ``if not identifier`` python_transform-mode guard for the
+        # config-update path. New guard rejects empty/whitespace whenever
+        # identifier is non-None, regardless of mode.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_automation(
+                config={"alias": "x", "trigger": [], "action": []},
+                identifier=bad,
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "identifier"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        # Guard fires before any upsert / WS round-trip.
+        if hasattr(tools._client, "upsert_automation_config"):
+            tools._client.upsert_automation_config.assert_not_called()
+
 
 class TestScriptsIdentifierValidation:
     @pytest.fixture
@@ -570,6 +606,143 @@ class TestScriptsIdentifierValidation:
             await tools.ha_config_remove_script(script_id=bad)
         _assert_invalid_param(excinfo)
         tools._client.delete_script_config.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_get_rejects_empty_script_id(self, tools, bad):
+        # Empty/whitespace script_id would propagate to
+        # ``get_script_config`` and surface as misleading
+        # ``RESOURCE_NOT_FOUND``. #1313 extension.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_get_script(script_id=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "script_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        if hasattr(tools._client, "get_script_config"):
+            tools._client.get_script_config.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_rejects_empty_script_id(self, tools, bad):
+        # ``script_id`` is required for set_script. Empty/whitespace would
+        # propagate to ``upsert_script_config`` and surface as a
+        # misleading HA write-failure. #1313 extension.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_config_set_script(
+                script_id=bad,
+                config={"sequence": [{"delay": {"seconds": 1}}]},
+            )
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "script_id"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        if hasattr(tools._client, "upsert_script_config"):
+            tools._client.upsert_script_config.assert_not_called()
+
+
+# --- tools_config_dashboards.py (#1313) ---------------------------------
+#
+# ``ha_config_get_dashboard`` / ``ha_config_set_dashboard`` /
+# ``ha_config_delete_dashboard`` are module-level (closure-pattern), not
+# class-based — so the tests use the register-and-capture pattern.
+
+
+def _register_dashboard_tools_and_capture(mock_client):
+    from ha_mcp.tools.tools_config_dashboards import (
+        register_config_dashboard_tools,
+    )
+
+    mock_mcp = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def fake_tool(**kwargs):
+        def decorator(fn):
+            captured[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    mock_mcp.tool = fake_tool
+    register_config_dashboard_tools(mock_mcp, mock_client)
+    return captured
+
+
+class TestDashboardsIdentifierValidation:
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_get_dashboard_rejects_empty_url_path(
+        self, mock_ws_client, bad
+    ):
+        # ``url_path`` is optional (omit + ``list_only=True`` lists all).
+        # When provided, empty/whitespace would slip past the list_only
+        # check and reach the search-mode / get-mode WS dispatch. Guard
+        # rejects with ``VALIDATION_INVALID_PARAMETER`` instead.
+        captured = _register_dashboard_tools_and_capture(mock_ws_client)
+        ha_config_get_dashboard = captured["ha_config_get_dashboard"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_config_get_dashboard(url_path=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "url_path"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    async def test_get_dashboard_list_only_skips_guard(self, mock_ws_client):
+        # Control: when ``list_only=True`` and ``url_path`` is omitted,
+        # the guard must not fire — the tool legitimately ignores
+        # ``url_path`` in list mode. Any downstream failure (mocked
+        # client returning unstructured data) is independent of the
+        # guard-not-tripping assertion.
+        captured = _register_dashboard_tools_and_capture(mock_ws_client)
+        ha_config_get_dashboard = captured["ha_config_get_dashboard"]
+
+        try:
+            await ha_config_get_dashboard(list_only=True)
+        except Exception:
+            pass
+        # Positive proof: at least one WS message was attempted (the
+        # list-dashboards fetch). Guard would have raised before that.
+        assert mock_ws_client.send_websocket_message.call_count > 0, (
+            "list_only=True must not trip the url_path guard"
+        )
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_dashboard_rejects_empty_url_path(
+        self, mock_ws_client, bad
+    ):
+        # ``url_path`` is required for set_dashboard. Empty/whitespace
+        # would pass the ``"default"`` alias (False), reach the
+        # pre-resolver / hyphen-check, and surface as a misleading
+        # downstream failure. Guard rejects with
+        # ``VALIDATION_INVALID_PARAMETER`` instead.
+        captured = _register_dashboard_tools_and_capture(mock_ws_client)
+        ha_config_set_dashboard = captured["ha_config_set_dashboard"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_config_set_dashboard(url_path=bad, config={"views": []})
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "url_path"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_delete_dashboard_rejects_empty_url_path(
+        self, mock_ws_client, bad
+    ):
+        # ``url_path`` is required for delete_dashboard. Empty/whitespace
+        # would reach ``_resolve_dashboard`` and surface as a misleading
+        # "no dashboard found" — the guard names the actual problem
+        # (empty parameter) instead.
+        captured = _register_dashboard_tools_and_capture(mock_ws_client)
+        ha_config_delete_dashboard = captured["ha_config_delete_dashboard"]
+
+        with pytest.raises(ToolError) as excinfo:
+            await ha_config_delete_dashboard(url_path=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "url_path"' in str(excinfo.value), str(
+            excinfo.value
+        )
+        mock_ws_client.send_websocket_message.assert_not_called()
 
 
 class TestGroupsIdentifierValidation:


### PR DESCRIPTION
## What does this PR do?

Extends the `validate_identifier_not_empty` helper (introduced in #1312) to the three remaining `tools_config_*` CRUD families: `automations`, `scripts`, `dashboards`. Explicit Tier-3 follow-up from the #1312 PR body — "a separate PR can extend the helper to `tools_config_{automations,scripts,dashboards}` get/set/remove if a maintainer signal endorses the blanket expansion. The helper is ready; only call-site additions would be needed." This is that separate PR.

### Sites guarded (7 new + 2 pre-existing)

#1312 already guarded `ha_config_remove_automation` (`tools_config_automations.py:970`) and `ha_config_remove_script` (`tools_config_scripts.py:624`); they're listed for completeness, not re-touched here.

| File | Tool | Anchor | Pattern |
|---|---|---|---|
| `tools_config_automations.py` | `ha_config_get_automation` | L296 | unconditional (identifier is required `str`) |
| `tools_config_automations.py` | `ha_config_set_automation` | L565 | conditional `if identifier is not None:` (None → create new; non-None → update — guard fires only on update path) |
| `tools_config_automations.py` | `ha_config_remove_automation` | L1002 | pre-existing from #1312 |
| `tools_config_scripts.py` | `ha_config_get_script` | L111 | unconditional |
| `tools_config_scripts.py` | `ha_config_set_script` | L434 | unconditional (script_id is required `str`) |
| `tools_config_scripts.py` | `ha_config_remove_script` | L652 | pre-existing from #1312 |
| `tools_config_dashboards.py` | `ha_config_get_dashboard` | L618 | conditional `if url_path is not None:` (placed after the `if list_only:` early-return so list-mode is unaffected; the documented "omit url_path → default dashboard" fallback remains reachable via `url_path=None` without `list_only`) |
| `tools_config_dashboards.py` | `ha_config_set_dashboard` | L1026 | unconditional, placed BEFORE the `"default"` alias so empty doesn't accidentally normalise |
| `tools_config_dashboards.py` | `ha_config_delete_dashboard` | L1534 | unconditional, placed BEFORE `_resolve_dashboard` so empty doesn't surface as a misleading "no dashboard found" |

Plus 1 import added to `tools_config_dashboards.py` (the other two files already imported the helper via #1312).

### Mypy narrowing

Per the issue body's caveat: only `set_automation` has a `str | None` identifier. The implementation uses the side-effect call form (`validate_identifier_not_empty(identifier, …)` not `identifier = validate_identifier_not_empty(…)`) because downstream code at the python_transform branch already gates on `if not identifier:` independently — no narrowing-rebind needed for type safety. `set_script` and `set_dashboard` both take `str` (always non-None) so unconditional side-effect calls fit cleanly.

### Tests

`tests/src/unit/test_identifier_validation_family.py` — 15 new test scenarios across 3 classes:

- **`TestAutomationsIdentifierValidation`** extended with `test_get_rejects_empty_identifier` (×2 params) + `test_set_rejects_empty_identifier_on_update` (×2 params)
- **`TestScriptsIdentifierValidation`** extended with `test_get_rejects_empty_script_id` (×2) + `test_set_rejects_empty_script_id` (×2)
- **`TestDashboardsIdentifierValidation`** (new) — closure-pattern register-and-capture, covers all three dashboard tools plus a `test_get_dashboard_list_only_skips_guard` control test that proves `list_only=True` does NOT trip the conditional guard (positive assertion: `send_websocket_message.call_count > 0` confirms the call reached `_fetch_dashboards_list`)

Each rejection test asserts:
- `VALIDATION_INVALID_PARAMETER` error code
- `'"parameter": "<name>"' in str(excinfo.value)` to discriminate the new guard from any pre-existing validation in the same function
- Underlying client method (`upsert_*_config` / `send_websocket_message` / etc.) NOT called

### Local

- ruff `check` clean on all 4 modified files
- mypy clean on the 3 modified production files
- Full unit suite: **2658 passed, 1 skipped** (the skip is `test_numpy_version_constraint.py` — by-design on Alpine musl); +15 new tests vs the master baseline

### Diff

Both parent PRs (#1312 + #1320) have merged. Rebased on master @ `264bfc2`. Diff: **4 files / +283 / −0** (3 production + 1 test).

### Out of scope (intentional)

- **Scenes inline-guard migration** — already handled in #1320 (the parent of this PR). Not duplicated here.
- **Dashboard-resource tools** (`tools_resources.py`) — already covered by #1312 (resource_id guard on `_upsert_resource` + `ha_config_delete_dashboard_resource`).
- **ruff format pre-existing debt** — all 4 modified files would be reformatted by `ruff format`, but the format-debt is inherited from master / base branch (verified by stash-and-recheck during idiot-check). New guard lines themselves are well-formatted. Out-of-scope per the established mechanical-PR scope-brake convention; tracked under #1318.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None planned for these three families. The helper is now applied across all `tools_config_*` CRUD entry points that have an identifier-shaped parameter and pass it to a backend call.

## Checklist
- [x] I have updated documentation if needed — no doc updates required for additive validation guards; cross-references in `AGENTS.md` / skill content unchanged.

Closes #1313

