### PR TITLE
feat: return canonical script_id from ha_config_get_script (#1334)

### DIFF
--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -96,6 +96,8 @@ class ConfigScriptTools:
 
         The returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.
 
+        The returned `script_id` is the canonical storage key resolved by the REST client (matching what `ha_config_set_script` / `ha_config_remove_script` expect), falling back to the input identifier on the rare path where the REST envelope omits it.
+
         EXAMPLES:
         - Get script: ha_config_get_script("morning_routine")
         - Get script: ha_config_get_script("backup_script")
@@ -128,16 +130,26 @@ class ConfigScriptTools:
             if cat_id:
                 config_result["category"] = cat_id
 
+            # Issue #1334: return the canonical storage key from the
+            # rest_client envelope so callers can thread the result into
+            # subsequent ha_config_*_script calls without re-resolving.
+            # Falls back to the input when the rest_client response omits
+            # the key — a contract violation that we surface via warning
+            # rather than mask silently.
+            canonical_id = config_result.get("script_id")
+            if canonical_id is None:
+                logger.warning(
+                    "get_script_config envelope missing 'script_id' for "
+                    "input %r; falling back to caller input. This indicates "
+                    "a rest_client contract violation.",
+                    script_id,
+                )
+                canonical_id = script_id
+
             return {
                 "success": True,
                 "action": "get",
-                # Issue #1334: return the canonical storage key from the
-                # rest_client envelope so callers can thread the result into
-                # subsequent ha_config_*_script calls without re-resolving.
-                # Falls back to the input on edge cases where the envelope
-                # lacks the key. Aligns scripts with scenes / dashboards /
-                # automations (see ha_config_get_automation's automation_id).
-                "script_id": config_result.get("script_id", script_id),
+                "script_id": canonical_id,
                 "config": config_result,
                 "config_hash": config_hash_value,
             }

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -131,7 +131,13 @@ class ConfigScriptTools:
             return {
                 "success": True,
                 "action": "get",
-                "script_id": script_id,
+                # Issue #1334: return the canonical storage key from the
+                # rest_client envelope so callers can thread the result into
+                # subsequent ha_config_*_script calls without re-resolving.
+                # Falls back to the input on edge cases where the envelope
+                # lacks the key. Aligns scripts with scenes / dashboards /
+                # automations (see ha_config_get_automation's automation_id).
+                "script_id": config_result.get("script_id", script_id),
                 "config": config_result,
                 "config_hash": config_hash_value,
             }

--- a/tests/src/e2e/workflows/scripts/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scripts/test_lifecycle.py
@@ -293,6 +293,15 @@ class TestScriptOrchestration:
                 { "script_id": script_id}
             )
 
