### PR TITLE
fix: cache YAML instance to prevent CPU spikes in bulk edits (#1370)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -319,7 +319,6 @@ def _build_edit_yaml_config_handler(hass):
 
     async def handle_edit_yaml_config(call: ServiceCall) -> dict[str, Any]:
         """Handle the edit_yaml_config service call."""
-        ry = make_yaml()
         rel_path = call.data["file"]
         action = call.data["action"]
         yaml_path = call.data["yaml_path"]
@@ -361,7 +360,9 @@ def _build_edit_yaml_config_handler(hass):
                     "error": f"'content' is required for action '{action}'.",
                 }
             try:
-                parsed_content = ry.load(StringIO(content))
+                parsed_content = await hass.async_add_executor_job(
+                    lambda: make_yaml().load(StringIO(content))
+                )
             except YAMLError as err:
                 return {
                     "success": False,
@@ -382,7 +383,9 @@ def _build_edit_yaml_config_handler(hass):
             if target_exists:
                 raw_content = await hass.async_add_executor_job(target_file.read_text)
                 try:
-                    data = ry.load(StringIO(raw_content)) or {}
+                    data = await hass.async_add_executor_job(
+                        lambda: make_yaml().load(StringIO(raw_content)) or {}
+                    )
                 except YAMLError as err:
                     return {
                         "success": False,
@@ -518,7 +521,9 @@ def _build_edit_yaml_config_handler(hass):
 
             # Serialize back to YAML
             try:
-                new_content = yaml_dumps(ry, data)
+                new_content = await hass.async_add_executor_job(
+                    lambda: yaml_dumps(make_yaml(), data)
+                )
             except YAMLError as err:
                 return {
                     "success": False,
@@ -527,7 +532,9 @@ def _build_edit_yaml_config_handler(hass):
 
             # Validate the result parses cleanly
             try:
-                ry.load(StringIO(new_content))
+                await hass.async_add_executor_job(
+                    lambda: make_yaml().load(StringIO(new_content))
+                )
             except YAMLError as err:
                 return {
                     "success": False,

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -417,9 +417,7 @@ def _build_edit_yaml_config_handler(hass):
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 safe_name = normalized.replace(os.sep, "_")
                 backup_file = backup_dir / f"{safe_name}.{timestamp}.bak"
-                await hass.async_add_executor_job(
-                    backup_file.write_text, raw_content
-                )
+                await hass.async_add_executor_job(backup_file.write_text, raw_content)
                 backup_path_str = str(backup_file.relative_to(config_dir))
                 _LOGGER.info("Backup created: %s", backup_path_str)
 
@@ -457,7 +455,9 @@ def _build_edit_yaml_config_handler(hass):
                 if action == "add":
                     if url_path in dashboards:
                         existing = dashboards[url_path]
-                        if isinstance(existing, dict) and isinstance(parsed_content, dict):
+                        if isinstance(existing, dict) and isinstance(
+                            parsed_content, dict
+                        ):
                             existing.update(parsed_content)
                         else:
                             return {
@@ -493,9 +493,13 @@ def _build_edit_yaml_config_handler(hass):
                     if yaml_key in data:
                         existing = data[yaml_key]
                         # Merge: list extends list, dict merges dict
-                        if isinstance(existing, list) and isinstance(parsed_content, list):
+                        if isinstance(existing, list) and isinstance(
+                            parsed_content, list
+                        ):
                             data[yaml_key] = existing + parsed_content
-                        elif isinstance(existing, dict) and isinstance(parsed_content, dict):
+                        elif isinstance(existing, dict) and isinstance(
+                            parsed_content, dict
+                        ):
                             existing.update(parsed_content)
                         else:
                             return {

--- a/custom_components/ha_mcp_tools/yaml_rt.py
+++ b/custom_components/ha_mcp_tools/yaml_rt.py
@@ -73,11 +73,21 @@ def _register_ha_tags() -> None:
 _register_ha_tags()
 
 
+_CACHED_YAML: YAML | None = None
+
+
 def make_yaml() -> YAML:
-    """Return a fresh round-trip YAML instance with HA tag support."""
-    ry = YAML(typ="rt")
-    ry.preserve_quotes = True
-    return ry
+    """Return a round-trip YAML instance with HA tag support.
+
+    The instance is cached to prevent ruamel.yaml from performing
+    expensive plugin discovery (glob/scandir) on every call, which
+    causes CPU spikes and event loop blocking during bulk edits.
+    """
+    global _CACHED_YAML
+    if _CACHED_YAML is None:
+        _CACHED_YAML = YAML(typ="rt")
+        _CACHED_YAML.preserve_quotes = True
+    return _CACHED_YAML
 
 
 def yaml_dumps(ry: YAML, data: Any) -> str:

--- a/custom_components/ha_mcp_tools/yaml_rt.py
+++ b/custom_components/ha_mcp_tools/yaml_rt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from io import StringIO
 from typing import Any
 
@@ -73,21 +74,24 @@ def _register_ha_tags() -> None:
 _register_ha_tags()
 
 
-_CACHED_YAML: YAML | None = None
+_THREAD_LOCAL = threading.local()
 
 
 def make_yaml() -> YAML:
     """Return a round-trip YAML instance with HA tag support.
 
-    The instance is cached to prevent ruamel.yaml from performing
+    The instance is cached per-thread to prevent ruamel.yaml from performing
     expensive plugin discovery (glob/scandir) on every call, which
     causes CPU spikes and event loop blocking during bulk edits.
+
+    Thread-local storage is used because ruamel.yaml instances are not
+    thread-safe.
     """
-    global _CACHED_YAML
-    if _CACHED_YAML is None:
-        _CACHED_YAML = YAML(typ="rt")
-        _CACHED_YAML.preserve_quotes = True
-    return _CACHED_YAML
+    if not hasattr(_THREAD_LOCAL, "yaml"):
+        ry = YAML(typ="rt")
+        ry.preserve_quotes = True
+        _THREAD_LOCAL.yaml = ry
+    return _THREAD_LOCAL.yaml
 
 
 def yaml_dumps(ry: YAML, data: Any) -> str:

--- a/tests/src/unit/test_yaml_roundtrip.py
+++ b/tests/src/unit/test_yaml_roundtrip.py
@@ -10,11 +10,13 @@ import pytest
 
 # Mock Home Assistant imports so the package __init__ can be loaded.
 sys.modules["voluptuous"] = MagicMock()
-sys.modules["homeassistant"] = MagicMock()
-sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
-sys.modules["homeassistant.helpers"] = MagicMock()
-sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
+homeassistant = MagicMock()
+sys.modules["homeassistant"] = homeassistant
+sys.modules["homeassistant.components"] = homeassistant.components
+sys.modules["homeassistant.config_entries"] = homeassistant.config_entries
+sys.modules["homeassistant.core"] = homeassistant.core
+sys.modules["homeassistant.helpers"] = homeassistant.helpers
+sys.modules["homeassistant.helpers.config_validation"] = homeassistant.helpers.config_validation
 
 from custom_components.ha_mcp_tools.yaml_rt import (  # noqa: E402
     _TaggedScalar,

--- a/tests/src/unit/test_yaml_rt_singleton.py
+++ b/tests/src/unit/test_yaml_rt_singleton.py
@@ -17,7 +17,9 @@ sys.modules["homeassistant.components"] = homeassistant.components
 sys.modules["homeassistant.config_entries"] = homeassistant.config_entries
 sys.modules["homeassistant.core"] = homeassistant.core
 sys.modules["homeassistant.helpers"] = homeassistant.helpers
-sys.modules["homeassistant.helpers.config_validation"] = homeassistant.helpers.config_validation
+sys.modules["homeassistant.helpers.config_validation"] = (
+    homeassistant.helpers.config_validation
+)
 
 from custom_components.ha_mcp_tools.yaml_rt import (  # noqa: E402
     _THREAD_LOCAL,

--- a/tests/src/unit/test_yaml_rt_singleton.py
+++ b/tests/src/unit/test_yaml_rt_singleton.py
@@ -1,0 +1,70 @@
+"""Unit tests for the YAML singleton behavior in yaml_rt."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ruamel.yaml import YAML
+
+# Mock Home Assistant imports so the package __init__ can be loaded.
+sys.modules["voluptuous"] = MagicMock()
+homeassistant = MagicMock()
+sys.modules["homeassistant"] = homeassistant
+sys.modules["homeassistant.components"] = homeassistant.components
+sys.modules["homeassistant.config_entries"] = homeassistant.config_entries
+sys.modules["homeassistant.core"] = homeassistant.core
+sys.modules["homeassistant.helpers"] = homeassistant.helpers
+sys.modules["homeassistant.helpers.config_validation"] = homeassistant.helpers.config_validation
+
+from custom_components.ha_mcp_tools.yaml_rt import (  # noqa: E402
+    _THREAD_LOCAL,
+    make_yaml,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_thread_local():
+    """Ensure the thread-local storage is clean before each test."""
+    if hasattr(_THREAD_LOCAL, "yaml"):
+        del _THREAD_LOCAL.yaml
+    yield
+    if hasattr(_THREAD_LOCAL, "yaml"):
+        del _THREAD_LOCAL.yaml
+
+
+def test_make_yaml_singleton_in_same_thread():
+    """Verify that make_yaml returns the same instance when called multiple times in one thread."""
+    # We patch YAML constructor to count instantiations.
+    # Since YAML is a class, we patch its __init__.
+    with patch.object(YAML, "__init__", return_value=None) as mock_init:
+        y1 = make_yaml()
+        y2 = make_yaml()
+
+        assert y1 is y2
+        assert mock_init.call_count == 1
+
+
+def test_make_yaml_singleton_per_thread():
+    """Verify that make_yaml returns different instances for different threads."""
+    instances = {}
+
+    def worker(name):
+        instances[name] = make_yaml()
+
+    with patch.object(YAML, "__init__", return_value=None) as mock_init:
+        t1 = threading.Thread(target=worker, args=("t1",))
+        t2 = threading.Thread(target=worker, args=("t2",))
+
+        t1.start()
+        t1.join()
+        t2.start()
+        t2.join()
+
+        assert "t1" in instances
+        assert "t2" in instances
+        assert instances["t1"] is not instances["t2"]
+        # One instantiation per thread
+        assert mock_init.call_count == 2


### PR DESCRIPTION
## What does this PR do?

This PR implements a thread-local singleton cache for the ruamel.yaml instance in the `ha_mcp_tools` custom component, and wraps all `ry.load` and `yaml_dumps` calls in `hass.async_add_executor_job`. 

Previously, a fresh instance was created on every `ha_config_set_yaml` call, triggering expensive plugin discovery (glob/scandir) which blocked the asyncio event loop and caused CPU spikes in bulk edit scenarios. By caching the instance and offloading the heavy YAML parsing/dumping to the executor thread pool, this PR completely resolves #1370.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
