### PR TITLE
test(haos-e2e): trim cache-save race, compress GHCR qcow2, eval boot snapshot

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -28,7 +28,13 @@ on:
           to ``:HAOS_VERSION-<suffix>`` instead of ``:HAOS_VERSION-latest``
           — used by perf-iteration branches that need a non-latest tag
           they can point the e2e test workflows at without touching the
-          master-served image.
+          master-served image. Pointing the e2e lanes at the override is
+          a SEPARATE manual edit on the branch: change the ``tag=`` line
+          in the ``Try pulling from GHCR`` step of both
+          ``haos-e2e-tests.yml`` and ``haos-e2e-inaddon-tests.yml``.
+          Allowed character set is ``[A-Za-z0-9._-]+`` (OCI tag rules);
+          the ``Push image to GHCR`` step validates and fails fast on
+          anything else.
         type: string
         required: false
         default: 'latest'
@@ -158,32 +164,58 @@ jobs:
           retention-days: 14
 
       - name: Compress qcow2 in-format (qemu-img convert -c)
-        # Re-pack the qcow2 with in-format zlib compression before upload.
-        # The HAOS image is ~12 GB on disk after the bake, almost all of
-        # which is sparse-zeroed space from the ``qemu-img resize 32G``
-        # in ``fetch_haos_qcow2`` plus addon Docker layers. ``-c`` is the
-        # qcow2-native compression flag — the resulting file stays a
-        # standard qcow2 (same media type, same consumer code path), and
-        # qemu decompresses sectors lazily during VM I/O when the e2e
-        # workflow boots it. No upfront decompress step on the pull side.
+        # Re-pack the qcow2 with qcow2-native zlib *cluster* compression
+        # before upload. The post-bake file is ~12 GB *apparent* size on
+        # disk — sparse, with ~5 GB actually allocated; the rest is
+        # un-allocated holes from ``qemu-img resize 32G`` in
+        # ``fetch_haos_qcow2``. ORAS pushes/pulls
+        # ``application/octet-stream`` as a raw byte stream, so the
+        # sparse holes get serialised over the wire as actual zero bytes
+        # — the *apparent* size, not the allocated size, is what GHCR
+        # pull pays for.
         #
-        # Wins:
-        #   - ``oras push``/``oras pull`` wire bytes scale with the file
-        #     size; a ~3–5 GB compressed qcow2 cuts the 6-minute single-
-        #     stream GHCR pull on cache-miss runs to ~2 min.
-        #   - actions/cache also benefits: the existing zstdmt over a
-        #     compressed qcow2 still wins on the addon Docker layer bytes
-        #     that zstd hasn't already squashed.
+        # ``qemu-img convert -c -O qcow2`` re-encodes the data densely
+        # at the cluster level (default 64 KiB). The output stays a
+        # standard qcow2 (same OCI media-type, same consumer code path);
+        # QEMU decompresses clusters on-demand during VM I/O when the
+        # e2e workflow boots, so no upfront decompress step on the pull
+        # side. Trade-off worth knowing about: qcow2 cluster compression
+        # is read-only — the first write to any compressed cluster makes
+        # QEMU re-allocate it uncompressed in place. The e2e workflow's
+        # boot is read-heavy (HA starts, recorder DB rebuilds, addon
+        # containers come up), so write-side re-allocation cost is small
+        # relative to the pull-time saved, but it's why this convert
+        # pass lives at publish time and not at every consumer.
         #
-        # Cost: one extra ``qemu-img convert`` pass on the publish runner
-        # (~1–2 min on a 12 GB sparse qcow2), which only runs on
-        # master push / weekly cron / manual dispatch — not on PR runs.
+        # Measured at publish run 26361263298 step 11:
+        #   12 GB → 5.1 GB (2.3x ratio), convert pass took 6m 15s.
+        # First e2e run that consumed the result (runs 26361656780 +
+        # 26361656754) saw GHCR pull drop from ~6 min (uncompressed
+        # baseline) to 47–58 s.
+        #
+        # Cost: the convert pass adds ~6 min to the publish runner —
+        # paid only on master push / weekly cron / manual dispatch,
+        # not on PR runs.
         run: |
           orig_bytes=$(stat -c%s haos-test-image.qcow2)
