### PR TITLE
docs(#1157): bump skills-vendor + auto-update via Renovate + native for: field + scrub eval_template anti-patterns

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/ha_mcp/resources/skills-vendor"]
 	path = src/ha_mcp/resources/skills-vendor
 	url = https://github.com/homeassistant-ai/skills.git
+	branch = main

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   ],
   "enabledManagers": [
     "custom.regex",
-    "dockerfile"
+    "dockerfile",
+    "git-submodules"
   ],
   "ignorePaths": [],
   "customManagers": [

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -457,9 +457,8 @@ class AutomationConfigTools:
           `{{ states(x) in [...] }}`
         - `condition: time` instead of `{{ now().hour ... }}` or `{{ now().weekday() ... }}`
         - `condition: sun` instead of `{{ is_state('sun.sun', ...) }}`
-        - Native `for:` field on `state`/`numeric_state` triggers and conditions instead of
-          `{{ now() - X.last_changed > timedelta(...) }}` duration math (HA 2026.5 expanded
-          `for:` to purpose-specific triggers like motion, occupancy, doors, windows).
+        - Native `for:` field on `state`/`numeric_state` triggers and conditions over
+          `{{ now() - X.last_changed > timedelta(...) }}` duration math.
         - `wait_for_trigger` instead of `wait_template`
         - `choose` action instead of template-based service names
         - For one-shot date firing, use a `time` trigger plus `automation.turn_off` on a
@@ -521,7 +520,7 @@ class AutomationConfigTools:
             "action": [{"service": "light.turn_on", "target": {"area_id": "bedroom"}}]
         })
 
