### PR TITLE
fix(calendar): switch ha_config_remove_calendar_event to WebSocket (closes #1413, #1416)

### DIFF
--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -19,6 +19,7 @@ from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
 from .helpers import (
     exception_to_structured_error,
+    get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
@@ -421,32 +422,33 @@ class CalendarTools:
             # Delete is exposed exclusively via the WebSocket command
             # ``calendar/event/delete`` (see HA Core
             # ``homeassistant/components/calendar/__init__.py``).
-            ws_message: dict[str, Any] = {
-                "type": "calendar/event/delete",
-                "entity_id": entity_id,
-                "uid": uid,
-            }
+            ws_kwargs: dict[str, Any] = {"entity_id": entity_id, "uid": uid}
             if recurrence_id:
-                ws_message["recurrence_id"] = recurrence_id
+                ws_kwargs["recurrence_id"] = recurrence_id
             if recurrence_range:
-                ws_message["recurrence_range"] = recurrence_range
+                ws_kwargs["recurrence_range"] = recurrence_range
 
-            result = await self._client.send_websocket_message(ws_message)
-
-            if not result.get("success"):
-                ws_error = result.get("error", "Failed to delete calendar event")
+            ws_client, conn_error = await get_connected_ws_client(
+                self._client.base_url,
+                self._client.token,
+                verify_ssl=self._client.verify_ssl,
+            )
+            if conn_error or ws_client is None:
                 raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        str(ws_error),
+                    conn_error
+                    or create_error_response(
+                        ErrorCode.CONNECTION_FAILED,
+                        "Failed to connect to Home Assistant WebSocket",
                         context={"entity_id": entity_id, "uid": uid},
-                        suggestions=[
-                            f"Verify event with UID '{uid}' exists in {entity_id}",
-                            "Use ha_config_get_calendar_events() to find the correct event UID",
-                            "Some calendar integrations may not support event deletion",
-                        ],
                     )
                 )
+
+            try:
+                result = await ws_client.send_command(
+                    "calendar/event/delete", **ws_kwargs
+                )
+            finally:
+                await ws_client.disconnect()
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -448,7 +448,15 @@ class CalendarTools:
                     "calendar/event/delete", **ws_kwargs
                 )
             finally:
-                await ws_client.disconnect()
+                # Guard disconnect: a transport-teardown error here would
+                # otherwise replace the original send_command exception.
+                try:
+                    await ws_client.disconnect()
+                except Exception as disconnect_error:
+                    logger.debug(
+                        f"WebSocket disconnect after delete_event for "
+                        f"{entity_id} uid={uid}: {disconnect_error}"
+                    )
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -354,7 +354,10 @@ class CalendarTools:
         """
         Delete an event from a calendar.
 
-        Deletes a calendar event using the calendar.delete_event service.
+        Deletes a calendar event via the WebSocket ``calendar/event/delete``
+        command. HA's calendar component only registers ``create_event`` and
+        ``get_events`` as REST services — delete and update live on the
+        WebSocket API only.
 
         **Parameters:**
         - entity_id: Calendar entity ID (e.g., 'calendar.family')
@@ -402,8 +405,8 @@ class CalendarTools:
                 )
 
             # entity_id format-check above does not cover the ``uid`` parameter.
-            # Empty/whitespace uid would flow through to ``calendar.delete_event``
-            # and HA returns a misleading "event not found".
+            # Empty/whitespace uid would flow through to the WS command and HA
+            # returns a misleading "event not found".
             validate_identifier_not_empty(
                 uid,
                 "uid",
@@ -413,21 +416,37 @@ class CalendarTools:
                 context={"entity_id": entity_id},
             )
 
-            # Build service data
-            service_data: dict[str, Any] = {
+            # ``calendar.delete_event`` is NOT a REST service — HA only
+            # registers ``calendar.create_event`` and ``calendar.get_events``.
+            # Delete is exposed exclusively via the WebSocket command
+            # ``calendar/event/delete`` (see HA Core
+            # ``homeassistant/components/calendar/__init__.py``).
+            ws_message: dict[str, Any] = {
+                "type": "calendar/event/delete",
                 "entity_id": entity_id,
                 "uid": uid,
             }
-
             if recurrence_id:
-                service_data["recurrence_id"] = recurrence_id
+                ws_message["recurrence_id"] = recurrence_id
             if recurrence_range:
-                service_data["recurrence_range"] = recurrence_range
+                ws_message["recurrence_range"] = recurrence_range
 
-            # Call the calendar.delete_event service
-            result = await self._client.call_service(
-                "calendar", "delete_event", service_data
-            )
+            result = await self._client.send_websocket_message(ws_message)
+
+            if not result.get("success"):
+                ws_error = result.get("error", "Failed to delete calendar event")
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        str(ws_error),
+                        context={"entity_id": entity_id, "uid": uid},
+                        suggestions=[
+                            f"Verify event with UID '{uid}' exists in {entity_id}",
+                            "Use ha_config_get_calendar_events() to find the correct event UID",
+                            "Some calendar integrations may not support event deletion",
+                        ],
+                    )
+                )
 
             return {
                 "success": True,

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -12,6 +12,7 @@ Use ha_search_entities(query='calendar', domain_filter='calendar') to find calen
 """
 
 import logging
