### PR TITLE
feat(haos-e2e): add parallel inaddon test tier (ha-mcp runs inside HAOS addon)

### DIFF
--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -204,6 +204,10 @@ jobs:
           name: haos-inaddon-diagnostics
           path: |
             /tmp/haos-inaddon-diagnostics/
+            # conftest's finally-block dumps HA Core + Supervisor logs into
+            # /tmp/haos-diagnostics; surface those too so we can see why
+            # ``addons/{slug}/update`` failed with "unknown error".
+            /tmp/haos-diagnostics/
             /tmp/haos-e2e-serial.log
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -158,6 +158,57 @@ jobs:
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2
           HAOS_TEST_MODE: inaddon
 
+      - name: SSH into HAOS for inaddon network diagnostics (always)
+        # Bake includes the Advanced SSH & Web Terminal addon on port
+        # 22222 with password=haosdebug (CI-only). Hostfwd maps 22222 →
+        # runner:22222. SSH in, dump network state from inside HAOS so
+        # we can see whether localhost:9583 is reachable internally,
+        # what HAOS's nftables policy is for port 9583, etc.
+        if: always()
+        run: |
+          sudo apt-get install -y --no-install-recommends sshpass openssh-client
+          mkdir -p /tmp/haos-inaddon-diagnostics
+          # ssh-keyscan first so we don't need StrictHostKeyChecking=no
+          # but also do StrictHostKeyChecking=no to handle the case
+          # where the HAOS instance was rebuilt with new host keys.
+          # Don't fail the step if any individual command fails — we
+          # want all the output we can get.
+          ssh_cmd() {
+            sshpass -p haosdebug ssh \
+              -p 22222 \
+              -o StrictHostKeyChecking=no \
+              -o UserKnownHostsFile=/dev/null \
+              -o LogLevel=ERROR \
+              -o ConnectTimeout=10 \
+              root@127.0.0.1 "$@" 2>&1 || true
+          }
+          {
+            echo "=== whoami / uname ==="
+            ssh_cmd "whoami; uname -a"
+            echo
+            echo "=== Listening sockets (ss -tlnp) ==="
+            ssh_cmd "ss -tlnp 2>&1 | head -50"
+            echo
+            echo "=== nftables rules (nft list ruleset) ==="
+            ssh_cmd "nft list ruleset 2>&1 | head -200"
+            echo
+            echo "=== iptables -L (legacy fallback) ==="
+            ssh_cmd "iptables -L -n -v 2>&1 | head -100"
+            echo
+            echo "=== curl localhost:9583/mcp_e2e_test_path (from inside HAOS) ==="
+            ssh_cmd "curl -v -m 5 http://localhost:9583/mcp_e2e_test_path 2>&1 | head -30"
+            echo
+            echo "=== curl 10.0.2.15:9583/mcp_e2e_test_path (eth0 IP from inside) ==="
+            ssh_cmd "curl -v -m 5 http://10.0.2.15:9583/mcp_e2e_test_path 2>&1 | head -30"
+            echo
+            echo "=== docker ps ==="
+            ssh_cmd "docker ps 2>&1 | head -20"
+            echo
+            echo "=== ip a (interfaces) ==="
+            ssh_cmd "ip a 2>&1 | head -50"
+          } > /tmp/haos-inaddon-diagnostics/ssh-diag.txt
+          cat /tmp/haos-inaddon-diagnostics/ssh-diag.txt
+
       - name: Extract HAOS + addon diagnostics from booted qcow2 (always)
         if: always()
         run: |

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -7,7 +7,7 @@ name: HAOS E2E Tests (inaddon)
 # when they install the addon + cloudflared on a real HAOS install.
 #
 # The HAOS_TEST_MODE=inaddon env flips conftest.py's HAOS dispatch:
-# refresh_dev_addon_source_in_qcow2 overwrites /addons/local/ha_mcp_dev/
+# refresh_dev_addon_source_in_qcow2 overwrites /supervisor/addons/local/ha_mcp_dev/
 # with PR source + bumps config.yaml ``version:`` → Supervisor detects an
 # update on next boot → trigger_dev_addon_update calls supervisor/api
 # addons/{slug}/update via WS → Docker rebuilds with layer cache → addon
@@ -182,12 +182,12 @@ jobs:
           # source actually landed.
           guestfish --ro -a /tmp/haos-test-image.qcow2 run \
             : mount /dev/sda8 / \
-            : ll /addons/local/ha_mcp_dev \
+            : ll /supervisor/addons/local/ha_mcp_dev \
             > /tmp/haos-inaddon-diagnostics/addon-dir-listing.txt 2>&1 \
             || echo "addon dir listing failed"
           guestfish --ro -a /tmp/haos-test-image.qcow2 run \
             : mount /dev/sda8 / \
-            : copy-out /addons/local/ha_mcp_dev/config.yaml /tmp/haos-inaddon-diagnostics/ \
+            : copy-out /supervisor/addons/local/ha_mcp_dev/config.yaml /tmp/haos-inaddon-diagnostics/ \
             || echo "addon config.yaml copy-out failed"
           ls -la /tmp/haos-inaddon-diagnostics/ || true
           echo '--- config dir listing ---'

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -63,17 +63,24 @@ jobs:
 
       - name: Compute image cache key
         id: key
-        # MUST match haos-e2e-tests.yml's cache-key formula exactly so
-        # both workflows share the same actions/cache entry. Any drift
-        # here means the inaddon job re-bakes from scratch every run.
+        # Distinct ``-inaddon`` suffix from haos-e2e-tests.yml's cache
+        # key. The inaddon tier requires the bake-installed dev addon
+        # to be present in the qcow2, but the GHCR ``:HAOS_VERSION-latest``
+        # tag the external tier falls back to is published from master
+        # and doesn't yet include the addon. Sharing the cache would
+        # let an external-tier run save a GHCR-served (addon-less)
+        # qcow2 into the cache, breaking inaddon for everyone hitting
+        # that cache.
         run: |
           hash=$(git ls-tree -r HEAD \
             tests/haos_image_build \
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy/mcp_proxy \
+            homeassistant-addon \
+            homeassistant-addon-dev \
             | sha256sum | cut -d' ' -f1 | head -c16)
-          echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
+          echo "cache-key=haos-image-inaddon-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
         id: restore-cache
@@ -96,27 +103,18 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Try pulling from GHCR
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        id: ghcr-pull
-        continue-on-error: true
-        run: |
-          version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
-          tag="${IMAGE_REPO}:${version}-latest"
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
-            -u ${{ github.actor }} --password-stdin
-          curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \
-            | tar -xz -C /tmp oras
-          mkdir -p /tmp/haos-pull
-          (cd /tmp/haos-pull && /tmp/oras pull "$tag")
-          mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
+      # No GHCR fallback for the inaddon tier: GHCR's ``:HAOS_VERSION-latest``
+      # tag is published from master by build-haos-test-image.yml, but the
+      # addon-install bake step lives on this PR branch. Until the PR
+      # lands and the publish workflow re-bakes, GHCR doesn't have an
+      # inaddon-ready image. Cache miss here always means local build.
 
-      - name: Install build-script Python deps (cache miss + GHCR miss)
-        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+      - name: Install build-script Python deps (cache miss)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: pip install -r tests/haos_image_build/requirements.txt
 