-        Motion-activated lighting with native `for:` (no action-delay, no template):
+        Motion-activated lighting — `for:` on the off-transition replaces action-delay:
         ha_config_set_automation(config={
             "alias": "Motion Light",
             "trigger": [
@@ -529,10 +528,12 @@ class AutomationConfigTools:
                 {"platform": "state", "entity_id": "binary_sensor.motion", "to": "off",
                  "for": {"minutes": 5}, "id": "motion_off"}
             ],
-            "condition": [{"condition": "sun", "after": "sunset"}],
             "action": [
                 {"choose": [
-                    {"conditions": [{"condition": "trigger", "id": "motion_on"}],
+                    {"conditions": [
+                        {"condition": "trigger", "id": "motion_on"},
+                        {"condition": "sun", "after": "sunset"}
+                    ],
                      "sequence": [{"service": "light.turn_on", "target": {"entity_id": "light.hallway"}}]},
                     {"conditions": [{"condition": "trigger", "id": "motion_off"}],
                      "sequence": [{"service": "light.turn_off", "target": {"entity_id": "light.hallway"}}]}

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -457,6 +457,9 @@ class AutomationConfigTools:
           `{{ states(x) in [...] }}`
         - `condition: time` instead of `{{ now().hour ... }}` or `{{ now().weekday() ... }}`
         - `condition: sun` instead of `{{ is_state('sun.sun', ...) }}`
+        - Native `for:` field on `state`/`numeric_state` triggers and conditions instead of
+          `{{ now() - X.last_changed > timedelta(...) }}` duration math (HA 2026.5 expanded
+          `for:` to purpose-specific triggers like motion, occupancy, doors, windows).
         - `wait_for_trigger` instead of `wait_template`
         - `choose` action instead of template-based service names
         - For one-shot date firing, use a `time` trigger plus `automation.turn_off` on a
@@ -518,17 +521,23 @@ class AutomationConfigTools:
             "action": [{"service": "light.turn_on", "target": {"area_id": "bedroom"}}]
         })
 
-        Motion-activated lighting with condition:
+        Motion-activated lighting with native `for:` (no action-delay, no template):
         ha_config_set_automation(config={
             "alias": "Motion Light",
-            "trigger": [{"platform": "state", "entity_id": "binary_sensor.motion", "to": "on"}],
+            "trigger": [
+                {"platform": "state", "entity_id": "binary_sensor.motion", "to": "on", "id": "motion_on"},
+                {"platform": "state", "entity_id": "binary_sensor.motion", "to": "off",
+                 "for": {"minutes": 5}, "id": "motion_off"}
+            ],
             "condition": [{"condition": "sun", "after": "sunset"}],
             "action": [
-                {"service": "light.turn_on", "target": {"entity_id": "light.hallway"}},
-                {"delay": {"minutes": 5}},
-                {"service": "light.turn_off", "target": {"entity_id": "light.hallway"}}
-            ],
-            "mode": "restart"
+                {"choose": [
+                    {"conditions": [{"condition": "trigger", "id": "motion_on"}],
+                     "sequence": [{"service": "light.turn_on", "target": {"entity_id": "light.hallway"}}]},
+                    {"conditions": [{"condition": "trigger", "id": "motion_off"}],
+                     "sequence": [{"service": "light.turn_off", "target": {"entity_id": "light.hallway"}}]}
+                ]}
+            ]
         })
 
         Update existing automation:

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1059,16 +1059,19 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         {{ device_id('light.bedroom') }}               # Get device ID for entity
         ```
 
-        **Common Use Cases:**
+        **When NOT to use this for automation/script logic:**
+        Templates have legitimate uses (notification bodies, dynamic `data.*` values,
+        debugging existing templates), but `condition:` / `trigger:` / action service
+        names are better expressed as native HA constructs — they validate at config
+        load, fail loudly, and avoid silent runtime failures. Prefer:
+        - `condition: numeric_state` over `{{ states('x') | float > N }}`
+        - `condition: state` over `{{ is_state(...) }}`
+        - `condition: time` / `condition: sun` over `now().hour` / `is_state('sun.sun', ...)`
+        - Native `for:` field on state/numeric_state triggers and conditions over
+          `{{ now() - X.last_changed > timedelta(...) }}` duration math
+        See `ha_get_skill_guide` (best-practices skill) for the full anti-pattern list.
 
-        **Automation Conditions:**
-        ```jinja2
-        # Check if it's a workday and after 7 AM
-        {{ is_state('binary_sensor.workday', 'on') and now().hour >= 7 }}
-
-        # Temperature-based condition
-        {{ states('sensor.outdoor_temp') | float < 0 }}
-        ```
+        **Common Use Cases (legitimate template positions):**
 
         **Dynamic Service Data:**
         ```jinja2
@@ -1086,7 +1089,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ha_eval_template("{{ states('light.living_room') }}")
         ```
 
-        **Test conditional logic:**
+        **Test a string expression (e.g. for a notification body):**
         ```python
         ha_eval_template("{{ 'Day' if now().hour < 18 else 'Night' }}")
         ```
@@ -1094,11 +1097,6 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         **Test mathematical operations:**
         ```python
         ha_eval_template("{{ (states('sensor.temperature') | float + 5) | round(1) }}")
-        ```
-
-        **Test complex automation condition:**
-        ```python
-        ha_eval_template("{{ is_state('binary_sensor.workday', 'on') and now().hour >= 7 and states('sensor.temperature') | float > 20 }}")
         ```
 
         **Test entity counting:**

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1026,13 +1026,13 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         {{ now().weekday() }}                          # Day of week (0=Monday)
         ```
 
-        **Conditional Logic:**
+        **Conditional Logic (for display strings — not for `condition:` positions):**
         ```jinja2
         {{ 'Day' if now().hour < 18 else 'Night' }}    # Ternary operator
-        {% if is_state('sun.sun', 'above_horizon') %}
-          It's daytime
+        {% if is_state('alarm_control_panel.home', 'armed_away') %}
+          Alarm is armed
         {% else %}
-          It's nighttime
+          Alarm is disarmed
         {% endif %}
         ```
 
@@ -1061,14 +1061,16 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         **When NOT to use this for automation/script logic:**
         Templates have legitimate uses (notification bodies, dynamic `data.*` values,
-        debugging existing templates), but `condition:` / `trigger:` / action service
-        names are better expressed as native HA constructs — they validate at config
-        load, fail loudly, and avoid silent runtime failures. Prefer:
+        debugging existing templates), but `condition:` / `trigger:` positions and
+        action service names are better expressed as native HA constructs — they
+        validate at config load, fail loudly, and avoid silent runtime failures.
+        Prefer:
         - `condition: numeric_state` over `{{ states('x') | float > N }}`
         - `condition: state` over `{{ is_state(...) }}`
         - `condition: time` / `condition: sun` over `now().hour` / `is_state('sun.sun', ...)`
         - Native `for:` field on state/numeric_state triggers and conditions over
           `{{ now() - X.last_changed > timedelta(...) }}` duration math
+        - `choose` action over templated `service:` / `action:` strings
         See `ha_get_skill_guide` (best-practices skill) for the full anti-pattern list.
 
         **Common Use Cases (legitimate template positions):**


### PR DESCRIPTION
## What does this PR do?

Refs #1157 (complements #1264 by SealKan, which adds the best-practice
detector for the same anti-pattern).

Four commits, two layers:

### Stop-the-bleeding: ship fresh skill content + scrub stale examples

The vendored `skills-vendor` submodule was pinned to a March-ish SHA.
Calling `ha_get_skill_guide` at runtime returns a `helper-selection.md`
that has 7 sections; upstream has 12. Missing from what agents currently
see:

- **Data Smoothing → `filter` helper** (outlier, lowpass,
  time_simple_moving_average) — agents asked to smooth a noisy sensor
  fall back to template math
- **Random Values → `random` helper** — agents fall back to
  `{{ range(0, 100) | random }}`
- **Climate Control → `generic_thermostat` / `generic_hygrostat`** — agents
  write a complex automation instead
- **Domain Conversion → `switch_as_x`** — exposing a switch as
  light/lock/cover
- **Menu-Based Helpers** protocol (`{"next_step_id": "<sub-type>"}` for
  `template`/`group`/`random`)
- **Template Helpers** as the documented escape hatch
- **Purpose-Specific Triggers (2026.2+)** section in
  `automation-patterns.md` (Labs preview — UI editor abstraction that
  generates standard state/numeric_state YAML under the hood)
- HA 2024+ plural keyword form (`triggers:`/`actions:`/`conditions:`)

The `ha_config_set_helper` tool docstring already advertises all 27
types including the missing ones — it points agents to
`ha_get_skill_guide` for design guidance, but the runtime resource
doesn't cover those types. The docstring was promising something the
runtime bundle didn't deliver.

`d868078d` bumps the submodule to `cf2b714`, pulling in upstream PRs
#42, #43, #45, #46, #47.

Two docstring scrubs in the same vein:

- `955cd341` — `ha_config_set_automation` docstring gets a `for:` bullet
  in the PREFER NATIVE SOLUTIONS list, and the Motion Light example is
  modernized from the stale `turn_on` + `delay 5 min` + `turn_off` (with
  `mode: restart`) to a two-trigger + `choose` pattern using motion-off
  + `for: 5 minutes` and native `condition: trigger` IDs. No templates,
  no action-delay; `mode: single` suffices because `for:` handles
  re-trigger semantics natively.

- `a06d98b4` — `ha_eval_template` docstring drops two example blocks
  that taught the exact anti-patterns the best-practice checker now
  flags (`{{ is_state(...) and now().hour >= 7 }}` and the
  `is_state + now().hour + | float > 20` "complex automation condition"
  block). Replaced with a "When NOT to use this for automation/script
  logic" callout. Remaining examples are reframed as legitimate template
  positions (notification bodies, dynamic `data.*` values, debugging
  existing templates).

Scripts docstring intentionally untouched — scripts have no
triggers/conditions, so `for:` doesn't apply, and the existing `delay`
examples are correct (delay is a legitimate script sequencing
primitive).

### Structural fix: stop the drift from recurring

`168e5403` enables Renovate's `git-submodules` manager and adds
`branch = main` to `.gitmodules`. The next time
`homeassistant-ai/skills` lands a commit on `main`, Renovate opens a
bump PR on the existing Tuesday-3pm-UTC schedule; merging it ships the
new skill content in the next `publish-dev` / release cycle. The pinned-
SHA model stays (reproducible builds, vetted updates) but the manual-
bump step is removed.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
