### PR TITLE
perf: tighten _poll_for_automation_entity first-poll cadence

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -922,11 +922,18 @@ class HomeAssistantClient:
                 ) from e
             raise
 
+    # Cadence preserves the prior 3-attempt × 6s upper-bound budget while
+    # tightening the first poll to 0.1s. HA Core typically publishes a new
+    # automation entity to the state machine well under 1s, so the prior
+    # 1s/2s/3s shape spent most of its first-iteration budget waiting on the
+    # common case. Failure-path cost is unchanged (still 3 get_states() calls).
+    _POLL_CADENCE: tuple[float, ...] = (0.1, 1.0, 4.9)
+
     async def _poll_for_automation_entity(self, unique_id: str) -> str | None:
         """Poll HA state to find the entity_id assigned to a newly created automation."""
         try:
-            for attempt in range(3):
-                await asyncio.sleep(1 * (attempt + 1))
+            for sleep_time in self._POLL_CADENCE:
+                await asyncio.sleep(sleep_time)
                 states = await self.get_states()
                 for state in states:
                     if not state.get("entity_id", "").startswith("automation."):

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -945,14 +945,16 @@ class HomeAssistantClient:
                         )
                         return entity_id
         except HomeAssistantError as e:
-            # Polling-loop discipline (.gemini/styleguide.md HIGH-severity rule
-            # "Polling-loop exception handling"): narrow to expected transient
-            # classes. HomeAssistantError is the base of the four typed REST
-            # exceptions raised by get_states() (Connection / Auth / API /
-            # Command). Programming bugs (TypeError, KeyError, AttributeError,
-            # AssertionError) propagate so they fail loud with a stack trace
-            # instead of being swallowed and surfacing as entity_not_verified.
-            # Mirrors the wait_helpers.py::_POLLING_TRANSIENT_ERRORS pattern.
+            # Narrow to expected transient classes: HomeAssistantError is the
+            # base of the four typed REST exceptions raised by get_states()
+            # (Connection / Auth / API / Command). Programming bugs (TypeError,
+            # KeyError, AttributeError, AssertionError) propagate so they fail
+            # loud with a stack trace instead of being swallowed and surfacing
+            # as entity_not_verified. The convention is codified for tests at
+            # .gemini/styleguide.md:43-46 (section "Exception Handling in Test
+            # Polling Loops") and implemented by
+            # tests/src/e2e/utilities/wait_helpers.py::_POLLING_TRANSIENT_ERRORS
+            # — the same principle applies to this production polling loop.
             logger.warning(
                 f"Failed to query actual entity_id for unique_id {unique_id}: {e}"
             )

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -944,7 +944,15 @@ class HomeAssistantClient:
                             f"Found actual entity_id for unique_id {unique_id}: {entity_id}"
                         )
                         return entity_id
-        except Exception as e:
+        except HomeAssistantError as e:
+            # Polling-loop discipline (.gemini/styleguide.md HIGH-severity rule
+            # "Polling-loop exception handling"): narrow to expected transient
+            # classes. HomeAssistantError is the base of the four typed REST
+            # exceptions raised by get_states() (Connection / Auth / API /
+            # Command). Programming bugs (TypeError, KeyError, AttributeError,
+            # AssertionError) propagate so they fail loud with a stack trace
+            # instead of being swallowed and surfacing as entity_not_verified.
+            # Mirrors the wait_helpers.py::_POLLING_TRANSIENT_ERRORS pattern.
             logger.warning(
                 f"Failed to query actual entity_id for unique_id {unique_id}: {e}"
             )

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -782,6 +782,9 @@ class HomeAssistantClient:
             else:
                 return False, "Invalid response from Home Assistant"
         except Exception as e:
+            # Intentional broad-catch: is_connected() contract maps any failure
+            # to (False, error_msg); styleguide § "broad except at top-level
+            # setup/teardown handlers" applies (connection probe is the analog).
             logger.error(f"Failed to connect to Home Assistant: {e}")
             return False, str(e)
 
