### PR TITLE
test(e2e): tighten 5 readiness-gate budgets with 2-63x headroom (refs #366)

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -92,9 +92,9 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     going through pytest's own reporting plumbing is the reliable path.
     History: this gate-instrumentation was added in #1310; the
     ``HA_MCP_TOOLS_WAIT`` gate was added in #1346. The 5 gate budgets
-    were tightened with 2-63x headroom over observed-max in this
-    tightening PR after 24-69 [READINESS_GATE_TIMING] samples
-    accumulated across 23 master runs (49h cross-day span).
+    were tightened with 2-63x headroom over observed-max in #1369
+    after 24-69 [READINESS_GATE_TIMING] samples accumulated across
+    23 master runs (49h cross-day span).
     """
     _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})
 
@@ -644,7 +644,7 @@ def _wait_for_ha_mcp_tools_services(
             )
             if svc_resp.status_code == 200:
                 # Filter on truthy domain to mirror the diagnostic dump at
-                # _dump_ha_readiness_diagnostics (L671). Drops None /
+                # _dump_ha_readiness_diagnostics. Drops None /
                 # empty-string ``domain`` values that would otherwise inflate
                 # ``len(domains)`` and pollute the ``ha_mcp_tools in domains``
                 # membership check.
@@ -1258,7 +1258,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # Tightened from 30s to 10s based on [READINESS_GATE_TIMING] samples
         # (#1310 instrumentation + 69-sample aggregate across 23 master runs):
         # observed max 3.04s, p95 2.07s. New budget gives 3.3× / 4.8× headroom
-        # while surfacing real degradations (>5s) as fast-fail signals.
+        # while surfacing real degradations (>10s) as fast-fail signals.
         # Precedent: #1273 tightened INPUT_BOOLEAN_WAIT the same way.
         STABILIZATION_TIMEOUT = 10
 
@@ -1478,7 +1478,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # Tightened from 30s to 5s based on the same 69-sample aggregate:
         # observed max 0.21s, p95 0.07s. Already the loosest gate by a wide
         # margin pre-tightening (142×); 5s still leaves 24× / 71× headroom.
-        # (The L967 HAOS-boot SUN_WAIT = 60 is a different scope — HAOS-qemu
+        # (The HAOS-boot branch's SUN_WAIT = 60 is a different scope — HAOS-qemu
         # readiness, no [READINESS_GATE_TIMING] emit — and is intentionally
         # left untouched here.)
         SUN_WAIT = 5

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -92,8 +92,8 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     going through pytest's own reporting plumbing is the reliable path.
     History: this gate-instrumentation was added in #1310; the
     ``HA_MCP_TOOLS_WAIT`` gate was added in #1346. The 5 gate budgets
-    were tightened with 2-63x headroom over observed-max in their
-    respective tightening PR after 69 [READINESS_GATE_TIMING] samples
+    were tightened with 2-63x headroom over observed-max in this
+    tightening PR after 24-69 [READINESS_GATE_TIMING] samples
     accumulated across 23 master runs (49h cross-day span).
     """
     _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -89,12 +89,12 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     The data points are routed to the master process and rendered at
     session end by ``pytest_terminal_summary``. Direct ``sys.stderr``
     writes don't survive pytest-xdist's per-worker capture buffer, so
-    going through pytest's own reporting plumbing is the reliable path
-    (follow-up to #1273 which lowered the only previously-measured gate
-    ``INPUT_BOOLEAN_WAIT`` from 30s to 10s based on a 1s observed-resolve;
-    the remaining 30s ``STABILIZATION_TIMEOUT`` /
-    ``ENTITY_STABILIZATION_TIMEOUT`` / ``SUN_WAIT`` budgets need
-    empirical timings to scope a follow-up tightening PR).
+    going through pytest's own reporting plumbing is the reliable path.
+    History: this gate-instrumentation was added in #1310; the
+    ``HA_MCP_TOOLS_WAIT`` gate was added in #1346. The 5 gate budgets
+    were tightened to observed-max x 3-5 in their respective tightening
+    PR after 69 [READINESS_GATE_TIMING] samples accumulated across 23
+    master runs (49h cross-day span).
     """
     _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})
 
@@ -1255,7 +1255,12 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # components; 50 is the minimum needed for tests (covers automation,
         # script, input_*, group, scene, and other commonly-tested domains).
         MIN_COMPONENTS = 50
-        STABILIZATION_TIMEOUT = 30
+        # Tightened from 30s to 10s based on [READINESS_GATE_TIMING] samples
+        # (#1310 instrumentation + 69-sample aggregate across 23 master runs):
+        # observed max 3.04s, p95 2.07s. New budget gives 3.3× / 4.8× headroom
+        # while surfacing real degradations (>5s) as fast-fail signals.
+        # Precedent: #1273 tightened INPUT_BOOLEAN_WAIT the same way.
+        STABILIZATION_TIMEOUT = 10
 
         logger.info("⏳ Waiting for Home Assistant components to stabilize...")
         last_count = 0
@@ -1308,7 +1313,11 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # their entities and WebSocket handlers. The demo integration alone
         # creates 60+ entities (lights, sensors, switches, etc.).
         MIN_ENTITIES = 50
-        ENTITY_STABILIZATION_TIMEOUT = 30
+        # Tightened from 30s to 10s based on the same 69-sample aggregate:
+        # observed max 4.29s, p95 4.14s. New budget gives 2.3× / 2.4× headroom
+        # — the tightest landing in this PR, but the cross-day distribution
+        # held steady across the 49h sampling window.
+        ENTITY_STABILIZATION_TIMEOUT = 10
         logger.info("⏳ Waiting for entities to register...")
         last_entity_count = 0
         # Wall-clock-bound polling — same rationale as the component-
@@ -1356,7 +1365,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # (sun is intentionally not polled here — it registers sun.sun as an
         # entity but never a service domain, so it would always time out.
         # sun.sun readiness is gated by the state check below.)
-        INPUT_BOOLEAN_WAIT = 10
+        # Tightened from 10s to 3s based on the same 69-sample aggregate:
+        # observed max 0.83s, p95 0.59s. New budget gives 3.6× / 5.1× headroom
+        # while continuing the precedent set by #1273 (30s → 10s).
+        INPUT_BOOLEAN_WAIT = 3
         logger.info("⏳ Waiting for input_boolean service domain to register...")
         # Wall-clock-bound polling — same rationale as the loops above.
         ib_start = time.monotonic()
@@ -1417,7 +1429,13 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         #               the test environment doesn't provide
         # Reintroduce a bounded retry only if a future dump surfaces one
         # of those in the wild.
-        HA_MCP_TOOLS_WAIT = 180  # session-level cap; covers slow CI runners
+        # Tightened from 180s to 5s based on 24 [READINESS_GATE_TIMING]
+        # samples since #1346 instrumented this gate (observed max 0.08s,
+        # p95 0.07s). The original 180s was a defensive guess pre-data;
+        # actual emission consistently completes under 100ms across all
+        # observed master runs. 5s gives ~63× headroom over max — still
+        # well within CI runner variance tolerance.
+        HA_MCP_TOOLS_WAIT = 5
         ha_mcp_tools_src = repo_root / "custom_components" / "ha_mcp_tools"
         if ha_mcp_tools_src.exists():
             logger.info("⏳ Waiting for ha_mcp_tools services to register...")
@@ -1457,7 +1475,13 @@ def ha_container_with_fresh_config(_blueprint_http_server):
         # sun integration reports 'unknown' until it computes the first position.
         # Template tests that assert above/below_horizon will fail if we proceed
         # before the sun integration finishes its first calculation.
-        SUN_WAIT = 30
+        # Tightened from 30s to 5s based on the same 69-sample aggregate:
+        # observed max 0.21s, p95 0.07s. Already the loosest gate by a wide
+        # margin pre-tightening (142×); 5s still leaves 24× / 71× headroom.
+        # (The L967 HAOS-boot SUN_WAIT = 60 is a different scope — HAOS-qemu
+        # readiness, no [READINESS_GATE_TIMING] emit — and is intentionally
+        # left untouched here.)
+        SUN_WAIT = 5
         logger.info("⏳ Waiting for sun.sun to reach a known state...")
         # Wall-clock-bound polling — same rationale as the loops above.
         sun_start = time.monotonic()

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -92,9 +92,9 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     going through pytest's own reporting plumbing is the reliable path.
     History: this gate-instrumentation was added in #1310; the
     ``HA_MCP_TOOLS_WAIT`` gate was added in #1346. The 5 gate budgets
-    were tightened to observed-max x 3-5 in their respective tightening
-    PR after 69 [READINESS_GATE_TIMING] samples accumulated across 23
-    master runs (49h cross-day span).
+    were tightened with 2-63x headroom over observed-max in their
+    respective tightening PR after 69 [READINESS_GATE_TIMING] samples
+    accumulated across 23 master runs (49h cross-day span).
     """
     _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})
 


