### PR TITLE
refactor: complete singular warning → warnings list migration repo-wide (closes #1332)

### DIFF
--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -450,7 +450,9 @@ async def restore_backup(
                 "status": "Restore initiated - Home Assistant will restart",
                 "safety_backup_id": safety_backup_id,
                 "restore_database": restore_database,
-                "warning": "Home Assistant is restarting. Connection will be temporarily lost.",
+                "warnings": [
+                    "Home Assistant is restarting. Connection will be temporarily lost."
+                ],
                 "note": "A safety backup was created before restore. You can restore from it if needed.",
             }
         else:

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1272,7 +1272,7 @@ def _apply_array_ops(
                 and inspectable
                 and not any(field in it for it in inspectable)
             ):
-                entry["warning"] = (
+                entry.setdefault("warnings", []).append(
                     f"field {field!r} is not present on any item — "
                     "check for a typo in the field name"
                 )
@@ -2212,7 +2212,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
                     "submitted_fields": submitted_fields,
                 }
             if ignored_fields:
-                response["warning"] = (
+                response.setdefault("warnings", []).append(
                     f"{len(ignored_fields)} field(s) not in add-on schema were ignored "
                     f"before write: {ignored_fields}. Use ha_get_addon(slug) to see the "
                     "declared schema."

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -673,7 +673,7 @@ class EnergyTools:
             }
             if validate_warning is not None:
                 response["partial"] = True
-                response["warning"] = validate_warning
+                response.setdefault("warnings", []).append(validate_warning)
             return response
 
         except ToolError:
@@ -953,14 +953,14 @@ class EnergyTools:
             }
             if post_save_errors:
                 response["post_save_validation_errors"] = post_save_errors
-                response["warning"] = (
+                response.setdefault("warnings", []).append(
                     f"Save succeeded, but the persisted config has "
                     f"{len(post_save_errors)} validation error(s). Review "
                     "and re-write if any relate to this change."
                 )
             elif post_save_validate_error is not None:
                 response["partial"] = True
-                response["warning"] = (
+                response.setdefault("warnings", []).append(
                     f"Save succeeded, but post-save energy/validate "
                     f"failed: {post_save_validate_error}. The persisted "
                     "config has not been re-validated."

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -379,6 +379,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         "warnings": [
                             "Entity registry lookup failed — could not determine device. Retry may succeed."
                         ],
+                        "lookup_failed": True,
                     }
 
             device_id = (
@@ -533,10 +534,14 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         if device_rename_result is not None:
             response_data["device_rename"] = device_rename_result
-            # Only mark partial when device rename was attempted and failed
-            # (not when entity simply has no device)
-            if device_rename_result.get("warnings") and device_rename_result.get(
-                "device_id"
+            # Mark partial when a device rename was requested but didn't complete
+            # for an operational reason: WS-call failure (device_id present + warnings)
+            # or upstream registry lookup failure (lookup_failed marker). Not partial
+            # when the entity simply has no device — that's a no-op, not an incomplete
+            # operation.
+            if device_rename_result.get("warnings") and (
+                device_rename_result.get("device_id")
+                or device_rename_result.get("lookup_failed")
             ):
                 response_data["partial"] = True
 

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -385,11 +385,17 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 entity_entry.get("device_id") if not device_rename_result else None
             )
             if not device_id:
-                device_rename_result = {
-                    "warnings": [
-                        "Entity has no associated device — device rename skipped"
-                    ],
-                }
+                # Only fire the "no device" warning when the registry lookup
+                # succeeded — otherwise the L378 "lookup failed" warning
+                # already carries the more accurate signal, and a second
+                # "no associated device" claim would be unverified (we don't
+                # actually know what the registry says when the lookup failed).
+                if device_rename_result is None:
+                    device_rename_result = {
+                        "warnings": [
+                            "Entity has no associated device — device rename skipped"
+                        ],
+                    }
             else:
                 device_msg: dict[str, Any] = {
                     "type": "config/device_registry/update",

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -376,7 +376,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         _extract_ws_error(get_result),
                     )
                     device_rename_result = {
-                        "warning": "Entity registry lookup failed — could not determine device. Retry may succeed.",
+                        "warnings": [
+                            "Entity registry lookup failed — could not determine device. Retry may succeed."
+                        ],
                     }
 
             device_id = (
@@ -384,7 +386,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             )
             if not device_id:
                 device_rename_result = {
-                    "warning": "Entity has no associated device — device rename skipped",
+                    "warnings": [
+                        "Entity has no associated device — device rename skipped"
+                    ],
                 }
             else:
                 device_msg: dict[str, Any] = {
@@ -397,7 +401,9 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     device_rename_result = {"success": True, "device_id": device_id}
                 else:
                     device_rename_result = {
-                        "warning": f"Entity updated but device rename failed: {_extract_ws_error(device_result)}",
+                        "warnings": [
+                            f"Entity updated but device rename failed: {_extract_ws_error(device_result)}"
+                        ],
                         "device_id": device_id,
                     }
 
@@ -511,7 +517,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         # Include old_entity_id and rename warning when a rename was performed
         if new_entity_id is not None:
             response_data["old_entity_id"] = original_entity_id
-            response_data["warning"] = (
+            response_data.setdefault("warnings", []).append(
                 "Remember to update any automations, scripts, or dashboards "
                 "that reference the old entity_id"
             )
@@ -523,7 +529,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             response_data["device_rename"] = device_rename_result
             # Only mark partial when device rename was attempted and failed
             # (not when entity simply has no device)
-            if "warning" in device_rename_result and device_rename_result.get(
+            if device_rename_result.get("warnings") and device_rename_result.get(
                 "device_id"
             ):
                 response_data["partial"] = True

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -1237,13 +1237,13 @@ class IntegrationTools:
                     if res is not True
                 ]
                 if not_removed:
-                    response["warning"] = (
+                    response.setdefault("warnings", []).append(
                         f"Deletion confirmed but the following entities "
                         f"are still present after the wait window: "
                         f"{not_removed}"
                     )
             if warnings:
-                response["warnings"] = warnings
+                response.setdefault("warnings", []).extend(warnings)
             return response
 
         except ToolError:
@@ -1388,7 +1388,7 @@ class IntegrationTools:
                             client, entity_id
                         )
                         if not removed:
-                            response["warning"] = (
+                            response.setdefault("warnings", []).append(
                                 f"Deletion confirmed but {entity_id} "
                                 "is still present after the wait window."
                             )
@@ -1531,7 +1531,7 @@ class IntegrationTools:
                         client, entity_id
                     )
                     if not removed:
-                        response["warning"] = (
+                        response.setdefault("warnings", []).append(
                             f"Deletion confirmed but {entity_id} "
                             "is still present after the wait window."
                         )

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -736,7 +736,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
             # Add warning and partial flag if fallback was used
             if warning:
-                result["warning"] = warning
+                result.setdefault("warnings", []).append(warning)
                 result["partial"] = True
 
             return await add_timezone_metadata(client, result)

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -145,14 +145,14 @@ class ServiceTools:
                 f"did not respond within the timeout period. The operation is likely "
                 f"still running in the background."
             ),
-            "warning": (
+            "warnings": [
                 "Response timed out. This is normal for long-running services "
                 f"like updates or firmware installs. Use ha_get_state('{entity_id}') "
                 "to check the current status."
                 if entity_id
                 else "Response timed out. This is normal for long-running services. "
                 "The service was dispatched and may still be executing."
-            ),
+            ],
         }
 
     async def _capture_initial_state(self, entity_id: str | None) -> str | None:
@@ -186,11 +186,11 @@ class ServiceTools:
             if new_state:
                 response["verified_state"] = new_state.get("state")
             else:
-                response["warning"] = (
+                response.setdefault("warnings", []).append(
                     "Service executed but state change could not be verified within timeout."
                 )
         except Exception as e:
-            response["warning"] = (
+            response.setdefault("warnings", []).append(
                 f"Service executed but state verification failed: {e}"
             )
 
@@ -512,10 +512,10 @@ class ServiceTools:
                         f"Event {event_type} was dispatched but Home Assistant "
                         "did not respond within the timeout period."
                     ),
-                    "warning": (
+                    "warnings": [
                         "Response timed out. The event was dispatched and may still "
                         "have been delivered to subscribers."
-                    ),
+                    ],
                 }
             exception_to_structured_error(
                 error,

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -186,10 +186,10 @@ class SystemTools:
                     "Home Assistant restart initiated. "
                     "The system will be unavailable for 1-5 minutes."
                 ),
-                "warning": (
+                "warnings": [
                     "Connection will be lost during restart. "
                     "Wait for Home Assistant to become available again."
-                ),
+                ],
             }
 
         except ToolError:
@@ -208,7 +208,7 @@ class SystemTools:
                         "Home Assistant restart initiated. "
                         "Connection was closed as expected during restart."
                     ),
-                    "warning": "Wait 1-5 minutes for Home Assistant to restart.",
+                    "warnings": ["Wait 1-5 minutes for Home Assistant to restart."],
                 }
 
             exception_to_structured_error(e)

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -299,12 +299,14 @@ class SystemTools:
                         if "not found" not in error_msg.lower():
                             errors.append(f"{reload_target}: {error_msg}")
 
-                return {
+                response: dict[str, Any] = {
                     "success": True,
                     "message": f"Reloaded {len(results)} components",
                     "reloaded": results,
-                    "warnings": errors if errors else None,
                 }
+                if errors:
+                    response["warnings"] = errors
+                return response
 
             else:
                 # Reload specific component

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -325,7 +325,7 @@ async def test_search_entities_successful_fuzzy_search_no_warning(mcp_client):
     assert data.get("success") is True
     assert data.get("search_type") == "fuzzy_search"
     # Normal fuzzy search should NOT have warning or partial flag
-    assert "warning" not in data or data.get("warning") is None
+    assert not data.get("warnings"), f"Unexpected warnings: {data.get('warnings')}"
     assert "partial" not in data or data.get("partial") is not True
     # Strong matches should not include suggestions
     assert "suggestions" not in data, "Strong matches should not include suggestions"
@@ -392,10 +392,13 @@ async def test_search_entities_fallback_fields_when_present(mcp_client):
     raw_data = assert_mcp_success(result, "Fallback field types")
     data = raw_data.get("data", raw_data)
 
-    # If warning is present, it should be a string
-    if "warning" in data and data["warning"] is not None:
-        assert isinstance(data["warning"], str), "warning must be a string"
-        logger.info(f"Warning present: {data['warning']}")
+    # If warnings are present, they should be a list of strings
+    if data.get("warnings"):
+        assert isinstance(data["warnings"], list), "warnings must be a list"
+        assert all(isinstance(w, str) for w in data["warnings"]), (
+            "every warning must be a string"
+        )
+        logger.info(f"Warnings present: {data['warnings']}")
 
     # If partial is present, it should be a boolean
     if "partial" in data and data["partial"] is not None:

--- a/tests/src/e2e/workflows/registry/test_entity_rename.py
+++ b/tests/src/e2e/workflows/registry/test_entity_rename.py
@@ -469,8 +469,12 @@ class TestRenameEntityWithDevice:
 
         # Check device rename was skipped (no device for helper)
         device_result = rename_data.get("device_rename", {})
-        assert device_result.get("warnings"), (
+        warnings = device_result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
             f"Device rename should have warnings for helper entity (no device): {device_result}"
+        )
+        assert any("no associated device" in w for w in warnings), (
+            f"Expected no-associated-device warning content; got: {warnings!r}"
         )
         logger.info(f"Device rename result: {device_result}")
 

--- a/tests/src/e2e/workflows/registry/test_entity_rename.py
+++ b/tests/src/e2e/workflows/registry/test_entity_rename.py
@@ -469,8 +469,8 @@ class TestRenameEntityWithDevice:
 
         # Check device rename was skipped (no device for helper)
         device_result = rename_data.get("device_rename", {})
-        assert "warning" in device_result, (
-            "Device rename should have warning for helper entity (no device)"
+        assert device_result.get("warnings"), (
+            f"Device rename should have warnings for helper entity (no device): {device_result}"
         )
         logger.info(f"Device rename result: {device_result}")
 

--- a/tests/src/e2e/workflows/registry/test_rename_consolidation.py
+++ b/tests/src/e2e/workflows/registry/test_rename_consolidation.py
@@ -64,8 +64,14 @@ class TestRenameConsolidationEdgeCases:
         )
 
         # Rename should include a warning about updating references
-        assert rename_data.get("warnings"), (
+        warnings = rename_data.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
             f"Rename should include warnings about updating references: {rename_data.keys()}"
+        )
+        assert any(
+            "automations, scripts, or dashboards" in w for w in warnings
+        ), (
+            f"Expected update-references warning content; got: {warnings!r}"
         )
 
         logger.info("Verified simple response format (no 'results' key, has warnings)")

--- a/tests/src/e2e/workflows/registry/test_rename_consolidation.py
+++ b/tests/src/e2e/workflows/registry/test_rename_consolidation.py
@@ -64,11 +64,11 @@ class TestRenameConsolidationEdgeCases:
         )
 
         # Rename should include a warning about updating references
-        assert "warning" in rename_data, (
-            f"Rename should include a warning about updating references: {rename_data.keys()}"
+        assert rename_data.get("warnings"), (
+            f"Rename should include warnings about updating references: {rename_data.keys()}"
         )
 
-        logger.info("Verified simple response format (no 'results' key, has warning)")
+        logger.info("Verified simple response format (no 'results' key, has warnings)")
 
         # Cleanup
         await safe_call_tool(

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -5,12 +5,12 @@ tools on HA Core installs (which only register `backup.local`).
 """
 
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.backup import _get_local_backup_agent_id
+from ha_mcp.tools.backup import _get_local_backup_agent_id, restore_backup
 
 
 def _ws_client(agents_payload: dict) -> AsyncMock:
@@ -109,3 +109,50 @@ class TestGetLocalBackupAgentId:
             await _get_local_backup_agent_id(ws)
         error = json.loads(str(exc_info.value))
         assert "No local backup agent found" in error["error"]["message"]
+
+
+class TestRestoreBackupWarnings:
+    """Pin the post-#1332 warnings-list contract on the restore_backup
+    success path (``backup.py`` ~L447-457). Pre-#1332 emitted singular
+    ``warning``; the migrated shape is ``warnings: list[str]`` containing
+    the connection-lost-during-restart notice.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_returns_top_level_warnings_list(self):
+        ws = AsyncMock()
+        ws.send_command.side_effect = [
+            # backup/info — verify backup exists
+            {"success": True, "result": {"backups": [{"backup_id": "abc123"}]}},
+            # _get_local_backup_agent_id → backup/agents/info
+            {"success": True, "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]}},
+            # _get_backup_password → backup/config/info
+            {"success": True, "result": {"config": {"create_backup": {"password": "pw"}}}},
+            # _create_safety_backup → backup/generate
+            {"success": True, "result": {"backup_job_id": "safety_job_1"}},
+            # _create_safety_backup polling → backup/info loop
+            {"success": True, "result": {"backups": [{"name": "Pre_Restore_Safety", "backup_id": "safety_xyz"}]}},
+            # backup/restore — the actual restore call
+            {"success": True},
+        ]
+
+        client = MagicMock()
+        client.base_url = "http://test"
+        client.token = "token"
+        client.verify_ssl = False
+
+        with patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ):
+            result = await restore_backup(client, "abc123")
+
+        assert result["success"] is True
+        assert result["backup_id"] == "abc123"
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result!r}"
+        )
+        assert any("Connection will be temporarily lost" in w for w in warnings), (
+            f"Expected connection-lost warning content; got: {warnings!r}"
+        )

--- a/tests/src/unit/test_ha_call_event.py
+++ b/tests/src/unit/test_ha_call_event.py
@@ -2,9 +2,11 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.client.rest_client import HomeAssistantConnectionError
 from ha_mcp.tools.tools_service import ServiceTools
 
 
@@ -96,3 +98,27 @@ class TestHaCallEvent:
         tools = _make_tools(ToolError("already structured"))
         with pytest.raises(ToolError, match="already structured"):
             await tools.ha_call_event("my_event")
+
+    async def test_timeout_returns_partial_success_with_warning(self):
+        """Connection-timeout from fire_event surfaces as partial-success with a top-level warnings list.
+
+        Pins the post-#1332 contract on the timeout branch (`tools_service.py:495+`):
+        the migrated `warnings: list[str]` shape replaces the legacy singular
+        `warning` string and must contain the dispatched-may-still-deliver note.
+        """
+        conn_error = HomeAssistantConnectionError("connection timed out")
+        conn_error.__cause__ = httpx.TimeoutException("Read timed out")
+        tools = _make_tools(conn_error)
+
+        result = await tools.ha_call_event("my_event")
+
+        assert result["success"] is True
+        assert result["partial"] is True
+        assert result["event_type"] == "my_event"
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result!r}"
+        )
+        assert any("timed out" in w.lower() for w in warnings), (
+            f"Expected timeout-related warning content; got: {warnings!r}"
+        )

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -1037,3 +1037,95 @@ class TestLifecycleWriteWarningsShape:
         assert any(
             "removal verification failed" in w for w in result["warnings"]
         )
