### PR TITLE
ci: add ruff format --check on changed Python files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,28 @@ jobs:
     - name: Run ruff check
       run: uv run ruff check src/ tests/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ scripts/
 
+    - name: Run ruff format check on changed Python files
+      run: |
+        # Changed-files-only gate per the maintainer call on issue #1318:
+        # new edits must be formatted; pre-existing format-debt on
+        # untouched files stays grandfathered. Avoids the disruption of a
+        # repo-wide sweep while still preventing fresh debt from landing.
+        if [ -z "${GITHUB_BASE_REF}" ]; then
+          echo "No PR base ref (workflow_dispatch); skipping format check."
+          exit 0
+        fi
+        git fetch --depth=1 origin "${GITHUB_BASE_REF}"
+        base_sha=$(git rev-parse "origin/${GITHUB_BASE_REF}")
+        changed_py=$(git diff --name-only --diff-filter=ACMR "${base_sha}" -- '*.py')
+        if [ -z "$changed_py" ]; then
+          echo "No Python files changed; skipping ruff format check."
+          exit 0
+        fi
+        count=$(echo "$changed_py" | wc -l)
+        echo "Checking ruff format on $count changed Python files:"
+        echo "$changed_py" | sed 's/^/  /'
+        echo "$changed_py" | xargs uv run ruff format --check
+
   ast-grep:
     name: AST Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+    - name: Install git for changed-files diff
+      run: apt-get update -qq && apt-get install -y -qq git >/dev/null 2>&1
+
     - uses: actions/checkout@v6
 
     - name: Install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,11 @@ jobs:
 
     - name: Run ruff format check on changed Python files
       run: |
+        # actions/checkout@v6 sets safe.directory in a temp HOME that this
+        # step doesn't inherit; re-add it here so git operations succeed
+        # when the checkout dir is owned by a different UID than the
+        # container's root.
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         # Changed-files-only gate per the maintainer call on issue #1318:
         # new edits must be formatted; pre-existing format-debt on
         # untouched files stays grandfathered. Avoids the disruption of a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ uv run mypy src/                   # Type check
 uv run ast-grep scan               # AST lint (error handling patterns)
 ```
 
-On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). The **Ruff Lint** and **AST Lint** CI jobs also enforce this on pull requests.
+On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). The **Ruff Lint** and **AST Lint** CI jobs also enforce these on pull requests; **Ruff Lint** additionally runs `ruff format --check` on changed Python files.
 
 ## 🔄 Migrating from pre-commit to lefthook
 


### PR DESCRIPTION
## What does this PR do?

Adds a new step to `pr.yml`'s Ruff Lint job that runs `uv run ruff format --check` only on the `.py` files touched by the PR (diffed against `$GITHUB_BASE_REF`). Skips cleanly when no Python files are changed, and on `workflow_dispatch` when no base ref is set.

**Maintainer-chosen scope** (per [@kingpanther13's 2026-05-20 reply on #1318](https://github.com/homeassistant-ai/ha-mcp/issues/1318#issuecomment-4498146534)): gate on changed files only, no repo-wide sweep. Pre-existing format-debt across the tree stays grandfathered; new edits must pass `ruff format --check`. Closes the loop on the three deferred format-debt comments (#1254, #1258, #1303) without the disruption a sweep would impose on the open PRs currently in flight against master.

This PR itself touches only `pr.yml` (no `.py` files) so the new step exercises its own no-Python-changed exit path during validation. The actual `ruff format --check` codepath is end-to-end-verified on the first subsequent PR that touches a `.py` file.

Closes #1318

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
