### PR TITLE
test(e2e): wait for addon state=started in haos proxy header test

### DIFF
--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -45,6 +45,8 @@ and the prefix is not stable across bakes.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
 
 import pytest
@@ -52,6 +54,16 @@ import pytest
 from ..utilities.assertions import parse_mcp_result, safe_call_tool
 
 pytestmark = [pytest.mark.haos_only]
+
+# Node-RED's container takes 20–60s after install to leave "startup" and
+# enter "started". Any test whose contract requires the addon to actually
+# answer HTTP (i.e. asserts on ``status_code`` rather than tolerating a
+# structured error) must wait for it; otherwise CI flakes whenever the
+# runner is slow enough that the addon isn't ready by test-call time.
+# The bake installs Node-RED with ``start=True`` (build_image.py ADDONS),
+# so we only need to wait — never to start it ourselves.
+_ADDON_RUNNING_TIMEOUT_S = 120.0
+_ADDON_RUNNING_POLL_S = 2.0
 
 
 # Display names as they appear in build_image.py's ADDONS tuple — slugs
@@ -86,6 +98,50 @@ async def _resolve_slug(mcp_client: Any, display_name: str) -> str:
         f"Addon {display_name!r} not found in installed listing. "
         f"Installed: {installed}. Check build_image.py ADDONS tuple."
     )
+
+
+async def _wait_addon_running(
+    mcp_client: Any,
+    slug: str,
+    timeout: float = _ADDON_RUNNING_TIMEOUT_S,
+) -> None:
+    """Block until ``ha_get_addon(slug=...)`` reports ``state=started``.
+
+    Use this before any test that asserts on the HTTP/WS contract of an
+    addon (rather than tolerating an addon-not-running structured
+    error). ``ha_manage_addon`` short-circuits with
+    ``{"success": False, "error": {...}, "state": "startup"}`` when
+    Supervisor reports the addon as anything other than ``started``;
+    the bake installs addons with ``start=True`` but their containers
+    can take 20-60s to leave the ``startup`` phase, which is enough to
+    flake any strict-shape assertion. Mirrors the
+    ``wait_for_entity_registered`` discipline already mandated by
+    AGENTS.md for tests that act on freshly created entities.
+
+    Transient ``ToolError`` from ``ha_get_addon`` (e.g. a momentary
+    Supervisor 5xx during boot) is treated as "not ready yet" and the
+    poll continues until the outer timeout. The deadline still fires;
+    transient errors can't mask a wedged addon forever.
+    """
+    from fastmcp.exceptions import ToolError
+
+    deadline = time.monotonic() + timeout
+    last_state: str | None = None
+    while True:
+        try:
+            detail_raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+            detail = parse_mcp_result(detail_raw).get("addon") or {}
+            last_state = detail.get("state")
+        except ToolError as e:
+            last_state = f"<ToolError: {e!s}[:60]>"
+        if last_state == "started":
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(
+                f"Addon {slug!r} did not reach state=started within "
+                f"{timeout:.0f}s (last state: {last_state!r})"
+            )
+        await asyncio.sleep(_ADDON_RUNNING_POLL_S)
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +290,9 @@ async def test_proxy_http_request_headers_pass_through(mcp_client: Any) -> None:
     invalid", which proves the value crossed the wire.
     """
     slug = await _resolve_slug(mcp_client, NODERED_NAME)
+    # Strict assertion on ``status_code`` below requires the addon to
+    # actually answer HTTP; wait it out (see ``_wait_addon_running``).
+    await _wait_addon_running(mcp_client, slug)
     without = await safe_call_tool(
         mcp_client,
         "ha_manage_addon",

--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -52,16 +52,16 @@ from typing import Any
 import pytest
 
 from ..utilities.assertions import parse_mcp_result, safe_call_tool
+from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 pytestmark = [pytest.mark.haos_only]
 
-# Node-RED's container takes 20–60s after install to leave "startup" and
-# enter "started". Any test whose contract requires the addon to actually
-# answer HTTP (i.e. asserts on ``status_code`` rather than tolerating a
-# structured error) must wait for it; otherwise CI flakes whenever the
-# runner is slow enough that the addon isn't ready by test-call time.
-# The bake installs Node-RED with ``start=True`` (build_image.py ADDONS),
-# so we only need to wait — never to start it ourselves.
+# Tests that assert strictly on ``status_code`` (with no fall-back error
+# branch) need the addon's container to have reached Supervisor's
+# ``started`` state — the bake installs every addon with ``start=True``,
+# but the container can take tens of seconds to leave its transient boot
+# phase, which is enough to flake the strict assertion. Timeout sized
+# for cache-cold runners; 2s poll matches sibling lifecycle helpers.
 _ADDON_RUNNING_TIMEOUT_S = 120.0
 _ADDON_RUNNING_POLL_S = 2.0
 
@@ -109,22 +109,24 @@ async def _wait_addon_running(
 
     Use this before any test that asserts on the HTTP/WS contract of an
     addon (rather than tolerating an addon-not-running structured
-    error). ``ha_manage_addon`` short-circuits with
-    ``{"success": False, "error": {...}, "state": "startup"}`` when
-    Supervisor reports the addon as anything other than ``started``;
-    the bake installs addons with ``start=True`` but their containers
-    can take 20-60s to leave the ``startup`` phase, which is enough to
-    flake any strict-shape assertion. Mirrors the
-    ``wait_for_entity_registered`` discipline already mandated by
-    AGENTS.md for tests that act on freshly created entities.
+    error). When Supervisor reports the addon as anything other than
+    ``started``, ``ha_manage_addon`` raises ``ToolError`` from its
+    running-state guard (``tools_addons.py`` "Verify add-on is running");
+    the JSON-encoded error payload carries the observed transient state.
+    The bake installs addons with ``start=True``, but their containers
+    can take tens of seconds to reach ``started`` — long enough to
+    flake any strict-shape assertion on the proxy path. Mirrors
+    ``_wait_for_state`` in ``test_addon_lifecycle.py`` (same private-
+    sibling convention as ``_resolve_slug``).
 
-    Transient ``ToolError`` from ``ha_get_addon`` (e.g. a momentary
-    Supervisor 5xx during boot) is treated as "not ready yet" and the
-    poll continues until the outer timeout. The deadline still fires;
-    transient errors can't mask a wedged addon forever.
+    Transient errors from ``ha_get_addon`` are caught via the project's
+    canonical ``_POLLING_TRANSIENT_ERRORS`` tuple (see
+    ``tests/src/e2e/utilities/wait_helpers.py``) — the same discipline
+    every other polling helper in the suite uses. Bugs (``TypeError`` /
+    ``AttributeError`` / ``KeyError`` / ``AssertionError``) propagate.
+    The deadline still fires; transient errors can't mask a wedged
+    addon forever.
     """
-    from fastmcp.exceptions import ToolError
-
     deadline = time.monotonic() + timeout
     last_state: str | None = None
     while True:
@@ -132,8 +134,8 @@ async def _wait_addon_running(
             detail_raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
             detail = parse_mcp_result(detail_raw).get("addon") or {}
             last_state = detail.get("state")
-        except ToolError as e:
-            last_state = f"<ToolError: {e!s}[:60]>"
+        except _POLLING_TRANSIENT_ERRORS as e:
+            last_state = f"<transient: {str(e)[:60]}>"
         if last_state == "started":
             return
         if time.monotonic() >= deadline:

--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -46,6 +46,7 @@ and the prefix is not stable across bakes.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import Any
 
@@ -53,6 +54,8 @@ import pytest
 
 from ..utilities.assertions import parse_mcp_result, safe_call_tool
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.haos_only]
 
@@ -135,6 +138,7 @@ async def _wait_addon_running(
             detail = parse_mcp_result(detail_raw).get("addon") or {}
             last_state = detail.get("state")
         except _POLLING_TRANSIENT_ERRORS as e:
+            logger.debug(f"⚠️ Transient error polling addon {slug!r}: {e}")
             last_state = f"<transient: {str(e)[:60]}>"
         if last_state == "started":
             return


### PR DESCRIPTION
## What does this PR do?

Fixes the HAOS E2E flake observed on PR #1397's CI lane:

```
FAILED src/e2e/haos_only/test_manage_addon_modes.py::test_proxy_http_request_headers_pass_through
  assert (True and False)
  +  where False = isinstance(None, int)
  +    where None = ... .get('status_code')
  +      where ... = {'success': False, 'error': {'code': 'SERVICE_CALL_FAILED',
                      'message': "Add-on 'Node-RED' is not running (state: startup)", ...}}
```

`test_proxy_http_request_headers_pass_through` asserts `isinstance(without.get("status_code"), int)` against both calls — no tolerance for the addon-not-running structured-error path that the sibling proxy tests in this file accept. On HAOS CI runners, Node-RED's container takes 20–60s after install to leave Supervisor's `startup` phase and enter `started`; on slow runners the test fires before that transition completes, and `ha_manage_addon`'s running-state guard (`tools_addons.py`'s "Verify add-on is running") short-circuits with a `SERVICE_CALL_FAILED` that has no `status_code` key.

Adds `_wait_addon_running(mcp_client, slug, timeout=120.0)` — mirrors the `wait_for_entity_registered` discipline AGENTS.md already mandates for tests that act on freshly created entities — and calls it from the failing test between slug resolution and the strict assertion. The other proxy tests in the file (HTTP GET, WebSocket validate, array-patch, python_transform) already tolerate the structured-error path, so they don't need the wait.

**Coordination with #1381**: #1381 bundles the same fix as part of its broader settings-UI work. This PR extracts the test-only piece so the flake can land independently. The diff is shape-identical to #1381's `test_manage_addon_modes.py` hunk — when #1381 rebases on master, those 59 lines drop out cleanly.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (\`uv run pytest\`)
- [x] Code follows style guidelines (\`uv run ruff check\`)

Local \`uv run pytest\` isn't possible from my dev environment (Termux on Android — no Docker for testcontainers, no Python 3.13). Verified \`ruff check\`, \`ruff format --check\`, and \`ast.parse\` syntax locally; this PR's HAOS E2E lane is the durable verification.

## Checklist
- [x] I have updated documentation if needed