### PR DESCRIPTION
## What does this PR do?

Tightens 5 readiness-gate budgets in `tests/src/e2e/conftest.py` based on the 69-sample aggregate `[READINESS_GATE_TIMING]` dataset accumulated across 23 master E2E runs since PR #1310 (gate instrumentation, 2026-05-16) and PR #1346 (`ha_mcp_tools` gate instrumentation, 2026-05-18 morning).

**Refs #366** — this work is the empirical-tightening follow-up scoped under the e2e flake/efficiency consolidation hub. Sequence under #366: instrumentation (#1310 → #1346) → sampling window (49h cross-day) → this tightening PR. Precedent in the same hub: #1273 lowered `INPUT_BOOLEAN_WAIT` from 30s to 10s on similar empirical reasoning.

| Gate | Constant | Current → New | × max | × p95 |
|---|---|---:|---:|---:|
| components | `STABILIZATION_TIMEOUT` (L1263) | **30s → 10s** | 3.3× | 4.8× |
| entities | `ENTITY_STABILIZATION_TIMEOUT` (L1320) | **30s → 10s** | 2.3× | 2.4× |
| input_boolean | `INPUT_BOOLEAN_WAIT` (L1371) | **10s → 3s** | 3.6× | 5.1× |
| ha_mcp_tools | `HA_MCP_TOOLS_WAIT` (L1438) | **180s → 5s** | 63× | 71× |
| sun | `SUN_WAIT` (L1484, standard gate) | **30s → 5s** | 24× | 71× |