+
+
+class TestSweepWarningsShape:
+    """Cross-cutting warnings-list shape coverage for tools migrated under
+    #1341 (the non-lifecycle-write half of #1332).
+
+    Mirrors the TestLifecycleWriteWarningsShape pattern from #1340, using
+    ``_assert_warnings_list_shape`` which enforces:
+      - ``success: True`` at top level
+      - ``warnings`` is a non-empty ``list[str]`` at the top level
+      - No singular ``warning`` legacy key
+      - ``warnings`` doesn't leak into nested dicts
+
+    **In-scope here (3 of 8 PR-touched src files):**
+    - ``backup.py`` (restore_backup) — top-level success+warnings
+    - ``tools_service.py`` (ha_call_event timeout) — top-level success+warnings
+    - ``tools_system.py`` (ha_restart success) — top-level success+warnings
+
+    **Out-of-scope here (5 of 8) — divergent shape, by design:**
+    - ``tools_addons.py``: ``ha_manage_addon`` returns ``status: "pending_restart"``
+      instead of ``success: True``. Content-level coverage of the ``ignored_fields``
+      warning lives in ``test_tools_addons.py::test_config_mode_options_unknown_fields_warned``.
+    - ``tools_entities.py``: ``ha_set_entity`` has a nested ``device_rename: {warnings: [...]}``
+      sub-result (its own success/warnings shape per the lookup_failed/no-device design).
+      Content-level coverage lives in ``test_entity_rename.py`` and
+      ``test_rename_consolidation.py``.
+    - ``tools_energy.py``: ``ha_manage_energy_prefs`` dry_run returns ``mode/dry_run/...``
+      payload without top-level ``success``.
+    - ``tools_integrations.py``: ``ha_get_integration`` (list mode) returns ``integrations``
+      payload without top-level ``success``.
+    - ``tools_search.py``: ``ha_deep_search`` fallback path returns ``search_type/by_domain/...``
+      payload without top-level ``success``.
+
+    These 5 divergent shapes are pre-existing design choices, not regressions
+    of #1332. Each tool's migrated warning emit is content-asserted in its
+    per-tool unit/e2e test file. A future "uniform success-marker contract"
+    PR would be the natural place to bring them under one shape-test umbrella.
+    """
+
+    @pytest.mark.asyncio
+    async def test_backup_restore_warnings_shape(self):
+        from ha_mcp.tools.backup import restore_backup
+
+        ws = AsyncMock()
+        ws.send_command.side_effect = [
+            {"success": True, "result": {"backups": [{"backup_id": "abc"}]}},
+            {"success": True, "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]}},
+            {"success": True, "result": {"config": {"create_backup": {"password": "pw"}}}},
+            {"success": True, "result": {"backup_job_id": "job"}},
+            {"success": True, "result": {"backups": [{"name": "Pre_Restore_Safety", "backup_id": "sxyz"}]}},
+            {"success": True},
+        ]
+        client = MagicMock()
+        client.base_url = "http://test"
+        client.token = "t"
+        client.verify_ssl = False
+        with patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ):
+            result = await restore_backup(client, "abc")
+        _assert_warnings_list_shape(result)
+
+
+    @pytest.mark.asyncio
+    async def test_service_call_event_timeout_warnings_shape(self):
+        import httpx
+
+        from ha_mcp.tools.tools_service import ServiceTools
+
+        conn_error = HomeAssistantConnectionError("timeout")
+        conn_error.__cause__ = httpx.TimeoutException("read timed out")
+        client = MagicMock()
+        client.fire_event = AsyncMock(side_effect=conn_error)
+        tools = ServiceTools.__new__(ServiceTools)
+        tools._client = client
+        tools._device_tools = MagicMock()
+
+        result = await tools.ha_call_event("evt_x")
+        _assert_warnings_list_shape(result)
+
+    @pytest.mark.asyncio
+    async def test_system_restart_warnings_shape(self):
+        from ha_mcp.tools.tools_system import SystemTools
+
+        client = AsyncMock()
+        client.check_config.return_value = {"result": "valid"}
+        client.call_service.return_value = None
+        tools = SystemTools(client)
+
+        result = await tools.ha_restart(confirm=True)
+        _assert_warnings_list_shape(result)

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -575,20 +575,18 @@ class TestUniformResponseShape:
         assert any("not yet queryable" in w for w in result["warnings"])
 
 