+import uuid
 from datetime import datetime, timedelta
 
 import pytest
@@ -59,9 +60,7 @@ class TestCalendarEvents:
         if not calendar_entity:
             pytest.skip("No calendar entities available for testing")
 
-        logger.info(
-            f"Testing ha_config_get_calendar_events with {calendar_entity}..."
-        )
+        logger.info(f"Testing ha_config_get_calendar_events with {calendar_entity}...")
 
         result = await mcp_client.call_tool(
             "ha_config_get_calendar_events", {"entity_id": calendar_entity}
@@ -165,9 +164,9 @@ class TestCalendarEvents:
 
         # Should fail with validation error
         assert data.get("success") is False, "Should fail for invalid format"
-        assert "calendar." in str(
-            data.get("error", "")
-        ), "Error should mention correct format"
+        assert "calendar." in str(data.get("error", "")), (
+            "Error should mention correct format"
+        )
 
         logger.info(f"Validation error (expected): {data.get('error', 'Unknown')}")
         logger.info("Invalid format test completed")
@@ -307,43 +306,122 @@ class TestCalendarEventLifecycle:
         )
 
         assert data.get("success") is False, "Should fail for invalid entity"
-        assert "calendar." in str(
-            data.get("error", "")
-        ), "Error should mention correct format"
+        assert "calendar." in str(data.get("error", "")), (
+            "Error should mention correct format"
+        )
 
         logger.info(f"Validation error (expected): {data.get('error', 'Unknown')}")
         logger.info("Invalid entity create test completed")
 
-    async def test_delete_calendar_event(self, mcp_client):
-        """
-        Test: Delete a calendar event
+    @pytest.fixture
+    async def deletable_event_uid(self, mcp_client):
+        """Create a temporary event, yield (entity_id, uid), then best-effort delete.
 
