### PR TITLE
feat: add automation_id parity key to ha_config_get_automation

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -280,6 +280,8 @@ class AutomationConfigTools:
 
         The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
 
+        The returned `automation_id` is the resolved entity_id (canonical form, e.g. `automation.morning_routine`) when the registry lookup succeeds, falling back to the input `identifier` otherwise. Use `automation_id` for sibling parity with `ha_config_get_script` (`script_id`), `ha_config_get_scene` (`scene_id`), and `ha_config_get_dashboard` (`url_path`); `identifier` continues to echo the raw input.
+
         EXAMPLES:
         - Get automation: ha_config_get_automation("automation.morning_routine")
         - Get by unique_id: ha_config_get_automation("my_unique_automation_id")
@@ -301,6 +303,7 @@ class AutomationConfigTools:
                 "success": True,
                 "action": "get",
                 "identifier": identifier,
+                "automation_id": entity_id or identifier,
                 "config": normalized_config,
                 "config_hash": config_hash,
             }

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -280,7 +280,7 @@ class AutomationConfigTools:
 
         The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
 
-        The returned `automation_id` is the resolved entity_id (canonical form, e.g. `automation.morning_routine`) when the registry lookup succeeds, falling back to the input `identifier` otherwise. Use `automation_id` for sibling parity with `ha_config_get_script` (`script_id`), `ha_config_get_scene` (`scene_id`), and `ha_config_get_dashboard` (`url_path`); `identifier` continues to echo the raw input.
+        The returned `automation_id` is the resolved entity_id (canonical form, e.g. `automation.morning_routine`) when the registry lookup succeeds, falling back to the input `identifier` otherwise.
 
         EXAMPLES:
         - Get automation: ha_config_get_automation("automation.morning_routine")

--- a/tests/src/unit/test_tools_config_automations.py
+++ b/tests/src/unit/test_tools_config_automations.py
@@ -1,0 +1,85 @@
+"""Unit tests for Automation configuration tools.
+
+Validates the `automation_id` typed-id key on `ha_config_get_automation`
+(issue #1299), which gives sibling parity with `ha_config_get_script`
+(`script_id`), `ha_config_get_scene` (`scene_id`), and
+`ha_config_get_dashboard` (`url_path`). The value is the resolved
+entity_id when registry lookup succeeds, falling back to the raw input
+otherwise — same canonical-with-fallback semantic as scenes/dashboards.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+
+
+@pytest.fixture
+def mock_client():
+    """Mock client satisfying the ha_config_get_automation read path."""
+    client = MagicMock()
+    client.get_automation_config = AsyncMock(
+        return_value={
+            "id": "abc123unique",
+            "alias": "Morning Routine",
+            "trigger": [{"platform": "time", "at": "07:00:00"}],
+            "action": [
+                {"service": "light.turn_on", "target": {"entity_id": "light.bedroom"}}
+            ],
+        }
+    )
+    # Default: registry returns the canonical entity_id for unique_id "abc123unique".
+    # Individual tests override .get_states for the no-match case.
+    client.get_states = AsyncMock(
+        return_value=[
+            {
+                "entity_id": "automation.morning_routine",
+                "attributes": {"id": "abc123unique"},
+            }
+        ]
+    )
+    # fetch_entity_category path — empty success result keeps category injection off.
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": {"categories": {}}}
+    )
+    return client
+
+
+@pytest.fixture
+def tools(mock_client):
+    return AutomationConfigTools(mock_client)
+
+
+class TestGetAutomationIdKey:
+    """`automation_id` parity key on `ha_config_get_automation` (issue #1299)."""
+
+    async def test_returns_resolved_entity_id_when_input_is_unique_id(self, tools):
+        """unique_id input → automation_id = resolved entity_id; identifier echoes input."""
+        result = await tools.ha_config_get_automation(identifier="abc123unique")
+
+        assert result["success"] is True
+        assert result["identifier"] == "abc123unique"
+        assert result["automation_id"] == "automation.morning_routine"
+
+    async def test_returns_input_when_input_is_entity_id(self, tools):
+        """entity_id input → automation_id == identifier (short-circuit in resolver)."""
+        result = await tools.ha_config_get_automation(
+            identifier="automation.morning_routine"
+        )
+
+        assert result["success"] is True
+        assert result["identifier"] == "automation.morning_routine"
+        assert result["automation_id"] == "automation.morning_routine"
+
+    async def test_falls_back_to_identifier_when_registry_lookup_misses(
+        self, tools, mock_client
+    ):
+        """unique_id with no registry match → automation_id falls back to raw input."""
+        mock_client.get_states = AsyncMock(return_value=[])
+
+        result = await tools.ha_config_get_automation(identifier="orphaned_unique_id")
+
+        assert result["success"] is True
+        assert result["identifier"] == "orphaned_unique_id"
+        assert result["automation_id"] == "orphaned_unique_id"


### PR DESCRIPTION
## What does this PR do?

Adds an `automation_id` key to the return dict of `ha_config_get_automation` (issue #1299) for sibling parity with `ha_config_get_script` (`script_id`), `ha_config_get_scene` (`scene_id`), and `ha_config_get_dashboard` (`url_path`).

**Value semantic** — canonical entity_id with fallback to the raw input (same pattern as scenes/dashboards). Concretely: `entity_id or identifier` where `entity_id` is the result of `_resolve_automation_entity_id(identifier)`. When the input is already an entity_id the helper short-circuits to identity; when it's a `unique_id` the helper looks up the canonical entity_id via the registry; on registry miss it falls back to the raw input.

**Why this value choice (issue analysis recap):**

- The four `get_*` siblings already disagree on value semantics for their typed-id key. Scripts/automations were pure input echo; scenes/dashboards are canonical-with-fallback. This PR aligns automations with the canonical-with-fallback pattern, the closest faithful sibling extension.
- The bot's first recommendation (`normalized_config.get("id") or identifier`, i.e. the unique_id from the YAML/storage `id` field) would have introduced a *fourth* value semantic and a codebase-wide naming collision with `tools_traces.py`'s `automation_id`, which carries entity_id semantics (asserted at `tests/src/unit/test_tools_traces.py:21` and `test_tools_traces_detail.py:50`). Going with entity_id semantics keeps the cross-file meaning of `automation_id` consistent.

**Non-breaking** — `identifier` continues to echo the polymorphic input. Live grep confirms zero in-tree consumers of `result["identifier"]` on `ha_config_get_automation` returns; the change is purely additive.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local: `tests/src/unit/test_tools_config_automations.py` (3 new unit tests covering input=entity_id, input=unique_id resolves via registry, input=unique_id registry-miss falls back). Full unit suite passes locally (2641 passed, 1 musl-skip, 0 failures) on Python 3.13.

## Future improvements

- The `python_transform` return path on the same tool file (`tools_config_automations.py:632`) emits the same `"identifier"`-only shape; mirroring `automation_id` there would extend the parity to the transform path. Left out of this PR to keep the change minimal and scoped to the issue.
- `tools_config_automations.py` has pre-existing ruff-format diff in surrounding lines unrelated to this change — belongs to #1318's canonical format-sweep tracker, not this PR.
- Cross-family value-semantic alignment (scripts/automations on input-echo vs. scenes/dashboards on canonical-with-fallback) is a broader decision that would need its own follow-up issue.

## Checklist
- [x] I have updated documentation if needed

Closes #1299