@@ -823,7 +826,7 @@ class HomeAssistantClient:
                     f"Converted entity_id {identifier} to unique_id {unique_id}"
                 )
                 return str(unique_id)
-            except Exception as e:
+            except HomeAssistantError as e:
                 raise HomeAssistantAPIError(
                     f"Failed to resolve automation {identifier}: {str(e)}",
                     status_code=404,
@@ -853,8 +856,8 @@ class HomeAssistantClient:
                 "GET", f"/config/automation/config/{unique_id}"
             )
             return response
-        except Exception as e:
-            if "404" in str(e):
+        except HomeAssistantAPIError as e:
+            if e.status_code == 404:
                 raise HomeAssistantAPIError(
                     f"Automation not found: {identifier} (unique_id: {unique_id})",
                     status_code=404,
@@ -915,18 +918,15 @@ class HomeAssistantClient:
             if entity_not_verified:
                 result["entity_not_verified"] = True
             return result
-        except Exception as e:
-            if "400" in str(e):
+        except HomeAssistantAPIError as e:
+            if e.status_code == 400:
                 raise HomeAssistantAPIError(
                     f"Invalid automation configuration: {str(e)}", status_code=400
                 ) from e
             raise
 
-    # Cadence preserves the prior 3-attempt × 6s upper-bound budget while
-    # tightening the first poll to 0.1s. HA Core typically publishes a new
-    # automation entity to the state machine well under 1s, so the prior
-    # 1s/2s/3s shape spent most of its first-iteration budget waiting on the
-    # common case. Failure-path cost is unchanged (still 3 get_states() calls).
+    # 3-attempt × 6s upper-bound budget; first poll 0.1s catches the
+    # typical sub-1s entity-publish window.
     _POLL_CADENCE: tuple[float, ...] = (0.1, 1.0, 4.9)
 
     async def _poll_for_automation_entity(self, unique_id: str) -> str | None:
@@ -945,18 +945,13 @@ class HomeAssistantClient:
                         )
                         return entity_id
         except HomeAssistantError as e:
-            # Narrow to expected transient classes: HomeAssistantError is the
-            # base of the four typed REST exceptions raised by get_states()
-            # (Connection / Auth / API / Command). Programming bugs (TypeError,
-            # KeyError, AttributeError, AssertionError) propagate so they fail
-            # loud with a stack trace instead of being swallowed and surfacing
-            # as entity_not_verified. The convention is codified for tests at
-            # .gemini/styleguide.md:43-46 (section "Exception Handling in Test
-            # Polling Loops") and implemented by
-            # tests/src/e2e/utilities/wait_helpers.py::_POLLING_TRANSIENT_ERRORS
-            # — the same principle applies to this production polling loop.
+            # Narrow catch: programming bugs (TypeError/KeyError/etc.) propagate.
+            # Mirrors test-side _POLLING_TRANSIENT_ERRORS in
+            # tests/src/e2e/utilities/wait_helpers.py and styleguide §
+            # "Exception Handling in Test Polling Loops".
             logger.warning(
-                f"Failed to query actual entity_id for unique_id {unique_id}: {e}"
+                f"Failed to query actual entity_id for unique_id {unique_id}: {e}",
+                exc_info=True,
             )
             return None
 

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -137,3 +137,135 @@ class TestDeleteAutomationConfig:
         assert result["identifier"] == "direct_unique_id"
         assert result["unique_id"] == "direct_unique_id"
         assert result["operation"] == "deleted"