-          qemu-img convert -p -c -O qcow2 \
+          qemu-img convert -c -O qcow2 \
             haos-test-image.qcow2 haos-test-image.qcow2.compressed
           mv haos-test-image.qcow2.compressed haos-test-image.qcow2
+          # Integrity gate before consumers see the file: catch torn
+          # writes (e.g. ``qemu-img convert`` killed mid-run after the
+          # output file already exists, exit-0 from the shell wrapper
+          # but file is truncated) and broken refcount tables.
+          # ``qemu-img check`` reads metadata + L1/L2 tables only — it
+          # does not stream the full image — so this is fast.
+          qemu-img check haos-test-image.qcow2
           new_bytes=$(stat -c%s haos-test-image.qcow2)
+          # Sanity floor: the baked HAOS image is gigabytes; anything
+          # under 1 GiB after compress is corruption ``qemu-img check``
+          # didn't catch. Fail before the moving tag points at bad bytes.
+          if [ "$new_bytes" -lt 1073741824 ]; then
+            echo "::error::compressed qcow2 suspiciously small: ${new_bytes} bytes"
+            exit 1
+          fi
           ratio=$(awk -v o="$orig_bytes" -v n="$new_bytes" 'BEGIN{printf "%.1f", o/n}')
           echo "qcow2 size before: $(numfmt --to=iec "$orig_bytes")"
           echo "qcow2 size after : $(numfmt --to=iec "$new_bytes")"
@@ -210,13 +242,21 @@ jobs:
         env:
           HAOS_VERSION: ${{ steps.haos_version.outputs.version }}
           SHORT_SHA: ${{ github.sha }}
-          # workflow_dispatch lets perf-iteration branches publish to a
-          # non-``latest`` moving tag (e.g. ``:17.3-haose2eefficiency``)
-          # so they can point the e2e test workflows at a candidate image
-          # without disturbing the master-served ``:HAOS_VERSION-latest``
-          # that every other PR pulls from.
+          # See the ``tag_suffix`` workflow_dispatch input at the top of
+          # this file for the override semantics and required edits on
+          # the consumer side. The ``|| 'latest'`` fallback covers the
+          # ``push:`` / ``schedule:`` triggers where
+          # ``github.event.inputs`` is null.
           TAG_SUFFIX: ${{ github.event.inputs.tag_suffix || 'latest' }}
         run: |