+            # Issue #1334: returned ``script_id`` is the canonical storage
+            # key. For inputs already in canonical form (as here), it must
+            # round-trip unchanged so callers can thread the result back
+            # into ha_config_set_script / ha_config_remove_script.
+            assert get_data.get("script_id") == script_id, (
+                f"Expected canonical script_id={script_id!r} in get response, "
+                f"got {get_data.get('script_id')!r}"
+            )
+
             config = extract_script_config(get_data)
             assert config.get("alias") == "Test Basic Script", (
                 f"Alias mismatch: {config}"

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -170,6 +170,73 @@ class TestScriptToolsValidation:
         assert "Invalid" in error_data["error"]["message"]
 
 
+class TestGetScriptCanonicalId:
+    """Issue #1334: ha_config_get_script returns the canonical storage key.
+
+    Previously the tool echoed the caller-supplied ``script_id`` unchanged,
+    forcing clients to do their own resolution before chaining into
+    ``ha_config_set_script`` / ``ha_config_remove_script``. The rest_client
+    envelope already carries the resolved storage key; this test pins the
+    tool to surface that value (with fallback to the input when absent),
+    matching scenes / dashboards / automations.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        # send_websocket_message is invoked by fetch_entity_category; return
+        # a no-category response so the get path doesn't error.
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False}
+        )
+        return client
+
+    @pytest.fixture
+    def tools(self, mock_client):
+        return ConfigScriptTools(mock_client)
+
+    async def test_returns_canonical_script_id_from_envelope(
+        self, tools, mock_client
+    ):
+        """When the rest_client resolves an alias to a storage key, the
+        tool's returned ``script_id`` reflects the canonical key."""
+        mock_client.get_script_config = AsyncMock(
+            return_value={
+                "success": True,
+                "script_id": "1234567890",
+                "config": {
+                    "alias": "Morning Routine",
+                    "sequence": [{"delay": {"seconds": 1}}],
+                },
+            }
+        )
+
+        result = await tools.ha_config_get_script(script_id="morning_routine")
+
+        assert result["success"] is True
+        assert result["script_id"] == "1234567890"
+
+    async def test_falls_back_to_input_when_envelope_missing_key(
+        self, tools, mock_client
+    ):
+        """If the rest_client envelope omits ``script_id`` (defensive
+        fallback), the tool surfaces the caller-supplied identifier."""
+        mock_client.get_script_config = AsyncMock(
+            return_value={
+                "success": True,
+                "config": {
+                    "alias": "Test",
+                    "sequence": [{"delay": {"seconds": 1}}],
+                },
+            }
+        )
+
+        result = await tools.ha_config_get_script(script_id="caller_input")
+
+        assert result["success"] is True
+        assert result["script_id"] == "caller_input"
+
+
 class TestStripEmptyScriptFields:
     """Test the _strip_empty_script_fields helper function."""
 

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -6,6 +6,7 @@ especially for blueprint-based scripts (issue #466).
 """
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -171,15 +172,8 @@ class TestScriptToolsValidation:
 
 
 class TestGetScriptCanonicalId:
-    """Issue #1334: ha_config_get_script returns the canonical storage key.
-
-    Previously the tool echoed the caller-supplied ``script_id`` unchanged,
-    forcing clients to do their own resolution before chaining into
-    ``ha_config_set_script`` / ``ha_config_remove_script``. The rest_client
-    envelope already carries the resolved storage key; this test pins the
-    tool to surface that value (with fallback to the input when absent),
-    matching scenes / dashboards / automations.
-    """
+    """Issue #1334: returned ``script_id`` is the canonical storage key,
+    falling back to the caller input when the rest_client envelope omits it."""
 
     @pytest.fixture
     def mock_client(self):
@@ -214,13 +208,16 @@ class TestGetScriptCanonicalId:
         result = await tools.ha_config_get_script(script_id="morning_routine")
 
         assert result["success"] is True
+        assert result["action"] == "get"
         assert result["script_id"] == "1234567890"
+        assert "config_hash" in result
 
-    async def test_falls_back_to_input_when_envelope_missing_key(
-        self, tools, mock_client
+    async def test_falls_back_to_input_and_warns_when_envelope_missing_key(
+        self, tools, mock_client, caplog
     ):
-        """If the rest_client envelope omits ``script_id`` (defensive
-        fallback), the tool surfaces the caller-supplied identifier."""
+        """If the rest_client envelope omits ``script_id`` (contract
+        violation), the tool surfaces the caller-supplied identifier and
+        logs a warning rather than masking the missing key silently."""
         mock_client.get_script_config = AsyncMock(
             return_value={
                 "success": True,
@@ -231,10 +228,19 @@ class TestGetScriptCanonicalId:
             }
         )
 
-        result = await tools.ha_config_get_script(script_id="caller_input")
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.tools_config_scripts"
+        ):
+            result = await tools.ha_config_get_script(script_id="caller_input")
 
         assert result["success"] is True
+        assert result["action"] == "get"
         assert result["script_id"] == "caller_input"
+        assert any(
+            "rest_client contract violation" in r.message
+            and r.levelname == "WARNING"
+            for r in caplog.records
+        ), f"Expected contract-violation warning, got: {[r.message for r in caplog.records]}"
 
 
 class TestStripEmptyScriptFields:


### PR DESCRIPTION
## What does this PR do?

Closes #1334 by adopting Option B from the issue: `ha_config_get_script` now returns the resolved storage key in `script_id` instead of echoing the caller-supplied identifier. This brings the `ha_config_get_*` family fully onto canonical-with-fallback semantics — scenes, dashboards, and (post #1329) automations already do this.

The change is one line in the tool: the rest_client's `get_script_config` envelope already carries the resolved `script_id`, so the fix pulls it out with a fallback to the input on malformed envelopes.

```diff
-                "script_id": script_id,
+                "script_id": config_result.get("script_id", script_id),
```

After this, all four `ha_config_get_*` tools surface a typed-id key that clients can thread directly into `ha_config_set_*` / `ha_config_remove_*` without re-resolving — even when the caller passed an alias or entity_id slug.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) <!-- via CI -->
- [x] Code follows style guidelines (`uv run ruff check`) <!-- via CI -->

Two new unit tests in `tests/src/unit/test_tools_config_scripts.py::TestGetScriptCanonicalId`:
1. Canonical storage key from the rest_client envelope flows through unchanged on the tool return.
2. Falls back to the caller-supplied identifier when the envelope omits `script_id` (defensive path).

## Future improvements

Issue #1334 also notes that `ha_config_get_automation` still has a dual-key shape after #1329 (`identifier` echoes input alongside `automation_id` which is canonical-with-fallback). Converging `identifier` to canonical too is a follow-up consideration — not in scope here since this PR only addresses the script-side gap that was the cross-family odd-one-out.

## Checklist
- [x] I have updated documentation if needed <!-- none needed; behavior change is captured in the inline comment + commit message -->