+
+
+class TestPollForAutomationEntity:
+    """Tests for the poll cadence in _poll_for_automation_entity (issue #1380)."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock HomeAssistantClient for testing."""
+        with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+            client = HomeAssistantClient()
+            client.base_url = "http://test.local:8123"
+            client.token = "test-token"
+            client.timeout = 30
+            client.httpx_client = MagicMock()
+            return client
+
+    def test_poll_cadence_shape(self):
+        """Pin the cadence tuple. Mutation test: changing the tuple in
+        rest_client.py without updating this assertion fails CI."""
+        assert HomeAssistantClient._POLL_CADENCE == (0.1, 1.0, 4.9)
+        # 3 attempts preserves the original failure-path get_states() load.
+        assert len(HomeAssistantClient._POLL_CADENCE) == 3
+        # 6.0s upper bound preserves the original 1+2+3s budget on slow HA.
+        assert sum(HomeAssistantClient._POLL_CADENCE) == pytest.approx(6.0)
+        # First poll is sub-200ms so the happy path returns before the
+        # original 1.0s first-iteration burn.
+        assert HomeAssistantClient._POLL_CADENCE[0] <= 0.2
+
+    @pytest.mark.asyncio
+    async def test_poll_returns_entity_id_on_first_attempt(self, mock_client):
+        """When HA publishes the entity within the first 0.1s window, the
+        poll returns on iteration 1 and only sleeps once."""
+        mock_client.get_states = AsyncMock(
+            return_value=[
+                {
+                    "entity_id": "automation.test_target",
+                    "attributes": {"id": "unique_42"},
+                }
+            ]
+        )
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(duration: float) -> None:
+            sleep_calls.append(duration)
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_42")
+
+        assert result == "automation.test_target"
+        assert sleep_calls == [0.1]
+        assert mock_client.get_states.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_returns_none_on_full_miss(self, mock_client):
+        """When the entity never appears, the poll exhausts the cadence,
+        sleeps for the full 6s budget across 3 attempts, and returns None."""
+        mock_client.get_states = AsyncMock(return_value=[])
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(duration: float) -> None:
+            sleep_calls.append(duration)
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_42")
+
+        assert result is None
+        assert sleep_calls == [0.1, 1.0, 4.9]
+        assert mock_client.get_states.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_poll_returns_entity_id_on_later_attempt(self, mock_client):
+        """When HA publishes after the first poll, later iterations succeed
+        without sleeping for the full cadence."""
+        # First call returns no match, second call returns the match.
+        mock_client.get_states = AsyncMock(
+            side_effect=[
+                [],
+                [
+                    {
+                        "entity_id": "automation.slow_target",
+                        "attributes": {"id": "unique_99"},
+                    }
+                ],
+            ]
+        )
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(duration: float) -> None:
+            sleep_calls.append(duration)
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_99")
+
+        assert result == "automation.slow_target"
+        assert sleep_calls == [0.1, 1.0]
+        assert mock_client.get_states.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_ignores_non_automation_entities(self, mock_client):
+        """States not starting with `automation.` are skipped so we don't
+        match a script/scene that happens to carry the same id attribute."""
+        mock_client.get_states = AsyncMock(
+            return_value=[
+                {"entity_id": "script.distractor", "attributes": {"id": "unique_42"}},
+                {
+                    "entity_id": "automation.actual",
+                    "attributes": {"id": "unique_42"},
+                },
+            ]
+        )
+
+        async def fake_sleep(duration: float) -> None:
+            return None
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_42")
+
+        assert result == "automation.actual"
+
+    @pytest.mark.asyncio
+    async def test_poll_swallows_get_states_exception(self, mock_client):
+        """A transient `get_states` failure must not propagate; the caller
+        gets None and the upsert path surfaces entity_not_verified=True."""
+        mock_client.get_states = AsyncMock(side_effect=RuntimeError("transient"))
+
+        async def fake_sleep(duration: float) -> None:
+            return None
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_42")
+
+        assert result is None

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -259,8 +259,16 @@ class TestPollForAutomationEntity:
     @pytest.mark.asyncio
     async def test_poll_swallows_get_states_exception(self, mock_client):
         """A transient `get_states` failure must not propagate; the caller
-        gets None and the upsert path surfaces entity_not_verified=True."""
-        mock_client.get_states = AsyncMock(side_effect=RuntimeError("transient"))
+        gets None and the upsert path surfaces entity_not_verified=True.
+
+        Uses ``HomeAssistantAPIError`` for the transient mock — the realistic
+        failure class for a polling-side ``get_states`` blip is an API error
+        from the REST client, not a bare ``RuntimeError``. Matches the
+        established sibling pattern in ``test_wait_helpers.py:54`` and
+        ``:88``."""
+        mock_client.get_states = AsyncMock(
+            side_effect=HomeAssistantAPIError("transient")
+        )
 
         async def fake_sleep(duration: float) -> None:
             return None

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -140,7 +140,15 @@ class TestDeleteAutomationConfig:
 
 
 class TestPollForAutomationEntity:
-    """Tests for the poll cadence in _poll_for_automation_entity (issue #1380)."""
+    """Tests for the poll cadence in _poll_for_automation_entity (issue #1380).
+
+    Patch-path note: tests patch ``ha_mcp.client.rest_client.asyncio.sleep``
+    by attribute access. A refactor to ``from asyncio import sleep`` in the
+    production module would silently let real sleeps run — the full-miss
+    test would hang for ~6s instead of completing instantly. If that
+    refactor lands, update the patch target to
+    ``ha_mcp.client.rest_client.sleep``.
+    """
 
     @pytest.fixture
     def mock_client(self):
@@ -154,15 +162,10 @@ class TestPollForAutomationEntity:
             return client
 
     def test_poll_cadence_shape(self):
-        """Pin the cadence tuple. Mutation test: changing the tuple in
-        rest_client.py without updating this assertion fails CI."""
+        """Pin the cadence tuple plus the sub-200ms first-poll bound — length
+        and sum are derivable from the tuple and would fail redundantly on a
+        mutation."""
         assert HomeAssistantClient._POLL_CADENCE == (0.1, 1.0, 4.9)
-        # 3 attempts preserves the original failure-path get_states() load.
-        assert len(HomeAssistantClient._POLL_CADENCE) == 3
-        # 6.0s upper bound preserves the original 1+2+3s budget on slow HA.
-        assert sum(HomeAssistantClient._POLL_CADENCE) == pytest.approx(6.0)
-        # First poll is sub-200ms so the happy path returns before the
-        # original 1.0s first-iteration burn.
         assert HomeAssistantClient._POLL_CADENCE[0] <= 0.2
 
     @pytest.mark.asyncio
@@ -258,21 +261,12 @@ class TestPollForAutomationEntity:
 
     @pytest.mark.asyncio
     async def test_poll_swallows_get_states_exception(self, mock_client):
-        """A transient `get_states` failure must not propagate; the caller
-        gets None and the upsert path surfaces entity_not_verified=True.
-
-        Uses ``HomeAssistantAPIError`` for the transient mock — the realistic
-        failure class for a polling-side ``get_states`` blip is an API error
-        from the REST client, not a bare ``RuntimeError``. Matches the
-        established sibling pattern in ``test_wait_helpers.py:54`` and
-        ``:88``.
-
-        Pins ``call_count == 1`` to lock in the early-exit semantics: the
-        ``try`` at ``rest_client.py:934`` wraps the entire ``for`` loop, so a
-        transient on iteration 1 hits the ``except HomeAssistantError`` clause
-        and exits without re-entering the cadence. A future refactor moving
-        the ``try`` inside the loop (so transients retry until cadence
-        exhaustion) would fail this assertion loudly."""
+        """Transient ``get_states`` failures yield None (and
+        ``entity_not_verified=True`` upstream), not a propagated exception.
+        Uses ``HomeAssistantAPIError`` — the realistic transient class,
+        mirrors ``_POLLING_TRANSIENT_ERRORS`` in ``wait_helpers.py``.
+        ``call_count == 1`` locks the wrap-scope: the ``try`` covers the
+        entire ``for``, so iteration-1 transients exit immediately."""
         mock_client.get_states = AsyncMock(
             side_effect=HomeAssistantAPIError("transient")
         )
@@ -285,3 +279,44 @@ class TestPollForAutomationEntity:
 
         assert result is None
         assert mock_client.get_states.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_swallows_get_states_exception_on_iteration_2(
+        self, mock_client
+    ):
+        """Mid-loop transient also exits early — locks the wrap-scope: the
+        ``try`` covers the entire ``for`` (not the loop body), so a transient
+        on iteration 2 hits the ``except HomeAssistantError`` clause and
+        returns immediately. ``call_count == 2`` would fail if a future
+        refactor moved the ``try`` inside the loop (which would retry
+        transients until cadence exhaustion)."""
+        mock_client.get_states = AsyncMock(
+            side_effect=[[], HomeAssistantAPIError("transient on iteration 2")]
+        )
+
+        async def fake_sleep(duration: float) -> None:
+            return None
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            result = await mock_client._poll_for_automation_entity("unique_42")
+
+        assert result is None
+        assert mock_client.get_states.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_propagates_typeerror_for_unexpected_errors(
+        self, mock_client
+    ):
+        """Programming bugs (TypeError, KeyError, AttributeError, …) must
+        propagate — they are not transient, and swallowing them would mask
+        the bug as ``entity_not_verified=True``. Locks the narrowed
+        ``except HomeAssistantError`` clause: a future widen-back to
+        ``except Exception`` would fail this test."""
+        mock_client.get_states = AsyncMock(side_effect=TypeError("bug"))
+
+        async def fake_sleep(duration: float) -> None:
+            return None
+
+        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
+            with pytest.raises(TypeError, match="bug"):
+                await mock_client._poll_for_automation_entity("unique_42")

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -317,6 +317,8 @@ class TestPollForAutomationEntity:
         async def fake_sleep(duration: float) -> None:
             return None
 
-        with patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep):
-            with pytest.raises(TypeError, match="bug"):
-                await mock_client._poll_for_automation_entity("unique_42")
+        with (
+            patch("ha_mcp.client.rest_client.asyncio.sleep", new=fake_sleep),
+            pytest.raises(TypeError, match="bug"),
+        ):
+            await mock_client._poll_for_automation_entity("unique_42")

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -265,7 +265,14 @@ class TestPollForAutomationEntity:
         failure class for a polling-side ``get_states`` blip is an API error
         from the REST client, not a bare ``RuntimeError``. Matches the
         established sibling pattern in ``test_wait_helpers.py:54`` and
