### PR TITLE
fix(ci): install libguestfs in HAOS publish workflow

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -88,6 +88,50 @@ jobs:
       - name: Build image
         run: python3 tests/haos_image_build/build_image.py --verbose --output haos-test-image.qcow2
 
+      - name: Extract publish-build diagnostics (always)
+        # On build failure (boot timeout, onboarding rejection, addon
+        # install error, bake step crash) Python's stdout via --verbose
+        # is the only signal otherwise. Grab the serial log + a
+        # post-mortem of the intermediate qcow2's /config dir so a
+        # future failure can be triaged without re-running locally.
+        # Tolerates missing files because the failure may be before
+        # boot (no serial yet) or before bake (no /config yet).
+        if: always()
+        run: |
+          sudo chmod +r /boot/vmlinuz-* || true
+          mkdir -p /tmp/haos-publish-diagnostics
+          intermediate=/tmp/haos-build/haos-test-image.qcow2
+          if [ -f "$intermediate" ]; then
+            guestfish --ro -a "$intermediate" run \
+              : mount /dev/sda8 / \
+              : ll /supervisor/homeassistant \
+              > /tmp/haos-publish-diagnostics/config-dir-listing.txt 2>&1 \
+              || echo "directory listing failed (qcow2 may not be baked yet)"
+            guestfish --ro -a "$intermediate" run \
+              : mount /dev/sda8 / \
+              : tar-out /supervisor/homeassistant/.storage \
+                /tmp/haos-publish-diagnostics/storage.tar \
+              || echo ".storage tar-out failed"
+          else
+            echo "intermediate qcow2 not present — build failed before bake" \
+              > /tmp/haos-publish-diagnostics/no-qcow2.txt
+          fi
+          # build_image.start_qemu writes the serial log to <work_dir>/
+          # haos-serial.log (default work_dir = /tmp/haos-build); copy
+          # it out for upload.
+          cp /tmp/haos-build/haos-serial.log /tmp/haos-publish-diagnostics/ \
+            2>/dev/null || true
+          ls -la /tmp/haos-publish-diagnostics/ || true
+
+      - name: Upload publish-build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: haos-publish-diagnostics-${{ github.sha }}
+          path: /tmp/haos-publish-diagnostics/
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload built image as workflow artifact
         # Always upload — even on PRs that don't push to GHCR — so reviewers
         # can pull the artifact and verify locally.

--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -28,6 +28,13 @@ permissions:
 
 env:
   IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/haos-test-image
+  # libguestfs defaults to libvirt which isn't running on GitHub-hosted
+  # runners (per-user libvirtd socket missing for the unprivileged
+  # runner UID). Direct backend bypasses libvirt and uses QEMU directly.
+  # Same setting as haos-e2e-tests.yml; the bake_test_state step added in
+  # #1326 shells out to guestfish and would otherwise hang trying to talk
+  # to libvirt.
+  LIBGUESTFS_BACKEND: direct
 
 jobs:
   build:
@@ -37,12 +44,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Submodules required because bake_test_state stages
+          # custom_components/ha_mcp_tools (+ siblings) into the image —
+          # see haos-e2e-tests.yml for the same rationale.
+          submodules: true
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            qemu-system-x86 qemu-utils ovmf xz-utils curl
+            qemu-system-x86 qemu-utils ovmf xz-utils curl libguestfs-tools
+          # Ubuntu installs the kernel image as 0600 root:root, but
+          # libguestfs's supermin appliance builder needs to read it.
+          # See https://libguestfs.org/guestfs-faq.1.html#kernel-permissions
+          sudo chmod +r /boot/vmlinuz-*
 
       - name: Enable KVM group perms
         # Same udev trick used by home-assistant/operating-system's test workflow:

--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -45,9 +45,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Submodules required because bake_test_state stages
-          # custom_components/ha_mcp_tools (+ siblings) into the image —
-          # see haos-e2e-tests.yml for the same rationale.
+          # Required for tests/src/e2e/tools/test_skills_resources.py — the
+          # skills bundle lives at src/ha_mcp/resources/skills-vendor. Kept
+          # in parity with haos-e2e-tests.yml even though the publish bake
+          # itself doesn't touch the submodule, so the two checkout shapes
+          # don't drift.
           submodules: true
 
       - name: Install build dependencies


### PR DESCRIPTION
## What does this PR do?

Fix CI regression introduced by #1326: the HAOS publish workflow (`.github/workflows/build-haos-test-image.yml`) wasn't updated when the bake step was added to `tests/haos_image_build/build_image.py`, so the first post-merge master push (sha 278163a, `actions/runs/26030444511`) failed with `FileNotFoundError: 'guestfish'` at `build_image.py:698`. Mirrors the libguestfs setup that's already in `haos-e2e-tests.yml`, plus closes the diagnostic-step parity gap (publish runs would otherwise leave no artifact when a bake fails mid-flight).

### What changed

`.github/workflows/build-haos-test-image.yml`:
- Add `libguestfs-tools` to the apt install line
- Add `chmod +r /boot/vmlinuz-*` for libguestfs supermin appliance access ([libguestfs FAQ](https://libguestfs.org/guestfs-faq.1.html#kernel-permissions))
- Set `LIBGUESTFS_BACKEND: direct` at workflow `env` (skip libvirt — no daemon on GitHub-hosted runners)
- Set `submodules: true` on `actions/checkout@v6` for parity with the e2e workflow (the skills bundle lives at `src/ha_mcp/resources/skills-vendor`)
- Add an `always()`-conditional diagnostic step that tar-outs `/supervisor/homeassistant/.storage` from the intermediate qcow2 and copies out `haos-serial.log`, uploaded as an artifact (mirrors `haos-e2e-tests.yml`)

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — no test code changed; PR-level CI verifies workflow YAML parses.
- [x] Code follows style guidelines (`uv run ruff check`) — workflow-YAML-only change, ruff doesn't apply.

The actual proof-of-fix runs on the publish workflow itself, which only fires on master push / cron / manual dispatch. PR-level CI here only exercises the YAML parser and unrelated suites.

## Future improvements

None — the diagnostic step caught during review is already in this PR.

## Checklist
- [x] I have updated documentation if needed (workflow comments updated inline)

Refs #1281, #1326.
