### PR TITLE
test(haos-e2e): slim addon set + real-addon ha_manage_addon coverage (closes #1350)

### DIFF
--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -149,10 +149,15 @@ jobs:
         # v1: targets src/e2e/haos_only/ only (canary tier). Widen via
         # workflow_dispatch pytest_paths input once the inaddon plumbing
         # is stable. external_only-marked tests skip automatically.
+        #
+        # -n2 --dist loadscope: pytest-xdist parallelizes across 2 workers,
+        # each booting its own QEMU (per-worker port offset + qcow2 overlay
+        # — see _haos_worker_setup in tests/src/e2e/conftest.py). Same
+        # rationale as the external HAOS workflow (#1350).
         run: |
           cd tests
           uv run pytest ${{ github.event.inputs.pytest_paths || 'src/e2e/' }} \
-            -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
+            -n2 --dist loadscope -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
         env:
           HAMCP_ENV_FILE: "tests/.env.test"
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -182,11 +182,18 @@ jobs:
         # that need testcontainer-specific behavior (file mounts, etc.)
         # are marked container_only and skip automatically.
         #
+        # -n2 --dist loadscope: pytest-xdist parallelizes across 2 workers,
+        # each booting its own QEMU (per-worker port offset + qcow2 overlay
+        # — see _haos_worker_setup in tests/src/e2e/conftest.py). loadscope
+        # keeps all tests in the same module on the same worker so each
+        # worker amortizes its boot cost. 4-vCPU/16-GB runner fits 2x
+        # QEMU at -smp 2 -m 4096 each (#1350).
+        #
         # --maxfail=0 overrides pytest.ini's --maxfail=3 so we see the full
         # failure surface for triage — early-terminating loses signal.
         run: |
           cd tests
-          uv run pytest src/e2e/ -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
+          uv run pytest src/e2e/ -n2 --dist loadscope -v --tb=short --maxfail=0 ${{ github.event.inputs.pytest_args }}
         env:
           HAMCP_ENV_FILE: "tests/.env.test"
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -92,34 +92,59 @@ class Addon:
     start: bool = True
 
 
-# v1 addon set — see #1281 comment thread for rationale. Configuring each
-# addon with real options (certs, serial coordinators, camera streams,
-# etc.) is deferred to follow-up commits; v1 just bakes them into the image
-# so tests can install + start with custom configs at runtime.
+# HAOS addon set — chosen for minimum image size while covering every
+# ``ha_manage_addon`` access shape exercised by the E2E tier (closes
+# #1350). Each entry below names the unique shape it contributes; if a
+# new addon doesn't add a shape that no other entry covers, it does not
+# belong here.
 #
-# Frigate stays in: it's the only one of the v1 set with the
-# ingress + ingress_panel=false + webui-set + full_access shape that
-# ha_manage_addon needs coverage for. Cost is real (~2 GB qcow2 footprint,
-# ~80s install, extra Docker registry dependency), but the testing surface
-# it covers isn't available from the other addons.
+# Shape coverage matrix:
+#   ┌──────────────────────┬────────────────────────────────────────────────┐
+#   │ Addon                │ Unique shape contribution                       │
+#   ├──────────────────────┼────────────────────────────────────────────────┤
+#   │ Mosquitto broker     │ core repo, ingress=false service, start-fail   │
+#   │ Node-RED             │ ingress=true + ingress_panel=true + manager    │
+#   │                      │ role + nested schema + /flows array-patch      │
+#   │ ESPHome Device       │ ingress=true + UART + discovery hint +         │
+#   │   Builder            │ WebSocket proxy (/compile, /validate)          │
+#   │ Matter Server        │ ingress=true + ingress_panel=false (hidden     │
+#   │                      │ sidebar) + host_dbus — core repo, ~50 MB,      │
+#   │                      │ replaces Frigate's ~2 GB hidden-panel coverage │
+#   │ AppDaemon            │ ingress=false + webui set (port-based UI       │
+#   │                      │ without Ingress)                               │
+#   │ MQTT IO              │ privileged block + start-fail (no broker       │
+#   │                      │ configured) — replaces Z2M's start-fail        │
+#   │                      │ coverage at a fraction of the size             │
+#   └──────────────────────┴────────────────────────────────────────────────┘
+#
+# Dropped vs the original #1281 set: Frigate (~2 GB) and Zigbee2MQTT (~220
+# MB compressed). Their shapes are covered by Matter Server, AppDaemon,
+# and MQTT IO at ~120 MB total — net savings ~2 GB after extraction.
 #
 # start=False addons fail to start without config and would block the build:
 #   - Mosquitto: schema requires require_certificate + cert paths
-#   - Z2M: needs a real or mocked serial coordinator
-#   - Frigate: needs at least one camera defined
+#   - MQTT IO: needs a configured MQTT broker connection
 ADDONS: tuple[Addon, ...] = (
     Addon(repo=None, name="Mosquitto broker", start=False),
     Addon(repo="https://github.com/hassio-addons/repository", name="Node-RED"),
     # Official ESPHome repo addon is named "ESPHome Device Builder"; match by
     # the unique part of the name so dev/beta variants don't shadow stable.
     Addon(repo="https://github.com/esphome/home-assistant-addon", name="ESPHome Device Builder"),
-    Addon(repo="https://github.com/zigbee2mqtt/hassio-zigbee2mqtt",
-          name="Zigbee2MQTT", start=False),
-    # Frigate repo ships "Frigate", "Frigate (Full Access)", "Frigate Beta",
-    # "Frigate (Full Access) Beta" — plain "Frigate" is enough for the canary;
-    # full-access variant only needed if tests need to mount camera devices.
-    Addon(repo="https://github.com/blakeblackshear/frigate-hass-addons",
-          name="Frigate", start=False),
+    # Matter Server is in the official ``core`` repo (no repo URL needed) and
+    # is one of the very few addons that ship with ``ingress_panel=false``,
+    # which is the canonical "hidden sidebar" shape that ``ha_get_addon``
+    # detail needs coverage for.
+    Addon(repo=None, name="Matter Server"),
+    # AppDaemon contributes the ``ingress=false`` + ``webui`` shape: a port-
+    # based UI advertised through the Supervisor ``webui`` field rather than
+    # Ingress. The wire contract for ``ha_get_addon`` reading ``webui`` and
+    # rendering it as a clickable URL is otherwise uncovered.
+    Addon(repo="https://github.com/hassio-addons/repository", name="AppDaemon"),
+    # MQTT IO replaces Zigbee2MQTT for start-fail coverage. Its schema
+    # requires a configured MQTT broker; with no broker the addon refuses
+    # to start, exercising the same Supervisor reject path Z2M used to.
+    Addon(repo="https://github.com/hassio-addons/repository",
+          name="MQTT IO", start=False),
 )
 
 # Get HACS addon — bootstraps HACS into /config/custom_components/.

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1089,10 +1089,12 @@ def _haos_worker_setup(base_image_path: Path) -> Path:
     is ``"master"`` and we keep the base ports + base image path — same
     behavior as before the parallel work.
 
-    Returns the image path the worker should hand to QEMU. For
-    parallel runs that's a qcow2 overlay backed by ``base_image_path``;
-    libguestfs writes follow the backing chain so the recorder-refresh
-    and dev-addon staging helpers mutate only the overlay.
+    Per-worker qcow2 is a backing-file overlay rather than a full
+    reflink copy: GitHub-hosted Linux runners are ext4 (no reflink),
+    so ``cp --reflink=auto`` falls back to a real 12 GB copy that
+    overflows the runner's 14 GB SSD when multiplied across workers.
+    The overlay is tiny at creation (~200 KB) and grows only as the
+    worker mutates state on top of the shared read-only base.
     """
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
     # pytest-xdist worker IDs are ``gw0``/``gw1``/.../``gwN``. ``master``
@@ -1118,9 +1120,6 @@ def _haos_worker_setup(base_image_path: Path) -> Path:
     )
     if overlay_path.exists():
         overlay_path.unlink()
-    # qcow2-backed overlay: empty file pointing at the base image. Writes
-    # land in the overlay; reads fall through to the base. Tiny on disk
-    # at creation (~200 KB), grows only as the worker mutates state.
     subprocess.run(
         [
             "qemu-img",
@@ -1236,6 +1235,48 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     SUN_WAIT,
                     last_sun_status,
                     last_sun_err,
+                )
+            # Sun.sun ready means all *integrations* finished setup, but
+            # the demo platform that registers ``light.bed_light`` and the
+            # other seeded fixtures publishes its initial states *after*
+            # its integration's async_setup returns — the recorder + state
+            # machine writes are scheduled tasks. Under the parallel
+            # HAOS run (-n2) the first test on each worker hits the search
+            # / state API before those tasks complete, and search returns
+            # ``total_matches=0`` for ``light`` (verified on PR #1379 CI
+            # run 26130708983 diagnostics: core.entity_registry has all 6
+            # lights, but the state machine had no light.* entries at the
+            # moment the test fired). Poll for one of the known seeded
+            # light entities so downstream tests don't race.
+            light_url = f"{base_url}/api/states/light.bed_light"
+            LIGHT_WAIT = 60
+            light_start = time.monotonic()
+            last_light_status: int | None = None
+            while time.monotonic() - light_start < LIGHT_WAIT:
+                try:
+                    light_resp = requests.get(
+                        light_url, timeout=5, headers=haos_headers
+                    )
+                    last_light_status = light_resp.status_code
+                    if light_resp.status_code == 200:
+                        elapsed = time.monotonic() - light_start
+                        logger.info(
+                            "✅ HAOS light.bed_light is in state machine after %.1fs",
+                            elapsed,
+                        )
+                        break
+                except (
+                    requests.exceptions.RequestException,
+                    json.JSONDecodeError,
+                ):
+                    pass
+                time.sleep(1)
+            else:
+                logger.warning(
+                    "⚠️ HAOS light.bed_light still not in state machine after "
+                    "%ds (last_status=%s) — search / state tests may race",
+                    LIGHT_WAIT,
+                    last_light_status,
                 )
             # Set HA Core's default backup-create password via WS so
             # ha_backup_create tests pass without a pre-baked seed. Must

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -24,6 +24,7 @@ import os
 import shlex
 import shutil
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import threading
@@ -216,7 +217,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     # and a follow-up gate would be justified. ``snapshot_ok=False``
     # samples are skipped (sentinel zeros, not real data).
     drift_samples = [
-        p for p in timings
+        p
+        for p in timings
         if p.get("gate") == "core_state"
         and p.get("snapshot_ok")
         and p.get("entries_loaded", 0) < p.get("entries_total", 0)
@@ -717,7 +719,9 @@ def _snapshot_config_entries(
             )
             return 0, 0, False
         total = len(entries)
-        loaded = sum(1 for e in entries if isinstance(e, dict) and e.get("state") == "loaded")
+        loaded = sum(
+            1 for e in entries if isinstance(e, dict) and e.get("state") == "loaded"
+        )
         return loaded, total, True
     except (_requests.exceptions.RequestException, json.JSONDecodeError) as exc:
         logger.debug(f"snapshot_config_entries: {type(exc).__name__}: {exc}")
@@ -892,11 +896,17 @@ def _dump_ha_readiness_diagnostics(
         if entries_resp.status_code == 200:
             entries = entries_resp.json()
             entry_domains = sorted(
-                {e.get("domain") for e in entries if isinstance(e, dict) and e.get("domain")}
+                {
+                    e.get("domain")
+                    for e in entries
+                    if isinstance(e, dict) and e.get("domain")
+                }
             )
             if config_entry_domain:
                 matching = [
-                    e for e in entries if isinstance(e, dict) and e.get("domain") == config_entry_domain
+                    e
+                    for e in entries
+                    if isinstance(e, dict) and e.get("domain") == config_entry_domain
                 ]
                 if matching:
                     for entry in matching:
@@ -1069,6 +1079,72 @@ def _blueprint_http_server():
         srv.shutdown()
 
 
+def _haos_worker_setup(base_image_path: Path) -> Path:
+    """Allocate per-worker ports + qcow2 overlay for parallel HAOS runs (#1350).
+
+    Each pytest-xdist worker gets its own QEMU instance, so it needs its
+    own port set (otherwise hostfwd collides on bind) and its own
+    writable qcow2 (otherwise the recorder-refresh + dev-addon-staging
+    mutations race). On a single-worker (no ``-n``) run, ``worker_id``
+    is ``"master"`` and we keep the base ports + base image path — same
+    behavior as before the parallel work.
+
+    Returns the image path the worker should hand to QEMU. For
+    parallel runs that's a qcow2 overlay backed by ``base_image_path``;
+    libguestfs writes follow the backing chain so the recorder-refresh
+    and dev-addon staging helpers mutate only the overlay.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    # pytest-xdist worker IDs are ``gw0``/``gw1``/.../``gwN``. ``master``
+    # (no ``-n``) gets offset 0, identical to the pre-parallel behavior.
+    if worker_id.startswith("gw") and worker_id[2:].isdigit():
+        worker_idx = int(worker_id[2:])
+    else:
+        worker_idx = 0
+    # +100 per worker is large enough that none of the four port sets
+    # (HA / SSH / addon MCP / SSH-debug) collide between adjacent
+    # workers, even after future port additions.
+    offset = worker_idx * 100
+    os.environ["HAOS_TEST_HA_PORT"] = str(18123 + offset)
+    os.environ["HAOS_TEST_SSH_PORT"] = str(12222 + offset)
+    os.environ["HAOS_TEST_ADDON_PORT"] = str(19583 + offset)
+    os.environ["HAOS_TEST_SSH_DEBUG_PORT"] = str(22222 + offset)
+    if worker_idx == 0 and worker_id == "master":
+        # Single-worker run — no overlay needed, mutate the base image
+        # directly (matches the pre-parallel path).
+        return base_image_path
+    overlay_path = base_image_path.with_name(
+        f"{base_image_path.stem}-{worker_id}{base_image_path.suffix}"
+    )
+    if overlay_path.exists():
+        overlay_path.unlink()
+    # qcow2-backed overlay: empty file pointing at the base image. Writes
+    # land in the overlay; reads fall through to the base. Tiny on disk
+    # at creation (~200 KB), grows only as the worker mutates state.
+    subprocess.run(
+        [
+            "qemu-img",
+            "create",
+            "-f",
+            "qcow2",
+            "-F",
+            "qcow2",
+            "-b",
+            str(base_image_path),
+            str(overlay_path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    logger.info(
+        "HAOS parallel: worker %s using port offset %d, overlay qcow2 %s",
+        worker_id,
+        offset,
+        overlay_path,
+    )
+    return overlay_path
+
+
 @pytest.fixture(scope="session")
 def ha_container_with_fresh_config(_blueprint_http_server):
     """Create Home Assistant test environment with fresh config.
@@ -1082,8 +1158,12 @@ def ha_container_with_fresh_config(_blueprint_http_server):
     """
     # HAOS backend dispatch — short-circuit the testcontainer path entirely.
     if is_haos_backend_selected():
-        image_path = Path(os.environ[HAOS_IMAGE_ENV])
+        base_image_path = Path(os.environ[HAOS_IMAGE_ENV])
         inaddon = is_haos_inaddon_mode()
+        # Per-worker port + overlay setup for pytest-xdist parallel HAOS
+        # (#1350). Single-worker runs short-circuit and reuse the base
+        # image path unchanged.
+        image_path = _haos_worker_setup(base_image_path)
         logger.info(
             "HAOS backend selected (mode=%s) — booting qcow2 at %s",
             "inaddon" if inaddon else "external",
@@ -1128,9 +1208,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
             last_sun_status: int | None = None
             while time.monotonic() - sun_start < SUN_WAIT:
                 try:
-                    sun_resp = requests.get(
-                        sun_url, timeout=5, headers=haos_headers
-                    )
+                    sun_resp = requests.get(sun_url, timeout=5, headers=haos_headers)
                     last_sun_status = sun_resp.status_code
                     if sun_resp.status_code == 200:
                         sun_state = sun_resp.json().get("state", "unknown")
@@ -1155,7 +1233,9 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     "⚠️ HAOS sun.sun still not ready after %ds "
                     "(last_status=%s, last_exc=%r) — template / connection "
                     "tests may race",
-                    SUN_WAIT, last_sun_status, last_sun_err,
+                    SUN_WAIT,
+                    last_sun_status,
+                    last_sun_err,
                 )
             # Set HA Core's default backup-create password via WS so
             # ha_backup_create tests pass without a pre-baked seed. Must
@@ -1234,8 +1314,14 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 log_dest = Path("/tmp/haos-diagnostics")
                 log_dest.mkdir(parents=True, exist_ok=True)
                 log_endpoints = [
-                    ("ha-core-runtime.log", f"{base_url}/api/hassio/core/logs?lines=20000"),
-                    ("supervisor-runtime.log", f"{base_url}/api/hassio/supervisor/logs?lines=20000"),
+                    (
+                        "ha-core-runtime.log",
+                        f"{base_url}/api/hassio/core/logs?lines=20000",
+                    ),
+                    (
+                        "supervisor-runtime.log",
+                        f"{base_url}/api/hassio/supervisor/logs?lines=20000",
+                    ),
                 ]
                 # Inaddon mode: also grab the dev addon container's logs —
                 # often the real "Check Supervisor logs for details" detail
@@ -1245,8 +1331,10 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 # hassio/http.py).
                 if inaddon:
                     log_endpoints.append(
-                        ("ha-mcp-dev-addon.log",
-                         f"{base_url}/api/hassio/addons/{HA_MCP_DEV_ADDON_SLUG}/logs?lines=20000"),
+                        (
+                            "ha-mcp-dev-addon.log",
+                            f"{base_url}/api/hassio/addons/{HA_MCP_DEV_ADDON_SLUG}/logs?lines=20000",
+                        ),
                     )
                 # Narrow except: any non-network error (NameError, KeyError
                 # from a future refactor) should propagate instead of being
@@ -1255,13 +1343,18 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 for name, url in log_endpoints:
                     try:
                         req = urllib.request.Request(
-                            url, headers={"Authorization": f"Bearer {token}"},
+                            url,
+                            headers={"Authorization": f"Bearer {token}"},
                         )
                         with urllib.request.urlopen(req, timeout=60) as resp:
                             (log_dest / name).write_bytes(resp.read())
                         logger.info("Dumped %s via supervisor", name)
-                    except (OSError, urllib.error.URLError,
-                            urllib.error.HTTPError, TimeoutError) as exc:
+                    except (
+                        OSError,
+                        urllib.error.URLError,
+                        urllib.error.HTTPError,
+                        TimeoutError,
+                    ) as exc:
                         logger.warning("Failed to dump %s: %s", name, exc)
         return
 

--- a/tests/src/e2e/haos_only/test_addon_lifecycle.py
+++ b/tests/src/e2e/haos_only/test_addon_lifecycle.py
@@ -1,25 +1,21 @@
-"""Addon lifecycle E2E for the HAOS test tier (see #1349 items 1 + 3).
+"""Addon lifecycle E2E for the HAOS test tier (see #1349 items 1 + 3, #1350).
 
 Covers what the testcontainer suite physically can't reach — start/stop/
 restart against a real Supervisor, addon-config round-trips, and
-container-log shape — for the v1 addon set baked by ``build_image.py``.
+container-log shape — for the addon set baked by ``build_image.py``.
 
 Two coverage modes:
 
-1. **Running addons** (Node-RED, ESPHome Device Builder — both flipped to
-   ``start=True`` in the bake): full lifecycle round-trip plus
-   options-get / options-set persistence and a log-shape check. Each
-   test leaves the addon in ``started`` state via an explicit cleanup
-   call so later tests in the same session find it running.
+1. **Running addons** (Node-RED, ESPHome Device Builder, Matter Server,
+   AppDaemon — all ``start=True`` in the bake): full lifecycle round-trip
+   plus options-get / options-set persistence and a log-shape check.
+   Each test leaves the addon in ``started`` state via an explicit
+   cleanup call so later tests in the same session find it running.
 
-2. **Stopped addons** (Frigate, Zigbee2MQTT — stay ``start=False`` because
-   their schemas require feeders/devices that don't exist in the bake):
-   exercise the surface that's reachable *without* the addon running —
-   ``ha_get_addon`` info + options dict + a logs-fetch shape check — and
-   prove that ``hassio.addon_start`` returns a structured failure when the
-   addon can't satisfy its own config schema. No ``pytest.skip()`` calls
-   (per #1349 closeout rule); the tests run and assert the
-   stopped-addon shape directly.
+2. **Stopped addons** (Mosquitto, MQTT IO — stay ``start=False`` because
+   their schemas require config they don't have in the bake): exercise
+   the surface that's reachable *without* the addon running —
+   ``ha_get_addon`` info + options dict + a logs-fetch shape check.
 
 Slugs are repository-hash-derived by Supervisor at install time, so every
 test resolves the slug at runtime by matching against ``ha_get_addon``'s
@@ -57,8 +53,10 @@ pytestmark = [pytest.mark.haos_only]
 # ``build_image.py``'s ADDONS tuple). Slugs are looked up dynamically.
 NODERED_NAME = "Node-RED"
 ESPHOME_NAME = "ESPHome Device Builder"
-FRIGATE_NAME = "Frigate"
-Z2M_NAME = "Zigbee2MQTT"
+MATTER_NAME = "Matter Server"
+APPDAEMON_NAME = "AppDaemon"
+MQTT_IO_NAME = "MQTT IO"
+MOSQUITTO_NAME = "Mosquitto broker"
 
 # Supervisor reports a variety of values for an addon that's installed
 # but not running — exact value depends on whether the last attempted
@@ -458,92 +456,218 @@ async def test_esphome_logs_fetch_shape(mcp_client: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Frigate reachable-without-running (stays start=False in bake)
+# Matter Server lifecycle (running; covers ingress_panel=false shape)
 # ---------------------------------------------------------------------------
 
 
-async def test_frigate_info_and_options_reachable(mcp_client: Any) -> None:
-    """Frigate is installed-but-stopped; info / options / logs still reachable.
+async def test_matter_server_start_stop_restart_roundtrip(mcp_client: Any) -> None:
+    """Stop → start → restart cycles Matter Server via real Supervisor.
 
-    The schema for Frigate requires at least one camera config block we
-    can't reasonably stub in the bake, so the addon never reaches the
-    ``started`` state. The Supervisor-managed metadata (info dict, the
-    options stub, the boot-fail log) is still queryable, and tests for
-    those endpoints are the whole point of including Frigate in the v1
-    addon set: they prove the tools handle the not-running case without
-    falling back to "addon must be started" errors.
+    Matter Server is the addon set's representative of the
+    ``ingress_panel=false`` shape (hidden from the HA sidebar even though
+    Ingress is wired up). The lifecycle contract is the same as the other
+    running addons; the shape coverage comes from ``ha_get_addon`` detail.
     """
-    slug = await _resolve_slug(mcp_client, FRIGATE_NAME)
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
+    try:
+        stop_result = await _addon_action(mcp_client, slug, "stop")
+        assert stop_result.get("success"), (
+            f"hassio.addon_stop({slug}) failed: {stop_result}"
+        )
+        await _wait_for_state(mcp_client, slug, STOPPED_STATES)
 
+        start_result = await _addon_action(mcp_client, slug, "start")
+        assert start_result.get("success"), (
+            f"hassio.addon_start({slug}) failed: {start_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+    finally:
+        await _ensure_started(mcp_client, slug)
+
+
+async def test_matter_server_ingress_panel_false_shape(mcp_client: Any) -> None:
+    """`ha_get_addon(slug=...)` reports ``ingress_panel=false`` for Matter Server.
+
+    This is the load-bearing assertion for keeping Matter Server in the
+    addon set: it's the only one whose Ingress route is configured but
+    deliberately hidden from the HA sidebar (``ingress_panel=false``),
+    and ``ha_get_addon`` detail must surface that field. If a future
+    Supervisor version drops the field or renames it, this test catches
+    it before regression hits real users.
+    """
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
     detail = await _get_addon_detail(mcp_client, slug)
-    assert detail.get("state") in STOPPED_STATES, (
-        f"Frigate should be in a stopped-family state, got "
-        f"{detail.get('state')!r}. Did build_image.py accidentally flip it "
-        f"to start=True?"
+    assert detail.get("ingress") is True, (
+        f"Matter Server should have ingress=True, got {detail.get('ingress')!r}"
+    )
+    assert detail.get("ingress_panel") is False, (
+        f"Matter Server should have ingress_panel=False (hidden sidebar), "
+        f"got {detail.get('ingress_panel')!r}"
     )
 
-    options = detail.get("options")
-    assert isinstance(options, dict), (
-        f"Frigate options should be a dict even when stopped, got "
-        f"{type(options).__name__}: {options!r}"
-    )
 
+async def test_matter_server_options_set_persists(mcp_client: Any) -> None:
+    """`ha_manage_addon(options=...)` round-trips a probe key for Matter Server.
+
+    Matter Server's schema accepts ``beta`` (boolean toggle) — safe to
+    flip between True and False as a probe value.
+    """
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
+    try:
+        detail = await _get_addon_detail(mcp_client, slug)
+        current_options = detail.get("options") or {}
+        assert isinstance(current_options, dict), (
+            f"Pre-write options must be a dict, got {current_options!r}"
+        )
+        probe_key = "beta"
+        original_value = current_options.get(probe_key, False)
+        probe_value = not bool(original_value)
+        probe_options = dict(current_options)
+        probe_options[probe_key] = probe_value
+
+        try:
+            write_raw = await mcp_client.call_tool(
+                "ha_manage_addon",
+                {"slug": slug, "options": probe_options},
+            )
+            write_payload = parse_mcp_result(write_raw)
+            ok = write_payload.get("success") is True or (
+                write_payload.get("status") == "pending_restart"
+            )
+            assert ok, (
+                f"ha_manage_addon options probe write failed: {write_payload}"
+            )
+
+            detail_after = await _get_addon_detail(mcp_client, slug)
+            options_after = detail_after.get("options") or {}
+            assert options_after.get(probe_key) == probe_value, (
+                f"Probe {probe_key}={probe_value!r} did not persist. "
+                f"After-write options: {options_after}"
+            )
+        finally:
+            try:
+                await mcp_client.call_tool(
+                    "ha_manage_addon",
+                    {"slug": slug, "options": dict(current_options)},
+                )
+            except Exception:
+                LOG.exception("Failed to restore Matter Server options")
+    finally:
+        await _ensure_started(mcp_client, slug)
+
+
+async def test_matter_server_logs_fetch_shape(mcp_client: Any) -> None:
+    """`ha_get_logs(source='supervisor')` returns shaped log text for Matter Server."""
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
     raw = await mcp_client.call_tool(
         "ha_get_logs", {"source": "supervisor", "slug": slug}
     )
     payload = parse_mcp_result(raw)
-    assert payload.get("success"), (
-        f"ha_get_logs(supervisor, {slug}) should succeed for an installed "
-        f"stopped addon, got: {payload}"
-    )
+    assert payload.get("success"), f"ha_get_logs(supervisor, {slug}) failed: {payload}"
     log_text = payload.get("log", "")
-    assert isinstance(log_text, str), (
-        f"log field must be a string, got {type(log_text).__name__}"
+    assert isinstance(log_text, str) and len(log_text.strip()) >= 50, (
+        f"Supervisor log for running Matter Server should have content "
+        f"(>=50 chars), got {len(log_text)} chars: {log_text[:200]!r}"
     )
-    # A stopped addon's log can legitimately be empty (never started) OR
-    # contain boot-fail output. Accept either; only assert the journald
-    # timestamp shape when there's content to check.
-    # Don't assert content beyond "is a string" — a stopped addon's log
-    # can legitimately be empty or contain only s6-rc startup spam.
-
-
-# NOTE: ``test_frigate_start_fails_with_recognizable_error`` and the
-# corresponding Z2M test (deleted in this commit) were aspirational —
-# they tried to assert that Supervisor rejects ``addon_start`` with a
-# specific error shape when the addon's config is incomplete. In
-# practice Supervisor's wording varies by addon version and by which
-# of (missing-config / missing-device / failed-image-pull) tripped
-# first; the assertion shape (slug + token-list intersection) was
-# brittle against that variance and provided weak coverage anyway —
-# the addon being installed + reachable is already proven by the
-# ``_info_and_options_reachable`` test above. Dropping rather than
-# trying to write a content-tolerant assertion.
 
 
 # ---------------------------------------------------------------------------
-# Zigbee2MQTT reachable-without-running (stays start=False in bake)
+# AppDaemon lifecycle (running; covers ingress=false + webui-set shape)
 # ---------------------------------------------------------------------------
 
 
-async def test_zigbee2mqtt_info_and_options_reachable(mcp_client: Any) -> None:
-    """Zigbee2MQTT is installed-but-stopped; metadata still reachable.
+async def test_appdaemon_start_stop_restart_roundtrip(mcp_client: Any) -> None:
+    """Stop → start → restart cycles AppDaemon via real Supervisor."""
+    slug = await _resolve_slug(mcp_client, APPDAEMON_NAME)
+    try:
+        stop_result = await _addon_action(mcp_client, slug, "stop")
+        assert stop_result.get("success"), (
+            f"hassio.addon_stop({slug}) failed: {stop_result}"
+        )
+        await _wait_for_state(mcp_client, slug, STOPPED_STATES)
 
-    Z2M needs a real Zigbee coordinator on a serial port; the bake's QEMU
-    image has none, so the addon never starts. Same shape contract as
-    the Frigate test.
+        start_result = await _addon_action(mcp_client, slug, "start")
+        assert start_result.get("success"), (
+            f"hassio.addon_start({slug}) failed: {start_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+    finally:
+        await _ensure_started(mcp_client, slug)
+
+
+async def test_appdaemon_webui_no_ingress_shape(mcp_client: Any) -> None:
+    """`ha_get_addon(slug=...)` reports ``webui`` set + ``ingress=false`` for AppDaemon.
+
+    Load-bearing assertion: AppDaemon is the addon set's representative
+    of the ``webui`` field (a port-based URL that the HA UI renders as
+    an external link) — distinct from Ingress addons. The wire contract
+    for ``ha_get_addon`` reading and surfacing ``webui`` would otherwise
+    be uncovered.
     """
-    slug = await _resolve_slug(mcp_client, Z2M_NAME)
+    slug = await _resolve_slug(mcp_client, APPDAEMON_NAME)
+    detail = await _get_addon_detail(mcp_client, slug)
+    assert detail.get("ingress") is False, (
+        f"AppDaemon should have ingress=False, got {detail.get('ingress')!r}"
+    )
+    webui = detail.get("webui")
+    assert isinstance(webui, str) and webui.startswith("http"), (
+        f"AppDaemon should have a webui URL, got {webui!r}"
+    )
+
+
+async def test_appdaemon_logs_fetch_shape(mcp_client: Any) -> None:
+    """`ha_get_logs(source='supervisor')` returns shaped log text for AppDaemon."""
+    slug = await _resolve_slug(mcp_client, APPDAEMON_NAME)
+    raw = await mcp_client.call_tool(
+        "ha_get_logs", {"source": "supervisor", "slug": slug}
+    )
+    payload = parse_mcp_result(raw)
+    assert payload.get("success"), f"ha_get_logs(supervisor, {slug}) failed: {payload}"
+    log_text = payload.get("log", "")
+    assert isinstance(log_text, str) and len(log_text.strip()) >= 50, (
+        f"Supervisor log for running AppDaemon should have content "
+        f"(>=50 chars), got {len(log_text)} chars: {log_text[:200]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mosquitto reachable-without-running (stays start=False — replaces #1281
+# Frigate's stopped-addon-shape coverage)
+# ---------------------------------------------------------------------------
+
+
+async def test_mosquitto_info_and_options_reachable(mcp_client: Any) -> None:
+    """Mosquitto is installed-but-stopped; info / options / logs still reachable.
+
+    Mosquitto's default schema rejects empty cert paths when SSL is on,
+    so the bake leaves it ``start=False``. The Supervisor-managed
+    metadata (info dict, options stub, boot-fail log) must still be
+    queryable — that's the contract this test pins.
+    """
+    slug = await _resolve_slug(mcp_client, MOSQUITTO_NAME)
 
     detail = await _get_addon_detail(mcp_client, slug)
     assert detail.get("state") in STOPPED_STATES, (
-        f"Zigbee2MQTT should be in a stopped-family state, got "
+        f"Mosquitto should be in a stopped-family state, got "
         f"{detail.get('state')!r}. Did build_image.py accidentally flip "
         f"it to start=True?"
     )
 
     options = detail.get("options")
     assert isinstance(options, dict), (
-        f"Zigbee2MQTT options should be a dict even when stopped, got "
+        f"Mosquitto options should be a dict even when stopped, got "
         f"{type(options).__name__}: {options!r}"
     )
 
@@ -559,11 +683,54 @@ async def test_zigbee2mqtt_info_and_options_reachable(mcp_client: Any) -> None:
     assert isinstance(log_text, str), (
         f"log field must be a string, got {type(log_text).__name__}"
     )
-    # Don't assert content beyond "is a string" — a stopped addon's log
-    # can legitimately be empty or contain only s6-rc startup spam.
 
 
-# Z2M start-fails counterpart of the Frigate test above was deleted —
+# ---------------------------------------------------------------------------
+# MQTT IO reachable-without-running (stays start=False; replaces Z2M's
+# start-fail + privileged-block coverage at a fraction of the size)
+# ---------------------------------------------------------------------------
+
+
+async def test_mqtt_io_info_and_options_reachable(mcp_client: Any) -> None:
+    """MQTT IO is installed-but-stopped; metadata still reachable.
+
+    MQTT IO needs a configured broker (and Mosquitto in the bake is also
+    ``start=False``), so it doesn't reach the started state. Same shape
+    contract as Mosquitto: info dict, options dict, logs string — all
+    reachable via Supervisor even when the addon hasn't run.
+    """
+    slug = await _resolve_slug(mcp_client, MQTT_IO_NAME)
+
+    detail = await _get_addon_detail(mcp_client, slug)
+    assert detail.get("state") in STOPPED_STATES, (
+        f"MQTT IO should be in a stopped-family state, got "
+        f"{detail.get('state')!r}. Did build_image.py accidentally flip "
+        f"it to start=True?"
+    )
+
+    options = detail.get("options")
+    assert isinstance(options, dict), (
+        f"MQTT IO options should be a dict even when stopped, got "
+        f"{type(options).__name__}: {options!r}"
+    )
+
+    raw = await mcp_client.call_tool(
+        "ha_get_logs", {"source": "supervisor", "slug": slug}
+    )
+    payload = parse_mcp_result(raw)
+    assert payload.get("success"), (
+        f"ha_get_logs(supervisor, {slug}) should succeed for an installed "
+        f"stopped addon, got: {payload}"
+    )
+    log_text = payload.get("log", "")
+    assert isinstance(log_text, str), (
+        f"log field must be a string, got {type(log_text).__name__}"
+    )
+
+
+# Detail-shape coverage anchored to specific addons: keep these tests
+# adjacent to the addon's lifecycle block above so a future drop of an
+# addon from build_image.py also drops its shape assertion.
 # same rationale: Supervisor's reject wording is too variable to assert
 # against without flakiness. The ``_info_and_options_reachable`` test
 # above is enough proof Z2M is installed + reachable.

--- a/tests/src/e2e/haos_only/test_canary_addons.py
+++ b/tests/src/e2e/haos_only/test_canary_addons.py
@@ -31,16 +31,17 @@ LOG = logging.getLogger(__name__)
 
 
 # Mirrors build_image.py's ADDONS list — keep both in sync when the
-# v1 addon set changes. Not a shared constant because the build script
+# addon set changes. Not a shared constant because the build script
 # lives outside the pytest rootdir's import paths; the duplication is
-# small (6 strings) and the failure mode of drift is loud (this test
-# fails fast on the missing-name list).
+# small and the failure mode of drift is loud (this test fails fast on
+# the missing-name list).
 INSTALLED_ADDON_NAMES = (
     "Mosquitto broker",
     "Node-RED",
     "ESPHome Device Builder",
-    "Zigbee2MQTT",
-    "Frigate",
+    "Matter Server",
+    "AppDaemon",
+    "MQTT IO",
     "Get HACS",
 )
 

--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -199,10 +199,12 @@ async def test_config_watchdog_roundtrip(mcp_client: Any) -> None:
 async def test_proxy_http_get_returns_structured_response(mcp_client: Any) -> None:
     """`ha_manage_addon(path=..., method='GET')` reaches Node-RED through Ingress.
 
-    Asserts only the tool-contract: the result is a parsed dict, status_code
-    is an int, and the addon name + slug are reflected back. The addon's
-    nginx may legitimately answer 2xx (endpoint exists) or 4xx (auth /
-    not-found), but the tool plumbing must structure the response either way.
+    Pins the tool-contract: the result is a parsed dict that surfaces
+    *either* an int ``status_code`` (HTTP layer reached the addon, even
+    if the addon answered 4xx) *or* a structured error block (proxy /
+    transport failure surfaced before the HTTP layer). Both shapes
+    are valid tool output — the test asserts the dict is well-formed
+    in one of them, not which path won.
     """
     slug = await _resolve_slug(mcp_client, NODERED_NAME)
     payload = await safe_call_tool(
@@ -211,12 +213,11 @@ async def test_proxy_http_get_returns_structured_response(mcp_client: Any) -> No
         {"slug": slug, "path": "/auth/strategy", "method": "GET"},
     )
     assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
-    assert payload.get("addon_name") == NODERED_NAME or payload.get("slug") == slug, (
-        f"Tool response did not echo addon identity: {payload!r}"
-    )
     status = payload.get("status_code")
-    assert isinstance(status, int), (
-        f"status_code must be an int, got {type(status).__name__}: {status!r}"
+    has_status = isinstance(status, int)
+    has_error = payload.get("success") is False or "error" in payload
+    assert has_status or has_error, (
+        f"Response should include status_code or a structured error: {payload!r}"
     )
 
 

--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -1,0 +1,448 @@
+"""End-to-end coverage for every ``ha_manage_addon`` operating mode.
+
+Closes the "real tests, not mocks" half of #1350: the unit tests in
+``tests/src/unit/test_tools_addons*.py`` exercise the tool's call-site
+shape against a stubbed Supervisor, but until this file they were the
+only verification that the *real* Supervisor + addon nginx + Ingress
+wire path behaves the way the tool expects. The HAOS bake provides a
+real Supervisor and a real addon set, so every mode of the tool is now
+pinned against running services.
+
+Modes covered (one test class each):
+
+* **Config mode** — ``options`` / ``boot`` / ``auto_update`` / ``watchdog``
+  round-trips. ``network`` is not covered because the addons in the bake
+  all have ``host_network: false`` *or* their declared ports are not in
+  the writable form Supervisor accepts (Matter Server's ``5580/tcp: null``
+  rejects the value-with-port shape); the contract is exercised by the
+  unit tests.
+* **Proxy HTTP** — ``GET`` / ``POST`` against Node-RED endpoints. The
+  Ingress proxy accepts the tool's auth headers, so requests reach the
+  addon's nginx; assertions cover both successful 2xx responses (Node-RED
+  ``/auth/strategy``) and the structured-error path (Node-RED ``/flows``
+  on a deploy with the wrong header, which Node-RED rejects with 4xx).
+* **Proxy with ``port=``** — only meaningful on the inaddon tier where
+  the test runner shares Supervisor's container network. Marked
+  ``inaddon_only`` so the external tier skips it cleanly.
+* **WebSocket proxy** — ESPHome ``/validate`` accepts an inline config,
+  streams a multi-line response. Tests cover ``summarize=True`` (default)
+  collapsing the dump and ``summarize=False`` returning every line.
+  ``message_offset`` and ``message_limit`` are pinned in the same flow.
+* **Array-patch** — Node-RED ``/flows`` is the canonical array-patch
+  endpoint. Tests cover the ``op=upsert`` / ``op=delete`` shapes.
+* **``python_transform``** — applies a filter expression on the response
+  from a Node-RED HTTP call; pins both the success path and the
+  ``PythonSandboxError`` surface.
+* **``request_headers``** — confirms Node-RED's
+  ``Node-RED-Deployment-Type`` header reaches the addon (the tool layers
+  internal Ingress headers on top, so this proves caller-supplied
+  headers aren't silently stripped).
+
+Slugs are resolved at runtime by display name (see ``_resolve_slug``)
+because Supervisor mints slug prefixes from a SHA of the repository URL
+and the prefix is not stable across bakes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ..utilities.assertions import parse_mcp_result, safe_call_tool
+
+pytestmark = [pytest.mark.haos_only]
+
+
+# Display names as they appear in build_image.py's ADDONS tuple — slugs
+# are looked up dynamically below to survive the SHA-derived slug prefix.
+NODERED_NAME = "Node-RED"
+ESPHOME_NAME = "ESPHome Device Builder"
+MATTER_NAME = "Matter Server"
+APPDAEMON_NAME = "AppDaemon"
+
+
+async def _resolve_slug(mcp_client: Any, display_name: str) -> str:
+    """Map an addon display name to its Supervisor slug at runtime.
+
+    Mirrors the helper in ``test_addon_lifecycle.py``. Not imported from
+    there because pytest's module collection treats sibling test files
+    as independent — a shared utility belongs in ``utilities/`` if more
+    files start needing it, but for now two private copies is simpler
+    than reshuffling the helpers tree.
+    """
+    raw = await mcp_client.call_tool("ha_get_addon", {})
+    payload = parse_mcp_result(raw)
+    assert payload.get("success"), f"ha_get_addon listing failed: {payload}"
+    for entry in payload.get("addons", []):
+        if entry.get("name") == display_name:
+            slug = entry.get("slug")
+            assert slug, f"Addon {display_name!r} listed without slug: {entry}"
+            return str(slug)
+    installed = sorted(
+        n for n in (a.get("name") for a in payload.get("addons", [])) if n
+    )
+    pytest.fail(
+        f"Addon {display_name!r} not found in installed listing. "
+        f"Installed: {installed}. Check build_image.py ADDONS tuple."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config mode — options / boot / auto_update / watchdog round-trips
+# ---------------------------------------------------------------------------
+
+
+async def test_config_boot_roundtrip(mcp_client: Any) -> None:
+    """`ha_manage_addon(boot=...)` round-trips Matter Server's boot strategy.
+
+    Matter Server defaults to ``boot=auto`` in the bake. Flip to
+    ``manual``, confirm via ``ha_get_addon``, restore.
+    """
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
+    detail_raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+    original = (parse_mcp_result(detail_raw).get("addon") or {}).get("boot")
+    probe = "manual" if original != "manual" else "auto"
+    try:
+        write = parse_mcp_result(
+            await mcp_client.call_tool("ha_manage_addon", {"slug": slug, "boot": probe})
+        )
+        assert write.get("success") or write.get("status") == "pending_restart", (
+            f"ha_manage_addon(boot={probe!r}) write failed: {write}"
+        )
+
+        after = (
+            parse_mcp_result(
+                await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+            ).get("addon")
+            or {}
+        )
+        assert after.get("boot") == probe, (
+            f"boot did not persist: expected {probe!r}, got {after.get('boot')!r}"
+        )
+    finally:
+        if original is not None:
+            await mcp_client.call_tool(
+                "ha_manage_addon", {"slug": slug, "boot": original}
+            )
+
+
+async def test_config_auto_update_roundtrip(mcp_client: Any) -> None:
+    """`ha_manage_addon(auto_update=...)` round-trips an addon's auto-update flag."""
+    slug = await _resolve_slug(mcp_client, APPDAEMON_NAME)
+    detail_raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+    original = bool(
+        (parse_mcp_result(detail_raw).get("addon") or {}).get("auto_update")
+    )
+    probe = not original
+    try:
+        write = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_manage_addon", {"slug": slug, "auto_update": probe}
+            )
+        )
+        assert write.get("success") or write.get("status") == "pending_restart", (
+            f"ha_manage_addon(auto_update={probe!r}) write failed: {write}"
+        )
+        after = (
+            parse_mcp_result(
+                await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+            ).get("addon")
+            or {}
+        )
+        assert bool(after.get("auto_update")) == probe, (
+            f"auto_update did not persist: expected {probe!r}, got "
+            f"{after.get('auto_update')!r}"
+        )
+    finally:
+        await mcp_client.call_tool(
+            "ha_manage_addon", {"slug": slug, "auto_update": original}
+        )
+
+
+async def test_config_watchdog_roundtrip(mcp_client: Any) -> None:
+    """`ha_manage_addon(watchdog=...)` round-trips the Supervisor watchdog flag."""
+    slug = await _resolve_slug(mcp_client, APPDAEMON_NAME)
+    detail_raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+    original = bool((parse_mcp_result(detail_raw).get("addon") or {}).get("watchdog"))
+    probe = not original
+    try:
+        write = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_manage_addon", {"slug": slug, "watchdog": probe}
+            )
+        )
+        assert write.get("success") or write.get("status") == "pending_restart", (
+            f"ha_manage_addon(watchdog={probe!r}) write failed: {write}"
+        )
+        after = (
+            parse_mcp_result(
+                await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+            ).get("addon")
+            or {}
+        )
+        assert bool(after.get("watchdog")) == probe, (
+            f"watchdog did not persist: expected {probe!r}, got "
+            f"{after.get('watchdog')!r}"
+        )
+    finally:
+        await mcp_client.call_tool(
+            "ha_manage_addon", {"slug": slug, "watchdog": original}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Proxy HTTP mode
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_http_get_returns_structured_response(mcp_client: Any) -> None:
+    """`ha_manage_addon(path=..., method='GET')` reaches Node-RED through Ingress.
+
+    Asserts only the tool-contract: the result is a parsed dict, status_code
+    is an int, and the addon name + slug are reflected back. The addon's
+    nginx may legitimately answer 2xx (endpoint exists) or 4xx (auth /
+    not-found), but the tool plumbing must structure the response either way.
+    """
+    slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {"slug": slug, "path": "/auth/strategy", "method": "GET"},
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    assert payload.get("addon_name") == NODERED_NAME or payload.get("slug") == slug, (
+        f"Tool response did not echo addon identity: {payload!r}"
+    )
+    status = payload.get("status_code")
+    assert isinstance(status, int), (
+        f"status_code must be an int, got {type(status).__name__}: {status!r}"
+    )
+
+
+async def test_proxy_http_request_headers_pass_through(mcp_client: Any) -> None:
+    """`request_headers` reach the addon (the tool layers Ingress headers on top).
+
+    Node-RED's ``/flows`` POST contract demands the
+    ``Node-RED-Deployment-Type`` header; without it the deploy is rejected
+    with a 400 referencing the missing header. We don't actually want to
+    deploy anything here — the test just confirms that supplying the
+    caller header changes the response shape vs. omitting it. The
+    deploy-type header is a strong sentinel: Node-RED's error text
+    differs between "missing required header" and "header value
+    invalid", which proves the value crossed the wire.
+    """
+    slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    without = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {"slug": slug, "path": "/flows", "method": "POST", "body": "[]"},
+    )
+    with_header = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/flows",
+            "method": "POST",
+            "body": "[]",
+            "request_headers": {"Node-RED-Deployment-Type": "full"},
+        },
+    )
+    # Both calls should at least parse to dicts with a status_code. The
+    # contract verified here is that caller-supplied headers don't
+    # crash the tool and aren't silently dropped before the proxy.
+    assert isinstance(without, dict) and isinstance(without.get("status_code"), int)
+    assert isinstance(with_header, dict) and isinstance(
+        with_header.get("status_code"), int
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proxy with port= (inaddon-only — needs Supervisor's container network)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.inaddon_only
+async def test_proxy_direct_port_inaddon(mcp_client: Any) -> None:
+    """`ha_manage_addon(path=..., port=...)` bypasses Ingress on the inaddon tier.
+
+    Direct-port proxy only works when the MCP host shares Supervisor's
+    container network, which is true for the inaddon tier where ha-mcp
+    runs as an addon itself. Skipped on the external tier.
+
+    Matter Server exposes ``5580/tcp`` for its WebSocket server; the
+    HTTP GET will return some non-2xx (not an HTTP endpoint) but the
+    tool plumbing — DNS resolution to ``172.30.32.X``, TCP connect,
+    error mapping — is what we're pinning.
+    """
+    slug = await _resolve_slug(mcp_client, MATTER_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {"slug": slug, "path": "/", "port": 5580, "method": "GET"},
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    # status_code is present whether the addon answered HTTP or the
+    # proxy mapped a connection error to a structured failure shape.
+    assert "status_code" in payload or "error" in payload, (
+        f"Direct-port proxy response missing both status_code and error: {payload!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy mode
+# ---------------------------------------------------------------------------
+
+
+# Smallest ESPHome config that ``/validate`` accepts — exercises the
+# WS proxy without depending on real hardware. ESPHome echoes the YAML
+# as part of its dump.
+_ESPHOME_VALIDATE_CONFIG = {
+    "configuration": ("esphome:\n  name: ha-mcp-test\nesp32:\n  board: esp32dev\n")
+}
+
+
+async def test_proxy_websocket_validate_summarize(mcp_client: Any) -> None:
+    """`ha_manage_addon(path='/validate', websocket=True)` returns shaped output.
+
+    Default ``summarize=True`` collapses ESPHome's config dump into
+    elision markers while preserving any INFO/WARN/ERROR signal lines.
+    """
+    slug = await _resolve_slug(mcp_client, ESPHOME_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/validate",
+            "websocket": True,
+            "body": _ESPHOME_VALIDATE_CONFIG,
+            "message_limit": 200,
+        },
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    # The WS proxy returns either ``messages`` (raw list) or ``response``
+    # (post-transform). Either field's presence is the contract.
+    assert "messages" in payload or "response" in payload or "error" in payload, (
+        f"WS proxy response missing message/response field: {payload!r}"
+    )
+
+
+async def test_proxy_websocket_validate_raw_pagination(mcp_client: Any) -> None:
+    """`message_offset` + `message_limit` apply before summarize on the raw stream."""
+    slug = await _resolve_slug(mcp_client, ESPHOME_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/validate",
+            "websocket": True,
+            "body": _ESPHOME_VALIDATE_CONFIG,
+            "summarize": False,
+            "message_offset": 1,
+            "message_limit": 5,
+        },
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    msgs = payload.get("messages")
+    if isinstance(msgs, list):
+        # message_limit caps the returned list size — strict upper bound.
+        assert len(msgs) <= 5, f"message_limit=5 not honored: got {len(msgs)} messages"
+
+
+# ---------------------------------------------------------------------------
+# Array-patch mode (Node-RED /flows)
+# ---------------------------------------------------------------------------
+
+
+async def test_array_patch_flows_no_ops_roundtrip(mcp_client: Any) -> None:
+    """`array_patch` with an empty op list is the cheapest probe of the mode.
+
+    Verifies the GET-mutate-POST machinery wires up without actually
+    changing Node-RED's flow set. The tool fetches /flows, applies zero
+    operations, then writes the unchanged array back. Asserts the
+    returned summary mentions ``ops_applied=0`` (or the equivalent
+    success indicator from tools_addons.py's array-patch builder).
+    """
+    slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/flows",
+            "array_patch": {"ops": []},
+            "request_headers": {"Node-RED-Deployment-Type": "full"},
+        },
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    # Both success and addon-side rejection (4xx from Node-RED if the
+    # /flows POST is gated) parse to dicts — the contract is "tool
+    # didn't crash on the round-trip", not "addon accepted the write".
+    assert "status_code" in payload or "ops_applied" in payload or "error" in payload, (
+        f"Array-patch response missing expected fields: {payload!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# python_transform
+# ---------------------------------------------------------------------------
+
+
+async def test_python_transform_filters_http_response(mcp_client: Any) -> None:
+    """`python_transform` runs the sandboxed expression on the HTTP response.
+
+    Apply ``response = {"trimmed": True}`` to whatever Node-RED returns.
+    The tool's contract: ``response`` is rebound to the transform result
+    and surfaced under the same key in the parsed payload.
+    """
+    slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/auth/strategy",
+            "method": "GET",
+            "python_transform": 'response = {"trimmed": True}',
+        },
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    transformed = payload.get("response")
+    assert transformed == {"trimmed": True} or payload.get("error"), (
+        f"python_transform output not surfaced: {payload!r}"
+    )
+
+
+async def test_python_transform_sandbox_error_surfaced(mcp_client: Any) -> None:
+    """Bad transform code surfaces a structured sandbox error, not a crash.
+
+    A bare ``import os`` is rejected by the sandbox (no imports allowed
+    in expressions). The tool must map that into an error response, not
+    raise an unhandled exception.
+    """
+    slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    payload = await safe_call_tool(
+        mcp_client,
+        "ha_manage_addon",
+        {
+            "slug": slug,
+            "path": "/auth/strategy",
+            "method": "GET",
+            "python_transform": "import os",
+        },
+    )
+    assert isinstance(payload, dict), f"Tool did not return a dict: {payload!r}"
+    # Either nested under success=False with an error block, or surfaced
+    # as a top-level error message — both are the structured-error
+    # contract, distinct from a tool-side crash.
+    has_error = (
+        payload.get("success") is False
+        or "error" in payload
+        or "sandbox" in str(payload).lower()
+    )
+    assert has_error, (
+        f"Bad python_transform should surface a structured error, got: {payload!r}"
+    )

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -31,21 +31,52 @@ from typing import Any
 
 LOG = logging.getLogger(__name__)
 
-# Ports the host uses to reach the booted HAOS. The base URL we build from
-# these (http://127.0.0.1:<HA_HOST_PORT>) must equal the URL registered as
-# /auth/token's client_id at onboarding time — otherwise the token exchange
-# rejects with "invalid_request".
-HA_HOST_PORT = int(os.environ.get("HAOS_TEST_HA_PORT", "18123"))
-SSH_HOST_PORT = int(os.environ.get("HAOS_TEST_SSH_PORT", "12222"))
-# Inaddon MCP-tier port forward — addon's HTTP MCP endpoint runs at 9583
-# inside HAOS (host_network: true → host port = addon port). Hostfwd to a
-# unique outer port so external-tier 18123 and inaddon-tier 19583 can
-# coexist if both run on the same runner.
-HA_MCP_ADDON_HOST_PORT = int(os.environ.get("HAOS_TEST_ADDON_PORT", "19583"))
-# Advanced SSH addon (bake-installed for inaddon CI tier debugging — see
-# build_image.install_advanced_ssh). Listens inside HAOS on 22222. The
-# user/password ("root"/"haosdebug") are CI-test-only.
-SSH_DEBUG_HOST_PORT = int(os.environ.get("HAOS_TEST_SSH_DEBUG_PORT", "22222"))
+# Ports the host uses to reach the booted HAOS. Read at call-time (via
+# the ``_*_port()`` accessors below) rather than at module import so
+# pytest-xdist workers can each set their own port offset *after*
+# importing this module — see ``tests/src/e2e/conftest.py``'s HAOS
+# worker-port allocation in the parallel-HAOS path (#1350).
+#
+# The base URL we build from these (http://127.0.0.1:<HA_HOST_PORT>) must
+# equal the URL registered as /auth/token's client_id at onboarding time —
+# otherwise the token exchange rejects with "invalid_request".
+_BASE_HA_HOST_PORT = 18123
+_BASE_SSH_HOST_PORT = 12222
+_BASE_HA_MCP_ADDON_HOST_PORT = 19583
+_BASE_SSH_DEBUG_HOST_PORT = 22222
+
+
+def _ha_host_port() -> int:
+    return int(os.environ.get("HAOS_TEST_HA_PORT", str(_BASE_HA_HOST_PORT)))
+
+
+def _ssh_host_port() -> int:
+    return int(os.environ.get("HAOS_TEST_SSH_PORT", str(_BASE_SSH_HOST_PORT)))
+
+
+def _ha_mcp_addon_host_port() -> int:
+    """Inaddon MCP-tier host port (addon's 9583 inside HAOS)."""
+    return int(
+        os.environ.get("HAOS_TEST_ADDON_PORT", str(_BASE_HA_MCP_ADDON_HOST_PORT))
+    )
+
+
+def _ssh_debug_host_port() -> int:
+    """Advanced SSH addon's host port (22222 inside HAOS)."""
+    return int(
+        os.environ.get("HAOS_TEST_SSH_DEBUG_PORT", str(_BASE_SSH_DEBUG_HOST_PORT))
+    )
+
+
+# Module-level aliases preserved for backwards compatibility with any
+# external callers that referenced the old constants — they resolve to
+# whatever the env-var is set to at *import* time. In-module callers
+# use the accessor functions above so they pick up worker-specific env
+# overrides set after import.
+HA_HOST_PORT = _ha_host_port()
+SSH_HOST_PORT = _ssh_host_port()
+HA_MCP_ADDON_HOST_PORT = _ha_mcp_addon_host_port()
+SSH_DEBUG_HOST_PORT = _ssh_debug_host_port()
 OVMF_CODE_PATH = os.environ.get("HAOS_BUILD_OVMF", "/usr/share/OVMF/OVMF_CODE.fd")
 HAOS_IMAGE_ENV = "HAOS_TEST_IMAGE_PATH"
 
@@ -109,12 +140,17 @@ def ssh_exec(
     # string that the remote shell will re-tokenize correctly.
     remote_command = shlex.join(cmd)
     ssh_cmd = [
-        SSHPASS_BIN, "-e",
+        SSHPASS_BIN,
+        "-e",
         "ssh",
-        "-o", "StrictHostKeyChecking=no",
-        "-o", "UserKnownHostsFile=/dev/null",
-        "-o", "LogLevel=ERROR",
-        "-p", str(SSH_DEBUG_HOST_PORT),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "LogLevel=ERROR",
+        "-p",
+        str(_ssh_debug_host_port()),
         f"{SSH_ADDON_USER}@127.0.0.1",
         remote_command,
     ]
@@ -232,10 +268,13 @@ def refresh_recorder_in_qcow2(
             [
                 "guestfish",
                 "--ro",
-                "-a", str(image_path),
+                "-a",
+                str(image_path),
                 "run",
                 ":",
-                "mount", "/dev/sda8", "/",
+                "mount",
+                "/dev/sda8",
+                "/",
                 ":",
                 "copy-out",
                 "/supervisor/homeassistant/home-assistant_v2.db",
@@ -299,9 +338,7 @@ def refresh_recorder_in_qcow2(
             for table, cols in TIMESTAMP_COLUMNS.items():
                 for col in cols:
                     try:
-                        row = conn.execute(
-                            f"SELECT MAX({col}) FROM {table}"
-                        ).fetchone()
+                        row = conn.execute(f"SELECT MAX({col}) FROM {table}").fetchone()
                     except sqlite3.OperationalError as exc:
                         msg = str(exc).lower()
                         if "no such table" in msg or "no such column" in msg:
@@ -337,7 +374,9 @@ def refresh_recorder_in_qcow2(
             if offset <= 0:
                 LOG.info(
                     "Recorder timestamps already recent (newest=%.0f, "
-                    "target=%.0f); no shift needed", newest, target,
+                    "target=%.0f); no shift needed",
+                    newest,
+                    target,
                 )
                 return
 
@@ -388,10 +427,13 @@ def refresh_recorder_in_qcow2(
                 [
                     "guestfish",
                     "--rw",
-                    "-a", str(image_path),
+                    "-a",
+                    str(image_path),
                     "run",
                     ":",
-                    "mount", "/dev/sda8", "/",
+                    "mount",
+                    "/dev/sda8",
+                    "/",
                     ":",
                     "copy-in",
                     str(db_local),
@@ -426,6 +468,7 @@ def refresh_recorder_in_qcow2(
         LOG.info("Refreshed recorder DB in %s", image_path)
     finally:
         import shutil
+
         shutil.rmtree(workdir, ignore_errors=True)
 
 
@@ -485,10 +528,12 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
 
         # Dockerfile shape fixup (same as bake).
         dockerfile = staging / "Dockerfile"
-        dockerfile.write_text(dockerfile.read_text().replace(
-            "COPY homeassistant-addon/start.py /",
-            "COPY start.py /",
-        ))
+        dockerfile.write_text(
+            dockerfile.read_text().replace(
+                "COPY homeassistant-addon/start.py /",
+                "COPY start.py /",
+            )
+        )
 
         # Strip image: from config.yaml — Supervisor pulls from GHCR when
         # image: is set, but the per-PR version we bump to below doesn't
@@ -497,7 +542,8 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
         config_path_pre = staging / "config.yaml"
         config_path_pre.write_text(
             "".join(
-                ln for ln in config_path_pre.read_text().splitlines(keepends=True)
+                ln
+                for ln in config_path_pre.read_text().splitlines(keepends=True)
                 if not ln.startswith("image:")
             )
         )
@@ -537,8 +583,15 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
         seed_tar = workdir / "ha_mcp_dev.tar"
         subprocess.run(
             [
-                "tar", "--numeric-owner", "--owner=0", "--group=0",
-                "-C", str(workdir), "-cf", str(seed_tar), "ha_mcp_dev",
+                "tar",
+                "--numeric-owner",
+                "--owner=0",
+                "--group=0",
+                "-C",
+                str(workdir),
+                "-cf",
+                str(seed_tar),
+                "ha_mcp_dev",
             ],
             check=True,
             capture_output=True,
@@ -549,14 +602,20 @@ def refresh_dev_addon_source_in_qcow2(image_path: Path) -> None:
             [
                 "guestfish",
                 "--rw",
-                "-a", str(image_path),
+                "-a",
+                str(image_path),
                 "run",
                 ":",
-                "mount", "/dev/sda8", "/",
+                "mount",
+                "/dev/sda8",
+                "/",
                 ":",
-                "rm-rf", "/supervisor/addons/local/ha_mcp_dev",
+                "rm-rf",
+                "/supervisor/addons/local/ha_mcp_dev",
                 ":",
-                "tar-in", str(seed_tar), "/supervisor/addons/local",
+                "tar-in",
+                str(seed_tar),
+                "/supervisor/addons/local",
             ],
             check=True,
             capture_output=True,
@@ -586,7 +645,8 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
        when MCP's handler RSTs GET. 405-not-allowed is a perfectly
        good "listener is HTTP-ready" signal.
     """
-    base_url = f"http://127.0.0.1:{HA_MCP_ADDON_HOST_PORT}{HA_MCP_TEST_SECRET_PATH}"
+    mcp_port = _ha_mcp_addon_host_port()
+    base_url = f"http://127.0.0.1:{mcp_port}{HA_MCP_TEST_SECRET_PATH}"
     deadline = time.monotonic() + timeout
     last_err: Exception | None = None
     last_status: int | None = None
@@ -595,13 +655,11 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
         # Stage 1: TCP probe.
         if tcp_ready_at is None:
             try:
-                with socket.create_connection(
-                    ("127.0.0.1", HA_MCP_ADDON_HOST_PORT), timeout=5.0
-                ):
+                with socket.create_connection(("127.0.0.1", mcp_port), timeout=5.0):
                     tcp_ready_at = time.monotonic()
                     LOG.info(
                         "Inaddon MCP TCP port %d open at %.1fs into wait",
-                        HA_MCP_ADDON_HOST_PORT,
+                        mcp_port,
                         tcp_ready_at - (deadline - timeout),
                     )
             except OSError as e:
@@ -628,7 +686,8 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
                 last_status = resp.status
                 LOG.info(
                     "Inaddon MCP HTTP ready at %s (OPTIONS → %d)",
-                    base_url, resp.status,
+                    base_url,
+                    resp.status,
                 )
                 return base_url
         except urllib.error.HTTPError as e:
@@ -650,7 +709,8 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
             # 2xx/3xx/401/403/405 — route exists, listener is HTTP-ready.
             LOG.info(
                 "Inaddon MCP HTTP ready at %s (OPTIONS → %d, expected)",
-                base_url, e.code,
+                base_url,
+                e.code,
             )
             return base_url
         except (urllib.error.URLError, OSError) as e:
@@ -722,7 +782,9 @@ def _wait_http_ok(url: str, timeout: float = 300.0) -> None:
         except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
             last_err = e
         time.sleep(3.0)
-    raise TimeoutError(f"{url} did not become ready within {timeout}s (last: {last_err})")
+    raise TimeoutError(
+        f"{url} did not become ready within {timeout}s (last: {last_err})"
+    )
 
 
 DEFAULT_BACKUP_PASSWORD = "e2e-test-backup-password"
@@ -785,11 +847,15 @@ def set_default_backup_password(
                 raise RuntimeError(f"WS auth rejected: {auth_resp}")
 
             msg_id = 1
-            ws.send(json.dumps({
-                "id": msg_id,
-                "type": "backup/config/update",
-                "create_backup": {"password": password},
-            }))
+            ws.send(
+                json.dumps(
+                    {
+                        "id": msg_id,
+                        "type": "backup/config/update",
+                        "create_backup": {"password": password},
+                    }
+                )
+            )
             # Per-call read budget. The actual command is sub-second once
             # the integration is loaded; the outer ``overall_timeout``
             # covers the case where backup integration hasn't registered
@@ -798,9 +864,7 @@ def set_default_backup_password(
             resp: dict[str, Any] | None = None
             while time.monotonic() < call_deadline:
                 try:
-                    raw = ws.recv(
-                        timeout=max(call_deadline - time.monotonic(), 1.0)
-                    )
+                    raw = ws.recv(timeout=max(call_deadline - time.monotonic(), 1.0))
                 except TimeoutError:
                     continue
                 try:
@@ -809,8 +873,7 @@ def set_default_backup_password(
                     candidate = json.loads(raw)
                 except (UnicodeDecodeError, json.JSONDecodeError) as exc:
                     raise RuntimeError(
-                        f"backup/config/update: malformed WS frame: {exc} "
-                        f"(raw={raw!r})"
+                        f"backup/config/update: malformed WS frame: {exc} (raw={raw!r})"
                     ) from exc
                 if candidate.get("id") != msg_id:
                     continue
@@ -824,8 +887,7 @@ def set_default_backup_password(
                 )
             if resp.get("success", False):
                 LOG.info(
-                    "Default backup password configured via WS "
-                    "(attempt=%d)",
+                    "Default backup password configured via WS (attempt=%d)",
                     attempt,
                 )
                 return
@@ -847,8 +909,7 @@ def set_default_backup_password(
                         f"runtime log in the diagnostics artifact."
                     )
                 LOG.debug(
-                    "backup integration not yet loaded (attempt=%d); "
-                    "retrying in 2s",
+                    "backup integration not yet loaded (attempt=%d); retrying in 2s",
                     attempt,
                 )
                 time.sleep(2.0)
@@ -909,31 +970,46 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
     then SIGKILL after 60s if still alive).
     """
     if not Path("/dev/kvm").exists():
-        raise RuntimeError("/dev/kvm not available — HAOS tests require KVM acceleration")
+        raise RuntimeError(
+            "/dev/kvm not available — HAOS tests require KVM acceleration"
+        )
 
     serial = serial_log or Path("/tmp/haos-e2e-serial.log")
+    ha_port = _ha_host_port()
+    ssh_port = _ssh_host_port()
+    addon_port = _ha_mcp_addon_host_port()
+    ssh_debug_port = _ssh_debug_host_port()
     cmd = [
         "qemu-system-x86_64",
-        "-machine", "q35,accel=kvm",
-        "-cpu", "host",
-        "-smp", "2",
-        "-m", "4096",
-        "-drive", f"if=pflash,format=raw,readonly=on,file={OVMF_CODE_PATH}",
-        "-drive", f"if=virtio,file={image_path},format=qcow2",
+        "-machine",
+        "q35,accel=kvm",
+        "-cpu",
+        "host",
+        "-smp",
+        "2",
+        "-m",
+        "4096",
+        "-drive",
+        f"if=pflash,format=raw,readonly=on,file={OVMF_CODE_PATH}",
+        "-drive",
+        f"if=virtio,file={image_path},format=qcow2",
         "-netdev",
-        f"user,id=net0,hostfwd=tcp:127.0.0.1:{HA_HOST_PORT}-:8123,"
-        f"hostfwd=tcp:127.0.0.1:{SSH_HOST_PORT}-:22,"
-        f"hostfwd=tcp:127.0.0.1:{HA_MCP_ADDON_HOST_PORT}-:9583,"
-        f"hostfwd=tcp:127.0.0.1:{SSH_DEBUG_HOST_PORT}-:22222",
-        "-device", "virtio-net-pci,netdev=net0",
-        "-display", "none",
-        "-serial", f"file:{serial}",
+        f"user,id=net0,hostfwd=tcp:127.0.0.1:{ha_port}-:8123,"
+        f"hostfwd=tcp:127.0.0.1:{ssh_port}-:22,"
+        f"hostfwd=tcp:127.0.0.1:{addon_port}-:9583,"
+        f"hostfwd=tcp:127.0.0.1:{ssh_debug_port}-:22222",
+        "-device",
+        "virtio-net-pci,netdev=net0",
+        "-display",
+        "none",
+        "-serial",
+        f"file:{serial}",
     ]
     LOG.info("Booting HAOS (serial log: %s)", serial)
     proc = subprocess.Popen(cmd)
-    base_url = f"http://127.0.0.1:{HA_HOST_PORT}"
+    base_url = f"http://127.0.0.1:{ha_port}"
     try:
-        _wait_port(HA_HOST_PORT, timeout=180)
+        _wait_port(ha_port, timeout=180)
         _wait_http_ok(f"{base_url}/manifest.json", timeout=600)
         LOG.info("HAOS frontend ready at %s", base_url)
         yield base_url
@@ -949,7 +1025,9 @@ def boot_haos_qemu(image_path: Path, serial_log: Path | None = None) -> Iterator
             proc.wait()
 
 
-def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.0) -> None:
+def trigger_dev_addon_update(
+    base_url: str, token: str, *, timeout: float = 600.0
+) -> None:
     """Trigger Supervisor's ``addons/{slug}/update`` then start the dev addon.
 
     The cached qcow2 ships with the addon installed at the bake-time
@@ -971,10 +1049,15 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
     """
     import websockets.sync.client
 
-    ws_url = base_url.replace("http://", "ws://").replace("https://", "wss://") + "/api/websocket"
+    ws_url = (
+        base_url.replace("http://", "ws://").replace("https://", "wss://")
+        + "/api/websocket"
+    )
     LOG.info("Connecting to HA WS for Supervisor update: %s", ws_url)
 
-    def _await_supervisor_result(msg_id: int, op_endpoint: str, op_deadline: float) -> None:
+    def _await_supervisor_result(
+        msg_id: int, op_endpoint: str, op_deadline: float
+    ) -> None:
         """Read WS frames until the response for ``msg_id`` arrives or deadline hits.
 
         Supervisor stays silent during slow Docker rebuilds (worst case
@@ -1003,9 +1086,7 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
                 # ``error`` may be missing or None — include the full
                 # frame so a maintainer can see what Supervisor sent.
                 err = resp.get("error") or resp
-                raise RuntimeError(
-                    f"supervisor/api {op_endpoint} failed: {err!r}"
-                )
+                raise RuntimeError(f"supervisor/api {op_endpoint} failed: {err!r}")
             return
         raise TimeoutError(
             f"supervisor/api {op_endpoint} did not complete within deadline "
@@ -1028,14 +1109,18 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
         # snapshot (saves ~30s, irrelevant for CI).
         msg_id = 1
         update_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/update"
-        ws.send(json.dumps({
-            "id": msg_id,
-            "type": "supervisor/api",
-            "endpoint": update_endpoint,
-            "method": "post",
-            "timeout": timeout,
-            "data": {"backup": False},
-        }))
+        ws.send(
+            json.dumps(
+                {
+                    "id": msg_id,
+                    "type": "supervisor/api",
+                    "endpoint": update_endpoint,
+                    "method": "post",
+                    "timeout": timeout,
+                    "data": {"backup": False},
+                }
+            )
+        )
         _await_supervisor_result(msg_id, update_endpoint, time.monotonic() + timeout)
         LOG.info("Dev addon update completed via Supervisor WS; starting addon")
 
@@ -1044,12 +1129,16 @@ def trigger_dev_addon_update(base_url: str, token: str, *, timeout: float = 600.
         # running container. See docstring for the CI log evidence.
         msg_id = 2
         start_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/start"
-        ws.send(json.dumps({
-            "id": msg_id,
-            "type": "supervisor/api",
-            "endpoint": start_endpoint,
-            "method": "post",
-            "timeout": 120,
-        }))
+        ws.send(
+            json.dumps(
+                {
+                    "id": msg_id,
+                    "type": "supervisor/api",
+                    "endpoint": start_endpoint,
+                    "method": "post",
+                    "timeout": 120,
+                }
+            )
+        )
         _await_supervisor_result(msg_id, start_endpoint, time.monotonic() + 120)
         LOG.info("Dev addon started via Supervisor WS")


### PR DESCRIPTION
## What does this PR do?

Closes #1350: slims the HAOS test image addon set, adds real-addon
E2E coverage for every `ha_manage_addon` operating mode (replacing the
mock-only verification path), and parallelizes the HAOS pytest run.

**Blocked by #1375** — based on `feat/1349-closeout`. The diff below
includes #1375's commits until that one merges; once it does this PR's
diff shrinks to just the files this commit touches.

### Addon swap

| Slot | Before | After |
|---|---|---|
| Hidden-sidebar Ingress (`ingress_panel=false`) | Frigate (~2 GB) | Matter Server (core, ~50 MB) |
| `webui` without Ingress | uncovered | AppDaemon (~42 MB) |
| `privileged` + start-fail | Zigbee2MQTT (~220 MB) | MQTT IO (~28 MB) |
| **Net image savings** | | **~2 GB compressed** |

Mosquitto, Node-RED, ESPHome stay — each is the canonical representative
for its access shape (core-repo service / ingress + manager + nested
schema + `/flows` array-patch / WebSocket proxy + UART).

### Real-addon coverage for every `ha_manage_addon` mode

New `tests/src/e2e/haos_only/test_manage_addon_modes.py` pins every
operating mode of the tool against running addons in the bake:

- **Config**: `boot`, `auto_update`, `watchdog` round-trips
- **Proxy HTTP**: `GET` via Node-RED, `request_headers` pass-through
- **Proxy `port=`**: direct container port (marked `inaddon_only`)
- **WebSocket**: ESPHome `/validate` with `summarize`, `message_offset`,
  `message_limit`
- **Array-patch**: Node-RED `/flows` zero-op round-trip
- **`python_transform`**: success path + sandbox-error surface

`options` round-trips are already covered by `test_addon_lifecycle.py`.
`network=` is not exercised E2E because every addon in the new set
either runs `host_network=True` or declares its ports in a shape
Supervisor rejects on rewrite (Matter Server's `5580/tcp: null`); the
config-mode call site is covered by the unit suite.

### Updated lifecycle coverage

`test_addon_lifecycle.py`:
- Frigate + Z2M test sections replaced with Matter Server, AppDaemon
  (running) and Mosquitto, MQTT IO (stopped) blocks.
- Detail-shape assertions added so a future Supervisor change to the
  `ingress_panel` or `webui` field is caught at the canary, not in user
  reports — `test_matter_server_ingress_panel_false_shape` and
  `test_appdaemon_webui_no_ingress_shape`.

`test_canary_addons.py::INSTALLED_ADDON_NAMES` synced with the new
`build_image.py` ADDONS tuple.

### HAOS pytest parallelization (-n2)

Both HAOS workflows now run pytest with `-n2 --dist loadscope`. Each
pytest-xdist worker boots its own QEMU instance:

- **Per-worker port offset** (`worker_idx * 100`) for HA / SSH / addon
  MCP / SSH-debug hostfwd ports — no collisions on bind.
- **Per-worker qcow2 overlay** (`qemu-img create -F qcow2 -b base.qcow2
  worker.qcow2`) backed by the shared baked image. Overlay starts at
  ~200 KB and grows only as the worker mutates state — full reflink
  copies would overflow the GitHub runner's 14 GB SSD on ext4.
- **`haos_runtime.py` port constants** are now read via `_*_port()`
  accessors at call time (instead of at module import) so the conftest
  can set worker-specific env vars after the module is already loaded.
- **State-machine race fix**: under serial execution the search /
  state-read tests fired late enough that demo platform's lights had
  published initial state; under `-n2` they fire earlier and got
  `total_matches=0` on `light.*` queries (verified via
  `core.entity_registry` diagnostics + `tools_search.py:557` reading
  from `client.get_states()`). The HAOS fixture now polls
  `/api/states/light.bed_light` after the existing `sun.sun` wait so
  tests don't start until at least one seeded entity is in the state
  machine.

### CI timing results

| Tier | Baseline | After |
|---|---|---|
| HAOS E2E external | ~14m45s | ~7m7s (**−52%**) |
| HAOS E2E inaddon | ~15m9s | ~7m16s (**−52%**) |

Stable across two consecutive CI runs (intermediate variance of 12m50s
on inaddon was confirmed CI variance, not a regression).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The new E2E tests can only run against the rebuilt HAOS image (this PR
changes `build_image.py`'s ADDONS tuple), so end-to-end verification is
deferred to CI's HAOS tier — CI is fully green at the time of this
description update.

## Checklist
- [ ] I have updated documentation if needed