-        ``:88``."""
+        ``:88``.
+
+        Pins ``call_count == 1`` to lock in the early-exit semantics: the
+        ``try`` at ``rest_client.py:934`` wraps the entire ``for`` loop, so a
+        transient on iteration 1 hits the ``except HomeAssistantError`` clause
+        and exits without re-entering the cadence. A future refactor moving
+        the ``try`` inside the loop (so transients retry until cadence
+        exhaustion) would fail this assertion loudly."""
         mock_client.get_states = AsyncMock(
             side_effect=HomeAssistantAPIError("transient")
         )
@@ -277,3 +284,4 @@ class TestPollForAutomationEntity:
             result = await mock_client._poll_for_automation_entity("unique_42")
 
         assert result is None
+        assert mock_client.get_states.call_count == 1


### PR DESCRIPTION
## What does this PR do?

Replaces the linear `asyncio.sleep(1 * (attempt + 1))` cadence in `HomeAssistantClient._poll_for_automation_entity` (`src/ha_mcp/client/rest_client.py`) with an explicit `(0.1, 1.0, 4.9)` tuple. Same 3-attempt count, same 6.0s upper-bound budget — but the 0.1s first poll catches HA Core's typical sub-second entity-registration window an order of magnitude faster.

Removes ~1s of perceived latency from every `ha_config_set_automation` CREATE call with no `identifier` (the LLM-agent path), and ~6s of fixed cost from the slow-automation e2e suite (profiled on master run [26157120272](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26157120272)). Failure-path `get_states()` call count is unchanged (still 3).

Adds `TestPollForAutomationEntity` (6 tests in `tests/src/unit/test_rest_client_automations.py`): pin the cadence tuple, early-hit on first attempt, full-miss exhausting the 6s budget, mid-poll hit on second attempt, non-automation-entity filter, and `get_states` exception fallback.

Closes #1380

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
