### PR TITLE
docs: strip stale L-refs from test_identifier_validation_family.py docstrings (closes #1323)

### DIFF
--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -9,9 +9,8 @@ Two layers of coverage live here:
    ``VALIDATION_INVALID_PARAMETER`` with the parameter name in
    ``context``; every accept case (``"abc"``, ``" abc "``) is a no-op.
 
-2. **Call-site-level** — one rejection test per affected entry point in
-   ``tools_labels.py``, ``tools_categories.py``, ``tools_areas.py``, and
-   ``tools_config_helpers.py``, asserting:
+2. **Call-site-level** — one rejection test across the affected
+   destructive-class entry points, asserting:
 
    - empty / whitespace identifier surfaces ``VALIDATION_INVALID_PARAMETER``
      (no WS message sent), and
@@ -407,13 +406,13 @@ class TestSetHelperWhitespaceUpgrade:
         self, register_tools, mock_ws_client, bad
     ):
         # Explicit-action update on a FLOW helper with empty/whitespace
-        # helper_id. The L2378 ``helper_id is None`` guard does not catch
-        # this (value is a non-None empty string), and the simple-path
-        # whitespace twin inside ``elif action == "update":`` fires AFTER
-        # the FLOW dispatch returns. Without the new guard between L2401
-        # and the implicit-action branch, the value would reach
-        # ``update_flow_helper`` and HA returns a misleading "entry not
-        # found".
+        # helper_id. The explicit-action ``helper_id is None`` guard does
+        # not catch this (value is a non-None empty string), and the
+        # simple-path whitespace twin inside ``elif action == "update":``
+        # fires AFTER the FLOW dispatch returns. Without the new guard
+        # between the explicit-action raise and the implicit-action
+        # ``else:`` branch, the value would reach ``update_flow_helper``
+        # and HA returns a misleading "entry not found".
         set_helper = register_tools["ha_config_set_helper"]
         with pytest.raises(ToolError) as excinfo:
             await set_helper(


### PR DESCRIPTION
## What does this PR do?

Strips two anti-pattern stale-line-reference items from `tests/src/unit/test_identifier_validation_family.py` that @kingpanther13 surfaced in his approval of #1312 (review submitted `2026-05-17T11:01:01Z`). Filed as a follow-up rather than folded into #1312 because pushing iter9 there would have voided the just-issued APPROVED state (per `dismiss_stale_reviews_on_push: true` on master ruleset 11301803) — trading a 5-line cosmetic edit for a full re-review cycle.

### Edits

**1. File-level docstring at L12-14** — replaces the enumerated list of original four files (`tools_labels.py`, `tools_categories.py`, `tools_areas.py`, `tools_config_helpers.py`) with KP13's suggested open-ended phrasing:
```
2. **Call-site-level** — one rejection test across the affected
   destructive-class entry points, asserting:
```
The test file now covers a much broader set than the original four (groups, integrations, calendar, todo, entities, registry, addons, energy, HACS via #1312 iter5-8; automations/scripts/dashboards inbound via #1321). The open-ended phrasing won't drift on the next family addition.

**2. `test_flow_explicit_update_rejects_empty_helper_id` docstring at L410, L413** — drops the literal `L2378` and `L2401` references and describes by role instead:
- `L2378` → "the explicit-action ``helper_id is None`` guard"
- `L2401` → "between the explicit-action raise and the implicit-action ``else:`` branch"

iter6 of #1312 stripped this same anti-pattern from production code (per the round-2 review's item #4); the test-docstring side was missed in that pass.

### Local

- 1 file changed, +8 / −9 LOC (net −1)
- ruff `check` clean
- Full unit suite: **2639 passed, 1 skipped** (numpy by-design on Alpine musl) — no test logic touched; docstring-only refactor
- No production-code changes; no behavioural impact

### Stack note

This PR is independent of the `#1320` / `#1321` stack — `#1320` doesn't touch the test file, `#1321` extends it with new test classes at the bottom (no overlap with L12-14 or L410-413). Merge order doesn't matter.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

None.

## Checklist
- [x] I have updated documentation if needed — this PR _is_ the documentation update.

Closes #1323
