### PR TITLE
fix: guard against silent automation overwrite on id mismatch (#1404)

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -906,6 +906,29 @@ class HomeAssistantClient:
             operation = "updated"
             logger.debug(f"Updating automation with unique_id: {unique_id}")
 
+        # Reject mismatch between resolved storage key and inner ``config["id"]``.
+        # HA stores by the inner id field even though the URL carries one too —
+        # a divergence silently overwrites the automation whose unique_id matches
+        # the inner id, while reporting success for the URL target (#1404).
+        config_id = config.get("id")
+        if config_id is not None and str(config_id) != str(unique_id):
+            if identifier is None:
+                raise HomeAssistantAPIError(
+                    "Cannot create automation with explicit config['id']="
+                    f"{config_id!r}: Home Assistant stores by the inner id, "
+                    "which would silently overwrite an existing automation. "
+                    "Omit 'id' from config to auto-generate, or pass identifier "
+                    "to update an existing automation.",
+                    status_code=400,
+                )
+            raise HomeAssistantAPIError(
+                f"Mismatched automation id: identifier={identifier!r} resolves "
+                f"to unique_id={unique_id!r}, but config['id']={config_id!r}. "
+                "Refusing to write to prevent overwriting the wrong automation. "
+                "Remove 'id' from config or set it to match the identifier.",
+                status_code=400,
+            )
+
         # Add unique_id to config for updates
         if unique_id and "id" not in config:
             config = {**config, "id": unique_id}

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -925,7 +925,8 @@ class HomeAssistantClient:
                 f"Mismatched automation id: identifier={identifier!r} resolves "
                 f"to unique_id={unique_id!r}, but config['id']={config_id!r}. "
                 "Refusing to write to prevent overwriting the wrong automation. "
-                "Remove 'id' from config or set it to match the identifier.",
+                f"Remove 'id' from config or set it to the resolved unique_id "
+                f"({unique_id!r}).",
                 status_code=400,
             )
 

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -139,6 +139,117 @@ class TestDeleteAutomationConfig:
         assert result["operation"] == "deleted"
 
 
