### PR TITLE
refactor: drop redundant identifier echo key from ha_config_get_automation (#1334)

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -317,7 +317,6 @@ class AutomationConfigTools:
             return {
                 "success": True,
                 "action": "get",
-                "identifier": identifier,
                 "automation_id": entity_id or identifier,
                 "config": normalized_config,
                 "config_hash": config_hash,

--- a/tests/src/unit/test_tools_config_automations.py
+++ b/tests/src/unit/test_tools_config_automations.py
@@ -1,11 +1,11 @@
 """Unit tests for Automation configuration tools.
 
 Validates the `automation_id` typed-id key on `ha_config_get_automation`
-(issue #1299), which gives sibling parity with `ha_config_get_script`
+(issues #1299 and #1334). `automation_id` is the resolved entity_id when
+registry lookup succeeds, falling back to the raw input otherwise — same
+canonical-with-fallback semantic used by `ha_config_get_script`
 (`script_id`), `ha_config_get_scene` (`scene_id`), and
-`ha_config_get_dashboard` (`url_path`). The value is the resolved
-entity_id when registry lookup succeeds, falling back to the raw input
-otherwise — same canonical-with-fallback semantic as scenes/dashboards.
+`ha_config_get_dashboard` (`url_path`).
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -52,24 +52,22 @@ def tools(mock_client):
 
 
 class TestGetAutomationIdKey:
-    """`automation_id` parity key on `ha_config_get_automation` (issue #1299)."""
+    """`automation_id` canonical key on `ha_config_get_automation` (issues #1299, #1334)."""
 
     async def test_returns_resolved_entity_id_when_input_is_unique_id(self, tools):
-        """unique_id input → automation_id = resolved entity_id; identifier echoes input."""
+        """unique_id input → automation_id = resolved entity_id."""
         result = await tools.ha_config_get_automation(identifier="abc123unique")
 
         assert result["success"] is True
-        assert result["identifier"] == "abc123unique"
         assert result["automation_id"] == "automation.morning_routine"
 
     async def test_returns_input_when_input_is_entity_id(self, tools):
-        """entity_id input → automation_id == identifier (short-circuit in resolver)."""
+        """entity_id input → automation_id == caller input (resolver short-circuits)."""
         result = await tools.ha_config_get_automation(
             identifier="automation.morning_routine"
         )
 
         assert result["success"] is True
-        assert result["identifier"] == "automation.morning_routine"
         assert result["automation_id"] == "automation.morning_routine"
 
     async def test_falls_back_to_identifier_when_registry_lookup_misses(
@@ -81,5 +79,18 @@ class TestGetAutomationIdKey:
         result = await tools.ha_config_get_automation(identifier="orphaned_unique_id")
 
         assert result["success"] is True
-        assert result["identifier"] == "orphaned_unique_id"
         assert result["automation_id"] == "orphaned_unique_id"
+
+    async def test_identifier_key_no_longer_in_response(self, tools):
+        """Issue #1334: redundant `identifier` echo key dropped from response.
+
+        Family-level convergence — every `ha_config_get_*` tool surfaces one
+        canonical-with-fallback typed-id key. For automations that's
+        `automation_id`; the legacy `identifier` echo was the last
+        leftover of the pre-#1329 shape.
+        """
+        result = await tools.ha_config_get_automation(identifier="abc123unique")
+
+        assert "identifier" not in result, (
+            f"`identifier` key must not be present in response, got: {result}"
+        )


### PR DESCRIPTION
## What does this PR do?

Final convergence step for issue #1334. Drops the redundant `identifier` echo key from `ha_config_get_automation`'s response so the tool matches the rest of the `ha_config_get_*` family — one canonical-with-fallback typed-id key per tool.

After #1329 added `automation_id` as canonical-with-fallback and PR #1352 fixed the script-side gap, `ha_config_get_automation` was the last tool with a dual-key shape (`identifier` echoing input + `automation_id` canonical). The issue body for #1334 specifically criticized this as "stacking another value semantic alongside the existing two." This PR removes the leftover.

### Before / after

```diff
 {
     "success": True,
     "action": "get",
-    "identifier": identifier,           # input echo — redundant
     "automation_id": entity_id or identifier,  # canonical-with-fallback
     "config": normalized_config,
     "config_hash": config_hash,
 }
```

### Family parity after this PR

| Tool | Canonical typed-id key | Semantics |
|---|---|---|
| `ha_config_get_script` | `script_id` | canonical-with-fallback (#1352) |
| `ha_config_get_automation` | `automation_id` | canonical-with-fallback (#1329 + this PR) |
| `ha_config_get_scene` | `scene_id` | canonical-with-fallback |
| `ha_config_get_dashboard` | `url_path` | canonical-with-fallback |

One rule, family-wide.

### Compatibility

Per `.gemini/styleguide.md` L172-179, return-value restructuring is **not breaking** as long as the data remains accessible — `automation_id` carries the equivalent value (`entity_id or identifier`).

No in-tree consumers depend on `result["identifier"]`: grep of `tests/` + `src/` returned only the three test assertions this PR updates. The hits in `test_rest_client_automations.py` are on `delete_automation_config` (a separate function), not get_automation.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) <!-- via CI -->
- [x] Code follows style guidelines (`uv run ruff check`) <!-- via CI -->

- Updates 3 existing assertions in `tests/src/unit/test_tools_config_automations.py::TestGetAutomationIdKey` that read the now-removed `result["identifier"]`.
- Adds a regression test `test_identifier_key_no_longer_in_response` asserting the key is gone.
- Existing e2e lifecycle coverage for `ha_config_get_automation` (`tests/src/e2e/workflows/automation/test_lifecycle.py`) does not read `result["identifier"]` — verified by grep — so no e2e updates needed.

## Checklist
- [x] I have updated documentation if needed <!-- tool docstring already only documents `automation_id`; auto-regenerated tools.json/README/DOCS.md handled by sync-tool-docs.yml on merge -->
