### PR TITLE
docs: categorize Issue Labels table and document 6 reverse-drift labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ When implementing features or debugging, consult these resources:
 - **Claude `/my-pr-checker` (lifecycle)**: Resolve threads, fix issues, monitor CI, create improvement PRs
 
 ### Issue Labels
+
+**Triage-state labels** (applied by `gemini-triage.yml` or manual triage):
+
 | Label | Meaning |
 |-------|---------|
 | `ready-to-implement` | Clear path, no decisions needed |
@@ -115,6 +118,27 @@ When implementing features or debugging, consult these resources:
 | `triaged` | Automated Gemini triage complete |
 | `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on comments. Clear it (or run via `workflow_dispatch`) to retry |
 | `issue-analyzed` | Deep Claude analysis complete |
+
+**Scope labels** (manually applied during triage; orthogonal to bug-class — an issue can carry both `runtime-bug` AND a scope marker):
+
+| Label | Meaning |
+|-------|---------|
+| `addon` | Issue is specific to the Home Assistant Add-on deployment (`homeassistant-addon/`, Supervisor ingress) |
+| `docker` | Issue is specific to the Docker / containerised deployment (`Dockerfile`, container env) |
+| `javascript` | Issue concerns the project website / Astro app under `site/` |
+
+**Lifecycle labels** (manually applied; do not double as close-reasons):
+
+| Label | Meaning |
+|-------|---------|
+| `wontfix` | Issue is valid but a deliberate decision was made not to address it (typically paired with close). Use when the maintainer wants to record the rejection rationale rather than silently close |
+| `blocked` | Forward progress depends on an unresolved external item (upstream HA change, a sibling PR, an awaiting-design decision). Recorded so a sweeper search can find what's waiting |
+
+**Tracking / automation labels** (applied by tooling):
+
+| Label | Meaning | Source |
+|-------|---------|--------|
+| `python-upgrade` | Renovate-managed PR that bumps the project's Python version | `renovate.json` global `labels` array (auto-applied to all Renovate PRs alongside `dependencies`) |
 
 ### Issue Analysis Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,14 @@ When implementing features or debugging, consult these resources:
 | `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on comments. Clear it (or run via `workflow_dispatch`) to retry |
 | `issue-analyzed` | Deep Claude analysis complete |
 
+**Bug-class labels** (applied via `.github/ISSUE_TEMPLATE/` form selection or manual triage):
+
+| Label | Meaning |
+|-------|---------|
+| `runtime-bug` | Bug occurring during normal operation (post-startup) |
+| `startup-bug` | Bug during startup, install, or connect |
+| `agent-behavior` | AI agent behavior or workflow feedback (tool selection, prompt drift, etc.) |
+
 **Scope labels** (manually applied during triage; orthogonal to bug-class — an issue can carry both `runtime-bug` AND a scope marker):
 
 | Label | Meaning |
@@ -136,9 +144,9 @@ When implementing features or debugging, consult these resources:
 
 **Tracking / automation labels** (applied by tooling):
 
-| Label | Meaning | Source |
-|-------|---------|--------|
-| `python-upgrade` | Renovate-managed PR that bumps the project's Python version | `renovate.json` global `labels` array (auto-applied to all Renovate PRs alongside `dependencies`) |
+| Label | Meaning |
+|-------|---------|
+| `python-upgrade` | Renovate-managed PR that bumps the project's Python version. Applied via `renovate.json` global `labels` array (auto-applied to all Renovate PRs alongside `dependencies`). |
 
 ### Issue Analysis Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,14 +139,14 @@ When implementing features or debugging, consult these resources:
 
 | Label | Meaning |
 |-------|---------|
-| `wontfix` | Issue is valid but a deliberate decision was made not to address it (typically paired with close). Use when the maintainer wants to record the rejection rationale rather than silently close |
+| `wontfix` | Issue is valid but will not be addressed. Typically used when closing an issue to record the rejection rationale. |
 | `blocked` | Forward progress depends on an unresolved external item (upstream HA change, a sibling PR, a pending design decision). Recorded so a sweeper search can find what's waiting |
 
 **Tracking / automation labels** (applied by tooling):
 
 | Label | Meaning |
 |-------|---------|