-def _assert_warnings_list_shape(result: dict[str, Any]) -> None:
-    """Cross-cutting warnings-list contract for lifecycle-write tools (#1332).
+def _assert_warnings_list_shape_core(result: dict[str, Any]) -> None:
+    """Shared warnings-list assertions for both shape helpers below.
 
-    Tighter than ``_assert_uniform_shape`` for the warnings half: applies to
-    any successful tool response, regardless of payload-wrapper key.
+    Enforces the warnings-list contract independent of any ``success`` /
+    status-marker convention:
 
-    - ``success`` is True
     - ``warnings`` is a non-empty ``list[str]`` at the top level
     - No singular ``warning`` string at the top level (legacy shape)
     - ``warnings`` does not leak into any nested dict value (no
       ``"data": {"warnings": [...]}`` or ``"result": {"warnings": [...]}``
       nesting pattern that pre-#1332 callers had to chase)
     """
-    assert result["success"] is True
     assert "warning" not in result, (
         "singular 'warning' key must not appear at top level"
     )
@@ -615,6 +613,40 @@ def _assert_warnings_list_shape(result: dict[str, Any]) -> None:
             assert "warning" not in value, (
                 f"singular 'warning' leaked into nested '{key}'"
             )
+
+
+def _assert_warnings_list_shape(result: dict[str, Any]) -> None:
+    """Cross-cutting warnings-list contract for lifecycle-write tools (#1332).
+
+    Tighter than ``_assert_uniform_shape`` for the warnings half: applies to
+    any successful tool response, regardless of payload-wrapper key.
+
+    - ``success`` is True
+    - ``warnings`` is a non-empty ``list[str]`` at the top level
+    - No singular ``warning`` string at the top level (legacy shape)
+    - ``warnings`` does not leak into any nested dict value (no
+      ``"data": {"warnings": [...]}`` or ``"result": {"warnings": [...]}``
+      nesting pattern that pre-#1332 callers had to chase)
+    """
+    assert result["success"] is True
+    _assert_warnings_list_shape_core(result)
+
+
+def _assert_warnings_list_shape_no_success(result: dict[str, Any]) -> None:
+    """Relaxed warnings-list shape contract for tools without a top-level
+    ``success`` key by design.
+
+    Mirrors ``_assert_warnings_list_shape`` minus the ``success: True``
+    assertion. Used for tools whose response uses a status-marker
+    (e.g. ``status: "pending_restart"``) or a payload-bag (e.g. ``mode:
+    "dry_run"``, list-mode integrations payload, deep_search fallback)
+    instead of the ``success`` boolean — those shapes are pre-existing
+    design choices, not regressions of #1332.
+
+    The warnings-list contract itself remains identical to the strict
+    helper.
+    """
+    _assert_warnings_list_shape_core(result)
 
 
 class TestLifecycleWriteWarningsShape:
@@ -1050,30 +1082,36 @@ class TestSweepWarningsShape:
       - No singular ``warning`` legacy key
       - ``warnings`` doesn't leak into nested dicts
 
-    **In-scope here (3 of 8 PR-touched src files):**
-    - ``backup.py`` (restore_backup) — top-level success+warnings
-    - ``tools_service.py`` (ha_call_event timeout) — top-level success+warnings
-    - ``tools_system.py`` (ha_restart success) — top-level success+warnings
+    All 8 PR-touched src files now cross-cuttingly covered, split by
+    response-shape contract:
 
-    **Out-of-scope here (5 of 8) — divergent shape, by design:**
-    - ``tools_addons.py``: ``ha_manage_addon`` returns ``status: "pending_restart"``
-      instead of ``success: True``. Content-level coverage of the ``ignored_fields``
-      warning lives in ``test_tools_addons.py::test_config_mode_options_unknown_fields_warned``.
-    - ``tools_entities.py``: ``ha_set_entity`` has a nested ``device_rename: {warnings: [...]}``
-      sub-result (its own success/warnings shape per the lookup_failed/no-device design).
-      Content-level coverage lives in ``test_entity_rename.py`` and
-      ``test_rename_consolidation.py``.
-    - ``tools_energy.py``: ``ha_manage_energy_prefs`` dry_run returns ``mode/dry_run/...``
-      payload without top-level ``success``.
-    - ``tools_integrations.py``: ``ha_get_integration`` (list mode) returns ``integrations``
-      payload without top-level ``success``.
-    - ``tools_search.py``: ``ha_deep_search`` fallback path returns ``search_type/by_domain/...``
-      payload without top-level ``success``.
+    **Strict helper (top-level ``success: True`` + warnings) — 4 of 8:**
+    - ``backup.py`` (restore_backup)
+    - ``tools_service.py`` (ha_call_event timeout)
+    - ``tools_system.py`` (ha_restart success)
+    - ``tools_energy.py`` (ha_manage_energy_prefs dry_run with validate
+      failure — response carries ``success: True`` from
+      ``len(shape_errors) == 0``)
 
-    These 5 divergent shapes are pre-existing design choices, not regressions
-    of #1332. Each tool's migrated warning emit is content-asserted in its
-    per-tool unit/e2e test file. A future "uniform success-marker contract"
-    PR would be the natural place to bring them under one shape-test umbrella.
+    **Relaxed helper (no top-level ``success`` — status-marker / payload-bag
+    shape) — 3 of 8:**
+    - ``tools_addons.py``: ``ha_manage_addon`` config mode with
+      ``options`` returns ``status: "pending_restart"`` + top-level
+      warnings (closure tool, registered via ``register_addon_tools``)
+    - ``tools_integrations.py``: ``ha_get_integration`` single-entry
+      mode with ``include_diagnostics=False`` + ``device_id`` provided
+    - ``tools_search.py``: ``ha_deep_search`` fallback path with the
+      fuzzy-engine-unavailable warning (closure tool, registered via
+      ``register_search_tools``)
+
+    **Strict helper on nested sub-result — 1 of 8:**
+    - ``tools_entities.py``: ``ha_set_entity`` device_rename branch on
+      registry-lookup failure — nested ``device_rename: {success,
+      warnings, ...}`` sub-result carries its own warnings contract,
+      asserted via ``_assert_warnings_list_shape(result["device_rename"])``.
+      Top-level ``result`` may also carry ``warnings`` (e.g. entity-id
+      change reminder) — the strict helper on the nested dict pins the
+      sub-result contract specifically.
     """
 
     @pytest.mark.asyncio
@@ -1129,3 +1167,193 @@ class TestSweepWarningsShape:
 
         result = await tools.ha_restart(confirm=True)
         _assert_warnings_list_shape(result)
+
+    @pytest.mark.asyncio
+    async def test_integrations_get_integration_device_id_ignored_warnings_shape(self):
+        """Shape-pins the device_id-ignored warning emit in
+        ``ha_get_integration`` (entry_id mode, include_diagnostics=False,
+        device_id provided). Response shape is the single-entry payload
+        (no top-level ``success``) — uses the relaxed helper."""
+        from ha_mcp.tools.tools_integrations import IntegrationTools
+
+        tools = IntegrationTools.__new__(IntegrationTools)
+        tools._client = MagicMock()
+        tools._get_single_entry = AsyncMock(
+            return_value={
+                "entry_id": "abc",
+                "domain": "test_integration",
+                "state": "loaded",
+            }
+        )
+
+        result = await tools.ha_get_integration(
+            entry_id="abc",
+            device_id="dev_123",
+            include_diagnostics=False,
+        )
+        _assert_warnings_list_shape_no_success(result)
+
+    @pytest.mark.asyncio
+    async def test_addons_manage_addon_options_ignored_fields_warnings_shape(self):
+        """Shape-pins the ignored_fields warning emit in ``ha_manage_addon``
+        when options include a field not in the add-on schema. Config mode
+        with ``options`` returns ``status: "pending_restart"`` (no top-level
+        ``success``) — uses the relaxed helper. Mirrors the mock pattern in
+        ``test_tools_addons.py::test_config_mode_options_unknown_fields_warned``.
+        """
+        from ha_mcp.tools.tools_addons import register_addon_tools
+
+        registered: dict[str, Any] = {}
+        mock_mcp = MagicMock()
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                registered[func.__name__] = func
+                return func
+            return wrapper
+
+        mock_mcp.tool = tool_decorator
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.token = "test-token"
+        register_addon_tools(mock_mcp, client)
+        manage_addon = registered["ha_manage_addon"]
+
+        async def mock_supervisor_api(client_arg, endpoint, **kwargs):
+            if endpoint == "/addons/test_addon/info":
+                return {
+                    "success": True,
+                    "result": {
+                        "options": {"log_level": "info"},
+                        "schema": [
+                            {"name": "log_level", "required": False, "type": "str"}
+                        ],
+                    },
+                }
+            return {"success": True, "result": {}}
+
+        with patch(
+            "ha_mcp.tools.tools_addons._supervisor_api_call",
+            side_effect=mock_supervisor_api,
+        ):
+            result = await manage_addon(
+                slug="test_addon",
+                options={"log_level": "debug", "zombie_field": "ghost"},
+            )
+
+        _assert_warnings_list_shape_no_success(result)
+
+    @pytest.mark.asyncio
+    async def test_energy_manage_energy_prefs_dry_run_validate_failure_warnings_shape(self):
+        """Shape-pins the validate_warning emit in
+        ``_dry_run`` when HA's ``energy/validate`` fails. Response carries
+        ``success: True`` at top level (set from ``len(shape_errors) == 0``)
+        — uses the STRICT helper. Listed in the no-success bucket of the
+        Item 5 analysis but actually fits the strict contract.
+        """
+        from ha_mcp.tools.tools_energy import EnergyTools
+
+        tools = EnergyTools.__new__(EnergyTools)
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "energy not configured"}
+        )
+        tools._client = client
+
+        # Minimal valid prefs shape passing _shape_check() — empty source/device
+        # lists are accepted, only the top-level keys are required.
+        result = await tools._dry_run(
+            {
+                "energy_sources": [],
+                "device_consumption": [],
+            }
+        )
+
+        _assert_warnings_list_shape(result)
+
+    @pytest.mark.asyncio
+    async def test_search_deep_search_fuzzy_fallback_warnings_shape(self):
+        """Shape-pins the fuzzy-fallback warning emit in ``ha_deep_search``.
+        When the fuzzy engine raises a non-ToolError exception, the tool
+        falls back to ``_exact_match_search`` and appends a warning. Payload
+        shape (no top-level ``success``) — uses the relaxed helper.
+        """
+        from ha_mcp.tools.tools_search import register_search_tools
+
+        registered: dict[str, Any] = {}
+        mock_mcp = MagicMock()
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                registered[func.__name__] = func
+                return func
+            return wrapper
+
+        mock_mcp.tool = tool_decorator
+        client = MagicMock()
+        smart_tools = MagicMock()
+        smart_tools.smart_entity_search = AsyncMock(
+            side_effect=RuntimeError("fuzzy engine offline")
+        )
+        register_search_tools(mock_mcp, client, smart_tools=smart_tools)
+        deep_search = registered["ha_deep_search"]
+
+        async def exact_fallback(*args, **kwargs):
+            return {
+                "matches": [],
+                "total_matches": 0,
+            }
+
+        async def passthrough_tz(_client, payload):
+            return payload
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_search._exact_match_search",
+                side_effect=exact_fallback,
+            ),
+            patch(
+                "ha_mcp.tools.tools_search.add_timezone_metadata",
+                side_effect=passthrough_tz,
+            ),
+        ):
+            result = await deep_search(query="anything")
+
+        _assert_warnings_list_shape_no_success(result)
+
+    @pytest.mark.asyncio
+    async def test_entities_set_entity_device_rename_lookup_failed_warnings_shape(self):
+        """Shape-pins the device_rename nested-sub-result warnings in
+        ``ha_set_entity`` when the entity-registry lookup for the rename
+        target fails. The nested ``device_rename`` dict carries its own
+        ``success`` + ``warnings`` contract — uses the STRICT helper on
+        the sub-dict.
+        """
+        from ha_mcp.tools.tools_entities import register_entity_tools
+
+        registered: dict[str, Any] = {}
+        mock_mcp = MagicMock()
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                registered[func.__name__] = func
+                return func
+            return wrapper
+
+        mock_mcp.tool = tool_decorator
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            side_effect=RuntimeError("registry lookup failed")
+        )
+        register_entity_tools(mock_mcp, client)
+        set_entity = registered["ha_set_entity"]
+
+        result = await set_entity(
+            entity_id="light.kitchen",
+            new_device_name="Kitchen Lamp",
+        )
+
+        assert "device_rename" in result, (
+            f"device_rename sub-result missing: {result}"
+        )
+        _assert_warnings_list_shape(result["device_rename"])

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -1082,8 +1082,8 @@ class TestSweepWarningsShape:
       - No singular ``warning`` legacy key
       - ``warnings`` doesn't leak into nested dicts
 
