### PR TITLE
ci: exempt assigned issues from stale bot

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -21,4 +21,5 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-all-assignees: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Adds `exempt-all-assignees: true` to the stale bot workflow so issues with an assignee are never marked stale or auto-closed.

Currently 4 open issues are assigned and would be affected: #925, #1333, #1194, #863.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed