### PR TITLE
test: pin remaining _classify_by_message branches

### DIFF
--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -114,17 +114,13 @@ class TestUnknownConfigSpecifiedClassification:
 
 
 class TestClassifyByMessageBranches:
-    """One regression test per branch in ``_classify_by_message`` that wasn't
-    already pinned by ``TestUnknownConfigSpecifiedClassification`` above,
-    ``test_tool_error_signaling.py::TestErrorCodeMapping`` (timeout/connection
-    typed-dispatch), or
-    ``test_tool_error_signaling.py::TestSchemaAndAuthClassification``
-    (schema markers + auth phrases). Closes the branch-coverage gap so that
-    a future reordering, substring rename, or missed elif case is caught
-    against the classifier directly, not via whichever tool happens to
-    exercise it.
+    """Mutation-test coverage for every elif branch of ``_classify_by_message``
+    (``src/ha_mcp/tools/helpers.py:258-327``). Each test exercises exactly
+    one branch so reordering arms, renaming a substring, or dropping an elif
+    is caught against the classifier directly — not via whichever tool
+    happens to surface the branch through an integration path.
 
-    Six branches covered here (helpers.py:258-327 at HEAD):
+    Seven branches covered here:
 
     1. Plain ``"not found"`` substring without ``unknown config specified``
        and without ``entity_id`` context → ``RESOURCE_NOT_FOUND``
@@ -132,12 +128,24 @@ class TestClassifyByMessageBranches:
     3. Plain ``"not found"`` WITH ``entity_id`` context → ``ENTITY_NOT_FOUND``
        (symmetric case to
        ``test_unknown_config_specified_with_entity_id_context_promotes_to_entity_not_found``)
-    4. ``"timeout" in error_str`` message-substring path → ``TIMEOUT_OPERATION``
+    4. ``"timeout"`` message-substring path → ``TIMEOUT_OPERATION``
        (separately from the typed ``TimeoutError`` dispatch in
        ``_classify_exception``)
-    5. ``command failed:`` SERVICE_CALL_FAILED fallback (no schema markers,
+    5. ``"connection"``/``"connect"`` message-substring path →
+       ``CONNECTION_FAILED`` (separately from the typed
+       ``HomeAssistantConnectionError`` dispatch). Also indirectly pinned
+       at ``test_tool_error_signaling.py:229`` via plain
+       ``Exception("Connection refused")`` falling through to
+       ``_classify_by_message`` — duplicate-covered here for self-contained
+       mutation coverage in this class.
+    6. ``command failed:`` SERVICE_CALL_FAILED fallback (no schema markers,
        no ``expected <type>`` regex hit)
-    6. Final ``else`` → ``INTERNAL_ERROR``
+    7. Final ``else`` → ``INTERNAL_ERROR``
+
+    Schema markers + auth phrases (the two remaining branches of
+    ``_classify_by_message``) are mutation-grade covered in
+    ``test_tool_error_signaling.py::TestSchemaAndAuthClassification`` —
+    not duplicated here.
     """
 
     @pytest.mark.parametrize(
@@ -152,12 +160,16 @@ class TestClassifyByMessageBranches:
             #    the typed TimeoutError case in _classify_exception is
             #    bypassed and routing falls into _classify_by_message.
             ("request timeout after 30s", "TIMEOUT_OPERATION"),
-            # 5. command failed: fallback (no schema markers, no
+            # 5. Message-substring connection path. Plain Exception again
+            #    so the typed HomeAssistantConnectionError dispatch in
+            #    _classify_exception is bypassed.
+            ("connection refused", "CONNECTION_FAILED"),
+            # 6. command failed: fallback (no schema markers, no
             #    "expected <type>" regex, not auth, not 404) →
             #    SERVICE_CALL_FAILED. Mirrors the 4xx fallback in
             #    _classify_api_status.
             ("command failed: websocket dispatch error", "SERVICE_CALL_FAILED"),
-            # 6. Final else: an unmapped message reaches the catch-all
+            # 7. Final else: an unmapped message reaches the catch-all
             #    INTERNAL_ERROR sink, not a different bucket via accidental
             #    substring overlap.
             ("totally unexpected gibberish", "INTERNAL_ERROR"),
@@ -166,6 +178,7 @@ class TestClassifyByMessageBranches:
             "plain_not_found",
             "plain_404",
             "timeout_substring",
+            "connection_substring",
             "command_failed_fallback",
             "else_internal_error",
         ],

--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -115,12 +115,12 @@ class TestUnknownConfigSpecifiedClassification:
 
 class TestClassifyByMessageBranches:
     """Mutation-test coverage for every elif branch of ``_classify_by_message``
-    (``src/ha_mcp/tools/helpers.py:258-327``). Each test exercises exactly
-    one branch so reordering arms, renaming a substring, or dropping an elif
-    is caught against the classifier directly — not via whichever tool
-    happens to surface the branch through an integration path.
+    in ``src/ha_mcp/tools/helpers.py``. Each test exercises exactly one branch
+    so reordering arms, renaming a substring, or dropping an elif is caught
+    against the classifier directly — not via whichever tool happens to
+    surface the branch through an integration path.
 
-    Seven branches covered here:
+    Branches covered:
 
     1. Plain ``"not found"`` substring without ``unknown config specified``
        and without ``entity_id`` context → ``RESOURCE_NOT_FOUND``
@@ -134,18 +134,27 @@ class TestClassifyByMessageBranches:
     5. ``"connection"``/``"connect"`` message-substring path →
        ``CONNECTION_FAILED`` (separately from the typed
        ``HomeAssistantConnectionError`` dispatch). Also indirectly pinned
-       at ``test_tool_error_signaling.py:229`` via plain
-       ``Exception("Connection refused")`` falling through to
+       at
+       ``test_tool_error_signaling.py::TestErrorCodeMapping::test_connection_error_in_message_maps_correctly``
+       via plain ``Exception("Connection refused")`` falling through to
        ``_classify_by_message`` — duplicate-covered here for self-contained
        mutation coverage in this class.
-    6. ``command failed:`` SERVICE_CALL_FAILED fallback (no schema markers,
+    6. Schema markers under ``Command failed:`` prefix → ``VALIDATION_FAILED``
+       (Supervisor ``vol.Invalid`` wire format, issue #993).
+    7. Auth phrases (``unauthorized`` / ``authentication`` / ``invalid
+       token`` / ``access denied``) + ``401`` numeric signal →
+       ``AUTH_INVALID_TOKEN`` (issue #993).
+    8. ``command failed:`` SERVICE_CALL_FAILED fallback (no schema markers,
        no ``expected <type>`` regex hit)
-    7. Final ``else`` → ``INTERNAL_ERROR``
+    9. Final ``else`` → ``INTERNAL_ERROR``
 
-    Schema markers + auth phrases (the two remaining branches of
-    ``_classify_by_message``) are mutation-grade covered in
-    ``test_tool_error_signaling.py::TestSchemaAndAuthClassification`` —
-    not duplicated here.
+    Precedence/gate behaviour (``command failed:`` outer gate, ``authorized_keys``
+    false-positive guard) and typed-exception dispatch via
+    ``_classify_exception`` (HomeAssistantAuthError, HomeAssistantConnectionError,
+    HomeAssistantCommandError) live in
+    ``test_tool_error_signaling.py::TestSchemaAndAuthClassification`` — those
+    exercise the type-dispatch layer and the precedence gates, not the
+    message-substring elif chain.
     """
 
     @pytest.mark.parametrize(
@@ -205,10 +214,11 @@ class TestClassifyByMessageBranches:
     ):
         """Plain ``not found`` + entity_id context → ENTITY_NOT_FOUND.
 
-        Pins the context-promotion path for the pre-#1345 substring.
+        Pins the context-promotion path for the long-standing ``not found``
+        substring (predates #1345's ``unknown config specified`` addition).
         Drop the ``or "not found" in error_str`` clause from the elif and
-        this test fails (RESOURCE_NOT_FOUND on a missing entity instead of
-        ENTITY_NOT_FOUND).
+        the not-found path is skipped entirely; the result drops to
+        ``INTERNAL_ERROR`` via the final else.
         """
         result = exception_to_structured_error(
             Exception("entity light.living_room not found"),
@@ -220,3 +230,74 @@ class TestClassifyByMessageBranches:
             f"Expected ENTITY_NOT_FOUND under entity_id context with "
             f"plain 'not found' substring, got: {result['error'].get('code')}"
         )
+
+    # --- Schema markers: vol.Invalid messages under "Command failed:" prefix ---
+
+    SCHEMA_MARKER_MESSAGES: tuple[tuple[str, str], ...] = (
+        # marker id, full message
+        ("missing_option", "Command failed: Missing option 'authorized_keys' in ssh"),
+        ("extra_keys", "Command failed: extra keys not allowed @ data['foo']"),
+        ("unknown_secret", "Command failed: Unknown secret 'api_key'"),
+        ("unknown_type", "Command failed: Unknown type 'timedelta'"),
+        (
+            "expected_a",
+            "Command failed: expected a string for dictionary value @ data['host']",
+        ),
+        ("expected_str", "Command failed: expected str for 'name'"),
+        ("expected_int", "Command failed: expected int for 'port'"),
+        ("expected_bool", "Command failed: expected bool"),
+        ("expected_dict", "Command failed: expected dict"),
+        ("expected_list", "Command failed: expected list of strings"),
+        ("expected_float", "Command failed: expected float value"),
+        ("expected_type", "Command failed: expected type 'str'"),
+        ("expected_one_of", "Command failed: expected one of ['a', 'b', 'c']"),
+    )
+
+    @pytest.mark.parametrize(
+        "marker_id,message",
+        SCHEMA_MARKER_MESSAGES,
+        ids=[m[0] for m in SCHEMA_MARKER_MESSAGES],
+    )
+    def test_schema_marker_classified_as_validation_failed(self, marker_id, message):
+        """Each vol.Invalid marker under "Command failed:" routes to VALIDATION_FAILED.
+
+        Mutation-testing-style coverage: drop any marker from the source
+        tuple in helpers.py and the corresponding parametrized case fails.
+        """
+        exc = HomeAssistantCommandError(message)
+        result = exception_to_structured_error(exc, raise_error=False)
+        assert result["error"]["code"] == "VALIDATION_FAILED", (
+            f"marker {marker_id!r} did not route to VALIDATION_FAILED"
+        )
+
+    # --- Auth branch: phrase list + 401 numeric signal ---
+
+    AUTH_PHRASE_MESSAGES: tuple[tuple[str, str], ...] = (
+        ("unauthorized", "unauthorized: invalid bearer token"),
+        ("authentication", "authentication required"),
+        ("invalid_token", "token rejected: invalid token format"),
+        ("access_denied", "access denied for user"),
+    )
+
+    @pytest.mark.parametrize(
+        "phrase_id,message",
+        AUTH_PHRASE_MESSAGES,
+        ids=[m[0] for m in AUTH_PHRASE_MESSAGES],
+    )
+    def test_auth_phrase_classified(self, phrase_id, message):
+        """Each auth phrase routes to AUTH_INVALID_TOKEN.
+
+        Mutation-testing coverage: drop any phrase from the source tuple
+        in helpers.py and the corresponding case fails.
+        """
+        exc = Exception(message)
+        result = exception_to_structured_error(exc, raise_error=False)
+        assert result["error"]["code"] == "AUTH_INVALID_TOKEN", (
+            f"phrase {phrase_id!r} did not route to AUTH_INVALID_TOKEN"
+        )
+
+    def test_401_status_still_classified_as_auth(self):
+        """401 numeric signal in error text remains an auth error."""
+        exc = Exception("Server returned 401")
+        result = exception_to_structured_error(exc, raise_error=False)
+        assert result["error"]["code"] == "AUTH_INVALID_TOKEN"

--- a/tests/src/unit/test_helper_classifier.py
+++ b/tests/src/unit/test_helper_classifier.py
@@ -16,6 +16,8 @@ not-found branch, and falls into the ``command failed:`` SERVICE_CALL_FAILED
 fallback — losing the not-found signal the agent retry path branches on.
 """
 
+import pytest
+
 from ha_mcp.client.rest_client import HomeAssistantCommandError
 from ha_mcp.tools.helpers import exception_to_structured_error
 
@@ -108,4 +110,100 @@ class TestUnknownConfigSpecifiedClassification:
         assert result["error"]["code"] == "ENTITY_NOT_FOUND", (
             f"Expected ENTITY_NOT_FOUND under entity_id context, got: "
             f"{result['error'].get('code')}"
+        )
+
+
+class TestClassifyByMessageBranches:
+    """One regression test per branch in ``_classify_by_message`` that wasn't
+    already pinned by ``TestUnknownConfigSpecifiedClassification`` above,
+    ``test_tool_error_signaling.py::TestErrorCodeMapping`` (timeout/connection
+    typed-dispatch), or
+    ``test_tool_error_signaling.py::TestSchemaAndAuthClassification``
+    (schema markers + auth phrases). Closes the branch-coverage gap so that
+    a future reordering, substring rename, or missed elif case is caught
+    against the classifier directly, not via whichever tool happens to
+    exercise it.
+
+    Six branches covered here (helpers.py:258-327 at HEAD):
+
+    1. Plain ``"not found"`` substring without ``unknown config specified``
+       and without ``entity_id`` context → ``RESOURCE_NOT_FOUND``
+    2. Plain ``"404"`` substring → ``RESOURCE_NOT_FOUND``
+    3. Plain ``"not found"`` WITH ``entity_id`` context → ``ENTITY_NOT_FOUND``
+       (symmetric case to
+       ``test_unknown_config_specified_with_entity_id_context_promotes_to_entity_not_found``)
+    4. ``"timeout" in error_str`` message-substring path → ``TIMEOUT_OPERATION``
+       (separately from the typed ``TimeoutError`` dispatch in
+       ``_classify_exception``)
+    5. ``command failed:`` SERVICE_CALL_FAILED fallback (no schema markers,
+       no ``expected <type>`` regex hit)
+    6. Final ``else`` → ``INTERNAL_ERROR``
+    """
+
+    @pytest.mark.parametrize(
+        "error_str,expected_code",
+        [
+            # 1. Plain "not found" substring (no "unknown config specified"
+            #    marker, no entity_id context → bare RESOURCE_NOT_FOUND).
+            ("entity not found: light.foo", "RESOURCE_NOT_FOUND"),
+            # 2. Plain "404" substring.
+            ("HTTP 404", "RESOURCE_NOT_FOUND"),
+            # 4. Message-substring timeout path. Uses a plain Exception so
+            #    the typed TimeoutError case in _classify_exception is
+            #    bypassed and routing falls into _classify_by_message.
+            ("request timeout after 30s", "TIMEOUT_OPERATION"),
+            # 5. command failed: fallback (no schema markers, no
+            #    "expected <type>" regex, not auth, not 404) →
+            #    SERVICE_CALL_FAILED. Mirrors the 4xx fallback in
+            #    _classify_api_status.
+            ("command failed: websocket dispatch error", "SERVICE_CALL_FAILED"),
+            # 6. Final else: an unmapped message reaches the catch-all
+            #    INTERNAL_ERROR sink, not a different bucket via accidental
+            #    substring overlap.
+            ("totally unexpected gibberish", "INTERNAL_ERROR"),
+        ],
+        ids=[
+            "plain_not_found",
+            "plain_404",
+            "timeout_substring",
+            "command_failed_fallback",
+            "else_internal_error",
+        ],
+    )
+    def test_classify_by_message_routes_to_expected_code(
+        self, error_str, expected_code
+    ):
+        """Each test message exercises exactly one elif branch in
+        ``_classify_by_message`` that has no other direct pin."""
+        result = exception_to_structured_error(Exception(error_str), raise_error=False)
+        assert result["error"]["code"] == expected_code, (
+            f"input {error_str!r} routed to {result['error'].get('code')!r}, "
+            f"expected {expected_code!r}"
+        )
+
+    # 3. Plain "not found" WITH entity_id context: the symmetric case to
+    #    ``test_unknown_config_specified_with_entity_id_context_promotes_to_entity_not_found``.
+    #    The new ``unknown config specified`` substring lands on the same
+    #    context-promotion code path; this test pins that the OLDER ``not
+    #    found`` substring still promotes — a regression here would mean
+    #    the promotion got tied to the new substring alone.
+    def test_plain_not_found_with_entity_id_context_promotes_to_entity_not_found(
+        self,
+    ):
+        """Plain ``not found`` + entity_id context → ENTITY_NOT_FOUND.
+
+        Pins the context-promotion path for the pre-#1345 substring.
+        Drop the ``or "not found" in error_str`` clause from the elif and
+        this test fails (RESOURCE_NOT_FOUND on a missing entity instead of
+        ENTITY_NOT_FOUND).
+        """
+        result = exception_to_structured_error(
+            Exception("entity light.living_room not found"),
+            context={"entity_id": "light.living_room"},
+            raise_error=False,
+        )
+
+        assert result["error"]["code"] == "ENTITY_NOT_FOUND", (
+            f"Expected ENTITY_NOT_FOUND under entity_id context with "
+            f"plain 'not found' substring, got: {result['error'].get('code')}"
         )

--- a/tests/src/unit/test_tool_error_signaling.py
+++ b/tests/src/unit/test_tool_error_signaling.py
@@ -269,58 +269,25 @@ class TestIntegrationWithMCPProtocol:
 
 
 class TestSchemaAndAuthClassification:
-    """Tests for _classify_by_message schema and auth branches (issue #993).
+    """Precedence/gate behaviour and typed-dispatch carve-out for the schema
+    and auth branches of ``_classify_by_message`` (issue #993).
 
-    Pins three behaviours at the classifier boundary:
-    1. Supervisor vol.Invalid messages prefixed with "Command failed:" and
-       carrying any of the schema markers route to VALIDATION_FAILED.
-    2. Messages that merely contain the substring "auth" (e.g.
-       "authorized_keys") are NOT misclassified as AUTH_INVALID_TOKEN.
-       Only the phrase list (unauthorized, authentication, invalid token,
-       access denied) plus the 401 numeric signal match the auth branch.
+    The per-branch parametrize coverage for schema markers, auth phrases,
+    and the 401 numeric signal lives in
+    ``test_helper_classifier.py::TestClassifyByMessageBranches`` — that
+    class is the canonical mutation-grade per-elif pin. This class covers
+    the orthogonal concerns:
+
+    1. The ``Command failed:`` outer gate for schema-marker matching — a
+       schema phrase without the prefix must NOT route to VALIDATION_FAILED.
+    2. The ``authorized_keys`` false-positive guard (root cause of #993):
+       the substring ``"auth"`` inside ``authorized_keys`` must NOT trigger
+       the auth branch.
     3. Typed HA exceptions (HomeAssistantAuthError,
-       HomeAssistantConnectionError, HomeAssistantCommandError) route via
-       type dispatch in _classify_exception, skipping string
+       HomeAssistantConnectionError, HomeAssistantCommandError) routing
+       via ``_classify_exception`` type-dispatch, skipping string
        classification entirely.
     """
-
-    # --- Schema branch: all 5 vol.Invalid markers + the "expected" regex ---
-
-    SCHEMA_MARKER_MESSAGES: tuple[tuple[str, str], ...] = (
-        # marker id, full message
-        ("missing_option", "Command failed: Missing option 'authorized_keys' in ssh"),
-        ("extra_keys", "Command failed: extra keys not allowed @ data['foo']"),
-        ("unknown_secret", "Command failed: Unknown secret 'api_key'"),
-        ("unknown_type", "Command failed: Unknown type 'timedelta'"),
-        ("expected_a", "Command failed: expected a string for dictionary value @ data['host']"),
-        ("expected_str", "Command failed: expected str for 'name'"),
-        ("expected_int", "Command failed: expected int for 'port'"),
-        ("expected_bool", "Command failed: expected bool"),
-        ("expected_dict", "Command failed: expected dict"),
-        ("expected_list", "Command failed: expected list of strings"),
-        ("expected_float", "Command failed: expected float value"),
-        ("expected_type", "Command failed: expected type 'str'"),
-        ("expected_one_of", "Command failed: expected one of ['a', 'b', 'c']"),
-    )
-
-    @pytest.mark.parametrize(
-        "marker_id,message",
-        SCHEMA_MARKER_MESSAGES,
-        ids=[m[0] for m in SCHEMA_MARKER_MESSAGES],
-    )
-    def test_schema_marker_classified_as_validation_failed(self, marker_id, message):
-        """Each vol.Invalid marker under "Command failed:" routes to VALIDATION_FAILED.
-
-        Mutation-testing-style coverage: drop any marker from the source
-        tuple in helpers.py and the corresponding parametrized case fails.
-        """
-        from ha_mcp.client.rest_client import HomeAssistantCommandError
-
-        exc = HomeAssistantCommandError(message)
-        result = exception_to_structured_error(exc, raise_error=False)
-        assert result["error"]["code"] == "VALIDATION_FAILED", (
-            f"marker {marker_id!r} did not route to VALIDATION_FAILED"
-        )
 
     def test_schema_phrase_without_command_prefix_not_validation(self):
         """Negative test for the "command failed:" outer gate.
@@ -332,38 +299,6 @@ class TestSchemaAndAuthClassification:
         exc = Exception("Missing option 'foo' in bar")
         result = exception_to_structured_error(exc, raise_error=False)
         assert result["error"]["code"] != "VALIDATION_FAILED"
-
-    # --- Auth branch: all 4 phrases + 401 numeric signal ---
-
-    AUTH_PHRASE_MESSAGES: tuple[tuple[str, str], ...] = (
-        ("unauthorized", "unauthorized: invalid bearer token"),
-        ("authentication", "authentication required"),
-        ("invalid_token", "token rejected: invalid token format"),
-        ("access_denied", "access denied for user"),
-    )
-
-    @pytest.mark.parametrize(
-        "phrase_id,message",
-        AUTH_PHRASE_MESSAGES,
-        ids=[m[0] for m in AUTH_PHRASE_MESSAGES],
-    )
-    def test_auth_phrase_classified(self, phrase_id, message):
-        """Each auth phrase routes to AUTH_INVALID_TOKEN.
-
-        Mutation-testing coverage: drop any phrase from the source tuple
-        in helpers.py and the corresponding case fails.
-        """
-        exc = Exception(message)
-        result = exception_to_structured_error(exc, raise_error=False)
-        assert result["error"]["code"] == "AUTH_INVALID_TOKEN", (
-            f"phrase {phrase_id!r} did not route to AUTH_INVALID_TOKEN"
-        )
-
-    def test_401_status_still_classified_as_auth(self):
-        """401 numeric signal in error text remains an auth error."""
-        exc = Exception("Server returned 401")
-        result = exception_to_structured_error(exc, raise_error=False)
-        assert result["error"]["code"] == "AUTH_INVALID_TOKEN"
 
     # --- Regression tests: substrings that must NOT trigger auth ---
 


### PR DESCRIPTION
## What does this PR do?

Adds `TestClassifyByMessageBranches` to `tests/src/unit/test_helper_classifier.py` with 7 cases covering the elif branches in `_classify_by_message` (`src/ha_mcp/tools/helpers.py:258-327`) that weren't already pinned elsewhere:

1. Plain `"not found"` substring → `RESOURCE_NOT_FOUND`
2. Plain `"404"` substring → `RESOURCE_NOT_FOUND`
3. Plain `"not found"` + `entity_id` context → `ENTITY_NOT_FOUND` (symmetric case to the existing `unknown config specified` + context test)
4. `"timeout"` message-substring path → `TIMEOUT_OPERATION` (separate from the typed `TimeoutError` dispatch case already covered in `test_tool_error_signaling.py:221`)
5. `"connection"`/`"connect"` message-substring path → `CONNECTION_FAILED` (separate from the typed `HomeAssistantConnectionError` dispatch; also indirectly pinned at `test_tool_error_signaling.py:229`, duplicate-covered here for self-contained mutation surface)
6. `"command failed:"` fallback → `SERVICE_CALL_FAILED`
7. Final `else` → `INTERNAL_ERROR`

Test-only change; no production code touched. Reordering branches, renaming substrings, or dropping an elif in `_classify_by_message` now fails this class directly rather than via whichever tool happens to exercise it.

Closes #1357

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