+class TestUpsertAutomationConfigIdMismatch:
+    """Guard against silent overwrite when ``identifier`` and ``config['id']``
+    disagree (#1404).
+
+    Home Assistant's automation storage uses the inner ``config['id']`` as the
+    primary key. If the MCP server POSTs to ``/config/automation/config/{X}``
+    with a body carrying ``id=Y``, HA stores the body under ``Y`` and the
+    automation that previously owned ``Y`` is silently overwritten — while the
+    response reports success for ``X``. The guard converts that silent data
+    loss into a structured 400 error.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+            client = HomeAssistantClient()
+            client.base_url = "http://test.local:8123"
+            client.token = "test-token"
+            client.timeout = 30
+            client.httpx_client = MagicMock()
+            return client
+
+    @pytest.mark.asyncio
+    async def test_update_with_mismatched_inner_id_is_rejected(self, mock_client):
+        """identifier resolves to AAA but config carries id=BBB → reject."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
+        mock_client._request = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.upsert_automation_config(
+                {"id": "BBB", "alias": "x", "trigger": [], "action": []},
+                identifier="automation.foo",
+            )
+
+        assert exc_info.value.status_code == 400
+        msg = str(exc_info.value)
+        assert "Mismatched" in msg
+        assert "'AAA'" in msg
+        assert "'BBB'" in msg
+        # Critical: the offending POST never reaches HA.
+        mock_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_with_matching_inner_id_proceeds(self, mock_client):
+        """identifier and config.id both resolve to the same unique_id → ok."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+        mock_client._poll_for_automation_entity = AsyncMock(return_value=None)
+
+        result = await mock_client.upsert_automation_config(
+            {"id": "AAA", "alias": "x", "trigger": [], "action": []},
+            identifier="automation.foo",
+        )
+
+        assert result["unique_id"] == "AAA"
+        assert result["operation"] == "updated"
+        mock_client._request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_without_inner_id_proceeds(self, mock_client):
+        """No inner id → existing code path injects unique_id, no guard fires."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.upsert_automation_config(
+            {"alias": "x", "trigger": [], "action": []},
+            identifier="automation.foo",
+        )
+
+        assert result["unique_id"] == "AAA"
+        # Sent body should carry the resolved id.
+        sent_config = mock_client._request.call_args.kwargs["json"]
+        assert sent_config["id"] == "AAA"
+
+    @pytest.mark.asyncio
+    async def test_create_with_inner_id_is_rejected(self, mock_client):
+        """identifier=None + config['id']=X → reject (would silently overwrite
+        X if it exists; would create with caller-chosen id if it doesn't —
+        both are agent-slip patterns the guard converts to a loud error)."""
+        mock_client._request = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.upsert_automation_config(
+                {"id": "BBB", "alias": "x", "trigger": [], "action": []},
+                identifier=None,
+            )
+
+        assert exc_info.value.status_code == 400
+        msg = str(exc_info.value)
+        assert "Cannot create" in msg
+        assert "'BBB'" in msg
+        assert "Omit 'id'" in msg
+        mock_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_without_inner_id_proceeds(self, mock_client):
+        """Normal create path: no inner id, fresh timestamp assigned."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+        mock_client._poll_for_automation_entity = AsyncMock(
+            return_value="automation.new"
+        )
+
+        result = await mock_client.upsert_automation_config(
+            {"alias": "x", "trigger": [], "action": []},
+            identifier=None,
+        )
+
+        assert result["operation"] == "created"
+        assert result["entity_id"] == "automation.new"
+
+
 class TestPollForAutomationEntity:
     """Tests for the poll cadence in _poll_for_automation_entity (issue #1380).
 

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -34,7 +34,9 @@ class TestDeleteAutomationConfig:
         mock_client._request = AsyncMock(return_value={"result": "ok"})
         mock_client._resolve_automation_id = AsyncMock(return_value="test_unique_id")
 
-        result = await mock_client.delete_automation_config("automation.test_automation")
+        result = await mock_client.delete_automation_config(
+            "automation.test_automation"
+        )
 
         assert result["identifier"] == "automation.test_automation"
         assert result["unique_id"] == "test_unique_id"
@@ -117,9 +119,7 @@ class TestDeleteAutomationConfig:
     async def test_delete_automation_generic_exception_propagates(self, mock_client):
         """Non-API exceptions should propagate."""
         mock_client._resolve_automation_id = AsyncMock(return_value="test_unique_id")
-        mock_client._request = AsyncMock(
-            side_effect=RuntimeError("Unexpected error")
-        )
+        mock_client._request = AsyncMock(side_effect=RuntimeError("Unexpected error"))
 
         with pytest.raises(RuntimeError) as exc_info:
             await mock_client.delete_automation_config("automation.test_automation")
@@ -392,9 +392,7 @@ class TestPollForAutomationEntity:
         assert mock_client.get_states.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_poll_swallows_get_states_exception_on_iteration_2(
-        self, mock_client
-    ):
+    async def test_poll_swallows_get_states_exception_on_iteration_2(self, mock_client):
         """Mid-loop transient also exits early — locks the wrap-scope: the
         ``try`` covers the entire ``for`` (not the loop body), so a transient
         on iteration 2 hits the ``except HomeAssistantError`` clause and
@@ -415,9 +413,7 @@ class TestPollForAutomationEntity:
         assert mock_client.get_states.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_poll_propagates_typeerror_for_unexpected_errors(
-        self, mock_client
-    ):
+    async def test_poll_propagates_typeerror_for_unexpected_errors(self, mock_client):
         """Programming bugs (TypeError, KeyError, AttributeError, …) must
         propagate — they are not transient, and swallowing them would mask
         the bug as ``entity_not_verified=True``. Locks the narrowed

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -183,7 +183,12 @@ class TestUpsertAutomationConfigIdMismatch:
 
     @pytest.mark.asyncio
     async def test_update_with_matching_inner_id_proceeds(self, mock_client):
-        """identifier and config.id both resolve to the same unique_id → ok."""
+        """identifier and config.id both resolve to the same unique_id → ok.
+
+        Asserts URL and body id both equal the resolved unique_id so a future
+        refactor that mutates one without the other (the exact failure mode
+        this PR fixes) would regress.
+        """
         mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
         mock_client._request = AsyncMock(return_value={"result": "ok"})
         mock_client._poll_for_automation_entity = AsyncMock(return_value=None)
@@ -196,6 +201,44 @@ class TestUpsertAutomationConfigIdMismatch:
         assert result["unique_id"] == "AAA"
         assert result["operation"] == "updated"
         mock_client._request.assert_called_once()
+        method, url = mock_client._request.call_args.args
+        assert method == "POST"
+        assert url == "/config/automation/config/AAA"
+        assert mock_client._request.call_args.kwargs["json"]["id"] == "AAA"
+
+    @pytest.mark.asyncio
+    async def test_update_with_int_vs_str_id_equivalence_passes(self, mock_client):
+        """``config['id']`` as int matching the resolved str id is treated as
+        a match. HA accepts both shapes and stringifies on storage, so the
+        guard's ``str(...)`` coercion is intentional — pin it so a future
+        tightening to strict-type compare is a deliberate decision."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="1234")
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+        mock_client._poll_for_automation_entity = AsyncMock(return_value=None)
+
+        result = await mock_client.upsert_automation_config(
+            {"id": 1234, "alias": "x", "trigger": [], "action": []},
+            identifier="automation.foo",
+        )
+
+        assert result["unique_id"] == "1234"
+        mock_client._request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_with_empty_string_inner_id_is_rejected(self, mock_client):
+        """``config['id']=''`` is a real agent-slip pattern (templating with an
+        empty variable). It is not None, so the guard fires and rejects."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
+        mock_client._request = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.upsert_automation_config(
+                {"id": "", "alias": "x", "trigger": [], "action": []},
+                identifier="automation.foo",
+            )
+
+        assert exc_info.value.status_code == 400
+        mock_client._request.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_without_inner_id_proceeds(self, mock_client):


### PR DESCRIPTION
## What does this PR do?

Closes #1404.

`upsert_automation_config` now rejects calls where the resolved storage
key (the URL `unique_id`) disagrees with the inner `config["id"]`. HA
stores automations by the inner id, so a mismatch silently overwrites
the automation owning that inner id while the response reports success
for the URL target — the failure mode the reporter hit in production.

Two paths are now guarded:

1. **Update with mismatched id** — `identifier="automation.foo"` (resolves
   to `AAA`) + `config={"id": "BBB", ...}`: rejected with a 400 that
   names both ids and tells the caller how to fix it. This is the
   reporter's exact scenario.
2. **Create with explicit id** — `identifier=None` + `config={"id": "BBB"}`:
   rejected with a 400 that tells the caller to either omit `id` (to
   auto-generate) or pass `identifier` (to update an existing one). HA
   would otherwise overwrite whatever owns `BBB`.

Match-id updates and id-less creates/updates continue to work unchanged.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit tests added in `tests/src/unit/test_rest_client_automations.py`
covering all five states: matched update (ok), mismatched update
(rejected), id-less update (ok), create with inner id (rejected), plain
create (ok). Each rejection test also asserts `_request` is never
called, locking in that the offending POST never reaches HA.

## Checklist
- [ ] I have updated documentation if needed