### PR TITLE
refactor(internal): consolidate lovelace/dashboards/list through shared helper

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -22,6 +22,7 @@ from ..utils.fuzzy_search import (
     tokenize,
 )
 from .helpers import exception_to_structured_error, safe_info, safe_progress
+from .tools_config_dashboards import fetch_dashboards_list
 
 logger = logging.getLogger(__name__)
 
@@ -1773,14 +1774,9 @@ class SmartSearchTools:
             if "dashboard" in search_types:
                 try:
                     # List all storage-mode dashboards
-                    dash_list_resp = await self.client.send_websocket_message(
-                        {"type": "lovelace/dashboards/list"}
+                    dashboard_entries: list[dict[str, Any]] = (
+                        await fetch_dashboards_list(self.client) or []
                     )
-                    dashboard_entries: list[dict[str, Any]] = []
-                    if isinstance(dash_list_resp, dict) and dash_list_resp.get(
-                        "success"
-                    ):
-                        dashboard_entries = dash_list_resp.get("result", [])
 
                     # Build list of dashboards to search (include default)
                     dashboards_to_search: list[tuple[str, str]] = [

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -322,7 +322,7 @@ def _should_lazy_resolve(error_msg: str) -> bool:
     return _LAZY_RESOLVE_TRIGGER in error_msg
 
 
-async def _fetch_dashboards_list(
+async def fetch_dashboards_list(
     client: Any,
 ) -> list[dict[str, Any]] | None:
     """Fetch and normalise the lovelace/dashboards/list WebSocket response.
@@ -380,7 +380,7 @@ async def _resolve_dashboard(
       to the registry id before issuing the delete. Discards
       ``dashboards``.
     """
-    dashboards = await _fetch_dashboards_list(client)
+    dashboards = await fetch_dashboards_list(client)
     if dashboards is None:
         return None, None
 
@@ -597,7 +597,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         try:
             # List mode
             if list_only:
-                dashboards = await _fetch_dashboards_list(client) or []
+                dashboards = await fetch_dashboards_list(client) or []
                 return {
                     "success": True,
                     "action": "list",
@@ -1213,9 +1213,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             if pre_fetched_dashboards is not None:
                 existing_dashboards = pre_fetched_dashboards
             else:
-                existing_dashboards = (
-                    await _fetch_dashboards_list(client) or []
-                )
+                existing_dashboards = await fetch_dashboards_list(client) or []
             dashboard_exists = any(
                 d.get("url_path") == url_path for d in existing_dashboards
             )

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -20,6 +20,7 @@ from pydantic import Field
 from ..config import get_global_settings
 from ..errors import ErrorCode, create_error_response
 from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
+from .tools_config_dashboards import fetch_dashboards_list
 from .tools_filesystem import (
     MCP_TOOLS_DOMAIN,
     _assert_mcp_tools_available,
@@ -45,25 +46,11 @@ async def _check_storage_mode_dashboard_collision(
         return
     url_path = yaml_path[len(_LOVELACE_DASHBOARD_PREFIX):]
     try:
-        result = await client.send_websocket_message(
-            {"type": "lovelace/dashboards/list"}
-        )
+        dashboards = await fetch_dashboards_list(client)
     except Exception as exc:
         logger.warning(
             "lovelace/dashboards/list WS query failed (%s); skipping collision check",
             exc,
-        )
-        return
-
-    if isinstance(result, dict) and "result" in result:
-        dashboards = result["result"]
-    elif isinstance(result, list):
-        dashboards = result
-    else:
-        logger.warning(
-            "lovelace/dashboards/list returned unexpected shape (%s); "
-            "skipping collision check",
-            type(result).__name__,
         )
         return
 

--- a/tests/src/unit/test_config_get_dashboard_search_error.py
+++ b/tests/src/unit/test_config_get_dashboard_search_error.py
@@ -116,7 +116,7 @@ class TestConfigGetDashboardSearchErrorHandling:
 class TestGetDashboardListOnlyUnexpectedShape:
     """list_only=True emits a warning (not a failure) on unexpected HA response shape.
 
-    _fetch_dashboards_list logs at WARNING and returns None; the ``or []``
+    fetch_dashboards_list logs at WARNING and returns None; the ``or []``
     fallback means the tool still returns a valid success response with an
     empty dashboards list. This test pins the behavior introduced when the
     inline fetch was extracted to the shared helper so that a silent ``[]``


### PR DESCRIPTION
## What does this PR do?

Routes the two remaining raw `lovelace/dashboards/list` call sites through the existing `fetch_dashboards_list` helper:

- `tools_yaml_config.py:49` (`_check_storage_mode_dashboard_collision`)
- `smart_search.py:1778` (`ha_deep_search` dashboard branch)

Renames `_fetch_dashboards_list` → `fetch_dashboards_list` since it's now a cross-module helper (3 internal callers in `tools_config_dashboards.py` at L383/L600/L1216 + 1 docstring in `test_config_get_dashboard_search_error.py:119` updated).

Behaviour note: `smart_search`'s previous `.get("success")` gate silently treated bare-list HA responses as empty; the helper accepts both dict-with-`result`-key and bare-list shapes, so the branch now correctly populates from either.

Refs #1194 (Option B from [comment 4468552918](https://github.com/homeassistant-ai/ha-mcp/issues/1194#issuecomment-4468552918)). The client-level cache layer (the issue's actual subject) stays open in #1194 for separate decision.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No new tests — `test_yaml_config_tool.py` (5 collision-check scenarios) and `test_config_get_dashboard_search_error.py` mock `send_websocket_message` directly, so existing fixtures flow through the helper routing unchanged. Full local unit suite: 2641 passed, 1 skipped, 6 deselected.

## Future improvements

<!-- Out-of-scope items noted during this PR. -->

- Client-level cache layer (the actual subject of #1194) — out of scope; 4 open design questions still apply.
- `ha_deep_search` dashboard branch has no direct unit test — focused test exercising the bare-list path would close a real gap.

## Checklist
- [x] I have updated documentation if needed
