### PR TITLE
fix: sync addon settings UI with Supervisor options end-to-end

### DIFF
--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -98,14 +98,21 @@ TRANSFORM_GENERATED_TOOLS: dict[str, ToolStub] = {}
 # won't appear in local_provider._list_tools(), so we inject stub entries
 # into the settings UI so users discover the tool exists and how to enable
 # it. Keep this dict in sync with the ``"beta"`` tag added to each tool's
-# source file (tools_yaml_config.py, tools_filesystem.py, tools_mcp_component.py)
-# — a future rename or removal needs to land in both places.
+# source file (tools_yaml_config.py, tools_filesystem.py, tools_mcp_component.py,
+# tools_code.py) — a future rename or removal needs to land in both places.
 FEATURE_GATED_TOOLS: dict[str, ToolStub] = {
     "ha_config_set_yaml": {
         "title": "Set YAML Config",
         "primary_tag": "System",
         "description": "Add, replace, or remove top-level keys in configuration.yaml or package files.",
         "disabled_by": "enable_yaml_config_editing",
+        "destructiveHint": True,
+    },
+    "ha_manage_custom_tool": {
+        "title": "Custom Tool",
+        "primary_tag": "System",
+        "description": "Create and run a custom tool in a sandbox, or manage saved custom tools (code mode).",
+        "disabled_by": "enable_code_mode",
         "destructiveHint": True,
     },
     "ha_list_files": {
@@ -701,15 +708,20 @@ _SETTINGS_HTML = (
   <button class="tab" data-panel="server">Server Settings</button>
   <button class="tab" data-panel="backups">Backups</button>
 </div>
+<div class="restart-notice" id="restartNotice">
+  <span class="restart-notice-text" id="restartNoticeText">
+    ⚠ Changes saved. Restart ha-mcp for them to take effect — disabled
+    tools will be fully removed from the MCP tool list on next startup.
+  </span>
+  <button class="restart-btn" id="restartBtn" style="display:none">Restart Add-on</button>
+</div>
 <div class="panel active" id="panel-tools">
   <div class="readonly-notice">
     Server-wide features (Tool Search, YAML config editing, filesystem
     tools, etc.) appear in both the <strong>Server Settings</strong>
     tab and the add-on Configuration page — they're the same settings
-    either way. Add-on users edit them on the Configuration page;
-    every other install (Claude Desktop, Docker, standalone) edits
-    them in the Server Settings tab. Changes require an MCP-host
-    restart to apply.
+    either way. Either surface stays in sync with the other after the
+    addon restart. Changes require an MCP-host restart to apply.
   </div>
   <div class="pin-notice show" id="pinNotice">
     Pin toggles only take effect when Tool Search is enabled — either
@@ -717,13 +729,6 @@ _SETTINGS_HTML = (
     Configuration page (same setting either way). Without Tool Search,
     all enabled tools are always visible and pinning has no extra
     effect.
-  </div>
-  <div class="restart-notice" id="restartNotice">
-    <span class="restart-notice-text" id="restartNoticeText">
-      ⚠ Changes saved. Restart ha-mcp for them to take effect — disabled
-      tools will be fully removed from the MCP tool list on next startup.
-    </span>
-    <button class="restart-btn" id="restartBtn" style="display:none">Restart Add-on</button>
   </div>
   <div class="summary" id="summary"></div>
   <input type="text" class="search" id="search" placeholder="Search tools...">
@@ -1297,6 +1302,9 @@ async function saveBackupConfig() {
     }
     if (data.restarting) {
       statusEl.textContent = 'Saved — addon is restarting. Reload in ~30s.';
+      // Surface the cross-tab restart banner so the user has a clear
+      // reload-when-ready signal regardless of which tab they're on.
+      document.getElementById('restartNotice').classList.add('show');
     } else {
       statusEl.textContent = 'Saved.';
       btn.disabled = false;
@@ -1483,7 +1491,13 @@ const FEATURE_META = {
 
 const ORIGIN_LOCKED_NOTE = {
   env: 'Set via environment variable — unset it to edit here.',
-  addon: 'Managed by the add-on Configuration tab — open Settings → Add-ons → ha-mcp → Configuration to edit.',
+  // addon-origin fields are editable: save POSTs through Supervisor
+  // /addons/self/options and triggers a restart so both surfaces stay
+  // in sync. No locked note needed.
+};
+
+const ORIGIN_INFO_NOTE = {
+  addon: 'Synced to the add-on Configuration tab — save will restart the add-on.',
 };
 
 async function loadFeatureFlags() {
@@ -1541,10 +1555,14 @@ function renderFeatureFlags(flags) {
         `${escapeHtml(ORIGIN_LOCKED_NOTE[f.origin] || '')}${envVarSuffix}` +
         `</div>`
       : '';
+    const infoNote = f.editable && ORIGIN_INFO_NOTE[f.origin]
+      ? `<div class="feature-locked-note">` +
+        `${escapeHtml(ORIGIN_INFO_NOTE[f.origin])}</div>`
+      : '';
     info.innerHTML =
       `<div class="feature-name">${escapeHtml(meta.label)}</div>` +
       `<div class="feature-help">${escapeHtml(meta.help)}</div>` +
-      lockedNote;
+      lockedNote + infoNote;
 
     const control = document.createElement('div');
     control.className = 'feature-control';
@@ -1596,20 +1614,28 @@ async function saveFeatureFlag(fieldName, value) {
     updateStatus('Save failed: ' + e.message);
     return;
   }
+  let data = null;
+  try { data = await resp.json(); } catch (_e) {}
   if (!resp.ok) {
     let msg = `Save failed (HTTP ${resp.status})`;
-    try {
-      const err = await resp.json();
-      if (err.error && err.error.message) msg = 'Save failed: ' + err.error.message;
-    } catch (_e) {}
+    if (data && data.error && data.error.message) {
+      msg = 'Save failed: ' + data.error.message;
+    }
     updateStatus(msg);
     return;
   }
-  // Don't toggle the in-tab restartNotice — it lives in panel-tools
-  // and would be hidden behind a tab the user isn't on. The page-level
-  // status badge (set above) is visible across every tab and the
-  // panel sub-header up top already warns "Changes require restart".
-  updateStatus('Saved — restart required', true);
+  // In addon mode the server has already POSTed the merged options to
+  // Supervisor and scheduled a self-restart in a background task — the
+  // user just needs to wait. Surface the restart-required banner so it
+  // is visible regardless of which tab they are on (the banner now lives
+  // above the tabs). In standalone modes the cache is reset in-process
+  // and no restart is required, so just toast.
+  if (data && data.restarting) {
+    updateStatus('Saved — add-on is restarting. Reload in ~30s.', true);
+    document.getElementById('restartNotice').classList.add('show');
+  } else {
+    updateStatus('Saved — restart required', true);
+  }
 }
 
 // ===== Tab switching =====
@@ -1636,6 +1662,140 @@ loadTools();
 </html>
 """
 )
+
+
+async def _supervisor_fetch_current_options(
+    verify_ssl: bool,
+) -> tuple[dict[str, Any], str | None]:
+    """GET ``/addons/self/info`` and return the current options dict.
+
+    Supervisor's ``/addons/self/options`` POST is a *full* replacement
+    validated against the addon schema — every required key must be
+    present in the body. We can't ship a partial PATCH of just the
+    fields the user changed, so callers must merge their changes into
+    the full current options before posting. Mirrors the pattern in
+    ``homeassistant-addon/start.py::persist_addon_options``.
+
+    Returns ``(options_dict, error_msg)``. On any error
+    (network failure, non-200 from supervisor, malformed JSON,
+    non-dict options field) the dict is ``{}`` and an error message
+    describes the failure for surfacing to the user.
+    """
+    try:
+        async with make_supervisor_httpx_client(
+            timeout=10.0, verify=verify_ssl
+        ) as sclient:
+            resp = await sclient.get("/addons/self/info")
+    except httpx.HTTPError as exc:
+        return {}, f"Could not reach Supervisor for current options: {exc}"
+    if resp.status_code >= 400:
+        return {}, (
+            f"Supervisor returned {resp.status_code} for "
+            f"/addons/self/info: {resp.text[:300]}"
+        )
+    try:
+        body = resp.json()
+    except ValueError:
+        return {}, "Supervisor returned non-JSON for /addons/self/info"
+    # Supervisor REST envelope is {"result": "ok", "data": {...}}. Older
+    # mocks / variants may return the data dict directly — handle both.
+    data = body.get("data") if isinstance(body, dict) and "data" in body else body
+    if not isinstance(data, dict):
+        return {}, "Supervisor /addons/self/info had non-object body"
+    options = data.get("options")
+    if not isinstance(options, dict):
+        return {}, "Supervisor /addons/self/info had no options dict"
+    return options, None
+
+
+async def _supervisor_merge_and_post_options(
+    verify_ssl: bool, field_changes: dict[str, Any]
+) -> tuple[bool, str | None]:
+    """Merge ``field_changes`` into supervisor's current options and POST.
+
+    Necessary because supervisor's POST is full-replacement (see
+    :func:`_supervisor_fetch_current_options`). Without this merge, a
+    POST that only includes a handful of fields the user edited
+    drops every other key (including required ones like ``backup_hint``)
+    and supervisor rejects with a 400 ``addon_configuration_invalid_error``.
+
+    Returns ``(success, error_msg)``. On supervisor 4xx the error
+    message includes the supervisor body so the UI can surface
+    validation failures (e.g. attempting to set a key the addon's
+    schema doesn't declare on the production channel).
+    """
+    current, err = await _supervisor_fetch_current_options(verify_ssl)
+    if err is not None:
+        return False, err
+    merged = {**current, **field_changes}
+    try:
+        async with make_supervisor_httpx_client(
+            timeout=10.0, verify=verify_ssl
+        ) as sclient:
+            resp = await sclient.post("/addons/self/options", json={"options": merged})
+    except httpx.HTTPError as exc:
+        return False, f"Supervisor options POST failed: {exc}"
+    if resp.status_code >= 400:
+        return False, (
+            f"Supervisor rejected options update ({resp.status_code}): "
+            f"{resp.text[:400]}"
+        )
+    return True, None
+
+
+# Strong references to in-flight self-restart tasks, kept here so the
+# event loop's weakref-only task table doesn't garbage-collect a still-
+# running fire-and-forget coroutine before it can POST to supervisor.
+# Tasks remove themselves via ``add_done_callback`` when they finish.
+_BACKGROUND_RESTART_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _schedule_supervisor_self_restart(verify_ssl: bool, *, delay: float = 0.3) -> None:
+    """Schedule a background ``/addons/self/restart`` POST.
+
+    Fire-and-forget on the current event loop so the request handler
+    can return its JSON response *before* the supervisor kills the
+    addon. Without the gap, supervisor restarts our process mid-response
+    and the HA ingress proxy converts the dropped upstream connection
+    into a 5xx Bad Gateway, which the browser interprets as "Restart
+    failed" even though the restart actually succeeded.
+
+    The ``delay`` (default 0.3s) gives Starlette + uvicorn time to
+    serialize the JSONResponse onto the socket and have ingress flush
+    it to the browser before the background coroutine wakes up and
+    POSTs the supervisor restart. Tuned conservatively — too short
+    races the response flush; too long delays the user-visible
+    restart noticeably.
+
+    Errors are logged and swallowed: by the time this fires the
+    response has already gone out and the user has already been told
+    the restart is initiated, so there is no path to surface a late
+    failure here. The user discovers a failed restart by the addon
+    not actually restarting; the supervisor log captures the cause.
+    """
+
+    async def _do_restart() -> None:
+        await asyncio.sleep(delay)
+        try:
+            async with make_supervisor_httpx_client(
+                timeout=5.0, verify=verify_ssl
+            ) as sclient:
+                resp = await sclient.post("/addons/self/restart")
+            if resp.status_code >= 400:
+                logger.error(
+                    "Background self-restart returned %d: %s",
+                    resp.status_code,
+                    resp.text[:500],
+                )
+        except (httpx.ReadError, httpx.RemoteProtocolError):
+            # Supervisor killed us mid-call — expected; no action needed.
+            pass
+        except httpx.HTTPError:
+            logger.exception("Background self-restart failed")
+
+    task = asyncio.create_task(_do_restart())
+    _BACKGROUND_RESTART_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_RESTART_TASKS.discard)
 
 
 def build_settings_handlers(
@@ -1819,10 +1979,23 @@ def build_settings_handlers(
             ):
                 target_slug = requested.strip()
 
+        # Self-restart races the response flush: supervisor kills the addon
+        # mid-response, ingress sees the upstream drop, and converts it into
+        # a 5xx Bad Gateway at the browser — which the JS shows as
+        # "Restart failed" even though the restart actually succeeded.
+        # Schedule the supervisor POST from a background task so the JSON
+        # response below flushes BEFORE supervisor can kill us.
+        #
+        # Non-self slugs target a sibling addon: the inaddon E2E suite
+        # exercises that path against a non-test-critical addon, and we
+        # want the supervisor response (including 4xx) to surface
+        # synchronously so the test can assert on it. Keep the original
+        # synchronous behavior for that path.
+        if target_slug == "self":
+            _schedule_supervisor_self_restart(server.settings.verify_ssl)
+            return JSONResponse({"success": True, "message": "Restart initiated"})
+
         endpoint = f"/addons/{target_slug}/restart"
-        # Short timeout — when restarting self, the supervisor kills our
-        # process during restart so the connection will drop. A connection
-        # drop is actually success on that path.
         try:
             async with make_supervisor_httpx_client(
                 timeout=5.0, verify=server.settings.verify_ssl
@@ -1882,15 +2055,21 @@ def build_settings_handlers(
         Per-field origin/editable matrix (see
         :func:`config.get_feature_flag_origin`):
 
-            origin = get_feature_flag_origin(env_name)
-            editable = origin in ("file", "default")
+        - ``"addon"``: editable — POST routes through Supervisor
+          ``/addons/self/options`` and triggers a restart so
+          ``start.py`` writes the new env vars at next boot. The
+          add-on Configuration tab and this web UI now share state
+          bidirectionally; changing a toggle in either surface is
+          reflected in the other after the addon restart.
+        - ``"env"``: read-only — env var explicitly set wins; user
+          must unset it to edit here.
+        - ``"file"`` / ``"default"``: editable — POST writes the
+          override file in place.
 
-        ``"addon"`` and ``"env"`` are non-editable from the web UI;
-        the user is told which env var (or addon option) to change
-        instead. The envelope shape (``flags`` dict of
+        The envelope shape (``flags`` dict of
         ``{value, origin, editable, type, env_var, min?, max?}``
-        entries) is intentionally generic so other settings
-        surfaces can render rows with the same JS code.
+        entries) is intentionally generic so other settings surfaces
+        can render rows with the same JS code.
         """
         from .config import (
             _FEATURE_FLAG_INT_BOUNDS,
@@ -1907,7 +2086,7 @@ def build_settings_handlers(
             entry: dict[str, Any] = {
                 "value": value,
                 "origin": origin,
-                "editable": origin in ("file", "default"),
+                "editable": origin in ("addon", "file", "default"),
                 "type": ftype.__name__,
                 "env_var": env_name,
             }
@@ -1921,11 +2100,20 @@ def build_settings_handlers(
     async def _save_feature_flags(request: Request) -> JSONResponse:
         """Persist UI-edited feature-flag values.
 
-        Only ``editable`` fields (origin = ``file`` or ``default``)
-        accept writes; an attempt to write an env-locked or addon-
-        locked field returns ``VALIDATION_INVALID_PARAMETER`` so the
-        client surfaces the locking source instead of silently
-        discarding the change.
+        Routing by per-field origin (see
+        :func:`config.get_feature_flag_origin`):
+
+        - **addon**: POST the merged options to Supervisor and schedule
+          an addon restart so ``start.py`` re-derives env vars from
+          ``config.yaml`` on the next boot. Web UI edits and
+          Configuration-tab edits land in the same place, so the two
+          surfaces stay in sync.
+        - **env**: refuse — env var explicitly set wins. Returns
+          ``VALIDATION_INVALID_PARAMETER`` with the env var name so
+          the UI can surface the locking source.
+        - **file** / **default**: merge into the override file in the
+          data dir; takes effect on the next
+          ``get_global_settings()`` call (cache reset).
         """
         from .config import (
             _FEATURE_FLAG_INT_BOUNDS,
@@ -1964,12 +2152,14 @@ def build_settings_handlers(
             )
 
         # Build the validated override dict. Reject unknown fields and
-        # env/addon-locked fields up front so the user gets a precise
-        # error instead of a silent no-op.
+        # env-locked fields up front so the user gets a precise error
+        # instead of a silent no-op. ``addon``-origin fields are now
+        # editable — they route through Supervisor below.
         known: dict[str, tuple[str, type]] = {
             fname: (ename, ftype) for fname, ename, ftype in FEATURE_FLAG_FIELDS
         }
         new_overrides: dict[str, Any] = {}
+        addon_writes = False
         for field_name, raw in raw_flags.items():
             if field_name not in known:
                 return JSONResponse(
@@ -1981,7 +2171,9 @@ def build_settings_handlers(
                 )
             env_name, ftype = known[field_name]
             origin = get_feature_flag_origin(env_name)
-            if origin not in ("file", "default"):
+            if origin == "addon":
+                addon_writes = True
+            elif origin not in ("file", "default"):
                 return JSONResponse(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -2033,6 +2225,53 @@ def build_settings_handlers(
                     ),
                     status_code=400,
                 )
+
+        # Addon-mode writes go to Supervisor instead of the override file:
+        # ``start.py`` reads ``config.yaml`` options on every boot and
+        # writes the env vars that Settings consumes, so the override
+        # file is ignored anyway (see config.get_feature_flag_origin).
+        # POST a merged options dict (current options + this delta) so
+        # required schema keys like ``backup_hint`` survive — see
+        # _supervisor_merge_and_post_options for the rationale, and the
+        # parallel handling in _save_backup_config.
+        if addon_writes:
+            if not os.environ.get("SUPERVISOR_TOKEN"):
+                return JSONResponse(
+                    create_error_response(
+                        ErrorCode.CONFIG_VALIDATION_FAILED,
+                        "Supervisor token missing — cannot update add-on options",
+                    ),
+                    status_code=400,
+                )
+            if server is None:
+                return JSONResponse(
+                    create_error_response(
+                        ErrorCode.INTERNAL_ERROR,
+                        "Feature-flag POST requires a live MCP server",
+                    ),
+                    status_code=500,
+                )
+            ok, err = await _supervisor_merge_and_post_options(
+                server.settings.verify_ssl, new_overrides
+            )
+            if not ok:
+                logger.warning("Supervisor feature-flag update failed: %s", err)
+                return JSONResponse(
+                    create_error_response(
+                        ErrorCode.CONFIG_VALIDATION_FAILED,
+                        err or "Supervisor options update failed",
+                    ),
+                    status_code=502,
+                )
+            _schedule_supervisor_self_restart(server.settings.verify_ssl)
+            return JSONResponse(
+                {
+                    "success": True,
+                    "applied": new_overrides,
+                    "mode": "addon",
+                    "restarting": True,
+                }
+            )
 
         # Merge with the existing override file so a partial POST
         # only updates the keys it actually included — the front-end
@@ -2427,65 +2666,33 @@ def build_settings_handlers(
                     code=ErrorCode.INTERNAL_ERROR,
                     status=500,
                 )
-            options_body = {"options": clean}
-            try:
-                async with make_supervisor_httpx_client(
-                    timeout=10.0, verify=server.settings.verify_ssl
-                ) as sclient:
-                    opt_resp = await sclient.post(
-                        "/addons/self/options", json=options_body
-                    )
-            except httpx.HTTPError as exc:
-                logger.warning(
-                    "Failed to PUT /addons/self/options: %s", exc, exc_info=True
-                )
-                return JSONResponse(
-                    create_error_response(
-                        ErrorCode.CONNECTION_FAILED,
-                        f"Supervisor options update failed: {exc}",
-                    ),
-                    status_code=502,
-                )
-            if opt_resp.status_code >= 400:
-                body = opt_resp.text[:400]
-                logger.warning(
-                    "Supervisor rejected options update (%s): %s",
-                    opt_resp.status_code,
-                    body,
-                )
+            # Merge ``clean`` into the *full* current options before posting.
+            # Supervisor validates against the addon schema and rejects any
+            # body missing a required key (notably ``backup_hint`` on the
+            # production / dev manifests). The historical bug
+            # (#TODO: refer to PR) shipped just the auto-backup fields,
+            # producing `addon_configuration_invalid_error: Missing option
+            # 'backup_hint' in root` from supervisor and a confusing 400 in
+            # the UI even though the user only changed unrelated fields.
+            ok, err = await _supervisor_merge_and_post_options(
+                server.settings.verify_ssl, clean
+            )
+            if not ok:
+                logger.warning("Supervisor backup-config update failed: %s", err)
                 return JSONResponse(
                     create_error_response(
                         ErrorCode.CONFIG_VALIDATION_FAILED,
-                        f"Supervisor rejected options update: {body}",
+                        err or "Supervisor options update failed",
                     ),
-                    status_code=opt_resp.status_code,
+                    status_code=502,
                 )
-            # Trigger restart so start.py rewrites env vars from config.yaml.
-            # Socket may drop mid-response (self-restart) — treat that as
-            # success, same as the existing _restart_addon handler.
-            try:
-                async with make_supervisor_httpx_client(
-                    timeout=5.0, verify=server.settings.verify_ssl
-                ) as sclient:
-                    await sclient.post("/addons/self/restart")
-            except (httpx.ReadError, httpx.RemoteProtocolError):
-                pass
-            except httpx.HTTPError as exc:
-                logger.warning(
-                    "Options updated but restart request failed: %s", exc, exc_info=True
-                )
-                return JSONResponse(
-                    {
-                        "success": True,
-                        "applied": clean,
-                        "mode": "addon",
-                        "warning": (
-                            "Options saved to config.yaml but restart request "
-                            "failed; restart the add-on manually to apply."
-                        ),
-                    },
-                    status_code=200,
-                )
+            # Background restart so this JSON response can flush through HA
+            # ingress before supervisor kills the addon. The old code POSTed
+            # synchronously and the kill-mid-response would convert into a
+            # 5xx Bad Gateway at the proxy, which the JS rendered as
+            # "Save failed" / "Restart failed" — see _restart_addon for the
+            # same fix.
+            _schedule_supervisor_self_restart(server.settings.verify_ssl)
             return JSONResponse(
                 {
                     "success": True,

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -921,42 +921,139 @@ async function stopSidecar() {
   }
 }
 
-const RESTART_RELOAD_DELAY_S = 10;
+// Restart-readiness probe tunables. The grace period gives supervisor
+// time to actually kill the addon (so a too-eager first probe doesn't
+// hit the OLD instance and reload before the new one is up). The poll
+// interval is short enough to feel responsive on a fast restart, long
+// enough to not hammer ingress. The cap is the user-visible upper
+// bound; HAOS addon restarts are typically 15-25s but cold-start +
+// image pull can stretch further, so 60s gives genuine breathing room
+// before we tell the user the auto-reload failed.
+const RESTART_PROBE_INITIAL_GRACE_MS = 3000;
+const RESTART_PROBE_INTERVAL_MS = 2000;
+const RESTART_PROBE_MAX_TOTAL_MS = 60000;
+
+// Cross-tab restart broadcast channel. When any tab saves a setting
+// that needs a restart, it posts ``restart-required`` so the other
+// tabs surface the same banner. When any tab fires the supervisor
+// restart, it posts ``restart-initiated`` so the other tabs run the
+// same poll-then-reload cycle — that way ALL tabs come back to the
+// fresh addon instead of leaving stale ones spinning.
+const restartChannel =
+  typeof BroadcastChannel === 'function'
+    ? new BroadcastChannel('ha-mcp-settings')
+    : null;
+
+// Module-level concurrency guard. The button's ``disabled`` attribute
+// blocks normal clicks, but a second invocation via DevTools / a
+// keyboard accessibility tool / a cross-tab broadcast would otherwise
+// queue a second supervisor restart + a second auto-reload. Cleared
+// only on a 4xx genuine config error (so the user can reload and try
+// again); otherwise stays true through the restart cycle until the
+// page reloads.
+let restartInProgress = false;
+
+async function _probeAddonReady() {
+  // Resolve true when ``/api/settings/info`` returns 200 (addon is
+  // serving HTTP again), false when we hit the cap. Caller decides
+  // whether to reload, surface a "didn't come back" message, or
+  // both. ``cache: 'no-store'`` so the browser doesn't serve a
+  // stale 200 from before the restart.
+  const deadline = Date.now() + RESTART_PROBE_MAX_TOTAL_MS;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch('./api/settings/info', {cache: 'no-store'});
+      if (resp.ok) return true;
+    } catch (_e) {
+      // Connection drop / DNS / ingress 5xx while addon is down —
+      // expected. Suppress noise: a console.warn here would spam the
+      // devtools log during every restart.
+    }
+    await new Promise(r => setTimeout(r, RESTART_PROBE_INTERVAL_MS));
+  }
+  return false;
+}
+
+async function _runRestartReloadCycle() {
+  const btn = document.getElementById('restartBtn');
+  // Initial grace lets supervisor actually kill the addon before we
+  // start probing — otherwise the first probe may hit the OLD
+  // instance and we reload before the new one is up.
+  btn.textContent = 'Restarting…';
+  await new Promise(r => setTimeout(r, RESTART_PROBE_INITIAL_GRACE_MS));
+  btn.textContent = 'Waiting for add-on to come back online…';
+  const ready = await _probeAddonReady();
+  if (ready) {
+    window.location.reload();
+  } else {
+    // Probe gave up after RESTART_PROBE_MAX_TOTAL_MS. Restart may
+    // have failed entirely or supervisor is genuinely slow. Surface
+    // a clear next-step instead of silently doing nothing.
+    btn.textContent = 'Add-on did not come back online — reload manually';
+    btn.disabled = false;
+    restartInProgress = false;
+  }
+}
 
 async function restartAddon() {
+  if (restartInProgress) return;
   const btn = document.getElementById('restartBtn');
   if (!confirm('Restart the add-on now? The page will reload automatically once the add-on is back online.')) return;
+  restartInProgress = true;
   btn.disabled = true;
   btn.textContent = 'Restarting…';
-  // Only suppress the auto-reload on a genuine config error (4xx like
-  // SUPERVISOR_TOKEN missing). Anything else — 200, 5xx from ingress
-  // when supervisor killed our upstream mid-response, or a thrown
-  // network error from the same kill — means the restart is in flight
-  // and we should reload after the addon comes back.
-  let configError = false;
   try {
     const resp = await fetch('./api/settings/restart', {method: 'POST'});
     if (!resp.ok && resp.status < 500) {
-      configError = true;
+      // 4xx is a genuine config error (e.g. SUPERVISOR_TOKEN unset).
+      // The restart was NOT initiated — surface the error and let the
+      // user fix the underlying cause. Keep button enabled so they
+      // can retry once the issue is resolved. Don't broadcast (other
+      // tabs would only see a misleading "restart in progress").
       let msg = 'Restart failed';
       try {
         const err = await resp.json();
-        if (err && err.error && err.error.message) {
-          msg = 'Failed: ' + err.error.message;
-        }
-      } catch (_e) {}
+        if (err?.error?.message) msg = 'Failed: ' + err.error.message;
+      } catch (_e) { /* leave default msg */ }
       btn.textContent = msg;
       btn.disabled = false;
+      restartInProgress = false;
       alert(msg);
+      return;
     }
+    // 200 OK → background task scheduled. 5xx → ingress upstream
+    // drop, restart IS in flight. Both fall through to the reload
+    // cycle.
   } catch (_e) {
-    // Connection lost mid-request — restart in flight, fall through.
+    // Network error mid-request — supervisor killed our upstream.
+    // Restart in flight; fall through. Log for debug, suppress the
+    // unused-binding lint.
+    console.warn('restartAddon fetch dropped (expected during self-restart):', _e);
   }
-  if (!configError) {
-    btn.textContent =
-      'Restarting… page will reload in ' + RESTART_RELOAD_DELAY_S + 's';
-    setTimeout(() => window.location.reload(), RESTART_RELOAD_DELAY_S * 1000);
+  // Other tabs need to run the same cycle so they reload to the fresh
+  // addon, not stay on a stale view. Broadcast BEFORE we sleep.
+  if (restartChannel) {
+    restartChannel.postMessage({type: 'restart-initiated'});
   }
+  await _runRestartReloadCycle();
+}
+
+// Listener: when ANY tab broadcasts a save that needs a restart, all
+// open tabs surface the banner. When ANY tab fires the restart, all
+// open tabs run their own poll-then-reload cycle so none of them are
+// left holding a stale connection to a now-dead addon.
+if (restartChannel) {
+  restartChannel.addEventListener('message', (e) => {
+    const data = e.data || {};
+    if (data.type === 'restart-required') {
+      document.getElementById('restartNotice').classList.add('show');
+    } else if (data.type === 'restart-initiated' && !restartInProgress) {
+      restartInProgress = true;
+      const btn = document.getElementById('restartBtn');
+      if (btn) btn.disabled = true;
+      _runRestartReloadCycle();
+    }
+  });
 }
 
 const DEFAULT_PINNED = """
@@ -1167,6 +1264,10 @@ async function saveConfig() {
   if (resp.ok) {
     updateStatus('Saved — restart required', true);
     document.getElementById('restartNotice').classList.add('show');
+    // Cross-tab sync — other open settings tabs surface the same
+    // banner so the user can click Restart from whichever tab they
+    // are on.
+    if (restartChannel) restartChannel.postMessage({type: 'restart-required'});
   } else {
     updateStatus('Save failed!');
   }
@@ -1317,12 +1418,18 @@ async function saveBackupConfig() {
     if (data.restart_required) {
       // Unified restart flow — save persists but does NOT auto-restart.
       // Surface the cross-tab restart-required banner; user picks the
-      // moment via the global Restart Add-on button. Refresh the form
-      // so origins update (default → addon/file etc.) but skip the
-      // backup-list reload until after the actual restart.
+      // moment via the global Restart Add-on button.
+      //
+      // Don't reload the form here. In addon mode the GET reads
+      // env-derived ``get_global_settings()`` values which are still
+      // stale (Supervisor has the new options but ``start.py``
+      // doesn't re-derive env vars until the next addon boot). Reloading
+      // would snap the form back to old values, look like the save
+      // reverted, and clobber any further edits the user wanted to
+      // bundle before clicking Restart.
       statusEl.textContent = 'Saved — restart required';
       document.getElementById('restartNotice').classList.add('show');
-      loadBackupConfig();
+      if (restartChannel) restartChannel.postMessage({type: 'restart-required'});
     } else {
       statusEl.textContent = 'Saved.';
       // Refresh display so origins update (default → file, etc.).
@@ -1632,12 +1739,17 @@ async function saveFeatureFlag(fieldName, value) {
     return;
   }
   let data = null;
-  try { data = await resp.json(); } catch (_e) {}
+  try { data = await resp.json(); } catch (_e) {
+    // On a 200 OK with truncated / non-JSON body, default to the
+    // "restart needed" state so the user gets the banner — silently
+    // skipping it would let them think the change took effect live
+    // and they'd never restart. Only do this on resp.ok; for an
+    // error response we want the HTTP status to drive the message.
+    if (resp.ok) data = {restart_required: true};
+  }
   if (!resp.ok) {
     let msg = `Save failed (HTTP ${resp.status})`;
-    if (data && data.error && data.error.message) {
-      msg = 'Save failed: ' + data.error.message;
-    }
+    if (data?.error?.message) msg = 'Save failed: ' + data.error.message;
     updateStatus(msg);
     return;
   }
@@ -1648,8 +1760,9 @@ async function saveFeatureFlag(fieldName, value) {
   // button is hidden (no supervisor to drive it) but the banner still
   // surfaces "restart required" as guidance.
   updateStatus('Saved — restart required', true);
-  if (data && data.restart_required) {
+  if (data?.restart_required) {
     document.getElementById('restartNotice').classList.add('show');
+    if (restartChannel) restartChannel.postMessage({type: 'restart-required'});
   }
 }
 
@@ -1888,6 +2001,17 @@ def _schedule_supervisor_self_restart(
         except (httpx.ReadError, httpx.RemoteProtocolError):
             # Supervisor killed us mid-call — expected; no action needed.
             pass
+        except RuntimeError:
+            # ``make_supervisor_httpx_client`` raises RuntimeError when
+            # SUPERVISOR_TOKEN is unset. The route guard at handler entry
+            # already checks for this, but a race that unsets the token
+            # between request entry and the 300ms-later task wakeup
+            # would otherwise propagate uncaught and surface only as
+            # asyncio's "Task exception was never retrieved" at GC time.
+            # Log it loudly so the user can find it in the addon log.
+            # Mirrors the same RuntimeError catch in the supervisor
+            # options helpers.
+            logger.exception("Background self-restart aborted: SUPERVISOR_TOKEN unset")
         except httpx.HTTPError:
             logger.exception("Background self-restart failed")
 
@@ -2025,11 +2149,18 @@ def build_settings_handlers(
             pinned_count,
         )
 
+        # Same response shape as ``_save_feature_flags`` and
+        # ``_save_backup_config``: every save endpoint returns
+        # ``{success, applied, mode, restart_required}`` so the JS can
+        # branch on a single field and BroadcastChannel listeners in
+        # other tabs can react uniformly. Tool config writes only ever
+        # land in the on-disk JSON (no Supervisor round-trip), hence
+        # ``mode="file"`` regardless of addon/standalone deployment.
         return JSONResponse(
             {
                 "success": True,
-                "disabled": disabled_count,
-                "pinned": pinned_count,
+                "applied": states,
+                "mode": "file",
                 "restart_required": True,
             }
         )
@@ -2201,17 +2332,22 @@ def build_settings_handlers(
         Routing by per-field origin (see
         :func:`config.get_feature_flag_origin`):
 
-        - **addon**: POST the merged options to Supervisor and schedule
-          an addon restart so ``start.py`` re-derives env vars from
-          ``config.yaml`` on the next boot. Web UI edits and
-          Configuration-tab edits land in the same place, so the two
-          surfaces stay in sync.
+        - **addon**: POST the merged options to Supervisor and return
+          ``restart_required=True``. ``start.py`` will re-derive env
+          vars from ``config.yaml`` on the next addon boot — but the
+          actual restart is fired by the user clicking the global
+          Restart Add-on button, NOT by this handler. Web UI edits
+          and Configuration-tab edits land in the same place, so the
+          two surfaces stay in sync after the restart.
         - **env**: refuse — env var explicitly set wins. Returns
           ``VALIDATION_INVALID_PARAMETER`` with the env var name so
           the UI can surface the locking source.
         - **file** / **default**: merge into the override file in the
           data dir; takes effect on the next
-          ``get_global_settings()`` call (cache reset).
+          ``get_global_settings()`` call (cache reset). The response
+          still carries ``restart_required=True`` because most
+          flag descriptions advertise "Requires restart to take
+          effect" — the UI shows the banner regardless of mode.
         """
         from .config import (
             _FEATURE_FLAG_INT_BOUNDS,
@@ -2407,9 +2543,10 @@ def build_settings_handlers(
             # restart (Tools, Server Settings, Backups) returns
             # ``restart_required=True`` and lets the user pick when to
             # fire the actual restart via the global Restart Add-on
-            # button. Don't auto-restart here — racing the response
-            # against the supervisor kill caused the "Restart failed"
-            # alert reported by the user.
+            # button. Don't auto-restart from the save handler —
+            # supervisor would kill the addon before this JSON response
+            # could flush through HA ingress, surfacing as a spurious
+            # "Restart failed" alert at the browser.
             return JSONResponse(
                 {
                     "success": True,
@@ -2501,17 +2638,26 @@ def build_settings_handlers(
             )
 
         # Publish the change so the same process picks it up on the
-        # next ``get_global_settings()`` call (server-restart still
-        # required for many flags — the UI surfaces that — but the
-        # cached singleton must not return the stale pre-write
-        # values to subsequent /api/settings/features GETs).
-        # ``restart_required=True`` because every flag in
-        # FEATURE_META carries "Requires restart to take effect" in its
-        # help text — file-mode saves persist the value but the live
-        # process keeps the old reads until the MCP host is restarted
+        # next ``get_global_settings()`` call. The cached singleton
+        # must not return the stale pre-write values to subsequent
+        # /api/settings/features GETs.
+        #
+        # ``restart_required=True`` because the feature flags here gate
+        # tool registration, FastMCP transforms, and other startup-time
+        # reads. File-mode persists the value, but the live process
+        # keeps the old behavior until the MCP host is restarted
         # (Claude Desktop relaunch, Docker container restart, etc.).
+        # Surfacing the banner is the same contract Tools, Server
+        # Settings, and Backups all advertise.
         _reset_global_settings()
-        return JSONResponse({"success": True, "mode": "file", "restart_required": True})
+        return JSONResponse(
+            {
+                "success": True,
+                "applied": new_overrides,
+                "mode": "file",
+                "restart_required": True,
+            }
+        )
 
     # ---- Auto-backup routes (#1288) ----
 
@@ -2779,16 +2925,21 @@ def build_settings_handlers(
         """Persist auto-backup config edits and publish to the live process.
 
         Routing:
-        - Addon mode: POST ``/addons/self/options`` to update ``config.yaml``,
-          then ``/addons/self/restart`` to make the new values take effect via
-          ``start.py``'s env-var write at next boot. The HTTP response races
-          the restart-induced socket drop; the JS treats both 200 and
-          connection-drop as success and reloads the page after ~30s.
-        - Standalone (file) mode: refuse any field that's pinned by an env
-          var (process or ``.env``) — return 409 with the offending names so
-          the UI can refresh and show the read-only banner. Editable fields
-          merge into ``<data_dir>/backup_settings.json`` and a Settings
-          cache reset publishes them immediately (no restart).
+        - Addon mode: POST ``/addons/self/options`` (with the existing
+          options merged so required schema keys like ``backup_hint``
+          survive the full-replacement validation) and return
+          ``restart_required=True``. ``start.py`` will re-derive env
+          vars from ``config.yaml`` on the next addon boot, but the
+          actual restart is fired by the user clicking the global
+          Restart Add-on button — NOT by this handler. Same unified
+          flow as the Tools and Server Settings save endpoints.
+        - Standalone (file) mode: refuse any field that's pinned by an
+          env var (process or ``.env``) — return 409 with the offending
+          names so the UI can refresh and show the read-only banner.
+          Editable fields merge into
+          ``<data_dir>/backup_settings.json`` and a Settings cache
+          reset publishes them immediately, hence
+          ``restart_required=False``.
         """
         try:
             payload = await request.json()

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -1298,6 +1298,15 @@ function render() {
     `<span style="color:var(--success)">${enabledCount} enabled</span>` +
     `<span style="color:var(--accent)">${pinnedCount} pinned</span>` +
     `<span style="color:var(--danger)">${disabledCount} disabled</span>`;
+
+  // ``render()`` rebuilds the entire ``.tool`` DOM, so any
+  // ``hidden`` class previously applied by ``applyToolSearch`` is
+  // wiped. The search ``<input>`` is a separate element and keeps
+  // its value across the rebuild — re-apply the filter so the
+  // visible list matches what the user has typed. Otherwise
+  // toggling a setting on a filtered tool snaps the full list back
+  // even though the search box still shows the query.
+  applyToolSearch();
 }
 
 function scheduleSave() {
@@ -1331,8 +1340,12 @@ function updateStatus(text, saved) {
   el.className = saved ? 'status saved' : 'status';
 }
 
-document.getElementById('search').addEventListener('input', (e) => {
-  const q = e.target.value.toLowerCase();
+function applyToolSearch() {
+  // Read the current search query directly from the DOM rather than
+  // taking it as a parameter — ``render()`` calls this after rebuilding
+  // the tool DOM and needs to use whatever the user currently has
+  // typed without coordinating with the input event.
+  const q = (document.getElementById('search').value || '').toLowerCase();
   document.querySelectorAll('.tool').forEach(el => {
     const match = !q || el.dataset.name.includes(q) || el.dataset.title.includes(q);
     el.classList.toggle('hidden', !match);
@@ -1346,7 +1359,9 @@ document.getElementById('search').addEventListener('input', (e) => {
       g.querySelector('.group-chevron').classList.add('open');
     }
   });
-});
+}
+
+document.getElementById('search').addEventListener('input', applyToolSearch);
 
 document.getElementById('restartBtn').addEventListener('click', restartAddon);
 

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -921,28 +921,41 @@ async function stopSidecar() {
   }
 }
 
+const RESTART_RELOAD_DELAY_S = 10;
+
 async function restartAddon() {
   const btn = document.getElementById('restartBtn');
-  if (!confirm('Restart the add-on now? The web UI will become unreachable for ~30 seconds.')) return;
+  if (!confirm('Restart the add-on now? The page will reload automatically once the add-on is back online.')) return;
   btn.disabled = true;
-  btn.textContent = 'Restarting...';
+  btn.textContent = 'Restarting…';
+  // Only suppress the auto-reload on a genuine config error (4xx like
+  // SUPERVISOR_TOKEN missing). Anything else — 200, 5xx from ingress
+  // when supervisor killed our upstream mid-response, or a thrown
+  // network error from the same kill — means the restart is in flight
+  // and we should reload after the addon comes back.
+  let configError = false;
   try {
     const resp = await fetch('./api/settings/restart', {method: 'POST'});
-    if (resp.ok) {
-      btn.textContent = 'Restart initiated — reload page in ~30s';
-    } else {
+    if (!resp.ok && resp.status < 500) {
+      configError = true;
       let msg = 'Restart failed';
       try {
         const err = await resp.json();
-        if (err.error && err.error.message) msg = 'Failed: ' + err.error.message;
+        if (err && err.error && err.error.message) {
+          msg = 'Failed: ' + err.error.message;
+        }
       } catch (_e) {}
       btn.textContent = msg;
       btn.disabled = false;
       alert(msg);
     }
   } catch (_e) {
-    // Connection lost mid-request is actually expected — the addon is restarting
-    btn.textContent = 'Restart initiated (connection dropped)';
+    // Connection lost mid-request — restart in flight, fall through.
+  }
+  if (!configError) {
+    btn.textContent =
+      'Restarting… page will reload in ' + RESTART_RELOAD_DELAY_S + 's';
+    setTimeout(() => window.location.reload(), RESTART_RELOAD_DELAY_S * 1000);
   }
 }
 
@@ -1204,7 +1217,7 @@ const BACKUP_FIELD_LABELS = {
 };
 
 const BACKUP_ORIGIN_LABELS = {
-  addon: 'Synced to Supervisor — save will restart the add-on.',
+  addon: 'Synced to Supervisor — restart required after save.',
   env: null,  // banner generated dynamically with the env var name
   file: 'Persisted locally; takes effect immediately.',
   default: 'Using default; first save creates a local override file.',
@@ -1300,14 +1313,18 @@ async function saveBackupConfig() {
       statusEl.textContent = msg;
       return;
     }
-    if (data.restarting) {
-      statusEl.textContent = 'Saved — addon is restarting. Reload in ~30s.';
-      // Surface the cross-tab restart banner so the user has a clear
-      // reload-when-ready signal regardless of which tab they're on.
+    btn.disabled = false;
+    if (data.restart_required) {
+      // Unified restart flow — save persists but does NOT auto-restart.
+      // Surface the cross-tab restart-required banner; user picks the
+      // moment via the global Restart Add-on button. Refresh the form
+      // so origins update (default → addon/file etc.) but skip the
+      // backup-list reload until after the actual restart.
+      statusEl.textContent = 'Saved — restart required';
       document.getElementById('restartNotice').classList.add('show');
+      loadBackupConfig();
     } else {
       statusEl.textContent = 'Saved.';
-      btn.disabled = false;
       // Refresh display so origins update (default → file, etc.).
       loadBackupConfig();
       loadBackups();
@@ -1497,7 +1514,7 @@ const ORIGIN_LOCKED_NOTE = {
 };
 
 const ORIGIN_INFO_NOTE = {
-  addon: 'Synced to the add-on Configuration tab — save will restart the add-on.',
+  addon: 'Synced to the add-on Configuration tab — restart required after save.',
 };
 
 async function loadFeatureFlags() {
@@ -1624,19 +1641,15 @@ async function saveFeatureFlag(fieldName, value) {
     updateStatus(msg);
     return;
   }
-  if (data && data.restarting) {
-    // Addon mode: the server has already POSTed the merged options to
-    // Supervisor and scheduled a self-restart in a background task —
-    // the user just needs to wait. Surface the restart-required banner
-    // so it is visible regardless of which tab they are on (the banner
-    // lives above the tabs).
-    updateStatus('Saved — add-on is restarting. Reload in ~30s.', true);
+  // Unified restart flow — save persists the change but does NOT fire
+  // the addon restart. The user picks when to restart by clicking the
+  // global Restart Add-on button in the cross-tab restart-required
+  // banner. Same UX as the Tools tab. In standalone modes the restart
+  // button is hidden (no supervisor to drive it) but the banner still
+  // surfaces "restart required" as guidance.
+  updateStatus('Saved — restart required', true);
+  if (data && data.restart_required) {
     document.getElementById('restartNotice').classList.add('show');
-  } else {
-    // Standalone modes: the cache is reset in-process. Most flags still
-    // require an MCP-host restart to take effect (the docstring on each
-    // flag says so) but the addon itself is not the host — just toast.
-    updateStatus('Saved — restart required', true);
   }
 }
 
@@ -2390,13 +2403,19 @@ def build_settings_handlers(
                     create_error_response(code, err.message),
                     status_code=err.status_code,
                 )
-            _schedule_supervisor_self_restart(server.settings.verify_ssl)
+            # Unified restart flow: every save that requires an addon
+            # restart (Tools, Server Settings, Backups) returns
+            # ``restart_required=True`` and lets the user pick when to
+            # fire the actual restart via the global Restart Add-on
+            # button. Don't auto-restart here — racing the response
+            # against the supervisor kill caused the "Restart failed"
+            # alert reported by the user.
             return JSONResponse(
                 {
                     "success": True,
                     "applied": new_overrides,
                     "mode": "addon",
-                    "restarting": True,
+                    "restart_required": True,
                 }
             )
 
@@ -2486,8 +2505,13 @@ def build_settings_handlers(
         # required for many flags — the UI surfaces that — but the
         # cached singleton must not return the stale pre-write
         # values to subsequent /api/settings/features GETs).
+        # ``restart_required=True`` because every flag in
+        # FEATURE_META carries "Requires restart to take effect" in its
+        # help text — file-mode saves persist the value but the live
+        # process keeps the old reads until the MCP host is restarted
+        # (Claude Desktop relaunch, Docker container restart, etc.).
         _reset_global_settings()
-        return JSONResponse({"success": True})
+        return JSONResponse({"success": True, "mode": "file", "restart_required": True})
 
     # ---- Auto-backup routes (#1288) ----
 
@@ -2817,19 +2841,15 @@ def build_settings_handlers(
                     create_error_response(code, sup_err.message),
                     status_code=sup_err.status_code,
                 )
-            # Background restart so this JSON response can flush through HA
-            # ingress before supervisor kills the addon. The old code POSTed
-            # synchronously and the kill-mid-response would convert into a
-            # 5xx Bad Gateway at the proxy, which the JS rendered as
-            # "Save failed" / "Restart failed" — see _restart_addon for the
-            # same fix.
-            _schedule_supervisor_self_restart(server.settings.verify_ssl)
+            # Unified restart flow — see _save_feature_flags for the
+            # rationale. Don't auto-restart from a save handler; the
+            # global Restart Add-on button is the single restart path.
             return JSONResponse(
                 {
                     "success": True,
                     "applied": clean,
                     "mode": "addon",
-                    "restarting": True,
+                    "restart_required": True,
                 }
             )
 
@@ -2871,13 +2891,18 @@ def build_settings_handlers(
                 status_code=500,
             )
         # Drop the cached Settings so the next read sees the merged value.
+        # File-mode auto-backup settings take effect immediately on the
+        # next ``get_global_settings()`` read — no restart needed, hence
+        # ``restart_required=False``. The JS uses the same field name on
+        # every save endpoint to decide whether to surface the
+        # restart-required banner.
         _reset_global_settings()
         return JSONResponse(
             {
                 "success": True,
                 "applied": clean,
                 "mode": "file",
-                "restarting": False,
+                "restart_required": False,
             }
         )
 

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -14,6 +14,8 @@ import contextlib
 import json
 import logging
 import os
+import time
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, TypedDict
 
@@ -62,6 +64,17 @@ class ToolStub(TypedDict):
 
 
 _VALID_STATES = frozenset({"enabled", "disabled", "pinned"})
+
+# Per-process identity surfaced via ``/api/settings/info`` so the
+# restart UI can tell whether the addon actually restarted (vs. the
+# poll-cycle succeeding against the still-running OLD instance because
+# the supervisor restart silently no-op'd). Generated once at module
+# import; a fresh Python process gets a fresh value, so any restart
+# that actually swaps processes flips both. ``started_at`` is Unix
+# epoch seconds for human debuggability; ``instance_id`` is the
+# load-bearing identifier the JS poll compares against.
+_PROCESS_INSTANCE_ID: str = uuid.uuid4().hex
+_PROCESS_STARTED_AT: float = time.time()
 
 logger = logging.getLogger(__name__)
 
@@ -953,28 +966,52 @@ const restartChannel =
 // page reloads.
 let restartInProgress = false;
 
-async function _probeAddonReady() {
-  // Resolve true when ``/api/settings/info`` returns 200 (addon is
-  // serving HTTP again), false when we hit the cap. Caller decides
-  // whether to reload, surface a "didn't come back" message, or
-  // both. ``cache: 'no-store'`` so the browser doesn't serve a
-  // stale 200 from before the restart.
+async function _fetchSettingsInfo() {
+  // Read ``/api/settings/info`` once; return the parsed JSON or null
+  // on any failure. ``cache: 'no-store'`` so the browser can't serve
+  // a stale 200 from before the restart.
+  try {
+    const resp = await fetch('./api/settings/info', {cache: 'no-store'});
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch (_e) {
+    return null;
+  }
+}
+
+async function _probeAddonRestarted(previousInstanceId) {
+  // Resolve true when ``/api/settings/info`` returns a different
+  // ``instance_id`` than the one captured before the restart —
+  // proves a NEW process is serving, not the same OLD one (which
+  // would happen if supervisor silently failed to restart and the
+  // probe just saw the still-running upstream answer 200). When
+  // ``previousInstanceId`` is null (couldn't capture pre-restart,
+  // or server is on an older build that doesn't expose the field)
+  // fall back to "any 200 means it's back" — same behavior as
+  // before this fix landed, so we degrade gracefully.
   const deadline = Date.now() + RESTART_PROBE_MAX_TOTAL_MS;
   while (Date.now() < deadline) {
-    try {
-      const resp = await fetch('./api/settings/info', {cache: 'no-store'});
-      if (resp.ok) return true;
-    } catch (_e) {
-      // Connection drop / DNS / ingress 5xx while addon is down —
-      // expected. Suppress noise: a console.warn here would spam the
-      // devtools log during every restart.
+    const info = await _fetchSettingsInfo();
+    if (info) {
+      if (previousInstanceId) {
+        if (info.instance_id && info.instance_id !== previousInstanceId) {
+          return true;
+        }
+        // Same instance_id (or field missing on the response) — keep
+        // polling; do NOT reload yet because the restart hasn't
+        // actually happened yet.
+      } else {
+        // No baseline to compare against — best we can do is the
+        // old "200 = up" check.
+        return true;
+      }
     }
     await new Promise(r => setTimeout(r, RESTART_PROBE_INTERVAL_MS));
   }
   return false;
 }
 
-async function _runRestartReloadCycle() {
+async function _runRestartReloadCycle(previousInstanceId) {
   const btn = document.getElementById('restartBtn');
   // Initial grace lets supervisor actually kill the addon before we
   // start probing — otherwise the first probe may hit the OLD
@@ -982,13 +1019,14 @@ async function _runRestartReloadCycle() {
   btn.textContent = 'Restarting…';
   await new Promise(r => setTimeout(r, RESTART_PROBE_INITIAL_GRACE_MS));
   btn.textContent = 'Waiting for add-on to come back online…';
-  const ready = await _probeAddonReady();
-  if (ready) {
+  const restarted = await _probeAddonRestarted(previousInstanceId);
+  if (restarted) {
     window.location.reload();
   } else {
-    // Probe gave up after RESTART_PROBE_MAX_TOTAL_MS. Restart may
-    // have failed entirely or supervisor is genuinely slow. Surface
-    // a clear next-step instead of silently doing nothing.
+    // Probe gave up after RESTART_PROBE_MAX_TOTAL_MS. Restart either
+    // never actually fired (silent supervisor failure → instance_id
+    // never flipped) OR supervisor is genuinely slower than the cap.
+    // Surface a clear next-step instead of silently doing nothing.
     btn.textContent = 'Add-on did not come back online — reload manually';
     btn.disabled = false;
     restartInProgress = false;
@@ -1002,6 +1040,12 @@ async function restartAddon() {
   restartInProgress = true;
   btn.disabled = true;
   btn.textContent = 'Restarting…';
+  // Capture the current process's ``instance_id`` BEFORE firing the
+  // restart so the poll cycle has a baseline to compare against.
+  // null is fine — the probe degrades to the old "any 200 means up"
+  // mode rather than refusing to reload.
+  const info = await _fetchSettingsInfo();
+  const previousInstanceId = info?.instance_id ?? null;
   try {
     const resp = await fetch('./api/settings/restart', {method: 'POST'});
     if (!resp.ok && resp.status < 500) {
@@ -1031,11 +1075,15 @@ async function restartAddon() {
     console.warn('restartAddon fetch dropped (expected during self-restart):', _e);
   }
   // Other tabs need to run the same cycle so they reload to the fresh
-  // addon, not stay on a stale view. Broadcast BEFORE we sleep.
+  // addon, not stay on a stale view. Broadcast the baseline so each
+  // tab compares against the same pre-restart ``instance_id``.
   if (restartChannel) {
-    restartChannel.postMessage({type: 'restart-initiated'});
+    restartChannel.postMessage({
+      type: 'restart-initiated',
+      previousInstanceId,
+    });
   }
-  await _runRestartReloadCycle();
+  await _runRestartReloadCycle(previousInstanceId);
 }
 
 // Listener: when ANY tab broadcasts a save that needs a restart, all
@@ -1051,7 +1099,11 @@ if (restartChannel) {
       restartInProgress = true;
       const btn = document.getElementById('restartBtn');
       if (btn) btn.disabled = true;
-      _runRestartReloadCycle();
+      // Use the originating tab's baseline ``instance_id`` so every
+      // tab waits for the SAME ``instance_id`` flip before reloading.
+      // Falls back to null → "any 200 = ready" mode if the originator
+      // couldn't capture one.
+      _runRestartReloadCycle(data.previousInstanceId ?? null);
     }
   });
 }
@@ -2275,8 +2327,23 @@ def build_settings_handlers(
         # button (HTML show/hide); it MUST NOT leak True for HTTP modes
         # since stopping the FastMCP-mounted route would mean killing
         # the MCP server itself.
+        #
+        # ``instance_id`` + ``started_at`` are surfaced so the
+        # restart-then-reload JS cycle can prove a restart actually
+        # happened (the value flips across processes) instead of
+        # trusting that a poll returning 200 means the new instance
+        # is up — a silent restart no-op would otherwise see the OLD
+        # instance still answering and the page would reload to the
+        # same state.
         addon = False if is_sidecar else is_running_in_addon()
-        return JSONResponse({"is_addon": addon, "is_sidecar": is_sidecar})
+        return JSONResponse(
+            {
+                "is_addon": addon,
+                "is_sidecar": is_sidecar,
+                "instance_id": _PROCESS_INSTANCE_ID,
+                "started_at": _PROCESS_STARTED_AT,
+            }
+        )
 
     async def _get_feature_flags(_: Request) -> JSONResponse:
         """Return live feature-flag values + per-field origin + editable flag.

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, TypedDict
 
 import httpx
 from starlette.requests import Request
@@ -1624,16 +1624,18 @@ async function saveFeatureFlag(fieldName, value) {
     updateStatus(msg);
     return;
   }
-  // In addon mode the server has already POSTed the merged options to
-  // Supervisor and scheduled a self-restart in a background task — the
-  // user just needs to wait. Surface the restart-required banner so it
-  // is visible regardless of which tab they are on (the banner now lives
-  // above the tabs). In standalone modes the cache is reset in-process
-  // and no restart is required, so just toast.
   if (data && data.restarting) {
+    // Addon mode: the server has already POSTed the merged options to
+    // Supervisor and scheduled a self-restart in a background task —
+    // the user just needs to wait. Surface the restart-required banner
+    // so it is visible regardless of which tab they are on (the banner
+    // lives above the tabs).
     updateStatus('Saved — add-on is restarting. Reload in ~30s.', true);
     document.getElementById('restartNotice').classList.add('show');
   } else {
+    // Standalone modes: the cache is reset in-process. Most flags still
+    // require an MCP-host restart to take effect (the docstring on each
+    // flag says so) but the addon itself is not the host — just toast.
     updateStatus('Saved — restart required', true);
   }
 }
@@ -1664,9 +1666,35 @@ loadTools();
 )
 
 
+class _SupervisorOptionsError(NamedTuple):
+    """Discriminated failure shape for the supervisor options helpers.
+
+    Two distinct failure classes need different recovery paths in the UI:
+
+    - ``kind="transport"``: network / DNS / Supervisor unreachable / token
+      missing. The route maps this to :class:`ErrorCode.CONNECTION_FAILED`
+      so the UI surfaces the "is HA running, check connectivity"
+      suggestions. ``status_code`` is always ``502`` for this kind.
+    - ``kind="validation"``: Supervisor accepted the request but rejected
+      the body against the addon schema (e.g. an unknown key, a missing
+      required field). The route maps this to
+      :class:`ErrorCode.CONFIG_VALIDATION_FAILED` and forwards the
+      supervisor ``status_code`` verbatim so the UI shows a real 4xx and
+      surfaces the schema-recovery suggestions.
+
+    Collapsing both into a single string return (the previous shape)
+    sent transport failures down the wrong recovery path. See
+    PR #1420's code review for the motivation.
+    """
+
+    kind: Literal["transport", "validation"]
+    message: str
+    status_code: int
+
+
 async def _supervisor_fetch_current_options(
     verify_ssl: bool,
-) -> tuple[dict[str, Any], str | None]:
+) -> tuple[dict[str, Any], _SupervisorOptionsError | None]:
     """GET ``/addons/self/info`` and return the current options dict.
 
     Supervisor's ``/addons/self/options`` POST is a *full* replacement
@@ -1674,43 +1702,74 @@ async def _supervisor_fetch_current_options(
     present in the body. We can't ship a partial PATCH of just the
     fields the user changed, so callers must merge their changes into
     the full current options before posting. Mirrors the pattern in
-    ``homeassistant-addon/start.py::persist_addon_options``.
+    ``homeassistant-addon/start.py::maybe_persist_secret_path`` which
+    spreads existing config (``{**config, "secret_path": secret_path}``)
+    before calling ``persist_addon_options``.
 
-    Returns ``(options_dict, error_msg)``. On any error
-    (network failure, non-200 from supervisor, malformed JSON,
-    non-dict options field) the dict is ``{}`` and an error message
-    describes the failure for surfacing to the user.
+    Returns ``(options_dict, error)`` where ``error`` is a
+    :class:`_SupervisorOptionsError` carrying ``kind="transport"`` for
+    network / token / non-JSON failures (mapped to ``CONNECTION_FAILED``
+    upstream) and ``kind="validation"`` for supervisor ``>=400``
+    responses (mapped to ``CONFIG_VALIDATION_FAILED`` with supervisor's
+    real status code preserved). On success the dict carries the
+    full options and ``error`` is ``None``.
     """
     try:
         async with make_supervisor_httpx_client(
             timeout=10.0, verify=verify_ssl
         ) as sclient:
             resp = await sclient.get("/addons/self/info")
+    except RuntimeError as exc:
+        # `make_supervisor_httpx_client` raises RuntimeError when
+        # SUPERVISOR_TOKEN is unset. Both current callers gate on that
+        # env var, but treat this as transport (env / setup failure) so
+        # a future third caller missing the gate gets a sane 502 rather
+        # than an uncaught 500.
+        return {}, _SupervisorOptionsError(
+            "transport", f"Supervisor client unavailable: {exc}", 502
+        )
     except httpx.HTTPError as exc:
-        return {}, f"Could not reach Supervisor for current options: {exc}"
+        return {}, _SupervisorOptionsError(
+            "transport",
+            f"Could not reach Supervisor for current options: {exc}",
+            502,
+        )
     if resp.status_code >= 400:
-        return {}, (
-            f"Supervisor returned {resp.status_code} for "
-            f"/addons/self/info: {resp.text[:300]}"
+        # Supervisor returning a 4xx/5xx for /info is itself a transport-
+        # class failure (we never sent body — there is no schema for
+        # the GET to validate). 502 with CONNECTION_FAILED is right.
+        return {}, _SupervisorOptionsError(
+            "transport",
+            (
+                f"Supervisor returned {resp.status_code} for "
+                f"/addons/self/info: {resp.text[:300]}"
+            ),
+            502,
         )
     try:
         body = resp.json()
     except ValueError:
-        return {}, "Supervisor returned non-JSON for /addons/self/info"
+        return {}, _SupervisorOptionsError(
+            "transport", "Supervisor returned non-JSON for /addons/self/info", 502
+        )
     # Supervisor REST envelope is {"result": "ok", "data": {...}}. Older
     # mocks / variants may return the data dict directly — handle both.
     data = body.get("data") if isinstance(body, dict) and "data" in body else body
     if not isinstance(data, dict):
-        return {}, "Supervisor /addons/self/info had non-object body"
+        return {}, _SupervisorOptionsError(
+            "transport", "Supervisor /addons/self/info had non-object body", 502
+        )
     options = data.get("options")
     if not isinstance(options, dict):
-        return {}, "Supervisor /addons/self/info had no options dict"
+        return {}, _SupervisorOptionsError(
+            "transport", "Supervisor /addons/self/info had no options dict", 502
+        )
     return options, None
 
 
 async def _supervisor_merge_and_post_options(
     verify_ssl: bool, field_changes: dict[str, Any]
-) -> tuple[bool, str | None]:
+) -> tuple[bool, _SupervisorOptionsError | None]:
     """Merge ``field_changes`` into supervisor's current options and POST.
 
     Necessary because supervisor's POST is full-replacement (see
@@ -1719,10 +1778,13 @@ async def _supervisor_merge_and_post_options(
     drops every other key (including required ones like ``backup_hint``)
     and supervisor rejects with a 400 ``addon_configuration_invalid_error``.
 
-    Returns ``(success, error_msg)``. On supervisor 4xx the error
-    message includes the supervisor body so the UI can surface
-    validation failures (e.g. attempting to set a key the addon's
-    schema doesn't declare on the production channel).
+    Returns ``(success, error)`` where ``error`` is a
+    :class:`_SupervisorOptionsError`. Transport failures (token missing,
+    network drop, malformed response from /info) bubble up from the
+    fetch helper unchanged. Supervisor 4xx on the actual POST is
+    classified as ``kind="validation"`` with supervisor's status code
+    preserved so the UI can show the real 4xx code and the
+    ``CONFIG_VALIDATION_FAILED`` recovery suggestions.
     """
     current, err = await _supervisor_fetch_current_options(verify_ssl)
     if err is not None:
@@ -1733,12 +1795,22 @@ async def _supervisor_merge_and_post_options(
             timeout=10.0, verify=verify_ssl
         ) as sclient:
             resp = await sclient.post("/addons/self/options", json={"options": merged})
+    except RuntimeError as exc:
+        return False, _SupervisorOptionsError(
+            "transport", f"Supervisor client unavailable: {exc}", 502
+        )
     except httpx.HTTPError as exc:
-        return False, f"Supervisor options POST failed: {exc}"
+        return False, _SupervisorOptionsError(
+            "transport", f"Supervisor options POST failed: {exc}", 502
+        )
     if resp.status_code >= 400:
-        return False, (
-            f"Supervisor rejected options update ({resp.status_code}): "
-            f"{resp.text[:400]}"
+        return False, _SupervisorOptionsError(
+            "validation",
+            (
+                f"Supervisor rejected options update ({resp.status_code}): "
+                f"{resp.text[:400]}"
+            ),
+            resp.status_code,
         )
     return True, None
 
@@ -1749,8 +1821,21 @@ async def _supervisor_merge_and_post_options(
 # Tasks remove themselves via ``add_done_callback`` when they finish.
 _BACKGROUND_RESTART_TASKS: set[asyncio.Task[None]] = set()
 
+# Delay (seconds) before the background self-restart task fires the
+# supervisor POST. Picked to give Starlette + uvicorn time to serialize
+# the JSONResponse onto the socket and have HA ingress flush it to the
+# browser BEFORE supervisor kills the addon container. Too short races
+# the response flush (browser sees a 5xx Bad Gateway from ingress); too
+# long delays the visible restart noticeably. 0.3s is comfortably above
+# observed flush times in addon-mode while staying well under any
+# reasonable user attention threshold. Tests override via the ``delay``
+# kwarg of ``_schedule_supervisor_self_restart``.
+_SUPERVISOR_SELF_RESTART_FLUSH_DELAY_S: float = 0.3
 
-def _schedule_supervisor_self_restart(verify_ssl: bool, *, delay: float = 0.3) -> None:
+
+def _schedule_supervisor_self_restart(
+    verify_ssl: bool, *, delay: float = _SUPERVISOR_SELF_RESTART_FLUSH_DELAY_S
+) -> None:
     """Schedule a background ``/addons/self/restart`` POST.
 
     Fire-and-forget on the current event loop so the request handler
@@ -2159,7 +2244,17 @@ def build_settings_handlers(
             fname: (ename, ftype) for fname, ename, ftype in FEATURE_FLAG_FIELDS
         }
         new_overrides: dict[str, Any] = {}
+        # Per ``config.get_feature_flag_origin``, addon mode (i.e.
+        # ``SUPERVISOR_TOKEN`` set) makes the helper return ``"addon"``
+        # for *every* registered flag — there is no path that yields a
+        # mixed addon + file/default batch from a single addon-mode UI
+        # session. The loop still tracks ``addon_writes`` per-field as
+        # belt-and-braces in case a future origin-resolution change
+        # breaks that invariant; the post-loop assertion below makes the
+        # invariant explicit so a regression fails loudly instead of
+        # silently routing a file-mode write through Supervisor.
         addon_writes = False
+        file_or_default_writes = False
         for field_name, raw in raw_flags.items():
             if field_name not in known:
                 return JSONResponse(
@@ -2173,7 +2268,9 @@ def build_settings_handlers(
             origin = get_feature_flag_origin(env_name)
             if origin == "addon":
                 addon_writes = True
-            elif origin not in ("file", "default"):
+            elif origin in ("file", "default"):
+                file_or_default_writes = True
+            else:
                 return JSONResponse(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -2234,15 +2331,33 @@ def build_settings_handlers(
         # required schema keys like ``backup_hint`` survive — see
         # _supervisor_merge_and_post_options for the rationale, and the
         # parallel handling in _save_backup_config.
-        if addon_writes:
-            if not os.environ.get("SUPERVISOR_TOKEN"):
-                return JSONResponse(
-                    create_error_response(
-                        ErrorCode.CONFIG_VALIDATION_FAILED,
-                        "Supervisor token missing — cannot update add-on options",
+        #
+        # Reject mixed-origin batches loudly. The current
+        # ``get_feature_flag_origin`` implementation guarantees a single
+        # mode per request, but if a future change broke that invariant
+        # we would silently route a file/default-origin field through
+        # Supervisor (which would reject it as an unknown schema key in
+        # production addon mode) — better to fail clearly here.
+        if addon_writes and file_or_default_writes:
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    (
+                        "Batch contains a mix of addon-origin and "
+                        "file/default-origin fields; route each batch "
+                        "through a single persistence path."
                     ),
-                    status_code=400,
-                )
+                ),
+                status_code=500,
+            )
+        if addon_writes:
+            # ``addon_writes=True`` is equivalent to
+            # ``is_running_in_addon()`` (origin=="addon" requires
+            # SUPERVISOR_TOKEN per ``get_feature_flag_origin``), so the
+            # only guard we still need here is the sidecar-shape
+            # ``server is None``. The helpers below catch the missing-
+            # token ``RuntimeError`` from ``make_supervisor_httpx_client``
+            # as defense-in-depth.
             if server is None:
                 return JSONResponse(
                     create_error_response(
@@ -2255,13 +2370,25 @@ def build_settings_handlers(
                 server.settings.verify_ssl, new_overrides
             )
             if not ok:
-                logger.warning("Supervisor feature-flag update failed: %s", err)
+                assert err is not None
+                logger.warning(
+                    "Supervisor feature-flag update failed (%s): %s",
+                    err.kind,
+                    err.message,
+                )
+                # Transport failures get CONNECTION_FAILED so the UI shows the
+                # "is HA reachable" suggestions; supervisor schema rejections
+                # get CONFIG_VALIDATION_FAILED with supervisor's real status
+                # code preserved so the UI shows the actual 4xx, not a generic
+                # 502. See _SupervisorOptionsError for the rationale.
+                code = (
+                    ErrorCode.CONNECTION_FAILED
+                    if err.kind == "transport"
+                    else ErrorCode.CONFIG_VALIDATION_FAILED
+                )
                 return JSONResponse(
-                    create_error_response(
-                        ErrorCode.CONFIG_VALIDATION_FAILED,
-                        err or "Supervisor options update failed",
-                    ),
-                    status_code=502,
+                    create_error_response(code, err.message),
+                    status_code=err.status_code,
                 )
             _schedule_supervisor_self_restart(server.settings.verify_ssl)
             return JSONResponse(
@@ -2648,14 +2775,11 @@ def build_settings_handlers(
             return _bad_request(err)
 
         if is_running_in_addon():
-            if not os.environ.get("SUPERVISOR_TOKEN"):
-                return JSONResponse(
-                    create_error_response(
-                        ErrorCode.CONFIG_VALIDATION_FAILED,
-                        "Supervisor token missing — cannot update add-on options",
-                    ),
-                    status_code=400,
-                )
+            # ``is_running_in_addon()`` checks SUPERVISOR_TOKEN — the
+            # helpers below also catch the missing-token ``RuntimeError``
+            # from ``make_supervisor_httpx_client`` as defense-in-depth,
+            # so we only still need the sidecar-shape ``server is None``
+            # guard.
             if server is None:
                 # Addon mode without a live server means we're in the
                 # stdio sidecar — but addon detection should already be
@@ -2669,22 +2793,29 @@ def build_settings_handlers(
             # Merge ``clean`` into the *full* current options before posting.
             # Supervisor validates against the addon schema and rejects any
             # body missing a required key (notably ``backup_hint`` on the
-            # production / dev manifests). The historical bug
-            # (#TODO: refer to PR) shipped just the auto-backup fields,
-            # producing `addon_configuration_invalid_error: Missing option
-            # 'backup_hint' in root` from supervisor and a confusing 400 in
+            # production / dev manifests). A previous version of this code
+            # shipped just the auto-backup fields, producing
+            # ``addon_configuration_invalid_error: Missing option
+            # 'backup_hint' in root`` from supervisor and a confusing 400 in
             # the UI even though the user only changed unrelated fields.
-            ok, err = await _supervisor_merge_and_post_options(
+            ok, sup_err = await _supervisor_merge_and_post_options(
                 server.settings.verify_ssl, clean
             )
             if not ok:
-                logger.warning("Supervisor backup-config update failed: %s", err)
+                assert sup_err is not None
+                logger.warning(
+                    "Supervisor backup-config update failed (%s): %s",
+                    sup_err.kind,
+                    sup_err.message,
+                )
+                code = (
+                    ErrorCode.CONNECTION_FAILED
+                    if sup_err.kind == "transport"
+                    else ErrorCode.CONFIG_VALIDATION_FAILED
+                )
                 return JSONResponse(
-                    create_error_response(
-                        ErrorCode.CONFIG_VALIDATION_FAILED,
-                        err or "Supervisor options update failed",
-                    ),
-                    status_code=502,
+                    create_error_response(code, sup_err.message),
+                    status_code=sup_err.status_code,
                 )
             # Background restart so this JSON response can flush through HA
             # ingress before supervisor kills the addon. The old code POSTed

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -1094,7 +1094,13 @@ class TestSaveBackupConfigEndpoint:
         assert resp.status_code == 200
         body = json.loads(resp.body)
         assert body["mode"] == "file"
-        assert body["restarting"] is False
+        # File-mode auto-backup save applies live via the cache reset;
+        # no addon restart needed, hence restart_required=False. The
+        # field name was renamed from "restarting" → "restart_required"
+        # as part of the unified restart flow (Tools / Server Settings
+        # / Backups all use the same field).
+        assert body["restart_required"] is False
+        assert "restarting" not in body  # legacy field name must be gone
         on_disk = json.loads(override_path.read_text())
         assert on_disk["enable_auto_backup"] is True
         assert on_disk["auto_backup_throttle_minutes"] == 9
@@ -1526,7 +1532,20 @@ class TestSaveBackupConfigAddonMode:
         return captured["post"]
 
     @pytest.mark.asyncio
-    async def test_addon_save_merges_and_schedules_restart(self, monkeypatch):
+    async def test_addon_save_merges_without_restart_returns_restart_required(
+        self, monkeypatch
+    ):
+        """Unified restart flow: every save endpoint (Tools, Server
+        Settings, Backups) commits the change but **does not** fire the
+        addon restart. The user picks when to restart via the global
+        Restart Add-on button. The save response carries
+        ``restart_required=True`` so the cross-tab banner appears.
+
+        Pins the contract — a regression that re-introduces an
+        auto-restart from inside the save handler races the supervisor
+        kill against the JSON response flush and surfaces a spurious
+        "Restart failed" alert / "addon is restarting" message.
+        """
         post_handler = self._capture_post_handler(monkeypatch)
 
         merge_mock = AsyncMock(return_value=(True, None))
@@ -1547,12 +1566,13 @@ class TestSaveBackupConfigAddonMode:
         assert resp.status_code == 200
         body = json.loads(resp.body)
         assert body["mode"] == "addon"
-        assert body["restarting"] is True
+        assert body["restart_required"] is True
+        assert "restarting" not in body  # legacy field name must be gone
         merge_mock.assert_awaited_once_with(
             True,
             {"enable_auto_backup": True, "auto_backup_throttle_minutes": 5},
         )
-        schedule_mock.assert_called_once_with(True)
+        schedule_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_addon_save_surfaces_validation_error_with_supervisor_status(
@@ -1670,7 +1690,12 @@ class TestSaveFeatureFlagsAddonMode:
         return captured["post"]
 
     @pytest.mark.asyncio
-    async def test_addon_save_merges_and_schedules_restart(self, monkeypatch):
+    async def test_addon_save_merges_without_restart_returns_restart_required(
+        self, monkeypatch
+    ):
+        """Mirror of TestSaveBackupConfigAddonMode's counterpart — see
+        that test for the unified-restart-flow rationale.
+        """
         post_handler = self._capture_post_handler(monkeypatch)
 
         merge_mock = AsyncMock(return_value=(True, None))
@@ -1689,9 +1714,10 @@ class TestSaveFeatureFlagsAddonMode:
         assert resp.status_code == 200
         body = json.loads(resp.body)
         assert body["mode"] == "addon"
-        assert body["restarting"] is True
+        assert body["restart_required"] is True
+        assert "restarting" not in body
         merge_mock.assert_awaited_once_with(True, {"enable_yaml_config_editing": True})
-        schedule_mock.assert_called_once_with(True)
+        schedule_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_addon_save_surfaces_validation_error_with_supervisor_status(

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -1952,6 +1952,78 @@ class TestSaveToolsResponseShape:
         assert "pinned" not in body
 
 
+class TestSettingsInfoEndpoint:
+    """``GET /api/settings/info`` exposes per-process identity so the
+    restart-then-reload JS cycle can prove a restart actually happened.
+
+    Without ``instance_id`` the JS poll cycle can't tell the difference
+    between "addon successfully restarted and the new instance is up"
+    and "addon never restarted (silent supervisor failure) and the OLD
+    instance is still serving 200" — both look identical to a status-
+    only probe. Pins the contract: ``instance_id`` must be present,
+    stable within a process, and ``started_at`` must be a positive
+    epoch-seconds float.
+    """
+
+    def _capture_handler(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/info") and "GET" in methods:
+                    captured["get"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        server = MagicMock()
+        server.settings.verify_ssl = True
+        register_settings_routes(mcp, server, secret_path="/x")
+        return captured["get"]
+
+    @pytest.mark.asyncio
+    async def test_returns_instance_id_and_started_at(self, monkeypatch):
+        from ha_mcp.settings_ui import (
+            _PROCESS_INSTANCE_ID,
+            _PROCESS_STARTED_AT,
+        )
+
+        handler = self._capture_handler(monkeypatch)
+        resp = await handler(MagicMock())
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        # Pre-existing fields still there.
+        assert "is_addon" in body
+        assert "is_sidecar" in body
+        # New restart-detection fields.
+        assert body["instance_id"] == _PROCESS_INSTANCE_ID
+        assert body["started_at"] == _PROCESS_STARTED_AT
+        # Sanity: instance_id is a non-empty string, started_at is a
+        # positive epoch-seconds float (i.e. truly an instant in time,
+        # not a serialization artifact).
+        assert isinstance(body["instance_id"], str)
+        assert len(body["instance_id"]) > 0
+        assert isinstance(body["started_at"], int | float)
+        assert body["started_at"] > 0
+
+    @pytest.mark.asyncio
+    async def test_instance_id_stable_within_process(self, monkeypatch):
+        """Two calls within the same process must return the same
+        ``instance_id``. Without this invariant the JS poll cycle
+        would see the value flip on every call and reload immediately,
+        completely defeating the restart-detection contract.
+        """
+        handler = self._capture_handler(monkeypatch)
+        first = json.loads((await handler(MagicMock())).body)
+        second = json.loads((await handler(MagicMock())).body)
+        assert first["instance_id"] == second["instance_id"]
+        assert first["started_at"] == second["started_at"]
+
+
 class TestFeatureGatedToolsCustomCode:
     """``ha_manage_custom_tool`` (gated by ``enable_code_mode``) must
     appear in the settings-UI tool list when the toggle is off — same

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -30,6 +30,25 @@ from ha_mcp.settings_ui import (
 SaveHandler = Callable[[Request], Awaitable[JSONResponse]]
 
 
+async def _drain_background_restart_tasks() -> None:
+    """Deterministically wait for every in-flight self-restart task.
+
+    `_schedule_supervisor_self_restart` is fire-and-forget but keeps
+    strong references in `_BACKGROUND_RESTART_TASKS` (so the GC doesn't
+    reap mid-run). Tests that exercise the schedule helper need to
+    wait for those tasks to finish before asserting on side effects;
+    `asyncio.sleep`-based polling is flaky on slow CI runners, so
+    snapshot the set and await each task.
+    """
+    import asyncio
+
+    from ha_mcp.settings_ui import _BACKGROUND_RESTART_TASKS
+
+    pending = list(_BACKGROUND_RESTART_TASKS)
+    if pending:
+        await asyncio.wait(pending)
+
+
 class TestConfigPersistence:
     """Test load/save of tool_config.json."""
 
@@ -722,28 +741,32 @@ class TestRestartAddon:
         (background task pattern — see
         ``test_self_restart_returns_200_and_schedules_background_task``),
         so the verifier here is "the schedule helper got called" rather
-        than "Supervisor was POSTed synchronously". The synchronous
-        ``httpx.AsyncClient`` path is also patched to confirm it is NOT
-        invoked for the fall-back-to-self case.
+        than "Supervisor was POSTed synchronously". Patch the supervisor
+        client factory at its public API to confirm the synchronous path
+        is NOT invoked for the fall-back-to-self case.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
         request = self._make_request(body=body)
 
-        sync_mock = AsyncMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=MagicMock(post=sync_mock))
-        cm.__aexit__ = AsyncMock(return_value=None)
         schedule_mock = MagicMock()
         monkeypatch.setattr(
             "ha_mcp.settings_ui._schedule_supervisor_self_restart",
             schedule_mock,
         )
 
-        with patch("ha_mcp.settings_ui.httpx.AsyncClient", return_value=cm):
+        # Patch the same surface the schedule-vs-sync branch consults:
+        # ``make_supervisor_httpx_client`` (not the lower-level
+        # ``httpx.AsyncClient``). Lets us assert the synchronous POST
+        # was never awaited without juggling the AsyncClient context-
+        # manager dance inline.
+        response = MagicMock()
+        response.status_code = 200
+        patcher, mock_client = self._patch_supervisor_client(post_return=response)
+        with patcher:
             await restart(request)
 
         schedule_mock.assert_called_once_with(True)
-        sync_mock.assert_not_awaited()
+        mock_client.post.assert_not_awaited()
 
 
 class TestBackupSettingsOverridePersistence:
@@ -1209,9 +1232,37 @@ class TestSupervisorOptionsHelpers:
         assert options == {"backup_hint": "normal", "enable_tool_search": True}
 
     @pytest.mark.asyncio
-    async def test_fetch_current_options_supervisor_4xx_returns_error(
+    async def test_fetch_current_options_accepts_bare_options_dict(self, monkeypatch):
+        """``_supervisor_fetch_current_options`` documents that it accepts
+        BOTH the wrapped ``{"data": {"options": ...}}`` envelope AND a
+        bare ``{"options": ...}`` shape (older mocks / variants). Pin the
+        bare-dict path so a future supervisor variant or mock cleanup
+        cannot silently regress it.
+        """
+        from ha_mcp.settings_ui import _supervisor_fetch_current_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        response = MagicMock()
+        response.status_code = 200
+        response.json = MagicMock(
+            return_value={"options": {"backup_hint": "normal", "verify_ssl": True}}
+        )
+        patcher, _ = self._patch_supervisor_client(get_response=response)
+        with patcher:
+            options, err = await _supervisor_fetch_current_options(verify_ssl=True)
+        assert err is None
+        assert options == {"backup_hint": "normal", "verify_ssl": True}
+
+    @pytest.mark.asyncio
+    async def test_fetch_current_options_supervisor_4xx_returns_transport_error(
         self, monkeypatch
     ):
+        """Supervisor 4xx/5xx on the /info GET is a transport-class failure
+        (we sent no body — there is no schema for the GET to validate).
+        Must be classified ``kind="transport"`` with status_code=502 so
+        the route maps it to CONNECTION_FAILED rather than the
+        schema-recovery suggestions of CONFIG_VALIDATION_FAILED.
+        """
         from ha_mcp.settings_ui import _supervisor_fetch_current_options
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
@@ -1223,10 +1274,14 @@ class TestSupervisorOptionsHelpers:
             options, err = await _supervisor_fetch_current_options(verify_ssl=True)
         assert options == {}
         assert err is not None
-        assert "503" in err
+        assert err.kind == "transport"
+        assert err.status_code == 502
+        assert "503" in err.message
 
     @pytest.mark.asyncio
-    async def test_fetch_current_options_http_error_returns_error(self, monkeypatch):
+    async def test_fetch_current_options_http_error_returns_transport_error(
+        self, monkeypatch
+    ):
         from ha_mcp.settings_ui import _supervisor_fetch_current_options
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
@@ -1237,6 +1292,30 @@ class TestSupervisorOptionsHelpers:
             options, err = await _supervisor_fetch_current_options(verify_ssl=True)
         assert options == {}
         assert err is not None
+        assert err.kind == "transport"
+        assert err.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_fetch_current_options_runtime_error_returns_transport_error(
+        self, monkeypatch
+    ):
+        """``make_supervisor_httpx_client`` raises RuntimeError when
+        SUPERVISOR_TOKEN is unset. Both call sites gate on the env var
+        first, but the helper must still catch the RuntimeError as a
+        defense-in-depth measure so a future third caller missing the
+        gate doesn't get an uncaught 500.
+        """
+        from ha_mcp.settings_ui import _supervisor_fetch_current_options
+
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        # Without the env var, make_supervisor_httpx_client raises before
+        # any HTTP call — no patching needed.
+        options, err = await _supervisor_fetch_current_options(verify_ssl=True)
+        assert options == {}
+        assert err is not None
+        assert err.kind == "transport"
+        assert err.status_code == 502
+        assert "Supervisor client unavailable" in err.message
 
     @pytest.mark.asyncio
     async def test_merge_and_post_options_preserves_existing_keys(self, monkeypatch):
@@ -1299,10 +1378,15 @@ class TestSupervisorOptionsHelpers:
         assert merged["auto_backup_throttle_minutes"] == 5  # changed
 
     @pytest.mark.asyncio
-    async def test_merge_and_post_supervisor_400_returns_error(self, monkeypatch):
-        """Supervisor 4xx on the POST surfaces back as ``(False, msg)`` with
-        the body text included so the UI can show e.g. an
-        addon_configuration_invalid_error from a schema mismatch.
+    async def test_merge_and_post_supervisor_400_returns_validation_error(
+        self, monkeypatch
+    ):
+        """Supervisor 4xx on the POST is classified ``kind="validation"``
+        and supervisor's real status code is preserved. The route maps
+        validation errors to CONFIG_VALIDATION_FAILED and uses
+        supervisor's status_code (NOT 502) so the UI shows the actual
+        4xx. Collapsing transport + validation into a single 502 sent
+        users down the wrong recovery path in the previous version.
         """
         from ha_mcp.settings_ui import _supervisor_merge_and_post_options
 
@@ -1324,18 +1408,49 @@ class TestSupervisorOptionsHelpers:
             )
         assert ok is False
         assert err is not None
-        assert "400" in err
-        assert "backup_hint" in err
+        assert err.kind == "validation"
+        assert err.status_code == 400  # supervisor's status, NOT 502
+        assert "backup_hint" in err.message
+
+    @pytest.mark.asyncio
+    async def test_merge_and_post_transport_error_returns_transport_kind(
+        self, monkeypatch
+    ):
+        """``httpx.HTTPError`` on the POST (network drop / DNS failure /
+        supervisor unreachable) must be classified ``kind="transport"``
+        with status_code=502 so the route maps it to CONNECTION_FAILED.
+        """
+        from ha_mcp.settings_ui import _supervisor_merge_and_post_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        get_response = MagicMock()
+        get_response.status_code = 200
+        get_response.json = MagicMock(return_value={"data": {"options": {}}})
+        patcher, _ = self._patch_supervisor_client(
+            get_response=get_response,
+            post_side_effect=httpx.ConnectError("no route"),
+        )
+        with patcher:
+            ok, err = await _supervisor_merge_and_post_options(
+                verify_ssl=True, field_changes={"enable_auto_backup": True}
+            )
+        assert ok is False
+        assert err is not None
+        assert err.kind == "transport"
+        assert err.status_code == 502
 
     @pytest.mark.asyncio
     async def test_schedule_self_restart_fires_task_after_delay(self, monkeypatch):
         """``_schedule_supervisor_self_restart`` fires a background task
         that posts to ``/addons/self/restart`` after ``delay``. Override
-        the delay to 0 so this runs fast.
+        the delay to 0 and deterministically wait on the scheduled task
+        rather than ``asyncio.sleep``-ing — sleep is flaky on slow CI
+        runners.
         """
-        import asyncio
-
-        from ha_mcp.settings_ui import _schedule_supervisor_self_restart
+        from ha_mcp.settings_ui import (
+            _BACKGROUND_RESTART_TASKS,
+            _schedule_supervisor_self_restart,
+        )
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
         post_response = MagicMock()
@@ -1345,10 +1460,14 @@ class TestSupervisorOptionsHelpers:
         )
         with patcher:
             _schedule_supervisor_self_restart(verify_ssl=True, delay=0)
-            # Yield to the event loop so the scheduled task runs.
-            await asyncio.sleep(0.05)
+            # Deterministic wait — gather the strong-ref set the helper
+            # maintains rather than relying on a fixed sleep.
+            await _drain_background_restart_tasks()
 
         mock_client.post.assert_awaited_with("/addons/self/restart")
+        # Strong-ref set self-clears via add_done_callback once the task
+        # finishes — pin that contract too.
+        assert set() == _BACKGROUND_RESTART_TASKS
 
     @pytest.mark.asyncio
     async def test_schedule_self_restart_swallows_connection_drop(self, monkeypatch):
@@ -1358,8 +1477,6 @@ class TestSupervisorOptionsHelpers:
         swallow these without logging at ERROR (we are mid-restart, by
         design).
         """
-        import asyncio
-
         from ha_mcp.settings_ui import _schedule_supervisor_self_restart
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
@@ -1368,7 +1485,7 @@ class TestSupervisorOptionsHelpers:
         )
         with patcher:
             _schedule_supervisor_self_restart(verify_ssl=True, delay=0)
-            await asyncio.sleep(0.05)
+            await _drain_background_restart_tasks()
         # No assertion — passing means the swallowed exception didn't
         # propagate out of the background task.
 
@@ -1438,15 +1555,67 @@ class TestSaveBackupConfigAddonMode:
         schedule_mock.assert_called_once_with(True)
 
     @pytest.mark.asyncio
-    async def test_addon_save_surfaces_supervisor_error(self, monkeypatch):
-        """Supervisor rejecting the merged options must surface to the
-        client (502 with the supervisor body) — the restart must not
-        fire if the options write itself failed.
+    async def test_addon_save_surfaces_validation_error_with_supervisor_status(
+        self, monkeypatch
+    ):
+        """Supervisor schema rejection (``kind="validation"``) must surface
+        as ``CONFIG_VALIDATION_FAILED`` with supervisor's real status
+        code preserved (not a generic 502). The restart must NOT fire
+        if the options write itself failed.
         """
+        from ha_mcp.settings_ui import _SupervisorOptionsError
+
         post_handler = self._capture_post_handler(monkeypatch)
 
         merge_mock = AsyncMock(
-            return_value=(False, "Supervisor rejected (400): bad schema")
+            return_value=(
+                False,
+                _SupervisorOptionsError(
+                    kind="validation",
+                    message="Supervisor rejected (400): bad schema",
+                    status_code=400,
+                ),
+            )
+        )
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._supervisor_merge_and_post_options", merge_mock
+        )
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart", schedule_mock
+        )
+
+        resp = await post_handler(self._make_request({"enable_auto_backup": True}))
+
+        assert resp.status_code == 400  # supervisor's status, not 502
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert body["error"]["code"] == "CONFIG_VALIDATION_FAILED"
+        assert "bad schema" in body["error"]["message"]
+        schedule_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_addon_save_surfaces_transport_error_as_connection_failed(
+        self, monkeypatch
+    ):
+        """Transport-class failures (``kind="transport"``) get mapped to
+        ``CONNECTION_FAILED`` with 502 — distinct recovery path from the
+        validation case (the UI shows "is HA reachable" suggestions
+        instead of schema-recovery suggestions).
+        """
+        from ha_mcp.settings_ui import _SupervisorOptionsError
+
+        post_handler = self._capture_post_handler(monkeypatch)
+
+        merge_mock = AsyncMock(
+            return_value=(
+                False,
+                _SupervisorOptionsError(
+                    kind="transport",
+                    message="Could not reach Supervisor: connect refused",
+                    status_code=502,
+                ),
+            )
         )
         schedule_mock = MagicMock()
         monkeypatch.setattr(
@@ -1461,7 +1630,7 @@ class TestSaveBackupConfigAddonMode:
         assert resp.status_code == 502
         body = json.loads(resp.body)
         assert body["success"] is False
-        assert "bad schema" in body["error"]["message"]
+        assert body["error"]["code"] == "CONNECTION_FAILED"
         schedule_mock.assert_not_called()
 
 
@@ -1525,11 +1694,28 @@ class TestSaveFeatureFlagsAddonMode:
         schedule_mock.assert_called_once_with(True)
 
     @pytest.mark.asyncio
-    async def test_addon_save_surfaces_supervisor_error(self, monkeypatch):
+    async def test_addon_save_surfaces_validation_error_with_supervisor_status(
+        self, monkeypatch
+    ):
+        """Mirror of the backup-config test: supervisor schema rejection
+        must surface as CONFIG_VALIDATION_FAILED with supervisor's real
+        status code, not a generic 502. (e.g. attempting to set a
+        beta-only flag on the production addon channel where the schema
+        doesn't include it.)
+        """
+        from ha_mcp.settings_ui import _SupervisorOptionsError
+
         post_handler = self._capture_post_handler(monkeypatch)
 
         merge_mock = AsyncMock(
-            return_value=(False, "Supervisor rejected (400): unknown option")
+            return_value=(
+                False,
+                _SupervisorOptionsError(
+                    kind="validation",
+                    message="Supervisor rejected (400): unknown option",
+                    status_code=400,
+                ),
+            )
         )
         schedule_mock = MagicMock()
         monkeypatch.setattr(
@@ -1543,10 +1729,45 @@ class TestSaveFeatureFlagsAddonMode:
             self._make_request({"flags": {"enable_yaml_config_editing": True}})
         )
 
-        assert resp.status_code == 502
+        assert resp.status_code == 400
         body = json.loads(resp.body)
         assert body["success"] is False
+        assert body["error"]["code"] == "CONFIG_VALIDATION_FAILED"
         schedule_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_addon_save_returns_500_when_server_is_none(self, monkeypatch):
+        """Defensive guard for the stdio-sidecar shape. ``server is None``
+        means the handler was constructed without a live MCP server
+        (the sidecar process); addon detection should already be False
+        there, so this branch is type-checker + future-refactor safety
+        net rather than a user-visible code path. Pin it so removal
+        becomes a deliberate decision.
+        """
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/features") and "POST" in methods:
+                    captured["post"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        # server=None — the sidecar shape.
+        register_settings_routes(mcp, None, secret_path="/x")
+
+        resp = await captured["post"](
+            self._make_request({"flags": {"enable_yaml_config_editing": True}})
+        )
+
+        assert resp.status_code == 500
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert body["error"]["code"] == "INTERNAL_ERROR"
 
 
 class TestFeatureGatedToolsCustomCode:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -1495,6 +1495,36 @@ class TestSupervisorOptionsHelpers:
         # No assertion — passing means the swallowed exception didn't
         # propagate out of the background task.
 
+    @pytest.mark.asyncio
+    async def test_schedule_self_restart_catches_runtime_error(
+        self, monkeypatch, caplog
+    ):
+        """``make_supervisor_httpx_client`` raises ``RuntimeError`` when
+        ``SUPERVISOR_TOKEN`` is unset. The two supervisor *options*
+        helpers already catch this; the schedule helper used to let it
+        escape as an uncaught task exception (asyncio surfaces it as
+        "Task exception was never retrieved" at GC time, server-visible
+        but not the loud ERROR-line of the other failure modes). Pin
+        the parity catch so the user gets a clear log when the rare
+        race fires.
+        """
+        import logging
+
+        from ha_mcp.settings_ui import _schedule_supervisor_self_restart
+
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        with caplog.at_level(logging.ERROR, logger="ha_mcp.settings_ui"):
+            _schedule_supervisor_self_restart(verify_ssl=True, delay=0)
+            await _drain_background_restart_tasks()
+
+        # Look for the specific log message we expect — broader
+        # "any ERROR record" would let unrelated noise pass the test.
+        assert any(
+            "SUPERVISOR_TOKEN unset" in rec.message
+            for rec in caplog.records
+            if rec.levelno >= logging.ERROR
+        ), "expected a logged ERROR mentioning the missing token"
+
 
 class TestSaveBackupConfigAddonMode:
     """Addon-mode ``POST /api/settings/backup-config`` flow.
@@ -1794,6 +1824,132 @@ class TestSaveFeatureFlagsAddonMode:
         body = json.loads(resp.body)
         assert body["success"] is False
         assert body["error"]["code"] == "INTERNAL_ERROR"
+
+
+class TestSaveFeatureFlagsStandaloneMode:
+    """Non-addon ``POST /api/settings/features`` flow.
+
+    Pins the file/default-mode response shape introduced when the save
+    handlers unified on ``restart_required``. The JS in
+    ``saveFeatureFlag`` branches on ``data.restart_required`` to show
+    the cross-tab restart banner; a regression to the old bare
+    ``{"success": True}`` shape would silently hide the banner for
+    every standalone / Docker / Claude Desktop user. Lock the shape.
+    """
+
+    def _make_request(self, body):
+        request = MagicMock()
+        request.json = AsyncMock(return_value=body)
+        return request
+
+    def _capture_post_handler(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        # Point feature-flag persistence at the test's temp dir so we
+        # don't write to the real data dir.
+        monkeypatch.setattr("ha_mcp.utils.data_paths.get_data_dir", lambda: tmp_path)
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/features") and "POST" in methods:
+                    captured["post"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        server = MagicMock()
+        server.settings.verify_ssl = True
+        register_settings_routes(mcp, server, secret_path="/x")
+        return captured["post"]
+
+    @pytest.mark.asyncio
+    async def test_standalone_save_returns_unified_contract_shape(
+        self, monkeypatch, tmp_path
+    ):
+        """File-mode response must match the unified
+        ``{success, applied, mode, restart_required}`` shape — same
+        keys as Tools and Server Settings save endpoints. The
+        ``restart_required: True`` carries the banner cue; ``mode:
+        "file"`` distinguishes the persistence path; ``applied``
+        echoes the new value(s) so the client can confirm what stuck.
+        """
+        post_handler = self._capture_post_handler(monkeypatch, tmp_path)
+
+        resp = await post_handler(
+            self._make_request({"flags": {"enable_yaml_config_editing": True}})
+        )
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["success"] is True
+        assert body["mode"] == "file"
+        assert body["restart_required"] is True
+        assert body["applied"] == {"enable_yaml_config_editing": True}
+        # Legacy field names from earlier iterations must not creep
+        # back in alongside the new shape.
+        assert "restarting" not in body
+
+
+class TestSaveToolsResponseShape:
+    """Pins the unified ``{success, applied, mode, restart_required}``
+    response shape on ``POST /api/settings/tools``. Previously returned
+    ``disabled`` and ``pinned`` count fields that no JS or test code
+    actually consumed; replaced with ``applied`` + ``mode`` so the
+    three save endpoints (Tools, Server Settings, Backups) share the
+    same contract and a cross-tab BroadcastChannel listener can react
+    uniformly. A regression to either the old counts shape or a
+    bare ``{"success": True}`` would break the JS banner.
+    """
+
+    def _make_request(self, body):
+        request = MagicMock()
+        request.json = AsyncMock(return_value=body)
+        return request
+
+    def _capture_post_handler(self, monkeypatch, tmp_path):
+        # Point the tool-config write at the test temp dir.
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/tools") and "POST" in methods:
+                    captured["post"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        server = MagicMock()
+        server.settings.verify_ssl = True
+        register_settings_routes(mcp, server, secret_path="/x")
+        return captured["post"]
+
+    @pytest.mark.asyncio
+    async def test_save_returns_unified_contract_shape(self, monkeypatch, tmp_path):
+        post_handler = self._capture_post_handler(monkeypatch, tmp_path)
+
+        resp = await post_handler(
+            self._make_request(
+                {"states": {"ha_get_state": "pinned", "ha_search_entities": "disabled"}}
+            )
+        )
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["success"] is True
+        assert body["mode"] == "file"
+        assert body["restart_required"] is True
+        assert body["applied"] == {
+            "ha_get_state": "pinned",
+            "ha_search_entities": "disabled",
+        }
+        # The retired count fields must not leak through.
+        assert "disabled" not in body
+        assert "pinned" not in body
 
 
 class TestFeatureGatedToolsCustomCode:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -538,15 +538,20 @@ class TestRestartAddon:
     async def test_treats_connection_drop_as_success(self, monkeypatch, exc_cls):
         """Drop-as-success branch (the catch on
         `(ReadError, RemoteProtocolError)` inside the `httpx.AsyncClient`
-        block): the Supervisor kills our process mid-request during a
-        restart, so the connection-drop is the documented success signal —
-        not a failure to surface. ConnectError is excluded because it fires
-        BEFORE a connection is established (DNS / TCP refused / socket
-        misconfigured) and means Supervisor was unreachable, not that a
-        restart was initiated.
+        block): when restarting a *sibling* addon, the Supervisor kills
+        that target mid-request, so the connection-drop is the documented
+        success signal — not a failure to surface. ConnectError is
+        excluded because it fires BEFORE a connection is established (DNS
+        / TCP refused / socket misconfigured) and means Supervisor was
+        unreachable, not that a restart was initiated.
+
+        Self-restart no longer flows through this code path — see
+        ``test_self_restart_returns_200_and_schedules_background_task``
+        — so the synchronous error-surfacing only fires for non-self
+        slugs. Mirror that asymmetry here by targeting a non-self addon.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
-        request = self._make_request()
+        request = self._make_request(body={"slug": "core_ssh"})
 
         patcher, _ = self._patch_supervisor_client(post_side_effect=exc_cls("kill"))
         with patcher:
@@ -562,10 +567,11 @@ class TestRestartAddon:
         """ConnectError fires before a connection is established and means
         Supervisor was unreachable — must NOT be treated as a successful
         restart. Falls through to the generic `httpx.HTTPError` handler
-        which returns 502 with `CONNECTION_FAILED`.
+        which returns 502 with `CONNECTION_FAILED`. Self-restart no
+        longer touches this path; use a non-self slug to exercise it.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
-        request = self._make_request()
+        request = self._make_request(body={"slug": "core_ssh"})
 
         patcher, _ = self._patch_supervisor_client(
             post_side_effect=httpx.ConnectError("no route")
@@ -582,10 +588,11 @@ class TestRestartAddon:
     async def test_generic_http_error_returns_502(self, monkeypatch):
         """The generic `httpx.HTTPError` handler (catches anything not
         already special-cased) maps to 502 + CONNECTION_FAILED. Pins the
-        last unconvered transport-error path in `_restart_addon`.
+        last uncovered transport-error path in `_restart_addon` —
+        non-self slug exercises the synchronous branch.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
-        request = self._make_request()
+        request = self._make_request(body={"slug": "core_ssh"})
 
         # PoolTimeout subclasses httpx.HTTPError but is NOT in the
         # drop-as-success tuple — exercises the fall-through.
@@ -602,12 +609,15 @@ class TestRestartAddon:
 
     @pytest.mark.asyncio
     async def test_supervisor_4xx_returns_502(self, monkeypatch):
-        """When Supervisor returns a non-2xx status (e.g. 401 Unauthorized),
-        the handler must surface a 502 to the caller — the restart was not
-        initiated. Pins the `status_code >= 400` branch in `_restart_addon`.
+        """When Supervisor returns a non-2xx status (e.g. 401 Unauthorized)
+        for a *sibling* addon restart, the handler must surface a 502 to
+        the caller — the restart was not initiated. Pins the
+        `status_code >= 400` branch in `_restart_addon`. Self-restart
+        path no longer surfaces supervisor errors (see
+        ``_schedule_supervisor_self_restart``); use a non-self slug.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
-        request = self._make_request()
+        request = self._make_request(body={"slug": "core_ssh"})
 
         response = MagicMock()
         response.status_code = 401
@@ -621,18 +631,31 @@ class TestRestartAddon:
         assert body["success"] is False
 
     @pytest.mark.asyncio
-    async def test_posts_relative_url_for_self_restart(self, monkeypatch):
-        """No-body request POSTs ``/addons/self/restart`` — the UI button's path."""
+    async def test_self_restart_returns_200_and_schedules_background_task(
+        self, monkeypatch
+    ):
+        """No-body request → target_slug='self' → schedules a background
+        ``/addons/self/restart`` POST and returns 200 immediately so the
+        JSON response can flush through HA ingress *before* Supervisor
+        kills the addon mid-response. Without this, ingress converts the
+        dropped upstream into a 5xx Bad Gateway, which the JS rendered
+        as 'Restart failed' even when the restart actually succeeded.
+        """
         restart = self._capture_handler(monkeypatch, with_token=True)
         request = self._make_request()
 
-        response = MagicMock()
-        response.status_code = 200
-        patcher, mock_client = self._patch_supervisor_client(post_return=response)
-        with patcher:
-            await restart(request)
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart",
+            schedule_mock,
+        )
+        resp = await restart(request)
 
-        mock_client.post.assert_awaited_once_with("/addons/self/restart")
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["success"] is True
+        assert "Restart initiated" in body["message"]
+        schedule_mock.assert_called_once_with(True)
 
     @pytest.mark.asyncio
     async def test_slug_in_body_targets_named_addon(self, monkeypatch):
@@ -689,27 +712,38 @@ class TestRestartAddon:
     async def test_invalid_slug_in_body_falls_back_to_self(self, monkeypatch, body):
         """Malformed/missing ``slug`` field → restart targets ``self``.
 
-        Preserves the historical self-restart behavior when callers post a
-        body that doesn't carry a usable slug. The settings-UI restart
+        Preserves the historical self-restart behavior when callers post
+        a body that doesn't carry a usable slug. The settings-UI restart
         button posts no body at all; the explicit slug paths exist purely
         for the E2E test surface and should never accidentally redirect
         a self-restart to ``/addons//restart`` or similar.
+
+        Self-restart now flows through ``_schedule_supervisor_self_restart``
+        (background task pattern — see
+        ``test_self_restart_returns_200_and_schedules_background_task``),
+        so the verifier here is "the schedule helper got called" rather
+        than "Supervisor was POSTed synchronously". The synchronous
+        ``httpx.AsyncClient`` path is also patched to confirm it is NOT
+        invoked for the fall-back-to-self case.
         """
         restart = self._capture_handler(monkeypatch, with_token=True)
         request = self._make_request(body=body)
 
-        response = MagicMock()
-        response.status_code = 200
-        mock_client = MagicMock()
-        mock_client.post = AsyncMock(return_value=response)
+        sync_mock = AsyncMock()
         cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aenter__ = AsyncMock(return_value=MagicMock(post=sync_mock))
         cm.__aexit__ = AsyncMock(return_value=None)
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart",
+            schedule_mock,
+        )
 
         with patch("ha_mcp.settings_ui.httpx.AsyncClient", return_value=cm):
             await restart(request)
 
-        mock_client.post.assert_awaited_once_with("/addons/self/restart")
+        schedule_mock.assert_called_once_with(True)
+        sync_mock.assert_not_awaited()
 
 
 class TestBackupSettingsOverridePersistence:
@@ -1107,3 +1141,430 @@ class TestRenderedHTMLJsSyntax:
                 "Settings UI <script> body failed node --check:\n"
                 f"stdout: {result.stdout}\nstderr: {result.stderr}"
             )
+
+
+class TestSupervisorOptionsHelpers:
+    """Module-level helpers for the addon-mode Supervisor options flow.
+
+    Supervisor's ``/addons/<slug>/options`` POST is a *full* replacement
+    validated against the addon schema, so a partial body (e.g. only the
+    auto-backup fields the user changed) is rejected with
+    ``addon_configuration_invalid_error`` when a required key like
+    ``backup_hint`` is omitted. These tests pin the merge contract that
+    ``_save_backup_config`` and ``_save_feature_flags`` now rely on in
+    addon mode.
+    """
+
+    def _patch_supervisor_client(
+        self,
+        *,
+        get_response=None,
+        post_response=None,
+        get_side_effect=None,
+        post_side_effect=None,
+    ):
+        """Return (patcher, mock_client) where mock_client.get/post are AsyncMocks."""
+        mock_client = MagicMock()
+        if get_side_effect is not None:
+            mock_client.get = AsyncMock(side_effect=get_side_effect)
+        else:
+            mock_client.get = AsyncMock(return_value=get_response)
+        if post_side_effect is not None:
+            mock_client.post = AsyncMock(side_effect=post_side_effect)
+        else:
+            mock_client.post = AsyncMock(return_value=post_response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=mock_client)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        factory = MagicMock(return_value=cm)
+        patcher = patch("ha_mcp.settings_ui.make_supervisor_httpx_client", factory)
+        return patcher, mock_client
+
+    @pytest.mark.asyncio
+    async def test_fetch_current_options_unwraps_data_envelope(self, monkeypatch):
+        """Supervisor wraps responses in ``{"result": "ok", "data": {...}}``.
+        The fetch helper must unwrap the envelope and return the inner
+        options dict.
+        """
+        from ha_mcp.settings_ui import _supervisor_fetch_current_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        response = MagicMock()
+        response.status_code = 200
+        response.json = MagicMock(
+            return_value={
+                "result": "ok",
+                "data": {
+                    "options": {
+                        "backup_hint": "normal",
+                        "enable_tool_search": True,
+                    }
+                },
+            }
+        )
+        patcher, _ = self._patch_supervisor_client(get_response=response)
+        with patcher:
+            options, err = await _supervisor_fetch_current_options(verify_ssl=True)
+        assert err is None
+        assert options == {"backup_hint": "normal", "enable_tool_search": True}
+
+    @pytest.mark.asyncio
+    async def test_fetch_current_options_supervisor_4xx_returns_error(
+        self, monkeypatch
+    ):
+        from ha_mcp.settings_ui import _supervisor_fetch_current_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        response = MagicMock()
+        response.status_code = 503
+        response.text = "Supervisor busy"
+        patcher, _ = self._patch_supervisor_client(get_response=response)
+        with patcher:
+            options, err = await _supervisor_fetch_current_options(verify_ssl=True)
+        assert options == {}
+        assert err is not None
+        assert "503" in err
+
+    @pytest.mark.asyncio
+    async def test_fetch_current_options_http_error_returns_error(self, monkeypatch):
+        from ha_mcp.settings_ui import _supervisor_fetch_current_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        patcher, _ = self._patch_supervisor_client(
+            get_side_effect=httpx.ConnectError("no route")
+        )
+        with patcher:
+            options, err = await _supervisor_fetch_current_options(verify_ssl=True)
+        assert options == {}
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_merge_and_post_options_preserves_existing_keys(self, monkeypatch):
+        """The merge must preserve untouched required keys (most importantly
+        ``backup_hint``, which has no ``?`` in the addon schema and would
+        cause supervisor to reject the entire POST with 400 if omitted).
+
+        Pins the fix for the bug where ``_save_backup_config`` was POSTing
+        only the auto-backup fields and dropping ``backup_hint`` in the
+        process — exact reproduction of the user-reported failure:
+        ``addon_configuration_invalid_error: Missing option 'backup_hint'
+        in root``.
+        """
+        from ha_mcp.settings_ui import _supervisor_merge_and_post_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        get_response = MagicMock()
+        get_response.status_code = 200
+        get_response.json = MagicMock(
+            return_value={
+                "data": {
+                    "options": {
+                        "backup_hint": "normal",
+                        "enable_tool_search": False,
+                        "verify_ssl": True,
+                        "auto_backup_throttle_minutes": 0,
+                        "auto_backup_retain_per_entity": 100,
+                        "enable_auto_backup": True,
+                    }
+                }
+            }
+        )
+        post_response = MagicMock()
+        post_response.status_code = 200
+        patcher, mock_client = self._patch_supervisor_client(
+            get_response=get_response, post_response=post_response
+        )
+        with patcher:
+            ok, err = await _supervisor_merge_and_post_options(
+                verify_ssl=True,
+                field_changes={
+                    "enable_auto_backup": False,
+                    "auto_backup_throttle_minutes": 5,
+                },
+            )
+
+        assert ok is True
+        assert err is None
+        # The POST body must contain backup_hint (unchanged) + the new values.
+        mock_client.post.assert_awaited_once()
+        post_call = mock_client.post.call_args
+        assert post_call.args[0] == "/addons/self/options"
+        body = post_call.kwargs["json"]
+        merged = body["options"]
+        assert merged["backup_hint"] == "normal"  # preserved
+        assert merged["verify_ssl"] is True  # preserved
+        assert merged["enable_tool_search"] is False  # preserved
+        assert merged["auto_backup_retain_per_entity"] == 100  # preserved
+        assert merged["enable_auto_backup"] is False  # changed
+        assert merged["auto_backup_throttle_minutes"] == 5  # changed
+
+    @pytest.mark.asyncio
+    async def test_merge_and_post_supervisor_400_returns_error(self, monkeypatch):
+        """Supervisor 4xx on the POST surfaces back as ``(False, msg)`` with
+        the body text included so the UI can show e.g. an
+        addon_configuration_invalid_error from a schema mismatch.
+        """
+        from ha_mcp.settings_ui import _supervisor_merge_and_post_options
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        get_response = MagicMock()
+        get_response.status_code = 200
+        get_response.json = MagicMock(return_value={"data": {"options": {}}})
+        post_response = MagicMock()
+        post_response.status_code = 400
+        post_response.text = (
+            "App has invalid options: Missing option 'backup_hint' in root"
+        )
+        patcher, _ = self._patch_supervisor_client(
+            get_response=get_response, post_response=post_response
+        )
+        with patcher:
+            ok, err = await _supervisor_merge_and_post_options(
+                verify_ssl=True, field_changes={"enable_auto_backup": True}
+            )
+        assert ok is False
+        assert err is not None
+        assert "400" in err
+        assert "backup_hint" in err
+
+    @pytest.mark.asyncio
+    async def test_schedule_self_restart_fires_task_after_delay(self, monkeypatch):
+        """``_schedule_supervisor_self_restart`` fires a background task
+        that posts to ``/addons/self/restart`` after ``delay``. Override
+        the delay to 0 so this runs fast.
+        """
+        import asyncio
+
+        from ha_mcp.settings_ui import _schedule_supervisor_self_restart
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        post_response = MagicMock()
+        post_response.status_code = 200
+        patcher, mock_client = self._patch_supervisor_client(
+            post_response=post_response
+        )
+        with patcher:
+            _schedule_supervisor_self_restart(verify_ssl=True, delay=0)
+            # Yield to the event loop so the scheduled task runs.
+            await asyncio.sleep(0.05)
+
+        mock_client.post.assert_awaited_with("/addons/self/restart")
+
+    @pytest.mark.asyncio
+    async def test_schedule_self_restart_swallows_connection_drop(self, monkeypatch):
+        """Self-restart deliberately kills the addon process — the
+        supervisor httpx call is expected to error out with
+        ReadError / RemoteProtocolError mid-flight. The helper must
+        swallow these without logging at ERROR (we are mid-restart, by
+        design).
+        """
+        import asyncio
+
+        from ha_mcp.settings_ui import _schedule_supervisor_self_restart
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        patcher, _ = self._patch_supervisor_client(
+            post_side_effect=httpx.ReadError("killed mid-call")
+        )
+        with patcher:
+            _schedule_supervisor_self_restart(verify_ssl=True, delay=0)
+            await asyncio.sleep(0.05)
+        # No assertion — passing means the swallowed exception didn't
+        # propagate out of the background task.
+
+
+class TestSaveBackupConfigAddonMode:
+    """Addon-mode ``POST /api/settings/backup-config`` flow.
+
+    Pins the fix for the user-reported supervisor 400 — the old code
+    POSTed only the three auto-backup fields, dropping ``backup_hint``
+    (the addon schema's only required key) and producing
+    ``addon_configuration_invalid_error``. The new flow merges through
+    ``_supervisor_merge_and_post_options`` and schedules a restart via
+    ``_schedule_supervisor_self_restart``.
+    """
+
+    def _make_request(self, body):
+        request = MagicMock()
+        request.json = AsyncMock(return_value=body)
+        return request
+
+    def _capture_post_handler(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/backup-config") and "POST" in methods:
+                    captured["post"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        server = MagicMock()
+        server.settings.verify_ssl = True
+        register_settings_routes(mcp, server, secret_path="/x")
+        return captured["post"]
+
+    @pytest.mark.asyncio
+    async def test_addon_save_merges_and_schedules_restart(self, monkeypatch):
+        post_handler = self._capture_post_handler(monkeypatch)
+
+        merge_mock = AsyncMock(return_value=(True, None))
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._supervisor_merge_and_post_options", merge_mock
+        )
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart", schedule_mock
+        )
+
+        resp = await post_handler(
+            self._make_request(
+                {"enable_auto_backup": True, "auto_backup_throttle_minutes": 5}
+            )
+        )
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["mode"] == "addon"
+        assert body["restarting"] is True
+        merge_mock.assert_awaited_once_with(
+            True,
+            {"enable_auto_backup": True, "auto_backup_throttle_minutes": 5},
+        )
+        schedule_mock.assert_called_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_addon_save_surfaces_supervisor_error(self, monkeypatch):
+        """Supervisor rejecting the merged options must surface to the
+        client (502 with the supervisor body) — the restart must not
+        fire if the options write itself failed.
+        """
+        post_handler = self._capture_post_handler(monkeypatch)
+
+        merge_mock = AsyncMock(
+            return_value=(False, "Supervisor rejected (400): bad schema")
+        )
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._supervisor_merge_and_post_options", merge_mock
+        )
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart", schedule_mock
+        )
+
+        resp = await post_handler(self._make_request({"enable_auto_backup": True}))
+
+        assert resp.status_code == 502
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert "bad schema" in body["error"]["message"]
+        schedule_mock.assert_not_called()
+
+
+class TestSaveFeatureFlagsAddonMode:
+    """Addon-mode ``POST /api/settings/features`` flow.
+
+    Mirror of TestSaveBackupConfigAddonMode for feature flags. In addon
+    mode, ``get_feature_flag_origin`` returns ``"addon"`` for every
+    flag (because SUPERVISOR_TOKEN is set), so the handler must route
+    through Supervisor instead of refusing the write or persisting to
+    the override file (the file is ignored in addon mode anyway —
+    ``start.py`` rewrites env vars from ``config.yaml`` on every boot).
+    """
+
+    def _make_request(self, body):
+        request = MagicMock()
+        request.json = AsyncMock(return_value=body)
+        return request
+
+    def _capture_post_handler(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict[str, SaveHandler] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path.endswith("/api/settings/features") and "POST" in methods:
+                    captured["post"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        server = MagicMock()
+        server.settings.verify_ssl = True
+        register_settings_routes(mcp, server, secret_path="/x")
+        return captured["post"]
+
+    @pytest.mark.asyncio
+    async def test_addon_save_merges_and_schedules_restart(self, monkeypatch):
+        post_handler = self._capture_post_handler(monkeypatch)
+
+        merge_mock = AsyncMock(return_value=(True, None))
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._supervisor_merge_and_post_options", merge_mock
+        )
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart", schedule_mock
+        )
+
+        resp = await post_handler(
+            self._make_request({"flags": {"enable_yaml_config_editing": True}})
+        )
+
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["mode"] == "addon"
+        assert body["restarting"] is True
+        merge_mock.assert_awaited_once_with(True, {"enable_yaml_config_editing": True})
+        schedule_mock.assert_called_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_addon_save_surfaces_supervisor_error(self, monkeypatch):
+        post_handler = self._capture_post_handler(monkeypatch)
+
+        merge_mock = AsyncMock(
+            return_value=(False, "Supervisor rejected (400): unknown option")
+        )
+        schedule_mock = MagicMock()
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._supervisor_merge_and_post_options", merge_mock
+        )
+        monkeypatch.setattr(
+            "ha_mcp.settings_ui._schedule_supervisor_self_restart", schedule_mock
+        )
+
+        resp = await post_handler(
+            self._make_request({"flags": {"enable_yaml_config_editing": True}})
+        )
+
+        assert resp.status_code == 502
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        schedule_mock.assert_not_called()
+
+
+class TestFeatureGatedToolsCustomCode:
+    """``ha_manage_custom_tool`` (gated by ``enable_code_mode``) must
+    appear in the settings-UI tool list when the toggle is off — same
+    pattern as ``ha_config_set_yaml`` — so users discover the beta
+    feature and how to enable it. Pins the fix for the asymmetry the
+    user reported.
+    """
+
+    def test_custom_code_tool_is_listed(self):
+        from ha_mcp.settings_ui import FEATURE_GATED_TOOLS
+
+        assert "ha_manage_custom_tool" in FEATURE_GATED_TOOLS
+        entry = FEATURE_GATED_TOOLS["ha_manage_custom_tool"]
+        # The "Beta — set X" hint copy is keyed off ``disabled_by`` —
+        # without this the JS template renders no hint at all.
+        assert entry["disabled_by"] == "enable_code_mode"  # type: ignore[typeddict-item]
+        # Lives in the System group, matching ha_config_set_yaml so the
+        # related beta tools render together.
+        assert entry["primary_tag"] == "System"

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -303,7 +303,13 @@ class TestSecurityMiddleware:
         assert resp.status_code == 200
         # is_sidecar=True because _build_app passes is_sidecar=True to
         # build_settings_handlers; covered separately in TestSidecarSettingsInfo.
-        assert resp.json() == {"is_addon": False, "is_sidecar": True}
+        # The endpoint also carries ``instance_id`` + ``started_at`` so the
+        # restart-then-reload JS cycle can prove a restart actually happened
+        # (covered by TestSettingsInfoEndpoint in test_settings_ui.py).
+        # This test pins the deployment-mode fields only.
+        body = resp.json()
+        assert body["is_addon"] is False
+        assert body["is_sidecar"] is True
 
     def test_post_origin_rejected(self, tmp_data_dir: Path) -> None:
         app = sidecar._build_app(
@@ -418,7 +424,13 @@ class TestSidecarSettingsInfo:
         assert resp.status_code == 200
         # Even with SUPERVISOR_TOKEN set, sidecar forces is_addon=False
         # AND advertises is_sidecar=True (drives the in-page Stop button).
-        assert resp.json() == {"is_addon": False, "is_sidecar": True}
+        # Per-process identity fields (``instance_id`` / ``started_at``)
+        # also land in this response — verified in
+        # TestSettingsInfoEndpoint (test_settings_ui.py); this test pins
+        # the deployment-mode override, not the full payload shape.
+        body = resp.json()
+        assert body["is_addon"] is False
+        assert body["is_sidecar"] is True
 
 
 class TestRunMainWiring:


### PR DESCRIPTION
## What does this PR do?

Fixes a cluster of related bugs in the addon-mode settings web UI and unifies the restart UX across every save endpoint (Tools, Server Settings, Backups). Originally a four-bug ticket; the review-toolkit + idiot-checker pass turned it into a structural rework of the save-and-restart flow.

### Bugs fixed

1. **Server-settings toggles are editable in addon mode.** They used to render `"Managed by the add-on Configuration tab — open Settings → Add-ons → ha-mcp → Configuration to edit."` and the checkboxes were disabled. Now each save POSTs through `/addons/self/options` (with the existing options merged so required schema keys like `backup_hint` survive Supervisor's full-replacement validation) and returns `restart_required: True`. Web UI ↔ Configuration tab stay in sync after the restart.

2. **No more spurious "Restart failed" alert / no more "addon is restarting" forever-message.** The old code had save handlers schedule a supervisor self-restart in a background task; the restart raced the JSON response flush, HA ingress returned a 5xx Bad Gateway, the JS surfaced "Restart failed". The new architecture removes the auto-restart from every save handler entirely.

3. **`ha_manage_custom_tool` is listed in the tool catalog** with the same `"Beta — set enable_code_mode in the dev add-on config"` hint as the other beta-gated tools, regardless of whether the toggle is on.

4. **Backup tab save no longer returns supervisor 400.** `_save_backup_config` was POSTing only the auto-backup fields and dropping `backup_hint` (the addon schema's only required key). Fixed by reading current options, merging the new values, then posting — same pattern `start.py::maybe_persist_secret_path` already uses.

### Unified restart UX (replaces every per-handler restart trigger)

Every save endpoint now returns the same `{success, applied, mode, restart_required}` shape. `restart_required: True` lights up a cross-tab restart-required banner; the global "Restart Add-on" button is the single restart trigger.

- **Save** persists the change to the right backend (Supervisor options / override file / tool config JSON) and does NOT restart.
- **Restart button click** captures the running process's `instance_id` (new field on `/api/settings/info`), POSTs `/api/settings/restart`, and broadcasts `restart-initiated` to every open settings tab. Each tab independently runs a poll-then-reload cycle.
- **Poll cycle** waits a 3s grace period (lets supervisor actually kill the addon) then polls `/api/settings/info` every 2s, comparing `instance_id` against the captured baseline. Reloads the page on first `instance_id` flip; gives up after 60s with `"Add-on did not come back online — reload manually"` (button re-enabled, user can retry).
- **Cross-tab** sync via `BroadcastChannel('ha-mcp-settings')` so saving in one tab surfaces the banner in others, and restarting in one tab triggers the same reload cycle in others (no tabs left dangling on a dead connection).

### Server-side architecture

- New `_SupervisorOptionsError` NamedTuple discriminates transport (network/DNS/token-missing → `CONNECTION_FAILED` 502) from validation (supervisor 4xx → `CONFIG_VALIDATION_FAILED` with supervisor's real status code) so the UI surfaces the right recovery suggestions.
- `_supervisor_fetch_current_options` + `_supervisor_merge_and_post_options` capture the GET-merge-POST contract once; both `_save_feature_flags` and `_save_backup_config` use them.
- `_schedule_supervisor_self_restart` fires the supervisor POST from a background `asyncio` task with a `_SUPERVISOR_SELF_RESTART_FLUSH_DELAY_S = 0.3s` head start, so the JSON response flushes through ingress before supervisor can kill the addon. Catches `(ReadError, RemoteProtocolError)` (expected mid-call kill), `RuntimeError` (token missing — defense-in-depth), and `httpx.HTTPError` (anything else, logged loud).
- `_PROCESS_INSTANCE_ID` (uuid4 at module import) + `_PROCESS_STARTED_AT` exposed via `/api/settings/info` so the JS can prove a restart actually happened rather than trusting a 200 from the still-running OLD instance.

### JS-side details

- Module-level `restartInProgress` boolean guards against DevTools / programmatic re-entry (the button's `disabled` attribute alone doesn't catch console invocations).
- `saveFeatureFlag` defaults to `{restart_required: true}` on a `resp.ok` with unparseable body so a truncated response doesn't silently hide the banner.
- `saveBackupConfig` no longer reloads the form after a `restart_required` save (would snap back to stale env-derived values and clobber in-flight edits).
- Optional chaining for null-checks; early returns flatten the 4xx branch.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit/test_settings_ui.py`: 90 passed, 1 skipped (`chmod 0o000` Windows-only EACCES). New tests added in this PR:

- `TestSupervisorOptionsHelpers` — 7 tests covering fetch / merge / POST / restart helpers including the `backup_hint`-preservation, transport-vs-validation discrimination, and `RuntimeError` catch.
- `TestSaveBackupConfigAddonMode` / `TestSaveFeatureFlagsAddonMode` — pin save-merge-without-restart, transport/validation error code routing, server=None guard.
- `TestSaveFeatureFlagsStandaloneMode` / `TestSaveToolsResponseShape` — pin the unified `{success, applied, mode, restart_required}` shape on the file-mode + tools endpoints.
- `TestSettingsInfoEndpoint` — pins `instance_id` + `started_at` presence and within-process stability.
- `TestFeatureGatedToolsCustomCode` — pins the `ha_manage_custom_tool` stub.
- `TestRestartAddon` — restructured: synchronous error paths exercise non-self slugs (the sync code path); a new test pins the self-restart "schedule + return 200" + background-task contract.

### Known scope-limited test gaps

The project's JS test infra is `node --check` syntax-only (no JSDOM, no fetch mock). The new client-side behaviors are structurally untestable in the current setup:
- `restartInProgress` concurrency guard
- 4xx-suppress-reload branch in `restartAddon`
- Poll-until-instance-id-flips cycle
- BroadcastChannel listener (`restart-required` / `restart-initiated`)

The server-side endpoints those behaviors depend on are all covered. Closing the JS gap is tracked separately in #1422.

## Checklist
- [ ] I have updated documentation if needed