### PR TITLE
perf: parallelize ha_get_system_health optional sections via asyncio.gather

### DIFF
--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -9,6 +9,7 @@ This module provides tools for Home Assistant system administration including:
 
 import asyncio
 import logging
+from collections.abc import Coroutine
 from typing import Any
 
 from fastmcp.exceptions import ToolError
@@ -392,7 +393,7 @@ class SystemTools:
             want_zha = zha_full or zha_summary
             want_zwave = "zwave_network" in includes
 
-            sections: list[tuple[str, Any]] = []
+            sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]] = []
             if want_repairs:
                 sections.append(
                     (
@@ -414,13 +415,39 @@ class SystemTools:
 
             if sections:
                 gathered = await asyncio.gather(
-                    *(coro for _, coro in sections), return_exceptions=True
+                    *[coro for _, coro in sections], return_exceptions=True
                 )
-                for (section_name, _), section_result in zip(sections, gathered, strict=True):
-                    if isinstance(section_result, BaseException):
-                        # Mirrors the helpers' own embeddable-sub-dict contract
-                        # so an unexpected exception attributes to its section
-                        # instead of bubbling out and dropping the others.
+                # Pre-pass: re-raise anything that must unwind the request
+                # rather than land as an embedded section error. ``gather``
+                # with ``return_exceptions=True`` returns ``CancelledError``
+                # (and any other ``BaseException``) as a result element
+                # instead of propagating, and a ``ToolError`` raised from
+                # inside a helper would otherwise be silently demoted to
+                # ``{"error": "ToolError: …"}`` and break the MCP
+                # ``isError=true`` contract for the whole tool.
+                for section_result in gathered:
+                    if isinstance(section_result, asyncio.CancelledError):
+                        raise section_result
+                    if isinstance(section_result, ToolError):
+                        raise section_result
+                    if isinstance(section_result, BaseException) and not isinstance(
+                        section_result, Exception
+                    ):
+                        # ``KeyboardInterrupt`` / ``SystemExit`` — never demote
+                        # these to a section-level error string.
+                        raise section_result
+                for (section_name, _), section_result in zip(
+                    sections, gathered, strict=True
+                ):
+                    if isinstance(section_result, Exception):
+                        # Last-resort fallback: emit a minimal ``{error: ...}``
+                        # dict so an unexpected exception attributes to its
+                        # section instead of bubbling out and dropping siblings.
+                        # The helpers themselves return richer
+                        # ``{<key>: <baseline>, ..., error: ...}`` shapes on
+                        # their own (caught) failures; this branch is the
+                        # belt-and-suspenders path that fires only on a
+                        # helper-edit regression that lets an exception escape.
                         logger.warning(
                             "Concurrent fetch for section %r raised: %s: %s",
                             section_name,

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -7,6 +7,7 @@ This module provides tools for Home Assistant system administration including:
 - System health monitoring
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -376,22 +377,63 @@ class SystemTools:
             if unknown:
                 result["warning"] = f"Unknown include sections ignored: {', '.join(sorted(unknown))}"
 
-            # Fetch optional sections
-            if "repairs" in includes:
-                result["repairs"] = await self._fetch_repairs(
-                    ws_client,
-                    include_dismissed=include_dismissed_repairs_bool,
-                )
-
+            # Fetch optional sections concurrently. The ws_client serialises
+            # outgoing writes via its internal `_send_lock`, but per-message
+            # futures keyed by message_id let response waits overlap — so this
+            # gives request pipelining instead of head-of-line blocking.
+            #
+            # Each ``_fetch_*`` helper already returns an embeddable sub-dict
+            # with an ``error`` field on backend failure (it never raises);
+            # ``return_exceptions=True`` is belt-and-suspenders against a future
+            # helper edit that lets an exception escape.
             zha_full = "zha_network_full" in includes
             zha_summary = "zha_network" in includes
-            if zha_full or zha_summary:
-                result["zha_network"] = await self._fetch_zha_network(
-                    ws_client, full=zha_full
+            want_repairs = "repairs" in includes
+            want_zha = zha_full or zha_summary
+            want_zwave = "zwave_network" in includes
+
+            sections: list[tuple[str, Any]] = []
+            if want_repairs:
+                sections.append(
+                    (
+                        "repairs",
+                        self._fetch_repairs(
+                            ws_client,
+                            include_dismissed=include_dismissed_repairs_bool,
+                        ),
+                    )
+                )
+            if want_zha:
+                sections.append(
+                    ("zha_network", self._fetch_zha_network(ws_client, full=zha_full))
+                )
+            if want_zwave:
+                sections.append(
+                    ("zwave_network", self._fetch_zwave_network(ws_client))
                 )
 
-            if "zwave_network" in includes:
-                result["zwave_network"] = await self._fetch_zwave_network(ws_client)
+            if sections:
+                gathered = await asyncio.gather(
+                    *(coro for _, coro in sections), return_exceptions=True
+                )
+                for (section_name, _), section_result in zip(sections, gathered, strict=True):
+                    if isinstance(section_result, BaseException):
+                        # Mirrors the helpers' own embeddable-sub-dict contract
+                        # so an unexpected exception attributes to its section
+                        # instead of bubbling out and dropping the others.
+                        logger.warning(
+                            "Concurrent fetch for section %r raised: %s: %s",
+                            section_name,
+                            type(section_result).__name__,
+                            section_result,
+                        )
+                        result[section_name] = {
+                            "error": (
+                                f"{type(section_result).__name__}: {section_result}"
+                            )
+                        }
+                    else:
+                        result[section_name] = section_result
 
             return result
 

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -4,6 +4,7 @@ Regression tests for https://github.com/homeassistant-ai/ha-mcp/issues/612
 ha_restart reports failure when a reverse proxy returns 504 during restart.
 """
 
+import asyncio
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -197,7 +198,7 @@ class TestGetSystemHealthGather:
         mock_zha = AsyncMock(return_value={"devices": [{"name": "A"}]})
         mock_zwave = AsyncMock(return_value={"nodes": []})
 
-        with _patch_health_info_baseline(), patch.object(
+        with _patch_health_info_baseline() as (_, ws_client), patch.object(
             SystemTools, "_fetch_repairs", new=mock_repairs
         ), patch.object(
             SystemTools, "_fetch_zha_network", new=mock_zha
@@ -216,6 +217,9 @@ class TestGetSystemHealthGather:
         mock_repairs.assert_awaited_once()
         mock_zha.assert_awaited_once()
         mock_zwave.assert_awaited_once()
+        # ``finally``-clause cleanup of the WS client must still fire on the
+        # gather path — guards against a regression that skips disconnect.
+        ws_client.disconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unrequested_sections_not_called(self):
@@ -243,42 +247,153 @@ class TestGetSystemHealthGather:
         mock_zwave.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_one_section_raising_does_not_block_siblings(self):
+    @pytest.mark.parametrize(
+        "raising_section",
+        ["repairs", "zha_network", "zwave_network"],
+    )
+    async def test_one_section_raising_does_not_block_siblings(
+        self, raising_section
+    ):
         """A raising helper attributes its failure to its section; others still populate.
 
         The helpers themselves are written never to raise (each wraps its WS
         call in try/except). This test exercises the defensive
         ``return_exceptions=True`` path on ``gather`` against an
         unexpected-exception regression in any one helper.
+
+        Parametrized over which helper raises so a future zip/mis-attribution
+        regression gets caught regardless of position in the sections list.
         """
         client = MagicMock()
         tools = SystemTools(client)
-        mock_repairs = AsyncMock(side_effect=RuntimeError("repairs blew up"))
-        mock_zha = AsyncMock(return_value={"devices": [{"name": "B"}]})
-        mock_zwave = AsyncMock(return_value={"nodes": [{"id": 1}]})
+
+        section_to_helper = {
+            "repairs": "_fetch_repairs",
+            "zha_network": "_fetch_zha_network",
+            "zwave_network": "_fetch_zwave_network",
+        }
+        section_success_values = {
+            "repairs": {"issues": [], "count": 0},
+            "zha_network": {"devices": [{"name": "B"}]},
+            "zwave_network": {"nodes": [{"id": 1}]},
+        }
+
+        mocks = {
+            section: AsyncMock(
+                side_effect=RuntimeError(f"{section} blew up")
+                if section == raising_section
+                else None,
+                return_value=None
+                if section == raising_section
+                else section_success_values[section],
+            )
+            for section in section_to_helper
+        }
 
         with _patch_health_info_baseline(), patch.object(
-            SystemTools, "_fetch_repairs", new=mock_repairs
+            SystemTools, "_fetch_repairs", new=mocks["repairs"]
         ), patch.object(
-            SystemTools, "_fetch_zha_network", new=mock_zha
+            SystemTools, "_fetch_zha_network", new=mocks["zha_network"]
         ), patch.object(
-            SystemTools, "_fetch_zwave_network", new=mock_zwave
+            SystemTools, "_fetch_zwave_network", new=mocks["zwave_network"]
         ):
             result = await tools.ha_get_system_health(
                 include="repairs,zha_network,zwave_network"
             )
 
-        # Raising section attributed by name
-        assert "error" in result["repairs"]
-        assert "RuntimeError" in result["repairs"]["error"]
-        assert "repairs blew up" in result["repairs"]["error"]
-        # Sibling sections unaffected
+        # Raising section attributed by name — confirms zip alignment between
+        # the sections list (insertion order) and the gather result list.
+        assert "error" in result[raising_section]
+        assert "RuntimeError" in result[raising_section]["error"]
+        assert f"{raising_section} blew up" in result[raising_section]["error"]
+        # Sibling sections unaffected and carry their success payload.
+        for sibling in section_to_helper:
+            if sibling == raising_section:
+                continue
+            assert result[sibling] == section_success_values[sibling]
+        # All three were attempted — proves the gather didn't short-circuit.
+        for section in section_to_helper:
+            mocks[section].assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_helpers_actually_run_concurrently(self):
+        """Two helpers can be in-flight simultaneously under the gather path
+        — guards against a regression that reverts to serial ``await``.
+
+        Helper A waits on an ``asyncio.Event`` that helper B sets. If gather
+        ran the helpers serially in registration order, helper A would
+        deadlock waiting for an event that helper B (queued behind it) has
+        no chance to set, and the test would time out. The parallel path
+        completes both helpers in well under the timeout."""
+        client = MagicMock()
+        tools = SystemTools(client)
+
+        signal = asyncio.Event()
+
+        async def waiting_helper(*_args, **_kwargs):
+            # Helper A: blocks until helper B signals; cap at 2s so a
+            # serial-regression fails fast rather than timing out the suite.
+            await asyncio.wait_for(signal.wait(), timeout=2.0)
+            return {"issues": [], "count": 0}
+
+        async def signalling_helper(*_args, **_kwargs):
+            # Helper B: trips the signal so helper A can complete.
+            signal.set()
+            return {"devices": [{"name": "B"}]}
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=AsyncMock(side_effect=waiting_helper)
+        ), patch.object(
+            SystemTools,
+            "_fetch_zha_network",
+            new=AsyncMock(side_effect=signalling_helper),
+        ):
+            result = await tools.ha_get_system_health(
+                include="repairs,zha_network"
+            )
+
+        assert result["repairs"] == {"issues": [], "count": 0}
         assert result["zha_network"] == {"devices": [{"name": "B"}]}
-        assert result["zwave_network"] == {"nodes": [{"id": 1}]}
-        # All three were attempted — proves the gather didn't short-circuit
-        mock_repairs.assert_awaited_once()
-        mock_zha.assert_awaited_once()
-        mock_zwave.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagated_not_demoted(self):
+        """``asyncio.CancelledError`` from a helper must propagate out of
+        ``ha_get_system_health`` rather than land as ``{"error": "CancelledError: …"}``.
+
+        ``asyncio.gather(return_exceptions=True)`` returns ``CancelledError``
+        as a result element instead of re-raising, so the pre-pass must
+        explicitly re-raise it. Without this, a cancelled request would
+        return ``success=True`` and the runtime wouldn't unwind."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_zha = AsyncMock(return_value={"devices": [{"name": "B"}]})
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), pytest.raises(asyncio.CancelledError):
+            await tools.ha_get_system_health(include="repairs,zha_network")
+
+    @pytest.mark.asyncio
+    async def test_tool_error_from_helper_re_raised_not_demoted(self):
+        """A ``ToolError`` raised inside a helper must propagate so the MCP
+        ``isError=true`` contract holds — not get silently demoted to
+        ``result[section] = {"error": "ToolError: …"}`` with ``success=True``."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        tool_err = ToolError("simulated helper-side tool error")
+        mock_repairs = AsyncMock(side_effect=tool_err)
+        mock_zha = AsyncMock(return_value={"devices": [{"name": "B"}]})
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_system_health(include="repairs,zha_network")
+        assert excinfo.value is tool_err
 
     @pytest.mark.asyncio
     async def test_zha_full_routes_to_full_flag(self):

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -4,13 +4,32 @@ Regression tests for https://github.com/homeassistant-ai/ha-mcp/issues/612
 ha_restart reports failure when a reverse proxy returns 504 during restart.
 """
 
-from unittest.mock import AsyncMock
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import HomeAssistantAPIError
 from ha_mcp.tools.tools_system import SystemTools
+
+
+@contextmanager
+def _patch_health_info_baseline():
+    """Patch ``_fetch_health_info`` to return a fixed (ws_client, baseline) pair.
+
+    The ws_client is a MagicMock so the section helpers (when not separately
+    mocked) won't accidentally hit a real connection; ``disconnect`` is async.
+    """
+    ws_client = MagicMock()
+    ws_client.disconnect = AsyncMock()
+    baseline = {"success": True, "health_info": {}}
+    with patch.object(
+        SystemTools,
+        "_fetch_health_info",
+        new=AsyncMock(return_value=(ws_client, baseline)),
+    ) as p:
+        yield p, ws_client
 
 
 def _make_client_that_fails_on_restart(exception):
@@ -160,3 +179,145 @@ class TestFetchRepairs:
 
         assert result["count"] == 0
         assert "ws disconnect" in result["error"]
+
+
+class TestGetSystemHealthGather:
+    """``ha_get_system_health`` runs optional sections concurrently via ``asyncio.gather``.
+
+    Issue #1331 — replaces the prior sequential ``await self._fetch_repairs(...)``
+    chain to halve wall-clock when multiple slow sections are requested.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_three_sections_populated_when_all_requested(self):
+        """``include="repairs,zha_network,zwave_network"`` populates all three from concurrent gather."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock(return_value={"issues": [], "count": 0})
+        mock_zha = AsyncMock(return_value={"devices": [{"name": "A"}]})
+        mock_zwave = AsyncMock(return_value={"nodes": []})
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), patch.object(
+            SystemTools, "_fetch_zwave_network", new=mock_zwave
+        ):
+            result = await tools.ha_get_system_health(
+                include="repairs,zha_network,zwave_network"
+            )
+
+        assert result["repairs"] == {"issues": [], "count": 0}
+        assert result["zha_network"] == {"devices": [{"name": "A"}]}
+        assert result["zwave_network"] == {"nodes": []}
+        # Each helper fired exactly once — guards against a regression that
+        # silently double-runs or skips a section under gather.
+        mock_repairs.assert_awaited_once()
+        mock_zha.assert_awaited_once()
+        mock_zwave.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unrequested_sections_not_called(self):
+        """Only requested sections fire; the other helpers stay un-awaited."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock(return_value={"issues": [], "count": 0})
+        mock_zha = AsyncMock()
+        mock_zwave = AsyncMock()
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), patch.object(
+            SystemTools, "_fetch_zwave_network", new=mock_zwave
+        ):
+            result = await tools.ha_get_system_health(include="repairs")
+
+        assert "repairs" in result
+        assert "zha_network" not in result
+        assert "zwave_network" not in result
+        mock_repairs.assert_awaited_once()
+        mock_zha.assert_not_awaited()
+        mock_zwave.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_section_raising_does_not_block_siblings(self):
+        """A raising helper attributes its failure to its section; others still populate.
+
+        The helpers themselves are written never to raise (each wraps its WS
+        call in try/except). This test exercises the defensive
+        ``return_exceptions=True`` path on ``gather`` against an
+        unexpected-exception regression in any one helper.
+        """
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock(side_effect=RuntimeError("repairs blew up"))
+        mock_zha = AsyncMock(return_value={"devices": [{"name": "B"}]})
+        mock_zwave = AsyncMock(return_value={"nodes": [{"id": 1}]})
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), patch.object(
+            SystemTools, "_fetch_zwave_network", new=mock_zwave
+        ):
+            result = await tools.ha_get_system_health(
+                include="repairs,zha_network,zwave_network"
+            )
+
+        # Raising section attributed by name
+        assert "error" in result["repairs"]
+        assert "RuntimeError" in result["repairs"]["error"]
+        assert "repairs blew up" in result["repairs"]["error"]
+        # Sibling sections unaffected
+        assert result["zha_network"] == {"devices": [{"name": "B"}]}
+        assert result["zwave_network"] == {"nodes": [{"id": 1}]}
+        # All three were attempted — proves the gather didn't short-circuit
+        mock_repairs.assert_awaited_once()
+        mock_zha.assert_awaited_once()
+        mock_zwave.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_zha_full_routes_to_full_flag(self):
+        """``include="zha_network_full"`` calls ``_fetch_zha_network`` with full=True."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_zha = AsyncMock(return_value={"devices": []})
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ):
+            await tools.ha_get_system_health(include="zha_network_full")
+
+        mock_zha.assert_awaited_once()
+        # Helper called with ws_client + full=True
+        assert mock_zha.await_args.kwargs == {"full": True}
+
+    @pytest.mark.asyncio
+    async def test_no_sections_when_include_omitted(self):
+        """No ``include`` → no gather call, only baseline health_info returned."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_repairs = AsyncMock()
+        mock_zha = AsyncMock()
+        mock_zwave = AsyncMock()
+
+        with _patch_health_info_baseline(), patch.object(
+            SystemTools, "_fetch_repairs", new=mock_repairs
+        ), patch.object(
+            SystemTools, "_fetch_zha_network", new=mock_zha
+        ), patch.object(
+            SystemTools, "_fetch_zwave_network", new=mock_zwave
+        ):
+            result = await tools.ha_get_system_health()
+
+        assert result["success"] is True
+        assert "repairs" not in result
+        assert "zha_network" not in result
+        assert "zwave_network" not in result
+        mock_repairs.assert_not_awaited()
+        mock_zha.assert_not_awaited()
+        mock_zwave.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Closes #1331. Replaces the sequential helper-fetch chain in `ha_get_system_health` with `asyncio.gather(*, return_exceptions=True)`, so independent backend calls for `repairs` / `zha_network` / `zwave_network` overlap on the wait side. Per-section error attribution preserved: a raising helper surfaces as `result["<section>"] = {"error": "..."}` while sibling sections still populate.

This PR sits on master at `bd9397f` (pre-#1328); the `diagnostics` section will need adding to the gather list once #1328 lands.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

(Closest fit: `perf:` per the conventional-commits matrix — patch-bump, user-facing.)

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`ruff` + `mypy` clean on the touched source file; 2643 unit tests pass, 1 musl-skip. New `TestGetSystemHealthGather` class with 5 cases (all-three / subset / raising-helper / `zha_network_full` route / no-include baseline).

## Future improvements

<!-- Out-of-scope items noted during this PR. -->

- After #1328 merges, add the `diagnostics` section (+ `diagnostics_fields` / `diagnostics_truncate_at_bytes` params) to the gather list.
- Real-world wall-clock measurement against a live HA install with ZHA + Z-Wave + dismissed repairs to quantify the win.

## Checklist
- [x] I have updated documentation if needed