+          # Validate the suffix against the OCI tag character set before
+          # building any tag strings — a typo like ``foo/bar``,
+          # ``:evil``, or a trailing space would otherwise surface as a
+          # confusing ``oras push`` error ten lines later.
+          if [[ ! "$TAG_SUFFIX" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::TAG_SUFFIX must match [A-Za-z0-9._-]+ (OCI tag chars), got: '$TAG_SUFFIX'"
+            exit 1
+          fi
           short_sha="${SHORT_SHA:0:7}"
           versioned="${IMAGE_REPO}:${HAOS_VERSION}-${short_sha}"
           moving="${IMAGE_REPO}:${HAOS_VERSION}-${TAG_SUFFIX}"

--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -21,6 +21,17 @@ name: Build HAOS Test Image (Publish to GHCR)
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: >-
+          Moving-tag suffix (default: ``latest``). Override to publish
+          to ``:HAOS_VERSION-<suffix>`` instead of ``:HAOS_VERSION-latest``
+          — used by perf-iteration branches that need a non-latest tag
+          they can point the e2e test workflows at without touching the
+          master-served image.
+        type: string
+        required: false
+        default: 'latest'
   push:
     branches: [master]
     paths:
@@ -146,9 +157,42 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Compress qcow2 in-format (qemu-img convert -c)
+        # Re-pack the qcow2 with in-format zlib compression before upload.
+        # The HAOS image is ~12 GB on disk after the bake, almost all of
+        # which is sparse-zeroed space from the ``qemu-img resize 32G``
+        # in ``fetch_haos_qcow2`` plus addon Docker layers. ``-c`` is the
+        # qcow2-native compression flag — the resulting file stays a
+        # standard qcow2 (same media type, same consumer code path), and
+        # qemu decompresses sectors lazily during VM I/O when the e2e
+        # workflow boots it. No upfront decompress step on the pull side.
+        #
+        # Wins:
+        #   - ``oras push``/``oras pull`` wire bytes scale with the file
+        #     size; a ~3–5 GB compressed qcow2 cuts the 6-minute single-
+        #     stream GHCR pull on cache-miss runs to ~2 min.
+        #   - actions/cache also benefits: the existing zstdmt over a
+        #     compressed qcow2 still wins on the addon Docker layer bytes
+        #     that zstd hasn't already squashed.
+        #
+        # Cost: one extra ``qemu-img convert`` pass on the publish runner
+        # (~1–2 min on a 12 GB sparse qcow2), which only runs on
+        # master push / weekly cron / manual dispatch — not on PR runs.
+        run: |
+          orig_bytes=$(stat -c%s haos-test-image.qcow2)
+          qemu-img convert -p -c -O qcow2 \
+            haos-test-image.qcow2 haos-test-image.qcow2.compressed
+          mv haos-test-image.qcow2.compressed haos-test-image.qcow2
+          new_bytes=$(stat -c%s haos-test-image.qcow2)
+          ratio=$(awk -v o="$orig_bytes" -v n="$new_bytes" 'BEGIN{printf "%.1f", o/n}')
+          echo "qcow2 size before: $(numfmt --to=iec "$orig_bytes")"
+          echo "qcow2 size after : $(numfmt --to=iec "$new_bytes")"
+          echo "compression ratio: ${ratio}x"
+
       - name: Upload built image as workflow artifact
         # Always upload — even on PRs that don't push to GHCR — so reviewers
-        # can pull the artifact and verify locally.
+        # can pull the artifact and verify locally. (Now also smaller thanks
+        # to the in-format compression step above.)
         uses: actions/upload-artifact@v7
         with:
           name: haos-test-image-${{ steps.haos_version.outputs.version }}-${{ github.sha }}
@@ -166,13 +210,19 @@ jobs:
         env:
           HAOS_VERSION: ${{ steps.haos_version.outputs.version }}
           SHORT_SHA: ${{ github.sha }}
+          # workflow_dispatch lets perf-iteration branches publish to a
+          # non-``latest`` moving tag (e.g. ``:17.3-haose2eefficiency``)
+          # so they can point the e2e test workflows at a candidate image
+          # without disturbing the master-served ``:HAOS_VERSION-latest``
+          # that every other PR pulls from.
+          TAG_SUFFIX: ${{ github.event.inputs.tag_suffix || 'latest' }}
         run: |
           short_sha="${SHORT_SHA:0:7}"
           versioned="${IMAGE_REPO}:${HAOS_VERSION}-${short_sha}"
-          moving="${IMAGE_REPO}:${HAOS_VERSION}-latest"
+          moving="${IMAGE_REPO}:${HAOS_VERSION}-${TAG_SUFFIX}"
           oras push "$versioned" \
             --artifact-type application/vnd.homeassistant-ai.haos-test-image.v1 \
             haos-test-image.qcow2:application/octet-stream
-          oras tag "$versioned" "${HAOS_VERSION}-latest"
+          oras tag "$versioned" "${HAOS_VERSION}-${TAG_SUFFIX}"
           echo "Pushed $versioned"
           echo "Pushed $moving"

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -162,6 +162,16 @@ jobs:
       # external lane save eliminates the wasted work without
       # changing what gets cached — both lanes still restore from the
       # shared key on the next run.
+      #
+      # The shared-key bet is safe because both lanes consume the SAME
+      # byte-identical qcow2: the cache key hashes the bake-input
+      # paths only, the qcow2 is built once at publish time and
+      # pulled identically by both lanes, and PR-level addon/source
+      # overrides happen *in-VM at test time* (see
+      # ``refresh_dev_addon_source_in_qcow2`` /
+      # ``refresh_recorder_in_qcow2`` in conftest.py) on each
+      # worker's per-worker overlay — never on the base qcow2 that
+      # gets cached.
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -133,12 +133,7 @@ jobs:
         continue-on-error: true
         run: |
           version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
-          # TEMPORARY (perf/haos-e2e-improvements PR #1428 only): pulling
-          # from the perf-iteration tag so we measure the in-format
-          # compressed qcow2 published from this branch via the publish
-          # workflow's tag_suffix dispatch input. Final cleanup commit
-          # reverts to ``-latest`` before merge.
-          tag="${IMAGE_REPO}:${version}-haose2eefficiency"
+          tag="${IMAGE_REPO}:${version}-latest"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -142,6 +142,20 @@ jobs:
           (cd /tmp/haos-pull && /tmp/oras pull "$tag")
           mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
 
+      - name: Free disk space for local build (cache miss + GHCR miss only)
+        # See ``haos-e2e-tests.yml`` for the full rationale — same prune
+        # set, same condition. PRs touching ``tests/haos_image_build/``
+        # force the local-build path on both lanes and would otherwise
+        # trip "No space left on device" mid-bake on the 14 GB SSD.
+        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
+            /usr/local/lib/android /usr/local/.ghcup
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h /
+
       - name: Install build-script Python deps (cache miss + GHCR miss)
         if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
         run: pip install -r tests/haos_image_build/requirements.txt

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -133,7 +133,12 @@ jobs:
         continue-on-error: true
         run: |
           version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
-          tag="${IMAGE_REPO}:${version}-latest"
+          # TEMPORARY (perf/haos-e2e-improvements PR #1428 only): pulling
+          # from the perf-iteration tag so we measure the in-format
+          # compressed qcow2 published from this branch via the publish
+          # workflow's tag_suffix dispatch input. Final cleanup commit
+          # reverts to ``-latest`` before merge.
+          tag="${IMAGE_REPO}:${version}-haose2eefficiency"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -152,16 +152,16 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      - name: Save image to cache (cache miss only)
-        # Save whenever the runtime cache missed — covers both the
-        # local-build path AND a successful GHCR pull. Without saving on
-        # the GHCR-served branch, the actions/cache entry stays empty
-        # forever and every future run pays the GHCR pull cost again.
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: /tmp/haos-test-image.qcow2
-          key: ${{ steps.key.outputs.cache-key }}
+      # No cache-save step here on purpose. The external lane
+      # (haos-e2e-tests.yml) computes the same cache key (#1407) and
+      # always tries to save the same qcow2; both lanes start in
+      # parallel on the same PR push, so whichever lost the save race
+      # was burning ~25s on a tar+zstd-write of a 12 GB qcow2 that
+      # the actions/cache service then refused with
+      # "another job may be creating this cache." Letting only the
+      # external lane save eliminates the wasted work without
+      # changing what gets cached — both lanes still restore from the
+      # shared key on the next run.
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -146,7 +146,12 @@ jobs:
         continue-on-error: true
         run: |
           version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
-          tag="${IMAGE_REPO}:${version}-latest"
+          # TEMPORARY (perf/haos-e2e-improvements PR #1428 only): pulling
+          # from the perf-iteration tag so we measure the in-format
+          # compressed qcow2 published from this branch via the publish
+          # workflow's tag_suffix dispatch input. Final cleanup commit
+          # reverts to ``-latest`` before merge.
+          tag="${IMAGE_REPO}:${version}-haose2eefficiency"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -157,6 +157,29 @@ jobs:
           # files into a subdirectory of pwd doesn't silently no-op the mv.
           mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
 
+      - name: Free disk space for local build (cache miss + GHCR miss only)
+        # GitHub-hosted Linux runners ship with ~30 GB of pre-installed
+        # tooling (dotnet, swift, ghc, android sdk) that the HAOS bake
+        # doesn't use, and only ~14 GB of usable SSD. The local-build
+        # path's qcow2 download (~1.5 GB xz) + decompress (~7 GB qcow2)
+        # + boot+addon-install (qcow2 grows to ~12 GB apparent / ~5 GB
+        # allocated) + ``cp`` to ``/tmp/haos-test-image.qcow2`` (another
+        # ~5 GB if reflink fails) peaks at the edge of available disk.
+        # Without this prune, PRs that touch ``tests/haos_image_build/``
+        # (which forces the local-build path via the ``Detect PR-modified
+        # bake inputs`` gate above) trip "No space left on device"
+        # mid-bake. The directories below are well-known unused on
+        # standard runners; we deliberately keep ``/opt/hostedtoolcache``
+        # because Python from there is still on PATH for build_image.py.
+        if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
+            /usr/local/lib/android /usr/local/.ghcup
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h /
+
       - name: Install build-script Python deps (cache miss + GHCR miss)
         if: steps.restore-cache.outputs.cache-hit != 'true' && steps.ghcr-pull.outcome != 'success'
         run: pip install -r tests/haos_image_build/requirements.txt

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -195,6 +195,10 @@ jobs:
         # local-build path AND a successful GHCR pull. Without saving on
         # the GHCR-served branch, the actions/cache entry stays empty
         # forever and every future run pays the GHCR pull cost again.
+        # This is the sole writer for the shared cache key (#1407 +
+        # #1428) — the inaddon lane intentionally doesn't save, see the
+        # block comment at the same position in
+        # ``haos-e2e-inaddon-tests.yml``.
         if: steps.restore-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -146,12 +146,7 @@ jobs:
         continue-on-error: true
         run: |
           version=$(python3 -c "from tests.haos_image_build.build_image import HAOS_VERSION; print(HAOS_VERSION)")
-          # TEMPORARY (perf/haos-e2e-improvements PR #1428 only): pulling
-          # from the perf-iteration tag so we measure the in-format
-          # compressed qcow2 published from this branch via the publish
-          # workflow's tag_suffix dispatch input. Final cleanup commit
-          # reverts to ``-latest`` before merge.
-          tag="${IMAGE_REPO}:${version}-haose2eefficiency"
+          tag="${IMAGE_REPO}:${version}-latest"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -1397,11 +1397,18 @@ def build(work_dir: Path, output: Path) -> None:
     # HAOS is shut down — safe to open the qcow2 with libguestfs and bake
     # the testcontainer's seed state into /config/ for the e2e suite.
     bake_test_state(qcow2)
-    # Skip post-build compression for now: empirically qemu-img convert -c
-    # only shrinks ~7 GB → ~7 GB (Docker layer contents don't compress well
-    # with zlib) but adds 9 min, and xz -9 -T0 adds >25 min. Just sparse-copy
-    # the raw qcow2. Image-size optimization (zstd? strip unused docker
-    # layers? slim addons?) is tracked separately as a follow-up.
+    # Output the qcow2 as-is (sparse copy, no compression). qcow2 in-format
+    # compression is a CI publish concern — handled by
+    # ``build-haos-test-image.yml``'s ``Compress qcow2 in-format`` step
+    # before the ``oras push`` (#1428). Local builds skip it deliberately:
+    # nothing downstream of ``build_image.py`` on the developer iteration
+    # path benefits from the smaller file, and the convert pass adds ~6 min
+    # per build. (The older comment here claimed ``~7 GB → ~7 GB`` compress
+    # ratio; that was for a smaller pre-#1379 addon set baked into a
+    # non-resized qcow2. The current image — 12 GB apparent / ~5 GB
+    # allocated after ``qemu-img resize 32G`` — compresses to 5.1 GB at
+    # publish time (measured run 26361263298 step 11, 2.3x ratio), which
+    # is the wire-bytes win the workflow step exists to capture.)
     LOG.info("Copying qcow2 to %s (uncompressed)", output)
     output.parent.mkdir(parents=True, exist_ok=True)
     _run(["cp", "--reflink=auto", str(qcow2), str(output)])

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -1397,18 +1397,11 @@ def build(work_dir: Path, output: Path) -> None:
     # HAOS is shut down — safe to open the qcow2 with libguestfs and bake
     # the testcontainer's seed state into /config/ for the e2e suite.
     bake_test_state(qcow2)
-    # Output the qcow2 as-is (sparse copy, no compression). qcow2 in-format
-    # compression is a CI publish concern — handled by
-    # ``build-haos-test-image.yml``'s ``Compress qcow2 in-format`` step
-    # before the ``oras push`` (#1428). Local builds skip it deliberately:
-    # nothing downstream of ``build_image.py`` on the developer iteration
-    # path benefits from the smaller file, and the convert pass adds ~6 min
-    # per build. (The older comment here claimed ``~7 GB → ~7 GB`` compress
-    # ratio; that was for a smaller pre-#1379 addon set baked into a
-    # non-resized qcow2. The current image — 12 GB apparent / ~5 GB
-    # allocated after ``qemu-img resize 32G`` — compresses to 5.1 GB at
-    # publish time (measured run 26361263298 step 11, 2.3x ratio), which
-    # is the wire-bytes win the workflow step exists to capture.)
+    # Skip post-build compression for now: empirically qemu-img convert -c
+    # only shrinks ~7 GB → ~7 GB (Docker layer contents don't compress well
+    # with zlib) but adds 9 min, and xz -9 -T0 adds >25 min. Just sparse-copy
+    # the raw qcow2. Image-size optimization (zstd? strip unused docker
+    # layers? slim addons?) is tracked separately as a follow-up.
     LOG.info("Copying qcow2 to %s (uncompressed)", output)
     output.parent.mkdir(parents=True, exist_ok=True)
     _run(["cp", "--reflink=auto", str(qcow2), str(output)])

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -1397,11 +1397,11 @@ def build(work_dir: Path, output: Path) -> None:
     # HAOS is shut down — safe to open the qcow2 with libguestfs and bake
     # the testcontainer's seed state into /config/ for the e2e suite.
     bake_test_state(qcow2)
-    # Skip post-build compression for now: empirically qemu-img convert -c
-    # only shrinks ~7 GB → ~7 GB (Docker layer contents don't compress well
-    # with zlib) but adds 9 min, and xz -9 -T0 adds >25 min. Just sparse-copy
-    # the raw qcow2. Image-size optimization (zstd? strip unused docker
-    # layers? slim addons?) is tracked separately as a follow-up.
+    # Output uncompressed: nothing downstream of this script on the
+    # developer iteration path benefits from a smaller file, and the
+    # convert pass adds ~6 min. GHCR-served image is compressed at
+    # publish time by build-haos-test-image.yml's ``Compress qcow2
+    # in-format`` step (#1428, measured 12 GB → 5.1 GB / 2.3x).
     LOG.info("Copying qcow2 to %s (uncompressed)", output)
     output.parent.mkdir(parents=True, exist_ok=True)
     _run(["cp", "--reflink=auto", str(qcow2), str(output)])


### PR DESCRIPTION
## What does this PR do?

CI perf wins for the HAOS e2e lanes. Two structural changes in
`.github/workflows/` (compression at publish, removed redundant
cache save) plus one disk-pressure fix on the local-build fallback
path. Validated in-PR via a publish-tag scaffold + dispatch input
that survive the final diff (the input is generally useful;
scaffolding was reverted).

### Productive net diff (155 insertions / 18 deletions, 4 files)

**`.github/workflows/build-haos-test-image.yml`** — `qemu-img
convert -c -O qcow2` compression step before the artifact upload +
`oras push`, plus a `workflow_dispatch.inputs.tag_suffix` so
perf-iteration branches can publish to a non-`latest` moving tag.
Compression is gated by post-bake integrity checks (`qemu-img
check` + 1 GiB sanity floor). `TAG_SUFFIX` is validated against
the OCI tag character set (`[A-Za-z0-9._-]+`) before any tag
string is built.

**`.github/workflows/haos-e2e-inaddon-tests.yml`** — removed
`Save image to cache (cache miss only)` step. Both lanes shared
the same actions/cache key since #1407 and raced; the loser
burned ~25s tar+zstd-writing a 12 GB qcow2 before the cache
service refused the reservation. External lane is now the sole
writer; both still restore from the shared key.

**`.github/workflows/haos-e2e-tests.yml`** — added a navigation
comment (sole-writer cross-reference) + a disk-cleanup step
before the local-build fallback (mirrored in inaddon lane).

**Both e2e workflows** — `Free disk space for local build` step
gated on `cache-hit != 'true' && ghcr-pull.outcome != 'success'`.
Prunes ~20 GB of unused runner tooling (`/usr/share/dotnet`,
`/usr/share/swift`, `/opt/ghc`, `/usr/local/lib/android`,
`/usr/local/.ghcup`) + Docker images + apt cache. Only runs on
the path that needs the disk headroom; cache-hit and GHCR-pull
paths are unaffected. Discovered during this PR (commit
`897dfd15` → `26362625939` tripped `No space left on device`
mid-bake when its `build_image.py` change forced the local-build
path); fixed in `2772942b` and verified by re-running the same
path.

**`tests/haos_image_build/build_image.py`** — 5-line comment
update on the no-compression decision. Old comment cited
out-of-date numbers (`~7 GB → ~7 GB`, `+9 min`) from a smaller
pre-#1379 addon set; replaced with a cross-reference to the
workflow step that now does the actual compression.

### Why qcow2-format compression instead of xz / zstd-over-blob

The post-bake qcow2 is ~12 GB *apparent* size on disk — sparse,
~5 GB allocated. The rest is un-allocated holes from `qemu-img
resize 32G`. ORAS pushes/pulls `application/octet-stream` as a
raw byte stream, so sparse holes get serialised over the wire as
actual zero bytes — apparent size is what GHCR pull pays for.
`qemu-img convert -c -O qcow2` re-packs the same data densely at
the cluster level (64 KiB clusters, zlib). The output stays a
standard qcow2 (same OCI media-type, same consumer code path);
QEMU decompresses clusters on-demand during VM I/O when the e2e
workflow boots — no upfront decompress step on the pull side.

`qemu-img check` on the published image reports
`88.29% compressed clusters` after the new step (publish run
[26362624613](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26362624613)).

Trade-off worth knowing: qcow2 cluster compression is read-only
— the first write to any compressed cluster makes QEMU
re-allocate it uncompressed. The e2e workflow's boot is
read-heavy (HA starts, recorder DB rebuilds, addon containers
come up), so write-side re-allocation cost is small relative to
the pull-time saved, but it's why this convert pass lives at
publish time and not at every consumer.

### Measured wins

Baseline: PR #1421's HAOS-e2e (run #283), uncached, GHCR pull, ~13m total.

| Lane | Path | Baseline | After this PR | Δ |
|---|---|---|---|---|
| inaddon | GHCR pull (cache miss) | 6m 24s | **58s** | −5m 26s |
| external | GHCR pull (cache miss) | ~5–6 min | **47s** | ~−5 min |
| inaddon | cache save (race-loser) | ~25s | **0s** (removed) | −25s |
| inaddon | **total job (cache miss, compressed)** | **12m 57s** | **6m 43s** | **−6m 14s** (−48%) |
| inaddon | **total job (cache hit, compressed)** | (n/a — eviction-rare) | **6m 27s** | similar |
| inaddon | **total job (local-build path)** | n/a — would have OOM'd disk | **11m 23s** | newly working |

Source runs:

- **Compressed pull (cache miss)**: inaddon
  [26361656780](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26361656780),
  external [26361656754](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26361656754).
- **Cache hit on compressed file** (cleanup commit): inaddon
  [26361854944](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26361854944),
  external [26361854969](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26361854969).
- **Local-build path (with disk prune)**: inaddon
  [26362891971](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26362891971),
  external [26362891973](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26362891973).
- **Compression measurement**: publish run
  [26361263298](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26361263298)
  step 11: 12 GB → 5.1 GB (2.3x ratio).
- **Publish safety steps validation** (`qemu-img check` + size
  guard + tag regex): publish run
  [26362624613](https://github.com/homeassistant-ai/ha-mcp/actions/runs/26362624613).

When the win lands:

| Path | Hit rate | Win size |
|---|---|---|
| Cache eviction → GHCR pull | occasional | **~5 min** |
| First PR after bake-input merge → GHCR pull | weekly-ish | **~5 min** |
| Cache hit (most PRs) | common | small (~10s smaller cache restore on compressed file) |
| Local-build fallback (bake-input PRs) | rare | newly working — was at risk of OOM before this PR |

### E2E correctness preserved

Nothing in this PR changes the source-refresh paths that make
HAOS e2e actually test current PR source:

- **External lane**: in-process FastMCP server reads `src/ha_mcp/`
  directly from the runner checkout. Always fresh.
- **Inaddon lane**: `refresh_dev_addon_source_in_qcow2` runs
  unconditionally at test time on each worker's per-worker
  overlay and bumps `homeassistant-addon-dev/config.yaml`
  version, triggering Supervisor's `addons/{slug}/update` WS
  call regardless of qcow2 cache hits. The cached qcow2 just
  provides a pre-baked HAOS + addon-installed shell; the addon
  Docker container rebuilds with PR source on every run.

### Considered and ruled out: pre-boot RAM snapshot

The next-biggest cost after the GHCR pull is the per-worker HA
boot — ~127s on each xdist worker before any test runs.
``savevm`` / ``loadvm`` to skip that boot was researched and
ruled out — not deferred, not a follow-up — because the
architecture won't support it cleanly and the win is small:

- **Architectural blocker:** `_haos_worker_setup`
  (`tests/src/e2e/conftest.py:1082`) uses qcow2 backing-file
  overlays to fit two QEMUs on the runner's 14 GB SSD. qcow2
  internal snapshots live in the qcow2 file they were created
  in; overlays don't inherit them.
- **File-mutation-disconnect:** `refresh_dev_addon_source_in_qcow2`
  writes to the qcow2 between `savevm` and `loadvm`. A restored
  VM's filesystem cache (frozen in RAM at `savevm` time) wouldn't
  see those writes until something forces a re-read.
- **Reward shrunk after compression:** ~127s already
  parallelized across workers (~127s wall once). Even with a
  clean implementation, the marginal win is small relative to
  the complexity (overlay topology rework + a working theory
  for how the addon-source refresh survives a snapshot resume).
  Not worth pursuing.

### PR review fixes (commit `2772942b`)

Three review agents (comment-analyzer, silent-failure-hunter,
code-reviewer) flagged 17 items. Applied:

**Correctness / safety:**
- `qemu-img check` on the compressed file before consumers see it.
- 1 GiB sanity floor on the compressed file size.
- `TAG_SUFFIX` regex guard.
- Dropped `-p` from `qemu-img convert` (was log spam).
- Disk-prune step before local-build (newly discovered).

**Comment accuracy:**
- "sectors" → "clusters" (qcow2's unit).
- Reframed "sparse-zeroed space" wording (sparse means *absent*,
  not zero-filled; explained where the wire-bytes win actually
  comes from).
- Added "writes re-allocate uncompressed" trade-off.
- Cited specific publish + e2e runs for the measured numbers.
- `tag_suffix` description now says *how* the override is
  consumed (separate manual edit on the two e2e lanes).
- Consolidated duplicate `TAG_SUFFIX` explanation in the push
  step.
- Added byte-identical-qcow2 invariant to the inaddon
  no-cache-save comment.
- Updated stale `build_image.py` compression comment.

**Flagged-only (agents explicitly recommended not fixing):**
- Cancellation-window failure mode for the removed inaddon
  cache save.
- Pre-existing absence of post-push `oras manifest fetch`
  verification.
- Unrelated stale `submodules: true` comment.

### Housekeeping post-merge

- `build-haos-test-image.yml`'s next master-push run republishes
  `:17.3-latest` through the new compression + integrity steps,
  so the master-served image benefits and every future PR's
  GHCR-pull path lands the win.
- The `:17.3-haose2eefficiency` GHCR tag from this PR's
  iteration can be deleted (or left — doesn't hurt anything).

## Type of change
- [x] 🧪 Tests only

## Testing

CI-validated across all four execution paths. See "Source runs"
table above. The publish-side safety steps (`qemu-img check` /
size guard / regex validation) all passed and reported
`88.29% compressed clusters` on the published image.

- [x] All automated tests pass
- [x] Code follows style guidelines — workflow YAML + shell;
      no `src/` touched; ruff / mypy / pytest n/a

## Checklist
- [ ] I have updated documentation if needed