-        Tests the delete event functionality (may fail if no deletable events exist).
+        ``ha_config_set_calendar_event`` does not return the assigned UID, so
+        the fixture round-trips through ``ha_config_get_calendar_events`` to
+        retrieve it. Teardown swallows exceptions to stay idempotent regardless
+        of whether the test body already deleted the event.
         """
         calendar_entity = await self._find_writable_calendar(mcp_client)
         if not calendar_entity:
-            pytest.skip("No calendar entities available for testing")
+            pytest.skip("No writable calendar found for testing")
 
+        summary = f"E2E Deletable Test Event {uuid.uuid4().hex[:8]}"
+        now = datetime.now()
+        start = (now + timedelta(days=1)).replace(
+            hour=14, minute=0, second=0, microsecond=0
+        )
+        end = start + timedelta(hours=1)
+
+        create_data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_calendar_event",
+            {
+                "entity_id": calendar_entity,
+                "summary": summary,
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        if not create_data.get("success"):
+            pytest.skip(
+                f"Calendar {calendar_entity} does not support event creation: "
+                f"{create_data.get('error', 'Unknown')}"
+            )
+
+        events_data = await safe_call_tool(
+            mcp_client,
+            "ha_config_get_calendar_events",
+            {
+                "entity_id": calendar_entity,
+                "start": start.isoformat(),
+                "end": (end + timedelta(hours=1)).isoformat(),
+            },
+        )
+        event_uid = next(
+            (
+                e.get("uid")
+                for e in events_data.get("events", [])
+                if e.get("summary") == summary
+            ),
+            None,
+        )
+        if not event_uid:
+            pytest.fail(
+                f"Created event '{summary}' did not surface a uid in "
+                f"ha_config_get_calendar_events for {calendar_entity}"
+            )
+
+        try:
+            yield calendar_entity, event_uid
+        finally:
+            try:
+                await mcp_client.call_tool(
+                    "ha_config_remove_calendar_event",
+                    {"entity_id": calendar_entity, "uid": event_uid},
+                )
+            except Exception as cleanup_error:
+                logger.debug(
+                    f"Cleanup of test event {event_uid} on {calendar_entity}: "
+                    f"{cleanup_error}"
+                )
+
+    async def test_delete_calendar_event(self, mcp_client, deletable_event_uid):
+        """
+        Test: Delete a calendar event (positive + negative paths)
+
+        Creates a fresh event, deletes it (positive: hard-assert success), then
+        re-attempts deletion of the released UID (negative: hard-assert failure
+        with suggestions). UID-collision risk is eliminated because the UID was
+        just held and released by this test.
+        """
+        calendar_entity, event_uid = deletable_event_uid
         logger.info(
-            f"Testing ha_config_remove_calendar_event for {calendar_entity}..."
+            f"Testing ha_config_remove_calendar_event for {calendar_entity} "
+            f"with uid={event_uid}..."
         )
 
-        # Try to delete with a fake UID (will likely fail, but tests the API)
-        # Use safe_call_tool since we expect this to fail
-        data = await safe_call_tool(
+        first_delete = await mcp_client.call_tool(
+            "ha_config_remove_calendar_event",
+            {"entity_id": calendar_entity, "uid": event_uid},
+        )
+        assert_mcp_success(first_delete, "first deletion of just-created event")
+        logger.info(f"Deleted event {event_uid} (positive path)")
+
+        second_delete = await safe_call_tool(
             mcp_client,
             "ha_config_remove_calendar_event",
-            {"entity_id": calendar_entity, "uid": "nonexistent-event-uid-xyz"},
+            {"entity_id": calendar_entity, "uid": event_uid},
         )
-
-        # This will likely fail since the event doesn't exist
-        # We're mainly testing that the tool handles errors gracefully
-        if data.get("success"):
-            logger.info("Unexpectedly succeeded (event may have existed)")
-        else:
-            logger.info(f"Delete failed as expected: {data.get('error', 'Unknown')}")
-            assert data.get("error", {}).get("suggestions"), "Should provide helpful suggestions"
-
+        assert second_delete.get("success") is False, (
+            f"Second deletion of released UID should fail: got {second_delete}"
+        )
+        assert second_delete.get("error", {}).get("suggestions"), (
+            "Delete failure should provide helpful suggestions"
+        )
+        logger.info(
+            f"Second delete failed as expected: {second_delete.get('error', 'Unknown')}"
+        )
         logger.info("ha_config_remove_calendar_event test completed")
 
     async def test_delete_calendar_event_invalid_entity(self, mcp_client):
@@ -362,9 +440,9 @@ class TestCalendarEventLifecycle:
         )
 
         assert data.get("success") is False, "Should fail for invalid entity"
-        assert "calendar." in str(
-            data.get("error", "")
-        ), "Error should mention correct format"
+        assert "calendar." in str(data.get("error", "")), (
+            "Error should mention correct format"
+        )
 
         logger.info(f"Validation error (expected): {data.get('error', 'Unknown')}")
         logger.info("Invalid entity delete test completed")
@@ -384,9 +462,9 @@ async def test_calendar_tools_overview(mcp_client):
     get_data = await safe_call_tool(
         mcp_client, "ha_config_get_calendar_events", {"entity_id": "calendar.test"}
     )
-    assert (
-        "events" in get_data or "error" in get_data
-    ), "ha_config_get_calendar_events should return events or error"
+    assert "events" in get_data or "error" in get_data, (
+        "ha_config_get_calendar_events should return events or error"
+    )
     logger.info("ha_config_get_calendar_events tool is registered and functional")
 
     # Test create event tool registration
@@ -401,9 +479,9 @@ async def test_calendar_tools_overview(mcp_client):
             "end": (now + timedelta(hours=1)).isoformat(),
         },
     )
-    assert (
-        "event" in create_data or "error" in create_data
-    ), "ha_config_set_calendar_event should return event or error"
+    assert "event" in create_data or "error" in create_data, (
+        "ha_config_set_calendar_event should return event or error"
+    )
     logger.info("ha_config_set_calendar_event tool is registered and functional")
 
     # Test delete event tool registration
@@ -412,9 +490,9 @@ async def test_calendar_tools_overview(mcp_client):
         "ha_config_remove_calendar_event",
         {"entity_id": "calendar.test", "uid": "test-uid"},
     )
-    assert (
-        "uid" in delete_data or "error" in delete_data
-    ), "ha_config_remove_calendar_event should return uid or error"
+    assert "uid" in delete_data or "error" in delete_data, (
+        "ha_config_remove_calendar_event should return uid or error"
+    )
     logger.info("ha_config_remove_calendar_event tool is registered and functional")
 
     logger.info("All calendar tools are properly registered")

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -13,7 +13,7 @@ Use ha_search_entities(query='calendar', domain_filter='calendar') to find calen
 
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -328,7 +328,10 @@ class TestCalendarEventLifecycle:
             pytest.skip("No writable calendar found for testing")
 
         summary = f"E2E Deletable Test Event {uuid.uuid4().hex[:8]}"
-        now = datetime.now()
+        # TZ-aware so ISO 8601 strings stay unambiguous when the test runner
+        # and the HA instance are in different timezones (matches the
+        # convention in tests/src/e2e/workflows/core/test_history.py).
+        now = datetime.now(UTC)
         start = (now + timedelta(days=1)).replace(
             hour=14, minute=0, second=0, microsecond=0
         )

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -22,6 +22,7 @@ from ...utilities.assertions import (
     parse_mcp_result,
     safe_call_tool,
 )
+from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
 
@@ -349,27 +350,75 @@ class TestCalendarEventLifecycle:
                 f"{create_data.get('error', 'Unknown')}"
             )
 
-        events_data = await safe_call_tool(
-            mcp_client,
-            "ha_config_get_calendar_events",
-            {
-                "entity_id": calendar_entity,
-                "start": start.isoformat(),
-                "end": (end + timedelta(hours=1)).isoformat(),
-            },
-        )
-        event_uid = next(
-            (
-                e.get("uid")
-                for e in events_data.get("events", [])
-                if e.get("summary") == summary
-            ),
-            None,
-        )
+        # Poll until the just-created event surfaces in the list endpoint —
+        # HA backends (CalDAV, Google) may not index immediately after create
+        # returns. Per AGENTS.md § "E2E tests: poll after creating entities".
+        event_uid: str | None = None
+        timed_out = False
+        try:
+            events_data = await wait_for_tool_result(
+                mcp_client,
+                "ha_config_get_calendar_events",
+                {
+                    "entity_id": calendar_entity,
+                    "start": start.isoformat(),
+                    "end": (end + timedelta(hours=1)).isoformat(),
+                },
+                predicate=lambda d: any(
+                    e.get("summary") == summary and e.get("uid")
+                    for e in d.get("events", [])
+                ),
+                timeout=15,
+                description=f"retrieval of UID for created event '{summary}'",
+            )
+            event_uid = next(
+                (
+                    e.get("uid")
+                    for e in events_data.get("events", [])
+                    if e.get("summary") == summary
+                ),
+                None,
+            )
+        except TimeoutError:
+            timed_out = True
+
         if not event_uid:
+            # Create succeeded but UID never appeared. Try a final scan-by-
+            # summary cleanup so we don't leak across CI runs (HAOS-inaddon
+            # reuses image), then fail — masking this would defeat the
+            # regression-test contract this PR establishes.
+            try:
+                final_events = await safe_call_tool(
+                    mcp_client,
+                    "ha_config_get_calendar_events",
+                    {
+                        "entity_id": calendar_entity,
+                        "start": start.isoformat(),
+                        "end": (end + timedelta(hours=1)).isoformat(),
+                    },
+                )
+                leaked_uid = next(
+                    (
+                        e.get("uid")
+                        for e in final_events.get("events", [])
+                        if e.get("summary") == summary and e.get("uid")
+                    ),
+                    None,
+                )
+                if leaked_uid:
+                    await mcp_client.call_tool(
+                        "ha_config_remove_calendar_event",
+                        {"entity_id": calendar_entity, "uid": leaked_uid},
+                    )
+            except Exception as leak_cleanup_error:
+                logger.warning(
+                    f"Could not clean up potentially-leaked event "
+                    f"'{summary}' on {calendar_entity}: {leak_cleanup_error}"
+                )
             pytest.fail(
                 f"Created event '{summary}' did not surface a uid in "
                 f"ha_config_get_calendar_events for {calendar_entity}"
+                + (" within 15s" if timed_out else "")
             )
 
         try:
@@ -381,7 +430,7 @@ class TestCalendarEventLifecycle:
                     {"entity_id": calendar_entity, "uid": event_uid},
                 )
             except Exception as cleanup_error:
-                logger.debug(
+                logger.warning(
                     f"Cleanup of test event {event_uid} on {calendar_entity}: "
                     f"{cleanup_error}"
                 )
@@ -405,7 +454,15 @@ class TestCalendarEventLifecycle:
             "ha_config_remove_calendar_event",
             {"entity_id": calendar_entity, "uid": event_uid},
         )
-        assert_mcp_success(first_delete, "first deletion of just-created event")
+        first_delete_data = assert_mcp_success(
+            first_delete, "first deletion of just-created event"
+        )
+        # Hard-require the explicit success flag — assert_mcp_success accepts
+        # several indicators, but this PR's regression test should fail loudly
+        # if a future refactor stops surfacing the flag.
+        assert first_delete_data.get("success") is True, (
+            f"First delete should return success=True; got {first_delete_data}"
+        )
         logger.info(f"Deleted event {event_uid} (positive path)")
 
         second_delete = await safe_call_tool(
@@ -416,8 +473,12 @@ class TestCalendarEventLifecycle:
         assert second_delete.get("success") is False, (
             f"Second deletion of released UID should fail: got {second_delete}"
         )
-        assert second_delete.get("error", {}).get("suggestions"), (
-            "Delete failure should provide helpful suggestions"
+        # Accept either plural ``suggestions`` (multi-item) or singular
+        # ``suggestion`` (single-item) — ``create_error_response`` writes the
+        # singular form when the suggestions list has one entry.
+        second_error = second_delete.get("error", {})
+        assert second_error.get("suggestions") or second_error.get("suggestion"), (
+            f"Delete failure should provide helpful suggestion(s); got {second_error}"
         )
         logger.info(
             f"Second delete failed as expected: {second_delete.get('error', 'Unknown')}"


### PR DESCRIPTION
## What does this PR do?

`ha_config_remove_calendar_event` called the REST service `calendar.delete_event` — but HA's calendar component only registers `calendar.create_event` and `calendar.get_events` as REST services. `delete_event` and `update_event` live exclusively on the WebSocket API (`calendar/event/delete`, `calendar/event/update`) — see `homeassistant/components/calendar/__init__.py:325-340`.

Calling the non-existent REST service returned `400 Bad Request` for every UID, regardless of whether the event existed. That is the same 400 #1416 was investigating against a freshly-created `calendar.local_e2e_test` event.

This PR:

1. Switches `ha_config_remove_calendar_event` to `self._client.send_websocket_message({"type": "calendar/event/delete", ...})`, checks `result["success"]`, and raises `ToolError(SERVICE_CALL_FAILED)` with suggestions on WS failure.
2. Replaces the soft-assert `test_delete_calendar_event` (which used a hard-coded fake UID) with a `deletable_event_uid` fixture that creates a fresh event, retrieves its UID via `ha_config_get_calendar_events`, yields `(entity_id, uid)`, and best-effort cleans up on teardown. The rewritten test hard-asserts both the positive path (first delete succeeds) and the negative path (re-delete of released UID fails with suggestions).

Closes #1413 — test hardening from #1413 is achievable now that the underlying delete works.
Closes #1416 — root cause is `calendar.delete_event` being WS-only, not a Local Calendar quirk or seeded-entity divergence.
Supersedes #1415.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

E2E suite needs Docker; running on a Termux dev host without it. CI validates end-to-end behavior.

## Checklist
- [x] I have updated documentation if needed