### PR TITLE
fix: actionable 403 suggestion when addon has unmapped container ports (#1319)

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1555,34 +1555,26 @@ async def _call_addon_api(
             )
         elif response.status_code == 403:
             ports_dict = addon.get("network") or addon.get("ports") or {}
-            # Unmapped container ports (host-side value is None) are the most
-            # common cause of a 403 here: ingress nginx in the target addon
-            # often rejects peer-container traffic, so the user's escape hatch
-            # is the direct-container-port path — which only works if they've
-            # mapped the port to host in the addon's Network config. Surface
-            # that gap explicitly instead of asking the LLM to infer it from
-            # an opaque "see addon_config" hint. (#1319)
-            unmapped = [k for k, v in ports_dict.items() if v is None]
+            # Ingress nginx in peer add-ons typically rejects cross-container
+            # traffic; the direct-port fallback only works if the user mapped
+            # a host port. Detect and call out the unmapped case explicitly.
+            unmapped = sorted(k for k, v in ports_dict.items() if v is None)
             result["addon_config"] = {
                 "options": addon.get("options"),
                 "ports": ports_dict or None,
                 "host_network": addon.get("host_network"),
                 "ingress_port": addon.get("ingress_port"),
             }
-            if unmapped:
-                addon_label = addon.get("name") or addon.get("slug") or "the add-on"
-                example_proto = unmapped[0]
-                example_port = example_proto.split("/", 1)[0]
+            slug = addon.get("slug") or "<slug>"
+            example_proto = unmapped[0] if unmapped else ""
+            example_port = example_proto.split("/", 1)[0] if example_proto else ""
+            if unmapped and example_port.isdigit():
+                addon_label = addon.get("name") or slug
                 result["suggestion"] = (
-                    f"Add-on '{addon_label}' has unmapped container port(s) "
-                    f"({', '.join(unmapped)}) — the ingress proxy is blocking the "
-                    f"request and no host-mapped port is available as a fallback. "
-                    f"In the HA UI: open '{addon_label}' → Configuration → Network, "
-                    f"map '{example_proto}' to a host port (e.g. {example_port}), "
-                    f"save, then restart the add-on. Then retry: "
-                    f"ha_manage_addon(slug='{addon.get('slug')}', path='...', "
-                    f"port={example_port}). This bypasses the ingress proxy via "
-                    f"the direct container port."
+                    f"Map {example_proto} to a host port in the HA UI "
+                    f"('{addon_label}' → Configuration → Network), restart the "
+                    f"add-on, then retry with ha_manage_addon(slug='{slug}', "
+                    f"path='...', port={example_port})."
                 )
             else:
                 result["suggestion"] = (

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1554,19 +1554,44 @@ async def _call_addon_api(
                 "token has admin rights and try again."
             )
         elif response.status_code == 403:
+            ports_dict = addon.get("network") or addon.get("ports") or {}
+            # Unmapped container ports (host-side value is None) are the most
+            # common cause of a 403 here: ingress nginx in the target addon
+            # often rejects peer-container traffic, so the user's escape hatch
+            # is the direct-container-port path — which only works if they've
+            # mapped the port to host in the addon's Network config. Surface
+            # that gap explicitly instead of asking the LLM to infer it from
+            # an opaque "see addon_config" hint. (#1319)
+            unmapped = [k for k, v in ports_dict.items() if v is None]
             result["addon_config"] = {
                 "options": addon.get("options"),
-                "ports": addon.get("network") or addon.get("ports"),
+                "ports": ports_dict or None,
                 "host_network": addon.get("host_network"),
                 "ingress_port": addon.get("ingress_port"),
             }
-            result["suggestion"] = (
-                "This add-on is blocking direct connections (likely Nginx IP restriction). "
-                "Try using the 'port' parameter to connect to the add-on's direct access port "
-                "(see addon_config.ports above) with 'leave_front_door_open' enabled. "
-                "Example: ha_manage_addon(slug='...', path='...', port=<direct_port>). "
-                "The user may need to change add-on settings in the HA UI and restart the add-on."
-            )
+            if unmapped:
+                addon_label = addon.get("name") or addon.get("slug") or "the add-on"
+                example_proto = unmapped[0]
+                example_port = example_proto.split("/", 1)[0]
+                result["suggestion"] = (
+                    f"Add-on '{addon_label}' has unmapped container port(s) "
+                    f"({', '.join(unmapped)}) — the ingress proxy is blocking the "
+                    f"request and no host-mapped port is available as a fallback. "
+                    f"In the HA UI: open '{addon_label}' → Configuration → Network, "
+                    f"map '{example_proto}' to a host port (e.g. {example_port}), "
+                    f"save, then restart the add-on. Then retry: "
+                    f"ha_manage_addon(slug='{addon.get('slug')}', path='...', "
+                    f"port={example_port}). This bypasses the ingress proxy via "
+                    f"the direct container port."
+                )
+            else:
+                result["suggestion"] = (
+                    "This add-on is blocking direct connections (likely Nginx IP restriction). "
+                    "Try using the 'port' parameter to connect to the add-on's direct access port "
+                    "(see addon_config.ports above) with 'leave_front_door_open' enabled. "
+                    "Example: ha_manage_addon(slug='...', path='...', port=<direct_port>). "
+                    "The user may need to change add-on settings in the HA UI and restart the add-on."
+                )
 
     return result
 

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -845,6 +845,64 @@ class TestCallAddonApiErrors:
         for key in ("options", "ports", "host_network", "ingress_port"):
             assert key in result["addon_config"], result["addon_config"]
 
+    @pytest.mark.asyncio
+    async def test_http_403_with_unmapped_ports_suggests_mapping(
+        self, mock_ingress_session
+    ):
+        """When the target addon has container ports with `None` host
+        mappings, the 403 suggestion must name the specific port and give a
+        concrete map-and-retry recipe — not the generic ``see
+        addon_config`` hint. Matches the reporter case in #1319 where
+        ESPHome's `6052/tcp` was unmapped."""
+        client = _make_mock_client()
+        addon_with_unmapped_port = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO["addon"],
+                "ports": {"6052/tcp": None, "9999/tcp": 9999},
+            },
+        }
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 403
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_with_unmapped_port,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        assert result["status_code"] == 403
+        suggestion = result["suggestion"]
+        # The unmapped port must be named explicitly and the recipe must
+        # include the exact ha_manage_addon retry call.
+        assert "6052/tcp" in suggestion, suggestion
+        assert "Configuration" in suggestion and "Network" in suggestion, suggestion
+        assert "port=6052" in suggestion, suggestion
+        # The mapped port (9999) shouldn't be flagged as needing remapping.
+        assert "9999/tcp" not in suggestion, suggestion
+        # The generic "Nginx IP restriction" wording should NOT fire when
+        # we've already identified a concrete next step.
+        assert "Nginx IP restriction" not in suggestion, suggestion
+
 
 class TestCreateIngressSession:
     """Tests for _create_ingress_session error and success paths.

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -849,11 +849,8 @@ class TestCallAddonApiErrors:
     async def test_http_403_with_unmapped_ports_suggests_mapping(
         self, mock_ingress_session
     ):
-        """When the target addon has container ports with `None` host
-        mappings, the 403 suggestion must name the specific port and give a
-        concrete map-and-retry recipe — not the generic ``see
-        addon_config`` hint. Matches the reporter case in #1319 where
-        ESPHome's `6052/tcp` was unmapped."""
+        """403 with an unmapped container port → suggestion names the port
+        and emits the exact map-and-retry recipe."""
         client = _make_mock_client()
         addon_with_unmapped_port = {
             "success": True,
@@ -892,16 +889,152 @@ class TestCallAddonApiErrors:
 
         assert result["status_code"] == 403
         suggestion = result["suggestion"]
-        # The unmapped port must be named explicitly and the recipe must
-        # include the exact ha_manage_addon retry call.
         assert "6052/tcp" in suggestion, suggestion
         assert "Configuration" in suggestion and "Network" in suggestion, suggestion
         assert "port=6052" in suggestion, suggestion
-        # The mapped port (9999) shouldn't be flagged as needing remapping.
+        assert "slug='test_addon'" in suggestion, suggestion
         assert "9999/tcp" not in suggestion, suggestion
-        # The generic "Nginx IP restriction" wording should NOT fire when
-        # we've already identified a concrete next step.
         assert "Nginx IP restriction" not in suggestion, suggestion
+
+    @pytest.mark.asyncio
+    async def test_http_403_with_multiple_unmapped_ports_picks_lowest(
+        self, mock_ingress_session
+    ):
+        """With multiple unmapped ports, the suggestion must be
+        deterministic (lowest-sorted port wins, not iteration order)."""
+        client = _make_mock_client()
+        addon_info = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO["addon"],
+                "ports": {"9000/tcp": None, "1880/tcp": None, "5000/tcp": None},
+            },
+        }
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 403
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        suggestion = result["suggestion"]
+        # Sorted ascending: "1880/tcp" wins over "5000/tcp" and "9000/tcp".
+        assert "1880/tcp" in suggestion, suggestion
+        assert "port=1880" in suggestion, suggestion
+
+    @pytest.mark.asyncio
+    async def test_http_403_reads_network_field_when_ports_absent(
+        self, mock_ingress_session
+    ):
+        """Supervisor responses sometimes carry the port map under
+        `network` instead of `ports`. The 403 suggestion must read both."""
+        client = _make_mock_client()
+        addon_info = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO["addon"],
+                "network": {"8080/tcp": None},
+                # No "ports" key at all.
+            },
+        }
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 403
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        suggestion = result["suggestion"]
+        assert "8080/tcp" in suggestion, suggestion
+        assert "port=8080" in suggestion, suggestion
+
+    @pytest.mark.asyncio
+    async def test_http_403_with_malformed_port_key_falls_back_to_generic(
+        self, mock_ingress_session
+    ):
+        """If a port-dict key isn't the canonical `<port>/<proto>` shape,
+        the unmapped-port suggestion would render `port=` with a non-numeric
+        value — fall back to the generic Nginx-restriction message instead."""
+        client = _make_mock_client()
+        addon_info = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO["addon"],
+                "ports": {"not-a-port": None},
+            },
+        }
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = 403
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/api/test")
+
+        suggestion = result["suggestion"].lower()
+        assert "nginx" in suggestion or "ip restriction" in suggestion, suggestion
 
 
 class TestCreateIngressSession:


### PR DESCRIPTION
## What does this PR do?

When `ha_manage_addon` hits a 403 from an addon's ingress nginx, the current generic suggestion ("see addon_config.ports above") requires the LLM to infer that the user's escape hatch is to map a container port to host. For addons that ship with unmapped ports — e.g. ESPHome's `6052/tcp` on a fresh install (#1319) — this gap is invisible to the model.

This PR inspects the addon's `ports` dict on a 403. If any entry has a `null` host mapping, the suggestion now:

1. Names the specific unmapped port(s)
2. Tells the user exactly where to map it in the HA UI (addon → Configuration → Network)
3. Emits the exact `ha_manage_addon(slug=..., path=..., port=<n>)` retry call with the right port number

Addons that already have all ports mapped keep the existing generic suggestion — we don't want to misdirect on a 403 with a different root cause.

### Why not "fix the routing"?

#1319's triage analysis proposed adding an `ingress_session` cookie to the addon-mode branch of `_resolve_http_route`. I tested that hypothesis empirically (see [#1319 comment](https://github.com/homeassistant-ai/ha-mcp/issues/1319#issuecomment-4470564851)) — even with a valid freshly-minted session token, the direct-container-port request to ESPHome's nginx still returns 403. ESPHome gates on something beyond cookie presence (likely source IP). The cookie-only patch would ship and still 403 for everyone whose port isn't host-mapped. So this PR ships the user-actionable workaround instead of disturbing the working routing logic.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Added unit test `test_http_403_with_unmapped_ports_suggests_mapping` covering the new branch. Existing 403 test (`test_http_403_response_hints_at_ip_restriction`) continues to assert the generic wording for the no-ports-defined case, validating backward compatibility.

## Future improvements

- The cookie-attachment routing experiment from #1319's triage may still be worth attempting under a separate PR with proper Bearer auth, since the off-host path demonstrably works end-to-end (200 with valid session). Out of scope for this PR per the "fragile tool, don't disturb working paths" call.

## Checklist
- [ ] I have updated documentation if needed
