### PR TITLE
refactor: drop logger.error in config-tool except blocks (#1302)

### DIFF
--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -396,6 +396,19 @@ def exception_to_structured_error(
 
     error_response = _classify_exception(error, error_str, error_msg, context)
 
+    # Tracebacks are operationally valuable only for genuinely unclassified
+    # exceptions (programmer errors, library bugs) — every other branch in
+    # _classify_exception produces a structured signal that's sufficient on
+    # its own. Logging at exception level here gives operators line numbers
+    # for the bug class where ``str(error)`` is least informative, without
+    # re-introducing the duplicate ERROR-log noise that classified failures
+    # produced.
+    if (
+        isinstance(error_response.get("error"), dict)
+        and error_response["error"].get("code") == ErrorCode.INTERNAL_ERROR
+    ):
+        logger.exception("Unclassified exception: %s", error_msg)
+
     if suggestions and "error" in error_response and isinstance(error_response["error"], dict):
         # Set both `suggestion` (singular, first item) and `suggestions`
         # (plural, full list). create_error_response (errors.py) sets the

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -325,7 +325,6 @@ class AutomationConfigTools:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error getting automation: {e}")
             exception_to_structured_error(
                 e,
                 context={"identifier": identifier, "action": "get"},
@@ -761,7 +760,6 @@ class AutomationConfigTools:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error upserting automation: {e}")
             suggestions = [
                 "Check automation configuration format",
                 "Ensure required fields: alias, trigger, action",
@@ -1033,7 +1031,6 @@ class AutomationConfigTools:
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error deleting automation: {e}")
             exception_to_structured_error(
                 e,
                 context={"identifier": identifier, "action": "delete"},

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -803,12 +803,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             raise
         except Exception as e:
             if search_mode:
-                logger.error(
-                    f"Error finding card in dashboard: url_path={url_path}, "
-                    f"entity_id={entity_id}, card_type={card_type}, heading={heading}, "
-                    f"error={e}",
-                    exc_info=True,
-                )
                 suggestions = [
                     "Check HA connection",
                     "Verify dashboard with ha_config_get_dashboard(list_only=True)",
@@ -821,7 +815,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     "heading": heading,
                 }
             else:
-                logger.error(f"Error getting dashboard: {e}", exc_info=True)
                 suggestions = [
                     "Use ha_config_get_dashboard(list_only=True) to see available dashboards",
                     "Check if you have permission to access this dashboard",
@@ -1482,7 +1475,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error setting dashboard: {e}")
             exception_to_structured_error(
                 e,
                 context={"action": "set", "url_path": url_path},
@@ -1564,8 +1556,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 else:
                     error_str = str(error_msg)
 
-                logger.error(f"Error deleting dashboard: {error_str}")
-
                 # If the error is "not found" / "doesn't exist", treat as success (idempotent)
                 if (
                     "unable to find" in error_str.lower()
@@ -1606,7 +1596,6 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Error deleting dashboard: {e}")
             exception_to_structured_error(
                 e,
                 context={"action": "delete", "url_path": url_path},

--- a/tests/src/unit/test_tool_error_signaling.py
+++ b/tests/src/unit/test_tool_error_signaling.py
@@ -7,6 +7,7 @@ Issue #518: Tool errors were not being signaled via isError in MCP protocol resp
 """
 
 import json
+import logging
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -159,6 +160,51 @@ class TestExceptionToStructuredError:
         # Should not raise JSONDecodeError
         error_data = json.loads(str(exc_info.value))
         assert error_data["success"] is False
+
+
+class TestInternalErrorTracebackLogging:
+    """Issue #1302: unclassified exceptions log a traceback once, in the helper.
+
+    The PR removed redundant per-call-site `logger.error(..., exc_info=True)`
+    lines from config-tool except blocks. Tracebacks remain operationally
+    valuable for the INTERNAL_ERROR fallback path (programmer errors,
+    library bugs) where `str(error)` alone is uninformative; this test
+    pins that observability at the centralized helper instead.
+    """
+
+    def test_internal_error_path_logs_traceback(self, caplog):
+        """An unclassified exception logs at exception level with traceback."""
+        with caplog.at_level(logging.ERROR, logger="ha_mcp.tools.helpers"):
+            result = exception_to_structured_error(
+                Exception("weird thing in card traversal"),
+                raise_error=False,
+            )
+
+        assert result["error"]["code"] == ErrorCode.INTERNAL_ERROR
+        traceback_records = [
+            r for r in caplog.records if r.exc_info is not None
+        ]
+        assert traceback_records, (
+            f"Expected an exc_info=True log record, got: "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    def test_classified_error_does_not_log_traceback(self, caplog):
+        """A classified exception (VALIDATION_FAILED here) does not log."""
+        with caplog.at_level(logging.ERROR, logger="ha_mcp.tools.helpers"):
+            result = exception_to_structured_error(
+                ValueError("Invalid parameter"),
+                raise_error=False,
+            )
+
+        assert result["error"]["code"] == ErrorCode.VALIDATION_FAILED
+        traceback_records = [
+            r for r in caplog.records if r.exc_info is not None
+        ]
+        assert not traceback_records, (
+            f"Classified exceptions must not log a traceback (noise), got: "
+            f"{[(r.levelname, r.message) for r in caplog.records]}"
+        )
 
 
 class TestErrorCodeMapping:


### PR DESCRIPTION
## What does this PR do?

Closes #1302 by adopting **Option A** (the maintainer-recommended pattern, ack'd in the issue body): drop `logger.error` in the 6 same-class `except Exception` blocks in `tools_config_automations.py` + `tools_config_dashboards.py`, plus the 1 adjacent log-before-classify call inside `ha_config_delete_dashboard`'s idempotent-404 path.

Also centralizes traceback observability for the unclassified-bug path (see commit 2 below) so the deletions don't drop server-side debuggability for genuine programmer errors / library bugs.

### Why

A 404 from `_client.get_automation_config(identifier)` / `_client.delete_dashboard(...)` for a missing identifier is the expected control-flow signal — not an error. The structured error returned to the MCP client (`ErrorCode.RESOURCE_NOT_FOUND` via `_classify_api_status`) is the observable signal; the server-side `logger.error` line was duplicate noise. Every existence probe was writing an `ERROR` row even though the operation completed correctly.

After this change, the affected tools match the pattern already in `tools_config_scripts.py` (which has no `logger.*` calls in its except blocks) and `tools_config_scenes.py` (only `logger.warning` / `debug` / `info` in non-except paths).

### Sites changed (commit 1)

| File | Function | Previously logged at |
|---|---|---|
| `tools_config_automations.py` | `ha_config_get_automation` | `logger.error` |
| `tools_config_automations.py` | `ha_config_set_automation` | `logger.error` |
| `tools_config_automations.py` | `ha_config_remove_automation` | `logger.error` |
| `tools_config_dashboards.py` | `ha_config_get_dashboard` (find_card branch) | `logger.error(..., exc_info=True)` |
| `tools_config_dashboards.py` | `ha_config_get_dashboard` (default branch) | `logger.error(..., exc_info=True)` |
| `tools_config_dashboards.py` | `ha_config_set_dashboard` | `logger.error` |
| `tools_config_dashboards.py` | `ha_config_delete_dashboard` (except Exception) | `logger.error` |
| `tools_config_dashboards.py` | `ha_config_delete_dashboard` (idempotent-404 inside try) | `logger.error` |

### Centralized traceback logging (commit 2)

Two of the eight deletions above (`get_dashboard` find_card + default branches) were `logger.error(..., exc_info=True)` — they captured tracebacks for the unclassified-bug class (e.g. `KeyError` in card traversal) where `str(error)` alone is least informative. To preserve that observability without re-introducing per-site duplication, `exception_to_structured_error` now calls `logger.exception(...)` when the classifier falls through to `ErrorCode.INTERNAL_ERROR`. Classified branches (404, auth, timeout, validation, connection, command-failed, service-call-failed) stay silent on the server side — the structured response to the MCP client is the signal.

Net effect: traceback observability is preserved for the bug class that needs it most, and now benefits every tool that uses the helper, not just the two dashboard sites that originally had `exc_info=True`.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) <!-- via CI -->
- [x] Code follows style guidelines (`uv run ruff check`) <!-- via CI -->

Adds two new unit tests in `tests/src/unit/test_tool_error_signaling.py::TestInternalErrorTracebackLogging`:
1. Unclassified exception → `caplog` captures an `exc_info`-bearing record.
2. Classified exception (e.g. `ValueError` → `VALIDATION_FAILED`) → no traceback record (noise stays gone).

Existing e2e lifecycle suites already pin the structured-error contract for not-found / invalid-config paths in both automations and dashboards.

## Checklist
- [x] I have updated documentation if needed <!-- none needed; behavior unchanged at MCP boundary -->
