### PR TITLE
docs: merge Boy Scout Rule + Handling Discovered Improvements; tighten deferral gate

### DIFF
--- a/.claude/skills/issue-to-pr-resolver/SKILL.md
+++ b/.claude/skills/issue-to-pr-resolver/SKILL.md
@@ -48,9 +48,6 @@ PR_NUMBER=$(gh pr create --draft \
 
 ## What does this PR do?
 [description]
-
-## Future improvements
-<!-- Out-of-scope improvements noticed during implementation -->
 " | grep -oE '[0-9]+$')
 ```
 
@@ -113,4 +110,4 @@ Report to user: PR number, status, key choices.
 - **Never commit to master** — always work in the worktree
 - **Always create PRs as draft** — never mark ready without user request
 - Maximum 5 resolution iterations before reporting blockers
-- **Discovered improvements**: fix small things inline; surface mid-sized ones to user before pushing; document large/unrelated ones in the PR description's **Future improvements** section — never open a separate improvement PR without explicit user approval
+- **Discovered improvements**: fix-in-place by default. See AGENTS.md § *Boy Scout Rule — Handling Discovered Improvements* for the full rubric. Never open a follow-up PR or issue without explicit user approval; never populate `## Future improvements` without the user explicitly confirming the work is out of scope.

--- a/.claude/skills/my-pr-checker/SKILL.md
+++ b/.claude/skills/my-pr-checker/SKILL.md
@@ -90,13 +90,9 @@ Repeat Steps 1–5 until:
 
 ## Step 6: Final Report
 
-If improvements were identified during review, add them to the PR description's **Future improvements** section first:
-```bash
-gh pr edit "$ARGUMENTS" --repo homeassistant-ai/ha-mcp --body "..."
-```
-(Edit the existing `## Future improvements` section, or append it if absent.)
+If improvements were identified during review, **default to fix-in-place** per AGENTS.md § *Boy Scout Rule — Handling Discovered Improvements*. Only add to the PR description's `## Future improvements` section if the user has explicitly confirmed the work is out of scope. Never self-bucket findings there.
 
-Then post a summary comment:
+Post a summary comment:
 ```bash
 gh pr comment "$ARGUMENTS" --repo homeassistant-ai/ha-mcp --body "## PR Assessment Summary
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -185,3 +185,5 @@ Scope is defined by the user (the maintainer / author of the PR), not by the rev
 If you believe a finding is likely out of scope, say so explicitly so the user can verify: *"This may be out of scope — user should verify. I think it is out of scope because [specific reason]."* Do not bucket findings as "for a future PR" or "post-merge follow-up."
 
 Do not phrase findings as "post-merge follow-up," "nice to have," or "happy to file an issue" when the change is small and bundleable. Either apply the suggestion inline with a code suggestion block, or raise it plainly and let the user decide.
+
+See AGENTS.md § *Boy Scout Rule — Handling Discovered Improvements* for the author/agent-side rule.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -178,10 +178,10 @@ A change is BREAKING only if it removes functionality that users depend on.
 
 **Rationale:** Tool consolidation reduces token usage and cognitive load for AI agents. Refactoring improves maintainability. Only flag CRITICAL when functionality is genuinely lost forever.
 
-## Non-blocking suggestions and scope
+## Non-Blocking Suggestions and Scope
 
-Scope is defined by the maintainer / author of the PR, not by the reviewer (bot or human). **Never request a follow-up issue or PR unless a finding is grossly unrelated to the PR at hand.** For everything else, raise the finding in the PR review and let the author decide whether to address it inline, defer it, or dismiss it. Do not skip legitimate findings — surface them.
+Scope is defined by the user (the maintainer / author of the PR), not by the reviewer (bot or human). **Never unilaterally file a follow-up issue or PR** — raise scope concerns in the PR review and let the user decide whether to address inline, defer, or dismiss. Do not skip legitimate findings — surface them.
 
-If you believe a finding is likely out of scope, say so explicitly so the author can verify: *"This may not be within scope — author should verify. I think it is out of scope because [specific reason]."* Do not unilaterally bucket findings as "for a future PR" or "post-merge follow-up."
+If you believe a finding is likely out of scope, say so explicitly so the user can verify: *"This may be out of scope — user should verify. I think it is out of scope because [specific reason]."* Do not bucket findings as "for a future PR" or "post-merge follow-up."
 
-Do not phrase findings as "post-merge follow-up," "nice to have," or "happy to file an issue" when the change is small and bundleable. Either apply the suggestion inline with a code suggestion block, or raise it plainly and let the author decide.
+Do not phrase findings as "post-merge follow-up," "nice to have," or "happy to file an issue" when the change is small and bundleable. Either apply the suggestion inline with a code suggestion block, or raise it plainly and let the user decide.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -177,3 +177,11 @@ A change is BREAKING only if it removes functionality that users depend on.
 - Tool renaming with clear migration path
 
 **Rationale:** Tool consolidation reduces token usage and cognitive load for AI agents. Refactoring improves maintainability. Only flag CRITICAL when functionality is genuinely lost forever.
+
+## Non-blocking suggestions and scope
+
+Scope is defined by the maintainer / author of the PR, not by the reviewer (bot or human). **Never request a follow-up issue or PR unless a finding is grossly unrelated to the PR at hand.** For everything else, raise the finding in the PR review and let the author decide whether to address it inline, defer it, or dismiss it. Do not skip legitimate findings — surface them.
+
+If you believe a finding is likely out of scope, say so explicitly so the author can verify: *"This may not be within scope — author should verify. I think it is out of scope because [specific reason]."* Do not unilaterally bucket findings as "for a future PR" or "post-merge follow-up."
+
+Do not phrase findings as "post-merge follow-up," "nice to have," or "happy to file an issue" when the change is small and bundleable. Either apply the suggestion inline with a code suggestion block, or raise it plainly and let the author decide.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,22 @@
 
 ## Future improvements
 
-<!-- Optional: things noticed during this PR that are out of scope but worth doing later.
-     Small things fixable in a few lines should be fixed inline rather than listed here. -->
+<!-- LEAVE EMPTY unless ALL THREE are true:
+     1. The work is too large to bundle (different subsystem, design decisions,
+        or would meaningfully change this PR's review surface), AND would
+        exceed roughly 100 lines of changes.
+     2. You can name a concrete user-facing or maintainer benefit in one sentence.
+     3. A maintainer would act on it, not close it as stale.
+
+     Do NOT list:
+     - Anything describable by line count ("one-line fix", "3-site sweep")
+     - Sweeps of the same pattern across files (bundle with this PR)
+     - "Mirror X parity onto Y" / "Migrate singular → list" / drift fixes
+     - Bot non-blocking suggestions (apply inline or dismiss — unless the
+       maintainer explicitly confirms it's a large, out-of-scope change)
+     - "Consider X" without acceptance criteria
+
+     If nothing meets all three, DELETE this section entirely. -->
 
 ## Checklist
 - [ ] I have updated documentation if needed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,22 +17,25 @@
 
 ## Future improvements
 
-<!-- LEAVE EMPTY unless ALL THREE are true:
-     1. The work is too large to bundle (different subsystem, design decisions,
-        or would meaningfully change this PR's review surface), AND would
-        exceed roughly 100 lines of changes.
-     2. You can name a concrete user-facing or maintainer benefit in one sentence.
-     3. A maintainer would act on it, not close it as stale.
+<!-- Use this section ONLY for genuinely out-of-scope work the user (PR author)
+     has explicitly confirmed should be deferred. If nothing qualifies, DELETE
+     this section entirely.
+
+     A discovered improvement is "out of scope" when BOTH are true:
+     - It touches a different subsystem, requires design decisions, or would
+       meaningfully change this PR's review surface.
+     - The user has confirmed deferral after being asked.
 
      Do NOT list:
-     - Anything describable by line count ("one-line fix", "3-site sweep")
-     - Sweeps of the same pattern across files (bundle with this PR)
-     - "Mirror X parity onto Y" / "Migrate singular → list" / drift fixes
-     - Bot non-blocking suggestions (apply inline or dismiss — unless the
-       maintainer explicitly confirms it's a large, out-of-scope change)
+     - Anything you can fix inline (typos, dead imports, drift, "mirror X
+       parity onto Y", "migrate singular → list", sweeps of the same pattern
+       across files)
+     - Bot non-blocking suggestions
      - "Consider X" without acceptance criteria
 
-     If nothing meets all three, DELETE this section entirely. -->
+     If you (the AI agent) are unsure whether a finding is out of scope, ASK
+     the user rather than self-bucketing it here. See AGENTS.md §
+     "Boy Scout Rule — Handling Discovered Improvements" for the full rubric. -->
 
 ## Checklist
 - [ ] I have updated documentation if needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,8 @@ cd worktree/<branch-name>
 - **For non-obvious choices with consequences**: Create 2 mutually exclusive PRs (one for each approach) and let user choose
 - **For obvious choices**: Implement and document in final summary
 
+**When you notice an improvement during a PR**: fix it in place by default. See *Boy Scout Rule — Handling Discovered Improvements* below for the deferral scale.
+
 **Final reporting (only after ALL workflow steps complete):**
 
 Once the PR is ready (all checks green, comments addressed), provide:
@@ -315,17 +317,59 @@ Once the PR is ready (all checks green, comments addressed), provide:
    - Any choices that may need user input
    - Current PR status
 
-### Handling Discovered Improvements
+### Boy Scout Rule — Handling Discovered Improvements
 
-When you notice something that could be improved while working on a PR, use this scale:
+**IMPORTANT — Default is fix-in-place.** "Boy Scout Rule" means leave touched code better than you found it. "Improve incrementally" means commit-by-commit within *this* PR — not across follow-up PRs. Deferral is the exception, not the default.
 
-| Size | Action |
-|------|--------|
-| **Small** — a few lines, clearly in scope | Fix it inline, no mention needed |
-| **Mid-sized** — meaningful effort, worth doing but out of scope | Pause **before pushing** and ask the user whether to include it |
-| **Large / unrelated** — many files, design decisions, or different domain | Document in the PR description's **Future improvements** section; open a separate PR only if the user asks |
+When you notice something while working on a PR, apply this scale:
 
-**Never open a separate improvement PR without explicit user approval.** Document it in the PR description first — it may already be covered by an open issue or the user may not want it at all.
+| What you find | Examples | Action |
+|---|---|---|
+| **Small** — a few lines, clearly in scope | Typo, dead import, stale docstring/comment, misnamed local, 1–N line cleanup of code in this diff, multi-site sweep of the same pattern you can grep for, missing test for code you're touching, low coverage for the area you're working in, straightforward test-quality fix (better assertions, clearer names, removing duplication) | **Fix in this PR** as a separate commit. No mention in PR description. |
+| **Mid-sized** — meaningful effort, worth doing but out of scope | Refactor of a sibling function, gap that needs non-trivial new test scaffolding, code-quality issue that's *not* really low | **Pause before pushing.** Ask the author whether to bundle. |
+| **Large / unrelated** — many files, design decisions, different subsystem | Would double the diff size or change the review surface, code quality is *really* low (technical debt) | One-line mention in PR description. Open a separate issue **only if** the author asks AND you can state a concrete benefit in one sentence. |
+
+**Size threshold for deferral.** A rough size benchmark: if you expect the discovered improvement to stay under ~100 lines of changes, bundle it in this PR by default. If you expect it to exceed ~100 lines, flag it to the author and ask whether to bundle or defer — the author decides. Estimate honestly; do not inflate an estimate to manufacture a reason to defer. If you're uncertain about the size, ask the author rather than guessing high.
+
+**Anti-noise gate — before filing any follow-up issue or PR, all three must be true:**
+
+1. The work is genuinely too large to bundle. **All three sub-tests must pass:**
+   (a) It cannot be done by mirroring an existing sibling pattern in the same file or a closely-related file.
+   (b) You can name the actual design choice in one sentence, with two named alternatives.
+   (c) It would meaningfully change this PR's review surface, not just add to it.
+2. You can name a concrete user-facing or maintainer benefit in one sentence.
+3. A maintainer reading the issue 6 months later would act on it, not close as stale.
+
+If any are false: fix it now, or let it go. **Do not file an issue to "track" it.**
+
+**Sometimes a follow-up is genuinely necessary.** The rules above tighten the bar; they do not abolish follow-ups. But these phrases are escape hatches that signal the AI is making a scope decision the author should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
+
+- "Post-merge follow-up" / "follow-up consideration"
+- "Nice to have"
+- "Happy to file an issue (or note in PR body)"
+- "Pre-existing — not touching it" (pre-existing is not a reason to skip; addressing pre-existing things is the point of the Boy Scout Rule)
+- "Out of scope for this PR"
+- "Real design work, not N lines"
+- "Worth tracking as a real follow-up issue rather than buried in a comment"
+
+**Scope is the author's call, not yours.** You do not decide whether something is in scope. If you think a discovered improvement is out of scope, say so explicitly and ask the author to confirm — do not silently drop it into a "future improvements" bucket:
+
+> "This may be out of scope — author should verify. I think it is out of scope because [specific reason]. Should I fix it here or defer?"
+
+Then defer to the author's answer.
+
+**These are NOT follow-up material — fix them in this PR:**
+
+- Anything describable by line count ("one-line fix", "3-site sweep", "N call sites")
+- Sweeps of the same pattern across files (find them with grep, fix them all in the same PR that introduced or revealed the inconsistency — do not split a sweep across multiple issues)
+- Drift between docs and live state you can fix by reading both
+- Stale references in docstrings or comments
+- "Mirror X parity onto Y" where Y is in the diff
+- "Migrate singular → list" or similar shape consistency fixes
+
+**Same rule for issues as for PRs.** AGENTS.md forbids opening a separate improvement PR without approval — the same applies to issues. The default for things you noticed is *fix it now* or *let it go*, not *file paperwork*.
+
+**Code-review bot suggestions** (Gemini Code Assist, CodeRabbit, Copilot non-blocking nits) are informational. Either apply them inline or dismiss them — do **not** spawn a follow-up issue from a bot suggestion **UNLESS** it is a genuinely large, legitimate change AND the author (maintainer) explicitly confirms it is out of scope for the current PR. Scope is the author's call, not the bot's. The bot phrasing something as "consider" or "for future work" is not on its own sufficient.
 
 ### Hotfix Process (Critical Bugs Only)
 
@@ -342,17 +386,6 @@ gh pr create --draft --base master
 ```
 
 On merge, `hotfix-release.yml` runs semantic-release, creates GitHub release, syncs CHANGELOG to addon, updates `stable` tag (after changelog sync), and builds binaries.
-
-### Boy Scout Rule
-
-Improve code incrementally when touching it — especially tool docstrings and tests. Balance against regression risk (complexity, coverage, scope).
-
-| Scenario | Action |
-|----------|--------|
-| **No tests exist for code you're touching** | Add tests for the specific behavior you're implementing/fixing, without refactoring existing code |
-| **Tests exist but coverage is low** | Add tests for gaps if you're already working in that area |
-| **Tests exist, quality is low** | Improve test quality if it's straightforward (better assertions, clearer names, remove duplication) |
-| **Code quality is really low** | Open an issue describing the technical debt instead of fixing it inline |
 
 ### Test Coverage Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ cd worktree/<branch-name>
 - **For non-obvious choices with consequences**: Create 2 mutually exclusive PRs (one for each approach) and let user choose
 - **For obvious choices**: Implement and document in final summary
 
-**When you notice an improvement during a PR**: fix it in place by default. See *Boy Scout Rule — Handling Discovered Improvements* below for the deferral scale.
+**When you notice an improvement during a PR**: fix it in place by default. See [Boy Scout Rule — Handling Discovered Improvements](#boy-scout-rule--handling-discovered-improvements) below for the deferral scale.
 
 **Final reporting (only after ALL workflow steps complete):**
 
@@ -319,57 +319,50 @@ Once the PR is ready (all checks green, comments addressed), provide:
 
 ### Boy Scout Rule — Handling Discovered Improvements
 
-**IMPORTANT — Default is fix-in-place.** "Boy Scout Rule" means leave touched code better than you found it. "Improve incrementally" means commit-by-commit within *this* PR — not across follow-up PRs. Deferral is the exception, not the default.
+**IMPORTANT — Default is fix-in-place.** "Boy Scout Rule" means leave touched code better than you found it. "Improve incrementally" means commit-by-commit within *this* PR — not across follow-up PRs. Deferral is the exception, not the default. Weigh fix-in-place sweeps against regression risk: if a sweep would meaningfully expand the diff or change the review surface, treat it as Mid-sized and ask the user.
+
+> Throughout this section, **"user"** = the human directing this PR or issue (the author). Same person referred to as `user` elsewhere in this document.
+
+**Never open a follow-up PR or issue without explicit user approval.**
 
 When you notice something while working on a PR, apply this scale:
 
 | What you find | Examples | Action |
 |---|---|---|
-| **Small** — a few lines, clearly in scope | Typo, dead import, stale docstring/comment, misnamed local, 1–N line cleanup of code in this diff, multi-site sweep of the same pattern you can grep for, missing test for code you're touching, low coverage for the area you're working in, straightforward test-quality fix (better assertions, clearer names, removing duplication) | **Fix in this PR** as a separate commit. No mention in PR description. |
-| **Mid-sized** — meaningful effort, worth doing but out of scope | Refactor of a sibling function, gap that needs non-trivial new test scaffolding, code-quality issue that's *not* really low | **Pause before pushing.** Ask the author whether to bundle. |
-| **Large / unrelated** — many files, design decisions, different subsystem | Would double the diff size or change the review surface, code quality is *really* low (technical debt) | One-line mention in PR description. Open a separate issue **only if** the author asks AND you can state a concrete benefit in one sentence. |
+| **Small** — a few lines, clearly in scope | Typo, dead import, stale docstring/comment or stale reference, misnamed local, 1–N line cleanup of code in this diff, multi-site sweep of the same pattern you can grep for, missing test for code you're touching (add the test without refactoring the surrounding code), low coverage for the area you're working in, straightforward test-quality fix (better assertions, clearer names, removing duplication), "mirror X parity onto Y" where Y is in the diff, migrating a singular→list or similar shape-consistency fix, drift between docs and live state you can fix by reading both | **Fix in this PR** as a separate commit. No mention in PR description. |
+| **Mid-sized** — meaningful effort, worth doing but out of scope | Adding a new helper module that doesn't exist yet, gap that needs non-trivial new test scaffolding, code-quality issue that's *not* really low | **Pause before pushing.** Ask the user whether to bundle. |
+| **Large / unrelated** — many files, design decisions, different subsystem | Would double the diff size or change the review surface, code quality is *really* low (technical debt) | Mention in PR description only if the user confirms. Open a separate issue **only if** the user asks AND you can state a concrete benefit in one sentence. |
 
-**Size threshold for deferral.** A rough size benchmark: if you expect the discovered improvement to stay under ~100 lines of changes, bundle it in this PR by default. If you expect it to exceed ~100 lines, flag it to the author and ask whether to bundle or defer — the author decides. Estimate honestly; do not inflate an estimate to manufacture a reason to defer. If you're uncertain about the size, ask the author rather than guessing high.
+**When to ask the user about bundling.** ~200 lines is a *should-I-ask* heuristic, not a bundling cap. Under ~200 lines: bundle without asking. Over ~200 lines: ask the user whether to bundle — but **bundling at any size is fine if the work is not grossly out of scope**. The 200-line mark exists so the user hears about large bundled changes before they land, not to push large work out of the PR. Estimate honestly; do not inflate to manufacture a reason to defer.
 
 **Anti-noise gate — before filing any follow-up issue or PR, all three must be true:**
 
-1. The work is genuinely too large to bundle. **All three sub-tests must pass:**
+1. The work is genuinely too large to bundle (i.e. truly out of scope, not just over the ~200-line ask-heuristic above). **All three sub-tests must pass:**
    (a) It cannot be done by mirroring an existing sibling pattern in the same file or a closely-related file.
-   (b) You can name the actual design choice in one sentence, with two named alternatives.
+   (b) You can name the actual design choice in one sentence with two named alternatives, **OR** the work is a genuinely large mechanical migration (e.g. *"replace `requests` with `httpx` across 40 sites"*) that exceeds this PR's scope by size alone.
    (c) It would meaningfully change this PR's review surface, not just add to it.
 2. You can name a concrete user-facing or maintainer benefit in one sentence.
 3. A maintainer reading the issue 6 months later would act on it, not close as stale.
 
 If any are false: fix it now, or let it go. **Do not file an issue to "track" it.**
 
-**Sometimes a follow-up is genuinely necessary.** The rules above tighten the bar; they do not abolish follow-ups. But these phrases are escape hatches that signal the AI is making a scope decision the author should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
+**Sometimes a follow-up is genuinely necessary.** The rules above tighten the bar; they do not abolish follow-ups. But these phrases are escape hatches that signal the AI is making a scope decision the user should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
 
 - "Post-merge follow-up" / "follow-up consideration"
 - "Nice to have"
 - "Happy to file an issue (or note in PR body)"
 - "Pre-existing — not touching it" (pre-existing is not a reason to skip; addressing pre-existing things is the point of the Boy Scout Rule)
-- "Out of scope for this PR"
+- "Out of scope for this PR" (used as an assertion to skip — not as a question to the user via the verification template below)
 - "Real design work, not N lines"
 - "Worth tracking as a real follow-up issue rather than buried in a comment"
 
-**Scope is the author's call, not yours.** You do not decide whether something is in scope. If you think a discovered improvement is out of scope, say so explicitly and ask the author to confirm — do not silently drop it into a "future improvements" bucket:
+**Scope is the user's call, not yours.** You do not decide whether something is in scope. If you think a discovered improvement is out of scope, say so explicitly and ask the user to confirm — do not silently drop it into a "future improvements" bucket:
 
-> "This may be out of scope — author should verify. I think it is out of scope because [specific reason]. Should I fix it here or defer?"
+> *"This may be out of scope — user should verify. I think it is out of scope because [specific reason]. Should I fix it here or defer?"*
 
-Then defer to the author's answer.
+Then defer to the user's answer. The same rule applies to filing follow-up issues: never file paperwork on your own scope judgment.
 
-**These are NOT follow-up material — fix them in this PR:**
-
-- Anything describable by line count ("one-line fix", "3-site sweep", "N call sites")
-- Sweeps of the same pattern across files (find them with grep, fix them all in the same PR that introduced or revealed the inconsistency — do not split a sweep across multiple issues)
-- Drift between docs and live state you can fix by reading both
-- Stale references in docstrings or comments
-- "Mirror X parity onto Y" where Y is in the diff
-- "Migrate singular → list" or similar shape consistency fixes
-
-**Same rule for issues as for PRs.** AGENTS.md forbids opening a separate improvement PR without approval — the same applies to issues. The default for things you noticed is *fix it now* or *let it go*, not *file paperwork*.
-
-**Code-review bot suggestions** (Gemini Code Assist, CodeRabbit, Copilot non-blocking nits) are informational. Either apply them inline or dismiss them — do **not** spawn a follow-up issue from a bot suggestion **UNLESS** it is a genuinely large, legitimate change AND the author (maintainer) explicitly confirms it is out of scope for the current PR. Scope is the author's call, not the bot's. The bot phrasing something as "consider" or "for future work" is not on its own sufficient.
+**Code-review bot suggestions** (Gemini Code Assist, CodeRabbit, Copilot non-blocking nits): apply inline or dismiss. Never spawn a follow-up issue from a bot suggestion unless the user explicitly confirms it's a large, out-of-scope change. See `.gemini/styleguide.md` § *Non-Blocking Suggestions and Scope* for the bot-side rule.
 
 ### Hotfix Process (Critical Bugs Only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,17 +321,28 @@ Once the PR is ready (all checks green, comments addressed), provide:
 
 **IMPORTANT — Default is fix-in-place.** "Boy Scout Rule" means leave touched code better than you found it. "Improve incrementally" means commit-by-commit within *this* PR — not across follow-up PRs. Deferral is the exception, not the default. Weigh fix-in-place sweeps against regression risk: if a sweep would meaningfully expand the diff or change the review surface, treat it as Mid-sized and ask the user.
 
-> Throughout this section, **"user"** = the human directing this PR or issue (the author). Same person referred to as `user` elsewhere in this document.
-
 **Never open a follow-up PR or issue without explicit user approval.**
 
 When you notice something while working on a PR, apply this scale:
 
-| What you find | Examples | Action |
-|---|---|---|
-| **Small** — a few lines, clearly in scope | Typo, dead import, stale docstring/comment or stale reference, misnamed local, 1–N line cleanup of code in this diff, multi-site sweep of the same pattern you can grep for, missing test for code you're touching (add the test without refactoring the surrounding code), low coverage for the area you're working in, straightforward test-quality fix (better assertions, clearer names, removing duplication), "mirror X parity onto Y" where Y is in the diff, migrating a singular→list or similar shape-consistency fix, drift between docs and live state you can fix by reading both | **Fix in this PR** as a separate commit. No mention in PR description. |
-| **Mid-sized** — meaningful effort, worth doing but out of scope | Adding a new helper module that doesn't exist yet, gap that needs non-trivial new test scaffolding, code-quality issue that's *not* really low | **Pause before pushing.** Ask the user whether to bundle. |
-| **Large / unrelated** — many files, design decisions, different subsystem | Would double the diff size or change the review surface, code quality is *really* low (technical debt) | Mention in PR description only if the user confirms. Open a separate issue **only if** the user asks AND you can state a concrete benefit in one sentence. |
+| What you find | Action |
+|---|---|
+| **Small** — a few lines, clearly in scope (see examples below) | **Fix in this PR** as a separate commit. No mention in PR description. |
+| **Mid-sized** — meaningful effort, worth doing but out of scope (e.g. adding a new helper module that doesn't exist yet, a gap that needs non-trivial new test scaffolding, a code-quality issue that's *not* really low) | **Pause before pushing.** Ask the user whether to bundle. |
+| **Large / unrelated** — many files, design decisions, different subsystem (e.g. would double the diff size or change the review surface, code quality is *really* low / technical debt) | Mention in PR description only if the user confirms. Open a separate issue **only if** the user asks AND you can state a concrete benefit in one sentence. |
+
+**"Small" examples — fix these inline, no mention needed:**
+
+- Typo, dead import, misnamed local
+- Stale docstring/comment or stale reference
+- 1–N line cleanup of code in this diff
+- Multi-site sweep of the same pattern you can grep for
+- Missing test for code you're touching (add the test without refactoring the surrounding code)
+- Low coverage for the area you're working in
+- Straightforward test-quality fix (better assertions, clearer names, removing duplication)
+- "Mirror X parity onto Y" where Y is in the diff
+- Migrating a singular→list or similar shape-consistency fix
+- Drift between docs and live state you can fix by reading both
 
 **When to ask the user about bundling.** ~200 lines is a *should-I-ask* heuristic, not a bundling cap. Under ~200 lines: bundle without asking. Over ~200 lines: ask the user whether to bundle — but **bundling at any size is fine if the work is not grossly out of scope**. The 200-line mark exists so the user hears about large bundled changes before they land, not to push large work out of the PR. Estimate honestly; do not inflate to manufacture a reason to defer.
 
@@ -341,12 +352,12 @@ When you notice something while working on a PR, apply this scale:
    (a) It cannot be done by mirroring an existing sibling pattern in the same file or a closely-related file.
    (b) You can name the actual design choice in one sentence with two named alternatives, **OR** the work is a genuinely large mechanical migration (e.g. *"replace `requests` with `httpx` across 40 sites"*) that exceeds this PR's scope by size alone.
    (c) It would meaningfully change this PR's review surface, not just add to it.
-2. You can name a concrete user-facing or maintainer benefit in one sentence.
+2. You can name a concrete end-user-facing or maintainer benefit in one sentence.
 3. A maintainer reading the issue 6 months later would act on it, not close as stale.
 
 If any are false: fix it now, or let it go. **Do not file an issue to "track" it.**
 
-**Sometimes a follow-up is genuinely necessary.** The rules above tighten the bar; they do not abolish follow-ups. But these phrases are escape hatches that signal the AI is making a scope decision the user should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
+These phrases are escape hatches that signal the AI is making a scope decision the user should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
 
 - "Post-merge follow-up" / "follow-up consideration"
 - "Nice to have"
@@ -360,7 +371,7 @@ If any are false: fix it now, or let it go. **Do not file an issue to "track" it
 
 > *"This may be out of scope — user should verify. I think it is out of scope because [specific reason]. Should I fix it here or defer?"*
 
-Then defer to the user's answer. The same rule applies to filing follow-up issues: never file paperwork on your own scope judgment.
+Then defer to the user's answer.
 
 **Code-review bot suggestions** (Gemini Code Assist, CodeRabbit, Copilot non-blocking nits): apply inline or dismiss. Never spawn a follow-up issue from a bot suggestion unless the user explicitly confirms it's a large, out-of-scope change. See `.gemini/styleguide.md` § *Non-Blocking Suggestions and Scope* for the bot-side rule.
 
@@ -394,7 +405,7 @@ On merge, `hotfix-release.yml` runs semantic-release, creates GitHub release, sy
 - Minor parameter additions to well-tested tools
 - Internal utilities already covered by E2E tests
 
-**When to open an issue instead:** Refactoring would touch many files, requires design decisions, or would significantly expand PR scope.
+**When to open an issue instead:** See § *Boy Scout Rule — Handling Discovered Improvements* for the gate. Never open without explicit user approval.
 
 ## CI/CD Workflows
 


### PR DESCRIPTION
## What does this PR do?

Merges and rewrites AGENTS.md's `Handling Discovered Improvements` and `Boy Scout Rule` sections into a single **"Boy Scout Rule — Handling Discovered Improvements"** section that defaults to fix-in-place and tightens the bar for filing follow-up issues/PRs. Also adds a strict-gate "Future improvements" comment in the PR template, and a new "Non-blocking suggestions and scope" section in `.gemini/styleguide.md` so the same rule applies to Gemini Code Assist's own non-blocking review suggestions.

**Why:** AI agents (and human reviewers leaning on AI-generated review prose) are over-deferring small, bundleable fixes — sometimes describing them in the issue body as "one-line dict entry" or "3-site sweep" while still spawning a separate issue. The current guidance is ambiguous on two axes: "in scope" reads narrowly so anything tangential gets pushed to a future-improvements bucket, and "improve incrementally" reads as *across future PRs* rather than *commit-by-commit within this PR*. The result is a steady accumulation of [FEATURE] paperwork that often never gets prioritized.

**Goals:**
1. Make "fix in place" the default, with deferral as the exception.
2. Define "incremental" as commit-by-commit within this PR.
3. Make scope determination the author's call — bots and AI agents flag, the author decides.
4. Catch the common evasion phrases ("post-merge follow-up", "nice to have", "happy to file an issue") at the language level, not only the structural level.

## Type of change
- [x] 📚 Documentation
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Markdown-only changes; no code paths affected. ruff/mypy/pytest do not apply.

## Future improvements

<!-- LEAVE EMPTY unless ALL THREE are true:
     1. The work is too large to bundle (different subsystem, design decisions,
        or would meaningfully change this PR's review surface), AND would
        exceed roughly 100 lines of changes.
     2. You can name a concrete user-facing or maintainer benefit in one sentence.
     3. A maintainer would act on it, not close it as stale.

     If nothing meets all three, DELETE this section entirely. -->

## Checklist
- [x] I have updated documentation if needed

## Summary of edits

### `AGENTS.md`
- Removed standalone `### Handling Discovered Improvements` and `### Boy Scout Rule` sections.
- Added merged `### Boy Scout Rule — Handling Discovered Improvements` section with: IMPORTANT default; one consolidated three-row size table with examples that fold in the original test-quality gradient; ~100-line size threshold; three-sub-test anti-noise gate; weasel-phrase re-check cue; "scope is the author's call" rule with verbatim ask-the-author template; not-follow-up list; same-rule-for-issues clause; code-review-bot carve-out.
- Added one-line cross-reference at the end of `### PR Execution Philosophy` pointing to the merged section.

### `.github/pull_request_template.md`
- Replaced the permissive "Future improvements" comment with a strict gate: leave empty unless all three criteria met; explicit do-not-list bullets covering line-count items, sweeps, parity/migration fixes, bot non-blocking suggestions, and "Consider X" without acceptance criteria; delete the section entirely if nothing qualifies.

### `.gemini/styleguide.md`
- Added new `## Non-blocking suggestions and scope` section: scope is defined by the maintainer, not the reviewer; never request a follow-up issue or PR unless a finding is grossly unrelated; surface legitimate findings rather than skipping them; don't phrase findings as "post-merge follow-up" / "nice to have" / "happy to file an issue" when the change is small and bundleable.