### PR TITLE
docs: extend weasel-phrase list with variants; clarify semantic match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,13 +357,13 @@ When you notice something while working on a PR, apply this scale:
 
 If any are false: fix it now, or let it go. **Do not file an issue to "track" it.**
 
-These phrases are escape hatches that signal the AI is making a scope decision the user should make instead. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
+These phrases — and **any semantically equivalent variant** — are escape hatches that signal the AI is making a scope decision the user should make instead. The list below is non-exhaustive; match on intent, not exact string. When you find yourself drafting any of them, treat it as a cue to re-apply the rules in this section before continuing:
 
-- "Post-merge follow-up" / "follow-up consideration"
+- "Post-merge follow-up" / "follow-up consideration" / "forward-looking note"
 - "Nice to have"
 - "Happy to file an issue (or note in PR body)"
 - "Pre-existing — not touching it" (pre-existing is not a reason to skip; addressing pre-existing things is the point of the Boy Scout Rule)
-- "Out of scope for this PR" (used as an assertion to skip — not as a question to the user via the verification template below)
+- "Out of scope for this PR" / "not blocking this PR" (used as an assertion to skip — not as a question to the user via the verification template below)
 - "Real design work, not N lines"
 - "Worth tracking as a real follow-up issue rather than buried in a comment"
 


### PR DESCRIPTION
## What does this PR do?

Extends the weasel-phrase list in AGENTS.md §*Boy Scout Rule — Handling Discovered Improvements* with two common variants that were being missed by literal-string pattern-matching, and clarifies that the list applies to semantically equivalent phrases.

Specifically:
- Adds `"forward-looking note"` to the "Post-merge follow-up" / "follow-up consideration" line
- Adds `"not blocking this PR"` to the "Out of scope for this PR" line
- Reframes the intro paragraph: *"These phrases — and **any semantically equivalent variant** — are escape hatches… The list below is non-exhaustive; match on intent, not exact string."*

**Why:** Reviews on this repo have been using \"Forward-looking note (not blocking this PR)\" framing that's semantically identical to existing list entries but doesn't trigger a literal pattern-match. A literal-minded AI reviewer checking against the list won't catch it. Closes the loophole without changing the underlying rule.

## Type of change
- [x] 📚 Documentation
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`)
- [ ] Code follows style guidelines (\`uv run ruff check\`)

Markdown-only change; no code paths affected. ruff/mypy/pytest do not apply.

## Checklist
- [x] I have updated documentation if needed