-      - name: Build image locally (cache miss + GHCR miss)
-        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+      - name: Build image locally (cache miss)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: |
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -1,0 +1,211 @@
+name: HAOS E2E Tests (inaddon)
+
+# Parallel to haos-e2e-tests.yml — exercises the SAME test suite against
+# the SAME cached qcow2, but routes ``mcp_client`` to the ha-mcp dev
+# addon's HTTP endpoint INSIDE the booted HAOS instead of using an
+# in-process FastMCP server. This is the deployment path real users hit
+# when they install the addon + cloudflared on a real HAOS install.
+#
+# The HAOS_TEST_MODE=inaddon env flips conftest.py's HAOS dispatch:
+# refresh_dev_addon_source_in_qcow2 overwrites /addons/local/ha_mcp_dev/
+# with PR source + bumps config.yaml ``version:`` → Supervisor detects an
+# update on next boot → trigger_dev_addon_update calls supervisor/api
+# addons/{slug}/update via WS → Docker rebuilds with layer cache → addon
+# restarts with PR source → mcp_client connects via HTTP transport.
+#
+# v1 scope: run ONLY tests/src/e2e/haos_only/ (the canary suite) so the
+# initial green CI gives us a fast feedback loop. Once the full inaddon
+# plumbing is verified, expand to the full src/e2e/ tree (gated by
+# external_only / inaddon_only markers).
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'homeassistant-addon/**'
+      - 'homeassistant-addon-dev/**'
+      - '.github/workflows/haos-e2e-inaddon-tests.yml'
+  workflow_dispatch:
+    inputs:
+      pytest_args:
+        description: 'Extra pytest args (e.g. "-k test_simple_connection") for targeted iteration'
+        type: string
+        required: false
+        default: ''
+      pytest_paths:
+        description: 'Test paths to run (default: haos_only canary only; widen as inaddon tier stabilises)'
+        type: string
+        required: false
+        default: 'src/e2e/haos_only/'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  PYTHON_VERSION: "3.13"
+  UV_CACHE_DIR: /tmp/.uv-cache
+  IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/haos-test-image
+  LIBGUESTFS_BACKEND: direct
+
+jobs:
+  haos-e2e-inaddon:
+    name: HAOS E2E Tests (inaddon)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Compute image cache key
+        id: key
+        # MUST match haos-e2e-tests.yml's cache-key formula exactly so
+        # both workflows share the same actions/cache entry. Any drift
+        # here means the inaddon job re-bakes from scratch every run.
+        run: |
+          hash=$(git ls-tree -r HEAD \
+            tests/haos_image_build \
+            tests/initial_test_state \
+            custom_components/ha_mcp_tools \
+            homeassistant-addon-webhook-proxy/mcp_proxy \
+            | sha256sum | cut -d' ' -f1 | head -c16)
+          echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Restore image from cache
+        id: restore-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/haos-test-image.qcow2
+          key: ${{ steps.key.outputs.cache-key }}
+
+      - name: Install QEMU + OVMF + libguestfs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils ovmf xz-utils curl libguestfs-tools
+          sudo chmod +r /boot/vmlinuz-*
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Try pulling from GHCR
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        id: ghcr-pull
+        continue-on-error: true
+        run: |
+          version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
+          tag="${IMAGE_REPO}:${version}-latest"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+          curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \
+            | tar -xz -C /tmp oras
+          mkdir -p /tmp/haos-pull
+          (cd /tmp/haos-pull && /tmp/oras pull "$tag")
+          mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
+
+      - name: Install build-script Python deps (cache miss + GHCR miss)
+        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+        run: pip install -r tests/haos_image_build/requirements.txt
+
+      - name: Build image locally (cache miss + GHCR miss)
+        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+        run: |
+          python3 tests/haos_image_build/build_image.py --verbose \
+            --output /tmp/haos-test-image.qcow2
+
+      - name: Save image to cache (cache miss only)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/haos-test-image.qcow2
+          key: ${{ steps.key.outputs.cache-key }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Install test dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Confirm image present
+        run: ls -lh /tmp/haos-test-image.qcow2
+
+      - name: Run inaddon E2E suite
+        # HAOS_TEST_MODE=inaddon flips conftest.py's HAOS dispatch into
+        # the inaddon branch: addon source is overwritten with PR source
+        # before boot, Supervisor update is triggered, mcp_client uses
+        # HTTP transport to the addon's MCP endpoint.
+        #
+        # v1: targets src/e2e/haos_only/ only (canary tier). Widen via
+        # workflow_dispatch pytest_paths input once the inaddon plumbing
+        # is stable. external_only-marked tests skip automatically.
+        run: |
+          cd tests
+          uv run pytest ${{ github.event.inputs.pytest_paths || 'src/e2e/haos_only/' }} \
+            -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
+        env:
+          HAMCP_ENV_FILE: "tests/.env.test"
+          HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2
+          HAOS_TEST_MODE: inaddon
+
+      - name: Extract HAOS + addon diagnostics from booted qcow2 (always)
+        if: always()
+        run: |
+          sudo chmod +r /boot/vmlinuz-* || true
+          mkdir -p /tmp/haos-inaddon-diagnostics
+          # /supervisor/homeassistant/.storage state + log files (HA Core).
+          guestfish --ro -a /tmp/haos-test-image.qcow2 run \
+            : mount /dev/sda8 / \
+            : ll /supervisor/homeassistant \
+            > /tmp/haos-inaddon-diagnostics/config-dir-listing.txt 2>&1 \
+            || echo "directory listing failed"
+          guestfish --ro -a /tmp/haos-test-image.qcow2 run \
+            : mount /dev/sda8 / \
+            : tar-out /supervisor/homeassistant/.storage /tmp/haos-inaddon-diagnostics/storage.tar \
+            || echo ".storage tar-out failed"
+          guestfish --ro -a /tmp/haos-test-image.qcow2 run \
+            : mount /dev/sda8 / \
+            : glob copy-out '/supervisor/homeassistant/*.log*' /tmp/haos-inaddon-diagnostics/ \
+            || echo "log glob copy failed"
+          # Addon-specific: capture the dev addon's source dir AND its
+          # config.yaml version after refresh, so we can verify the PR
+          # source actually landed.
+          guestfish --ro -a /tmp/haos-test-image.qcow2 run \
+            : mount /dev/sda8 / \
+            : ll /addons/local/ha_mcp_dev \
+            > /tmp/haos-inaddon-diagnostics/addon-dir-listing.txt 2>&1 \
+            || echo "addon dir listing failed"
+          guestfish --ro -a /tmp/haos-test-image.qcow2 run \
+            : mount /dev/sda8 / \
+            : copy-out /addons/local/ha_mcp_dev/config.yaml /tmp/haos-inaddon-diagnostics/ \
+            || echo "addon config.yaml copy-out failed"
+          ls -la /tmp/haos-inaddon-diagnostics/ || true
+          echo '--- config dir listing ---'
+          cat /tmp/haos-inaddon-diagnostics/config-dir-listing.txt || true
+          echo '--- addon dir listing ---'
+          cat /tmp/haos-inaddon-diagnostics/addon-dir-listing.txt || true
+          echo '--- addon config.yaml ---'
+          cat /tmp/haos-inaddon-diagnostics/config.yaml || true
+
+      - name: Upload HAOS inaddon diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: haos-inaddon-diagnostics
+          path: |
+            /tmp/haos-inaddon-diagnostics/
+            /tmp/haos-e2e-serial.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -35,10 +35,10 @@ on:
         required: false
         default: ''
       pytest_paths:
-        description: 'Test paths to run (default: haos_only canary only; widen as inaddon tier stabilises)'
+        description: 'Test paths to run (default: full src/e2e/ — markers handle external_only / inaddon_only skips)'
         type: string
         required: false
-        default: 'src/e2e/haos_only/'
+        default: 'src/e2e/'
 
 permissions:
   contents: read
@@ -151,63 +151,12 @@ jobs:
         # is stable. external_only-marked tests skip automatically.
         run: |
           cd tests
-          uv run pytest ${{ github.event.inputs.pytest_paths || 'src/e2e/haos_only/' }} \
+          uv run pytest ${{ github.event.inputs.pytest_paths || 'src/e2e/' }} \
             -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
         env:
           HAMCP_ENV_FILE: "tests/.env.test"
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2
           HAOS_TEST_MODE: inaddon
-
-      - name: SSH into HAOS for inaddon network diagnostics (always)
-        # Bake includes the Advanced SSH & Web Terminal addon on port
-        # 22222 with password=haosdebug (CI-only). Hostfwd maps 22222 →
-        # runner:22222. SSH in, dump network state from inside HAOS so
-        # we can see whether localhost:9583 is reachable internally,
-        # what HAOS's nftables policy is for port 9583, etc.
-        if: always()
-        run: |
-          sudo apt-get install -y --no-install-recommends sshpass openssh-client
-          mkdir -p /tmp/haos-inaddon-diagnostics
-          # ssh-keyscan first so we don't need StrictHostKeyChecking=no
-          # but also do StrictHostKeyChecking=no to handle the case
-          # where the HAOS instance was rebuilt with new host keys.
-          # Don't fail the step if any individual command fails — we
-          # want all the output we can get.
-          ssh_cmd() {
-            sshpass -p haosdebug ssh \
-              -p 22222 \
-              -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              -o LogLevel=ERROR \
-              -o ConnectTimeout=10 \
-              root@127.0.0.1 "$@" 2>&1 || true
-          }
-          {
-            echo "=== whoami / uname ==="
-            ssh_cmd "whoami; uname -a"
-            echo
-            echo "=== Listening sockets (ss -tlnp) ==="
-            ssh_cmd "ss -tlnp 2>&1 | head -50"
-            echo
-            echo "=== nftables rules (nft list ruleset) ==="
-            ssh_cmd "nft list ruleset 2>&1 | head -200"
-            echo
-            echo "=== iptables -L (legacy fallback) ==="
-            ssh_cmd "iptables -L -n -v 2>&1 | head -100"
-            echo
-            echo "=== curl localhost:9583/mcp_e2e_test_path (from inside HAOS) ==="
-            ssh_cmd "curl -v -m 5 http://localhost:9583/mcp_e2e_test_path 2>&1 | head -30"
-            echo
-            echo "=== curl 10.0.2.15:9583/mcp_e2e_test_path (eth0 IP from inside) ==="
-            ssh_cmd "curl -v -m 5 http://10.0.2.15:9583/mcp_e2e_test_path 2>&1 | head -30"
-            echo
-            echo "=== docker ps ==="
-            ssh_cmd "docker ps 2>&1 | head -20"
-            echo
-            echo "=== ip a (interfaces) ==="
-            ssh_cmd "ip a 2>&1 | head -50"
-          } > /tmp/haos-inaddon-diagnostics/ssh-diag.txt
-          cat /tmp/haos-inaddon-diagnostics/ssh-diag.txt
 
       - name: Extract HAOS + addon diagnostics from booted qcow2 (always)
         if: always()

--- a/src/ha_mcp/__init__.py
+++ b/src/ha_mcp/__init__.py
@@ -4,8 +4,6 @@ Home Assistant MCP Server
 A Model Context Protocol server that provides complete control over Home Assistant
 through REST API and WebSocket integration with 20+ enhanced tools.
 """
-# inaddon-source-refresh verification marker (PR #1361). Will be reverted
-# after CI confirms the inaddon addon picks up this src/ change end-to-end.
 
 from ._version import get_version
 

--- a/src/ha_mcp/__init__.py
+++ b/src/ha_mcp/__init__.py
@@ -4,6 +4,8 @@ Home Assistant MCP Server
 A Model Context Protocol server that provides complete control over Home Assistant
 through REST API and WebSocket integration with 20+ enhanced tools.
 """
+# inaddon-source-refresh verification marker (PR #1361). Will be reverted
+# after CI confirms the inaddon addon picks up this src/ change end-to-end.
 
 from ._version import get_version
 

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -132,6 +132,19 @@ GET_HACS_ADDON = Addon(
     start=True,
 )
 
+# Advanced SSH & Web Terminal — used by the inaddon CI tier for network
+# diagnostics (#1349 item 7 debugging). The official ``core_ssh`` addon
+# wants port 22 which conflicts with HAOS's host SSHD; the community
+# ``Advanced SSH & Web Terminal`` addon defaults to its OWN port (22222)
+# and accepts password auth, so we can SSH from the CI runner into HAOS
+# to dump nftables rules, curl localhost:9583 from inside, etc. when
+# the addon's MCP port isn't reachable from outside HAOS.
+ADVANCED_SSH_ADDON = Addon(
+    repo="https://github.com/hassio-addons/repository",
+    name="Advanced SSH & Web Terminal",
+    start=False,  # configured + started by ``install_advanced_ssh`` below
+)
+
 HA_MCP_ADDON_REPO = "https://github.com/homeassistant-ai/ha-mcp"
 
 # Dev-channel ha-mcp addon baked into the qcow2 from local source for the
@@ -648,6 +661,49 @@ def stage_dev_addon_source(qcow2: Path) -> None:
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def install_advanced_ssh(ws: HAWebSocket) -> str:
+    """Install + configure Advanced SSH & Web Terminal for CI diagnostics.
+
+    Sets a known root password ("haosdebug") so the CI workflow can
+    SSH in unattended. Configures listen port 22222 (avoids HAOS host
+    SSHD on 22) — the QEMU hostfwd in haos_runtime.py exposes this on
+    127.0.0.1:22222 on the runner.
+    """
+    slug = _discover_slug(ws, ADVANCED_SSH_ADDON)
+    LOG.info("Installing Advanced SSH (slug=%s) for inaddon CI diagnostics", slug)
+    ws.supervisor_api(f"/store/addons/{slug}/install", method="post", timeout=600.0)
+    # Schema: ssh.username, ssh.password, ssh.authorized_keys (list),
+    # ssh.sftp (bool), ssh.compatibility_mode (bool); top-level:
+    # apks (list), packages (list), init_commands (list)
+    ws.supervisor_api(
+        f"/addons/{slug}/options",
+        method="post",
+        data={
+            "options": {
+                "ssh": {
+                    "username": "root",
+                    "password": "haosdebug",
+                    "authorized_keys": [],
+                    "sftp": False,
+                    "compatibility_mode": False,
+                    "allow_agent_forwarding": False,
+                    "allow_remote_port_forwarding": False,
+                    "allow_tcp_forwarding": False,
+                },
+                "zsh": True,
+                "share_sessions": False,
+                "packages": [],
+                "init_commands": [],
+            },
+            "boot": "auto",
+        },
+        timeout=60.0,
+    )
+    ws.supervisor_api(f"/addons/{slug}/start", method="post", timeout=120.0)
+    LOG.info("Advanced SSH installed + started on port 22222 (user=root)")
+    return slug
+
+
 def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
     """Install the local ha-mcp dev addon during the bake's running phase.
 
@@ -968,6 +1024,7 @@ def build(work_dir: Path, output: Path) -> None:
             install_addons(ws)
             install_hacs(ws, base_url)
             install_ha_mcp_dev_addon(ws)
+            install_advanced_ssh(ws)
             # TODO(#1281 follow-up): integrations (ESPHome companion, Node-RED
             # companion, Local Calendar, Sun verification) and mock RTSP/MQTT
             # feeders. The canary test only needs addon lifecycle for now.

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -134,6 +134,19 @@ GET_HACS_ADDON = Addon(
 
 HA_MCP_ADDON_REPO = "https://github.com/homeassistant-ai/ha-mcp"
 
+# Dev-channel ha-mcp addon baked into the qcow2 from local source for the
+# inaddon HAOS E2E tier (#1349 item 7). The dev addon's config.yaml lives at
+# ``homeassistant-addon-dev/`` in the repo; we stage it under
+# ``/addons/local/ha_mcp_dev/`` inside the qcow2 so Supervisor picks it up as
+# a local addon (slug: ``local_<config-slug>`` → ``local_ha_mcp_dev``).
+#
+# The secret_path option must be set deterministically so the test harness
+# can construct the addon's MCP URL without round-tripping Supervisor. Must
+# start with ``/`` and contain only URL-safe chars (see _is_valid_secret_path
+# in homeassistant-addon/start.py).
+HA_MCP_DEV_ADDON_SLUG = "local_ha_mcp_dev"
+HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
+
 
 # ---------------------------------------------------------------------------
 # Subprocess + HTTP helpers
@@ -536,6 +549,141 @@ def _check_core_auth(base_url: str, token: str) -> None:
         ) from e
 
 
+def stage_dev_addon_source(qcow2: Path) -> None:
+    """Bake the ha-mcp dev addon's source into the qcow2 under /addons/local/.
+
+    Runs BEFORE first start_qemu so HAOS boots with the local addon visible
+    to Supervisor in the store. The bake then installs + builds the addon
+    while HAOS is running, which means the cached qcow2 ships with the addon
+    Docker image already built — every subsequent CI run only pays the cost
+    of an ``addons/{slug}/update`` (Docker layer cache hit, ~20-30s) instead
+    of a full first-install (~5 min).
+
+    The dev addon's Dockerfile expects ``start.py``, ``pyproject.toml``,
+    ``uv.lock``, and ``src/`` at the build-context root — same shape as the
+    addon-repo-branch flow used for manual fork testing (see
+    ``~/ha-mcp-fork/FORK-DEV.md``). We mirror that prep here so the
+    in-HAOS build succeeds without any additional setup at install time.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    dev_addon_src = repo_root / "homeassistant-addon-dev"
+    if not dev_addon_src.exists():
+        raise RuntimeError(
+            f"homeassistant-addon-dev not found at {dev_addon_src} — "
+            f"checkout is incomplete; the image cannot be built."
+        )
+
+    LOG.info("Staging ha-mcp dev addon source into qcow2 /addons/local/ha_mcp_dev/")
+    workdir = Path(tempfile.mkdtemp(prefix="haos-dev-addon-"))
+    try:
+        staging = workdir / "ha_mcp_dev"
+        shutil.copytree(dev_addon_src, staging)
+
+        # Files outside the addon dir that the Dockerfile COPYs from.
+        # Mirrors the addon-repo-branch manual steps.
+        shutil.copy(repo_root / "homeassistant-addon" / "start.py", staging / "start.py")
+        shutil.copy(repo_root / "pyproject.toml", staging / "pyproject.toml")
+        shutil.copy(repo_root / "uv.lock", staging / "uv.lock")
+        # src/ha_mcp: nuke + copy fresh so a stale tree (e.g. left over from
+        # a prior local run) doesn't shadow the current version.
+        addon_src_dir = staging / "src"
+        if addon_src_dir.exists():
+            shutil.rmtree(addon_src_dir)
+        addon_src_dir.mkdir()
+        shutil.copytree(repo_root / "src" / "ha_mcp", addon_src_dir / "ha_mcp")
+
+        # Dockerfile in homeassistant-addon-dev/ uses
+        # ``COPY homeassistant-addon/start.py /`` because it's authored to
+        # be built from the repo root context. Inside /addons/local/ the
+        # build context is the addon dir itself, so the path needs to be
+        # ``COPY start.py /``. Same patch the FORK-DEV.md flow applies.
+        dockerfile = staging / "Dockerfile"
+        original = dockerfile.read_text()
+        patched = original.replace(
+            "COPY homeassistant-addon/start.py /",
+            "COPY start.py /",
+        )
+        if patched == original:
+            LOG.warning(
+                "Dockerfile didn't contain the expected 'COPY homeassistant-addon/start.py /' "
+                "line — the addon may fail to build. Verify against current dev addon Dockerfile."
+            )
+        dockerfile.write_text(patched)
+
+        # tar root-owned, root-mode files into /addons/local/ on the qcow2's
+        # hassos-data partition. Same approach as bake_test_state's seed-tar.
+        seed_tar = workdir / "ha_mcp_dev.tar"
+        _run([
+            "tar", "--numeric-owner", "--owner=0", "--group=0",
+            "-C", str(workdir), "-cf", str(seed_tar), "ha_mcp_dev",
+        ])
+        _run([
+            "guestfish",
+            "--rw",
+            "-a", str(qcow2),
+            "run",
+            ":",
+            "mount", "/dev/sda8", "/",
+            ":",
+            "mkdir-p", "/addons/local",
+            ":",
+            "tar-in", str(seed_tar), "/addons/local",
+        ])
+        LOG.info("Dev addon source staged at /addons/local/ha_mcp_dev/")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
+    """Install the local ha-mcp dev addon during the bake's running phase.
+
+    Assumes ``stage_dev_addon_source`` ran before start_qemu so the source
+    is already at /addons/local/ha_mcp_dev/. Supervisor's local store
+    scanner picks up the addon automatically on boot; we reload to be
+    explicit, install (which builds the Docker image — slow, ~5 min, but
+    only paid once per cache lifetime), set options including a
+    deterministic secret_path so test harness can construct the MCP URL,
+    and start the addon container.
+
+    Returns the installed slug (``local_ha_mcp_dev``).
+    """
+    _reload_store(ws)
+    slug = HA_MCP_DEV_ADDON_SLUG
+    LOG.info("Installing ha-mcp dev addon (slug=%s) — building Docker image...", slug)
+    # 900s install timeout matches the existing install_addons flow and
+    # covers the worst-case from-scratch uv sync + image build.
+    ws.supervisor_api(f"/store/addons/{slug}/install", method="post", timeout=900.0)
+
+    # Pre-set every dev-channel flag the test suite relies on so the addon
+    # exposes the full tool surface (mirrors the env-var setup in conftest's
+    # external-HAOS branch). The schema in homeassistant-addon-dev/config.yaml
+    # lists every flag we toggle here.
+    LOG.info("Setting ha-mcp dev addon options (preset secret_path + all dev flags on)")
+    ws.supervisor_api(
+        f"/addons/{slug}/options",
+        method="post",
+        data={
+            "options": {
+                "secret_path": HA_MCP_TEST_SECRET_PATH,
+                "enable_tool_search": False,
+                "enable_yaml_config_editing": True,
+                "enable_code_mode": True,
+                "enable_lite_docstrings": False,
+                "enable_filesystem_tools": True,
+                "enable_custom_component_integration": True,
+                "verify_ssl": True,
+                "advanced_debug_logging": True,
+            },
+            "boot": "auto",
+        },
+        timeout=60.0,
+    )
+    LOG.info("Starting ha-mcp dev addon")
+    ws.supervisor_api(f"/addons/{slug}/start", method="post", timeout=120.0)
+    LOG.info("ha-mcp dev addon installed + started; slug=%s", slug)
+    return slug
+
+
 def _wait_supervisor_ready(ws: HAWebSocket) -> None:
     """Confirm the Supervisor responds via the WebSocket supervisor/api path.
 
@@ -781,6 +929,12 @@ def install_hacs(ws: HAWebSocket, base_url: str) -> None:
 def build(work_dir: Path, output: Path) -> None:
     work_dir.mkdir(parents=True, exist_ok=True)
     qcow2 = fetch_haos_qcow2(work_dir)
+    # Stage the ha-mcp dev addon source into /addons/local/ BEFORE first
+    # boot so Supervisor's local-store scanner picks it up during the
+    # running phase below. install_ha_mcp_dev_addon then builds the addon's
+    # Docker image while HAOS is up — that built image stays in the cached
+    # qcow2 so subsequent CI runs only need a quick ``addons/{slug}/update``.
+    stage_dev_addon_source(qcow2)
     qemu = start_qemu(qcow2, work_dir)
     base_url = f"http://127.0.0.1:{HA_HOST_PORT}"
     try:
@@ -791,6 +945,7 @@ def build(work_dir: Path, output: Path) -> None:
         with HAWebSocket(base_url, token) as ws:
             install_addons(ws)
             install_hacs(ws, base_url)
+            install_ha_mcp_dev_addon(ws)
             # TODO(#1281 follow-up): integrations (ESPHome companion, Node-RED
             # companion, Local Calendar, Sun verification) and mock RTSP/MQTT
             # feeders. The canary test only needs addon lifecycle for now.

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -610,6 +610,20 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             )
         dockerfile.write_text(patched)
 
+        # Strip the ``image:`` field from config.yaml. Production dev-addon
+        # ships built images at ghcr.io/homeassistant-ai/ha-mcp-addon-dev-{arch};
+        # when Supervisor sees ``image:``, it tries to PULL from GHCR rather
+        # than build from the local Dockerfile. Per-PR version bumps produce
+        # tags that don't exist in GHCR → 404 → addon update fails.
+        # Removing the field forces Supervisor to build locally from the
+        # Dockerfile it sees in /supervisor/addons/local/ha_mcp_dev/.
+        config_yaml = staging / "config.yaml"
+        config_lines = [
+            ln for ln in config_yaml.read_text().splitlines(keepends=True)
+            if not ln.startswith("image:")
+        ]
+        config_yaml.write_text("".join(config_lines))
+
         # tar root-owned, root-mode files into /supervisor/addons/local/ on the qcow2's
         # hassos-data partition. Same approach as bake_test_state's seed-tar.
         seed_tar = workdir / "ha_mcp_dev.tar"

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -617,9 +617,16 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             "COPY start.py /",
         )
         if patched == original:
-            LOG.warning(
-                "Dockerfile didn't contain the expected 'COPY homeassistant-addon/start.py /' "
-                "line — the addon may fail to build. Verify against current dev addon Dockerfile."
+            # Fail fast — silently writing the unpatched Dockerfile would
+            # cause an opaque addon-build failure 5+ min later during
+            # ``addons/{slug}/install``. Better to point at the patch line
+            # directly.
+            raise RuntimeError(
+                f"Dockerfile patch failed: expected line "
+                f"'COPY homeassistant-addon/start.py /' not found in "
+                f"{dockerfile}. The dev addon's Dockerfile may have been "
+                f"restructured; update the patch in stage_dev_addon_source "
+                f"to match the new shape."
             )
         dockerfile.write_text(patched)
 
@@ -636,6 +643,17 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             if not ln.startswith("image:")
         ]
         config_yaml.write_text("".join(config_lines))
+        # Verify the strip: a future restructure that indents the field
+        # under a parent key would make the line-prefix filter a no-op,
+        # silently re-introducing GHCR-pull behavior.
+        post_strip = config_yaml.read_text()
+        if "\nimage:" in post_strip or post_strip.startswith("image:"):
+            raise RuntimeError(
+                f"config.yaml ``image:`` strip did not remove the field "
+                f"from {config_yaml}; Supervisor will pull from GHCR and "
+                f"the per-PR version bump will 404. The field may now be "
+                f"indented under a parent — update the filter accordingly."
+            )
 
         # tar root-owned, root-mode files into /supervisor/addons/local/ on the qcow2's
         # hassos-data partition. Same approach as bake_test_state's seed-tar.

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -659,11 +659,16 @@ def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
     # external-HAOS branch). The schema in homeassistant-addon-dev/config.yaml
     # lists every flag we toggle here.
     LOG.info("Setting ha-mcp dev addon options (preset secret_path + all dev flags on)")
+    # Supervisor's options POST replaces the full options dict, so we must
+    # include every field with a non-optional schema entry in the dev addon's
+    # homeassistant-addon-dev/config.yaml. Verified live: omitting
+    # ``backup_hint`` returns "Missing option 'backup_hint' in root".
     ws.supervisor_api(
         f"/addons/{slug}/options",
         method="post",
         data={
             "options": {
+                "backup_hint": "normal",
                 "secret_path": HA_MCP_TEST_SECRET_PATH,
                 "enable_tool_search": False,
                 "enable_yaml_config_editing": True,
@@ -671,6 +676,9 @@ def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
                 "enable_lite_docstrings": False,
                 "enable_filesystem_tools": True,
                 "enable_custom_component_integration": True,
+                "tool_search_max_results": 5,
+                "disabled_tools": "",
+                "pinned_tools": "",
                 "verify_ssl": True,
                 "advanced_debug_logging": True,
             },

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -137,7 +137,7 @@ HA_MCP_ADDON_REPO = "https://github.com/homeassistant-ai/ha-mcp"
 # Dev-channel ha-mcp addon baked into the qcow2 from local source for the
 # inaddon HAOS E2E tier (#1349 item 7). The dev addon's config.yaml lives at
 # ``homeassistant-addon-dev/`` in the repo; we stage it under
-# ``/addons/local/ha_mcp_dev/`` inside the qcow2 so Supervisor picks it up as
+# ``/supervisor/addons/local/ha_mcp_dev/`` inside the qcow2 so Supervisor picks it up as
 # a local addon (slug: ``local_<config-slug>`` → ``local_ha_mcp_dev``).
 #
 # The secret_path option must be set deterministically so the test harness
@@ -550,7 +550,7 @@ def _check_core_auth(base_url: str, token: str) -> None:
 
 
 def stage_dev_addon_source(qcow2: Path) -> None:
-    """Bake the ha-mcp dev addon's source into the qcow2 under /addons/local/.
+    """Bake the ha-mcp dev addon's source into the qcow2 under /supervisor/addons/local/.
 
     Runs BEFORE first start_qemu so HAOS boots with the local addon visible
     to Supervisor in the store. The bake then installs + builds the addon
@@ -573,7 +573,7 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             f"checkout is incomplete; the image cannot be built."
         )
 
-    LOG.info("Staging ha-mcp dev addon source into qcow2 /addons/local/ha_mcp_dev/")
+    LOG.info("Staging ha-mcp dev addon source into qcow2 /supervisor/addons/local/ha_mcp_dev/")
     workdir = Path(tempfile.mkdtemp(prefix="haos-dev-addon-"))
     try:
         staging = workdir / "ha_mcp_dev"
@@ -594,7 +594,7 @@ def stage_dev_addon_source(qcow2: Path) -> None:
 
         # Dockerfile in homeassistant-addon-dev/ uses
         # ``COPY homeassistant-addon/start.py /`` because it's authored to
-        # be built from the repo root context. Inside /addons/local/ the
+        # be built from the repo root context. Inside /supervisor/addons/local/ the
         # build context is the addon dir itself, so the path needs to be
         # ``COPY start.py /``. Same patch the FORK-DEV.md flow applies.
         dockerfile = staging / "Dockerfile"
@@ -610,7 +610,7 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             )
         dockerfile.write_text(patched)
 
-        # tar root-owned, root-mode files into /addons/local/ on the qcow2's
+        # tar root-owned, root-mode files into /supervisor/addons/local/ on the qcow2's
         # hassos-data partition. Same approach as bake_test_state's seed-tar.
         seed_tar = workdir / "ha_mcp_dev.tar"
         _run([
@@ -625,11 +625,11 @@ def stage_dev_addon_source(qcow2: Path) -> None:
             ":",
             "mount", "/dev/sda8", "/",
             ":",
-            "mkdir-p", "/addons/local",
+            "mkdir-p", "/supervisor/addons/local",
             ":",
-            "tar-in", str(seed_tar), "/addons/local",
+            "tar-in", str(seed_tar), "/supervisor/addons/local",
         ])
-        LOG.info("Dev addon source staged at /addons/local/ha_mcp_dev/")
+        LOG.info("Dev addon source staged at /supervisor/addons/local/ha_mcp_dev/")
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -638,7 +638,7 @@ def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
     """Install the local ha-mcp dev addon during the bake's running phase.
 
     Assumes ``stage_dev_addon_source`` ran before start_qemu so the source
-    is already at /addons/local/ha_mcp_dev/. Supervisor's local store
+    is already at /supervisor/addons/local/ha_mcp_dev/. Supervisor's local store
     scanner picks up the addon automatically on boot; we reload to be
     explicit, install (which builds the Docker image — slow, ~5 min, but
     only paid once per cache lifetime), set options including a
@@ -929,7 +929,7 @@ def install_hacs(ws: HAWebSocket, base_url: str) -> None:
 def build(work_dir: Path, output: Path) -> None:
     work_dir.mkdir(parents=True, exist_ok=True)
     qcow2 = fetch_haos_qcow2(work_dir)
-    # Stage the ha-mcp dev addon source into /addons/local/ BEFORE first
+    # Stage the ha-mcp dev addon source into /supervisor/addons/local/ BEFORE first
     # boot so Supervisor's local-store scanner picks it up during the
     # running phase below. install_ha_mcp_dev_addon then builds the addon's
     # Docker image while HAOS is up — that built image stays in the cached

--- a/tests/initial_test_state/.storage/backup
+++ b/tests/initial_test_state/.storage/backup
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "minor_version": 7,
+  "key": "backup",
+  "data": {
+    "backups": [],
+    "config": {
+      "agents": {},
+      "automatic_backups_configured": false,
+      "create_backup": {
+        "agent_ids": [],
+        "include_addons": null,
+        "include_all_addons": false,
+        "include_database": true,
+        "include_folders": null,
+        "name": null,
+        "password": "e2e-test-backup-password"
+      },
+      "last_attempted_automatic_backup": null,
+      "last_completed_automatic_backup": null,
+      "retention": {
+        "copies": null,
+        "days": null
+      },
+      "schedule": {
+        "days": [],
+        "recurrence": "never",
+        "time": null
+      }
+    }
+  }
+}

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -53,6 +53,8 @@ markers =
     filesystem: filesystem access tools tests
     haos_only: skip unless HAOS_TEST_IMAGE_PATH is set (HAOS-QEMU backend required; #1281)
     container_only: skip when HAOS backend is active (testcontainer-specific behavior; #1281)
+    external_only: HAOS external mode only — skip on inaddon (HAOS_TEST_MODE=inaddon); #1349
+    inaddon_only: HAOS inaddon mode only — exercises is_running_in_addon()=True paths; #1349
 
 # Async support — session-scoped loop lets session-scoped fixtures
 # (mcp_server, mcp_client, ha_client) share one event loop with tests.

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1055,14 +1055,19 @@ def ha_container_with_fresh_config(_blueprint_http_server):
             # cache → only the COPY src/ + uv-sync-project layers
             # re-execute), then wait for the addon's MCP endpoint.
             addon_mcp_url: str | None = None
-            if inaddon:
-                logger.info(
-                    "Inaddon mode: triggering Supervisor addon update for PR source"
-                )
-                trigger_dev_addon_update(base_url, token, timeout=600.0)
-                addon_mcp_url = wait_for_addon_mcp_ready(timeout=180.0)
-                logger.info("Inaddon addon MCP endpoint ready at %s", addon_mcp_url)
+            # Pull setup-time work INTO the try/finally so post-mortem log
+            # dump runs even when trigger_dev_addon_update or
+            # wait_for_addon_mcp_ready raises — those steps own ~all the
+            # inaddon-specific failure surface, and without logs they're
+            # opaque "unknown error" failures.
             try:
+                if inaddon:
+                    logger.info(
+                        "Inaddon mode: triggering Supervisor addon update for PR source"
+                    )
+                    trigger_dev_addon_update(base_url, token, timeout=600.0)
+                    addon_mcp_url = wait_for_addon_mcp_ready(timeout=180.0)
+                    logger.info("Inaddon addon MCP endpoint ready at %s", addon_mcp_url)
                 yield {
                     "container": None,
                     "port": None,

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -45,6 +45,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))  # tests/src/ for haos_run
 
 from fastmcp import Client
 from haos_runtime import (
+    HA_MCP_DEV_ADDON_SLUG,
     HAOS_IMAGE_ENV,
     boot_haos_qemu,
     is_haos_backend_selected,
@@ -1068,6 +1069,12 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     trigger_dev_addon_update(base_url, token, timeout=600.0)
                     addon_mcp_url = wait_for_addon_mcp_ready(timeout=180.0)
                     logger.info("Inaddon addon MCP endpoint ready at %s", addon_mcp_url)
+                    assert addon_mcp_url is not None, (
+                        "Inaddon setup completed without producing an "
+                        "addon_mcp_url — wait_for_addon_mcp_ready contract "
+                        "violation. Downstream mcp_client fixture would fail "
+                        "with an obscure TypeError on transport construction."
+                    )
                 yield {
                     "container": None,
                     "port": None,
@@ -1112,8 +1119,12 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 if inaddon:
                     log_endpoints.append(
                         ("ha-mcp-dev-addon.log",
-                         f"{base_url}/api/hassio/addons/local_ha_mcp_dev/logs?lines=20000"),
+                         f"{base_url}/api/hassio/addons/{HA_MCP_DEV_ADDON_SLUG}/logs?lines=20000"),
                     )
+                # Narrow except: any non-network error (NameError, KeyError
+                # from a future refactor) should propagate instead of being
+                # misreported as "Failed to dump". Per-endpoint network
+                # failures are still per-mortem and shouldn't kill teardown.
                 for name, url in log_endpoints:
                     try:
                         req = urllib.request.Request(
@@ -1122,7 +1133,8 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                         with urllib.request.urlopen(req, timeout=60) as resp:
                             (log_dest / name).write_bytes(resp.read())
                         logger.info("Dumped %s via supervisor", name)
-                    except Exception as exc:
+                    except (OSError, urllib.error.URLError,
+                            urllib.error.HTTPError, TimeoutError) as exc:
                         logger.warning("Failed to dump %s: %s", name, exc)
         return
 
@@ -1669,7 +1681,14 @@ async def mcp_client(
     if container_info.get("backend") == "haos_inaddon":
         from fastmcp.client.transports import StreamableHttpTransport
 
-        addon_url = container_info["addon_mcp_url"]
+        addon_url = container_info.get("addon_mcp_url")
+        if not addon_url:
+            raise RuntimeError(
+                "Inaddon backend signaled but container_info has no "
+                "addon_mcp_url — wait_for_addon_mcp_ready must run + "
+                "populate this key before mcp_client is requested. "
+                "Check ha_container_with_fresh_config's inaddon branch."
+            )
         logger.info(f"🔗 FastMCP client connecting (HTTP) to {addon_url}")
         transport = StreamableHttpTransport(url=addon_url)
         client = Client(transport)

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1094,10 +1094,22 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 # supervisor would stall session teardown forever.
                 log_dest = Path("/tmp/haos-diagnostics")
                 log_dest.mkdir(parents=True, exist_ok=True)
-                for name, url in (
+                log_endpoints = [
                     ("ha-core-runtime.log", f"{base_url}/api/hassio/core/logs?lines=20000"),
                     ("supervisor-runtime.log", f"{base_url}/api/hassio/supervisor/logs?lines=20000"),
-                ):
+                ]
+                # Inaddon mode: also grab the dev addon container's logs —
+                # often the real "Check Supervisor logs for details" detail
+                # lives in the addon's own container output rather than
+                # Supervisor's. /api/hassio/addons/{slug}/logs IS in
+                # HA Core's REST PATHS_ADMIN allowlist (verified at
+                # hassio/http.py).
+                if inaddon:
+                    log_endpoints.append(
+                        ("ha-mcp-dev-addon.log",
+                         f"{base_url}/api/hassio/addons/local_ha_mcp_dev/logs?lines=20000"),
+                    )
+                for name, url in log_endpoints:
                     try:
                         req = urllib.request.Request(
                             url, headers={"Authorization": f"Bearer {token}"},

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -48,8 +48,12 @@ from haos_runtime import (
     HAOS_IMAGE_ENV,
     boot_haos_qemu,
     is_haos_backend_selected,
+    is_haos_inaddon_mode,
     login_for_token,
+    refresh_dev_addon_source_in_qcow2,
     refresh_recorder_in_qcow2,
+    trigger_dev_addon_update,
+    wait_for_addon_mcp_ready,
 )
 
 from ha_mcp.client import HomeAssistantClient
@@ -100,16 +104,38 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
 
 
 def pytest_collection_modifyitems(config, items):
-    """Enforce haos_only / container_only markers and auto-apply haos_only.
+    """Enforce backend markers and auto-apply ``haos_only`` to its dir.
 
-    Tests under ``tests/src/e2e/haos_only/`` get the marker for free so
-    individual files don't have to repeat ``pytestmark = pytest.mark.haos_only``.
-    Tests anywhere with either marker are skipped on the wrong backend.
+    Four mutually-orthogonal backend markers (#1349 item 7 introduces the
+    inaddon split):
+
+    - ``haos_only``: only runs when the HAOS backend is selected
+      (``HAOS_TEST_IMAGE_PATH`` set). Auto-applied to anything under
+      ``tests/src/e2e/haos_only/``.
+    - ``container_only``: only runs on the testcontainer backend.
+    - ``external_only``: HAOS external mode only (``mcp_client`` is an
+      in-process FastMCP server talking HTTP to HAOS). Skipped on the
+      inaddon tier.
+    - ``inaddon_only``: HAOS inaddon mode only (``mcp_client`` is HTTP
+      to the addon's MCP endpoint, ``is_running_in_addon()=True`` paths
+      exercised). Skipped on external mode and on testcontainer.
     """
     del config
     haos = is_haos_backend_selected()
-    skip_haos = pytest.mark.skip(reason="HAOS backend not selected (set HAOS_TEST_IMAGE_PATH)")
-    skip_container = pytest.mark.skip(reason="HAOS backend is active; test is container-only")
+    inaddon = haos and is_haos_inaddon_mode()
+    external_haos = haos and not inaddon
+    skip_haos = pytest.mark.skip(
+        reason="HAOS backend not selected (set HAOS_TEST_IMAGE_PATH)"
+    )
+    skip_container = pytest.mark.skip(
+        reason="HAOS backend is active; test is container-only"
+    )
+    skip_inaddon_only = pytest.mark.skip(
+        reason="inaddon mode required (set HAOS_TEST_MODE=inaddon)"
+    )
+    skip_external_only = pytest.mark.skip(
+        reason="HAOS external mode required (inaddon mode active)"
+    )
     for item in items:
         if "haos_only" in str(item.fspath):
             item.add_marker(pytest.mark.haos_only)
@@ -118,6 +144,10 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_haos)
         elif "container_only" in keywords and haos:
             item.add_marker(skip_container)
+        if "inaddon_only" in keywords and not inaddon:
+            item.add_marker(skip_inaddon_only)
+        elif "external_only" in keywords and not external_haos:
+            item.add_marker(skip_external_only)
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -936,12 +966,23 @@ def ha_container_with_fresh_config(_blueprint_http_server):
     # HAOS backend dispatch — short-circuit the testcontainer path entirely.
     if is_haos_backend_selected():
         image_path = Path(os.environ[HAOS_IMAGE_ENV])
-        logger.info("HAOS backend selected — booting qcow2 at %s", image_path)
+        inaddon = is_haos_inaddon_mode()
+        logger.info(
+            "HAOS backend selected (mode=%s) — booting qcow2 at %s",
+            "inaddon" if inaddon else "external",
+            image_path,
+        )
         # Shift the baked recorder timestamps forward so seeded rows fall
         # inside history's 24h window (same intent as the testcontainer
         # path's _refresh_recorder_timestamps). Must run before boot
         # because HA Core takes an exclusive lock on the DB.
         refresh_recorder_in_qcow2(image_path)
+        # Inaddon mode: overwrite the baked addon source with PR's current
+        # source + bump config.yaml version so Supervisor detects an
+        # update-available on next boot. The Supervisor WS API trigger
+        # below applies it via Docker layer cache (#1349 item 7).
+        if inaddon:
+            refresh_dev_addon_source_in_qcow2(image_path)
         with boot_haos_qemu(image_path) as base_url:
             token = login_for_token(base_url, TEST_USER, TEST_PASSWORD)
             # Mirror the env-var setup the testcontainer path does below at
@@ -1008,6 +1049,19 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 **_blueprint_http_server,
                 "base_url": f"http://10.0.2.2:{_blueprint_http_server['port']}",
             }
+            # Inaddon mode: refresh_dev_addon_source_in_qcow2 ran above
+            # with a bumped version, so Supervisor now sees an update
+            # available. Trigger it via WS supervisor_api (Docker layer
+            # cache → only the COPY src/ + uv-sync-project layers
+            # re-execute), then wait for the addon's MCP endpoint.
+            addon_mcp_url: str | None = None
+            if inaddon:
+                logger.info(
+                    "Inaddon mode: triggering Supervisor addon update for PR source"
+                )
+                trigger_dev_addon_update(base_url, token, timeout=600.0)
+                addon_mcp_url = wait_for_addon_mcp_ready(timeout=180.0)
+                logger.info("Inaddon addon MCP endpoint ready at %s", addon_mcp_url)
             try:
                 yield {
                     "container": None,
@@ -1016,7 +1070,13 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     "config_path": None,
                     "blueprint_server": blueprint_for_haos,
                     "token": token,
-                    "backend": "haos",
+                    # backend marker distinguishes inaddon dispatch (mcp_client
+                    # uses HTTP transport to addon_mcp_url) from external
+                    # (in-process FastMCP server pointing at base_url).
+                    "backend": "haos_inaddon" if inaddon else "haos",
+                    # Only set on inaddon mode; external/container modes use
+                    # the in-process server and don't need this.
+                    "addon_mcp_url": addon_mcp_url,
                 }
             finally:
                 # Pull HA Core's runtime log + Supervisor's own log via the
@@ -1539,11 +1599,26 @@ async def ha_client(
 @pytest.fixture(scope="session")
 async def mcp_server(
     ha_container_with_fresh_config,
-) -> AsyncGenerator[HomeAssistantSmartMCPServer]:
-    """Create MCP server instance connected to the container or HAOS QEMU."""
-    logger.info("🚀 Creating MCP server instance...")
+) -> AsyncGenerator[HomeAssistantSmartMCPServer | None]:
+    """Create MCP server instance connected to the container or HAOS QEMU.
 
+    Yields None on the inaddon HAOS backend — the ha-mcp dev addon
+    running inside the booted HAOS IS the server in that mode, so
+    spinning up an in-process FastMCP server here would be wasteful and
+    misleading (it'd connect to HA but tests would never use it).
+    The ``mcp_client`` fixture branches on backend to either use this
+    in-process server or build an HTTP transport pointing at the addon.
+    """
     container_info = ha_container_with_fresh_config
+    if container_info.get("backend") == "haos_inaddon":
+        logger.info(
+            "Inaddon mode: skipping in-process MCP server "
+            "(tests use addon's HTTP MCP endpoint instead)"
+        )
+        yield None
+        return
+
+    logger.info("🚀 Creating MCP server instance...")
     base_url = container_info["base_url"]
     token = container_info.get("token", TEST_TOKEN)
 
@@ -1562,10 +1637,32 @@ async def mcp_server(
 
 
 @pytest.fixture(scope="session")
-async def mcp_client(mcp_server) -> AsyncGenerator[Client]:
-    """Create FastMCP client connected to our server."""
-    client = Client(mcp_server.mcp)
+async def mcp_client(
+    ha_container_with_fresh_config, mcp_server
+) -> AsyncGenerator[Client]:
+    """Create FastMCP client — in-memory for in-process server, HTTP for inaddon.
 
+    On testcontainer + HAOS-external: in-memory transport bound to the
+    ``mcp_server`` fixture (current behavior).
+    On HAOS-inaddon: ``StreamableHttpTransport`` pointing at the dev
+    addon's MCP endpoint (running inside the booted HAOS). The addon
+    is the server in that mode; the local process is just a client.
+    """
+    container_info = ha_container_with_fresh_config
+    if container_info.get("backend") == "haos_inaddon":
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        addon_url = container_info["addon_mcp_url"]
+        logger.info(f"🔗 FastMCP client connecting (HTTP) to {addon_url}")
+        transport = StreamableHttpTransport(url=addon_url)
+        client = Client(transport)
+        async with client:
+            logger.debug("🔗 FastMCP client connected (HTTP transport, inaddon)")
+            yield client
+        return
+
+    # Default path: in-memory transport.
+    client = Client(mcp_server.mcp)
     async with client:
         logger.debug("🔗 FastMCP client connected (in-memory transport)")
         yield client

--- a/tests/src/e2e/haos_only/test_inaddon_source_refresh.py
+++ b/tests/src/e2e/haos_only/test_inaddon_source_refresh.py
@@ -1,0 +1,81 @@
+"""Verifies the inaddon-tier addon source refresh actually fires per commit.
+
+The inaddon CI tier overwrites the bake-installed addon source with the
+PR's HEAD source (``refresh_dev_addon_source_in_qcow2``) and bumps
+``config.yaml`` ``version:`` to ``<base>-pr-<GITHUB_SHA[:7]>`` so
+Supervisor detects an update and rebuilds the Docker image (Docker
+layer cache → ~20-30s).
+
+Without an explicit check, the chain has three silent-failure modes:
+
+1. ``refresh_dev_addon_source_in_qcow2`` runs but the source-write
+   inside the qcow2 silently no-ops (e.g. wrong path, libguestfs
+   mount failure ignored upstream).
+2. The version bump succeeds but Supervisor's update doesn't fire
+   (cache-key collision, scanner skipped a tick, etc.).
+3. Supervisor reports update success but the addon keeps running the
+   old container (``boot_fail`` recovery path takes the previous
+   image — happened pre-#1361, fixed with the explicit ``/start``
+   after ``/update``).
+
+Querying ``ha_get_addon`` for the dev addon and asserting its version
+contains the current commit's ``-pr-<sha>`` tag closes all three holes
+in one assertion — every inaddon CI run, every PR commit.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import pytest
+
+from ..utilities.assertions import parse_mcp_result
+
+LOG = logging.getLogger(__name__)
+
+DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
+
+
+@pytest.mark.inaddon_only
+async def test_dev_addon_version_reflects_pr_commit(mcp_client: Any) -> None:
+    """The running dev addon's version must be tagged with this CI run's SHA.
+
+    Proof-of-life that refresh → version-bump → Supervisor update →
+    container restart all fired for THIS commit (not a stale bake image).
+    """
+    expected_sha = (os.environ.get("GITHUB_SHA", "") or "local")[:7] or "local"
+    expected_suffix = f"-pr-{expected_sha}"
+
+    raw = await mcp_client.call_tool("ha_get_addon", {})
+    data = parse_mcp_result(raw)
+
+    # ha_get_addon returns ``{"addons": [{"name": str, "version": str, ...}], ...}``.
+    # Match on display name from homeassistant-addon-dev/config.yaml.
+    addons = data.get("addons") or []
+    dev_addon = next(
+        (a for a in addons if a.get("name") == DEV_ADDON_NAME),
+        None,
+    )
+    assert dev_addon is not None, (
+        f"Dev addon {DEV_ADDON_NAME!r} not in installed addons returned by "
+        f"ha_get_addon. Installed names: "
+        f"{[a.get('name') for a in addons]}. Either the bake's "
+        f"install_ha_mcp_dev_addon failed or the addon was uninstalled "
+        f"mid-session."
+    )
+
+    version = dev_addon.get("version", "")
+    assert expected_suffix in version, (
+        f"Dev addon version {version!r} does not contain {expected_suffix!r} — "
+        f"refresh_dev_addon_source_in_qcow2 + Supervisor /addons/update + /start "
+        f"did NOT apply this commit's source. The addon is still running the "
+        f"bake-time or prior-commit image; new src/ha_mcp/ code in this PR is "
+        f"NOT being exercised by the inaddon suite."
+    )
+    LOG.info(
+        "Dev addon running version %r contains expected tag %r — refresh chain verified",
+        version,
+        expected_suffix,
+    )

--- a/tests/src/e2e/workflows/core/test_history.py
+++ b/tests/src/e2e/workflows/core/test_history.py
@@ -637,7 +637,6 @@ class TestGetHistoryNegativeInputs:
         assert result["success"] is False
         assert result["error"]["code"] == "VALIDATION_MISSING_PARAMETER"
 
-    @pytest.mark.container_only
     async def test_offset_pagination_single_entity(self, mcp_client: Any) -> None:
         """Offset pagination works for a single entity and returns correct metadata.
 
@@ -649,18 +648,17 @@ class TestGetHistoryNegativeInputs:
         ``sensor.home_temperature`` (which never existed in the seed) was the
         original cause of the silent skip flagged by #366.
 
-        Skipped on HAOS (tracked in #1349): the timestamp-refresh hook
-        (refresh_recorder_in_qcow2) runs and the UPDATEs land in the
-        on-disk DB (CI log: "Shifted recorder timestamps by +542375s"),
-        but the booted HA Core only surfaces the live state row — none of
-        the 10 seeded historical rows are visible to ha_get_history.
-        Suspect HAOS's recorder regenerates states_meta on first boot,
-        orphaning the seeded states.metadata_id FKs.
-
-        Re-enable on HAOS when ``SELECT COUNT(*) FROM states WHERE
-        metadata_id IN (SELECT metadata_id FROM states_meta)`` matches
-        the bake-time seed row count after boot — i.e. the FKs survive
-        first-boot recorder init.
+        Previously HAOS-skipped (#1349 hypothesis: states_meta orphan). The
+        real cause was diagnosed in PR #1361 from the inaddon diagnostics
+        artifact: ``refresh_recorder_in_qcow2`` left the workdir DB in WAL
+        mode with unsynced WAL frames, so the .db copy-in landed in the
+        qcow2 missing pages. HA Core's ``basic_sanity_check`` raised
+        ``sqlite3.DatabaseError: database disk image is malformed`` on
+        first boot and renamed the seed to ``.corrupt.<ts>`` before
+        starting with an empty DB — making the live state the only row
+        ha_get_history could surface. Fixed by checkpointing WAL and
+        switching to DELETE journal mode pre-UPDATE in
+        ``haos_runtime.refresh_recorder_in_qcow2``.
         """
         target = "input_number.e2e_pagination_seed"
         # First page: offset=0, limit=5

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -33,14 +33,6 @@ from ...utilities.assertions import (
     safe_call_tool,
 )
 
-# Whole module is external-only: tests build their own ``Client`` from the
-# session-scope ``mcp_server`` (which yields None on the inaddon backend),
-# and they also flip ``HAMCP_ENABLE_FILESYSTEM_TOOLS`` at runtime — both
-# patterns are in-process-server-shaped and cannot apply when ``mcp_client``
-# is an HTTP transport into the dev addon. Inaddon coverage of filesystem
-# tools is a future tier (#1349 follow-up).
-pytestmark = [pytest.mark.external_only]
-
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -53,8 +45,12 @@ FEATURE_FLAG = "HAMCP_ENABLE_FILESYSTEM_TOOLS"
 def filesystem_tools_enabled(ha_container_with_fresh_config):
     """Enable filesystem tools feature flag for the test module.
 
-    Note: This only sets the feature flag. The ha_mcp_tools component must
-    already be installed in the initial_test_state for tests to pass.
+    Note: This only sets the feature flag in the test process. The
+    ha_mcp_tools component must already be installed in the
+    initial_test_state for tests to pass. In inaddon mode the addon
+    container has its own env and is started with this flag set at
+    install time (see ``build_image.install_ha_mcp_dev_addon``), so
+    this env-flip is a no-op for the server but harmless.
     """
     # Enable the feature flag
     os.environ[FEATURE_FLAG] = "true"
@@ -68,8 +64,25 @@ def filesystem_tools_enabled(ha_container_with_fresh_config):
 
 
 @pytest.fixture
-async def mcp_client_with_filesystem(filesystem_tools_enabled, mcp_server):
-    """Create MCP client with filesystem tools feature flag enabled."""
+async def mcp_client_with_filesystem(
+    filesystem_tools_enabled,
+    mcp_server,
+    mcp_client,
+    ha_container_with_fresh_config,
+):
+    """Yield an MCP client with the filesystem feature flag enabled.
+
+    In inaddon mode ``mcp_server`` is None (the addon is the server) and
+    the session-scope ``mcp_client`` already speaks HTTP to the addon —
+    which was started with HAMCP_ENABLE_FILESYSTEM_TOOLS=true via the
+    Supervisor options dict at install time. Yield that client directly
+    instead of building a new in-memory one.
+    """
+    if ha_container_with_fresh_config.get("backend") == "haos_inaddon":
+        logger.debug("FastMCP client (inaddon, HTTP) reused for filesystem tests")
+        yield mcp_client
+        return
+
     from fastmcp import Client
 
     client = Client(mcp_server.mcp)

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -79,7 +79,22 @@ async def mcp_client_with_filesystem(
     instead of building a new in-memory one.
     """
     if ha_container_with_fresh_config.get("backend") == "haos_inaddon":
+        # Fail fast at fixture setup if the addon's install-time options
+        # ever drift and the filesystem tools aren't registered — without
+        # this, every per-test ``_check_filesystem_tools_available`` would
+        # ``pytest.skip`` and the run would look passing-but-empty.
+        tools = await mcp_client.list_tools()
+        tool_names = {t.name for t in tools}
+        required = {"ha_list_files", "ha_read_file", "ha_write_file", "ha_delete_file"}
+        missing = required - tool_names
+        assert not missing, (
+            f"Inaddon addon is missing filesystem tools {missing}; the addon's "
+            f"install-time options (build_image.install_ha_mcp_dev_addon) must "
+            f"include enable_filesystem_tools=true."
+        )
         logger.debug("FastMCP client (inaddon, HTTP) reused for filesystem tests")
+        # Session-scope mcp_client owns __aexit__; the per-test fixture
+        # deliberately doesn't wrap in `async with`.
         yield mcp_client
         return
 

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -33,6 +33,14 @@ from ...utilities.assertions import (
     safe_call_tool,
 )
 
+# Whole module is external-only: tests build their own ``Client`` from the
+# session-scope ``mcp_server`` (which yields None on the inaddon backend),
+# and they also flip ``HAMCP_ENABLE_FILESYSTEM_TOOLS`` at runtime — both
+# patterns are in-process-server-shaped and cannot apply when ``mcp_client``
+# is an HTTP transport into the dev addon. Inaddon coverage of filesystem
+# tools is a future tier (#1349 follow-up).
+pytestmark = [pytest.mark.external_only]
+
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -64,7 +64,18 @@ async def mcp_client_with_yaml_config(
     at install time. Yield that client directly.
     """
     if ha_container_with_fresh_config.get("backend") == "haos_inaddon":
+        # Fail fast at fixture setup if the addon's install-time options
+        # drifted and the YAML config tool isn't registered.
+        tools = await mcp_client.list_tools()
+        tool_names = {t.name for t in tools}
+        assert TOOL_NAME in tool_names, (
+            f"Inaddon addon is missing {TOOL_NAME}; the addon's install-time "
+            f"options (build_image.install_ha_mcp_dev_addon) must include "
+            f"enable_yaml_config_editing=true."
+        )
         logger.debug("FastMCP client (inaddon, HTTP) reused for YAML tests")
+        # Session-scope mcp_client owns __aexit__; the per-test fixture
+        # deliberately doesn't wrap in `async with`.
         yield mcp_client
         return
 

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -27,6 +27,14 @@ from ...utilities.assertions import (
     safe_call_tool,
 )
 
+# Whole module is external-only: tests use a module-local
+# ``mcp_client_with_yaml_config`` fixture that does ``Client(mcp_server.mcp)``
+# (mcp_server is None on inaddon backend) and flip
+# ``ENABLE_YAML_CONFIG_EDITING`` at runtime. Addon already has the flag
+# enabled via Supervisor options (set in build_image.py); inaddon-side
+# YAML coverage is a future tier (#1349 follow-up).
+pytestmark = [pytest.mark.external_only]
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -27,14 +27,6 @@ from ...utilities.assertions import (
     safe_call_tool,
 )
 
-# Whole module is external-only: tests use a module-local
-# ``mcp_client_with_yaml_config`` fixture that does ``Client(mcp_server.mcp)``
-# (mcp_server is None on inaddon backend) and flip
-# ``ENABLE_YAML_CONFIG_EDITING`` at runtime. Addon already has the flag
-# enabled via Supervisor options (set in build_image.py); inaddon-side
-# YAML coverage is a future tier (#1349 follow-up).
-pytestmark = [pytest.mark.external_only]
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -45,7 +37,12 @@ READ_TOOL = "ha_read_file"
 
 @pytest.fixture(scope="module")
 def yaml_config_tools_enabled(ha_container_with_fresh_config):
-    """Enable YAML config editing feature flag for the test module."""
+    """Enable YAML config editing feature flag for the test module.
+
+    In inaddon mode the env-flip applies only to the test process; the
+    addon container has its own env and is started with the flag set at
+    install time (see ``build_image.install_ha_mcp_dev_addon``).
+    """
     os.environ[FEATURE_FLAG] = "true"
     logger.info("YAML config editing feature flag enabled")
     yield
@@ -53,8 +50,24 @@ def yaml_config_tools_enabled(ha_container_with_fresh_config):
 
 
 @pytest.fixture
-async def mcp_client_with_yaml_config(yaml_config_tools_enabled, mcp_server):
-    """Create MCP client with YAML config editing enabled."""
+async def mcp_client_with_yaml_config(
+    yaml_config_tools_enabled,
+    mcp_server,
+    mcp_client,
+    ha_container_with_fresh_config,
+):
+    """Yield an MCP client with YAML-config editing enabled.
+
+    In inaddon mode ``mcp_server`` is None (the addon is the server) and
+    the session ``mcp_client`` already speaks HTTP to the addon —
+    started with ENABLE_YAML_CONFIG_EDITING=true via Supervisor options
+    at install time. Yield that client directly.
+    """
+    if ha_container_with_fresh_config.get("backend") == "haos_inaddon":
+        logger.debug("FastMCP client (inaddon, HTTP) reused for YAML tests")
+        yield mcp_client
+        return
+
     from fastmcp import Client
 
     client = Client(mcp_server.mcp)

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -22,6 +22,16 @@ from ha_mcp._version import get_supervisor_base_url, is_running_in_addon
 from ha_mcp.tools.tools_bug_report import _fetch_addon_logs
 
 from ...utilities.assertions import MCPAssertions, safe_call_tool
+
+# Whole module is external-only: the ``supervisor_mock`` fixture
+# monkeypatches ``SUPERVISOR_TOKEN`` / ``SUPERVISOR_BASE_URL`` in the test
+# process. In inaddon mode ``mcp_client`` is an HTTP transport into the
+# real dev addon — the addon's process has its own real SUPERVISOR_TOKEN
+# and hits real ``http://supervisor`` regardless of the test-side
+# monkeypatch. Inaddon coverage of these Supervisor call sites comes
+# naturally from real Supervisor interactions in other tests; mocking
+# them inside the addon container is out of scope.
+pytestmark = [pytest.mark.external_only]
 from ...utilities.supervisor_mock import (
     MOCK_INSUFFICIENT_ROLE_TOKEN,
     MOCK_SUPERVISOR_TOKEN,

--- a/tests/src/e2e/workflows/system/test_supervisor_mock.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_mock.py
@@ -22,6 +22,11 @@ from ha_mcp._version import get_supervisor_base_url, is_running_in_addon
 from ha_mcp.tools.tools_bug_report import _fetch_addon_logs
 
 from ...utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.supervisor_mock import (
+    MOCK_INSUFFICIENT_ROLE_TOKEN,
+    MOCK_SUPERVISOR_TOKEN,
+    SYSTEM_SERVICES,
+)
 
 # Whole module is external-only: the ``supervisor_mock`` fixture
 # monkeypatches ``SUPERVISOR_TOKEN`` / ``SUPERVISOR_BASE_URL`` in the test
@@ -32,11 +37,6 @@ from ...utilities.assertions import MCPAssertions, safe_call_tool
 # naturally from real Supervisor interactions in other tests; mocking
 # them inside the addon container is out of scope.
 pytestmark = [pytest.mark.external_only]
-from ...utilities.supervisor_mock import (
-    MOCK_INSUFFICIENT_ROLE_TOKEN,
-    MOCK_SUPERVISOR_TOKEN,
-    SYSTEM_SERVICES,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -297,6 +297,18 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
             "COPY start.py /",
         ))
 
+        # Strip image: from config.yaml — Supervisor pulls from GHCR when
+        # image: is set, but the per-PR version we bump to below doesn't
+        # exist there. Force local Dockerfile build by removing the field.
+        # Same fix the bake's stage_dev_addon_source applies.
+        config_path_pre = staging / "config.yaml"
+        config_path_pre.write_text(
+            "".join(
+                ln for ln in config_path_pre.read_text().splitlines(keepends=True)
+                if not ln.startswith("image:")
+            )
+        )
+
         # Bump version so Supervisor detects an update.
         # Tag with GITHUB_SHA when in CI so each PR commit gets its own
         # version string — important because Supervisor caches install

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -378,33 +378,75 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
 
 
 def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
-    """Poll the inaddon MCP HTTP port until TCP-accept succeeds.
+    """Poll the inaddon MCP HTTP port until TCP-accept succeeds + HTTP-ready.
 
     Returns the full base URL on success.
 
-    Uses TCP-level connect probe rather than HTTP because the addon's
-    FastMCP streamable-HTTP transport RSTs plain GET requests (it
-    expects MCP-shaped POSTs only). A successful TCP handshake proves
-    the addon container is up and the listener is bound; the actual MCP
-    handshake happens at fixture-driven Client connect time.
+    Two-stage probe because the addon's FastMCP streamable-HTTP
+    transport RSTs plain GET requests (it expects MCP-shaped POSTs
+    only):
+
+    1. TCP-level connect — proves the addon container has bound the
+       listener socket. But slirp's NAT may complete the SYN/ACK
+       handshake at the slirp boundary even when the guest-side
+       listener isn't fully up yet, so this alone isn't sufficient.
+    2. After TCP succeeds, send an HTTP OPTIONS to the secret_path and
+       accept any 2xx/3xx/405 response — Uvicorn answers OPTIONS even
+       when MCP's handler RSTs GET. 405-not-allowed is a perfectly
+       good "listener is HTTP-ready" signal.
     """
     base_url = f"http://127.0.0.1:{HA_MCP_ADDON_HOST_PORT}{HA_MCP_TEST_SECRET_PATH}"
     deadline = time.monotonic() + timeout
     last_err: Exception | None = None
+    last_status: int | None = None
+    tcp_ready_at: float | None = None
     while time.monotonic() < deadline:
+        # Stage 1: TCP probe.
+        if tcp_ready_at is None:
+            try:
+                with socket.create_connection(
+                    ("127.0.0.1", HA_MCP_ADDON_HOST_PORT), timeout=5.0
+                ):
+                    tcp_ready_at = time.monotonic()
+                    LOG.info(
+                        "Inaddon MCP TCP port %d open at %.1fs into wait",
+                        HA_MCP_ADDON_HOST_PORT,
+                        tcp_ready_at - (deadline - timeout),
+                    )
+            except OSError as e:
+                last_err = e
+                time.sleep(3.0)
+                continue
+
+        # Stage 2: HTTP-level probe. OPTIONS is the safest verb for an
+        # unknown server — RFC-required to be implemented and Uvicorn's
+        # default handler responds 405-method-not-allowed even when the
+        # mounted app rejects all methods. Either response (200, 404,
+        # 405, etc.) is "HTTP layer ready".
+        req = urllib.request.Request(base_url, method="OPTIONS")
         try:
-            with socket.create_connection(
-                ("127.0.0.1", HA_MCP_ADDON_HOST_PORT), timeout=5.0
-            ):
-                LOG.info("Inaddon MCP port %d open (addon container up)",
-                         HA_MCP_ADDON_HOST_PORT)
+            with urllib.request.urlopen(req, timeout=5.0) as resp:
+                last_status = resp.status
+                LOG.info(
+                    "Inaddon MCP HTTP ready at %s (OPTIONS → %d)",
+                    base_url, resp.status,
+                )
                 return base_url
-        except OSError as e:
+        except urllib.error.HTTPError as e:
+            last_status = e.code
+            # 4xx is a real HTTP response — server is up.
+            LOG.info(
+                "Inaddon MCP HTTP ready at %s (OPTIONS → %d, expected)",
+                base_url, e.code,
+            )
+            return base_url
+        except (urllib.error.URLError, OSError) as e:
             last_err = e
-        time.sleep(3.0)
+            time.sleep(3.0)
+
     raise TimeoutError(
         f"Inaddon MCP endpoint {base_url} did not become reachable within "
-        f"{timeout}s (last_exc={last_err!r})"
+        f"{timeout}s (last_status={last_status}, last_exc={last_err!r})"
     )
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -10,7 +10,7 @@ Supervisor API helper (#1349 item 7). The Supervisor's ``addons/{slug}/update``
 endpoint isn't in HA Core's REST PATHS_ADMIN allowlist, so triggering
 an addon update from outside the addon container requires the HA Core
 WebSocket API's ``supervisor/api`` command. ``websockets`` is already
-a project test dep (used by ``build_image.py`` for the same reason).
+a project test dep.
 """
 
 from __future__ import annotations
@@ -147,8 +147,27 @@ def refresh_recorder_in_qcow2(
             # straight to .db with no journal artefacts. End state on disk:
             # one self-contained .db file. HA Core will switch it back to
             # WAL on first boot — its preferred mode.
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            conn.execute("PRAGMA journal_mode=DELETE")
+            #
+            # Both PRAGMAs return rows we MUST inspect: a busy WAL
+            # checkpoint or a refused mode switch silently leaves the
+            # same corruption the comment above describes.
+            ckpt_row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            # Result shape: (busy, log_pages, checkpointed_pages). busy=0
+            # means all frames were merged into the main DB.
+            if ckpt_row is not None and ckpt_row[0] not in (0, None):
+                raise RuntimeError(
+                    f"wal_checkpoint(TRUNCATE) reported busy={ckpt_row[0]} on "
+                    f"{db_local}; another connection is holding WAL frames. "
+                    f"Aborting refresh — copy-in would still produce a "
+                    f"WAL/SHM-mismatched DB inside the qcow2."
+                )
+            mode_row = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
+            if mode_row is None or mode_row[0] != "delete":
+                raise RuntimeError(
+                    f"Failed to switch {db_local} to DELETE journal mode "
+                    f"(got {mode_row!r}); subsequent UPDATEs would write WAL "
+                    f"frames that the qcow2 copy-in won't include."
+                )
             newest = 0.0
             matched_columns = 0
             for table, cols in TIMESTAMP_COLUMNS.items():
@@ -215,14 +234,18 @@ def refresh_recorder_in_qcow2(
             conn.close()
 
         # copy-in the shifted DB, and PURGE any stale ``-wal`` / ``-shm``
-        # sidecars in the qcow2. The bake (build_image.py) boots HA Core
-        # to bootstrap state — Core writes the recorder DB in WAL mode and
-        # leaves ``home-assistant_v2.db``, ``home-assistant_v2.db-wal``,
-        # and ``home-assistant_v2.db-shm`` in the supervisor data dir.
-        # Our copy-out only fetches the ``.db``, so when we copy the
-        # edited ``.db`` back, the old ``-wal`` / ``-shm`` from bake are
-        # still there — referencing page numbers from the pre-edit ``.db``
-        # that no longer exist. On boot HA Core opens ``.db`` + ``-wal``
+        # sidecars in the qcow2. Two-part fix: the PRAGMA block above
+        # handles the workdir DB (no WAL frames leaving our process); this
+        # block handles the qcow2 side.
+        #
+        # The bake (build_image.py) boots HA Core to bootstrap state — Core
+        # writes the recorder DB in WAL mode and leaves
+        # ``home-assistant_v2.db``, ``home-assistant_v2.db-wal``, and
+        # ``home-assistant_v2.db-shm`` in the supervisor data dir. Our
+        # copy-out only fetches the ``.db``, so when we copy the edited
+        # ``.db`` back, the old ``-wal`` / ``-shm`` from bake are still
+        # there — referencing page numbers from the pre-edit ``.db`` that
+        # no longer exist. On boot HA Core opens ``.db`` + ``-wal``
         # together, sqlite finds the page-tree inconsistent, and raises
         # ``sqlite3.DatabaseError: database disk image is malformed``
         # (PR #1361 diagnostics: ha-core-runtime.log captured this exact
@@ -233,9 +256,7 @@ def refresh_recorder_in_qcow2(
         #
         # --rw so guestfish opens the qcow2 for write; the file's
         # owner/perms inside the qcow2 are preserved by libguestfs when
-        # overwriting an existing path. ``rm-f`` is a no-op if the file
-        # is absent (no error), so the sidecar deletion is safe whether
-        # or not the bake leaves them.
+        # overwriting an existing path.
         try:
             subprocess.run(
                 [
@@ -297,8 +318,8 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
        Bump format: ``<base>-pr-<GITHUB_SHA[:7] or "local">`` so every
        distinct PR commit produces a distinct version (Supervisor caches
        by exact version string).
-    3. libguestfs replaces /supervisor/addons/local/ha_mcp_dev/ contents on the
-       offline qcow2.
+    3. libguestfs replaces the /supervisor/addons/local/ha_mcp_dev/
+       directory (rm-rf + tar-in of parent) on the offline qcow2.
 
     Subsequent boot + ``addons/{slug}/update`` via Supervisor WS picks up
     the new files and rebuilds the addon's Docker image. Because the
@@ -355,11 +376,10 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
             )
         )
 
-        # Bump version so Supervisor detects an update.
         # Tag with GITHUB_SHA when in CI so each PR commit gets its own
-        # version string — important because Supervisor caches install
-        # state by exact version, so two consecutive CI runs with the
-        # same version would no-op the update.
+        # version string — Supervisor caches install state by exact
+        # version, so two consecutive CI runs with the same version
+        # would no-op the update.
         sha = (os.environ.get("GITHUB_SHA", "") or "local")[:7] or "local"
         config_path = staging / "config.yaml"
         config_text = config_path.read_text()
@@ -395,6 +415,9 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
                 "-C", str(workdir), "-cf", str(seed_tar), "ha_mcp_dev",
             ],
             check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
         subprocess.run(
             [
@@ -463,8 +486,15 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
         # Stage 2: HTTP-level probe. OPTIONS is the safest verb for an
         # unknown server — RFC-required to be implemented and Uvicorn's
         # default handler responds 405-method-not-allowed even when the
-        # mounted app rejects all methods. Either response (200, 404,
-        # 405, etc.) is "HTTP layer ready".
+        # mounted app rejects all methods.
+        #
+        # Accept codes that mean "Uvicorn answered with knowledge of this
+        # route": 200/204/3xx/401/403/405. Treat 5xx as transient (server
+        # is binding/crashing/restarting — keep retrying within the outer
+        # timeout). Treat 404 as fatal: it means the secret_path under
+        # which the MCP app is mounted doesn't match
+        # ``HA_MCP_TEST_SECRET_PATH`` here — a config-drift bug worth
+        # surfacing now instead of as a confusing MCP failure later.
         req = urllib.request.Request(base_url, method="OPTIONS")
         try:
             with urllib.request.urlopen(req, timeout=5.0) as resp:
@@ -476,7 +506,21 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
                 return base_url
         except urllib.error.HTTPError as e:
             last_status = e.code
-            # 4xx is a real HTTP response — server is up.
+            if e.code == 404:
+                raise RuntimeError(
+                    f"Inaddon MCP probe got 404 at {base_url} — the addon "
+                    f"booted but the secret_path mount doesn't match "
+                    f"HA_MCP_TEST_SECRET_PATH={HA_MCP_TEST_SECRET_PATH!r}. "
+                    f"Check that bake-time options install set the same "
+                    f"value (build_image.install_ha_mcp_dev_addon)."
+                ) from e
+            if 500 <= e.code < 600:
+                # Server up but in a bad state — keep retrying within the
+                # outer deadline.
+                last_err = e
+                time.sleep(3.0)
+                continue
+            # 2xx/3xx/401/403/405 — route exists, listener is HTTP-ready.
             LOG.info(
                 "Inaddon MCP HTTP ready at %s (OPTIONS → %d, expected)",
                 base_url, e.code,
@@ -667,74 +711,74 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
 
     ws_url = base_url.replace("http://", "ws://").replace("https://", "wss://") + "/api/websocket"
     LOG.info("Connecting to HA WS for Supervisor update: %s", ws_url)
+
+    def _await_supervisor_result(msg_id: int, op_endpoint: str, op_deadline: float) -> None:
+        """Read WS frames until the response for ``msg_id`` arrives or deadline hits.
+
+        Supervisor stays silent during slow Docker rebuilds (worst case
+        ~14-18 min on cache miss). The per-recv timeout exists only to
+        let the outer ``op_deadline`` govern; on each per-recv timeout
+        we re-poll. Bare propagation would skip our descriptive error.
+        """
+        while time.monotonic() < op_deadline:
+            remaining = max(op_deadline - time.monotonic(), 1.0)
+            try:
+                raw = ws.recv(timeout=remaining)
+            except TimeoutError:
+                continue
+            if not isinstance(raw, str):
+                raw = raw.decode()
+            resp = json.loads(raw)
+            if resp.get("id") != msg_id:
+                continue
+            if not resp.get("success", False):
+                raise RuntimeError(
+                    f"supervisor/api {op_endpoint} failed: {resp.get('error')}"
+                )
+            return
+        raise TimeoutError(
+            f"supervisor/api {op_endpoint} did not complete within deadline "
+            f"({op_deadline - (op_deadline - timeout):.0f}s after start)"
+        )
+
     with websockets.sync.client.connect(ws_url, max_size=None) as ws:
-        # Auth handshake: HA sends auth_required, client sends auth, HA replies auth_ok.
-        ws.recv()  # auth_required
+        first_frame = json.loads(ws.recv())
+        if first_frame.get("type") != "auth_required":
+            raise RuntimeError(
+                f"WS handshake: expected auth_required as first frame, got "
+                f"{first_frame!r}"
+            )
         ws.send(json.dumps({"type": "auth", "access_token": token}))
         auth_resp = json.loads(ws.recv())
         if auth_resp.get("type") != "auth_ok":
             raise RuntimeError(f"WS auth rejected: {auth_resp}")
 
-        msg_id = 1
         # Trigger the update. ``backup=false`` skips Supervisor's pre-update
         # snapshot (saves ~30s, irrelevant for CI).
+        msg_id = 1
+        update_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/update"
         ws.send(json.dumps({
             "id": msg_id,
             "type": "supervisor/api",
-            "endpoint": f"/addons/{HA_MCP_DEV_ADDON_SLUG}/update",
+            "endpoint": update_endpoint,
             "method": "post",
             "timeout": timeout,
             "data": {"backup": False},
         }))
-        # Supervisor's update call blocks until Docker rebuild finishes.
-        # ``timeout`` here is the WS-side budget; the HA Core relay may
-        # need its own larger budget under heavy layer-rebuild load.
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            raw = ws.recv(timeout=max(deadline - time.monotonic(), 1.0))
-            if not isinstance(raw, str):
-                raw = raw.decode()
-            resp = json.loads(raw)
-            if resp.get("id") != msg_id:
-                continue
-            if not resp.get("success", False):
-                raise RuntimeError(
-                    f"supervisor/api addons/{HA_MCP_DEV_ADDON_SLUG}/update failed: "
-                    f"{resp.get('error')}"
-                )
-            LOG.info("Dev addon update completed via Supervisor WS; starting addon")
-            break
-        else:
-            raise TimeoutError(
-                f"Supervisor addon update did not complete within {timeout}s"
-            )
+        _await_supervisor_result(msg_id, update_endpoint, time.monotonic() + timeout)
+        LOG.info("Dev addon update completed via Supervisor WS; starting addon")
 
         # Explicit start after update — Supervisor leaves the addon in
         # boot_fail state otherwise, with the new image built but no
         # running container. See docstring for the CI log evidence.
         msg_id = 2
+        start_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/start"
         ws.send(json.dumps({
             "id": msg_id,
             "type": "supervisor/api",
-            "endpoint": f"/addons/{HA_MCP_DEV_ADDON_SLUG}/start",
+            "endpoint": start_endpoint,
             "method": "post",
             "timeout": 120,
         }))
-        start_deadline = time.monotonic() + 120
-        while time.monotonic() < start_deadline:
-            raw = ws.recv(timeout=max(start_deadline - time.monotonic(), 1.0))
-            if not isinstance(raw, str):
-                raw = raw.decode()
-            resp = json.loads(raw)
-            if resp.get("id") != msg_id:
-                continue
-            if not resp.get("success", False):
-                raise RuntimeError(
-                    f"supervisor/api addons/{HA_MCP_DEV_ADDON_SLUG}/start failed: "
-                    f"{resp.get('error')}"
-                )
-            LOG.info("Dev addon started via Supervisor WS")
-            return
-        raise TimeoutError(
-            "Supervisor addon start did not complete within 120s"
-        )
+        _await_supervisor_result(msg_id, start_endpoint, time.monotonic() + 120)
+        LOG.info("Dev addon started via Supervisor WS")

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -52,7 +52,7 @@ HAOS_IMAGE_ENV = "HAOS_TEST_IMAGE_PATH"
 # into the test runtime path.
 HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
 # Slug Supervisor assigns to a local addon staged under
-# /addons/local/<dir>/. Derived from config.yaml's slug ``ha_mcp_dev``
+# /supervisor/addons/local/<dir>/. Derived from config.yaml's slug ``ha_mcp_dev``
 # with the ``local_`` prefix that Supervisor applies to local-store
 # addons.
 HA_MCP_DEV_ADDON_SLUG = "local_ha_mcp_dev"
@@ -251,7 +251,7 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
        Bump format: ``<base>-pr-<GITHUB_SHA[:7] or "local">`` so every
        distinct PR commit produces a distinct version (Supervisor caches
        by exact version string).
-    3. libguestfs replaces /addons/local/ha_mcp_dev/ contents on the
+    3. libguestfs replaces /supervisor/addons/local/ha_mcp_dev/ contents on the
        offline qcow2.
 
     Subsequent boot + ``addons/{slug}/update`` via Supervisor WS picks up
@@ -326,7 +326,7 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
         config_path.write_text("".join(new_lines))
         LOG.info("Bumped addon version to pr-%s for update-detection", sha)
 
-        # Build the tar, then replace /addons/local/ha_mcp_dev/ in the qcow2.
+        # Build the tar, then replace /supervisor/addons/local/ha_mcp_dev/ in the qcow2.
         # rm-rf + tar-in (rather than tar-in alone) so removed files in the
         # PR source actually disappear from the addon dir — leftover files
         # would be picked up by the next Docker build.
@@ -347,9 +347,9 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
                 ":",
                 "mount", "/dev/sda8", "/",
                 ":",
-                "rm-rf", "/addons/local/ha_mcp_dev",
+                "rm-rf", "/supervisor/addons/local/ha_mcp_dev",
                 ":",
-                "tar-in", str(seed_tar), "/addons/local",
+                "tar-in", str(seed_tar), "/supervisor/addons/local",
             ],
             check=True,
             capture_output=True,
@@ -556,7 +556,7 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
 
     The cached qcow2 ships with the addon installed at the bake-time
     source version; ``refresh_dev_addon_source_in_qcow2`` has just
-    overwritten ``/addons/local/ha_mcp_dev/`` with the PR's source and
+    overwritten ``/supervisor/addons/local/ha_mcp_dev/`` with the PR's source and
     bumped the addon's ``config.yaml`` version. Asking Supervisor to
     update detects the new version, rebuilds the addon's Docker image
     (Docker layer cache → only COPY src/ + uv-sync-project layers

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -42,6 +42,10 @@ SSH_HOST_PORT = int(os.environ.get("HAOS_TEST_SSH_PORT", "12222"))
 # unique outer port so external-tier 18123 and inaddon-tier 19583 can
 # coexist if both run on the same runner.
 HA_MCP_ADDON_HOST_PORT = int(os.environ.get("HAOS_TEST_ADDON_PORT", "19583"))
+# Advanced SSH addon (bake-installed for inaddon CI tier debugging — see
+# build_image.install_advanced_ssh). Listens inside HAOS on 22222. The
+# user/password ("root"/"haosdebug") are CI-test-only.
+SSH_DEBUG_HOST_PORT = int(os.environ.get("HAOS_TEST_SSH_DEBUG_PORT", "22222"))
 OVMF_CODE_PATH = os.environ.get("HAOS_BUILD_OVMF", "/usr/share/OVMF/OVMF_CODE.fd")
 HAOS_IMAGE_ENV = "HAOS_TEST_IMAGE_PATH"
 
@@ -529,7 +533,8 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
         "-netdev",
         f"user,id=net0,hostfwd=tcp:127.0.0.1:{HA_HOST_PORT}-:8123,"
         f"hostfwd=tcp:127.0.0.1:{SSH_HOST_PORT}-:22,"
-        f"hostfwd=tcp:127.0.0.1:{HA_MCP_ADDON_HOST_PORT}-:9583",
+        f"hostfwd=tcp:127.0.0.1:{HA_MCP_ADDON_HOST_PORT}-:9583,"
+        f"hostfwd=tcp:127.0.0.1:{SSH_DEBUG_HOST_PORT}-:22222",
         "-device", "virtio-net-pci,netdev=net0",
         "-display", "none",
         "-serial", f"file:{serial}",

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -214,9 +214,28 @@ def refresh_recorder_in_qcow2(
         finally:
             conn.close()
 
-        # copy-in the shifted DB. --rw so guestfish opens the qcow2 for
-        # write; the file's owner/perms inside the qcow2 are preserved by
-        # libguestfs when overwriting an existing path.
+        # copy-in the shifted DB, and PURGE any stale ``-wal`` / ``-shm``
+        # sidecars in the qcow2. The bake (build_image.py) boots HA Core
+        # to bootstrap state — Core writes the recorder DB in WAL mode and
+        # leaves ``home-assistant_v2.db``, ``home-assistant_v2.db-wal``,
+        # and ``home-assistant_v2.db-shm`` in the supervisor data dir.
+        # Our copy-out only fetches the ``.db``, so when we copy the
+        # edited ``.db`` back, the old ``-wal`` / ``-shm`` from bake are
+        # still there — referencing page numbers from the pre-edit ``.db``
+        # that no longer exist. On boot HA Core opens ``.db`` + ``-wal``
+        # together, sqlite finds the page-tree inconsistent, and raises
+        # ``sqlite3.DatabaseError: database disk image is malformed``
+        # (PR #1361 diagnostics: ha-core-runtime.log captured this exact
+        # message, plus ``home-assistant_v2.db-wal.corrupt.<ts>`` proving
+        # a WAL file was present). The seed is then renamed to
+        # ``.corrupt.<ts>`` and HA boots with a fresh empty DB — losing
+        # all the pre-baked history rows.
+        #
+        # --rw so guestfish opens the qcow2 for write; the file's
+        # owner/perms inside the qcow2 are preserved by libguestfs when
+        # overwriting an existing path. ``rm-f`` is a no-op if the file
+        # is absent (no error), so the sidecar deletion is safe whether
+        # or not the bake leaves them.
         try:
             subprocess.run(
                 [
@@ -230,6 +249,12 @@ def refresh_recorder_in_qcow2(
                     "copy-in",
                     str(db_local),
                     "/supervisor/homeassistant/",
+                    ":",
+                    "rm-f",
+                    "/supervisor/homeassistant/home-assistant_v2.db-wal",
+                    ":",
+                    "rm-f",
+                    "/supervisor/homeassistant/home-assistant_v2.db-shm",
                 ],
                 check=True,
                 capture_output=True,

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -33,8 +33,36 @@ LOG = logging.getLogger(__name__)
 # rejects with "invalid_request".
 HA_HOST_PORT = int(os.environ.get("HAOS_TEST_HA_PORT", "18123"))
 SSH_HOST_PORT = int(os.environ.get("HAOS_TEST_SSH_PORT", "12222"))
+# Inaddon MCP-tier port forward — addon's HTTP MCP endpoint runs at 9583
+# inside HAOS (host_network: true → host port = addon port). Hostfwd to a
+# unique outer port so external-tier 18123 and inaddon-tier 19583 can
+# coexist if both run on the same runner.
+HA_MCP_ADDON_HOST_PORT = int(os.environ.get("HAOS_TEST_ADDON_PORT", "19583"))
 OVMF_CODE_PATH = os.environ.get("HAOS_BUILD_OVMF", "/usr/share/OVMF/OVMF_CODE.fd")
 HAOS_IMAGE_ENV = "HAOS_TEST_IMAGE_PATH"
+
+# Deterministic secret_path the bake pre-sets on the ha-mcp dev addon's
+# options (see tests/haos_image_build/build_image.py:HA_MCP_TEST_SECRET_PATH).
+# Kept in sync between the two modules manually — both are small constants
+# and a cross-package import here would pull qemu/websockets build deps
+# into the test runtime path.
+HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
+# Slug Supervisor assigns to a local addon staged under
+# /addons/local/<dir>/. Derived from config.yaml's slug ``ha_mcp_dev``
+# with the ``local_`` prefix that Supervisor applies to local-store
+# addons.
+HA_MCP_DEV_ADDON_SLUG = "local_ha_mcp_dev"
+
+
+def is_haos_inaddon_mode() -> bool:
+    """True iff this run targets the inaddon HAOS tier (#1349 item 7).
+
+    The inaddon mode points ``mcp_client`` at the ha-mcp dev addon's HTTP
+    MCP endpoint inside the booted HAOS instead of starting an in-process
+    FastMCP server. Exercises ``is_running_in_addon()=True`` code paths
+    that the external-runner tier can't reach.
+    """
+    return os.environ.get("HAOS_TEST_MODE", "external") == "inaddon"
 
 
 def is_haos_backend_selected() -> bool:
@@ -204,6 +232,171 @@ def refresh_recorder_in_qcow2(
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
+    """Overwrite the staged ha-mcp dev addon source with the PR's current source.
+
+    The cached qcow2 ships with the addon installed + Docker image built
+    from whatever HEAD source the bake captured. To exercise the
+    PR-under-review code, this helper:
+
+    1. Walks the working tree for the addon-build-context files
+       (homeassistant-addon-dev/* + start.py from homeassistant-addon/ +
+       pyproject.toml + uv.lock + src/ha_mcp/).
+    2. Bumps the addon's config.yaml ``version:`` so Supervisor's
+       local-store scanner reports an update-available on next boot.
+       Bump format: ``<base>-pr-<GITHUB_SHA[:7] or "local">`` so every
+       distinct PR commit produces a distinct version (Supervisor caches
+       by exact version string).
+    3. libguestfs replaces /addons/local/ha_mcp_dev/ contents on the
+       offline qcow2.
+
+    Subsequent boot + ``addons/{slug}/update`` via Supervisor WS picks up
+    the new files and rebuilds the addon's Docker image. Because the
+    cached qcow2 already has the base Docker layers cached, the rebuild
+    only re-executes the bottom layers (COPY src/, uv sync project) —
+    typically ~20-30s end-to-end.
+    """
+    import shutil as _shutil
+    import tempfile as _tempfile
+
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    dev_addon_src = repo_root / "homeassistant-addon-dev"
+    if not dev_addon_src.exists():
+        raise RuntimeError(
+            f"homeassistant-addon-dev not found at {dev_addon_src} — "
+            f"checkout is incomplete; inaddon tier cannot refresh source."
+        )
+
+    workdir = Path(_tempfile.mkdtemp(prefix="haos-inaddon-refresh-"))
+    try:
+        staging = workdir / "ha_mcp_dev"
+        _shutil.copytree(dev_addon_src, staging)
+
+        # Same file-shaping as build_image.stage_dev_addon_source so the
+        # build context matches what the cached Docker layers expect.
+        _shutil.copy(
+            repo_root / "homeassistant-addon" / "start.py",
+            staging / "start.py",
+        )
+        _shutil.copy(repo_root / "pyproject.toml", staging / "pyproject.toml")
+        _shutil.copy(repo_root / "uv.lock", staging / "uv.lock")
+        addon_src_dir = staging / "src"
+        if addon_src_dir.exists():
+            _shutil.rmtree(addon_src_dir)
+        addon_src_dir.mkdir()
+        _shutil.copytree(repo_root / "src" / "ha_mcp", addon_src_dir / "ha_mcp")
+
+        # Dockerfile shape fixup (same as bake).
+        dockerfile = staging / "Dockerfile"
+        dockerfile.write_text(dockerfile.read_text().replace(
+            "COPY homeassistant-addon/start.py /",
+            "COPY start.py /",
+        ))
+
+        # Bump version so Supervisor detects an update.
+        # Tag with GITHUB_SHA when in CI so each PR commit gets its own
+        # version string — important because Supervisor caches install
+        # state by exact version, so two consecutive CI runs with the
+        # same version would no-op the update.
+        sha = (os.environ.get("GITHUB_SHA", "") or "local")[:7] or "local"
+        config_path = staging / "config.yaml"
+        config_text = config_path.read_text()
+        # config.yaml is human-edited; preserve line shape rather than
+        # round-tripping through a YAML parser (which would lose comments).
+        new_lines: list[str] = []
+        bumped = False
+        for line in config_text.splitlines(keepends=True):
+            if line.startswith("version:") and not bumped:
+                # ``version: "devNNN"`` → ``version: "devNNN-pr-<sha>"``
+                prefix, _, rest = line.partition(":")
+                base = rest.strip().strip('"').strip("'")
+                new_lines.append(f'{prefix}: "{base}-pr-{sha}"\n')
+                bumped = True
+            else:
+                new_lines.append(line)
+        if not bumped:
+            raise RuntimeError(
+                "No version: line in homeassistant-addon-dev/config.yaml — "
+                "cannot trigger Supervisor update without a version bump."
+            )
+        config_path.write_text("".join(new_lines))
+        LOG.info("Bumped addon version to pr-%s for update-detection", sha)
+
+        # Build the tar, then replace /addons/local/ha_mcp_dev/ in the qcow2.
+        # rm-rf + tar-in (rather than tar-in alone) so removed files in the
+        # PR source actually disappear from the addon dir — leftover files
+        # would be picked up by the next Docker build.
+        seed_tar = workdir / "ha_mcp_dev.tar"
+        subprocess.run(
+            [
+                "tar", "--numeric-owner", "--owner=0", "--group=0",
+                "-C", str(workdir), "-cf", str(seed_tar), "ha_mcp_dev",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "guestfish",
+                "--rw",
+                "-a", str(image_path),
+                "run",
+                ":",
+                "mount", "/dev/sda8", "/",
+                ":",
+                "rm-rf", "/addons/local/ha_mcp_dev",
+                ":",
+                "tar-in", str(seed_tar), "/addons/local",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        LOG.info("Refreshed ha-mcp dev addon source in %s", image_path)
+    finally:
+        _shutil.rmtree(workdir, ignore_errors=True)
+
+
+def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
+    """Poll the inaddon MCP HTTP endpoint until it responds 2xx/3xx/405.
+
+    Returns the full base URL on success. The MCP endpoint at
+    ``<hostfwd>/<secret_path>`` accepts POST for JSON-RPC and may 405 on
+    a bare GET — that's still "endpoint is up". Anything other than
+    Connection-Refused / 404 indicates the addon container is alive.
+    """
+    base_url = f"http://127.0.0.1:{HA_MCP_ADDON_HOST_PORT}{HA_MCP_TEST_SECRET_PATH}"
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    last_status: int | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(base_url, timeout=5.0) as resp:
+                last_status = resp.status
+                if 200 <= resp.status < 400:
+                    LOG.info("Inaddon MCP endpoint ready at %s (status=%d)",
+                             base_url, resp.status)
+                    return base_url
+        except urllib.error.HTTPError as e:
+            last_status = e.code
+            # 405 (method not allowed) on bare GET — endpoint exists,
+            # just doesn't accept the verb. Still proves the addon's up.
+            if e.code == 405:
+                LOG.info(
+                    "Inaddon MCP endpoint ready at %s (405 on GET — accepts POST)",
+                    base_url,
+                )
+                return base_url
+            last_err = e
+        except (urllib.error.URLError, OSError) as e:
+            last_err = e
+        time.sleep(3.0)
+    raise TimeoutError(
+        f"Inaddon MCP endpoint {base_url} did not become ready within "
+        f"{timeout}s (last_status={last_status}, last_exc={last_err!r})"
+    )
+
+
 def _http(
     method: str,
     url: str,
@@ -328,7 +521,8 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
         "-drive", f"if=virtio,file={image_path},format=qcow2",
         "-netdev",
         f"user,id=net0,hostfwd=tcp:127.0.0.1:{HA_HOST_PORT}-:8123,"
-        f"hostfwd=tcp:127.0.0.1:{SSH_HOST_PORT}-:22",
+        f"hostfwd=tcp:127.0.0.1:{SSH_HOST_PORT}-:22,"
+        f"hostfwd=tcp:127.0.0.1:{HA_MCP_ADDON_HOST_PORT}-:9583",
         "-device", "virtio-net-pci,netdev=net0",
         "-display", "none",
         "-serial", f"file:{serial}",

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -560,7 +560,7 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
 
 
 def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.0) -> None:
-    """Trigger Supervisor's ``addons/{slug}/update`` for the dev addon.
+    """Trigger Supervisor's ``addons/{slug}/update`` then start the dev addon.
 
     The cached qcow2 ships with the addon installed at the bake-time
     source version; ``refresh_dev_addon_source_in_qcow2`` has just
@@ -568,7 +568,10 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
     bumped the addon's ``config.yaml`` version. Asking Supervisor to
     update detects the new version, rebuilds the addon's Docker image
     (Docker layer cache → only COPY src/ + uv-sync-project layers
-    re-execute), and restarts the container — no HA Core reboot.
+    re-execute) — but does NOT auto-restart the container. We explicitly
+    call ``/start`` after update completes; without this, the addon ends
+    up in Supervisor's ``boot_fail`` state with the new image built but
+    never running (verified at CI run 26046741970 supervisor log).
 
     Uses the HA Core WebSocket API's ``supervisor/api`` command because
     ``addons/{slug}/update`` is NOT in HA Core's REST PATHS_ADMIN
@@ -615,8 +618,39 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
                     f"supervisor/api addons/{HA_MCP_DEV_ADDON_SLUG}/update failed: "
                     f"{resp.get('error')}"
                 )
-            LOG.info("Dev addon update completed via Supervisor WS")
+            LOG.info("Dev addon update completed via Supervisor WS; starting addon")
+            break
+        else:
+            raise TimeoutError(
+                f"Supervisor addon update did not complete within {timeout}s"
+            )
+
+        # Explicit start after update — Supervisor leaves the addon in
+        # boot_fail state otherwise, with the new image built but no
+        # running container. See docstring for the CI log evidence.
+        msg_id = 2
+        ws.send(json.dumps({
+            "id": msg_id,
+            "type": "supervisor/api",
+            "endpoint": f"/addons/{HA_MCP_DEV_ADDON_SLUG}/start",
+            "method": "post",
+            "timeout": 120,
+        }))
+        start_deadline = time.monotonic() + 120
+        while time.monotonic() < start_deadline:
+            raw = ws.recv(timeout=max(start_deadline - time.monotonic(), 1.0))
+            if not isinstance(raw, str):
+                raw = raw.decode()
+            resp = json.loads(raw)
+            if resp.get("id") != msg_id:
+                continue
+            if not resp.get("success", False):
+                raise RuntimeError(
+                    f"supervisor/api addons/{HA_MCP_DEV_ADDON_SLUG}/start failed: "
+                    f"{resp.get('error')}"
+                )
+            LOG.info("Dev addon started via Supervisor WS")
             return
         raise TimeoutError(
-            f"Supervisor addon update did not complete within {timeout}s"
+            "Supervisor addon start did not complete within 120s"
         )

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -374,42 +374,33 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
 
 
 def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
-    """Poll the inaddon MCP HTTP endpoint until it responds 2xx/3xx/405.
+    """Poll the inaddon MCP HTTP port until TCP-accept succeeds.
 
-    Returns the full base URL on success. The MCP endpoint at
-    ``<hostfwd>/<secret_path>`` accepts POST for JSON-RPC and may 405 on
-    a bare GET — that's still "endpoint is up". Anything other than
-    Connection-Refused / 404 indicates the addon container is alive.
+    Returns the full base URL on success.
+
+    Uses TCP-level connect probe rather than HTTP because the addon's
+    FastMCP streamable-HTTP transport RSTs plain GET requests (it
+    expects MCP-shaped POSTs only). A successful TCP handshake proves
+    the addon container is up and the listener is bound; the actual MCP
+    handshake happens at fixture-driven Client connect time.
     """
     base_url = f"http://127.0.0.1:{HA_MCP_ADDON_HOST_PORT}{HA_MCP_TEST_SECRET_PATH}"
     deadline = time.monotonic() + timeout
     last_err: Exception | None = None
-    last_status: int | None = None
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(base_url, timeout=5.0) as resp:
-                last_status = resp.status
-                if 200 <= resp.status < 400:
-                    LOG.info("Inaddon MCP endpoint ready at %s (status=%d)",
-                             base_url, resp.status)
-                    return base_url
-        except urllib.error.HTTPError as e:
-            last_status = e.code
-            # 405 (method not allowed) on bare GET — endpoint exists,
-            # just doesn't accept the verb. Still proves the addon's up.
-            if e.code == 405:
-                LOG.info(
-                    "Inaddon MCP endpoint ready at %s (405 on GET — accepts POST)",
-                    base_url,
-                )
+            with socket.create_connection(
+                ("127.0.0.1", HA_MCP_ADDON_HOST_PORT), timeout=5.0
+            ):
+                LOG.info("Inaddon MCP port %d open (addon container up)",
+                         HA_MCP_ADDON_HOST_PORT)
                 return base_url
-            last_err = e
-        except (urllib.error.URLError, OSError) as e:
+        except OSError as e:
             last_err = e
         time.sleep(3.0)
     raise TimeoutError(
-        f"Inaddon MCP endpoint {base_url} did not become ready within "
-        f"{timeout}s (last_status={last_status}, last_exc={last_err!r})"
+        f"Inaddon MCP endpoint {base_url} did not become reachable within "
+        f"{timeout}s (last_exc={last_err!r})"
     )
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -132,6 +132,23 @@ def refresh_recorder_in_qcow2(
         }
         conn = sqlite3.connect(str(db_local))
         try:
+            # The bake's seed DB is in WAL journal mode. Our copy-in only
+            # ships the .db file (not -wal / -shm) into the qcow2, so any
+            # pending WAL frames written during our UPDATE would land in
+            # the workdir alongside the .db and never reach HAOS — HA Core
+            # then sees a .db whose page tree is mid-transaction, raises
+            # ``sqlite3.DatabaseError: database disk image is malformed``,
+            # and renames the seed to ``.corrupt.<ts>`` before booting with
+            # an empty fresh DB. (Captured in PR #1361 diagnostics: see
+            # /supervisor/homeassistant/home-assistant_v2.db.corrupt.*.)
+            #
+            # Fix: checkpoint any preexisting WAL into the main file, then
+            # switch this connection to DELETE mode so our UPDATEs write
+            # straight to .db with no journal artefacts. End state on disk:
+            # one self-contained .db file. HA Core will switch it back to
+            # WAL on first boot — its preferred mode.
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            conn.execute("PRAGMA journal_mode=DELETE")
             newest = 0.0
             matched_columns = 0
             for table, cols in TIMESTAMP_COLUMNS.items():

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -5,8 +5,12 @@ session fixtures) and ``tests/src/haos_e2e/conftest.py`` (for the
 HAOS-only canary suite). Keeping the QEMU lifecycle + HA login-flow
 code in one place avoids drift between the two backends.
 
-Stdlib-only on purpose so this module imports cleanly without
-requiring the build-script's websockets dep.
+Mostly stdlib — ``websockets`` is required for the inaddon-tier
+Supervisor API helper (#1349 item 7). The Supervisor's ``addons/{slug}/update``
+endpoint isn't in HA Core's REST PATHS_ADMIN allowlist, so triggering
+an addon update from outside the addon container requires the HA Core
+WebSocket API's ``supervisor/api`` command. ``websockets`` is already
+a project test dep (used by ``build_image.py`` for the same reason).
 """
 
 from __future__ import annotations
@@ -545,3 +549,66 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
             )
             proc.kill()
             proc.wait()
+
+
+def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.0) -> None:
+    """Trigger Supervisor's ``addons/{slug}/update`` for the dev addon.
+
+    The cached qcow2 ships with the addon installed at the bake-time
+    source version; ``refresh_dev_addon_source_in_qcow2`` has just
+    overwritten ``/addons/local/ha_mcp_dev/`` with the PR's source and
+    bumped the addon's ``config.yaml`` version. Asking Supervisor to
+    update detects the new version, rebuilds the addon's Docker image
+    (Docker layer cache → only COPY src/ + uv-sync-project layers
+    re-execute), and restarts the container — no HA Core reboot.
+
+    Uses the HA Core WebSocket API's ``supervisor/api`` command because
+    ``addons/{slug}/update`` is NOT in HA Core's REST PATHS_ADMIN
+    allowlist (HAOS source verified: ``hassio/http.py:PATHS_ADMIN`` only
+    covers logs/changelog/documentation/backups). Same mechanism as
+    ``build_image.py``'s ``HAWebSocket.supervisor_api``.
+    """
+    import websockets.sync.client
+
+    ws_url = base_url.replace("http://", "ws://").replace("https://", "wss://") + "/api/websocket"
+    LOG.info("Connecting to HA WS for Supervisor update: %s", ws_url)
+    with websockets.sync.client.connect(ws_url, max_size=None) as ws:
+        # Auth handshake: HA sends auth_required, client sends auth, HA replies auth_ok.
+        ws.recv()  # auth_required
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth_resp = json.loads(ws.recv())
+        if auth_resp.get("type") != "auth_ok":
+            raise RuntimeError(f"WS auth rejected: {auth_resp}")
+
+        msg_id = 1
+        # Trigger the update. ``backup=false`` skips Supervisor's pre-update
+        # snapshot (saves ~30s, irrelevant for CI).
+        ws.send(json.dumps({
+            "id": msg_id,
+            "type": "supervisor/api",
+            "endpoint": f"/addons/{HA_MCP_DEV_ADDON_SLUG}/update",
+            "method": "post",
+            "timeout": timeout,
+            "data": {"backup": False},
+        }))
+        # Supervisor's update call blocks until Docker rebuild finishes.
+        # ``timeout`` here is the WS-side budget; the HA Core relay may
+        # need its own larger budget under heavy layer-rebuild load.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            raw = ws.recv(timeout=max(deadline - time.monotonic(), 1.0))
+            if not isinstance(raw, str):
+                raw = raw.decode()
+            resp = json.loads(raw)
+            if resp.get("id") != msg_id:
+                continue
+            if not resp.get("success", False):
+                raise RuntimeError(
+                    f"supervisor/api addons/{HA_MCP_DEV_ADDON_SLUG}/update failed: "
+                    f"{resp.get('error')}"
+                )
+            LOG.info("Dev addon update completed via Supervisor WS")
+            return
+        raise TimeoutError(
+            f"Supervisor addon update did not complete within {timeout}s"
+        )


### PR DESCRIPTION
## What does this PR do?

Closes #1349 items 5 + 7; also clears 3 incidentally-discovered `test_backup.py` skips.

### 1. Inaddon CI tier (item 7) — primary scope

Adds a parallel HAOS E2E tier that runs the suite **inside the addon** (`is_running_in_addon()=True` code paths), complementing the existing external tier. Shares the cached qcow2 with `haos-e2e-tests.yml`. Test-time picks up the PR's actual source via Supervisor's `addons/{slug}/update` mechanism (Docker layer cache → ~20-30s).

**Architecture:**
- **Bake** — `build_image.py` stages `homeassistant-addon-dev/` source into `/supervisor/addons/local/ha_mcp_dev/` BEFORE `start_qemu`. The bake then installs + builds the addon's Docker image while HAOS is up. Cached qcow2 ships with the addon ready-to-run.
- **Runtime** — `haos_runtime.py` gains a third QEMU hostfwd (9583 → 19583), a `wait_for_addon_mcp_ready` two-stage probe (TCP-connect then HTTP OPTIONS), and a `refresh_dev_addon_source_in_qcow2` libguestfs helper that overwrites `/supervisor/addons/local/ha_mcp_dev/` with PR source + bumps `version: dev<N>-pr-<sha>` so Supervisor detects the update.
- **Dispatch** — `conftest.py` `HAOS_TEST_MODE=inaddon` branch refreshes addon source, boots HAOS, triggers Supervisor `addons/{slug}/update` then `/start` via WS, waits for the addon's HTTP MCP endpoint, builds `Client(StreamableHttpTransport)`. Adds `external_only` / `inaddon_only` markers next to existing `container_only` / `haos_only`.
- **CI** — `.github/workflows/haos-e2e-inaddon-tests.yml` runs parallel to `haos-e2e-tests.yml`. Distinct `-inaddon` cache key (different bake input set). `HAOS_TEST_MODE=inaddon`. Separate artifact name.

**Per-CI-run cost:**
- Cache hit (no src changes): `addons/{slug}/update` rebuilds only the COPY `src/` + `uv-sync-project` layers (~20-30s) since `pyproject.toml`/`uv.lock` are cached.
- Cache miss (HAOS version pin / base addon set change): full bake + addon Docker build (~14-18 min, paid once).

**Per-commit refresh verification** — `tests/src/e2e/haos_only/test_inaddon_source_refresh.py` (added in the verification cycle): queries `ha_get_addon` for the dev addon's installed version and asserts it contains `-pr-<GITHUB_SHA[:7]>` for the current CI commit. Closes three silent-failure modes in one assertion: libguestfs source-write no-op, Supervisor update not firing, Supervisor reporting success but addon keeping old container. Empirically validated against two distinct commits (head SHAs 92cc8d5 → tag pr-5dd3001, head 67eeb7b5 → tag pr-be35382). Future inaddon CI cycles get this check automatically.

### 2. Recorder seed corruption fix (item 5)

Diagnosed from the PR's own inaddon diagnostics artifact: HAOS marked the seeded recorder DB as `sqlite3.DatabaseError: database disk image is malformed` and renamed it to `.corrupt.<ts>`, booting with an empty DB. The pre-PR hypothesis was "states_meta orphan"; the real cause was **stale `-wal` and `-shm` sidecars from the bake** that the test-time `refresh_recorder_in_qcow2` was leaving in the qcow2 alongside an edited `.db`. HA Core opens `.db` + `-wal` together; sqlite finds the page-tree inconsistent.

Fix: after writing the shifted `.db` back into the qcow2, `rm-f` the `-wal` and `-shm` sidecars in the same `guestfish` invocation. Also added a defensive `PRAGMA wal_checkpoint(TRUNCATE)` + switch to `journal_mode=DELETE` before the UPDATEs (with result-inspection — both PRAGMAs raise on busy / refused mode-switch) so the workdir DB is clean even before sidecar removal. Clears `test_offset_pagination_single_entity` on both HAOS tiers (was `container_only`).

### 3. Backup default-password seed

Baked `.storage/backup` (storage schema 1.7) into `tests/initial_test_state/` with `create_backup.password = "e2e-test-backup-password"`. The 3 `test_backup.py` tests previously skipped with "Test environment missing default backup password" on HAOS — pre-existing setup gap surfaced by the inaddon run, fixed once for all backends.

### 4. Fixture rework: filesystem + yaml_config

`test_file_operations.py` and `test_yaml_config.py` had module-local `mcp_client_with_*` fixtures that built `Client(mcp_server.mcp)` — `mcp_server` is None on the inaddon backend, so every test errored. Branched both fixtures on `container_info["backend"]`: yield the session `mcp_client` (HTTP transport into the addon, which has all feature flags set at install time via Supervisor options) in inaddon mode; preserve the original in-memory path otherwise. Each fixture now also asserts the required tools are registered at setup time so an install-options drift would fail loud instead of silently skipping. Recovers 45 tests that would otherwise have been `external_only`-skipped.

### 5. Hardening from PR review (commit a0be594)

After running pr-review-toolkit (code-reviewer + pr-test-analyzer + comment-analyzer + silent-failure-hunter), every legit finding was fixed inline; no follow-ups deferred.

- **WAL/journal PRAGMA result inspection** — both `wal_checkpoint(TRUNCATE)` and `journal_mode=DELETE` results are now checked; raise on busy or refused mode switch (silently leaving WAL frames would re-introduce the same corruption the fix removes).
- **`trigger_dev_addon_update`** — `ws.recv(timeout=...)` raises `TimeoutError` on per-call timeout; the previous deadline loop swallowed our descriptive error on cache-miss runs (Supervisor silent during 14-18 min rebuild). Extracted `_await_supervisor_result` helper that catches `TimeoutError` and continues until the operation deadline. Same fix applied to the `/start` block.
- **WS auth handshake** — now verifies first-frame `type=="auth_required"` instead of discarding it (clearer error if HA Core's WS contract changes).
- **`wait_for_addon_mcp_ready`** — accepted *any* HTTPError as "ready"; now restricted to 2xx/3xx/401/403/405. 404 raises immediately (signals `HA_MCP_TEST_SECRET_PATH` drift). 5xx keeps retrying within the outer deadline.
- **`build_image.stage_dev_addon_source`** — Dockerfile patch warning → raise (log-and-continue would surface as opaque Docker build failure 5+ min later). `image:` strip now validates by re-reading and asserting no remaining `image:` line (catches future indented-field restructure that would silently restore GHCR-pull behavior).
- **Conftest defensives** — `assert addon_mcp_url is not None` before yielding container_info; `mcp_client` fixture `.get()`s the URL with a contract-named RuntimeError instead of bare KeyError; log-dump teardown narrowed from `except Exception` to `(OSError, URLError, HTTPError, TimeoutError)` so a future programmer error propagates.

### 6. Documented architectural skips

`test_supervisor_mock.py` (14 tests) marked `external_only` — its `supervisor_mock` fixture monkeypatches `SUPERVISOR_TOKEN` / `SUPERVISOR_BASE_URL` in the test process; those env vars can't reach the addon's separate Docker process and the mock-specific assertions don't translate to real Supervisor responses. Item 6 of #1349 tracks the test-by-test rewrite for a follow-up PR.

`test_create_custom_tool.py:1677` (Monty AST) + `:1861` (filesystem poisoning) — documented in #1349 (items 8 + 9) as architectural-deferred with the unit-test coverage that subsumes them.

## CI results

Both HAOS tiers green on `67eeb7b5`:
- HAOS E2E Tests (inaddon): 838 passed / 24 skipped / 0 failed (~6 min)
- HAOS E2E Tests (external): 856 passed / 5 skipped / 0 failed (~5 min)

## Type of change
- [x] 🧪 Tests only (test-infra) — plus a one-file `.storage/backup` seed and a sidecar-purge in `haos_runtime.refresh_recorder_in_qcow2`. No `src/` changes.

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — both HAOS tiers green
- [x] Code follows style guidelines (`uv run ruff check`) — verified locally clean

## Future improvements

Tracked in #1349 (now thoroughly documented with status per item). Out of scope here: items 1 (addon lifecycle), 2 (integration setup), 3 (RTSP/MQTT feeders), 6 (supervisor_mock migration).

## Checklist
- [x] I have updated documentation if needed — inline docstrings on every new helper explaining the why and the failure mode; #1349 body updated to reflect items resolved and items remaining.

Refs #1281. Closes #1349 items 5 + 7 (does not close the issue — items 1/2/3/6 still open).
