### PR TITLE
fix: classify dashboard 404s ("unknown config specified") as RESOURCE_NOT_FOUND

### DIFF
--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -284,7 +284,16 @@ def _classify_by_message(
         # heterogeneous vol.Invalid vocabulary without relying on an
         # error code (always unknown_error from the bridge).
         result = create_validation_error(error_msg, context=context)
-    elif "not found" in error_str or "404" in error_str:
+    elif (
+        "not found" in error_str
+        or "404" in error_str
+        or "unknown config specified" in error_str
+    ):
+        # ``unknown config specified`` is HA Core's WS-bridge phrasing for
+        # missing-dashboard 404s (lovelace/config with an unknown url_path).
+        # The string contains neither ``not found`` nor ``404``, so it would
+        # otherwise fall through to the ``command failed:`` SERVICE_CALL_FAILED
+        # fallback below and the agent would lose the not-found signal.
         entity_id = context.get("entity_id") if context else None
         if entity_id:
             result = create_entity_not_found_error(entity_id, details=error_msg)

--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -25,7 +25,7 @@ class TestUnknownConfigSpecifiedClassification:
     def test_dashboard_404_via_ws_bridge_classified_as_resource_not_found(self):
         """HA Core's standard wording (mixed case) must classify as 404,
         not SERVICE_CALL_FAILED. The classifier lowercases input via
-        ``exception_to_structured_error``'s ``str(error).lower()`` at L394,
+        ``exception_to_structured_error``'s ``str(error).lower()`` at L403,
         so the substring check matches regardless of upstream casing."""
         err = HomeAssistantCommandError(
             "Command failed: Unknown config specified: my-dash"

--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -5,9 +5,10 @@ bridge get classified as RESOURCE_NOT_FOUND (or ENTITY_NOT_FOUND when an
 ``entity_id`` is in context) rather than falling through to the generic
 SERVICE_CALL_FAILED bucket.
 
-Issue #1297 D1: HA Core's lovelace/config response for a missing dashboard
-arrives as ``HomeAssistantCommandError("Command failed: Unknown config
-specified: <url_path>")``. The classifier's 404 branch must catch the
+Issue #1297 dashboards-classifier extension: HA Core's lovelace/config
+response for a missing dashboard arrives as
+``HomeAssistantCommandError("Command failed: Unknown config specified:
+<url_path>")``. The classifier's 404 branch must catch the
 ``unknown config specified`` substring alongside the existing ``not found``
 and ``404`` substrings, otherwise the message clears the schema-validation
 gate (no schema markers, no ``expected <type>`` regex hit), misses the
@@ -25,8 +26,8 @@ class TestUnknownConfigSpecifiedClassification:
     def test_dashboard_404_via_ws_bridge_classified_as_resource_not_found(self):
         """HA Core's standard wording (mixed case) must classify as 404,
         not SERVICE_CALL_FAILED. The classifier lowercases input via
-        ``exception_to_structured_error``'s ``str(error).lower()`` at L403,
-        so the substring check matches regardless of upstream casing."""
+        ``exception_to_structured_error``, so the substring check matches
+        regardless of upstream casing."""
         err = HomeAssistantCommandError(
             "Command failed: Unknown config specified: my-dash"
         )
@@ -36,6 +37,37 @@ class TestUnknownConfigSpecifiedClassification:
         assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
             f"Expected RESOURCE_NOT_FOUND, got: {result['error'].get('code')}. "
             "Regression: dashboards 404s falling back into SERVICE_CALL_FAILED."
+        )
+
+    def test_unknown_config_specified_without_command_failed_prefix(self):
+        """Pins that the not-found classification fires on the substring
+        alone — without the ``Command failed: `` prefix that the schema
+        gate keys on. Guards against a future refactor that ties the
+        substring check to the prefix and silently breaks any caller
+        path that surfaces the wording outside the WS-bridge wrapping."""
+        err = HomeAssistantCommandError("Unknown config specified: my-dash")
+        result = exception_to_structured_error(err, raise_error=False)
+
+        assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected RESOURCE_NOT_FOUND without 'Command failed:' prefix, "
+            f"got: {result['error'].get('code')}"
+        )
+
+    def test_unknown_config_specified_all_lowercase_input(self):
+        """Pins the ``str(error).lower()`` normalization step in
+        ``exception_to_structured_error``. The substring check is
+        case-insensitive by construction (input is lowercased before
+        the elif chain), so a fully-lowercase input must still match.
+        Guards against a future change that drops the normalization
+        step and re-introduces case-sensitivity on the wire format."""
+        err = HomeAssistantCommandError(
+            "command failed: unknown config specified: my-dash"
+        )
+        result = exception_to_structured_error(err, raise_error=False)
+
+        assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected RESOURCE_NOT_FOUND on all-lowercase input, "
+            f"got: {result['error'].get('code')}"
         )
 
     def test_dashboard_404_preserves_message_for_agent_diagnostics(self):

--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -1,0 +1,79 @@
+"""Unit tests for the exception → structured-error classifier in tools/helpers.py.
+
+Pins the contract that domain-specific 404 wire formats from HA's WebSocket
+bridge get classified as RESOURCE_NOT_FOUND (or ENTITY_NOT_FOUND when an
+``entity_id`` is in context) rather than falling through to the generic
+SERVICE_CALL_FAILED bucket.
+
+Issue #1297 D1: HA Core's lovelace/config response for a missing dashboard
+arrives as ``HomeAssistantCommandError("Command failed: Unknown config
+specified: <url_path>")``. The classifier's 404 branch must catch the
+``unknown config specified`` substring alongside the existing ``not found``
+and ``404`` substrings, otherwise the message clears the schema-validation
+gate (no schema markers, no ``expected <type>`` regex hit), misses the
+not-found branch, and falls into the ``command failed:`` SERVICE_CALL_FAILED
+fallback — losing the not-found signal the agent retry path branches on.
+"""
+
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.tools.helpers import exception_to_structured_error
+
+
+class TestUnknownConfigSpecifiedClassification:
+    """``Unknown config specified`` WS-bridge string → RESOURCE_NOT_FOUND."""
+
+    def test_dashboard_404_via_ws_bridge_classified_as_resource_not_found(self):
+        """HA Core's standard wording (mixed case) must classify as 404,
+        not SERVICE_CALL_FAILED. The classifier lowercases input via
+        ``exception_to_structured_error``'s ``str(error).lower()`` at L394,
+        so the substring check matches regardless of upstream casing."""
+        err = HomeAssistantCommandError(
+            "Command failed: Unknown config specified: my-dash"
+        )
+        result = exception_to_structured_error(err, raise_error=False)
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected RESOURCE_NOT_FOUND, got: {result['error'].get('code')}. "
+            "Regression: dashboards 404s falling back into SERVICE_CALL_FAILED."
+        )
+
+    def test_dashboard_404_preserves_message_for_agent_diagnostics(self):
+        """Caller needs the original message visible so the agent can extract
+        the offending url_path for a retry/lookup. Pins that the
+        details/message fields carry the full upstream wording."""
+        err = HomeAssistantCommandError(
+            "Command failed: Unknown config specified: unifi-root"
+        )
+        result = exception_to_structured_error(err, raise_error=False)
+
+        haystack = (
+            (result["error"].get("message") or "")
+            + " "
+            + str(result["error"].get("details") or "")
+        )
+        assert "unifi-root" in haystack, (
+            f"Original url_path missing from result error fields: {result['error']}"
+        )
+
+    def test_unknown_config_specified_with_entity_id_context_promotes_to_entity_not_found(
+        self,
+    ):
+        """When caller supplies ``entity_id`` in context (atypical for
+        dashboards but symmetric with the existing ``not found``/``404``
+        branches), the result upgrades to ENTITY_NOT_FOUND. Pins that
+        the new substring lands on the same context-promotion code path,
+        not an isolated dashboards-specific branch."""
+        err = HomeAssistantCommandError(
+            "Command failed: Unknown config specified: my-dash"
+        )
+        result = exception_to_structured_error(
+            err,
+            context={"entity_id": "automation.foo"},
+            raise_error=False,
+        )
+
+        assert result["error"]["code"] == "ENTITY_NOT_FOUND", (
+            f"Expected ENTITY_NOT_FOUND under entity_id context, got: "
+            f"{result['error'].get('code')}"
+        )


### PR DESCRIPTION
## What does this PR do?

Adds `unknown config specified` to the not-found OR-chain in `_classify_by_message` (`src/ha_mcp/tools/helpers.py:L287`) so HA Core's WebSocket-bridge wording for missing dashboards (`Command failed: Unknown config specified: <url_path>`) gets classified as `RESOURCE_NOT_FOUND` instead of falling into the `SERVICE_CALL_FAILED` fallback at L316.

**Actual blast radius:** the new branch only fires when a caller lets `HomeAssistantCommandError` propagate to `exception_to_structured_error`'s generic `except Exception` arm. The dashboards tools themselves don't take that path — `RestClient.send_websocket_message` (`src/ha_mcp/client/rest_client.py:1136-1164`) catches `Exception` internally and returns `{"success": False, "error": str(e)}`, which `tools_config_dashboards.py:637/L656-L670` and `:737/L755` then re-wrap manually as `SERVICE_CALL_FAILED`. So this PR's classifier extension is correct on its own merits but does not, on its own, change the dashboards-tool 404 wire shape — that's a separate change (D2 in #1297) which rewires those tools to surface the wrapped error via `exception_to_structured_error` so the new classifier branch can fire.

PR 1 of 3 in #1297's split (per the [2026-05-16 re-anchor comment](https://github.com/homeassistant-ai/ha-mcp/issues/1297#issuecomment-4468471883)) — dashboards-classifier extension only. PR 2 (labels/categories code-swap) and PR 3 (Pattern-A removal + paired test classes) stay scoped out.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Five regression tests added in `tests/src/unit/test_helper_classifier.py` (new file). Full local unit suite: 2644 passed, 1 skipped (numpy unavailable on Alpine musl), 6 deselected.

## Future improvements

<!-- Out-of-scope items noted during this PR. -->

- The existing `not found` / `404` / `timeout` / `connection` / auth-phrase branches in `_classify_by_message` lack direct unit-test coverage too — a broader test class covering one regression per branch would close the gap. Tracked in #1357.

## Checklist
- [x] I have updated documentation if needed

Refs #1297
