### PR TITLE
test(e2e): instrument HA_MCP_TOOLS_WAIT readiness gate (refs #366)

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -579,12 +579,24 @@ def _wait_for_ha_mcp_tools_services(
     base_url: str,
     headers: dict[str, str],
     timeout: int,
-) -> bool:
+) -> tuple[bool, float, int]:
     """Poll ``/api/services`` for the ``ha_mcp_tools`` domain.
 
-    Returns True if the domain appears within ``timeout`` seconds, False
-    on timeout. The single caller lives in ``ha_container_with_fresh_config``;
-    the helper extraction is preserved so a future bounded retry (if a
+    Returns ``(ready, elapsed_s, domain_count)``:
+
+    - ``ready`` — True if the domain appears within ``timeout`` seconds,
+      False on timeout.
+    - ``elapsed_s`` — wall-clock seconds spent polling, float-precise
+      (matches the precision the other readiness gates emit).
+      Always populated, both on success and on timeout, so the caller can
+      ``_log_readiness_timing`` regardless of branch.
+    - ``domain_count`` — size of the registered-domain set when the
+      target domain appeared (0 on timeout / no-200-response). Surfaces
+      as the ``count=`` extra on the timing line, parity with the
+      ``components`` / ``entities`` gates.
+
+    The single caller lives in ``ha_container_with_fresh_config``; the
+    helper extraction is preserved so a future bounded retry (if a
     recoverable flake class surfaces in the dump) can re-use the same
     wait contract without duplicating the polling loop.
     """
@@ -601,16 +613,18 @@ def _wait_for_ha_mcp_tools_services(
             if svc_resp.status_code == 200:
                 domains = {s.get("domain") for s in svc_resp.json()}
                 if "ha_mcp_tools" in domains:
-                    elapsed = int(time.monotonic() - start_time)
-                    logger.info(f"✅ ha_mcp_tools services ready after {elapsed}s")
-                    return True
+                    elapsed_s = time.monotonic() - start_time
+                    logger.info(
+                        f"✅ ha_mcp_tools services ready after {elapsed_s:.2f}s"
+                    )
+                    return True, elapsed_s, len(domains)
         except (
             _requests.exceptions.RequestException,
             json.JSONDecodeError,
         ) as exc:
             logger.debug(f"ha_mcp_tools service check failed: {exc}")
         time.sleep(1)
-    return False
+    return False, time.monotonic() - start_time, 0
 
 
 def _dump_ha_readiness_diagnostics(
@@ -1232,9 +1246,22 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():
             logger.info("⏳ Waiting for ha_mcp_tools services to register...")
-            if not _wait_for_ha_mcp_tools_services(
-                base_url, headers, HA_MCP_TOOLS_WAIT
-            ):
+            ha_mcp_ready, ha_mcp_elapsed, ha_mcp_domain_count = (
+                _wait_for_ha_mcp_tools_services(
+                    base_url, headers, HA_MCP_TOOLS_WAIT
+                )
+            )
+            if ha_mcp_ready:
+                # Success-only emit, parity with the other four readiness
+                # gates above (components / entities / input_boolean / sun)
+                # which call _log_readiness_timing only inside their hit
+                # branch. ``count`` mirrors components/entities.
+                _log_readiness_timing(
+                    "ha_mcp_tools",
+                    ha_mcp_elapsed,
+                    count=ha_mcp_domain_count,
+                )
+            else:
                 _dump_ha_readiness_diagnostics(
                     container,
                     base_url,

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -611,7 +611,14 @@ def _wait_for_ha_mcp_tools_services(
                 f"{base_url}/api/services", timeout=5, headers=headers
             )
             if svc_resp.status_code == 200:
-                domains = {s.get("domain") for s in svc_resp.json()}
+                # Filter on truthy domain to mirror the diagnostic dump at
+                # _dump_ha_readiness_diagnostics (L671). Drops None /
+                # empty-string ``domain`` values that would otherwise inflate
+                # ``len(domains)`` and pollute the ``ha_mcp_tools in domains``
+                # membership check.
+                domains = {
+                    s.get("domain") for s in svc_resp.json() if s.get("domain")
+                }
                 if "ha_mcp_tools" in domains:
                     elapsed_s = time.monotonic() - start_time
                     logger.info(


### PR DESCRIPTION
## What does this PR do?

Completes the fifth readiness gate left out of [#1310](https://github.com/homeassistant-ai/ha-mcp/pull/1310) so the [#366 tightening sweep](https://github.com/homeassistant-ai/ha-mcp/issues/366#issuecomment-4472952805) has a `ha_mcp_tools` row to fold into the next sample-extraction aggregate.

The 4 inline-polling gates (`STABILIZATION_TIMEOUT` / `ENTITY_STABILIZATION_TIMEOUT` / `INPUT_BOOLEAN_WAIT` / `SUN_WAIT`) emit `[READINESS_GATE_TIMING]` from inside their hit branch. `HA_MCP_TOOLS_WAIT` couldn't follow that pattern because its polling loop is in the extracted `_wait_for_ha_mcp_tools_services` helper which returned `bool` only — the elapsed wall-clock was logged internally at L605 but never reached the caller. The helper extraction is deliberate (L587-590 docstring preserves it for a future bounded-retry hook) so the cleanest path is widening the return contract rather than inlining.

**Changes** (single file, `tests/src/e2e/conftest.py`):

- Helper signature `-> bool` → `-> tuple[bool, float, int]` returning `(ready, elapsed_s, domain_count)`. Float-precise elapsed matches the precision the inline gates already emit; `domain_count` mirrors the `count=` extra used by the `components` / `entities` gates. Both fields populate on success and on timeout (timeout returns `(False, <elapsed>, 0)`).
- Helper success-log line gains sub-second precision (`{:.2f}` instead of the prior `int(...)` cast which collapsed `1.02s` and `1.99s` into `"1s"`).
- Caller unpacks the tuple and calls `_log_readiness_timing("ha_mcp_tools", elapsed, count=domain_count)` only inside the success branch — parity with how the four inline gates emit (success-only; timeout falls through to `pytest.fail` / diagnostic dump unchanged).

No behaviour change on the success path beyond the log-precision bump and the new timing emission; no behaviour change on the timeout path.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ruff clean on the touched file; mypy clean within the edited region (the 3 pre-existing mypy errors at L1617+ predate this PR and live in untouched fixture helpers). E2E suite isn't impacted by the contract change — `_wait_for_ha_mcp_tools_services` has exactly one caller (the inline change here) and no test stubs out the helper directly.

The actual emission only fires when `ha_mcp_tools` is present in the test container's `custom_components/` tree, so the CI E2E job will produce the new timing line on every master run going forward — visible in the "Readiness gate timings" section that `pytest_terminal_summary` emits.

## Future improvements

- Once a sample window's worth of `ha_mcp_tools` timings has landed (suggest waiting for ~5-8 master runs after merge so the existing #366 sweep's aggregate can be re-derived with 5 gates instead of 4), the tightening PR can fold this gate's proposed target into its scope. Current budget is 180s — observed elapsed in the existing internal-log lines historically sits well below that; numbers will surface in the next #366 sweep comment.
- The `(ready, elapsed_s, domain_count)` return shape unblocks the bounded-retry hook the helper docstring already advertises (L587-590) — separate decision if a recoverable flake class surfaces in the diagnostic dumps.

## Checklist
- [x] I have updated documentation if needed
