### PR TITLE
refactor: complete warnings-list migration for lifecycle-write tools

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -12,6 +12,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import (
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ..errors import (
     ErrorCode,
     create_config_error,
@@ -717,7 +721,7 @@ class AutomationConfigTools:
 
             # If the client could not verify the entity was registered, warn but don't hard-fail.
             if result.get("entity_not_verified"):
-                result["warning"] = (
+                result.setdefault("warnings", []).append(
                     "Automation was submitted to Home Assistant but the entity was not found "
                     "after polling. The automation may still have been created -- check Home "
                     "Assistant logs and try reloading automations. Common causes: "
@@ -733,12 +737,18 @@ class AutomationConfigTools:
             if not entity_id and identifier and identifier.startswith("automation."):
                 entity_id = identifier
             if wait_bool and entity_id:
+                action_word = "created" if identifier is None else "updated"
                 try:
                     registered = await wait_for_entity_registered(self._client, entity_id)
                     if not registered:
-                        result["warning"] = f"Automation created but {entity_id} not yet queryable. It may take a moment to become available."
-                except Exception as e:
-                    result["warning"] = f"Automation created but verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Automation {action_word} but {entity_id} not yet queryable. "
+                            "It may take a moment to become available."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Automation {action_word} but verification failed: {e}"
+                    )
 
             # Apply category to entity registry if provided
             if effective_category and entity_id:
@@ -1022,9 +1032,13 @@ class AutomationConfigTools:
                 try:
                     removed = await wait_for_entity_removed(self._client, entity_id_for_wait)
                     if not removed:
-                        result["warning"] = f"Deletion confirmed by API but {entity_id_for_wait} may still appear briefly."
-                except Exception as e:
-                    result["warning"] = f"Deletion confirmed but removal verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Deletion confirmed by API but {entity_id_for_wait} may still appear briefly."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Deletion confirmed but removal verification failed: {e}"
+                    )
 
             return {"success": True, "action": "delete", **result}
         except ToolError:

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1473,8 +1473,8 @@ async def _apply_registry_updates_to_entity(
     elif cat_result is not None:
         if "category" in cat_result:
             applied["category"] = cat_result["category"]
-        elif "category_warning" in cat_result:
-            warnings.append(f"{entity_id}: {cat_result['category_warning']}")
+        elif cat_result.get("warnings"):
+            warnings.extend(f"{entity_id}: {w}" for w in cat_result["warnings"])
 
     return applied
 
@@ -2864,7 +2864,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
                     # Apply category via shared helper (consistent with automations/scripts).
                     # Issue #1293: route the success/failure through ``cat_result`` so any
-                    # ``category_warning`` lands in the top-level ``warnings`` list instead
+                    # category-apply failure lands in the top-level ``warnings`` list instead
                     # of leaking nested into ``helper_data``. Mirrors the precedent in
                     # ``_handle_flow_helper`` (the ``cat_result`` block near the end of
                     # ``_apply_registry_updates_to_entity``).
@@ -2880,8 +2880,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                         if "category" in cat_result:
                             helper_data["category"] = cat_result["category"]
-                        elif "category_warning" in cat_result:
-                            warnings.append(cat_result["category_warning"])
+                        elif cat_result.get("warnings"):
+                            warnings.extend(cat_result["warnings"])
 
                     return _helper_response(
                         "create",
@@ -3495,7 +3495,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                             )
 
                     # Apply category via shared helper. Issue #1293: route through
-                    # ``cat_result`` so any ``category_warning`` lands in the top-level
+                    # ``cat_result`` so any category-apply failure lands in the top-level
                     # ``warnings`` list instead of nested in ``updated_data``.
                     if category:
                         cat_result = {}
@@ -3509,8 +3509,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                         if "category" in cat_result:
                             updated_data["category"] = cat_result["category"]
-                        elif "category_warning" in cat_result:
-                            warnings.append(cat_result["category_warning"])
+                        elif cat_result.get("warnings"):
+                            warnings.extend(cat_result["warnings"])
 
                 else:
                     # Fallback for unknown/future helper types: entity registry update only
@@ -3558,8 +3558,8 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         )
                         if "category" in cat_result:
                             updated_data["category"] = cat_result["category"]
-                        elif "category_warning" in cat_result:
-                            warnings.append(cat_result["category_warning"])
+                        elif cat_result.get("warnings"):
+                            warnings.extend(cat_result["warnings"])
 
                 # Wait for entity to reflect the update
                 wait_bool = coerce_bool_param(wait, "wait", default=True)

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -17,6 +17,7 @@ from pydantic import Field
 
 from ..client.rest_client import (
     HomeAssistantAPIError,
+    HomeAssistantAuthError,
     HomeAssistantConnectionError,
 )
 from ..errors import ErrorCode, create_error_response
@@ -732,11 +733,7 @@ class ConfigSceneTools:
                                 f"Scene updated but {entity_id} not yet queryable. "
                                 "It may take a moment to become available."
                             )
-                    except (
-                        TimeoutError,
-                        HomeAssistantAPIError,
-                        HomeAssistantConnectionError,
-                    ) as e:
+                    except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
                         result.setdefault("warnings", []).append(
                             f"Scene updated but verification failed: {e}"
                         )
@@ -853,11 +850,7 @@ class ConfigSceneTools:
                             f"Scene created but {entity_id} not yet queryable. "
                             "It may take a moment to become available."
                         )
-                except (
-                    TimeoutError,
-                    HomeAssistantAPIError,
-                    HomeAssistantConnectionError,
-                ) as e:
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
                     result.setdefault("warnings", []).append(
                         f"Scene created but verification failed: {e}"
                     )
@@ -982,11 +975,7 @@ class ConfigSceneTools:
                         result.setdefault("warnings", []).append(
                             f"Deletion confirmed by API but {entity_id} may still appear briefly."
                         )