**Sampling methodology.** `[READINESS_GATE_TIMING] gate=<name> elapsed_s=<float>` lines from the `E2E Tests` push-only workflow on master between 2026-05-16 15:51 UTC and 2026-05-18 17:01 UTC (~49h cross-day span, 23 successful runs × 3 worker sessions = 69 samples per gate for the 4 originally-instrumented gates; 24 samples for `ha_mcp_tools` which was instrumented mid-window by #1346).

**Observed maximums driving the targets.** components 3.04s · entities 4.29s · input_boolean 0.83s · ha_mcp_tools 0.08s · sun 0.21s. Cross-day distribution held across the sampling window — no variance bump triggered between baseline (5/16-5/17) and fresh (5/17-5/18) windows on any of the 5 gates.

**Multiplier choice.** Target = observed-max × 3-5 for the tighter gates (components, entities, input_boolean), max × 24-63 for the gates whose budget was already wildly over (sun, ha_mcp_tools). p95 multipliers stay above 2.4× everywhere. Range chosen to surface a real degradation (≥5s on a 1s-typical gate, ≥10s on a 3s-typical gate) as a fast-fail signal while leaving comfortable headroom for runner variance.

**The L967 `SUN_WAIT = 60` is intentionally left untouched.** Different scope (HAOS-qemu boot context, no `_log_readiness_timing` emit — i.e. not part of this gate set, no data exists for it). Adding instrumentation + tightening that gate is a separate follow-up.

**Side effect:** the stale follow-up note in the `_log_readiness_timing` docstring (`conftest.py` L93-97, originally pointing at this PR as a TODO) is refreshed to history-paragraph form.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`ruff check tests/src/e2e/conftest.py` clean. The 5 budget reductions are wall-clock changes only; no logic flow modified. CI E2E runs are the empirical validation — if any gate is too tight in practice, the failure surfaces as the explicit `pytest.fail`/diagnostic-dump path that was already there.

## Checklist
- [x] I have updated documentation if needed