-    All 8 PR-touched src files now cross-cuttingly covered, split by
-    response-shape contract:
+    Coverage 6/8 of the PR-touched src files cross-cuttingly pinned,
+    split by response-shape contract:
 
     **Strict helper (top-level ``success: True`` + warnings) — 4 of 8:**
     - ``backup.py`` (restore_backup)
@@ -1094,24 +1094,32 @@ class TestSweepWarningsShape:
       ``len(shape_errors) == 0``)
 
     **Relaxed helper (no top-level ``success`` — status-marker / payload-bag
-    shape) — 3 of 8:**
+    shape) — 2 of 8:**
     - ``tools_addons.py``: ``ha_manage_addon`` config mode with
       ``options`` returns ``status: "pending_restart"`` + top-level
       warnings (closure tool, registered via ``register_addon_tools``)
     - ``tools_integrations.py``: ``ha_get_integration`` single-entry
       mode with ``include_diagnostics=False`` + ``device_id`` provided
-    - ``tools_search.py``: ``ha_deep_search`` fallback path with the
-      fuzzy-engine-unavailable warning (closure tool, registered via
-      ``register_search_tools``)
 
-    **Strict helper on nested sub-result — 1 of 8:**
-    - ``tools_entities.py``: ``ha_set_entity`` device_rename branch on
-      registry-lookup failure — nested ``device_rename: {success,
-      warnings, ...}`` sub-result carries its own warnings contract,
-      asserted via ``_assert_warnings_list_shape(result["device_rename"])``.
-      Top-level ``result`` may also carry ``warnings`` (e.g. entity-id
-      change reminder) — the strict helper on the nested dict pins the
-      sub-result contract specifically.
+    **Not folded in (2 of 8) — multi-step WebSocket call chains where a
+    reliable cross-cutting mock needs to branch on the WS message
+    ``type`` to pass early-success steps and fail only at the target
+    emit-site. Content-level coverage already lives in the per-tool
+    unit/e2e test files cited:**
+
+    - ``tools_search.py``: ``ha_deep_search`` fallback path. The tool
+      calls ``await client.<state-source>`` before the fuzzy/exact
+      branch; trivial ``MagicMock()`` clients trip the
+      ``"MagicMock can't be used in 'await' expression"`` error before
+      the warning emit-site is reached. Per-tool tests in
+      ``test_tools_search.py`` exercise the fallback content already.
+    - ``tools_entities.py``: ``ha_set_entity`` with ``new_device_name``
+      flows entity-registry-lookup → entity-registry-update →
+      device-registry-lookup → device-registry-update → optional
+      expose-update. The nested ``device_rename`` warnings live deep
+      in that chain. Per-tool tests in ``test_entity_rename.py`` and
+      ``test_rename_consolidation.py`` exercise the nested-result
+      shape directly.
     """
 
     @pytest.mark.asyncio
@@ -1271,89 +1279,3 @@ class TestSweepWarningsShape:
 
         _assert_warnings_list_shape(result)
 
-    @pytest.mark.asyncio
-    async def test_search_deep_search_fuzzy_fallback_warnings_shape(self):
-        """Shape-pins the fuzzy-fallback warning emit in ``ha_deep_search``.
-        When the fuzzy engine raises a non-ToolError exception, the tool
-        falls back to ``_exact_match_search`` and appends a warning. Payload
-        shape (no top-level ``success``) — uses the relaxed helper.
-        """
-        from ha_mcp.tools.tools_search import register_search_tools
-
-        registered: dict[str, Any] = {}
-        mock_mcp = MagicMock()
-
-        def tool_decorator(*args, **kwargs):
-            def wrapper(func):
-                registered[func.__name__] = func
-                return func
-            return wrapper
-
-        mock_mcp.tool = tool_decorator
-        client = MagicMock()
-        smart_tools = MagicMock()
-        smart_tools.smart_entity_search = AsyncMock(
-            side_effect=RuntimeError("fuzzy engine offline")
-        )
-        register_search_tools(mock_mcp, client, smart_tools=smart_tools)
-        deep_search = registered["ha_deep_search"]
-
-        async def exact_fallback(*args, **kwargs):
-            return {
-                "matches": [],
-                "total_matches": 0,
-            }
-
-        async def passthrough_tz(_client, payload):
-            return payload
-
-        with (
-            patch(
-                "ha_mcp.tools.tools_search._exact_match_search",
-                side_effect=exact_fallback,
-            ),
-            patch(
-                "ha_mcp.tools.tools_search.add_timezone_metadata",
-                side_effect=passthrough_tz,
-            ),
-        ):
-            result = await deep_search(query="anything")
-
-        _assert_warnings_list_shape_no_success(result)
-
-    @pytest.mark.asyncio
-    async def test_entities_set_entity_device_rename_lookup_failed_warnings_shape(self):
-        """Shape-pins the device_rename nested-sub-result warnings in
-        ``ha_set_entity`` when the entity-registry lookup for the rename
-        target fails. The nested ``device_rename`` dict carries its own
-        ``success`` + ``warnings`` contract — uses the STRICT helper on
-        the sub-dict.
-        """
-        from ha_mcp.tools.tools_entities import register_entity_tools
-
-        registered: dict[str, Any] = {}
-        mock_mcp = MagicMock()
-
-        def tool_decorator(*args, **kwargs):
-            def wrapper(func):
-                registered[func.__name__] = func
-                return func
-            return wrapper
-
-        mock_mcp.tool = tool_decorator
-        client = MagicMock()
-        client.send_websocket_message = AsyncMock(
-            side_effect=RuntimeError("registry lookup failed")
-        )
-        register_entity_tools(mock_mcp, client)
-        set_entity = registered["ha_set_entity"]
-
-        result = await set_entity(
-            entity_id="light.kitchen",
-            new_device_name="Kitchen Lamp",
-        )
-
-        assert "device_rename" in result, (
-            f"device_rename sub-result missing: {result}"
-        )
-        _assert_warnings_list_shape(result["device_rename"])

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -2970,7 +2970,13 @@ class TestManageAddon:
         assert result["status"] == "pending_restart"
         assert "ignored_fields" in result
         assert "zombie_field" in result["ignored_fields"]
-        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result}"
+        )
+        assert any("not in add-on schema were ignored" in w for w in warnings), (
+            f"Expected ignored-field warning content; got: {warnings!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_config_mode_boot(self, manage_addon_tool):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -2970,7 +2970,7 @@ class TestManageAddon:
         assert result["status"] == "pending_restart"
         assert "ignored_fields" in result
         assert "zombie_field" in result["ignored_fields"]
-        assert "warning" in result
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
 
     @pytest.mark.asyncio
     async def test_config_mode_boot(self, manage_addon_tool):

--- a/tests/src/unit/test_tools_addons_array_patch.py
+++ b/tests/src/unit/test_tools_addons_array_patch.py
@@ -128,8 +128,8 @@ class TestApplyArrayOps:
         assert new == items
         entry = summary["deleted_where"][0]
         assert entry["count"] == 0
-        assert "warning" in entry
-        assert "zzz_misspelled" in entry["warning"]
+        assert entry.get("warnings"), f"Expected warnings list, got: {entry}"
+        assert any("zzz_misspelled" in w for w in entry["warnings"])
 
     def test_delete_where_field_present_but_no_match_no_warning(self):
         """count=0 when the field exists on items but no value matched is
@@ -143,7 +143,7 @@ class TestApplyArrayOps:
         assert new == items
         entry = summary["deleted_where"][0]
         assert entry["count"] == 0
-        assert "warning" not in entry
+        assert not entry.get("warnings"), f"Unexpected warnings: {entry.get('warnings')}"
 
     def test_delete_where_against_empty_array_no_warning(self):
         """Empty input array is not a typo signal — there are no items to
@@ -157,7 +157,7 @@ class TestApplyArrayOps:
         assert new == []
         entry = summary["deleted_where"][0]
         assert entry["count"] == 0
-        assert "warning" not in entry
+        assert not entry.get("warnings"), f"Unexpected warnings: {entry.get('warnings')}"
 
     def test_delete_where_against_non_dict_items_no_warning(self):
         """Arrays of scalars (or other non-dict items) are not a typo signal
@@ -171,7 +171,7 @@ class TestApplyArrayOps:
         assert new == [1, 2, "x"]
         entry = summary["deleted_where"][0]
         assert entry["count"] == 0
-        assert "warning" not in entry
+        assert not entry.get("warnings"), f"Unexpected warnings: {entry.get('warnings')}"
 
     def test_delete_where_zero_matches_is_not_an_error(self):
         items = self._flows_fixture()

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -530,7 +530,8 @@ class TestDryRun:
         assert result["success"] is True  # shape is fine
         assert result["current_state_validation_errors"] == []
         assert result["partial"] is True
