### PR TITLE
feat: add Assist pipeline management tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <!-- mcp-name: io.github.homeassistant-ai/ha-mcp -->
 
   <p align="center">
-    <img src="https://img.shields.io/badge/tools-88-blue" alt="95+ Tools">
+    <img src="https://img.shields.io/badge/tools-89-blue" alt="95+ Tools">
     <a href="https://github.com/homeassistant-ai/ha-mcp/releases"><img src="https://img.shields.io/github/v/release/homeassistant-ai/ha-mcp" alt="Release"></a>
     <a href="https://github.com/homeassistant-ai/ha-mcp/actions/workflows/e2e-tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/homeassistant-ai/ha-mcp/e2e-tests.yml?branch=master&label=E2E%20Tests" alt="E2E Tests"></a>
     <a href="LICENSE.md"><img src="https://img.shields.io/github/license/homeassistant-ai/ha-mcp.svg" alt="License"></a>
@@ -151,12 +151,13 @@ Spend less time configuring, more time enjoying your smart home.
 <details>
 <!-- TOOLS_TABLE_START -->
 
-<summary><b>Complete Tool List (88 tools)</b></summary>
+<summary><b>Complete Tool List (89 tools)</b></summary>
 
 | Category | Tools |
 |----------|-------|
 | **Add-ons** | `ha_get_addon`, `ha_manage_addon` |
 | **Areas & Floors** | `ha_config_list_areas`, `ha_config_list_floors`, `ha_list_floors_areas`, `ha_remove_area_or_floor`, `ha_set_area_or_floor` |
+| **Assist** | `ha_manage_pipeline` |
 | **Automations** | `ha_config_get_automation`, `ha_config_remove_automation`, `ha_config_set_automation` |
 | **Blueprints** | `ha_get_blueprint`, `ha_import_blueprint` |
 | **Calendar** | `ha_config_get_calendar_events`, `ha_config_remove_calendar_event`, `ha_config_set_calendar_event` |

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -4,7 +4,7 @@ AI assistant integration for Home Assistant via Model Context Protocol (MCP).
 
 ## About
 
-This add-on enables AI assistants (Claude, ChatGPT, etc.) to control your Home Assistant installation through the Model Context Protocol (MCP). It provides 88+ tools for device control, automation management, entity search, calendars, todo lists, dashboards, backup/restore, history/statistics, camera snapshots, and system queries.
+This add-on enables AI assistants (Claude, ChatGPT, etc.) to control your Home Assistant installation through the Model Context Protocol (MCP). It provides 89+ tools for device control, automation management, entity search, calendars, todo lists, dashboards, backup/restore, history/statistics, camera snapshots, and system queries.
 
 **Key Features:**
 - **Zero Configuration** - Automatically discovers Home Assistant connection
@@ -256,7 +256,7 @@ Requires add-on restart to take effect.
 
 **Default:** `false`
 
-Replaces the full tool catalog (~88 tools, ~46K tokens) with search-based discovery (~4 proxy tools, ~5K tokens). When enabled, tools are found via `ha_search_tools` and executed through categorized proxies (read/write/delete).
+Replaces the full tool catalog (~89 tools, ~46K tokens) with search-based discovery (~4 proxy tools, ~5K tokens). When enabled, tools are found via `ha_search_tools` and executed through categorized proxies (read/write/delete).
 
 > ⚠️ **Do NOT enable this if you use Claude in Sonnet or Opus modes.** Those models run their own built-in tool search / deferred tools, which conflicts with ha-mcp's — running both at once does not work. To use ha-mcp's tool search with Claude, disable Claude's built-in tool search first; otherwise leave this off.
 
@@ -366,7 +366,7 @@ If the add-on is slow or unresponsive:
 
 <!-- ADDON_TOOLS_START -->
 
-The add-on provides 88+ MCP tools for controlling Home Assistant:
+The add-on provides 89+ MCP tools for controlling Home Assistant:
 
 > **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime. If so, calling it returns an "unknown tool" error until the next stable release.
 
@@ -382,6 +382,9 @@ The add-on provides 88+ MCP tools for controlling Home Assistant:
 - `ha_list_floors_areas` — List floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
 - `ha_remove_area_or_floor` — Remove a Home Assistant area or floor.
 - `ha_set_area_or_floor` — Create or update a Home Assistant area or floor.
+
+### Assist
+- `ha_manage_pipeline` — Manage Home Assistant Assist pipelines.
 
 ### Automations
 - `ha_config_get_automation` — Retrieve Home Assistant automation configuration.

