### PR TITLE
feat: expose integration diagnostics via ha_get_integration and ha_get_system_health (closes #1148)

### DIFF
--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -35,7 +35,9 @@ from .util_helpers import (
     build_pagination_metadata,
     coerce_bool_param,
     coerce_int_param,
+    fetch_integration_diagnostics,
     get_logger_levels,
+    parse_diagnostics_fields,
     wait_for_entity_removed,
 )
 
@@ -219,6 +221,114 @@ class IntegrationTools:
                 description="Number of entries to skip for pagination (default: 0)",
             ),
         ] = 0,
+        include_diagnostics: Annotated[
+            bool | str,
+            Field(
+                description=(
+                    "When entry_id is set, also fetch the integration's diagnostics "
+                    "dump — integration-defined JSON (commonly includes redacted "
+                    "config, device list, state snapshots; exact top-level keys "
+                    "vary by integration). The canonical artifact users grab via "
+                    "Settings → Devices & Services → [integration] → ⋯ → Download "
+                    "diagnostics. Use when triaging integration bugs or filing "
+                    "ha_report_issue for a specific integration. Payloads can be "
+                    "large (Hue ~290 KB, ZHA/MQTT/ESPHome several MB) — pair with "
+                    "diagnostics_fields or diagnostics_truncate_at_bytes to fit "
+                    "the LLM context budget."
+                ),
+                default=False,
+            ),
+        ] = False,
+        device_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional. When set with include_diagnostics=True, returns the "
+                    "device-scoped diagnostics dump for that specific device under "
+                    "the integration (rather than the full integration dump). Some "
+                    "integrations only expose config-entry-level dumps; others "
+                    "expose both."
+                ),
+                default=None,
+            ),
+        ] = None,
+        diagnostics_fields: Annotated[
+            list[str] | str | None,
+            Field(
+                description=(
+                    "Optional list of top-level keys to keep from the diagnostics "
+                    "data payload (e.g. ['home_assistant', 'issues']). Trims the "
+                    "payload before it hits the LLM context budget. Accepts a JSON "
+                    "list or comma-separated string. Only applies when "
+                    "include_diagnostics=True and the data payload is a dict. "
+                    "Unknown keys are silently dropped and surfaced via the "
+                    "omitted_fields sub-key."
+                ),
+                default=None,
+            ),
+        ] = None,
+        diagnostics_truncate_at_bytes: Annotated[
+            int | str | None,
+            Field(
+                description=(
+                    "Optional byte cap on the serialized diagnostics payload "
+                    "(after diagnostics_fields and diagnostics_data_path have "
+                    "been applied). On hit, drops data and emits truncated=true, "
+                    "bytes_total, byte_cap, plus available_fields (when the "
+                    "capped value is a dict). Recommended starting point: "
+                    "20000 bytes. Only applies when include_diagnostics=True."
+                ),
+                default=None,
+            ),
+        ] = None,
+        diagnostics_data_path: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Optional dotted path into the diagnostics data sub-tree "
+                    "(e.g. '<list-valued path>' for per-device records, "
+                    "'home_assistant.version' for HA core version; the exact "
+                    "key path varies by integration version). Walks into the "
+                    "post-fields payload. Resolution failures replace data "
+                    "with null and surface data_path_error. Use this when the "
+                    "interesting payload lives several levels deep — top-level "
+                    "diagnostics_fields can't address sub-trees on integrations "
+                    "where the bulk lives under one key (ZHA, MQTT, ESPHome). "
+                    "Only applies when include_diagnostics=True."
+                ),
+                default=None,
+            ),
+        ] = None,
+        diagnostics_data_offset: Annotated[
+            int | str | None,
+            Field(
+                description=(
+                    "Pagination start index (default 0) for list-valued "
+                    "diagnostics_data_path results. Ignored when "
+                    "diagnostics_data_path is unset, diagnostics_data_limit is "
+                    "unset, or the resolved value is not a list. Only applies "
+                    "when include_diagnostics=True."
+                ),
+                default=0,
+            ),
+        ] = 0,
+        diagnostics_data_limit: Annotated[
+            int | str | None,
+            Field(
+                description=(
+                    "Pagination window size for list-valued "
+                    "diagnostics_data_path results. When set with a "
+                    "list-resolved path, swaps data for a pagination envelope "
+                    "{path, items, offset, limit, total, has_more}. Default "
+                    "None returns the full resolved value. Workflow: probe "
+                    "with a list-valued diagnostics_data_path and "
+                    "diagnostics_data_limit=10 to walk a large list one page "
+                    "at a time (the exact path varies by integration version). "
+                    "Only applies when include_diagnostics=True."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Get integration (config entry) information with pagination.
 
@@ -231,6 +341,10 @@ class IntegrationTools:
         - Search: ha_get_integration(query="zigbee")
         - Get specific entry: ha_get_integration(entry_id="abc123")
         - Get entry with editable fields: ha_get_integration(entry_id="abc123", include_schema=True)
+        - Get entry with diagnostics dump: ha_get_integration(entry_id="abc123", include_diagnostics=True)
+        - Get device-scoped diagnostics: ha_get_integration(entry_id="abc123", include_diagnostics=True, device_id="dev123")
+        - Walk a sub-tree: ha_get_integration(entry_id="abc123", include_diagnostics=True, diagnostics_data_path="<dotted-path>")
+        - Paginate a large list: ha_get_integration(entry_id="abc123", include_diagnostics=True, diagnostics_data_path="<list-valued path>", diagnostics_data_limit=10, diagnostics_data_offset=20)
         - List template entries: ha_get_integration(domain="template")
 
         STATES: 'loaded', 'setup_error', 'setup_retry', 'not_loaded',
@@ -256,6 +370,9 @@ class IntegrationTools:
             include_schema_bool = coerce_bool_param(
                 include_schema, "include_schema", default=False
             )
+            include_diagnostics_bool = coerce_bool_param(
+                include_diagnostics, "include_diagnostics", default=False
+            )
             exact_match_bool = coerce_bool_param(
                 exact_match, "exact_match", default=True
             )
@@ -263,18 +380,86 @@ class IntegrationTools:
                 limit, "limit", default=50, min_value=1, max_value=200
             )
             offset_int = coerce_int_param(offset, "offset", default=0, min_value=0)
+            fields_list = parse_diagnostics_fields(diagnostics_fields)
+            truncate_bytes = coerce_int_param(
+                diagnostics_truncate_at_bytes,
+                "diagnostics_truncate_at_bytes",
+                default=None,
+                min_value=1,
+            )
+            data_offset_int = coerce_int_param(
+                diagnostics_data_offset,
+                "diagnostics_data_offset",
+                default=0,
+                min_value=0,
+            )
+            data_limit_int = coerce_int_param(
+                diagnostics_data_limit,
+                "diagnostics_data_limit",
+                default=None,
+                min_value=1,
+            )
+            # Type-guard ``diagnostics_data_path`` here so a bad caller (dict /
+            # list) surfaces as ``VALIDATION_INVALID_PARAMETER`` instead of
+            # leaking as ``INTERNAL_ERROR`` from the resolver's ``.strip()``
+            # downstream. Mirrors the coerce_int_param guards above.
+            if diagnostics_data_path is not None and not isinstance(
+                diagnostics_data_path, str
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "diagnostics_data_path must be a string, got "
+                        f"{type(diagnostics_data_path).__name__}",
+                        context={"parameter": "diagnostics_data_path"},
+                    )
+                )
             # Auto-enable options when domain filter is set
             if domain is not None:
                 include_opts = True
 
             # If entry_id provided, get specific config entry
             if entry_id is not None:
-                return await self._get_single_entry(entry_id, include_schema_bool)
+                resp = await self._get_single_entry(entry_id, include_schema_bool)
+                if include_diagnostics_bool:
+                    resp["diagnostics"] = await fetch_integration_diagnostics(
+                        self._client,
+                        entry_id,
+                        device_id,
+                        fields=fields_list,
+                        truncate_at_bytes=truncate_bytes,
+                        data_path=diagnostics_data_path,
+                        data_offset=data_offset_int,
+                        data_limit=data_limit_int,
+                    )
+                elif device_id is not None:
+                    resp.setdefault("warnings", []).append(
+                        "device_id was provided but ignored because "
+                        "include_diagnostics=False"
+                    )
+                return resp
 
             # List mode - get all config entries
-            return await self._list_entries(
+            result = await self._list_entries(
                 domain, query, include_opts, exact_match_bool, limit_int, offset_int
             )
+            if (
+                include_diagnostics_bool
+                or device_id is not None
+                or fields_list is not None
+                or truncate_bytes is not None
+                or diagnostics_data_path is not None
+                or data_limit_int is not None
+                or data_offset_int > 0
+            ):
+                result.setdefault("warnings", []).append(
+                    "include_diagnostics, device_id, diagnostics_fields, "
+                    "diagnostics_truncate_at_bytes, diagnostics_data_path, "
+                    "diagnostics_data_offset, and/or diagnostics_data_limit "
+                    "were provided but ignored because entry_id was not set "
+                    "(list mode)"
+                )
+            return result
 
         except ToolError:
             raise

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -23,7 +23,13 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
-from .util_helpers import coerce_bool_param, filter_active_repairs
+from .util_helpers import (
+    coerce_bool_param,
+    coerce_int_param,
+    fetch_integration_diagnostics,
+    filter_active_repairs,
+    parse_diagnostics_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -334,17 +340,24 @@ class SystemTools:
 
     @tool(
         name="ha_get_system_health",
-        tags={"System", "Zigbee", "Z-Wave"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get System Health (incl. ZHA/Z-Wave diagnostics)"},
+        tags={"System", "Zigbee", "Z-Wave", "Integrations"},
+        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get System Health (incl. ZHA/Z-Wave/integration diagnostics)"},
     )
     @log_tool_usage
     async def ha_get_system_health(
         self,
         include: str | None = None,
         include_dismissed_repairs: bool | str | None = False,
+        config_entry_id: str | None = None,
+        device_id: str | None = None,
+        diagnostics_fields: list[str] | str | None = None,
+        diagnostics_truncate_at_bytes: int | str | None = None,
+        diagnostics_data_path: str | None = None,
+        diagnostics_data_offset: int | str | None = 0,
+        diagnostics_data_limit: int | str | None = None,
     ) -> dict[str, Any]:
         """
-        Get Home Assistant system health, including Zigbee (ZHA) and Z-Wave JS network diagnostics.
+        Get Home Assistant system health, including Zigbee (ZHA), Z-Wave JS, and per-integration diagnostics dumps.
 
         Returns health check results from integrations, system resources, and connectivity.
         Available information varies by installation type and loaded integrations.
@@ -355,8 +368,50 @@ class SystemTools:
           - "zha_network": ZHA Zigbee devices with radio signal summary (name, LQI, RSSI)
           - "zha_network_full": ZHA Zigbee devices with all device details (can be large on 100+ device networks; prefer "zha_network" for summary)
           - "zwave_network": Z-Wave JS network status and node summary (status, security, routing)
+          - "diagnostics": Per-integration diagnostics dump — integration-defined JSON
+            (commonly includes redacted config, device list, state snapshots; exact
+            top-level keys vary by integration). REQUIRES ``config_entry_id``. The
+            canonical artifact users grab via Settings → Devices & Services →
+            [integration] → ⋯ → Download diagnostics. Use this when triaging integration
+            bugs or filing ``ha_report_issue`` for a specific integration. Payloads can
+            be large (Hue ~290 KB, ZHA/MQTT/ESPHome several MB) — pair with
+            ``diagnostics_fields`` or ``diagnostics_truncate_at_bytes`` to fit the LLM
+            context budget.
           - Example: include="repairs,zha_network,zwave_network"
+          - Example: include="diagnostics", config_entry_id="abc123..."
         - include_dismissed_repairs: Include user-dismissed/ignored repairs (default: False). Only meaningful when "repairs" is in `include`.
+        - config_entry_id: Required when ``include`` contains ``diagnostics``. The config
+          entry ID of the integration (find via ``ha_get_integration``).
+        - device_id: Optional. When set with ``include=diagnostics``, returns the
+          device-scoped diagnostics dump for that specific device under the integration
+          (rather than the full integration dump). Some integrations only expose
+          config-entry-level dumps; others expose both.
+        - diagnostics_fields: Optional list of top-level keys to keep from the
+          diagnostics ``data`` payload (e.g. ``["home_assistant", "issues"]``). Accepts
+          a JSON list or comma-separated string. Only applies with ``include=diagnostics``.
+        - diagnostics_truncate_at_bytes: Optional byte cap on the serialized
+          diagnostics payload (post-projection / post-data_path). On hit,
+          drops ``data`` and emits ``truncated=true``, ``bytes_total``,
+          ``byte_cap``, plus ``available_fields`` (when the capped value
+          is a dict). Only applies when ``include`` contains ``diagnostics``.
+          Recommended starting point: 20000 bytes.
+        - diagnostics_data_path: Optional dotted path into the diagnostics
+          ``data`` sub-tree (e.g. ``"data.devices"`` for ZHA per-device records).
+          Walks into the post-fields payload. Resolution failures replace
+          ``data`` with ``null`` and surface ``data_path_error``. Only applies
+          when ``include`` contains ``diagnostics``.
+        - diagnostics_data_offset / diagnostics_data_limit: Pagination on
+          list-valued ``diagnostics_data_path`` results. When ``data_limit``
+          is set and the resolved path is a list, ``data`` becomes
+          ``{"path", "items", "offset", "limit", "total", "has_more"}``. Only
+          applies when ``include`` contains ``diagnostics``.
+
+          Example workflow (walk a list-valued sub-tree one page at a time;
+          the exact ``data_path`` varies by integration version):
+          ``ha_get_system_health(include="diagnostics", config_entry_id="abc",
+          diagnostics_data_path="<list-valued path>", diagnostics_data_limit=10)``
+          → inspect the page envelope's ``total`` / ``has_more`` → repeat
+          with ``diagnostics_data_offset=10`` for the next slice.
         """
         includes = self._parse_includes(include)
         include_dismissed_repairs_bool = bool(
@@ -373,10 +428,18 @@ class SystemTools:
             ws_client, result = await self._fetch_health_info()
 
             # Warn about unrecognized include values
-            VALID_INCLUDES = {"repairs", "zha_network", "zha_network_full", "zwave_network"}
+            VALID_INCLUDES = {
+                "repairs",
+                "zha_network",
+                "zha_network_full",
+                "zwave_network",
+                "diagnostics",
+            }
             unknown = includes - VALID_INCLUDES
             if unknown:
-                result["warning"] = f"Unknown include sections ignored: {', '.join(sorted(unknown))}"
+                result.setdefault("warnings", []).append(
+                    f"Unknown include sections ignored: {', '.join(sorted(unknown))}"
+                )
 
             # Fetch optional sections concurrently. The ws_client serialises
             # outgoing writes via its internal `_send_lock`, but per-message
@@ -461,6 +524,81 @@ class SystemTools:
                         }
                     else:
                         result[section_name] = section_result
+
+            # Diagnostics-related coercions live outside the includes branch
+            # so the orphan-args warning at the ``elif`` after the
+            # ``if "diagnostics" in includes`` block (see below) can see
+            # canonicalised values — passing ``diagnostics_data_offset=20``
+            # without ``include=diagnostics`` would otherwise slip past the gate.
+            fields_list = parse_diagnostics_fields(diagnostics_fields)
+            truncate_bytes = coerce_int_param(
+                diagnostics_truncate_at_bytes,
+                "diagnostics_truncate_at_bytes",
+                default=None,
+                min_value=1,
+            )
+            data_offset_int = coerce_int_param(
+                diagnostics_data_offset,
+                "diagnostics_data_offset",
+                default=0,
+                min_value=0,
+            )
+            data_limit_int = coerce_int_param(
+                diagnostics_data_limit,
+                "diagnostics_data_limit",
+                default=None,
+                min_value=1,
+            )
+            # Type-guard ``diagnostics_data_path`` here so a bad caller (dict /
+            # list) surfaces as ``VALIDATION_INVALID_PARAMETER`` instead of
+            # leaking as ``INTERNAL_ERROR`` from the resolver's ``.strip()``
+            # downstream. Mirrors the coerce_int_param guards above.
+            if diagnostics_data_path is not None and not isinstance(
+                diagnostics_data_path, str
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "diagnostics_data_path must be a string, got "
+                        f"{type(diagnostics_data_path).__name__}",
+                        context={"parameter": "diagnostics_data_path"},
+                    )
+                )
+
+            if "diagnostics" in includes:
+                # ``fetch_integration_diagnostics`` carries the empty-id guard
+                # (returns {"config_entry_id": ..., "error": ...}); calling it
+                # unconditionally keeps the missing-id error shape consistent
+                # with the populated path instead of returning a bare
+                # ``{"error": ...}`` sub-dict on the inline branch. Forward
+                # ``config_entry_id`` as-is (None / "") so the helper's echo
+                # field reflects what the caller actually passed.
+                result["diagnostics"] = await fetch_integration_diagnostics(
+                    self._client,
+                    config_entry_id,
+                    device_id,
+                    fields=fields_list,
+                    truncate_at_bytes=truncate_bytes,
+                    data_path=diagnostics_data_path,
+                    data_offset=data_offset_int,
+                    data_limit=data_limit_int,
+                )
+            elif (
+                config_entry_id
+                or device_id
+                or diagnostics_fields is not None
+                or diagnostics_truncate_at_bytes is not None
+                or diagnostics_data_path is not None
+                or diagnostics_data_limit is not None
+                or data_offset_int > 0
+            ):
+                result.setdefault("warnings", []).append(
+                    "config_entry_id, device_id, diagnostics_fields, "
+                    "diagnostics_truncate_at_bytes, diagnostics_data_path, "
+                    "diagnostics_data_offset, and/or diagnostics_data_limit "
+                    "were provided but ignored because 'diagnostics' is not "
+                    "in include"
+                )
 
             return result
 

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -741,3 +741,381 @@ def merge_validation_meta(
     if blueprint_skipped:
         entry["blueprint_skipped"] = True
     result["validation"] = entry
+
+
+DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS = 60.0
+
+
+def parse_diagnostics_fields(value: list[str] | str | None) -> list[str] | None:
+    """Normalise the ``diagnostics_fields`` MCP-tool parameter to ``list[str] | None``.
+
+    Accepts a native list of strings, a JSON-encoded list (e.g.
+    ``'["home_assistant","issues"]'``), or a comma-separated string
+    (e.g. ``'home_assistant, issues'``). Empty / whitespace-only input
+    coerces to ``None`` so the diagnostics helper skips the projection.
+
+    Raises:
+        ValueError: when the input is not parseable as a list of strings —
+            specifically: JSON that fails to decode, JSON that decodes to a
+            non-list value (object, scalar), or any non-(list/str/None) type.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        parsed = [str(v).strip() for v in value if str(v).strip()]
+        return parsed or None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped.startswith("["):
+            try:
+                decoded = json.loads(stripped)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"diagnostics_fields must be a valid JSON list, got '{stripped}': {e}"
+                ) from e
+            if not isinstance(decoded, list):
+                raise ValueError(
+                    f"diagnostics_fields JSON must decode to a list, got {type(decoded).__name__}"
+                )
+            parsed = [str(v).strip() for v in decoded if str(v).strip()]
+            return parsed or None
+        if stripped.startswith("{"):
+            raise ValueError(
+                "diagnostics_fields must decode to a list, got a JSON object"
+            )
+        parsed = [p.strip() for p in stripped.split(",") if p.strip()]
+        return parsed or None
+    raise ValueError(
+        f"diagnostics_fields must be list, string, or None; got {type(value).__name__}"
+    )
+
+
+async def fetch_integration_diagnostics(
+    client: Any,
+    config_entry_id: str | None,
+    device_id: str | None = None,
+    *,
+    timeout_seconds: float = DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS,
+    fields: list[str] | None = None,
+    truncate_at_bytes: int | None = None,
+    data_path: str | None = None,
+    data_offset: int = 0,
+    data_limit: int | None = None,
+) -> dict[str, Any]:
+    """Get the integration diagnostics dump from HA's diagnostics REST endpoint.
+
+    Hits ``GET /api/diagnostics/config_entry/{entry_id}`` (or the device-scoped
+    variant when ``device_id`` is set). Requires a valid admin-scope token —
+    401 surfaces as invalid/expired token, 403 as insufficient scope. Same
+    artifact users grab via Settings → Devices & Services → [integration] → ⋯
+    → Download diagnostics.
+
+    Returns an embeddable sub-dict so callers can attach it to a larger response
+    without raising on diagnostics-specific failures (matches the
+    ``_fetch_repairs`` / ``_fetch_zha_network`` convention in
+    ``tools_system.py``). The ``DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS`` default
+    covers slow integrations like ZHA on large networks.
+
+    Args:
+        client: REST client exposing an async ``_request(method, endpoint,
+            *, timeout)`` method that returns the decoded JSON body.
+        config_entry_id: Config-entry id of the integration. Required;
+            ``None`` / empty string short-circuits with a structured error
+            sub-dict and no backend call.
+        device_id: Optional device id under the entry. When set, switches
+            the endpoint to the device-scoped variant.
+        timeout_seconds: Per-request timeout (default
+            ``DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS`` = 60.0s). ZHA dumps on
+            large networks can run 30-60s, so the default is generous.
+        fields: Optional list of top-level keys to keep from the integration's
+            ``data`` payload (e.g. ``["home_assistant", "issues"]`` for Hue).
+            Trims the payload before it hits the LLM context budget. Unknown
+            keys are silently dropped; an ``omitted_fields`` list surfaces
+            which requested keys weren't present. Only applies when ``data``
+            is a dict. Applied before ``data_path``.
+        truncate_at_bytes: Optional byte cap on the serialized resolved value
+            (the post-``fields``/``data_path`` payload, or its paginated
+            ``items`` when pagination applies). On hit, drops ``data`` /
+            ``items`` and emits ``truncated: True``, ``bytes_total: <actual>``,
+            ``byte_cap: <cap>``, plus ``available_fields: <top-level keys>``
+            (when the capped value is a dict) so the model knows which
+            ``fields`` or sub-path to request on the next call. Applied last.
+        data_path: Optional dotted path into ``data`` to walk into a sub-tree
+            (e.g. ``"data.devices"``, ``"home_assistant.version"``). Resolution
+            failures (missing key, non-traversable value) replace ``data`` with
+            ``null`` and add ``data_path_error`` to the result. When the
+            resolved value is a list and ``data_limit`` is set, pagination
+            applies — see ``data_limit``. Applied after ``fields``.
+        data_offset: Pagination start index for list-valued ``data_path``
+            results (default ``0``). Ignored when ``data_path`` is unset or
+            ``data_limit`` is unset, or the resolved value is not a list.
+        data_limit: Pagination window size for list-valued ``data_path``
+            results. When set with a list-resolved path, swaps ``data`` for
+            a pagination envelope ``{"path", "items", "offset", "limit",
+            "total", "has_more"}``. Default ``None`` (return the full
+            resolved value).
+    """
+    result: dict[str, Any] = {"config_entry_id": config_entry_id}
+    if device_id:
+        result["device_id"] = device_id
+
+    if not config_entry_id:
+        result["error"] = (
+            "config_entry_id is required for diagnostics fetch. "
+            "Use ha_get_integration() to find the config_entry_id for the "
+            "integration."
+        )
+        return result
+
+    endpoint = f"/diagnostics/config_entry/{config_entry_id}"
+    if device_id:
+        endpoint += f"/device/{device_id}"
+
+    try:
+        result["data"] = await client._request("GET", endpoint, timeout=timeout_seconds)
+    except HomeAssistantAuthError as e:
+        logger.warning("Diagnostics fetch auth error: %s", e)
+        result["error"] = (
+            "Authentication failed for diagnostics endpoint (HTTP 401): the "
+            "configured access token is invalid or expired. Generate a new "
+            "long-lived access token from the HA user profile page."
+        )
+    except HomeAssistantAPIError as e:
+        status = getattr(e, "status_code", None)
+        if status == 404:
+            scope = "device" if device_id else "config entry"
+            result["error"] = (
+                f"Diagnostics not available for this {scope}: integration may "
+                "not implement the diagnostics platform, or the id is invalid. "
+                "Verify via ha_get_integration()."
+            )
+            logger.debug("Diagnostics not available (404): %s", e)
+        elif status == 403:
+            result["error"] = (
+                "Diagnostics endpoint refused the request: admin scope required "
+                "(HA's @http.require_admin gate)."
+            )
+            logger.warning("Diagnostics fetch refused (403): %s", e)
+        else:
+            result["error"] = f"Diagnostics fetch failed (HTTP {status or '<status>'}): {e}"
+            logger.warning("Diagnostics fetch API error: %s", e)
+    except HomeAssistantConnectionError as e:
+        msg = str(e)
+        if "timeout" in msg.lower():
+            result["error"] = (
+                f"Diagnostics fetch timed out after {timeout_seconds:.1f}s "
+                "(ZHA dumps on large networks can exceed this; the integration "
+                "may be too slow to return diagnostics on this network)"
+            )
+        else:
+            result["error"] = f"Diagnostics fetch connection failed: {e}"
+        logger.warning("Diagnostics fetch connection error: %s", e)
+    except Exception as e:  # pragma: no cover - defensive last-resort guard
+        logger.warning(
+            "Diagnostics fetch unexpected error: %s: %s", type(e).__name__, e
+        )
+        result["error"] = f"Diagnostics fetch failed: {e}"
+
+    if "data" in result and result["data"] is None and "error" not in result:
+        # Empty response body — distinct from an explicit error or a
+        # cap-driven drop. Surface it as an error so callers don't confuse
+        # ``{"data": null}`` with a successful zero-payload fetch.
+        result["error"] = "Diagnostics endpoint returned an empty body"
+        del result["data"]
+
+    if "data" in result:
+        _project_cap_and_paginate_diagnostics(
+            result, fields, truncate_at_bytes, data_path, data_offset, data_limit
+        )
+
+    return result
+
+
+def _project_cap_and_paginate_diagnostics(
+    result: dict[str, Any],
+    fields: list[str] | None,
+    truncate_at_bytes: int | None,
+    data_path: str | None,
+    data_offset: int,
+    data_limit: int | None,
+) -> None:
+    """Apply field projection, data_path walk, optional pagination, then byte
+    cap. Mutates ``result`` (adds keys, may replace or delete
+    ``result["data"]``). When pagination produced an envelope and the cap
+    fires, the envelope's metadata (``path``, ``offset``, ``limit``,
+    ``total``, ``has_more``) is preserved sans ``items`` so the caller can
+    issue a narrower follow-up; the unpaginated case drops ``data`` entirely.
+
+    See ``fetch_integration_diagnostics`` for the public contract.
+    """
+    data = result.get("data")
+
+    if fields and isinstance(data, dict):
+        kept = {k: data[k] for k in fields if k in data}
+        # Dedup caller-supplied duplicates while preserving order.
+        omitted = list(dict.fromkeys(k for k in fields if k not in data))
+        result["data"] = kept
+        if omitted:
+            result["omitted_fields"] = omitted
+        data = kept
+
+    # Whitespace-only (or empty) paths normalize to "unset"; surface a warning
+    # so callers can tell their intent was swallowed instead of resolving
+    # silently. The earlier whitespace branch nulls ``data_path``, so the
+    # ``elif data_offset > 0`` branch below is guarded against clobbering
+    # this warning when both inputs land together.
+    if data_path is not None and not data_path.strip():
+        result["data_pagination_warning"] = (
+            "data_path ignored: value was empty or whitespace-only"
+        )
+        data_path = None
+
+    paginated = False
+    if data_path:
+        resolved, path_error = _resolve_data_path(data, data_path)
+        if path_error is not None:
+            result["data"] = None
+            result["data_path_error"] = path_error
+            data = None
+        else:
+            result["data_path"] = data_path
+            if isinstance(resolved, list) and data_limit is not None:
+                total = len(resolved)
+                start = max(0, data_offset)
+                end = start + data_limit
+                items = resolved[start:end]
+                page: dict[str, Any] = {
+                    "path": data_path,
+                    "items": items,
+                    "offset": start,
+                    "limit": data_limit,
+                    "total": total,
+                    "has_more": end < total,
+                }
+                result["data"] = page
+                data = items
+                paginated = True
+            else:
+                # Pagination intent has nowhere to apply: either ``data_limit``
+                # is set but the resolved value isn't a list, or ``data_offset``
+                # is set without ``data_limit`` (no window to slice). Surface
+                # a structured warning rather than silently dropping the kwarg.
+                if data_limit is not None:
+                    type_name = (
+                        "null" if resolved is None else type(resolved).__name__
+                    )
+                    result["data_pagination_warning"] = (
+                        f"data_limit ignored: resolved value at '{data_path}' "
+                        f"is {type_name}, not a list"
+                    )
+                elif data_offset > 0:
+                    result["data_pagination_warning"] = (
+                        "data_offset ignored: data_limit not set "
+                        "(no pagination window to slice)"
+                    )
+                result["data"] = resolved
+                data = resolved
+    elif data_offset > 0 and "data_pagination_warning" not in result:
+        # ``data_offset`` set without ``data_path`` — the resolver branch is
+        # skipped entirely, so the offset has no effect on the response.
+        # Mirrors the orphan-warning gates at the tool layer. Guarded so the
+        # whitespace-path warning above isn't clobbered when both inputs
+        # land together (the whitespace input nulled ``data_path``, dropping
+        # us into this elif; the earlier warning takes precedence).
+        result["data_pagination_warning"] = (
+            "data_offset ignored: data_path not set "
+            "(no resolved sub-tree to paginate)"
+        )
+
+    if truncate_at_bytes is not None and data is not None:
+        try:
+            serialized = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            # Non-serialisable payload (shouldn't happen for HA diagnostics, but
+            # don't suppress the data on a serializer hiccup).
+            return
+        bytes_total = len(serialized.encode("utf-8"))
+        if bytes_total > truncate_at_bytes:
+            result["truncated"] = True
+            result["bytes_total"] = bytes_total
+            result["byte_cap"] = truncate_at_bytes
+            if paginated:
+                # ``paginated=True`` is only set on the branch that writes a
+                # dict envelope to ``result["data"]`` — preserve the metadata
+                # (path / offset / limit / total / has_more) so the caller can
+                # shrink the window in the next call. Only ``items`` is dropped.
+                envelope = result["data"]
+                preserved = {k: v for k, v in envelope.items() if k != "items"}
+                preserved["truncated"] = True
+                result["data"] = preserved
+            else:
+                if isinstance(data, dict):
+                    result["available_fields"] = sorted(data.keys())
+                del result["data"]
+
+
+def _resolve_data_path(
+    data: Any, path: str
+) -> tuple[Any, str | None]:
+    """Walk ``data`` along the dotted ``path`` and return ``(value, error)``.
+
+    Returns ``(value, None)`` on success or ``(None, error_message)`` when
+    a segment can't be resolved (missing key, descent into non-dict / null,
+    empty path). List indices are not supported: address a list-valued
+    sub-tree by name and let the caller's pagination kwargs (``data_offset``
+    / ``data_limit``) slice it. Index-segment support is a candidate
+    follow-up.
+
+    Limitation: dotted keys (e.g. ``sensor.zha_temp_42``, MQTT-style topics
+    containing a literal ``.``) are not addressable — the path is split on
+    ``.`` without escape support. Workaround: omit ``data_path`` and walk
+    the returned payload in the caller. Escape syntax is a candidate
+    follow-up.
+    """
+    if not path or not path.strip():
+        return None, "data_path must be a non-empty dotted path"
+    segments = path.split(".")
+    current: Any = data
+    walked: list[str] = []
+    for seg in segments:
+        if not seg:
+            return None, (
+                f"data_path '{path}' has an empty segment "
+                f"(after '{'.'.join(walked)}')"
+            )
+        if current is None:
+            return None, (
+                f"data_path '{path}' resolved to null at "
+                f"'{'.'.join(walked) or '<root>'}' — "
+                "sub-tree not present in this payload"
+            )
+        if not isinstance(current, dict):
+            return None, (
+                f"data_path '{path}' cannot descend into "
+                f"{type(current).__name__} at '{'.'.join(walked) or '<root>'}'"
+            )
+        if seg not in current:
+            available = sorted(current.keys()) if isinstance(current, dict) else []
+            # Only mention the dotted-key limitation when the available keys
+            # at this level actually contain one — a plain typo (e.g.
+            # ``data.versionz``) shouldn't be told its ``.`` is being
+            # mis-parsed as a separator when no sibling key has a ``.`` in it.
+            ambiguous = any(isinstance(k, str) and "." in k for k in available)
+            if ambiguous:
+                hint = (
+                    "; note: a sibling key here contains a literal '.' which "
+                    "is not addressable via data_path — omit data_path and "
+                    "walk the returned payload in the caller"
+                )
+            else:
+                hint = ""
+            return None, (
+                f"data_path '{path}' missing key '{seg}' at "
+                f"'{'.'.join(walked) or '<root>'}' "
+                f"(available: {available}{hint})"
+            )
+        current = current[seg]
+        walked.append(seg)
+    return current, None

--- a/tests/src/e2e/workflows/integrations/test_list_integrations.py
+++ b/tests/src/e2e/workflows/integrations/test_list_integrations.py
@@ -13,7 +13,7 @@ from typing import ClassVar
 
 import pytest
 
-from ...utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.assertions import assert_mcp_success, parse_mcp_result, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -600,3 +600,89 @@ class TestGetIntegrationNegativeInputs:
         assert "not found" in error_msg, (
             f"Expected 'not found' in error message, got: {data['error']}"
         )
+
+
+class TestGetIntegrationDiagnostics:
+    """E2E coverage for include_diagnostics=True on ha_get_integration."""
+
+    @pytest.mark.asyncio
+    async def test_include_diagnostics_returns_subdict_with_entry_id(
+        self, mcp_client
+    ):
+        """include_diagnostics=True attaches a `diagnostics` sub-dict that always
+        carries `config_entry_id`. Whether it also carries `data` (helper happy
+        path) or `error` (404 from integrations without a diagnostics platform —
+        typical in CI's bare HA container) depends on the loaded integrations.
+        """
+        logger.info("Locating a config entry to probe diagnostics on...")
+        list_result = await mcp_client.call_tool("ha_get_integration", {})
+        list_data = parse_mcp_result(list_result)
+        assert list_data.get("success"), f"List failed: {list_data}"
+        entries = list_data.get("entries") or list_data.get("results") or []
+        if not entries:
+            pytest.skip("No config entries loaded in test container")
+        entry = entries[0]
+        entry_id = entry.get("entry_id")
+        entry_domain = entry.get("domain")
+        entry_title = entry.get("title")
+        assert entry_id, f"First entry has no entry_id: {entry}"
+
+        logger.info(
+            "Probing diagnostics for entry_id=%s domain=%s title=%s",
+            entry_id,
+            entry_domain,
+            entry_title,
+        )
+        result = await mcp_client.call_tool(
+            "ha_get_integration",
+            {"entry_id": entry_id, "include_diagnostics": True},
+        )
+        data = parse_mcp_result(result)
+        assert "diagnostics" in data, (
+            f"Expected 'diagnostics' key when include_diagnostics=True. Got: {list(data.keys())}"
+        )
+        diag = data["diagnostics"]
+        assert diag.get("config_entry_id") == entry_id, (
+            f"Diagnostics sub-dict should echo entry_id. Got: {diag}"
+        )
+        # Either success (`data` populated) OR a graceful error string — never both
+        has_data = "data" in diag
+        has_error = "error" in diag
+        assert has_data ^ has_error, (
+            f"Diagnostics sub-dict should have exactly one of 'data' or 'error'. Got: {diag}"
+        )
+        if has_error:
+            logger.info(
+                "Diagnostics 404 path exercised for domain=%s: %s",
+                entry_domain,
+                diag["error"],
+            )
+        else:
+            logger.info(
+                "Diagnostics happy path exercised for domain=%s", entry_domain
+            )
+
+    @pytest.mark.asyncio
+    async def test_device_id_without_include_surfaces_warning(self, mcp_client):
+        """device_id without include_diagnostics=True is ignored with a warning."""
+        list_result = await mcp_client.call_tool("ha_get_integration", {})
+        list_data = parse_mcp_result(list_result)
+        entries = list_data.get("entries") or list_data.get("results") or []
+        if not entries:
+            pytest.skip("No config entries loaded in test container")
+        entry_id = entries[0].get("entry_id")
+
+        result = await mcp_client.call_tool(
+            "ha_get_integration",
+            {
+                "entry_id": entry_id,
+                "include_diagnostics": False,
+                "device_id": "spurious_device_id",
+            },
+        )
+        data = parse_mcp_result(result)
+        assert "diagnostics" not in data
+        warnings = data.get("warnings") or []
+        assert any(
+            "device_id" in w and "ignored" in w for w in warnings
+        ), f"Expected ignored-device_id warning. Got warnings: {warnings}"

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -582,10 +582,12 @@ class TestSystemTools:
             else:
                 pytest.fail(f"Get system health with unknown include failed: {error_msg}")
 
-        assert "warning" in data, "Unknown include value should produce a warning"
-        assert "bogus_section" in data["warning"], "Warning should mention the unknown section"
+        assert "warnings" in data, "Unknown include value should produce a warnings entry"
+        assert any(
+            "bogus_section" in w for w in data["warnings"]
+        ), "Warnings should mention the unknown section"
 
-        logger.info(f"Unknown include warning: {data['warning']}")
+        logger.info(f"Unknown include warnings: {data['warnings']}")
 
 
 @pytest.mark.system
@@ -753,3 +755,67 @@ class TestSystemToolsIntegration:
             assert not_found, "Test notification should be dismissed"
 
         logger.info("Notification lifecycle test completed successfully")
+
+
+class TestGetSystemHealthDiagnosticsE2E:
+    """E2E coverage for include='diagnostics' on ha_get_system_health."""
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_without_config_entry_id_returns_error_subdict(
+        self, mcp_client
+    ):
+        """include='diagnostics' without config_entry_id returns an error inside
+        result['diagnostics'] — the outer call still succeeds (matches the
+        repairs/zha_network embed pattern)."""
+        logger.info("Testing include='diagnostics' without config_entry_id...")
+
+        result = await mcp_client.call_tool(
+            "ha_get_system_health", {"include": "diagnostics"}
+        )
+        data = parse_mcp_result(result)
+        if not data.get("success"):
+            error_msg = str(data.get("error", ""))
+            if "not available" in error_msg.lower():
+                pytest.skip("system_health not available in test environment")
+            else:
+                pytest.fail(f"Outer call should succeed; got: {error_msg}")
+        assert "diagnostics" in data, "Missing 'diagnostics' sub-dict"
+        diag = data["diagnostics"]
+        assert "error" in diag, f"Expected error in diagnostics sub-dict, got: {diag}"
+        assert "config_entry_id" in diag["error"]
+        assert "ha_get_integration" in diag["error"]
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_with_config_entry_id_returns_subdict(
+        self, mcp_client
+    ):
+        """include='diagnostics' + a real config_entry_id returns either a
+        populated data payload or a graceful 404 error — same contract as the
+        helper test."""
+        logger.info("Locating a config entry to probe diagnostics on...")
+        list_result = await mcp_client.call_tool("ha_get_integration", {})
+        list_data = parse_mcp_result(list_result)
+        entries = list_data.get("entries") or list_data.get("results") or []
+        if not entries:
+            pytest.skip("No config entries loaded in test container")
+        entry_id = entries[0].get("entry_id")
+
+        result = await mcp_client.call_tool(
+            "ha_get_system_health",
+            {"include": "diagnostics", "config_entry_id": entry_id},
+        )
+        data = parse_mcp_result(result)
+        if not data.get("success"):
+            error_msg = str(data.get("error", ""))
+            if "not available" in error_msg.lower():
+                pytest.skip("system_health not available in test environment")
+            else:
+                pytest.fail(f"Outer call should succeed; got: {error_msg}")
+        assert "diagnostics" in data
+        diag = data["diagnostics"]
+        assert diag.get("config_entry_id") == entry_id
+        has_data = "data" in diag
+        has_error = "error" in diag
+        assert has_data ^ has_error, (
+            f"Diagnostics sub-dict should have exactly one of 'data' or 'error'. Got: {diag}"
+        )

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -820,3 +820,282 @@ class TestDeleteHelpersIntegrations:
         assert "sensor.energy_offpeak" in result["warning"]
         assert "sensor.energy_peak" not in result["warning"]
         assert mock_wait.await_count == 2
+
+
+class TestGetIntegrationDiagnostics:
+    """Wire-up tests for ha_get_integration's include_diagnostics/device_id branch."""
+
+    @pytest.mark.asyncio
+    async def test_include_diagnostics_attaches_helper_result(self) -> None:
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        diag_payload = {
+            "config_entry_id": "entry_abc",
+            "data": {"home_assistant": {"version": "2026.5.0"}},
+        }
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(return_value=diag_payload),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                entry_id="entry_abc", include_diagnostics=True
+            )
+        assert result["diagnostics"] == diag_payload
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=None,
+            truncate_at_bytes=None,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_device_id_forwarded_to_helper(self) -> None:
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=True,
+                device_id="dev_xyz",
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            "dev_xyz",
+            fields=None,
+            truncate_at_bytes=None,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_id_without_include_surfaces_warning(self) -> None:
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=False,
+                device_id="dev_xyz",
+            )
+        mock_fetch.assert_not_awaited()
+        assert "diagnostics" not in result
+        assert "warnings" in result
+        assert any(
+            "device_id" in w and "ignored" in w for w in result["warnings"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_include_diagnostics_false_omits_call(self) -> None:
+        """The diagnostics helper must not run when the flag is off."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                entry_id="entry_abc", include_diagnostics=False
+            )
+        mock_fetch.assert_not_awaited()
+        assert "diagnostics" not in result
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_mode_with_diagnostics_args_surfaces_warning(self) -> None:
+        """include_diagnostics or device_id without entry_id (list mode) surfaces a warning."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        list_payload = {"entries": [], "count": 0}
+        with patch.object(
+            IntegrationTools,
+            "_list_entries",
+            new=AsyncMock(return_value=list_payload),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                include_diagnostics=True, device_id="dev_xyz"
+            )
+        mock_fetch.assert_not_awaited()
+        assert "warnings" in result
+        assert any(
+            "entry_id was not set" in w for w in result["warnings"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_fields_and_truncate_forwarded(self) -> None:
+        """Tool surfaces ``diagnostics_fields`` + ``diagnostics_truncate_at_bytes``."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=True,
+                diagnostics_fields='["home_assistant", "issues"]',
+                diagnostics_truncate_at_bytes=15000,
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=["home_assistant", "issues"],
+            truncate_at_bytes=15000,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_data_path_and_pagination_forwarded(self) -> None:
+        """Tool surfaces ``diagnostics_data_path`` + offset/limit on the
+        single-entry path."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_get_single_entry",
+            new=AsyncMock(return_value={"success": True, "entry_id": "entry_abc"}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=True,
+                diagnostics_data_path="data.devices",
+                diagnostics_data_offset="5",
+                diagnostics_data_limit="10",
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=None,
+            truncate_at_bytes=None,
+            data_path="data.devices",
+            data_offset=5,
+            data_limit=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_mode_warns_on_data_path_too(self) -> None:
+        """``diagnostics_data_path`` / ``diagnostics_data_limit`` in list mode
+        are also caught by the orphan-args parity warning."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_list_entries",
+            new=AsyncMock(return_value={"entries": [], "count": 0}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                diagnostics_data_path="data.devices",
+                diagnostics_data_limit=10,
+            )
+        mock_fetch.assert_not_awaited()
+        assert any(
+            "diagnostics_data_path" in w for w in result.get("warnings", [])
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_mode_warns_on_diagnostics_fields_too(self) -> None:
+        """Passing ``diagnostics_fields`` in list mode is also ignored, with warning."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_list_entries",
+            new=AsyncMock(return_value={"entries": [], "count": 0}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                diagnostics_fields=["home_assistant"],
+            )
+        mock_fetch.assert_not_awaited()
+        assert any(
+            "diagnostics_fields" in w for w in result.get("warnings", [])
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_mode_warns_on_data_offset_alone(self) -> None:
+        """Pure ``diagnostics_data_offset > 0`` (no other diagnostics args)
+        in list mode triggers the orphan-args warning — guards the
+        ``data_offset_int > 0`` term in the predicate. A regression that
+        drops the term would silently swallow the orphan offset."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with patch.object(
+            IntegrationTools,
+            "_list_entries",
+            new=AsyncMock(return_value={"entries": [], "count": 0}),
+        ), patch(
+            "ha_mcp.tools.tools_integrations.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_integration(
+                diagnostics_data_offset=5,
+            )
+        mock_fetch.assert_not_awaited()
+        assert any(
+            "diagnostics_data_offset" in w for w in result.get("warnings", [])
+        )
+
+    @pytest.mark.asyncio
+    async def test_data_path_non_string_rejected_with_validation_error(self) -> None:
+        """Non-string ``diagnostics_data_path`` (dict / list / int) surfaces
+        as ``VALIDATION_INVALID_PARAMETER`` instead of leaking ``INTERNAL_ERROR``
+        from the resolver's ``.strip()`` call downstream. Pins the
+        ``isinstance(str)`` type-guard."""
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=True,
+                diagnostics_data_path={"not": "a string"},  # type: ignore[arg-type]
+            )
+        err_payload = json.loads(str(excinfo.value))
+        assert err_payload["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "diagnostics_data_path" in err_payload["error"]["message"]

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -5,6 +5,7 @@ ha_restart reports failure when a reverse proxy returns 504 during restart.
 """
 
 import asyncio
+import json
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -436,3 +437,270 @@ class TestGetSystemHealthGather:
         mock_repairs.assert_not_awaited()
         mock_zha.assert_not_awaited()
         mock_zwave.assert_not_awaited()
+
+
+class TestGetSystemHealthDiagnostics:
+    """Wire-up tests for ha_get_system_health's include='diagnostics' branch."""
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_without_config_entry_id_returns_error_subdict(self):
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health(include="diagnostics")
+        assert "diagnostics" in result
+        assert "error" in result["diagnostics"]
+        assert "config_entry_id is required" in result["diagnostics"]["error"]
+        assert "ha_get_integration" in result["diagnostics"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_with_config_entry_id_calls_helper(self):
+        client = MagicMock()
+        tools = SystemTools(client)
+        diag_payload = {
+            "config_entry_id": "entry_abc",
+            "data": {"home_assistant": {"version": "2026.5.0"}},
+        }
+        with _patch_health_info_baseline(), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(return_value=diag_payload),
+        ) as mock_fetch:
+            result = await tools.ha_get_system_health(
+                include="diagnostics", config_entry_id="entry_abc"
+            )
+        assert result["diagnostics"] == diag_payload
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=None,
+            truncate_at_bytes=None,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_with_device_id_forwarded_to_helper(self):
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_system_health(
+                include="diagnostics",
+                config_entry_id="entry_abc",
+                device_id="dev_xyz",
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            "dev_xyz",
+            fields=None,
+            truncate_at_bytes=None,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_combined_with_repairs(self):
+        """include='repairs,diagnostics' should populate both sections."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock(return_value={"issues": [], "count": 0})
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {"x": 1}}),
+        ) as mock_diag:
+            result = await tools.ha_get_system_health(
+                include="repairs,diagnostics", config_entry_id="entry_abc"
+            )
+        assert "repairs" in result
+        assert "diagnostics" in result
+        assert result["diagnostics"]["data"] == {"x": 1}
+        # Both branches actually fired — guards against a silent no-op
+        # in either fetch.
+        mock_repairs.assert_awaited_once()
+        mock_diag.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_fields_and_truncate_forwarded_to_helper(self):
+        """Tool surfaces ``diagnostics_fields`` + ``diagnostics_truncate_at_bytes``."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_system_health(
+                include="diagnostics",
+                config_entry_id="entry_abc",
+                diagnostics_fields="home_assistant, issues",
+                diagnostics_truncate_at_bytes="20000",
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=["home_assistant", "issues"],
+            truncate_at_bytes=20000,
+            data_path=None,
+            data_offset=0,
+            data_limit=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_data_path_and_pagination_forwarded_to_helper(self):
+        """Tool surfaces ``diagnostics_data_path`` + offset/limit through to
+        the helper."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(return_value={"data": {}}),
+        ) as mock_fetch:
+            await tools.ha_get_system_health(
+                include="diagnostics",
+                config_entry_id="entry_abc",
+                diagnostics_data_path="data.devices",
+                diagnostics_data_offset="10",
+                diagnostics_data_limit="5",
+            )
+        mock_fetch.assert_awaited_once_with(
+            client,
+            "entry_abc",
+            None,
+            fields=None,
+            truncate_at_bytes=None,
+            data_path="data.devices",
+            data_offset=10,
+            data_limit=5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_config_entry_id_forwarded_as_none_not_empty_string(
+        self,
+    ):
+        """``include=diagnostics`` without ``config_entry_id`` forwards ``None``
+        to the helper (not ``""``) so the echo field reflects the actual input
+        rather than a coerced placeholder."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(
+                return_value={
+                    "config_entry_id": None,
+                    "error": "config_entry_id is required for diagnostics fetch.",
+                }
+            ),
+        ) as mock_fetch:
+            result = await tools.ha_get_system_health(include="diagnostics")
+        # Positional config_entry_id is None, not "".
+        assert mock_fetch.await_args.args[1] is None
+        assert result["diagnostics"]["config_entry_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_omitted_from_include_skips_helper(self):
+        """include='repairs' (no diagnostics) must not invoke the diagnostics helper."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools,
+            "_fetch_repairs",
+            new=AsyncMock(return_value={"issues": [], "count": 0}),
+        ), patch(
+            "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await tools.ha_get_system_health(
+                include="repairs", config_entry_id="entry_abc"
+            )
+        mock_fetch.assert_not_awaited()
+        assert "diagnostics" not in result
+
+    @pytest.mark.asyncio
+    async def test_orphaned_ids_surface_parity_warning(self):
+        """config_entry_id/device_id without 'diagnostics' in include surface a
+        warnings entry (parity with ha_get_integration's `include_diagnostics=False
+        + device_id` warning)."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools,
+            "_fetch_repairs",
+            new=AsyncMock(return_value={"issues": [], "count": 0}),
+        ):
+            result = await tools.ha_get_system_health(
+                include="repairs",
+                config_entry_id="entry_abc",
+                device_id="dev_xyz",
+            )
+        assert "warnings" in result
+        assert any(
+            "config_entry_id" in w or "device_id" in w
+            for w in result["warnings"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_orphaned_data_offset_alone_surfaces_warning(self):
+        """Pure ``diagnostics_data_offset > 0`` (no other diagnostics args)
+        without 'diagnostics' in include triggers the orphan-args warning —
+        guards the ``data_offset_int > 0`` term in the predicate."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools,
+            "_fetch_repairs",
+            new=AsyncMock(return_value={"issues": [], "count": 0}),
+        ):
+            result = await tools.ha_get_system_health(
+                include="repairs",
+                diagnostics_data_offset=5,
+            )
+        assert "warnings" in result
+        assert any(
+            "diagnostics_data_offset" in w for w in result["warnings"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_data_path_non_string_rejected_with_validation_error(self):
+        """Non-string ``diagnostics_data_path`` (dict / list / int) surfaces
+        as ``VALIDATION_INVALID_PARAMETER`` instead of leaking ``INTERNAL_ERROR``
+        from the resolver's ``.strip()`` call downstream. Pins the
+        ``isinstance(str)`` type-guard at the ``ha_get_system_health`` layer."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_system_health(
+                include="diagnostics",
+                config_entry_id="entry_abc",
+                diagnostics_data_path={"not": "a string"},  # type: ignore[arg-type]
+            )
+        err_payload = json.loads(str(excinfo.value))
+        assert err_payload["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "diagnostics_data_path" in err_payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_data_limit_zero_rejected_with_validation_error(self):
+        """``diagnostics_data_limit=0`` violates the ``min_value=1`` guard on
+        the coerce_int_param call — surfaces as a structured validation
+        error rather than slipping through as a no-op pagination window.
+        Coercion was moved outside the includes branch deliberately (see
+        ``tools_system.py`` comment); a regression putting it back would
+        skip validation for no-include callers."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with _patch_health_info_baseline(), pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_system_health(
+                include="diagnostics",
+                config_entry_id="entry_abc",
+                diagnostics_data_limit=0,
+            )
+        msg = str(excinfo.value)
+        assert "diagnostics_data_limit" in msg
+        assert "min" in msg.lower() or "must be" in msg.lower()

--- a/tests/src/unit/test_util_helpers.py
+++ b/tests/src/unit/test_util_helpers.py
@@ -4,12 +4,21 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ha_mcp.tools.util_helpers import (
+    DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS,
+    _resolve_data_path,
     build_pagination_metadata,
     coerce_int_param,
+    fetch_integration_diagnostics,
     filter_active_repairs,
     get_logger_levels,
     normalize_log_level,
+    parse_diagnostics_fields,
     parse_json_param,
     parse_string_list_param,
     project_repair_fields,
@@ -451,3 +460,804 @@ class TestProjectRepairFields:
         """Only project fields that exist on the source dict."""
         out = project_repair_fields({"issue_id": "x", "domain": "demo"})
         assert out == {"issue_id": "x", "domain": "demo"}
+
+
+class TestFetchIntegrationDiagnostics:
+    """Test fetch_integration_diagnostics helper — wraps /api/diagnostics/config_entry/* REST call."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_config_entry_only(self):
+        """Successful fetch returns config_entry_id + data, no error."""
+        client = MagicMock()
+        payload = {"home_assistant": {"version": "2026.5.0"}, "data": {"some": "blob"}}
+        client._request = AsyncMock(return_value=payload)
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert result == {"config_entry_id": "entry_abc", "data": payload}
+        client._request.assert_awaited_once()
+        call = client._request.await_args
+        assert call.args == ("GET", "/diagnostics/config_entry/entry_abc")
+        assert call.kwargs["timeout"] == DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_happy_path_with_device_id(self):
+        """device_id extends endpoint and is echoed in the response."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"data": {}})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", device_id="dev_xyz"
+        )
+        assert result["config_entry_id"] == "entry_abc"
+        assert result["device_id"] == "dev_xyz"
+        assert "error" not in result
+        endpoint_arg = client._request.await_args.args[1]
+        assert endpoint_arg == "/diagnostics/config_entry/entry_abc/device/dev_xyz"
+
+    @pytest.mark.asyncio
+    async def test_custom_timeout_propagates(self):
+        client = MagicMock()
+        client._request = AsyncMock(return_value={})
+        await fetch_integration_diagnostics(
+            client, "entry_abc", timeout_seconds=10.0
+        )
+        assert client._request.await_args.kwargs["timeout"] == 10.0
+
+    @pytest.mark.asyncio
+    async def test_empty_config_entry_id_short_circuits(self):
+        client = MagicMock()
+        client._request = AsyncMock()
+        result = await fetch_integration_diagnostics(client, "")
+        assert result["config_entry_id"] == ""
+        assert "config_entry_id is required" in result["error"]
+        assert "ha_get_integration" in result["error"]
+        client._request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_none_config_entry_id_echoes_none_in_response(self):
+        """None propagates as None in the echo field — not normalised to ''.
+
+        Tool-layer callers pass through whatever the user supplied so the
+        sub-dict reflects the actual input. Coercing to "" would mask the
+        difference between "user didn't supply an id" (None) and "user
+        supplied the empty string" — both error states, but distinguishable.
+        """
+        client = MagicMock()
+        client._request = AsyncMock()
+        result = await fetch_integration_diagnostics(client, None)
+        assert result["config_entry_id"] is None
+        assert "config_entry_id is required" in result["error"]
+        client._request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_404_maps_to_unavailable_error(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not Found", status_code=404
+            )
+        )
+        result = await fetch_integration_diagnostics(client, "missing_entry")
+        assert result["config_entry_id"] == "missing_entry"
+        assert "Diagnostics not available" in result["error"]
+        assert "config entry" in result["error"]
+        assert "ha_get_integration" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_404_device_scope_mentions_device_in_error(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not Found", status_code=404
+            )
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", device_id="dev_xyz"
+        )
+        assert "device" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_403_maps_to_admin_required(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 403 - Forbidden", status_code=403
+            )
+        )
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "admin scope required" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_auth_error_maps_to_token_validity_message(self):
+        """401 = stale/invalid token, NOT admin scope.
+
+        ``HomeAssistantAuthError`` only fires on HTTP 401 per
+        ``rest_client.py``. The @require_admin gate rejects with 403, which
+        is handled by ``HomeAssistantAPIError``. The 401 message must steer
+        operators toward token validity, not admin scope.
+        """
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAuthError("Invalid authentication token")
+        )
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "HTTP 401" in result["error"]
+        assert "invalid or expired" in result["error"]
+        assert "long-lived access token" in result["error"]
+        # The admin-scope hint belongs on the 403 branch only.
+        assert "admin scope" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_maps_to_timeout_message_with_duration(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantConnectionError("Request timeout: read")
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", timeout_seconds=45.0
+        )
+        assert "timed out after 45.0s" in result["error"]
+        assert "ZHA" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_other_connection_error_distinct_from_timeout(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantConnectionError("HTTP error: connection refused")
+        )
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "connection failed" in result["error"]
+        assert "timed out" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_generic_5xx_falls_through_to_http_status_message(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 500 - Internal Server Error", status_code=500
+            )
+        )
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "HTTP 500" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_api_error_without_status_code_falls_back_to_placeholder(self):
+        """``HomeAssistantAPIError`` with ``status_code=None`` should not crash.
+
+        ``status_code`` is optional on the exception. The fallback branch must
+        emit a ``HTTP <status>`` placeholder so the response stays informative
+        even when the wrapper omits the numeric code.
+        """
+        client = MagicMock()
+        api_error = HomeAssistantAPIError("API error: unknown failure")
+        # Verify the fixture's premise — status_code unset / None falls into
+        # the generic branch, not the 404/403 specialised branches.
+        assert getattr(api_error, "status_code", None) is None
+        client._request = AsyncMock(side_effect=api_error)
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "HTTP <status>" in result["error"]
+        assert "API error: unknown failure" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_fields_projects_top_level_keys_when_data_is_dict(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={
+                "home_assistant": {"version": "2026.5.0"},
+                "custom_components": {"hacs": "1.0"},
+                "integration_manifest": {"domain": "hue"},
+                "issues": [],
+                "data": {"bridge": {"ip": "10.0.0.5"}},
+            }
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", fields=["home_assistant", "issues"]
+        )
+        assert set(result["data"].keys()) == {"home_assistant", "issues"}
+        assert result["data"]["home_assistant"] == {"version": "2026.5.0"}
+        assert "omitted_fields" not in result
+
+    @pytest.mark.asyncio
+    async def test_fields_unknown_keys_surface_via_omitted_fields(self):
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"home_assistant": {}, "issues": []})
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["home_assistant", "made_up_key", "another_missing"],
+        )
+        assert set(result["data"].keys()) == {"home_assistant"}
+        assert result["omitted_fields"] == ["made_up_key", "another_missing"]
+
+    @pytest.mark.asyncio
+    async def test_fields_noop_when_data_is_not_dict(self):
+        """A non-dict ``data`` (string/list payload) is left untouched by fields."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value=["a", "b", "c"])
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", fields=["unused"]
+        )
+        assert result["data"] == ["a", "b", "c"]
+        assert "omitted_fields" not in result
+
+    @pytest.mark.asyncio
+    async def test_truncate_at_bytes_emits_truncated_flag_when_payload_oversize(self):
+        client = MagicMock()
+        big_payload = {"home_assistant": {"version": "1"}, "blob": "x" * 5000}
+        client._request = AsyncMock(return_value=big_payload)
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", truncate_at_bytes=200
+        )
+        assert result["truncated"] is True
+        assert result["byte_cap"] == 200
+        assert result["bytes_total"] > 200
+        assert result["available_fields"] == ["blob", "home_assistant"]
+        assert "data" not in result
+
+    @pytest.mark.asyncio
+    async def test_truncate_at_bytes_no_op_when_payload_under_cap(self):
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"small": "ok"})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", truncate_at_bytes=10_000
+        )
+        assert result["data"] == {"small": "ok"}
+        assert "truncated" not in result
+        assert "bytes_total" not in result
+
+    @pytest.mark.asyncio
+    async def test_truncate_applied_after_fields_projection(self):
+        """``fields`` runs first so ``truncate_at_bytes`` measures the projected payload."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={
+                "small": "ok",
+                "big": "x" * 5000,
+            }
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["small"],
+            truncate_at_bytes=200,
+        )
+        assert "truncated" not in result
+        assert result["data"] == {"small": "ok"}
+
+    # --- Round-2 KP13 gap-tests --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_fields_all_missing_keeps_empty_dict_and_records_all_omitted(self):
+        """All requested fields absent → ``data`` is the empty dict and every
+        requested key appears in ``omitted_fields`` (no silent fall-through to
+        the full payload)."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"home_assistant": {}, "issues": []}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["foo", "bar", "baz"],
+        )
+        assert result["data"] == {}
+        assert result["omitted_fields"] == ["foo", "bar", "baz"]
+
+    @pytest.mark.asyncio
+    async def test_fields_dedupes_caller_supplied_duplicates_in_omitted_fields(self):
+        """``omitted_fields`` deduplicates caller-supplied repeats so the model
+        doesn't see ``["x", "x"]`` when it asked for ``fields=["x", "x"]``."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"present": 1})
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["missing", "missing", "present", "also_missing"],
+        )
+        assert result["omitted_fields"] == ["missing", "also_missing"]
+
+    @pytest.mark.asyncio
+    async def test_fields_no_op_on_error_response(self):
+        """When the fetch fails, ``fields`` must not project on a partial /
+        absent ``data`` — error responses ship without ``omitted_fields``."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not Found", status_code=404
+            )
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["home_assistant", "issues"],
+        )
+        assert "error" in result
+        assert "data" not in result
+        assert "omitted_fields" not in result
+
+    @pytest.mark.asyncio
+    async def test_truncate_on_non_dict_omits_available_fields(self):
+        """Truncation on a list/string payload skips ``available_fields``
+        (it's only meaningful for dict payloads). The truncated/bytes_total/
+        byte_cap signals still fire so the model knows the cap engaged."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value=["x" * 1000 for _ in range(50)])
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", truncate_at_bytes=200
+        )
+        assert result["truncated"] is True
+        assert result["byte_cap"] == 200
+        assert result["bytes_total"] > 200
+        assert "available_fields" not in result
+        assert "data" not in result
+
+    @pytest.mark.asyncio
+    async def test_empty_body_surfaces_explicit_error(self):
+        """``_request`` returning ``None`` (empty body) ships an explicit error
+        instead of ``{"data": null}``, which would be indistinguishable from a
+        zero-payload success."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value=None)
+        result = await fetch_integration_diagnostics(client, "entry_abc")
+        assert "empty body" in result["error"]
+        assert "data" not in result
+
+    # --- Round-2 KP13 pagination — data_path / data_offset / data_limit ----
+
+    @pytest.mark.asyncio
+    async def test_data_path_resolves_into_dict_sub_tree(self):
+        """``data_path`` replaces ``data`` with the resolved sub-tree and
+        records the path."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={
+                "home_assistant": {"version": "2026.5.0"},
+                "data": {"bridge": {"ip": "10.0.0.5"}},
+            }
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="home_assistant"
+        )
+        assert result["data"] == {"version": "2026.5.0"}
+        assert result["data_path"] == "home_assistant"
+
+    @pytest.mark.asyncio
+    async def test_data_path_resolves_to_scalar(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"home_assistant": {"version": "2026.5.0"}}
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="home_assistant.version"
+        )
+        assert result["data"] == "2026.5.0"
+        assert result["data_path"] == "home_assistant.version"
+
+    @pytest.mark.asyncio
+    async def test_data_path_resolves_to_list_without_limit_returns_full_list(self):
+        """No ``data_limit`` → return the resolved list as-is, no pagination
+        envelope."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"data": {"devices": [{"id": i} for i in range(5)]}}
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="data.devices"
+        )
+        assert result["data"] == [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+        assert result["data_path"] == "data.devices"
+
+    @pytest.mark.asyncio
+    async def test_data_path_with_limit_returns_pagination_envelope(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"data": {"devices": [{"id": i} for i in range(25)]}}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="data.devices",
+            data_limit=10,
+        )
+        assert result["data"] == {
+            "path": "data.devices",
+            "items": [{"id": i} for i in range(10)],
+            "offset": 0,
+            "limit": 10,
+            "total": 25,
+            "has_more": True,
+        }
+        assert result["data_path"] == "data.devices"
+
+    @pytest.mark.asyncio
+    async def test_data_path_pagination_offset_skips_then_has_more_false_at_end(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"items": [str(i) for i in range(25)]}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="items",
+            data_offset=20,
+            data_limit=10,
+        )
+        page = result["data"]
+        assert page["items"] == ["20", "21", "22", "23", "24"]
+        assert page["offset"] == 20
+        assert page["limit"] == 10
+        assert page["total"] == 25
+        assert page["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_data_path_offset_ignored_when_limit_unset(self):
+        """``data_offset`` only applies in pagination mode (when ``data_limit``
+        is also set). Without ``data_limit``, the full list is returned and a
+        ``data_pagination_warning`` is surfaced so the caller knows the offset
+        was dropped."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"items": [{"id": i} for i in range(5)]}
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="items", data_offset=2
+        )
+        assert result["data"] == [{"id": i} for i in range(5)]
+        assert "data_offset ignored" in result.get("data_pagination_warning", "")
+        assert "data_limit not set" in result["data_pagination_warning"]
+
+    @pytest.mark.asyncio
+    async def test_data_path_missing_key_surfaces_data_path_error(self):
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"home_assistant": {}})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="data.devices"
+        )
+        assert result["data"] is None
+        assert "data_path_error" in result
+        assert "missing key 'data'" in result["data_path_error"]
+
+    @pytest.mark.asyncio
+    async def test_data_path_descent_into_non_dict_surfaces_error(self):
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"devices": ["d1", "d2"]}
+        )
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="devices.0"
+        )
+        assert result["data"] is None
+        assert "data_path_error" in result
+        assert "cannot descend into list" in result["data_path_error"]
+
+    @pytest.mark.asyncio
+    async def test_data_path_empty_string_treated_as_unset(self):
+        """An empty / whitespace ``data_path`` is treated as ``None`` and does
+        not engage the resolver. Whitespace-only inputs (incl. ``""``) surface
+        a ``data_pagination_warning`` so the caller can tell their intent was
+        swallowed instead of resolving silently."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"foo": "bar"})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path=""
+        )
+        # Data passes through unchanged; resolver branch is skipped.
+        assert result["data"] == {"foo": "bar"}
+        assert "data_path" not in result
+        assert "data_path_error" not in result
+        # New: empty / whitespace-stripped inputs surface a warning.
+        assert "empty or whitespace-only" in result.get(
+            "data_pagination_warning", ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_data_path_combined_with_fields_projection(self):
+        """``fields`` runs first, then ``data_path`` walks into the projected
+        sub-tree. A path through a dropped key surfaces as resolution error."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={
+                "home_assistant": {"version": "1"},
+                "data": {"devices": [{"id": i} for i in range(3)]},
+            }
+        )
+        # fields keeps only home_assistant, so data_path='data.devices' fails.
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            fields=["home_assistant"],
+            data_path="data.devices",
+        )
+        assert result["data"] is None
+        assert "data_path_error" in result
+        assert "missing key 'data'" in result["data_path_error"]
+
+    @pytest.mark.asyncio
+    async def test_data_path_pagination_with_truncate_preserves_envelope_metadata(
+        self,
+    ):
+        """``truncate_at_bytes`` runs last, measured on the paginated ``items``
+        list. On cap-hit with a paginated payload, the envelope's metadata
+        (``path``, ``offset``, ``limit``, ``total``, ``has_more``) is
+        preserved sans ``items`` so the caller can issue a narrower
+        follow-up; only the bulky ``items`` slice is dropped."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"items": ["x" * 200 for _ in range(20)]}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="items",
+            data_limit=10,
+            truncate_at_bytes=500,
+        )
+        # 10 items × ~200 bytes each = ~2000 bytes serialized → exceeds cap.
+        assert result["truncated"] is True
+        assert result["byte_cap"] == 500
+        assert result["data_path"] == "items"
+        # Envelope metadata preserved without the items slice.
+        envelope = result["data"]
+        assert "items" not in envelope
+        assert envelope["path"] == "items"
+        assert envelope["offset"] == 0
+        assert envelope["limit"] == 10
+        assert envelope["total"] == 20
+        assert envelope["has_more"] is True
+        assert envelope["truncated"] is True
+
+    # --- KP13 round-3 gap tests --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_data_path_pagination_offset_past_total_returns_empty_page(
+        self,
+    ):
+        """``data_offset >= total`` yields empty items with ``has_more=False``
+        — boundary check that the slice doesn't wrap or error."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"items": [{"id": i} for i in range(5)]}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="items",
+            data_offset=10,
+            data_limit=3,
+        )
+        page = result["data"]
+        assert page["items"] == []
+        assert page["offset"] == 10
+        assert page["total"] == 5
+        assert page["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_data_limit_on_non_list_resolved_value_surfaces_warning(self):
+        """``data_limit`` with a dict-resolved path can't paginate. Surface a
+        structured ``data_pagination_warning`` so the caller doesn't mistake
+        the raw value for ``page 1 of N``."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"home_assistant": {"version": "2026.5.0"}}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="home_assistant",
+            data_limit=10,
+        )
+        assert result["data"] == {"version": "2026.5.0"}
+        assert "data_pagination_warning" in result
+        assert "not a list" in result["data_pagination_warning"]
+        assert "dict" in result["data_pagination_warning"]
+
+    @pytest.mark.asyncio
+    async def test_data_path_resolves_to_null_emits_dedicated_error(self):
+        """A path landing on a ``None``-valued key surfaces the dedicated
+        "sub-tree not present" message rather than the generic
+        ``cannot descend into NoneType`` wording."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value={"home_assistant": {"version": None}}
+        )
+        result = await fetch_integration_diagnostics(
+            client,
+            "entry_abc",
+            data_path="home_assistant.version.minor",
+        )
+        assert result["data"] is None
+        assert "sub-tree not present" in result["data_path_error"]
+        assert "resolved to null" in result["data_path_error"]
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_data_limit_zero_rejected_at_tool_layer(self):
+        """``data_limit=0`` is rejected by ``coerce_int_param(min_value=1)``
+        at the wire-up — caller sees a structured validation error rather
+        than an empty page that silently swallows pagination intent."""
+        from fastmcp.exceptions import ToolError as _ToolError
+
+        from ha_mcp.tools.tools_integrations import IntegrationTools
+
+        client = MagicMock()
+        tools = IntegrationTools(client)
+        with pytest.raises(_ToolError) as excinfo:
+            await tools.ha_get_integration(
+                entry_id="entry_abc",
+                include_diagnostics=True,
+                diagnostics_data_limit=0,
+            )
+        msg = str(excinfo.value)
+        assert "diagnostics_data_limit" in msg
+        assert "min" in msg.lower() or "must be" in msg.lower()
+
+    # --- KP13 round-4 gap tests --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_data_offset_without_data_path_surfaces_warning(self):
+        """``data_offset > 0`` without a ``data_path`` skips the resolver
+        entirely. Surfaces a ``data_pagination_warning`` so the caller knows
+        the offset was dropped (rather than silently doing nothing)."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"foo": "bar"})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_offset=5
+        )
+        assert "data_pagination_warning" in result
+        assert "data_path not set" in result["data_pagination_warning"]
+        # Underlying data is unchanged — the warning is the only signal.
+        assert result["data"] == {"foo": "bar"}
+
+    @pytest.mark.asyncio
+    async def test_data_path_whitespace_only_surfaces_warning(self):
+        """Whitespace-only ``data_path`` (e.g. ``"   "``) normalizes to
+        unset but surfaces a structured warning so the caller doesn't
+        mistake the silent unwind for "path applied"."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"foo": "bar"})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="   "
+        )
+        assert result["data"] == {"foo": "bar"}
+        assert "data_path" not in result
+        assert "empty or whitespace-only" in result.get(
+            "data_pagination_warning", ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_whitespace_path_plus_offset_keeps_whitespace_warning(self):
+        """Both inputs landing together (``data_path="   "`` AND
+        ``data_offset > 0``) must not clobber the whitespace warning —
+        the whitespace input is the primary user-facing problem and the
+        ``data_offset ignored: data_path not set`` warning is its
+        downstream consequence. Guarded via the ``data_pagination_warning
+        not in result`` check on the orphan-offset elif."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"foo": "bar"})
+        result = await fetch_integration_diagnostics(
+            client, "entry_abc", data_path="   ", data_offset=5
+        )
+        assert "empty or whitespace-only" in result.get(
+            "data_pagination_warning", ""
+        )
+        # Specifically NOT the downstream-consequence warning.
+        assert "data_path not set" not in result["data_pagination_warning"]
+
+
+class TestResolveDataPath:
+    """Direct tests for the dotted-path resolver."""
+
+    def test_resolves_single_segment(self):
+        value, err = _resolve_data_path({"a": 1, "b": 2}, "a")
+        assert value == 1
+        assert err is None
+
+    def test_resolves_multi_segment(self):
+        value, err = _resolve_data_path({"a": {"b": {"c": "deep"}}}, "a.b.c")
+        assert value == "deep"
+        assert err is None
+
+    def test_resolves_to_list(self):
+        value, err = _resolve_data_path({"items": [1, 2, 3]}, "items")
+        assert value == [1, 2, 3]
+        assert err is None
+
+    def test_missing_top_level_key(self):
+        value, err = _resolve_data_path({"a": 1}, "missing")
+        assert value is None
+        assert err is not None
+        assert "missing key 'missing'" in err
+        # Available keys hint surfaces in the error to guide the caller.
+        assert "['a']" in err
+
+    def test_descent_into_non_dict_value(self):
+        value, err = _resolve_data_path({"a": "scalar"}, "a.b")
+        assert value is None
+        assert err is not None
+        assert "cannot descend into str" in err
+
+    def test_descent_into_list_value(self):
+        value, err = _resolve_data_path({"a": [1, 2]}, "a.0")
+        assert value is None
+        assert err is not None
+        assert "cannot descend into list" in err
+
+    def test_empty_path_returns_error(self):
+        value, err = _resolve_data_path({"a": 1}, "")
+        assert value is None
+        assert err == "data_path must be a non-empty dotted path"
+
+    def test_whitespace_path_returns_error(self):
+        value, err = _resolve_data_path({"a": 1}, "   ")
+        assert value is None
+        assert err == "data_path must be a non-empty dotted path"
+
+    def test_empty_segment_in_middle(self):
+        value, err = _resolve_data_path({"a": {"b": 1}}, "a..b")
+        assert value is None
+        assert err is not None
+        assert "empty segment" in err
+
+    def test_missing_key_hint_suppressed_when_no_ambiguous_sibling(self):
+        """A plain typo (e.g. ``data.versionz``) on a payload whose siblings
+        contain no literal ``.`` must not mention the dotted-key limitation
+        — otherwise the caller reads the hint as "your '.' is being
+        mis-parsed", which is misleading when no sibling has one."""
+        value, err = _resolve_data_path({"version": "1", "build": "abc"}, "versionz")
+        assert value is None
+        assert err is not None
+        assert "missing key 'versionz'" in err
+        # Hint substrings must not appear when no sibling contains '.'.
+        assert "literal '.'" not in err
+        assert "not addressable" not in err
+
+    def test_missing_key_hint_surfaces_when_ambiguous_sibling_present(self):
+        """When a sibling key actually contains a literal ``.`` (e.g.
+        ``sensor.zha_temp_42``), surface the dotted-key hint so the caller
+        sees why a plausible-looking path fails. Pins the wording so a
+        future refactor doesn't drop the substring."""
+        payload = {"sensor.zha_temp_42": 21.5, "binary_sensor.door": True}
+        value, err = _resolve_data_path(payload, "sensor")
+        assert value is None
+        assert err is not None
+        assert "missing key 'sensor'" in err
+        assert "literal '.'" in err
+        assert "not addressable" in err
+
+
+class TestParseDiagnosticsFields:
+    """Test parse_diagnostics_fields normalisation."""
+
+    def test_none_returns_none(self):
+        assert parse_diagnostics_fields(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert parse_diagnostics_fields("") is None
+        assert parse_diagnostics_fields("   ") is None
+
+    def test_empty_list_returns_none(self):
+        assert parse_diagnostics_fields([]) is None
+
+    def test_native_list_passes_through(self):
+        assert parse_diagnostics_fields(["a", "b"]) == ["a", "b"]
+
+    def test_csv_string_split_and_trimmed(self):
+        assert parse_diagnostics_fields("home_assistant, issues") == [
+            "home_assistant",
+            "issues",
+        ]
+
+    def test_json_array_string_parsed(self):
+        assert parse_diagnostics_fields('["home_assistant", "issues"]') == [
+            "home_assistant",
+            "issues",
+        ]
+
+    def test_invalid_json_array_raises(self):
+        with pytest.raises(ValueError, match="valid JSON list"):
+            parse_diagnostics_fields("[broken")
+
+    def test_json_non_list_raises(self):
+        with pytest.raises(ValueError, match="decode to a list"):
+            parse_diagnostics_fields('{"home_assistant": 1}')
+
+    def test_non_string_non_list_raises(self):
+        with pytest.raises(ValueError, match="must be list, string, or None"):
+            parse_diagnostics_fields(42)  # type: ignore[arg-type]


### PR DESCRIPTION
## What does this PR do?

Implements [#1148](https://github.com/homeassistant-ai/ha-mcp/issues/1148) Option A+C
(decided 2026-05-17 in [#1148#issuecomment-4470872978](https://github.com/homeassistant-ai/ha-mcp/issues/1148#issuecomment-4470872978) after the [schema-size measurement](https://github.com/homeassistant-ai/ha-mcp/issues/1148#issuecomment-4470843314) showed +1.00 % / +2,274 bytes for the combo).

Exposes Home Assistant's integration diagnostics dumps (the JSON users grab via
Settings → Devices & Services → [integration] → ⋯ → Download diagnostics)
through two existing tools — no new tool added.

| Tool | Param | When to use |
|---|---|---|
| `ha_get_integration` | `include_diagnostics: bool` + optional `device_id` | Agent already has a `config_entry_id` and is inspecting a specific integration |
| `ha_get_system_health` | `include='diagnostics'` + `config_entry_id` + optional `device_id` | Triage flow bundling diagnostics with repairs / ZHA / Z-Wave in one call |

Both call sites share a new `fetch_integration_diagnostics()` helper in
`util_helpers.py`. It hits `GET /api/diagnostics/config_entry/{entry_id}`
(or the device-scoped variant) with a 60-second default timeout — ZHA dumps
on large networks can run 30–60 s. Helper returns an embeddable sub-dict
(no raise) so a diagnostics failure never poisons the larger response — mirrors
the existing `_fetch_repairs` / `_fetch_zha_network` convention. Status mapping:
401 → token-validity guidance (stale/invalid access token), 403 → admin-scope
guidance (HA's `@http.require_admin` gate), 404 → "integration may not
implement diagnostics or the id is invalid" with a pointer to `ha_get_integration()`,
timeout → message naming the limit, generic → fallback.

**Payload-size controls** (added after the PR-review BAT against Hue showed
~290 KB / ~80k tokens for a single integration, and round-2 maintainer review
flagged that top-level projection still can't reach into per-device sub-trees
on ZHA / MQTT / ESPHome):

| Param | Type | Effect |
|---|---|---|
| `diagnostics_fields` | `list[str] \| str \| None` | Top-level key projection on the integration `data` payload (e.g. `["home_assistant", "issues"]`). Accepts native list, JSON array string, or comma-separated string. Unknown keys surface via `omitted_fields`. |
| `diagnostics_data_path` | `str \| None` | Dotted path into the post-projection payload (e.g. `"data.devices"` for ZHA per-device records, `"home_assistant.version"`). Dict-only descent; resolution failures replace `data` with `null` and surface `data_path_error`. |
| `diagnostics_data_offset` / `diagnostics_data_limit` | `int` / `int \| None` | Pagination on list-resolved `diagnostics_data_path` results. When `data_limit` is set and the resolved path is a list, `data` becomes a `{path, items, offset, limit, total, has_more}` envelope. |
| `diagnostics_truncate_at_bytes` | `int \| str \| None` | Byte cap on the serialized resolved value (post `fields` + `data_path` + pagination). On hit, drops `data` and emits `truncated=true`, `bytes_total`, `byte_cap`, plus `available_fields` (when the capped value is a dict). |

Defaults `None` preserve current full-result behavior. Order of operations:
`fields` → `data_path` resolve → pagination (when list + `data_limit`) →
`truncate_at_bytes`. Each stage operates on the previous stage's output.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local results: ruff + mypy clean on the 3 src files; **2709 unit tests pass, 1
skipped** (numpy-by-design). New unit coverage in `test_util_helpers.py` covers
the projection / byte-cap / parser-normalisation paths, the `<status>` fallback
when `HomeAssistantAPIError.status_code` is None, the empty-body surfacing,
and the `data_path` + pagination resolver (16 new tests across the 3 test files
for round-2 review additions). Wire-up tests on both tools assert kwarg
forwarding for all 5 diagnostics params. E2E coverage logs domain + title
alongside `entry_id` and attributes happy / 404 outcomes to the specific
integration probed.

## Future improvements

- `ha_get_system_health` runs optional sections sequentially. When two slow
  ones are requested together (e.g. `include="zha_network,diagnostics"`),
  `asyncio.gather` would halve the wall-clock — left to a follow-up so
  error attribution stays straightforward.

## Checklist
- [x] I have updated documentation if needed — the tool docstrings carry the
  new params + examples; `README.md` / `homeassistant-addon/DOCS.md` /
  `site/src/data/tools.json` are regenerated automatically by `sync-tool-docs.yml`
  on merge.