-| `python-upgrade` | Auto-attached to every Renovate-managed PR — not only Python version bumps, but any dependency update. Configured via `renovate.json` global `labels` array alongside `dependencies`. The label name predates the wider Renovate config rollout; rename or scope-restriction is a candidate for a separate decision. |
+| `python-upgrade` | Auto-attached to every Renovate-managed PR (including non-Python dependency updates) via `renovate.json` global `labels` array. |
 
 ### Issue Analysis Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,21 +132,21 @@ When implementing features or debugging, consult these resources:
 | Label | Meaning |
 |-------|---------|
 | `addon` | Issue is specific to the Home Assistant Add-on deployment (`homeassistant-addon/`, Supervisor ingress) |
-| `docker` | Issue is specific to the Docker / containerised deployment (`Dockerfile`, container env) |
-| `javascript` | Issue concerns the project website / Astro app under `site/` |
+| `docker` | Issue is specific to the Docker / containerized deployment (`Dockerfile`, container env) |
+| `javascript` | Issue concerns the project website / Astro app (TypeScript) under `site/` |
 
 **Lifecycle labels** (manually applied; do not double as close-reasons):
 
 | Label | Meaning |
 |-------|---------|
 | `wontfix` | Issue is valid but a deliberate decision was made not to address it (typically paired with close). Use when the maintainer wants to record the rejection rationale rather than silently close |
-| `blocked` | Forward progress depends on an unresolved external item (upstream HA change, a sibling PR, an awaiting-design decision). Recorded so a sweeper search can find what's waiting |
+| `blocked` | Forward progress depends on an unresolved external item (upstream HA change, a sibling PR, a pending design decision). Recorded so a sweeper search can find what's waiting |
 
 **Tracking / automation labels** (applied by tooling):
 
 | Label | Meaning |
 |-------|---------|
-| `python-upgrade` | Renovate-managed PR that bumps the project's Python version. Applied via `renovate.json` global `labels` array (auto-applied to all Renovate PRs alongside `dependencies`). |
+| `python-upgrade` | Auto-attached to every Renovate-managed PR — not only Python version bumps, but any dependency update. Configured via `renovate.json` global `labels` array alongside `dependencies`. The label name predates the wider Renovate config rollout; rename or scope-restriction is a candidate for a separate decision. |
 
 ### Issue Analysis Workflow
 


### PR DESCRIPTION
## What does this PR do?

Closes #1330. Adds 6 active labels to the AGENTS.md Issue Labels table (grouped Triage-state / Bug-class / Scope / Lifecycle / Tracking): `addon`, `docker`, `javascript`, `wontfix`, `blocked`, `python-upgrade`. Round-1 review feedback folded in `c72ed29`: added the missing Bug-class table (`runtime-bug`, `startup-bug`, `agent-behavior`) since the Scope-labels header already forward-references `runtime-bug`, and unified the Tracking-labels table to the 2-column shape used by the other three tables. Round-2 review feedback folded in `764ae84`: rewrote the `python-upgrade` description after live-verifying `renovate.json` (the label is auto-attached to every Renovate PR, not only Python version bumps); aligned spelling to American English (`containerized`); mentioned TypeScript in the `javascript` label description (sibling-confirmed via .astro frontmatter); dropped the awkward `awaiting-design` hyphenation. Round-3 review feedback folded in `1f96a8e`: tightened `wontfix` (dropped a near-redundant clause) and `python-upgrade` (kept the `renovate.json` pointer, dropped the rename meta-commentary now living in Future improvements). Flags 2 labels for maintainer decision: `to-merge` and `codex` exist on the repo but have no live emitter — left unmodified in this PR; resolution path (delete / keep+document / mixed) open in review thread.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Docs-only — no code paths changed.

## Future improvements

<!-- Out-of-scope items noted during this PR. -->

- The 6 emit-only labels from `gemini-triage.yml` (`bug`, `enhancement`, `question`, `documentation`, `duplicate`, `invalid`) are also absent from the AGENTS.md table.
- `python-upgrade` label scoping mismatch — currently attached to every Renovate PR per `renovate.json` global `labels` array, despite the name suggesting Python version bumps only. Candidate fixes (out of scope for a docs PR): rename the label (e.g. `dependency-update`) or scope-restrict via a Renovate `packageRules` block.

## Checklist
- [x] I have updated documentation if needed
