### PR TITLE
fix: detect HA addon installs as http transport, not stdio (#1322)

### DIFF
--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -243,12 +243,6 @@ def _detect_mcp_transport() -> str:
     and well-known env hints. The result is informational — the bug template
     surfaces it as an auto-detect that the agent or user can override.
     """
-    # Home Assistant add-on always runs HTTP via homeassistant-addon/start.py.
-    # Checked before the stdin-isatty fallback because Supervisor-launched
-    # containers have no TTY on stdin and would otherwise be mislabeled stdio.
-    if is_running_in_addon():
-        return "http"
-
     # Entry-point script name (e.g. ``ha-mcp-web`` for HTTP, ``ha-mcp-sse``
     # for SSE; pyproject.toml's [project.scripts] is the source of truth).
     argv0 = (sys.argv[0] if sys.argv else "").lower()
@@ -267,6 +261,14 @@ def _detect_mcp_transport() -> str:
     if transport_env == "streamable-http":
         return "http"
     if os.environ.get("MCP_HTTP_PORT") or os.environ.get("FASTMCP_PORT"):
+        return "http"
+
+    # Home Assistant add-on always runs HTTP via homeassistant-addon/start.py.
+    # Placed after the explicit hints (argv0 / env) so an operator override
+    # still wins, but before the stdin-isatty fallback because Supervisor-
+    # launched containers have no TTY on stdin and would otherwise be
+    # mislabeled stdio.
+    if is_running_in_addon():
         return "http"
 
     # If stdin is piped (not a TTY), ha-mcp was launched by an MCP host on

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from ha_mcp import __version__
 
+from .._version import is_running_in_addon
 from ..client.supervisor_client import make_supervisor_httpx_client
 from ..config import Settings, get_global_settings
 from ..utils.usage_logger import (
@@ -71,7 +72,7 @@ def _detect_installation_method() -> str:
         return "pyinstaller"
 
     # 2. Home Assistant Add-on (has supervisor token)
-    if os.environ.get("SUPERVISOR_TOKEN"):
+    if is_running_in_addon():
         return "addon"
 
     # 3. Docker container (non-addon)
@@ -242,6 +243,12 @@ def _detect_mcp_transport() -> str:
     and well-known env hints. The result is informational — the bug template
     surfaces it as an auto-detect that the agent or user can override.
     """
+    # Home Assistant add-on always runs HTTP via homeassistant-addon/start.py.
+    # Checked before the stdin-isatty fallback because Supervisor-launched
+    # containers have no TTY on stdin and would otherwise be mislabeled stdio.
+    if is_running_in_addon():
+        return "http"
+
     # Entry-point script name (e.g. ``ha-mcp-web`` for HTTP, ``ha-mcp-sse``
     # for SSE; pyproject.toml's [project.scripts] is the source of truth).
     argv0 = (sys.argv[0] if sys.argv else "").lower()
@@ -349,7 +356,7 @@ async def _fetch_addon_logs() -> str:
     """
     # Redundant with the caller's `install_method == "addon"` gate, but kept
     # as a defensive guard for any direct callers added later.
-    if not os.environ.get("SUPERVISOR_TOKEN"):
+    if not is_running_in_addon():
         return ""
 
     try:

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -884,7 +884,12 @@ class TestDetectMcpTransport:
     @pytest.fixture(autouse=True)
     def _clear_transport_env(self, monkeypatch):
         """Drop any env vars that could otherwise leak between tests."""
-        for var in ("FASTMCP_TRANSPORT", "MCP_HTTP_PORT", "FASTMCP_PORT"):
+        for var in (
+            "FASTMCP_TRANSPORT",
+            "MCP_HTTP_PORT",
+            "FASTMCP_PORT",
+            "SUPERVISOR_TOKEN",
+        ):
             monkeypatch.delenv(var, raising=False)
 
     def test_http_argv0(self, monkeypatch):
@@ -953,6 +958,18 @@ class TestDetectMcpTransport:
 
         monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=boom))
         assert _detect_mcp_transport() == "unknown"
+
+    def test_addon_short_circuits_to_http(self, monkeypatch):
+        # Regression for #1322: addon launches via `python start.py` (no -web
+        # argv0, no FASTMCP_TRANSPORT env) inside a TTY-less Supervisor
+        # container, so the stdin-isatty fallback used to mislabel addon
+        # installs as "stdio". The addon entrypoint always invokes
+        # mcp.run(transport="http", ...), so short-circuit on SUPERVISOR_TOKEN.
+        monkeypatch.setattr("sys.argv", ["/usr/bin/python", "start.py"])
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake-supervisor-token")
+        fake_stdin = SimpleNamespace(isatty=lambda: False)
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        assert _detect_mcp_transport() == "http"
 
 
 class TestFormatConfigTogglesForTemplate:


### PR DESCRIPTION
## What does this PR do?

Fixes #1322. `_detect_mcp_transport()` now short-circuits to `"http"` when running inside a Home Assistant add-on (Supervisor token present), before the stdin-isatty fallback. Addon installs launch via `python start.py` with no `-web` argv0 and no `FASTMCP_TRANSPORT` env, and the Supervisor container has no TTY on stdin — so the old logic reported `"stdio"` even though the addon's `start.py` always invokes `mcp.run(transport="http", ...)`.

Also routes `_detect_installation_method` and `_fetch_addon_logs` through the existing `is_running_in_addon()` helper for consistency.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

mypy and pytest deferred to CI for this push — the Termux dev environment can't run them in this session.

Added `test_addon_short_circuits_to_http` to `TestDetectMcpTransport` covering the regression (simulates `SUPERVISOR_TOKEN` + non-TTY stdin + neutral argv0).

## Future improvements

None.

## Checklist
- [x] I have updated documentation if needed