--- a/site/src/data/tools.json
+++ b/site/src/data/tools.json
@@ -260,6 +260,90 @@
     "source_file": "tools_areas.py"
   },
   {
+    "name": "ha_manage_pipeline",
+    "title": "Manage Assist Pipeline",
+    "description": "Manage Home Assistant Assist pipelines.\n\nUse action='list' to discover pipeline IDs, action='get' to inspect one\npipeline, action='create' or action='update' to write pipeline settings,\nand action='set_preferred' to choose the preferred pipeline.\n\nEXAMPLES:\n- List pipelines: ha_manage_pipeline(action=\"list\")\n- Get one pipeline: ha_manage_pipeline(action=\"get\", pipeline_id=\"preferred\")\n- Create by cloning preferred: ha_manage_pipeline(\n      action=\"create\",\n      name=\"Local Assist\",\n      conversation_engine=\"conversation.local_llm\",\n  )\n- Create by cloning a specific pipeline: ha_manage_pipeline(\n      action=\"create\",\n      base_pipeline_id=\"preferred\",\n      name=\"Local Assist\",\n      conversation_engine=\"conversation.local_llm\",\n  )\n- Update conversation agent and clear TTS voice: ha_manage_pipeline(\n      action=\"update\",\n      pipeline_id=\"preferred\",\n      conversation_engine=\"conversation.local_llm\",\n      tts_voice=\"\",\n  )\n- Set preferred: ha_manage_pipeline(\n      action=\"set_preferred\",\n      pipeline_id=\"preferred\",\n  )\n\nEmpty string clears nullable STT/TTS/wake-word fields. Non-nullable\nfields such as name, language, conversation_language, and\nconversation_engine must be omitted or non-empty.",
+    "inputSchema": {
+      "properties": {
+        "action": {
+          "type": "Annotated[PipelineAction, Field(description='Pipeline operation: list, get, create, update, or set_preferred.')]"
+        },
+        "pipeline_id": {
+          "type": "Annotated[str | None, Field(description='Assist pipeline ID. Required for get, update, and set_preferred.', default=None)]",
+          "default": null
+        },
+        "name": {
+          "type": "Annotated[str | None, Field(description=\"Pipeline display name. Required when action='create'.\", default=None)]",
+          "default": null
+        },
+        "conversation_engine": {
+          "type": "Annotated[str | None, Field(description=\"Conversation agent entity ID or engine ID. Required when action='create'.\", default=None)]",
+          "default": null
+        },
+        "base_pipeline_id": {
+          "type": "Annotated[str | None, Field(description='Pipeline ID to clone when creating. Omit to clone the preferred pipeline. Ignored for non-create actions.', default=None)]",
+          "default": null
+        },
+        "conversation_language": {
+          "type": "Annotated[str | None, Field(description=\"Conversation language, usually '*'.\", default=None)]",
+          "default": null
+        },
+        "language": {
+          "type": "Annotated[str | None, Field(description=\"Pipeline language, e.g. 'en'.\", default=None)]",
+          "default": null
+        },
+        "stt_engine": {
+          "type": "Annotated[str | None, Field(description='Speech-to-text engine. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "stt_language": {
+          "type": "Annotated[str | None, Field(description='Speech-to-text language. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "tts_engine": {
+          "type": "Annotated[str | None, Field(description='Text-to-speech engine. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "tts_language": {
+          "type": "Annotated[str | None, Field(description='Text-to-speech language. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "tts_voice": {
+          "type": "Annotated[str | None, Field(description='Text-to-speech voice. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "wake_word_entity": {
+          "type": "Annotated[str | None, Field(description='Wake-word entity ID. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "wake_word_id": {
+          "type": "Annotated[str | None, Field(description='Wake-word ID. Pass empty string to clear.', default=None)]",
+          "default": null
+        },
+        "prefer_local_intents": {
+          "type": "Annotated[bool | None, Field(description='Whether Home Assistant local intents should be preferred before the conversation engine.', default=None)]",
+          "default": null
+        },
+        "make_preferred": {
+          "type": "Annotated[bool, Field(description='For create/update only, also set the resulting pipeline as preferred with an extra websocket call. Ignored for other actions.', default=False)]",
+          "default": false
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    "annotations": {
+      "destructiveHint": true,
+      "idempotentHint": false,
+      "readOnlyHint": false
+    },
+    "tags": [
+      "Assist"
+    ],
+    "source_file": "tools_voice_assistant.py"
+  },
+  {
     "name": "ha_config_get_automation",
     "title": "Get Automation Config",
     "description": "Retrieve Home Assistant automation configuration.\n\nReturns the complete configuration including triggers, conditions, actions, and mode settings.\n\nThe returned `config_hash` is stable across consecutive reads of an unchanged config — `compute_config_hash` documents the underlying contract.\n\nThe returned `automation_id` is the resolved entity_id (canonical\nform, e.g. `automation.morning_routine`) when the registry lookup\nsucceeds, falling back to the input `identifier` otherwise.\n\nEXAMPLES:\n- Get automation: ha_config_get_automation(\"automation.morning_routine\")\n- Get by unique_id: ha_config_get_automation(\"my_unique_automation_id\")\n\nFor comprehensive automation documentation, use ha_get_skill_guide.",

--- a/src/ha_mcp/tools/tools_voice_assistant.py
+++ b/src/ha_mcp/tools/tools_voice_assistant.py
@@ -11,7 +11,7 @@ Known assistant identifiers:
 """
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -24,11 +24,52 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .util_helpers import websocket_error_message
 
 logger = logging.getLogger(__name__)
 
 # Known voice assistant identifiers in Home Assistant
 KNOWN_ASSISTANTS = ["conversation", "cloud.alexa", "cloud.google_assistant"]
+
+PipelineAction = Literal["list", "get", "create", "update", "set_preferred"]
+
+# Mirrors HA Core's assist_pipeline/pipeline.py pipeline create/update schema.
+_PIPELINE_FIELDS = (
+    "conversation_engine",
+    "conversation_language",
+    "language",
+    "name",
+    "stt_engine",
+    "stt_language",
+    "tts_engine",
+    "tts_language",
+    "tts_voice",
+    "wake_word_entity",
+    "wake_word_id",
+    "prefer_local_intents",
+)
+
+_NULLABLE_PIPELINE_FIELDS = {
+    "stt_engine",
+    "stt_language",
+    "tts_engine",
+    "tts_language",
+    "tts_voice",
+    "wake_word_entity",
+    "wake_word_id",
+}
+
+
+def _normalize_pipeline_value(field: str, value: Any) -> Any:
+    """Convert empty string to None for clearable pipeline fields."""
+    if field in _NULLABLE_PIPELINE_FIELDS and value == "":
+        return None
+    return value
+
+
+def _drop_pipeline_id(pipeline: dict[str, Any]) -> dict[str, Any]:
+    """Return only the fields HA accepts for create/update pipeline commands."""
+    return {field: pipeline[field] for field in _PIPELINE_FIELDS if field in pipeline}
 
 
 class VoiceAssistantTools:
@@ -36,6 +77,471 @@ class VoiceAssistantTools:
 
     def __init__(self, client: Any) -> None:
         self._client = client
+
+    async def _send_pipeline_message(
+        self,
+        message: dict[str, Any],
+        *,
+        operation: str,
+        pipeline_id: str | None = None,
+    ) -> Any:
+        """Send an Assist pipeline websocket message and map HA failures."""
+        result = await self._client.send_websocket_message(message)
+
+        if not result.get("success"):
+            error_msg = websocket_error_message(result.get("error", "Operation failed"))
+            raise_tool_error(create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                f"Failed to {operation} Assist pipeline: {error_msg}",
+                context={"pipeline_id": pipeline_id, "operation": operation},
+            ))
+
+        return result.get("result")
+
+    async def _get_pipeline_for_write(self, pipeline_id: str | None) -> dict[str, Any]:
+        """Fetch a pipeline for create/update merge operations."""
+        message: dict[str, Any] = {"type": "assist_pipeline/pipeline/get"}
+        if pipeline_id is not None:
+            message["pipeline_id"] = pipeline_id
+
+        pipeline = await self._send_pipeline_message(
+            message,
+            operation="get",
+            pipeline_id=pipeline_id,
+        )
+        if not isinstance(pipeline, dict):
+            if pipeline_id is None:
+                raise_tool_error(create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "No preferred Assist pipeline is configured",
+                    context={"pipeline_id": pipeline_id, "details": pipeline},
+                    suggestions=[
+                        "Call ha_manage_pipeline(action='list') to find pipeline IDs.",
+                        "Pass base_pipeline_id explicitly when creating a pipeline.",
+                    ],
+                ))
+            raise_tool_error(create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Unexpected Assist pipeline response",
+                context={"pipeline_id": pipeline_id, "details": pipeline},
+            ))
+        return pipeline
+
+    @staticmethod
+    def _pipeline_updates(
+        *,
+        conversation_engine: str | None,
+        conversation_language: str | None,
+        language: str | None,
+        name: str | None,
+        stt_engine: str | None,
+        stt_language: str | None,
+        tts_engine: str | None,
+        tts_language: str | None,
+        tts_voice: str | None,
+        wake_word_entity: str | None,
+        wake_word_id: str | None,
+        prefer_local_intents: bool | None,
+    ) -> dict[str, Any]:
+        """Collect supplied pipeline fields into HA's pipeline storage shape."""
+        values = {
+            "conversation_engine": conversation_engine,
+            "conversation_language": conversation_language,
+            "language": language,
+            "name": name,
+            "stt_engine": stt_engine,
+            "stt_language": stt_language,
+            "tts_engine": tts_engine,
+            "tts_language": tts_language,
+            "tts_voice": tts_voice,
+            "wake_word_entity": wake_word_entity,
+            "wake_word_id": wake_word_id,
+            "prefer_local_intents": prefer_local_intents,
+        }
+        for field, value in values.items():
+            if value == "" and field not in _NULLABLE_PIPELINE_FIELDS:
+                raise_tool_error(create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{field} cannot be an empty string",
+                    context={"field": field},
+                    suggestions=[
+                        f"Omit {field} to keep the existing or cloned value.",
+                        f"Pass a non-empty value for {field}.",
+                    ],
+                ))
+        return {
+            field: _normalize_pipeline_value(field, value)
+            for field, value in values.items()
+            if value is not None
+        }
+
+    async def _manage_pipeline_read(
+        self,
+        *,
+        action: PipelineAction,
+        pipeline_id: str | None,
+    ) -> dict[str, Any]:
+        """Handle Assist pipeline list/get actions."""
+        if action == "list":
+            data = await self._send_pipeline_message(
+                {"type": "assist_pipeline/pipeline/list"},
+                operation="list",
+            )
+            pipelines = data.get("pipelines", []) if isinstance(data, dict) else []
+            return {
+                "success": True,
+                "operation": "list",
+                "count": len(pipelines),
+                "pipelines": pipelines,
+                "preferred_pipeline": (
+                    data.get("preferred_pipeline") if isinstance(data, dict) else None
+                ),
+                "message": f"Found {len(pipelines)} Assist pipeline(s)",
+            }
+
+        if pipeline_id is None:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "action='get' requires pipeline_id",
+                context={"action": action},
+                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
+            ))
+
+        data = await self._send_pipeline_message(
+            {"type": "assist_pipeline/pipeline/get", "pipeline_id": pipeline_id},
+            operation="get",
+            pipeline_id=pipeline_id,
+        )
+        return {
+            "success": True,
+            "operation": "get",
+            "pipeline_id": pipeline_id,
+            "pipeline": data,
+            "message": (
+                f"Found Assist pipeline: {data.get('name', pipeline_id)}"
+                if isinstance(data, dict)
+                else f"Found Assist pipeline: {pipeline_id}"
+            ),
+        }
+
+    async def _set_preferred_pipeline(self, pipeline_id: str | None) -> dict[str, Any]:
+        """Set the preferred Assist pipeline."""
+        if pipeline_id is None:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "action='set_preferred' requires pipeline_id",
+                context={"action": "set_preferred"},
+                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
+            ))
+
+        await self._send_pipeline_message(
+            {
+                "type": "assist_pipeline/pipeline/set_preferred",
+                "pipeline_id": pipeline_id,
+            },
+            operation="set preferred",
+            pipeline_id=pipeline_id,
+        )
+        return {
+            "success": True,
+            "operation": "set_preferred",
+            "pipeline_id": pipeline_id,
+            "message": f"Successfully set preferred Assist pipeline: {pipeline_id}",
+        }
+
+    async def _write_pipeline(
+        self,
+        *,
+        action: PipelineAction,
+        pipeline_id: str | None,
+        base_pipeline_id: str | None,
+        updates: dict[str, Any],
+        make_preferred: bool,
+    ) -> dict[str, Any]:
+        """Handle Assist pipeline create/update actions."""
+        if action == "create" and (
+            updates.get("name") is None or updates.get("conversation_engine") is None
+        ):
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "action='create' requires name and conversation_engine",
+                context={"action": action},
+                suggestions=[
+                    "Provide name and conversation_engine.",
+                    "Use ha_manage_pipeline(action='list') to inspect current pipeline values.",
+                ],
+            ))
+
+        if action == "update" and pipeline_id is None:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_MISSING_PARAMETER,
+                "action='update' requires pipeline_id",
+                context={"action": action},
+                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
+            ))
+
+        if not updates and not make_preferred:
+            raise_tool_error(create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "No Assist pipeline changes requested",
+                context={"action": action, "pipeline_id": pipeline_id},
+                suggestions=[
+                    "Pass at least one pipeline field to update.",
+                    "Use action='set_preferred' to only change the preferred pipeline.",
+                ],
+            ))
+
+        source_pipeline_id = pipeline_id if action == "update" else base_pipeline_id
+        pipeline = await self._get_pipeline_for_write(source_pipeline_id)
+        payload = _drop_pipeline_id(pipeline)
+        payload.update(updates)
+
+        message = {
+            "type": f"assist_pipeline/pipeline/{action}",
+            **payload,
+        }
+        if action == "update":
+            message["pipeline_id"] = pipeline_id
+
+        result_pipeline = await self._send_pipeline_message(
+            message,
+            operation=action,
+            pipeline_id=pipeline_id,
+        )
+        if not isinstance(result_pipeline, dict):
+            raise_tool_error(create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Unexpected Assist pipeline write response",
+                context={
+                    "action": action,
+                    "pipeline_id": pipeline_id,
+                    "details": result_pipeline,
+                },
+            ))
+
+        result_pipeline_id = str(result_pipeline.get("id", pipeline_id))
+        preferred_changed = False
+        if make_preferred:
+            await self._set_preferred_pipeline(result_pipeline_id)
+            preferred_changed = True
+
+        operation = "created" if action == "create" else "updated"
+        return {
+            "success": True,
+            "operation": operation,
+            "pipeline_id": result_pipeline_id,
+            "pipeline": result_pipeline,
+            "preferred_changed": preferred_changed,
+            "message": (
+                f"Assist pipeline {operation}: "
+                f"{result_pipeline.get('name', result_pipeline_id)}"
+            ),
+        }
+
+    @tool(
+        name="ha_manage_pipeline",
+        tags={"Assist"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "readOnlyHint": False,
+            "title": "Manage Assist Pipeline",
+        },
+    )
+    @log_tool_usage
+    async def ha_manage_pipeline(
+        self,
+        action: Annotated[
+            PipelineAction,
+            Field(
+                description=(
+                    "Pipeline operation: list, get, create, update, or set_preferred."
+                ),
+            ),
+        ],
+        pipeline_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Assist pipeline ID. Required for get, update, and set_preferred."
+                ),
+                default=None,
+            ),
+        ] = None,
+        name: Annotated[
+            str | None,
+            Field(
+                description="Pipeline display name. Required when action='create'.",
+                default=None,
+            ),
+        ] = None,
+        conversation_engine: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Conversation agent entity ID or engine ID. Required when action='create'."
+                ),
+                default=None,
+            ),
+        ] = None,
+        base_pipeline_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Pipeline ID to clone when creating. Omit to clone the preferred "
+                    "pipeline. Ignored for non-create actions."
+                ),
+                default=None,
+            ),
+        ] = None,
+        conversation_language: Annotated[
+            str | None,
+            Field(description="Conversation language, usually '*'.", default=None),
+        ] = None,
+        language: Annotated[
+            str | None,
+            Field(description="Pipeline language, e.g. 'en'.", default=None),
+        ] = None,
+        stt_engine: Annotated[
+            str | None,
+            Field(
+                description="Speech-to-text engine. Pass empty string to clear.",
+                default=None,
+            ),
+        ] = None,
+        stt_language: Annotated[
+            str | None,
+            Field(
+                description="Speech-to-text language. Pass empty string to clear.",
+                default=None,
+            ),
+        ] = None,
+        tts_engine: Annotated[
+            str | None,
+            Field(
+                description="Text-to-speech engine. Pass empty string to clear.",
+                default=None,
+            ),
+        ] = None,
+        tts_language: Annotated[
+            str | None,
+            Field(
+                description="Text-to-speech language. Pass empty string to clear.",
+                default=None,
+            ),
+        ] = None,
+        tts_voice: Annotated[
+            str | None,
+            Field(description="Text-to-speech voice. Pass empty string to clear.", default=None),
+        ] = None,
+        wake_word_entity: Annotated[
+            str | None,
+            Field(description="Wake-word entity ID. Pass empty string to clear.", default=None),
+        ] = None,
+        wake_word_id: Annotated[
+            str | None,
+            Field(description="Wake-word ID. Pass empty string to clear.", default=None),
+        ] = None,
+        prefer_local_intents: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "Whether Home Assistant local intents should be preferred before "
+                    "the conversation engine."
+                ),
+                default=None,
+            ),
+        ] = None,
+        make_preferred: Annotated[
+            bool,
+            Field(
+                description=(
+                    "For create/update only, also set the resulting pipeline as "
+                    "preferred with an extra websocket call. Ignored for other actions."
+                ),
+                default=False,
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Manage Home Assistant Assist pipelines.
+
+        Use action='list' to discover pipeline IDs, action='get' to inspect one
+        pipeline, action='create' or action='update' to write pipeline settings,
+        and action='set_preferred' to choose the preferred pipeline.
+
+        EXAMPLES:
+        - List pipelines: ha_manage_pipeline(action="list")
+        - Get one pipeline: ha_manage_pipeline(action="get", pipeline_id="preferred")
+        - Create by cloning preferred: ha_manage_pipeline(
+              action="create",
+              name="Local Assist",
+              conversation_engine="conversation.local_llm",
+          )
+        - Create by cloning a specific pipeline: ha_manage_pipeline(
+              action="create",
+              base_pipeline_id="preferred",
+              name="Local Assist",
+              conversation_engine="conversation.local_llm",
+          )
+        - Update conversation agent and clear TTS voice: ha_manage_pipeline(
+              action="update",
+              pipeline_id="preferred",
+              conversation_engine="conversation.local_llm",
+              tts_voice="",
+          )
+        - Set preferred: ha_manage_pipeline(
+              action="set_preferred",
+              pipeline_id="preferred",
+          )
+
+        Empty string clears nullable STT/TTS/wake-word fields. Non-nullable
+        fields such as name, language, conversation_language, and
+        conversation_engine must be omitted or non-empty.
+        """
+        try:
+            if action in {"list", "get"}:
+                return await self._manage_pipeline_read(
+                    action=action,
+                    pipeline_id=pipeline_id,
+                )
+
+            if action == "set_preferred":
+                return await self._set_preferred_pipeline(pipeline_id)
+
+            updates = self._pipeline_updates(
+                conversation_engine=conversation_engine,
+                conversation_language=conversation_language,
+                language=language,
+                name=name,
+                stt_engine=stt_engine,
+                stt_language=stt_language,
+                tts_engine=tts_engine,
+                tts_language=tts_language,
+                tts_voice=tts_voice,
+                wake_word_entity=wake_word_entity,
+                wake_word_id=wake_word_id,
+                prefer_local_intents=prefer_local_intents,
+            )
+            return await self._write_pipeline(
+                action=action,
+                pipeline_id=pipeline_id,
+                base_pipeline_id=base_pipeline_id,
+                updates=updates,
+                make_preferred=make_preferred,
+            )
+
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"action": action, "pipeline_id": pipeline_id},
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Use ha_manage_pipeline(action='list') to inspect existing pipeline values",
+                    "Use ha_search_entities(domain_filter='conversation') to find conversation agent IDs",
+                ],
+            )
 
     @staticmethod
     def _get_entity_exposure(entity_id: str, exposed_entities: dict[str, Any]) -> dict[str, Any]:

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 
 
+def websocket_error_message(error: Any) -> str:
+    """Extract a readable message from a Home Assistant websocket error."""
+    if isinstance(error, dict):
+        return str(error.get("message", error))
+    return str(error)
+
+
 def strip_internal_fields(obj: Any, _seen: set[int] | None = None) -> Any:
     """Remove leading-underscore keys from ``obj`` and any nested dicts
     or lists in place.

--- a/tests/src/e2e/workflows/core/test_assist_pipeline.py
+++ b/tests/src/e2e/workflows/core/test_assist_pipeline.py
@@ -1,0 +1,83 @@
+"""E2E smoke tests for Assist pipeline tools."""
+
+import logging
+
+import pytest
+
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.core
+class TestAssistPipeline:
+    """Test Assist pipeline read and write tools."""
+
+    async def test_get_assist_pipeline_list(self, mcp_client):
+        """Assist pipeline listing succeeds when HA exposes the pipeline API."""
+        logger.info("Testing ha_manage_pipeline list path...")
+
+        data = await safe_call_tool(
+            mcp_client, "ha_manage_pipeline", {"action": "list"}
+        )
+        if data.get("success") is not True:
+            pytest.skip(f"Assist pipeline websocket API unavailable: {data}")
+
+        assert "count" in data
+        assert isinstance(data["pipelines"], list)
+        assert data["count"] == len(data["pipelines"])
+
+    async def test_set_preferred_assist_pipeline_idempotent_roundtrip(self, mcp_client):
+        """Setting the current preferred pipeline again is an idempotent write."""
+        logger.info("Testing preferred Assist pipeline idempotent roundtrip...")
+
+        list_data = await safe_call_tool(
+            mcp_client, "ha_manage_pipeline", {"action": "list"}
+        )
+        if list_data.get("success") is not True:
+            pytest.skip(f"Assist pipeline websocket API unavailable: {list_data}")
+
+        preferred = list_data.get("preferred_pipeline")
+        if not preferred:
+            pytest.skip("No preferred Assist pipeline configured")
+
+        set_result = await mcp_client.call_tool(
+            "ha_manage_pipeline",
+            {"action": "set_preferred", "pipeline_id": preferred},
+        )
+        set_data = assert_mcp_success(set_result, "set preferred Assist pipeline")
+
+        assert set_data["pipeline_id"] == preferred
+
+    async def test_set_assist_pipeline_idempotent_update(self, mcp_client):
+        """Updating the preferred pipeline with its current name succeeds."""
+        logger.info("Testing Assist pipeline idempotent update...")
+
+        list_data = await safe_call_tool(
+            mcp_client, "ha_manage_pipeline", {"action": "list"}
+        )
+        if list_data.get("success") is not True:
+            pytest.skip(f"Assist pipeline websocket API unavailable: {list_data}")
+
+        preferred = list_data.get("preferred_pipeline")
+        if not preferred:
+            pytest.skip("No preferred Assist pipeline configured")
+
+        pipeline_data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_pipeline",
+            {"action": "get", "pipeline_id": preferred},
+        )
+        if pipeline_data.get("success") is not True:
+            pytest.skip(f"Preferred Assist pipeline unavailable: {pipeline_data}")
+
+        pipeline = pipeline_data["pipeline"]
+        set_result = await mcp_client.call_tool(
+            "ha_manage_pipeline",
+            {"action": "update", "pipeline_id": preferred, "name": pipeline["name"]},
+        )
+        set_data = assert_mcp_success(set_result, "set Assist pipeline")
+
+        assert set_data["operation"] == "updated"
+        assert set_data["pipeline_id"] == preferred
+        assert set_data["pipeline"]["name"] == pipeline["name"]

--- a/tests/src/unit/test_tools_assist_pipeline.py
+++ b/tests/src/unit/test_tools_assist_pipeline.py
@@ -1,0 +1,574 @@
+"""Unit tests for Assist pipeline MCP tools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_voice_assistant import VoiceAssistantTools
+
+
+def _pipeline(**overrides):
+    """Build a complete Assist pipeline fixture."""
+    pipeline = {
+        "id": "pipeline_1",
+        "conversation_engine": "conversation.openai_conversation",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Voice",
+        "stt_engine": "stt.home_assistant_cloud",
+        "stt_language": "en-US",
+        "tts_engine": "tts.home_assistant_cloud",
+        "tts_language": "en-US",
+        "tts_voice": "MonicaNeural",
+        "wake_word_entity": "wake_word.openwakeword",
+        "wake_word_id": "hey_mycroft_v0.1",
+        "prefer_local_intents": True,
+    }
+    pipeline.update(overrides)
+    return pipeline
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Home Assistant client."""
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def tools(mock_client):
+    """Create VoiceAssistantTools instance."""
+    return VoiceAssistantTools(mock_client)
+
+
+async def test_get_assist_pipeline_lists_pipelines_when_id_omitted(tools):
+    """Omitting pipeline_id should list pipelines and preferred_pipeline."""
+    tools._client.send_websocket_message.return_value = {
+        "success": True,
+        "result": {
+            "pipelines": [
+                {"id": "pipeline_1", "name": "Home"},
+                {"id": "conversation.home_assistant", "name": "Home Assistant"},
+            ],
+            "preferred_pipeline": "pipeline_1",
+        },
+    }
+
+    result = await tools.ha_manage_pipeline(action="list")
+
+    assert result == {
+        "success": True,
+        "operation": "list",
+        "count": 2,
+        "pipelines": [
+            {"id": "pipeline_1", "name": "Home"},
+            {"id": "conversation.home_assistant", "name": "Home Assistant"},
+        ],
+        "preferred_pipeline": "pipeline_1",
+        "message": "Found 2 Assist pipeline(s)",
+    }
+    tools._client.send_websocket_message.assert_awaited_once_with(
+        {"type": "assist_pipeline/pipeline/list"}
+    )
+
+
+async def test_get_assist_pipeline_fetches_specific_pipeline(tools):
+    """Providing pipeline_id should fetch that pipeline."""
+    tools._client.send_websocket_message.return_value = {
+        "success": True,
+        "result": {"id": "pipeline_1", "name": "Home"},
+    }
+
+    result = await tools.ha_manage_pipeline(action="get", pipeline_id="pipeline_1")
+
+    assert result == {
+        "success": True,
+        "operation": "get",
+        "pipeline_id": "pipeline_1",
+        "pipeline": {"id": "pipeline_1", "name": "Home"},
+        "message": "Found Assist pipeline: Home",
+    }
+    tools._client.send_websocket_message.assert_awaited_once_with(
+        {"type": "assist_pipeline/pipeline/get", "pipeline_id": "pipeline_1"}
+    )
+
+
+async def test_set_preferred_assist_pipeline_sends_preferred_message(tools):
+    """Setting the preferred pipeline should use the set_preferred websocket command."""
+    tools._client.send_websocket_message.return_value = {
+        "success": True,
+        "result": None,
+    }
+
+    result = await tools.ha_manage_pipeline(action="set_preferred", pipeline_id="pipeline_1")
+
+    assert result == {
+        "success": True,
+        "operation": "set_preferred",
+        "pipeline_id": "pipeline_1",
+        "message": "Successfully set preferred Assist pipeline: pipeline_1",
+    }
+    tools._client.send_websocket_message.assert_awaited_once_with(
+        {"type": "assist_pipeline/pipeline/set_preferred", "pipeline_id": "pipeline_1"}
+    )
+
+
+async def test_set_assist_pipeline_creates_from_preferred_pipeline(tools):
+    """Creating a pipeline should clone the preferred pipeline and override fields."""
+    preferred_pipeline = {
+        "id": "preferred",
+        "conversation_engine": "conversation.openai_conversation",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Extended GPT4o",
+        "stt_engine": "stt.home_assistant_cloud",
+        "stt_language": "en-US",
+        "tts_engine": "tts.home_assistant_cloud",
+        "tts_language": "en-US",
+        "tts_voice": "MonicaNeural",
+        "wake_word_entity": "wake_word.openwakeword",
+        "wake_word_id": "hey_mycroft_v0.1",
+        "prefer_local_intents": False,
+    }
+    created_pipeline = {
+        **preferred_pipeline,
+        "id": "new_pipeline",
+        "conversation_engine": "conversation.local_llm",
+        "name": "Local Conversation",
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": preferred_pipeline},
+        {"success": True, "result": created_pipeline},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="create",
+        name="Local Conversation",
+        conversation_engine="conversation.local_llm",
+    )
+
+    assert result == {
+        "success": True,
+        "operation": "created",
+        "pipeline_id": "new_pipeline",
+        "pipeline": created_pipeline,
+        "preferred_changed": False,
+        "message": "Assist pipeline created: Local Conversation",
+    }
+    assert tools._client.send_websocket_message.await_args_list[0].args[0] == {
+        "type": "assist_pipeline/pipeline/get"
+    }
+    assert tools._client.send_websocket_message.await_args_list[1].args[0] == {
+        "type": "assist_pipeline/pipeline/create",
+        "conversation_engine": "conversation.local_llm",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Local Conversation",
+        "stt_engine": "stt.home_assistant_cloud",
+        "stt_language": "en-US",
+        "tts_engine": "tts.home_assistant_cloud",
+        "tts_language": "en-US",
+        "tts_voice": "MonicaNeural",
+        "wake_word_entity": "wake_word.openwakeword",
+        "wake_word_id": "hey_mycroft_v0.1",
+        "prefer_local_intents": False,
+    }
+
+
+async def test_set_assist_pipeline_updates_existing_pipeline_by_merging(tools):
+    """Updating a pipeline should fetch existing values and send a full payload."""
+    existing_pipeline = {
+        "id": "pipeline_1",
+        "conversation_engine": "conversation.openai_conversation",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Voice",
+        "stt_engine": "stt.home_assistant_cloud",
+        "stt_language": "en-US",
+        "tts_engine": "tts.home_assistant_cloud",
+        "tts_language": "en-US",
+        "tts_voice": "MonicaNeural",
+        "wake_word_entity": "wake_word.openwakeword",
+        "wake_word_id": "hey_mycroft_v0.1",
+        "prefer_local_intents": True,
+    }
+    updated_pipeline = {
+        **existing_pipeline,
+        "conversation_engine": "conversation.local_llm",
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": existing_pipeline},
+        {"success": True, "result": updated_pipeline},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="update",
+        pipeline_id="pipeline_1",
+        conversation_engine="conversation.local_llm",
+    )
+
+    assert result["success"] is True
+    assert result["operation"] == "updated"
+    assert result["pipeline_id"] == "pipeline_1"
+    assert result["pipeline"] == updated_pipeline
+    assert tools._client.send_websocket_message.await_args_list[0].args[0] == {
+        "type": "assist_pipeline/pipeline/get",
+        "pipeline_id": "pipeline_1",
+    }
+    assert tools._client.send_websocket_message.await_args_list[1].args[0] == {
+        "type": "assist_pipeline/pipeline/update",
+        "pipeline_id": "pipeline_1",
+        "conversation_engine": "conversation.local_llm",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Voice",
+        "stt_engine": "stt.home_assistant_cloud",
+        "stt_language": "en-US",
+        "tts_engine": "tts.home_assistant_cloud",
+        "tts_language": "en-US",
+        "tts_voice": "MonicaNeural",
+        "wake_word_entity": "wake_word.openwakeword",
+        "wake_word_id": "hey_mycroft_v0.1",
+        "prefer_local_intents": True,
+    }
+
+
+async def test_set_assist_pipeline_normalizes_nullable_empty_strings(tools):
+    """Empty string should clear nullable STT/TTS/wake-word fields."""
+    existing_pipeline = _pipeline()
+    updated_pipeline = {
+        **existing_pipeline,
+        "stt_engine": None,
+        "tts_voice": None,
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": existing_pipeline},
+        {"success": True, "result": updated_pipeline},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="update",
+        pipeline_id="pipeline_1",
+        stt_engine="",
+        tts_voice="",
+    )
+
+    assert result["success"] is True
+    assert tools._client.send_websocket_message.await_args_list[1].args[0][
+        "stt_engine"
+    ] is None
+    assert tools._client.send_websocket_message.await_args_list[1].args[0][
+        "tts_voice"
+    ] is None
+
+
+async def test_set_assist_pipeline_rejects_required_empty_strings(tools):
+    """Empty strings on required/non-nullable fields should fail before HA."""
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="update",
+            pipeline_id="pipeline_1",
+            name="",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["success"] is False
+    assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+    assert "name" in error_data["error"]["message"]
+    tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_set_assist_pipeline_creates_from_explicit_base_pipeline(tools):
+    """base_pipeline_id should drive the create clone source when supplied."""
+    base_pipeline = _pipeline(id="base_pipeline", name="Base Voice")
+    created_pipeline = {
+        **base_pipeline,
+        "id": "new_pipeline",
+        "conversation_engine": "conversation.local_llm",
+        "name": "Local Conversation",
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": base_pipeline},
+        {"success": True, "result": created_pipeline},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="create",
+        base_pipeline_id="base_pipeline",
+        name="Local Conversation",
+        conversation_engine="conversation.local_llm",
+    )
+
+    assert result["pipeline_id"] == "new_pipeline"
+    assert tools._client.send_websocket_message.await_args_list[0].args[0] == {
+        "type": "assist_pipeline/pipeline/get",
+        "pipeline_id": "base_pipeline",
+    }
+
+
+async def test_set_assist_pipeline_can_make_created_pipeline_preferred(tools):
+    """make_preferred should set the resulting pipeline as preferred."""
+    preferred_pipeline = {
+        "id": "preferred",
+        "conversation_engine": "conversation.openai_conversation",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Extended GPT4o",
+        "stt_engine": None,
+        "stt_language": None,
+        "tts_engine": None,
+        "tts_language": None,
+        "tts_voice": None,
+        "wake_word_entity": None,
+        "wake_word_id": None,
+        "prefer_local_intents": False,
+    }
+    created_pipeline = {
+        **preferred_pipeline,
+        "id": "new_pipeline",
+        "conversation_engine": "conversation.local_llm",
+        "name": "Local Conversation",
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": preferred_pipeline},
+        {"success": True, "result": created_pipeline},
+        {"success": True, "result": None},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="create",
+        name="Local Conversation",
+        conversation_engine="conversation.local_llm",
+        make_preferred=True,
+    )
+
+    assert result["success"] is True
+    assert result["pipeline_id"] == "new_pipeline"
+    assert result["preferred_changed"] is True
+    assert tools._client.send_websocket_message.await_args_list[2].args[0] == {
+        "type": "assist_pipeline/pipeline/set_preferred",
+        "pipeline_id": "new_pipeline",
+    }
+
+
+async def test_set_assist_pipeline_can_make_updated_pipeline_preferred(tools):
+    """make_preferred should set an updated pipeline as preferred."""
+    existing_pipeline = _pipeline()
+    updated_pipeline = {
+        **existing_pipeline,
+        "conversation_engine": "conversation.local_llm",
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": existing_pipeline},
+        {"success": True, "result": updated_pipeline},
+        {"success": True, "result": None},
+    ]
+
+    result = await tools.ha_manage_pipeline(
+        action="update",
+        pipeline_id="pipeline_1",
+        conversation_engine="conversation.local_llm",
+        make_preferred=True,
+    )
+
+    assert result["success"] is True
+    assert result["preferred_changed"] is True
+    assert tools._client.send_websocket_message.await_args_list[2].args[0] == {
+        "type": "assist_pipeline/pipeline/set_preferred",
+        "pipeline_id": "pipeline_1",
+    }
+
+
+async def test_manage_pipeline_create_requires_name_and_conversation_engine(tools):
+    """Create should fail locally when required fields are missing."""
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="create",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "VALIDATION_MISSING_PARAMETER"
+    assert "name and conversation_engine" in error_data["error"]["message"]
+    tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_manage_pipeline_update_requires_pipeline_id(tools):
+    """Update should fail locally when pipeline_id is missing."""
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="update",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "VALIDATION_MISSING_PARAMETER"
+    assert "pipeline_id" in error_data["error"]["message"]
+    tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_manage_pipeline_update_requires_changes(tools):
+    """Update with no fields and no make_preferred should fail locally."""
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="update",
+            pipeline_id="pipeline_1",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+    assert "No Assist pipeline changes requested" in error_data["error"]["message"]
+    tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_manage_pipeline_get_requires_pipeline_id(tools):
+    """Get should fail locally when pipeline_id is omitted."""
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(action="get")
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "VALIDATION_MISSING_PARAMETER"
+    assert "pipeline_id" in error_data["error"]["message"]
+    tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_manage_pipeline_create_rejects_unexpected_write_response(tools):
+    """Create should reject non-dict write responses."""
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": _pipeline(id="preferred")},
+        {"success": True, "result": None},
+    ]
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="create",
+            name="Local Conversation",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "Unexpected Assist pipeline write response" in error_data["error"]["message"]
+
+
+async def test_manage_pipeline_update_rejects_unexpected_write_response(tools):
+    """Update should reject non-dict write responses."""
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": _pipeline()},
+        {"success": True, "result": None},
+    ]
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="update",
+            pipeline_id="pipeline_1",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "Unexpected Assist pipeline write response" in error_data["error"]["message"]
+
+
+async def test_manage_pipeline_create_without_preferred_has_targeted_error(tools):
+    """Create without base should explain the missing preferred pipeline."""
+    tools._client.send_websocket_message.return_value = {
+        "success": True,
+        "result": None,
+    }
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="create",
+            name="Local Conversation",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "No preferred Assist pipeline" in error_data["error"]["message"]
+
+
+async def test_set_assist_pipeline_raises_tool_error_on_create_failure(tools):
+    """HA create failures should become structured ToolError responses."""
+    preferred_pipeline = {
+        "id": "preferred",
+        "conversation_engine": "conversation.openai_conversation",
+        "conversation_language": "*",
+        "language": "en",
+        "name": "Extended GPT4o",
+        "stt_engine": None,
+        "stt_language": None,
+        "tts_engine": None,
+        "tts_language": None,
+        "tts_voice": None,
+        "wake_word_entity": None,
+        "wake_word_id": None,
+    }
+    tools._client.send_websocket_message.side_effect = [
+        {"success": True, "result": preferred_pipeline},
+        {"success": False, "error": {"code": "invalid_format", "message": "bad"}},
+    ]
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(
+            action="create",
+            name="Local Conversation",
+            conversation_engine="conversation.local_llm",
+        )
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["success"] is False
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "bad" in error_data["error"]["message"]
+    assert error_data["operation"] == "create"
+
+
+async def test_get_assist_pipeline_raises_tool_error_on_ha_failure(tools):
+    """HA websocket failure responses should become structured ToolError."""
+    tools._client.send_websocket_message.return_value = {
+        "success": False,
+        "error": {"code": "not_found", "message": "unknown item"},
+    }
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(action="get", pipeline_id="missing")
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["success"] is False
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "unknown item" in error_data["error"]["message"]
+    assert error_data["pipeline_id"] == "missing"
+
+
+async def test_set_preferred_assist_pipeline_raises_tool_error_on_ha_failure(tools):
+    """set_preferred HA failures should become structured ToolError."""
+    tools._client.send_websocket_message.return_value = {
+        "success": False,
+        "error": {"code": "not_found", "message": "unknown item"},
+    }
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(action="set_preferred", pipeline_id="missing")
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["success"] is False
+    assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+    assert "unknown item" in error_data["error"]["message"]
+    assert error_data["pipeline_id"] == "missing"
+
+
+async def test_get_assist_pipeline_maps_unexpected_exception(tools):
+    """Unexpected client exceptions should be mapped through structured errors."""
+    tools._client.send_websocket_message.side_effect = RuntimeError("network down")
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_manage_pipeline(action="list")
+
+    error_data = json.loads(str(exc_info.value))
+    assert error_data["success"] is False
+    assert error_data["error"]["code"] == "INTERNAL_ERROR"
+    assert "network down" in error_data["error"]["details"]