-        assert "websocket timeout" in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        assert any("websocket timeout" in w for w in result["warnings"])
         assert any(
             "energy/validate (current state) failed" in rec.message
             for rec in caplog.records
@@ -650,7 +651,7 @@ class TestSetPrefs:
         assert result["success"] is True  # save succeeded
         assert "post_save_validation_errors" in result
         assert len(result["post_save_validation_errors"]) == 1
-        assert "warning" in result
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
 
     async def test_post_save_validation_failure_non_fatal(self, tools):
         """If the post-save validate itself fails, the save still succeeded.
@@ -675,7 +676,8 @@ class TestSetPrefs:
         assert result["success"] is True
         assert "post_save_validation_errors" not in result
         assert result["partial"] is True
-        assert "validate blew up" in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        assert any("validate blew up" in w for w in result["warnings"])
 
     async def test_post_save_validate_failure_surfaced_as_warning(self, tools, caplog):
         """If post-save energy/validate returns success=false, the caller sees
@@ -700,7 +702,8 @@ class TestSetPrefs:
         assert result["success"] is True
         assert "post_save_validation_errors" not in result
         assert result["partial"] is True
-        assert "validate endpoint missing" in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        assert any("validate endpoint missing" in w for w in result["warnings"])
         assert any(
             "energy/validate (post-save) failed" in rec.message
             for rec in caplog.records
@@ -2141,7 +2144,7 @@ class TestConvenienceResponsePassthrough:
         assert result["success"] is True
         assert "post_save_validation_errors" in result
         assert len(result["post_save_validation_errors"]) == 1
-        assert "warning" in result
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
 
     async def test_partial_warning_bubbles_through(self, tools):
         """When post-save validate itself fails, _set_prefs sets
@@ -2160,4 +2163,5 @@ class TestConvenienceResponsePassthrough:
         )
         assert result["success"] is True
         assert result["partial"] is True
-        assert "validate broken" in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        assert any("validate broken" in w for w in result["warnings"])

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -728,6 +728,70 @@ class TestHaSetEntityCombined:
         assert isinstance(error, dict)
         assert "suggestions" in error or "suggestion" in error
 
+    @pytest.mark.asyncio
+    async def test_device_rename_lookup_failure_marks_partial(
+        self, mock_mcp, mock_client
+    ):
+        """Registry lookup failure during device rename must mark response partial.
+
+        The user requested a device rename but the lookup that would identify the
+        target device failed — the rename was effectively skipped. ``partial: True``
+        signals to the agent that the operation didn't fully complete.
+        """
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": {"message": "WS lookup transport failure"},
+            }
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        result = await tool(
+            entity_id="light.test",
+            new_device_name="Living Room",
+        )
+
+        assert result["success"] is True
+        assert result.get("partial") is True
+        device_rename = result["device_rename"]
+        assert device_rename.get("lookup_failed") is True
+        assert any(
+            "Entity registry lookup failed" in w
+            for w in device_rename.get("warnings", [])
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_rename_no_device_does_not_mark_partial(
+        self, mock_mcp, mock_client
+    ):
+        """Entity with no associated device is a no-op, not a partial failure."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "entity_id": "light.test",
+                    "device_id": None,
+                },
+            }
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_set_entity"]
+
+        result = await tool(
+            entity_id="light.test",
+            new_device_name="Living Room",
+        )
+
+        assert result["success"] is True
+        assert "partial" not in result
+        device_rename = result["device_rename"]
+        assert device_rename.get("lookup_failed") is None
+        assert any(
+            "no associated device" in w
+            for w in device_rename.get("warnings", [])
+        )
+
 
 class TestHaSetEntityLabelOperations:
     """Test ha_set_entity label_operation parameter (add/remove)."""

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -693,7 +693,7 @@ class TestDeleteHelpersIntegrations:
                 wait=True,
             )
         assert result["success"] is True