-                except (
-                    TimeoutError,
-                    HomeAssistantAPIError,
-                    HomeAssistantConnectionError,
-                ) as e:
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
                     result.setdefault("warnings", []).append(
                         f"Deletion confirmed but removal verification failed: {e}"
                     )

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -847,12 +847,12 @@ class ConfigSceneTools:
                     )
                     if not registered:
                         result.setdefault("warnings", []).append(
-                            f"Scene created but {entity_id} not yet queryable. "
+                            f"Scene saved but {entity_id} not yet queryable. "
                             "It may take a moment to become available."
                         )
                 except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
                     result.setdefault("warnings", []).append(
-                        f"Scene created but verification failed: {e}"
+                        f"Scene saved but verification failed: {e}"
                     )
 
             # Apply category to entity registry if provided.

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -728,7 +728,7 @@ class ConfigSceneTools:
                             self._client, entity_id
                         )
                         if not registered:
-                            result["warning"] = (
+                            result.setdefault("warnings", []).append(
                                 f"Scene updated but {entity_id} not yet queryable. "
                                 "It may take a moment to become available."
                             )
@@ -737,7 +737,7 @@ class ConfigSceneTools:
                         HomeAssistantAPIError,
                         HomeAssistantConnectionError,
                     ) as e:
-                        result["warning"] = (
+                        result.setdefault("warnings", []).append(
                             f"Scene updated but verification failed: {e}"
                         )
                 if category and entity_id:
@@ -849,7 +849,7 @@ class ConfigSceneTools:
                         self._client, entity_id
                     )
                     if not registered:
-                        result["warning"] = (
+                        result.setdefault("warnings", []).append(
                             f"Scene created but {entity_id} not yet queryable. "
                             "It may take a moment to become available."
                         )
@@ -858,7 +858,9 @@ class ConfigSceneTools:
                     HomeAssistantAPIError,
                     HomeAssistantConnectionError,
                 ) as e:
-                    result["warning"] = f"Scene created but verification failed: {e}"
+                    result.setdefault("warnings", []).append(
+                        f"Scene created but verification failed: {e}"
+                    )
 
             # Apply category to entity registry if provided.
             if effective_category and entity_id:
@@ -977,7 +979,7 @@ class ConfigSceneTools:
                 try:
                     removed = await wait_for_entity_removed(self._client, entity_id)
                     if not removed:
-                        result["warning"] = (
+                        result.setdefault("warnings", []).append(
                             f"Deletion confirmed by API but {entity_id} may still appear briefly."
                         )
                 except (
@@ -985,7 +987,7 @@ class ConfigSceneTools:
                     HomeAssistantAPIError,
                     HomeAssistantConnectionError,
                 ) as e:
-                    result["warning"] = (
+                    result.setdefault("warnings", []).append(
                         f"Deletion confirmed but removal verification failed: {e}"
                     )
 

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -12,6 +12,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import (
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -584,9 +588,14 @@ class ConfigScriptTools:
                 try:
                     registered = await wait_for_entity_registered(self._client, entity_id)
                     if not registered:
-                        result["warning"] = f"Script created but {entity_id} not yet queryable. It may take a moment to become available."
-                except Exception as e:
-                    result["warning"] = f"Script created but verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Script saved but {entity_id} not yet queryable. "
+                            "It may take a moment to become available."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Script saved but verification failed: {e}"
+                    )
 
             # Apply category to entity registry if provided
             if effective_category and entity_id:
@@ -684,9 +693,13 @@ class ConfigScriptTools:
                 try:
                     removed = await wait_for_entity_removed(self._client, entity_id)
                     if not removed:
-                        result["warning"] = f"Deletion confirmed by API but {entity_id} may still appear briefly."
-                except Exception as e:
-                    result["warning"] = f"Deletion confirmed but removal verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Deletion confirmed by API but {entity_id} may still appear briefly."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Deletion confirmed but removal verification failed: {e}"
+                    )
 
             return {"success": True, "action": "delete", **result}
         except ToolError:

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -12,6 +12,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import (
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ..errors import ErrorCode, create_error_response
 from .helpers import (
     exception_to_structured_error,
@@ -305,12 +309,18 @@ class GroupTools:
             wait_bool = coerce_bool_param(wait, "wait", default=True)
             result: dict[str, Any] = {}
             if wait_bool:
+                action_word = "created" if is_create else "updated"
                 try:
                     registered = await wait_for_entity_registered(self._client, entity_id)
                     if not registered:
-                        result["warning"] = f"Group created but {entity_id} not yet queryable. It may take a moment to become available."
-                except Exception as e:
-                    result["warning"] = f"Group created but verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Group {action_word} but {entity_id} not yet queryable. "
+                            "It may take a moment to become available."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Group {action_word} but verification failed: {e}"
+                    )
 
             return {
                 "success": True,
@@ -409,9 +419,13 @@ class GroupTools:
                 try:
                     removed = await wait_for_entity_removed(self._client, entity_id)
                     if not removed:
-                        result["warning"] = f"Deletion confirmed by API but {entity_id} may still appear briefly."
-                except Exception as e:
-                    result["warning"] = f"Deletion confirmed but removal verification failed: {e}"
+                        result.setdefault("warnings", []).append(
+                            f"Deletion confirmed by API but {entity_id} may still appear briefly."
+                        )
+                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                    result.setdefault("warnings", []).append(
+                        f"Deletion confirmed but removal verification failed: {e}"
+                    )
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -666,8 +666,9 @@ async def apply_entity_category(
 ) -> None:
     """Apply a category to an entity via the entity registry.
 
-    Updates result_dict in-place with 'category' on success or
-    'category_warning' on failure.
+    Updates result_dict in-place: sets ``'category'`` on success, or appends
+    to the top-level ``'warnings'`` list on failure. The list shape mirrors
+    the canonical response contract documented at ``AGENTS.md`` L641-649.
 
     Args:
         client: HomeAssistantClient instance
@@ -695,12 +696,12 @@ async def apply_entity_category(
                 else str(error_detail)
             )
             logger.warning(f"Failed to set category for {entity_id}: {error_msg}")
-            result_dict["category_warning"] = (
+            result_dict.setdefault("warnings", []).append(
                 f"{entity_type.capitalize()} saved but failed to set category: {error_msg}"
             )
     except Exception as e:
         logger.warning(f"Failed to set category for {entity_id}: {e}")
-        result_dict["category_warning"] = (
+        result_dict.setdefault("warnings", []).append(
             f"{entity_type.capitalize()} saved but failed to set category: {e}"
         )
 

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -668,7 +668,8 @@ async def apply_entity_category(
 
     Updates result_dict in-place: sets ``'category'`` on success, or appends
     to the top-level ``'warnings'`` list on failure. The list shape mirrors
-    the canonical response contract documented at ``AGENTS.md`` L641-649.
+    the canonical response contract documented in ``AGENTS.md`` →
+    *Writing MCP Tools → Return Values*.
 
     Args:
         client: HomeAssistantClient instance

--- a/tests/src/e2e/workflows/scenes/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scenes/test_lifecycle.py
@@ -350,9 +350,10 @@ class TestSceneLifecycle:
         assert create_data.get("success") is True, f"Scene create failed: {create_data}"
         # No 'not yet queryable' warning means the resolver picked up the
         # real entity_id correctly — the regression KP13 surfaced via BAT.
-        assert "not yet queryable" not in str(create_data.get("warning", "")).lower(), (
-            f"Resolver fell back to scene.{scene_id}; create_data={create_data}"
-        )
+        assert not any(
+            "not yet queryable" in w.lower()
+            for w in create_data.get("warnings", [])
+        ), f"Resolver fell back to scene.{scene_id}; create_data={create_data}"
 
         # 2. Get via the storage scene_id — this drives the resolver to
         # find the actual entity_id under the hood for category fetch.
@@ -381,8 +382,9 @@ class TestSceneLifecycle:
         assert transform_data.get("success") is True, (
             f"Transform failed: {transform_data}"
         )
-        assert (
-            "not yet queryable" not in str(transform_data.get("warning", "")).lower()
+        assert not any(
+            "not yet queryable" in w.lower()
+            for w in transform_data.get("warnings", [])
         ), f"Resolver fell back on transform path; transform_data={transform_data}"
 
         # Cleanup via remove uses the same resolver under the hood.

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -15,7 +15,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ha_mcp.client.rest_client import HomeAssistantConnectionError
+from ha_mcp.client.rest_client import (
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 
 
 @pytest.fixture
@@ -415,6 +418,10 @@ class TestUniformResponseShape:
         warning to the top-level ``warnings`` list (mirrors the precedent in
         ``_handle_flow_helper``'s ``cat_result`` block in
         ``_apply_registry_updates_to_entity``).
+
+        Post-#1355: writer now appends directly to ``result_dict["warnings"]``
+        instead of setting singular ``category_warning``; the leak-check
+        assertions still hold (neither key should appear in ``data``).
         """
 
         async def ws_handler(msg: dict) -> dict:
@@ -434,7 +441,7 @@ class TestUniformResponseShape:
         async def fake_apply(
             client, entity_id, category, scope, result_dict, entity_type
         ):
-            result_dict["category_warning"] = (
+            result_dict.setdefault("warnings", []).append(
                 "Helper saved but failed to set category: forced failure"
             )
 
@@ -457,6 +464,9 @@ class TestUniformResponseShape:
         _assert_uniform_shape(result, expect_warnings=True)
         assert "category_warning" not in result["data"], (
             "category_warning leaked into data payload"
+        )
+        assert "warnings" not in result["data"], (
+            "warnings leaked into data payload — must stay top-level"
         )
         assert "category" not in result["data"], (
             "category should not be set in data when apply failed"
@@ -501,7 +511,7 @@ class TestUniformResponseShape:
         async def fake_apply(
             client, entity_id, category, scope, result_dict, entity_type
         ):
-            result_dict["category_warning"] = (
+            result_dict.setdefault("warnings", []).append(
                 "Helper saved but failed to set category: forced failure"
             )
 
@@ -525,6 +535,9 @@ class TestUniformResponseShape:
         _assert_uniform_shape(result, expect_warnings=True)
         assert "category_warning" not in result["data"], (
             "category_warning leaked into data payload"
+        )
+        assert "warnings" not in result["data"], (
+            "warnings leaked into data payload — must stay top-level"
         )
         assert "category" not in result["data"], (
             "category should not be set in data when apply failed"
@@ -560,3 +573,424 @@ class TestUniformResponseShape:
         )
         assert isinstance(result.get("warnings"), list)
         assert any("not yet queryable" in w for w in result["warnings"])
+
+
+def _assert_warnings_list_shape(result: dict[str, Any]) -> None:
+    """Cross-cutting warnings-list contract for lifecycle-write tools (#1332).
+
+    Tighter than ``_assert_uniform_shape`` for the warnings half: applies to
+    any successful tool response, regardless of payload-wrapper key.
+
+    - ``success`` is True
+    - ``warnings`` is a non-empty ``list[str]`` at the top level
+    - No singular ``warning`` string at the top level (legacy shape)
+    - ``warnings`` does not leak into any nested dict value (no
+      ``"data": {"warnings": [...]}`` or ``"result": {"warnings": [...]}``
+      nesting pattern that pre-#1332 callers had to chase)
+    """
+    assert result["success"] is True
+    assert "warning" not in result, (
+        "singular 'warning' key must not appear at top level"
+    )
+    assert isinstance(result.get("warnings"), list), (
+        f"warnings missing or not a list: {result.get('warnings')!r}"
+    )
+    assert all(isinstance(w, str) for w in result["warnings"]), (
+        f"non-string warning entries: {result['warnings']!r}"
+    )
+    assert result["warnings"], "warnings list present but empty"
+    # Defence against re-introduction of nested warning bags: scan every
+    # dict-typed top-level value for ``warnings`` / ``warning`` keys.
+    # ``validation`` is the intentional reference-validator metadata bag
+    # (``merge_validation_meta`` — separate concern from #1332's lifecycle
+    # warnings) and is whitelisted from the leak check.
+    nested_warnings_whitelist = {"validation"}
+    for key, value in result.items():
+        if key == "warnings" or key in nested_warnings_whitelist:
+            continue
+        if isinstance(value, dict):
+            assert "warnings" not in value, (
+                f"warnings leaked into nested '{key}': must stay top-level"
+            )
+            assert "warning" not in value, (
+                f"singular 'warning' leaked into nested '{key}'"
+            )
+
+
+class TestLifecycleWriteWarningsShape:
+    """Cross-cutting shape regression for the 4 lifecycle-write families
+    migrated under #1332. Asserts the warnings-list contract holds on
+    every emission path that landed in #1337-#1340 (now consolidated into #1340).
+
+    Per the narrow exception tuple decision (#1340 thread with kingpanther13):
+    only HomeAssistantConnectionError and HomeAssistantAuthError propagate
+    from wait_for_entity_registered / wait_for_entity_removed to the call
+    sites — TimeoutError returns False (handled separately), HomeAssistantAPIError
+    is fully swallowed by the helpers (util_helpers.py:495-499 + :537-543).
+    Tests only the two exception types that actually reach the call sites.
+    """
+
+    # ------------------------------------------------------------------
+    # Per-family tool factories.
+    # Each returns a tools instance plus a mock client wired so the
+    # underlying write succeeds and only the wait-verification step
+    # raises (the codepath under test).
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def groups_tools(self):
+        from ha_mcp.tools.tools_groups import GroupTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock(return_value=None)
+        client.get_entity_state = AsyncMock(return_value={"state": "on"})
+        client.get_states = AsyncMock(return_value=[])
+        return GroupTools(client)
+
+    @pytest.fixture
+    def scripts_tools(self):
+        from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
+
+        client = MagicMock()
+        client.upsert_script_config = AsyncMock(
+            return_value={"script_id": "test_script"}
+        )
+        client.delete_script_config = AsyncMock(
+            return_value={"script_id": "test_script"}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={"state": "off", "entity_id": "script.test_script"}
+        )
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        return ConfigScriptTools(client)
+
+    @pytest.fixture
+    def automations_tools(self):
+        from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+
+        client = MagicMock()
+        client.upsert_automation_config = AsyncMock(
+            return_value={"entity_id": "automation.test_auto"}
+        )
+        client.delete_automation_config = AsyncMock(
+            return_value={"identifier": "automation.test_auto"}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={"state": "on", "entity_id": "automation.test_auto"}
+        )
+        client.get_services = AsyncMock(return_value=[])
+        # _resolve_automation_entity_id reads states; for entity_id input
+        # the short-circuit triggers and this is never consulted.
+        client.get_states = AsyncMock(return_value=[])
+        return AutomationConfigTools(client)
+
+    @pytest.fixture
+    def scenes_tools(self, monkeypatch):
+        from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
+
+        # Issue #1168 R3 blocker 1 sleep — zero it so registry-miss
+        # retry doesn't stretch the unit-test wall clock.
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+
+        client = MagicMock()
+        client.upsert_scene_config = AsyncMock(
+            return_value={"scene_id": "test_scene"}
+        )
+        client.delete_scene_config = AsyncMock(
+            return_value={"scene_id": "test_scene"}
+        )
+        client.resolve_scene_id = AsyncMock(
+            side_effect=lambda sid: sid.removeprefix("scene.")
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={
+                "state": "2026-05-18T00:00:00+00:00",
+                "entity_id": "scene.test_scene",
+            }
+        )
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        # _resolve_scene_entity_id: empty registry → falls back to
+        # f"scene.{scene_id}" which matches what wait_for_entity_registered
+        # is patched to receive.
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        return ConfigSceneTools(client)
+
+    # ------------------------------------------------------------------
+    # Groups: set + remove × 2 exception types
+    # ------------------------------------------------------------------
+
+    async def test_groups_set_connection_error_yields_top_level_warnings_list(
+        self, groups_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_groups.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await groups_tools.ha_config_set_group(
+                object_id="test_group",
+                entities=["light.kitchen"],
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_groups_set_auth_error_yields_top_level_warnings_list(
+        self, groups_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_groups.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await groups_tools.ha_config_set_group(
+                object_id="test_group",
+                entities=["light.kitchen"],
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_groups_remove_connection_error_yields_top_level_warnings_list(
+        self, groups_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_groups.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await groups_tools.ha_config_remove_group(
+                object_id="test_group",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    async def test_groups_remove_auth_error_yields_top_level_warnings_list(
+        self, groups_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_groups.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await groups_tools.ha_config_remove_group(
+                object_id="test_group",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    # ------------------------------------------------------------------
+    # Scripts: set + remove × 2 exception types
+    # ------------------------------------------------------------------
+
+    async def test_scripts_set_connection_error_yields_top_level_warnings_list(
+        self, scripts_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scripts.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await scripts_tools.ha_config_set_script(
+                script_id="test_script",
+                config={"sequence": [{"delay": {"seconds": 1}}]},
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_scripts_set_auth_error_yields_top_level_warnings_list(
+        self, scripts_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scripts.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await scripts_tools.ha_config_set_script(
+                script_id="test_script",
+                config={"sequence": [{"delay": {"seconds": 1}}]},
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_scripts_remove_connection_error_yields_top_level_warnings_list(
+        self, scripts_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scripts.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await scripts_tools.ha_config_remove_script(
+                script_id="test_script",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    async def test_scripts_remove_auth_error_yields_top_level_warnings_list(
+        self, scripts_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scripts.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await scripts_tools.ha_config_remove_script(
+                script_id="test_script",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    # ------------------------------------------------------------------
+    # Automations: set + remove × 2 exception types
+    # ------------------------------------------------------------------
+
+    async def test_automations_set_connection_error_yields_top_level_warnings_list(
+        self, automations_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_automations.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await automations_tools.ha_config_set_automation(
+                config={
+                    "alias": "Test Auto",
+                    "trigger": [{"platform": "time", "at": "07:00:00"}],
+                    "action": [{"service": "light.turn_on"}],
+                },
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_automations_set_auth_error_yields_top_level_warnings_list(
+        self, automations_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_automations.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await automations_tools.ha_config_set_automation(
+                config={
+                    "alias": "Test Auto",
+                    "trigger": [{"platform": "time", "at": "07:00:00"}],
+                    "action": [{"service": "light.turn_on"}],
+                },
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_automations_remove_connection_error_yields_top_level_warnings_list(
+        self, automations_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_automations.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await automations_tools.ha_config_remove_automation(
+                identifier="automation.test_auto",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    async def test_automations_remove_auth_error_yields_top_level_warnings_list(
+        self, automations_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_automations.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await automations_tools.ha_config_remove_automation(
+                identifier="automation.test_auto",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    # ------------------------------------------------------------------
+    # Scenes: set + remove × 2 exception types
+    # ------------------------------------------------------------------
+
+    async def test_scenes_set_connection_error_yields_top_level_warnings_list(
+        self, scenes_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scenes.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await scenes_tools.ha_config_set_scene(
+                scene_id="test_scene",
+                config={
+                    "name": "Test Scene",
+                    "entities": {"light.kitchen": {"state": "on"}},
+                },
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_scenes_set_auth_error_yields_top_level_warnings_list(
+        self, scenes_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scenes.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await scenes_tools.ha_config_set_scene(
+                scene_id="test_scene",
+                config={
+                    "name": "Test Scene",
+                    "entities": {"light.kitchen": {"state": "on"}},
+                },
+            )
+        _assert_warnings_list_shape(result)
+        assert any("verification failed" in w for w in result["warnings"])
+
+    async def test_scenes_remove_connection_error_yields_top_level_warnings_list(
+        self, scenes_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scenes.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await scenes_tools.ha_config_remove_scene(
+                scene_id="test_scene",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )
+
+    async def test_scenes_remove_auth_error_yields_top_level_warnings_list(
+        self, scenes_tools
+    ):
+        with patch(
+            "ha_mcp.tools.tools_config_scenes.wait_for_entity_removed",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantAuthError("forced for test"),
+        ):
+            result = await scenes_tools.ha_config_remove_scene(
+                scene_id="test_scene",
+            )
+        _assert_warnings_list_shape(result)
+        assert any(
+            "removal verification failed" in w for w in result["warnings"]
+        )

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -785,6 +785,26 @@ class TestLifecycleWriteWarningsShape:
             "removal verification failed" in w for w in result["warnings"]
         )
 
+    async def test_groups_update_path_uses_updated_action_word(
+        self, groups_tools
+    ):
+        # Rename-only call (name set, entities/add/remove all None) — the
+        # is_create branch in tools_groups.py:306 evaluates to False, so
+        # action_word must be "updated". Pins the create/update branching
+        # against a regression hardcoding "created" on the update path.
+        with patch(
+            "ha_mcp.tools.tools_groups.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await groups_tools.ha_config_set_group(
+                object_id="test_group",
+                name="Renamed Test Group",
+            )
+        _assert_warnings_list_shape(result)
+        assert any("updated but" in w for w in result["warnings"])
+        assert not any("created but" in w for w in result["warnings"])
+
     # ------------------------------------------------------------------
     # Scripts: set + remove × 2 exception types
     # ------------------------------------------------------------------
@@ -922,6 +942,29 @@ class TestLifecycleWriteWarningsShape:
         assert any(
             "removal verification failed" in w for w in result["warnings"]
         )
+
+    async def test_automations_update_path_uses_updated_action_word(
+        self, automations_tools
+    ):
+        # identifier supplied — tools_config_automations.py:740 selects
+        # action_word = "updated". Pins the create/update branching against
+        # a regression hardcoding "created" on the update path.
+        with patch(
+            "ha_mcp.tools.tools_config_automations.wait_for_entity_registered",
+            new_callable=AsyncMock,
+            side_effect=HomeAssistantConnectionError("forced for test"),
+        ):
+            result = await automations_tools.ha_config_set_automation(
+                identifier="automation.test_auto",
+                config={
+                    "alias": "Test Auto",
+                    "trigger": [{"platform": "time", "at": "07:00:00"}],
+                    "action": [{"service": "light.turn_on"}],
+                },
+            )
+        _assert_warnings_list_shape(result)
+        assert any("updated but" in w for w in result["warnings"])
+        assert not any("created but" in w for w in result["warnings"])
 
     # ------------------------------------------------------------------
     # Scenes: set + remove × 2 exception types

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -13,6 +13,7 @@ from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import (
     HomeAssistantAPIError,
+    HomeAssistantAuthError,
     HomeAssistantConnectionError,
 )
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
@@ -2026,3 +2027,259 @@ class TestSmartSearchSceneIdFallbackPaths:
             "tier-3 slug-fallback must emit a WARNING; got "
             f"{[(r.levelname, r.message) for r in caplog.records]}"
         )
+
+
+class TestSceneVerificationFailureWarnings:
+    """Scene-tool-specific verification-failure coverage for the three
+    wait-helper call sites migrated under #1332 (PR #1340):
+
+    1. ``ha_config_set_scene`` python_transform update path
+    2. ``ha_config_set_scene`` main create path
+    3. ``ha_config_remove_scene`` delete path
+
+    Per the narrow exception tuple decision (#1340 thread with
+    kingpanther13): only ``HomeAssistantConnectionError`` and
+    ``HomeAssistantAuthError`` propagate from
+    ``wait_for_entity_registered`` / ``wait_for_entity_removed`` to the
+    call sites. ``TimeoutError`` returns False (handled separately;
+    surfaces a different "not yet queryable" warning), and
+    ``HomeAssistantAPIError`` is fully swallowed by the helpers in
+    ``util_helpers.py``.
+
+    Distinct from the cross-cutting shape regression in
+    ``test_helper_response_shape.py::TestLifecycleWriteWarningsShape`` —
+    these tests stay scoped to the scene tool family and assert on
+    scene-specific behaviour: exact warning verbiage per call site,
+    the underlying write still reports ``success=True``, the storage
+    key is threaded through unchanged, and the upstream exception
+    message is captured in the warning text.
+    """
+
+    async def test_scene_create_wait_connection_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """Create path: a ``HomeAssistantConnectionError`` from the wait
+        helper must surface as a top-level warning, leave ``success=True``
+        (the upsert itself succeeded), and carry the exception message
+        in the warning text."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantConnectionError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_registered", _raise)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            config={
+                "name": "Test Scene",
+                "entities": {"light.kitchen": {"state": "on"}},
+            },
+        )
+
+        # Underlying upsert succeeded — only the post-write verification
+        # tripped, so the operation is still reported as successful.
+        assert result["success"] is True
+        mock_client.upsert_scene_config.assert_called_once()
+        # Storage key threading unchanged by the warning path.
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"expected non-empty warnings list, got {warnings!r}"
+        )
+        assert all(isinstance(w, str) for w in warnings), (
+            f"warnings list must be list[str]; got {warnings!r}"
+        )
+        # Family-specific verbiage from the create branch.
+        assert any("Scene created but verification failed" in w for w in warnings), (
+            f"expected scene-create verbiage; got {warnings!r}"
+        )
+        # Exception message captured for caller-side diagnosis.
+        assert any("forced for test" in w for w in warnings), (
+            f"expected exception message in warning; got {warnings!r}"
+        )
+
+    async def test_scene_create_wait_auth_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """Create path: ``HomeAssistantAuthError`` is the second member of
+        the narrow exception tuple and must reach the same warning path."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantAuthError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_registered", _raise)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            config={
+                "name": "Test Scene",
+                "entities": {"light.kitchen": {"state": "on"}},
+            },
+        )
+
+        assert result["success"] is True
+        mock_client.upsert_scene_config.assert_called_once()
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings
+        assert all(isinstance(w, str) for w in warnings)
+        assert any("Scene created but verification failed" in w for w in warnings), (
+            f"expected scene-create verbiage; got {warnings!r}"
+        )
+        assert any("forced for test" in w for w in warnings)
+
+    async def test_scene_update_wait_connection_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """python_transform branch: a ``HomeAssistantConnectionError`` from
+        the wait helper surfaces a warning specific to the update verbiage
+        ("Scene updated but verification failed"). Asserts the warning is
+        appended on this branch — historically the python_transform path
+        had drift risk with the main create branch (cf. the G2 regression
+        for ``apply_entity_category``)."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        seed = {
+            "id": "test_scene",
+            "name": "Test Scene",
+            "entities": {"light.kitchen": {"state": "on"}},
+        }
+        mock_client.get_scene_config = AsyncMock(return_value=seed)
+        seed_hash = compute_config_hash(seed)
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantConnectionError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_registered", _raise)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            python_transform=(
+                "config['entities']['light.kitchen']['brightness'] = 100"
+            ),
+            config_hash=seed_hash,
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "python_transform"
+        mock_client.upsert_scene_config.assert_called_once()
+        # python_transform branch threads the storage key into the response.
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"expected non-empty warnings list, got {warnings!r}"
+        )
+        assert all(isinstance(w, str) for w in warnings)
+        # Update-branch verbiage differs from create-branch verbiage.
+        assert any("Scene updated but verification failed" in w for w in warnings), (
+            f"expected scene-update verbiage; got {warnings!r}"
+        )
+        assert any("forced for test" in w for w in warnings)
+
+    async def test_scene_update_wait_auth_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """python_transform branch: ``HomeAssistantAuthError`` reaches the
+        same warning path as the connection-error case."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        seed = {
+            "id": "test_scene",
+            "name": "Test Scene",
+            "entities": {"light.kitchen": {"state": "on"}},
+        }
+        mock_client.get_scene_config = AsyncMock(return_value=seed)
+        seed_hash = compute_config_hash(seed)
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantAuthError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_registered", _raise)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            python_transform=(
+                "config['entities']['light.kitchen']['brightness'] = 100"
+            ),
+            config_hash=seed_hash,
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "python_transform"
+        mock_client.upsert_scene_config.assert_called_once()
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings
+        assert all(isinstance(w, str) for w in warnings)
+        assert any("Scene updated but verification failed" in w for w in warnings), (
+            f"expected scene-update verbiage; got {warnings!r}"
+        )
+        assert any("forced for test" in w for w in warnings)
+
+    async def test_scene_remove_wait_connection_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """Remove path: a ``HomeAssistantConnectionError`` from the
+        ``wait_for_entity_removed`` helper surfaces a remove-specific
+        warning ("Deletion confirmed but removal verification failed"),
+        while the response still reports ``success=True`` (the delete
+        REST call itself completed) and threads the storage key."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantConnectionError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_removed", _raise)
+
+        result = await tools.ha_config_remove_scene(scene_id="test_scene")
+
+        assert result["success"] is True
+        assert result["action"] == "delete"
+        mock_client.delete_scene_config.assert_called_once()
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"expected non-empty warnings list, got {warnings!r}"
+        )
+        assert all(isinstance(w, str) for w in warnings)
+        # Remove-path verbiage is distinct from create / update.
+        assert any("removal verification failed" in w for w in warnings), (
+            f"expected scene-remove verbiage; got {warnings!r}"
+        )
+        assert any("forced for test" in w for w in warnings)
+
+    async def test_scene_remove_wait_auth_error_appends_warning(
+        self, tools, mock_client, monkeypatch
+    ):
+        """Remove path: ``HomeAssistantAuthError`` reaches the same
+        warning path as the connection-error case."""
+        from ha_mcp.tools import tools_config_scenes as scene_mod
+
+        async def _raise(*_args, **_kwargs):
+            raise HomeAssistantAuthError("forced for test")
+
+        monkeypatch.setattr(scene_mod, "wait_for_entity_removed", _raise)
+
+        result = await tools.ha_config_remove_scene(scene_id="test_scene")
+
+        assert result["success"] is True
+        assert result["action"] == "delete"
+        mock_client.delete_scene_config.assert_called_once()
+        assert result["scene_id"] == "test_scene"
+
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings
+        assert all(isinstance(w, str) for w in warnings)
+        assert any("removal verification failed" in w for w in warnings), (
+            f"expected scene-remove verbiage; got {warnings!r}"
+        )
+        assert any("forced for test" in w for w in warnings)

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -2091,9 +2091,11 @@ class TestSceneVerificationFailureWarnings:
         assert all(isinstance(w, str) for w in warnings), (
             f"warnings list must be list[str]; got {warnings!r}"
         )
-        # Family-specific verbiage from the create branch.
-        assert any("Scene created but verification failed" in w for w in warnings), (
-            f"expected scene-create verbiage; got {warnings!r}"
+        # Neutral verbiage on the full-config branch — upsert_scene_config
+        # returns no create/update signal, so wording follows the scripts
+        # pattern (rest_client.py::upsert_scene_config L1417-1428).
+        assert any("Scene saved but verification failed" in w for w in warnings), (
+            f"expected scene-saved verbiage; got {warnings!r}"
         )
         # Exception message captured for caller-side diagnosis.
         assert any("forced for test" in w for w in warnings), (
@@ -2127,8 +2129,8 @@ class TestSceneVerificationFailureWarnings:
         warnings = result.get("warnings")
         assert isinstance(warnings, list) and warnings
         assert all(isinstance(w, str) for w in warnings)
-        assert any("Scene created but verification failed" in w for w in warnings), (
-            f"expected scene-create verbiage; got {warnings!r}"
+        assert any("Scene saved but verification failed" in w for w in warnings), (
+            f"expected scene-saved verbiage; got {warnings!r}"
         )
         assert any("forced for test" in w for w in warnings)
 

--- a/tests/src/unit/test_util_helpers.py
+++ b/tests/src/unit/test_util_helpers.py
@@ -12,6 +12,7 @@ from ha_mcp.client.rest_client import (
 from ha_mcp.tools.util_helpers import (
     DIAGNOSTICS_DEFAULT_TIMEOUT_SECONDS,
     _resolve_data_path,
+    apply_entity_category,
     build_pagination_metadata,
     coerce_int_param,
     fetch_integration_diagnostics,
@@ -1261,3 +1262,104 @@ class TestParseDiagnosticsFields:
     def test_non_string_non_list_raises(self):
         with pytest.raises(ValueError, match="must be list, string, or None"):
             parse_diagnostics_fields(42)  # type: ignore[arg-type]
+
+
+class TestApplyEntityCategoryWriter:
+    """Direct writer-shape contract for ``apply_entity_category``.
+
+    Consumer-shim tests in ``test_helper_response_shape.py`` use a
+    hand-rolled ``fake_apply``; this class drives the REAL function to
+    pin the post-#1355 shape: success populates top-level ``warnings``
+    list, never the legacy singular ``category_warning`` key. A revert
+    of the writer to ``result_dict["category_warning"] = ...`` must
+    fail one of the assertions here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failure_response_appends_to_warnings_list(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": {"message": "boom"}}
+        )
+        result: dict[str, object] = {}
+
+        await apply_entity_category(
+            client,
+            entity_id="light.kitchen",
+            category="cat_test",
+            scope="light",
+            result_dict=result,
+            entity_type="light",
+        )
+
+        assert isinstance(result.get("warnings"), list)
+        assert any("failed to set category" in w for w in result["warnings"])
+        assert any("boom" in w for w in result["warnings"])
+        assert "category_warning" not in result
+        assert "category" not in result
+
+    @pytest.mark.asyncio
+    async def test_websocket_exception_appends_to_warnings_list(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            side_effect=HomeAssistantConnectionError("ws disconnected")
+        )
+        result: dict[str, object] = {}
+
+        await apply_entity_category(
+            client,
+            entity_id="light.kitchen",
+            category="cat_test",
+            scope="light",
+            result_dict=result,
+            entity_type="light",
+        )
+
+        assert isinstance(result.get("warnings"), list)
+        assert any("failed to set category" in w for w in result["warnings"])
+        assert any("ws disconnected" in w for w in result["warnings"])
+        assert "category_warning" not in result
+
+    @pytest.mark.asyncio
+    async def test_success_does_not_create_warnings_key(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True}
+        )
+        result: dict[str, object] = {}
+
+        await apply_entity_category(
+            client,
+            entity_id="light.kitchen",
+            category="cat_test",
+            scope="light",
+            result_dict=result,
+            entity_type="light",
+        )
+
+        assert result.get("category") == "cat_test"
+        assert "warnings" not in result
+        assert "category_warning" not in result
+
+    @pytest.mark.asyncio
+    async def test_failure_preserves_existing_warnings_entries(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": {"message": "boom"}}
+        )
+        result: dict[str, object] = {"warnings": ["earlier note"]}
+
+        await apply_entity_category(
+            client,
+            entity_id="light.kitchen",
+            category="cat_test",
+            scope="light",
+            result_dict=result,
+            entity_type="light",
+        )
+
+        warnings = result["warnings"]
+        assert isinstance(warnings, list)
+        assert "earlier note" in warnings
+        assert any("failed to set category" in w for w in warnings)
+        assert "category_warning" not in result

--- a/tests/src/unit/test_wait_parameter.py
+++ b/tests/src/unit/test_wait_parameter.py
@@ -102,7 +102,7 @@ class TestAutomationWaitParameter:
     async def test_set_automation_wait_timeout_adds_warning(
         self, register_tools, mock_client
     ):
-        """When wait times out, a warning is added to the response."""
+        """When wait times out, a warning is added to the top-level warnings list."""
         with patch(
             "ha_mcp.tools.tools_config_automations.wait_for_entity_registered",
             new_callable=AsyncMock,
@@ -116,7 +116,8 @@ class TestAutomationWaitParameter:
                 },
             )
             assert result["success"] is True
-            assert "warning" in result
+            assert isinstance(result.get("warnings"), list) and result["warnings"]
+            assert any("not yet queryable" in w for w in result["warnings"])
 
     async def test_remove_automation_wait_default_true(
         self, register_tools, mock_client
@@ -200,7 +201,8 @@ class TestAutomationWaitParameter:
                 },
             )
             assert result["success"] is True
-            assert "warning" in result
+            assert isinstance(result.get("warnings"), list) and result["warnings"]
+            assert any("verification failed" in w for w in result["warnings"])
 
 
 class TestScriptWaitParameter:


### PR DESCRIPTION
## What does this PR do?

Consolidates four per-domain PRs (#1337 groups, #1338 scripts, #1339 automations, #1340 scenes) into a single diff per @kingpanther13's bundling proposal ([comment](https://github.com/homeassistant-ai/ha-mcp/pull/1340#issuecomment-4478144806)). Also folds in #1355 (`apply_entity_category` shared-helper migration) and #1356 (cross-cutting regression test) since they share the same overwrite-footgun anti-pattern under different key names.

**Four lifecycle-write families** (`tools_groups.py`, `tools_config_scripts.py`, `tools_config_automations.py`, `tools_config_scenes.py`):

- Migrate `result["warning"] = "..."` (singular) → `result.setdefault("warnings", []).append(...)` (top-level list per `AGENTS.md` L675-681)
- Narrow except tuple at all wait-helper call sites to `(HomeAssistantConnectionError, HomeAssistantAuthError)`. Live-verified against `util_helpers.py:495-499` and `:537-543`: `TimeoutError` returns `False` on timeout (handled separately via `if not registered:`), `HomeAssistantAPIError` is fully swallowed by the helpers (404 → `pass` / return-True; non-404 → `logger.warning` without re-raise). Catching either at the call site was dead code.
- Drop call-site `logger.warning` at the wait-helper sites — the helpers already log Connection/Auth at `util_helpers.py:501` and `:544` before re-raising, so call-site logs would duplicate (KP13's 13:09 review item 2, retracted in his [follow-up](https://github.com/homeassistant-ai/ha-mcp/pull/1340#issuecomment-4478510837) once the narrow-tuple decision landed).
- Branch warning text on `is_create` (groups) / `identifier is None` (automations) to match the success-message wording where the tool surfaces a create/update signal. Scripts and scenes use neutral `"<Type> saved"` — HA's upsert response is identical for create vs update on these tools (see `rest_client.py::upsert_scene_config` L1417-1428), so no reliable signal exists post-upsert.

**#1355 `apply_entity_category` migration:**

- Writer in `util_helpers.py:698`+`:703` flipped from singular `result_dict["category_warning"] = "..."` to `result_dict.setdefault("warnings", []).append(...)`. Docstring updated to point at the canonical contract.
- 4 consumer unwrap-shims in `tools_config_helpers.py` (L1476, L2883, L3512, L3561) collapsed from `elif "category_warning" in cat_result:` to `elif cat_result.get("warnings"):` + `warnings.extend(...)`.
- 2 existing mock tests in `test_helper_response_shape.py` migrated to use the new writer shape + added no-leak-into-data assertion alongside the existing `category_warning` leak check.

**#1356 cross-cutting regression test:**

- New `TestLifecycleWriteWarningsShape` class in `test_helper_response_shape.py` with 18 methods: 16 baseline (4 families × create/remove × Connection/Auth) + 2 update-path cases for groups + automations pinning the create vs update branching (added in second-pass review). Pins the `warnings: list[str]` contract via a sibling `_assert_warnings_list_shape` helper — the existing `_assert_uniform_shape` assumes a `data` wrapper that lifecycle-write tools don't have.
- New `TestApplyEntityCategoryWriter` class in `test_util_helpers.py` (4 methods) drives the real `apply_entity_category` writer — failure response, WS exception, success-without-warnings, and existing-warnings-preserved invariants. Independent of the consumer-shim `fake_apply` used in `test_helper_response_shape.py`; pins the post-#1355 writer shape against a revert to the legacy `category_warning` key.

**Scene-specific verification-failure tests** (KP13 13:09 review item 3):

- New `TestSceneVerificationFailureWarnings` class in `test_tools_config_scenes.py` with 6 methods (3 scene ops × Connection/Auth). Asserts scene-specific verbiage + storage-key threading + action-branch identity.

**Out of scope (stays):**

- Scenes resolver tuple at `tools_config_scenes.py:105`/`:109`/`:151` left unchanged — KP13 explicitly approved keeping the wider tuple there since the helpers genuinely raise the full triad in resolver context (different call surface from wait-helper).
- `tools_service.py` / `tools_get_states.py` / other non-lifecycle-write singular-`warning` sites — covered by #1341 (different file set, non-lifecycle-write).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local: 2778 passed, 1 skipped (`test_numpy_version_constraint.py` — numpy unavailable on Alpine/musl, unrelated). Ruff + mypy clean on all touched files.

## Future improvements

<!-- Optional: things noticed during this PR that are out of scope but worth doing later.
     Small things fixable in a few lines should be fixed inline rather than listed here. -->

None — this PR completes the warnings-list migration for the lifecycle-write tool families. Remaining singular-`warning` sites in `tools_service.py` / `tools_search.py` / `tools_system.py` / etc. are tracked in #1341 (different file set, non-lifecycle-write).

## Checklist
- [x] I have updated documentation if needed

---

Closes #1332, #1355, #1356.
Supersedes #1337, #1338, #1339 (closing as superseded after merge).

