### PR TITLE
docs: credit @tomwilkie and six other contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **[@w3z315](https://github.com/w3z315)** — Financial support via [GitHub Sponsors](https://github.com/sponsors/julienld). Thank you! ☕
 - **[@griffinmartin](https://github.com/griffinmartin)** — Added OpenCode (by Anomaly) as a selectable AI client in the setup wizard, with both stdio and streamable HTTP support.
 - **[@hhopke](https://github.com/hhopke)** — Fixed addon API calls to route through HA Core ingress proxy instead of direct container connections, fixing `ha_manage_addon` proxy mode on addon installs.
+- **[@tomwilkie](https://github.com/tomwilkie)** — JMESPath middleware exploration (#1147) whose review-time token-measurement data informed the design of #1199 and #1225.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - **[@griffinmartin](https://github.com/griffinmartin)** — Added OpenCode (by Anomaly) as a selectable AI client in the setup wizard, with both stdio and streamable HTTP support.
 - **[@hhopke](https://github.com/hhopke)** — Fixed addon API calls to route through HA Core ingress proxy instead of direct container connections, fixing `ha_manage_addon` proxy mode on addon installs.
 - **[@tomwilkie](https://github.com/tomwilkie)** — JMESPath middleware exploration (#1147) whose review-time token-measurement data informed the design of #1199 and #1225.
+- **[@SealKan](https://github.com/SealKan)** — `fields=`/`attribute_keys=` projection on six read-heavy tools (#1225), `ha_call_event` tool (#1239), and dashboards-list helper refactor (#1207).
+- **[@KarelTestSpecial](https://github.com/KarelTestSpecial)** — Cached YAML instance to prevent CPU spikes during bulk edits (#1371).
+- **[@corgan2222](https://github.com/corgan2222)** — HA brand assets for custom integration (#1317).
+- **[@drseanwing](https://github.com/drseanwing)** — Progress emission via FastMCP `Context` in long-running tools (#1124); tool-discovery / categorized-search docs (#1123).
+- **[@fnordpig](https://github.com/fnordpig)** — Config subentry support (#1393) and Assist pipeline management tool (#1392).
+- **[@paul43210](https://github.com/paul43210)** — `array_patch` mode in `ha_manage_addon` for atomic GET-modify-POST (#1063).
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds seven entries to the Contributors list in README.md.

**@tomwilkie** — JMESPath middleware exploration (#1147); the review-time token-measurement data on that PR informed the design of issue #1199 and the implementation in PR #1225. The commit carries a `Co-authored-by:` trailer so GitHub attributes the contribution and he won't appear as a first-time contributor on future PRs.

**Six additional contributors** whose merged PRs weren't yet credited in the README:
- @SealKan (#1207, #1225, #1239)
- @KarelTestSpecial (#1371)
- @corgan2222 (#1317)
- @drseanwing (#1123, #1124)
- @fnordpig (#1392, #1393)
- @paul43210 (#1063)

## Type of change
- [x] 📚 Documentation

## Testing
N/A — README-only change.

## Checklist
- [x] I have updated documentation if needed