-        assert "warning" not in result
+        assert not result.get("warnings"), f"Unexpected warnings: {result.get('warnings')}"
         mock_wait.assert_awaited_once()
 
     async def test_simple_path_wait_true_timeout_warns(
@@ -718,8 +718,8 @@ class TestDeleteHelpersIntegrations:
                 wait=True,
             )
         assert result["success"] is True
-        assert "warning" in result
-        assert "still present" in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        assert any("still present" in w for w in result["warnings"])
 
     async def test_simple_path_wait_true_propagates_connection_error(
         self, tools, mock_client
@@ -816,9 +816,10 @@ class TestDeleteHelpersIntegrations:
                 wait=True,
             )
         assert result["success"] is True
-        assert "warning" in result
-        assert "sensor.energy_offpeak" in result["warning"]
-        assert "sensor.energy_peak" not in result["warning"]
+        assert result.get("warnings"), f"Expected warnings list, got: {result}"
+        warnings_text = " ".join(result["warnings"])
+        assert "sensor.energy_offpeak" in warnings_text
+        assert "sensor.energy_peak" not in warnings_text
         assert mock_wait.await_count == 2
 
 

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -51,6 +51,10 @@ class TestHaRestartErrorHandling:
 
         Reproduces issue #612: user behind a reverse proxy gets 504 when HA
         shuts down, but HA actually restarted successfully.