### PR DESCRIPTION
## What does this PR do?

Adds `ha_manage_pipeline`, a single action-based tool for Home Assistant Assist pipeline management. The tool supports `list`, `get`, `create`, `update`, and `set_preferred` actions through Home Assistant's `assist_pipeline/pipeline/*` websocket APIs.

Create and update actions clone the existing pipeline shape before applying requested fields, so callers can change conversation-agent settings without rebuilding STT, TTS, wake-word, or language options by hand.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Additional checks run locally:

- `uv run python scripts/extract_tools.py --check`
- `uv run ruff check src/ha_mcp/tools/tools_voice_assistant.py tests/src/unit/test_tools_assist_pipeline.py`
- `uv run mypy src/`
- `uv run ast-grep scan`
- `uv run pytest tests/src/unit/test_tool_annotations.py tests/src/unit/test_categorized_search.py tests/src/unit/test_tools_assist_pipeline.py` - 120 passed
- `uv run pytest tests/src/unit/test_tools_assist_pipeline.py` - 21 passed
- `DOCKER_HOST=unix:///var/run/docker.sock uv run pytest tests/src/e2e/tools/test_search_entities.py::test_search_entities_area_filter_only` - 1 passed

Full-suite note: `uv run pytest` was attempted locally. After enabling Docker Desktop's default `/var/run/docker.sock`, Docker/testcontainers startup works and the representative Docker-backed e2e test above passes, but the full suite did not complete locally; it appeared to stall in a Home Assistant testcontainer with no pytest or container-log progress. The full-suite checkbox remains unchecked and CI/upstream maintainer validation should be the final gate.

## Future improvements

Config subentry support was removed from this PR and split into follow-up PR #1393, extending the existing integration/helper/delete surfaces.

## Checklist
- [x] I have updated documentation if needed