+
+        Also pins the post-#1332 warnings-list contract on the
+        restart-initiated-but-connection-dropped branch
+        (``tools_system.py`` ~L208-214).
         """
         error = HomeAssistantAPIError("API error: 504 - ", status_code=504)
         client = _make_client_that_fails_on_restart(error)
@@ -59,6 +63,13 @@ class TestHaRestartErrorHandling:
         result = await tools.ha_restart(confirm=True)
 
         assert result["success"] is True
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result!r}"
+        )
+        assert any("Wait 1-5 minutes" in w for w in warnings), (
+            f"Expected wait-for-restart warning content; got: {warnings!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_unrelated_error_still_fails(self):
@@ -69,6 +80,28 @@ class TestHaRestartErrorHandling:
 
         with pytest.raises(ToolError):
             await tools.ha_restart(confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_success_path_returns_connection_lost_warning(self):
+        """Successful restart (no exception from call_service) surfaces a top-level
+        warnings list with the "connection will be lost" note. Pins the
+        post-#1332 contract on ``tools_system.py`` ~L188-194 (the first return
+        in ha_restart, previously emitting singular ``warning``)."""
+        client = AsyncMock()
+        client.check_config.return_value = {"result": "valid"}
+        client.call_service.return_value = None  # restart fires, no error
+        tools = SystemTools(client)
+
+        result = await tools.ha_restart(confirm=True)
+
+        assert result["success"] is True
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result!r}"
+        )
+        assert any("Connection will be lost" in w for w in warnings), (
+            f"Expected connection-lost warning content; got: {warnings!r}"
+        )
 
 
 def _ws_client_with_issues(issues):

--- a/tests/src/unit/test_wait_parameter.py
+++ b/tests/src/unit/test_wait_parameter.py
@@ -555,7 +555,8 @@ class TestServiceCallWaitParameter:
                 entity_id="light.test",
             )
             assert result["success"] is True
-            assert "warning" in result
+            assert result.get("warnings"), f"Expected warnings list, got: {result}"
+            assert any("could not be verified" in w for w in result["warnings"])
 
     async def test_call_service_toggle_waits(self, tools, mock_client):
         """toggle is a state-changing service and triggers wait."""
@@ -589,4 +590,5 @@ class TestServiceCallWaitParameter:
                 entity_id="light.test",
             )
             assert result["success"] is True
-            assert "warning" in result
+            assert result.get("warnings"), f"Expected warnings list, got: {result}"
+            assert any("state verification failed" in w for w in result["warnings"])


### PR DESCRIPTION
## What does this PR do?

Completes the singular `warning` → `warnings: list[str]` migration repo-wide after the four per-domain PRs (#1337-#1340). Single sweep PR for the remaining 8 files.

**Source migrations (top-level shape, post-rebase line numbers):** `tools_search.py:739`; `tools_system.py:189, 211, 442, 597`; `tools_integrations.py:436, 455, 1240, 1391, 1534`; `tools_service.py:148, 189, 193, 515`; `tools_entities.py:527`.

**Nested sub-dict shape (kept nested, flipped singular→list):** `tools_entities.py:379, 396, 411` (`device_rename_result["warnings"]` — the `lookup_failed` / no-device / WS-call-failure cases each keep their own warnings bag); `tools_addons.py:1275` (`entry["warnings"]` inside `summary["deleted_where"]`).

**Boy-Scout folded in:** `tools_integrations.py:1246` unconditional `response["warnings"] = warnings` switched to `setdefault().extend()` so accumulated + batch warnings merge instead of one wiping the other; `tools_entities.py:542` partial-detection check reads `.get("warnings") and (device_id or lookup_failed)` to distinguish operational error from no-op; `tools_system.py:302-308` reload-core response converted from `"warnings": errors if errors else None` (legacy None-footgun, breaks `setdefault().append()` for downstream callers) to conditional dict construction omitting the key when empty.

**Test assertions:** unit + e2e sites flipped; assertions verify presence *and* content substring (3 originally presence-only sites tightened in the second-pass review batch: `test_tools_addons.py:2970` ignored_fields, `test_entity_rename.py:469` no-associated-device, `test_rename_consolidation.py:64` update-references).

**New tests added during review:** `test_ha_call_event.py::test_timeout_returns_partial_success_with_warning` covers the `tools_service.py:515` `httpx.TimeoutException` path that previously had no test. `test_tools_system.py::test_success_path_returns_connection_lost_warning` covers the `tools_system.py:189-202` success branch. `test_backup_agent_lookup.py::TestRestoreBackupWarnings::test_success_returns_top_level_warnings_list` covers `backup.py:447-457` which had no test guard at all. `TestSweepWarningsShape` class added to `test_helper_response_shape.py` — provides cross-cutting shape-pin coverage for 6 of 8 PR-touched tools via two helpers: strict `_assert_warnings_list_shape` (top-level `success: True` + warnings) for `backup.py` / `tools_service.py` / `tools_system.py` / `tools_energy.py`, and the new relaxed `_assert_warnings_list_shape_no_success` (status-marker / payload-bag shape) for `tools_addons.py` / `tools_integrations.py`. The remaining 2 (`tools_search.py`, `tools_entities.py`) sit behind multi-step WebSocket call chains where cross-cutting mocks would need to branch on WS message `type`; per-tool content coverage exists in `test_tools_search.py`, `test_entity_rename.py`, and `test_rename_consolidation.py`.

**Intentional skips:** `tools_integrations.py:805` (error_context dict, not response field).

Closes #1332.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`ruff check src/ tests/` clean; `mypy` clean on the 8 touched source files; full unit suite 2638 passed, 1 musl-skip.

## Future improvements

<!-- Out-of-scope items noted during this PR. -->

- `apply_entity_category` `category_warning` was migrated by #1340 (merged 17:01 UTC) — confirmed live on post-rebase `util_helpers.py:663+`. No follow-up needed.
- `TestSweepWarningsShape` cross-cutting coverage for `tools_search.py` and `tools_entities.py` deferred — multi-step WebSocket call chains require per-tool WS-message-type-branched mocks beyond the cross-cutting test scope. Per-tool content coverage already lives in `test_tools_search.py`, `test_entity_rename.py`, and `test_rename_consolidation.py`.

## Checklist
- [x] I have updated documentation if needed
