### PR TITLE
refactor: remove duplicate flat area/floor list tools (consolidation followup to #1016)

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -389,7 +389,7 @@ class SmartSearchTools:
             # Two-pass area resolution. Pass 1 collects exact id / name /
             # alias matches; if any are found, fuzzy aggregation is
             # skipped entirely. This makes ``area_filter`` honor a
-            # literal area_id from ``ha_config_list_areas`` — pre-fix a
+            # literal area_id from ``ha_list_floors_areas`` — pre-fix a
             # query like ``"bedroom_kids"`` would also fuzzy-match its
             # parent ``"bedroom"`` (partial_ratio=100) and aggregate
             # sibling areas' entities. Aliases (per-area registry, used

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -197,14 +197,13 @@ class SmartSearchTools:
             aliases_map: dict[str, list[str]] = {}
             if survivor_ids:
                 try:
-                    entries_resp = await self.client.send_websocket_message({
-                        "type": "config/entity_registry/get_entries",
-                        "entity_ids": survivor_ids,
-                    })
-                    if (
-                        isinstance(entries_resp, dict)
-                        and entries_resp.get("success")
-                    ):
+                    entries_resp = await self.client.send_websocket_message(
+                        {
+                            "type": "config/entity_registry/get_entries",
+                            "entity_ids": survivor_ids,
+                        }
+                    )
+                    if isinstance(entries_resp, dict) and entries_resp.get("success"):
                         for eid, entry in (
                             entries_resp.get("result", {}) or {}
                         ).items():
@@ -232,11 +231,13 @@ class SmartSearchTools:
                 # Shallow copy + private-prefixed keys so downstream
                 # consumers that round-trip these dicts don't ship
                 # internal fields back to clients.
-                enriched.append({
-                    **entity,
-                    "_aliases": aliases_map.get(eid, []),
-                    "_hidden_by": slim.get("hidden_by"),
-                })
+                enriched.append(
+                    {
+                        **entity,
+                        "_aliases": aliases_map.get(eid, []),
+                        "_hidden_by": slim.get("hidden_by"),
+                    }
+                )
 
             entities = enriched
             if domain_filter:
@@ -519,9 +520,7 @@ class SmartSearchTools:
                                 ),
                                 "state": state_info.get("state", "unknown"),
                                 "_hidden_by": (
-                                    "hidden"
-                                    if entity_id in hidden_entity_ids
-                                    else None
+                                    "hidden" if entity_id in hidden_entity_ids else None
                                 ),
                             }
                         )
@@ -538,9 +537,7 @@ class SmartSearchTools:
                             "domain": entity_id.split(".")[0],
                             "state": state_info.get("state", "unknown"),
                             "_hidden_by": (
-                                "hidden"
-                                if entity_id in hidden_entity_ids
-                                else None
+                                "hidden" if entity_id in hidden_entity_ids else None
                             ),
                         }
                         for entity_id in area_entities

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -130,20 +130,20 @@ class AreaTools:
         return message
 
     # ============================================================
-    # AREA TOOLS
+    # AREA & FLOOR LISTING
     # ============================================================
 
     @tool(
-        name="ha_config_list_areas",
+        name="ha_list_floors_areas",
         tags={"Areas & Floors"},
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "List Areas",
+            "title": "List Floors and Areas",
         },
     )
     @log_tool_usage
-    async def ha_config_list_areas(
+    async def ha_list_floors_areas(
         self,
         fields: Annotated[
             str | list[str] | None,
@@ -151,9 +151,11 @@ class AreaTools:
                 default=None,
                 description=(
                     "Return only the specified top-level response keys to reduce "
-                    'response size (e.g. ["areas"]). '
+                    'response size (e.g. ["floors"]). '
                     "None = full response (default). "
-                    "Available keys: success, count, areas, message."
+                    "Available keys: success, floor_count, area_count, "
+                    "unassigned_count, orphaned_count, floors, unassigned_areas, "
+                    "orphaned_areas, message."
                 ),
             ),
         ] = None,
@@ -162,19 +164,24 @@ class AreaTools:
             Field(
                 default=None,
                 description=(
-                    "Project each area record to only the specified keys. "
-                    'E.g. ["area_id", "name"] returns slim area records. '
-                    "None = full records (default). Unknown keys yield empty records. "
-                    "Available keys: area_id, name, icon, floor_id, aliases, picture, labels."
+                    "Project each area record (in floors[].areas, unassigned_areas, "
+                    'and orphaned_areas) to only the specified keys. E.g. ["area_id", '
+                    '"name"] returns slim area records. None = full records (default). '
+                    "Unknown keys yield empty records. Available keys: area_id, name, "
+                    "icon, floor_id, aliases, picture, labels."
                 ),
             ),
         ] = None,
     ) -> dict[str, Any]:
         """
-        List all Home Assistant areas (rooms).
+        List floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
 
-        Returns area ID, name, icon, floor assignment, aliases, and picture URL.
+        Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level. Optionally project the response with fields= (top-level keys) or area_fields= (per-area-record keys, applied uniformly across nested, unassigned, and orphaned buckets).
+
+        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas; areas whose floor_id points to a non-existent floor appear in orphaned_areas — a topology snapshot may diverge from individual list calls if the registries change between reads.
         """
+        # Validate projection params first so a bad shape raises before any
+        # WS round-trips. Matches the pattern in the previous flat list tools.
         parsed_fields: list[str] | None = None
         if fields is not None:
             try:
@@ -195,128 +202,7 @@ class AreaTools:
                 raise_tool_error(
                     create_validation_error(str(exc), parameter="area_fields")
                 )
-        try:
-            message: dict[str, Any] = {
-                "type": "config/area_registry/list",
-            }
 
-            result = await self._client.send_websocket_message(message)
-
-            if result.get("success"):
-                areas = result.get("result", [])
-                _orig_areas = areas
-                if parsed_area_fields is not None:
-                    areas = project_records(areas, parsed_area_fields)
-                response: dict[str, Any] = {
-                    "success": True,
-                    "count": len(areas),
-                    "areas": areas,
-                    "message": f"Found {len(areas)} area(s)",
-                }
-                if parsed_area_fields is not None:
-                    _warn = result_fields_warning(
-                        _orig_areas, areas, parsed_area_fields, param_name="area_fields"
-                    )
-                    if _warn:
-                        response.setdefault("warnings", []).append(_warn)
-                return project_fields(response, parsed_fields)
-            else:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result.get("error", "Failed to list areas"),
-                    )
-                )
-
-        except ToolError:
-            raise
-        except Exception as e:
-            logger.error(f"Error listing areas: {e}")
-            exception_to_structured_error(
-                e,
-                context={"operation": "list_areas"},
-                suggestions=[
-                    "Check Home Assistant connection",
-                    "Verify WebSocket connection is active",
-                ],
-            )
-
-    # ============================================================
-    # FLOOR TOOLS
-    # ============================================================
-
-    @tool(
-        name="ha_config_list_floors",
-        tags={"Areas & Floors"},
-        annotations={
-            "idempotentHint": True,
-            "readOnlyHint": True,
-            "title": "List Floors",
-        },
-    )
-    @log_tool_usage
-    async def ha_config_list_floors(self) -> dict[str, Any]:
-        """
-        List all Home Assistant floors.
-
-        Returns floor ID, name, icon, level (0=ground, 1=first, -1=basement), and aliases.
-        """
-        try:
-            message: dict[str, Any] = {
-                "type": "config/floor_registry/list",
-            }
-
-            result = await self._client.send_websocket_message(message)
-
-            if result.get("success"):
-                floors = result.get("result", [])
-                return {
-                    "success": True,
-                    "count": len(floors),
-                    "floors": floors,
-                    "message": f"Found {len(floors)} floor(s)",
-                }
-            else:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result.get("error", "Failed to list floors"),
-                    )
-                )
-
-        except ToolError:
-            raise
-        except Exception as e:
-            logger.error(f"Error listing floors: {e}")
-            exception_to_structured_error(
-                e,
-                context={"operation": "list_floors"},
-                suggestions=[
-                    "Check Home Assistant connection",
-                    "Verify WebSocket connection is active",
-                ],
-            )
-
-    @tool(
-        name="ha_list_floors_areas",
-        tags={"Areas & Floors"},
-        annotations={
-            "idempotentHint": True,
-            "readOnlyHint": True,
-            "title": "List Floors and Areas",
-        },
-    )
-    @log_tool_usage
-    async def ha_list_floors_areas(self) -> dict[str, Any]:
-        """
-        List floors sorted by level ascending, each with their assigned areas nested, plus areas without a floor.
-
-        Do not use for flat listings — ha_config_list_areas and ha_config_list_floors cover those.
-
-        Use for location-based reasoning where floor-to-area relationships matter, such as "which rooms are on the ground floor" or operations scoped to a level.
-
-        Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas; areas whose floor_id points to a non-existent floor appear in orphaned_areas — a topology snapshot may diverge from individual list calls if the registries change between reads.
-        """
         progress: dict[str, Any] = {
             "operation": "list_floors_areas",
             "phase": "start",
@@ -410,21 +296,49 @@ class AreaTools:
             topology.sort(key=_floor_sort_key)
             progress["phase"] = "sorted"
 
-            return {
+            # Apply per-area projection across all 3 buckets uniformly.
+            # Snapshot pre-projection areas for the typo-guard warning.
+            _orig_all_areas = list(areas)
+            if parsed_area_fields is not None:
+                for floor in topology:
+                    floor["areas"] = project_records(floor["areas"], parsed_area_fields)
+                unassigned_areas = project_records(unassigned_areas, parsed_area_fields)
+                orphaned_areas = project_records(orphaned_areas, parsed_area_fields)
+
+            response: dict[str, Any] = {
                 "success": True,
                 "floor_count": len(topology),
-                "area_count": len(areas),
+                "area_count": len(_orig_all_areas),
                 "unassigned_count": len(unassigned_areas),
                 "orphaned_count": len(orphaned_areas),
                 "floors": topology,
                 "unassigned_areas": unassigned_areas,
                 "orphaned_areas": orphaned_areas,
                 "message": (
-                    f"Found {len(topology)} floor(s), {len(areas)} area(s), "
+                    f"Found {len(topology)} floor(s), {len(_orig_all_areas)} area(s), "
                     f"{len(unassigned_areas)} unassigned, "
                     f"{len(orphaned_areas)} orphaned"
                 ),
             }
+
+            # Typo-guard: combine projected areas across buckets to detect the
+            # all-empty-records situation that signals an unknown area_fields key.
+            if parsed_area_fields is not None:
+                _projected_all = (
+                    [a for f in topology for a in f["areas"]]
+                    + unassigned_areas
+                    + orphaned_areas
+                )
+                _warn = result_fields_warning(
+                    _orig_all_areas,
+                    _projected_all,
+                    parsed_area_fields,
+                    param_name="area_fields",
+                )
+                if _warn:
+                    response.setdefault("warnings", []).append(_warn)
+
+            return project_fields(response, parsed_fields)
 
         except ToolError:
             raise

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -216,8 +216,10 @@ class AreaTools:
             # tool-side latency. Use return_exceptions=True so a failure on
             # one side doesn't cancel the other — the post-fetch guard
             # below reports both registries' state in the error context for
-            # diagnosis.
-            areas_result, floors_result = await asyncio.gather(
+            # diagnosis. Indexed access + explicit annotations rather than
+            # tuple-unpack — gather returns list[Any] which mypy can't
+            # statically narrow to a 2-tuple.
+            results = await asyncio.gather(
                 self._client.send_websocket_message(
                     {"type": "config/area_registry/list"}
                 ),
@@ -230,12 +232,12 @@ class AreaTools:
 
             # Re-raise transport-level exceptions from either fetch so the
             # outer except handler classifies them via exception_to_structured_error.
-            # Per-variable isinstance checks (rather than a loop) so mypy can
-            # narrow each name's type from `dict | BaseException` to `dict`.
-            if isinstance(areas_result, BaseException):
-                raise areas_result
-            if isinstance(floors_result, BaseException):
-                raise floors_result
+            if isinstance(results[0], BaseException):
+                raise results[0]
+            if isinstance(results[1], BaseException):
+                raise results[1]
+            areas_result: dict[str, Any] = results[0]
+            floors_result: dict[str, Any] = results[1]
 
             # A response with success=True but no "result" key is malformed —
             # treat it as a service call failure rather than silently returning

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -5,6 +5,7 @@ This module provides tools for listing, creating, updating, and deleting
 Home Assistant areas and floors - essential organizational features for smart homes.
 """
 
+import asyncio
 import logging
 from typing import Annotated, Any, Literal
 
@@ -210,14 +211,28 @@ class AreaTools:
             "phase": "start",
         }
         try:
-            areas_result = await self._client.send_websocket_message(
-                {"type": "config/area_registry/list"}
+            # Fetch both registries concurrently. Sequential awaits add a
+            # round-trip per call on the WS transport; gather halves the
+            # tool-side latency. Use return_exceptions=True so a failure on
+            # one side doesn't cancel the other — the post-fetch guard
+            # below reports both registries' state in the error context for
+            # diagnosis.
+            areas_result, floors_result = await asyncio.gather(
+                self._client.send_websocket_message(
+                    {"type": "config/area_registry/list"}
+                ),
+                self._client.send_websocket_message(
+                    {"type": "config/floor_registry/list"}
+                ),
+                return_exceptions=True,
             )
-            progress["phase"] = "areas_fetched"
-            floors_result = await self._client.send_websocket_message(
-                {"type": "config/floor_registry/list"}
-            )
-            progress["phase"] = "floors_fetched"
+            progress["phase"] = "registries_fetched"
+
+            # Re-raise transport-level exceptions from either fetch so the
+            # outer except handler classifies them via exception_to_structured_error.
+            for r in (areas_result, floors_result):
+                if isinstance(r, BaseException):
+                    raise r
 
             # A response with success=True but no "result" key is malformed —
             # treat it as a service call failure rather than silently returning
@@ -248,7 +263,7 @@ class AreaTools:
             # Partition areas into three disjoint sets:
             #   - nested:    floor_id present AND points to a known floor
             #   - orphaned:  floor_id present BUT points to a non-existent floor
-            #                (race between the two sequential reads, or manual
+            #                (race between the concurrent reads, or manual
             #                .storage inconsistency)
             #   - unassigned: no floor_id at all
             # Orphaned is surfaced as a separate key so the LLM can diagnose

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -180,14 +180,16 @@ class AreaTools:
 
         Floors with level=None sort alongside level 0 (ground floor). Areas without a floor assignment appear in unassigned_areas; areas whose floor_id points to a non-existent floor appear in orphaned_areas — a topology snapshot may diverge from individual list calls if the registries change between reads.
         """
-        # Validate projection params first so a bad shape raises before any
-        # WS round-trips. Matches the pattern in the previous flat list tools.
+        # Validate projection params before any WS round-trips so a bad shape
+        # fails fast without burning two registry reads.
         parsed_fields: list[str] | None = None
         if fields is not None:
             try:
                 parsed_fields = parse_string_list_param(
                     fields, "fields", allow_csv=True
                 )
+                if parsed_fields is not None and len(parsed_fields) == 0:
+                    raise ValueError("fields must contain at least one key")
             except ValueError as exc:
                 raise_tool_error(create_validation_error(str(exc), parameter="fields"))
         parsed_area_fields: list[str] | None = None

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -230,9 +230,12 @@ class AreaTools:
 
             # Re-raise transport-level exceptions from either fetch so the
             # outer except handler classifies them via exception_to_structured_error.
-            for r in (areas_result, floors_result):
-                if isinstance(r, BaseException):
-                    raise r
+            # Per-variable isinstance checks (rather than a loop) so mypy can
+            # narrow each name's type from `dict | BaseException` to `dict`.
+            if isinstance(areas_result, BaseException):
+                raise areas_result
+            if isinstance(floors_result, BaseException):
+                raise floors_result
 
             # A response with success=True but no "result" key is malformed —
             # treat it as a service call failure rather than silently returning

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1154,7 +1154,7 @@ async def _validate_registry_ids(
                     f"area_id={area_id!r} does not exist in the area registry.",
                     context={"area_id": area_id},
                     suggestions=[
-                        "Use ha_config_list_areas() to list valid area IDs.",
+                        "Use ha_list_floors_areas() to list valid area IDs.",
                         'Pass area_id="" to clear the area assignment.',
                         f"Available area_ids: {sorted(valid_area_ids)}",
                     ],

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -1362,7 +1362,7 @@ async def test_exact_area_id_short_circuits_fuzzy_aggregation(
     mcp_client, two_areas_with_shared_prefix
 ):
     """When ``area_filter`` is a literal area_id from
-    ``ha_config_list_areas``, exact match wins — fuzzy aggregation of
+    ``ha_list_floors_areas``, exact match wins — fuzzy aggregation of
     sibling areas is suppressed. Pre-fix a query like
     ``bedroom_y_<suffix>`` would also partial_ratio-match its sibling
     ``bedroom_x_<suffix>`` (and the seeded ``bedroom`` area), surfacing

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -604,8 +604,7 @@ async def area_with_mixed_domains(mcp_client):
     )
     boolean_data = assert_mcp_success(boolean_result, "Create input_boolean")
     boolean_id = (
-        boolean_data.get("entity_id")
-        or f"input_boolean.{boolean_data['data']['id']}"
+        boolean_data.get("entity_id") or f"input_boolean.{boolean_data['data']['id']}"
     )
 
     number_result = await mcp_client.call_tool(
@@ -621,8 +620,7 @@ async def area_with_mixed_domains(mcp_client):
     )
     number_data = assert_mcp_success(number_result, "Create input_number")
     number_id = (
-        number_data.get("entity_id")
-        or f"input_number.{number_data['data']['id']}"
+        number_data.get("entity_id") or f"input_number.{number_data['data']['id']}"
     )
 
     # Wait until both entities are visible under this area in the registries
@@ -927,8 +925,7 @@ async def two_areas_fuzzy_match(mcp_client):
         )
         bool_data = assert_mcp_success(bool_result, f"Create boolean {tag}")
         bool_id = (
-            bool_data.get("entity_id")
-            or f"input_boolean.{bool_data['data']['id']}"
+            bool_data.get("entity_id") or f"input_boolean.{bool_data['data']['id']}"
         )
         created.append(("input_boolean", bool_id))
         helpers.append({"area_id": area_id, "boolean_id": bool_id, "tag": tag})
@@ -1041,7 +1038,13 @@ async def test_domain_filter_uppercase_normalized_issue_1170(mcp_client):
 @pytest.mark.parametrize(
     "padded",
     ["  light  ", "\tlight", "light\n", "  Light  ", " LIGHT\t"],
-    ids=["padded", "tab-prefix", "newline-suffix", "padded-mixed-case", "tab-and-upper"],
+    ids=[
+        "padded",
+        "tab-prefix",
+        "newline-suffix",
+        "padded-mixed-case",
+        "tab-and-upper",
+    ],
 )
 @pytest.mark.asyncio
 async def test_domain_filter_whitespace_normalized_issue_1170(mcp_client, padded):
@@ -1112,8 +1115,7 @@ async def populated_area_for_shape_test(mcp_client):
     )
     helper_data = assert_mcp_success(helper_result, "Create shape-test helper")
     boolean_id = (
-        helper_data.get("entity_id")
-        or f"input_boolean.{helper_data['data']['id']}"
+        helper_data.get("entity_id") or f"input_boolean.{helper_data['data']['id']}"
     )
     await wait_for_tool_result(
         mcp_client,
@@ -1186,9 +1188,7 @@ async def test_area_filtered_query_no_per_result_area_filter_issue_1170(
         f"top-level area_filter should still echo: {data}"
     )
     for r in data["results"]:
-        assert "area_filter" not in r, (
-            f"per-result area_filter should be dropped: {r}"
-        )
+        assert "area_filter" not in r, f"per-result area_filter should be dropped: {r}"
 
 
 @pytest.mark.asyncio
@@ -1226,15 +1226,18 @@ async def test_result_shape_consistent_across_branches(mcp_client):
         ({"query": "light", "exact_match": False, "limit": 1}, "fuzzy_search"),
         ({"area_filter": "kitchen", "limit": 1}, "area_only"),
         (
-            {"area_filter": "kitchen", "query": "light", "exact_match": False, "limit": 1},
+            {
+                "area_filter": "kitchen",
+                "query": "light",
+                "exact_match": False,
+                "limit": 1,
+            },
             "area_filtered_query",
         ),
     ]
     for params, expected_type in calls:
         res = await mcp_client.call_tool("ha_search_entities", params)
-        data = assert_mcp_success(res, f"shape check {expected_type}").get(
-            "data", {}
-        )
+        data = assert_mcp_success(res, f"shape check {expected_type}").get("data", {})
         assert data["search_type"] == expected_type, (
             f"unexpected search_type for {params}: {data}"
         )
@@ -1246,8 +1249,7 @@ async def test_result_shape_consistent_across_branches(mcp_client):
             f"{base_keys - result_keys} (have {result_keys})"
         )
         assert not (forbidden & result_keys), (
-            f"{expected_type} surfaced forbidden keys: "
-            f"{forbidden & result_keys}"
+            f"{expected_type} surfaced forbidden keys: {forbidden & result_keys}"
         )
 
 
@@ -1263,7 +1265,9 @@ async def test_validation_error_carries_no_generic_suggestions(mcp_client):
     inner = data.get("data", data)
     assert inner.get("success") is False, f"expected failure: {inner}"
     error = inner.get("error", {})
-    assert error.get("code") == "VALIDATION_FAILED", f"expected VALIDATION_FAILED: {inner}"
+    assert error.get("code") == "VALIDATION_FAILED", (
+        f"expected VALIDATION_FAILED: {inner}"
+    )
     # No misleading "Check Home Assistant connection" boilerplate.
     suggestions = error.get("suggestions") or []
     if isinstance(error.get("suggestion"), str):
@@ -1376,15 +1380,12 @@ async def test_exact_area_id_short_circuits_fuzzy_aggregation(
     )
     data = assert_mcp_success(res, "exact area_id resolution").get("data", {})
     entity_ids = {r["entity_id"] for r in data["results"]}
-    assert target_helper in entity_ids, (
-        f"target area's helper missing: {data}"
-    )
+    assert target_helper in entity_ids, f"target area's helper missing: {data}"
     assert sibling_helper not in entity_ids, (
         f"sibling area's helper leaked into exact-id resolution: {data}"
     )
     assert len(data["area_names"]) == 1, (
-        f"exact area_id should resolve to exactly one area, got "
-        f"{data['area_names']}"
+        f"exact area_id should resolve to exactly one area, got {data['area_names']}"
     )
 
 
@@ -1449,13 +1450,8 @@ async def helper_with_alias(mcp_client):
         {"helper_type": "input_boolean", "name": f"e2e 1170 alias src {suffix}"},
     )
     helper_data = assert_mcp_success(helper_res, "Create alias-target helper")
-    eid = (
-        helper_data.get("entity_id")
-        or f"input_boolean.{helper_data['data']['id']}"
-    )
-    await mcp_client.call_tool(
-        "ha_set_entity", {"entity_id": eid, "aliases": [alias]}
-    )
+    eid = helper_data.get("entity_id") or f"input_boolean.{helper_data['data']['id']}"
+    await mcp_client.call_tool("ha_set_entity", {"entity_id": eid, "aliases": [alias]})
     yield {"entity_id": eid, "alias": alias}
     try:
         await mcp_client.call_tool(
@@ -1484,8 +1480,7 @@ async def test_search_concat_token_elision_issue_1170(mcp_client):
     entity_ids = [r["entity_id"] for r in data.get("results", [])]
     # `light.bed_light` is part of the initial_test_state seed.
     assert "light.bed_light" in entity_ids, (
-        f"separator-elided query 'bedlight' should match light.bed_light: "
-        f"{entity_ids}"
+        f"separator-elided query 'bedlight' should match light.bed_light: {entity_ids}"
     )
 
 
@@ -1519,8 +1514,7 @@ async def area_with_alias(mcp_client):
             tool_name="ha_search_entities",
             arguments={"area_filter": area_id, "limit": 10},
             predicate=lambda d: any(
-                r.get("entity_id") == eid
-                for r in d.get("data", d).get("results", [])
+                r.get("entity_id") == eid for r in d.get("data", d).get("results", [])
             ),
             description="helper visible in alias-area",
         )
@@ -1630,16 +1624,13 @@ async def test_search_includes_hidden_with_penalty_by_default_issue_1170(
     assert fixture["entity_id"] in entity_ids, (
         f"hidden entity should be in default results (option c): {data}"
     )
-    target = next(
-        r for r in data["results"] if r["entity_id"] == fixture["entity_id"]
-    )
+    target = next(r for r in data["results"] if r["entity_id"] == fixture["entity_id"])
     # The hidden entity is the only match for a uuid-suffixed query, so
     # its raw score would be 100 (exact substring) — minus the 20-point
     # penalty → 80. Asserting ``< 100`` keeps the test robust to small
     # tuning changes in the penalty constant.
     assert target["score"] < 100, (
-        f"hidden entity should carry score penalty (got {target['score']}): "
-        f"{target}"
+        f"hidden entity should carry score penalty (got {target['score']}): {target}"
     )
 
 
@@ -1668,9 +1659,7 @@ async def test_search_include_hidden_false_filters_issue_1170(
 
 
 @pytest.mark.asyncio
-async def test_search_fuzzy_mode_penalises_hidden_issue_1170(
-    mcp_client, hidden_helper
-):
+async def test_search_fuzzy_mode_penalises_hidden_issue_1170(mcp_client, hidden_helper):
     """Fuzzy mode applies the same hidden-score penalty.
 
     Default-True ``exact_match`` and the fuzzy path are SEPARATE code
@@ -1692,9 +1681,7 @@ async def test_search_fuzzy_mode_penalises_hidden_issue_1170(
     assert fixture["entity_id"] in entity_ids, (
         f"fuzzy mode should keep hidden entity (option c): {data}"
     )
-    target = next(
-        r for r in data["results"] if r["entity_id"] == fixture["entity_id"]
-    )
+    target = next(r for r in data["results"] if r["entity_id"] == fixture["entity_id"])
     assert target["score"] < 100, (
         f"fuzzy mode hidden entity should carry penalty (got "
         f"{target['score']}): {target}"
@@ -1710,9 +1697,7 @@ async def test_search_fuzzy_mode_penalises_hidden_issue_1170(
             "limit": 5,
         },
     )
-    data2 = assert_mcp_success(res2, "fuzzy include_hidden=False").get(
-        "data", {}
-    )
+    data2 = assert_mcp_success(res2, "fuzzy include_hidden=False").get("data", {})
     entity_ids2 = [r["entity_id"] for r in data2["results"]]
     assert fixture["entity_id"] not in entity_ids2, (
         f"fuzzy + include_hidden=False should filter hidden: {data2}"
@@ -1753,14 +1738,11 @@ async def test_search_area_only_penalises_hidden_issue_1170(mcp_client):
             tool_name="ha_search_entities",
             arguments={"area_filter": area_id, "limit": 10},
             predicate=lambda d: any(
-                r.get("entity_id") == eid
-                for r in d.get("data", d).get("results", [])
+                r.get("entity_id") == eid for r in d.get("data", d).get("results", [])
             ),
             description="area entity visible before hide",
         )
-        await mcp_client.call_tool(
-            "ha_set_entity", {"entity_id": eid, "hidden": True}
-        )
+        await mcp_client.call_tool("ha_set_entity", {"entity_id": eid, "hidden": True})
 
         # Default include_hidden=True: hidden entity surfaces with penalty
         res = await mcp_client.call_tool(
@@ -1839,10 +1821,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
         },
     )
     v_data = assert_mcp_success(v_res, "create visible")
-    v_eid = (
-        v_data.get("entity_id")
-        or f"input_boolean.{v_data['data']['id']}"
-    )
+    v_eid = v_data.get("entity_id") or f"input_boolean.{v_data['data']['id']}"
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
         {
@@ -1852,10 +1831,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
         },
     )
     h_data = assert_mcp_success(h_res, "create hidden-target")
-    h_eid = (
-        h_data.get("entity_id")
-        or f"input_boolean.{h_data['data']['id']}"
-    )
+    h_eid = h_data.get("entity_id") or f"input_boolean.{h_data['data']['id']}"
 
     try:
         # Hide the second helper.
@@ -1874,8 +1850,7 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
                 "limit": 20,
             },
             predicate=lambda d: any(
-                r.get("entity_id") == v_eid
-                for r in d.get("data", d).get("results", [])
+                r.get("entity_id") == v_eid for r in d.get("data", d).get("results", [])
             ),
             description="visible helper visible in area+query",
         )
@@ -1888,17 +1863,13 @@ async def test_search_area_filtered_query_penalises_hidden_issue_1170(mcp_client
                 "limit": 20,
             },
         )
-        data = assert_mcp_success(res, "area+query hidden penalty").get(
-            "data", {}
-        )
+        data = assert_mcp_success(res, "area+query hidden penalty").get("data", {})
         ids = [r["entity_id"] for r in data["results"]]
         # With the distinctive token hitting BM25 at score 100 in both
         # entity_id and friendly_name, both helpers must surface — the
         # earlier "hidden may be absent" escape hatch was masking the
         # threshold-edge regression that's now locked down separately.
-        assert v_eid in ids, (
-            f"visible area+query match disappeared: {ids}"
-        )
+        assert v_eid in ids, f"visible area+query match disappeared: {ids}"
         assert h_eid in ids, (
             f"hidden area+query match should still surface (option-c): {ids}"
         )
@@ -1944,19 +1915,13 @@ async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
         {"helper_type": "input_boolean", "name": visible_name},
     )
     v_data = assert_mcp_success(v_res, "create visible dl")
-    v_eid = (
-        v_data.get("entity_id")
-        or f"input_boolean.{v_data['data']['id']}"
-    )
+    v_eid = v_data.get("entity_id") or f"input_boolean.{v_data['data']['id']}"
     h_res = await mcp_client.call_tool(
         "ha_config_set_helper",
         {"helper_type": "input_boolean", "name": hidden_name},
     )
     h_data = assert_mcp_success(h_res, "create hidden dl")
-    h_eid = (
-        h_data.get("entity_id")
-        or f"input_boolean.{h_data['data']['id']}"
-    )
+    h_eid = h_data.get("entity_id") or f"input_boolean.{h_data['data']['id']}"
 
     try:
         await mcp_client.call_tool(
@@ -1971,12 +1936,10 @@ async def test_search_domain_listing_penalises_hidden_issue_1170(mcp_client):
         data = assert_mcp_success(res, "domain_listing default").get("data", {})
         by_id = {r["entity_id"]: r for r in data["results"]}
         assert h_eid in by_id, (
-            f"hidden helper should appear in domain_listing default: "
-            f"{list(by_id)[:5]}"
+            f"hidden helper should appear in domain_listing default: {list(by_id)[:5]}"
         )
         assert by_id[h_eid]["score"] < 100, (
-            f"hidden should carry penalty in domain_listing: "
-            f"{by_id[h_eid]}"
+            f"hidden should carry penalty in domain_listing: {by_id[h_eid]}"
         )
         if v_eid in by_id:
             assert by_id[v_eid]["score"] >= by_id[h_eid]["score"], (
@@ -2088,10 +2051,7 @@ class TestSearchEntitiesSeededAreasIssue1170:
                 tool_name="ha_search_entities",
                 arguments={"area_filter": "bedroom", "limit": 50},
                 predicate=lambda d: expected.issubset(
-                    {
-                        r.get("entity_id")
-                        for r in d.get("data", d).get("results", [])
-                    }
+                    {r.get("entity_id") for r in d.get("data", d).get("results", [])}
                 ),
                 description="all seed assignments visible under bedroom",
             )
@@ -2161,9 +2121,7 @@ class TestSearchEntitiesSeededAreasIssue1170:
         )
 
     @pytest.mark.asyncio
-    async def test_area_only_pagination_realistic(
-        self, mcp_client, seeded_bedroom
-    ):
+    async def test_area_only_pagination_realistic(self, mcp_client, seeded_bedroom):
         """Pagination works correctly at realistic populated-area scale."""
         fixture = seeded_bedroom
         res = await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -860,9 +860,12 @@ class TestAreaFloorIntegration:
 @pytest.mark.area
 async def test_area_list_empty_or_populated(mcp_client):
     """
-    Test: List areas works correctly (empty or with existing areas)
+    Test: ha_list_floors_areas returns the area facet correctly (empty or populated).
 
-    Basic validation that the list endpoint works.
+    Validates the area-facing parts of the combined topology response —
+    area_count and the flattened union of nested/unassigned/orphaned buckets.
+    Pairs with test_floor_list_empty_or_populated which covers the floor facet
+    of the same endpoint.
     """
     logger.info("Testing ha_list_floors_areas functionality")
 
@@ -880,9 +883,12 @@ async def test_area_list_empty_or_populated(mcp_client):
 @pytest.mark.floor
 async def test_floor_list_empty_or_populated(mcp_client):
     """
-    Test: List floors works correctly (empty or with existing floors)
+    Test: ha_list_floors_areas returns the floor facet correctly (empty or populated).
 
-    Basic validation that the list endpoint works.
+    Validates the floor-facing parts of the combined topology response —
+    floor_count and the floors list (each carrying nested areas).
+    Pairs with test_area_list_empty_or_populated which covers the area facet
+    of the same endpoint.
     """
     logger.info("Testing ha_list_floors_areas functionality")
 

--- a/tests/src/e2e/workflows/areas/test_lifecycle.py
+++ b/tests/src/e2e/workflows/areas/test_lifecycle.py
@@ -25,6 +25,16 @@ REGISTRY_OPERATION_DELAY = 0.5  # Time to wait after create/delete for registry 
 BATCH_OPERATION_DELAY = 0.2  # Time to wait between batch operations
 
 
+def _flatten_areas(topology: dict) -> list[dict]:
+    """Flatten ha_list_floors_areas' 3-bucket area shape into a single list."""
+    nested = [a for f in topology.get("floors", []) for a in f.get("areas", [])]
+    return (
+        nested
+        + topology.get("unassigned_areas", [])
+        + topology.get("orphaned_areas", [])
+    )
+
+
 def generate_unique_name(prefix: str) -> str:
     """Generate a unique name for test entities to avoid conflicts."""
     return f"{prefix}_{uuid.uuid4().hex[:8]}"
@@ -62,12 +72,12 @@ class TestAreaLifecycle:
         logger.info(f"Created area: {area_name} (ID: {area_id})")
 
         # 2. LIST: Verify area exists in list
-        list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
 
         list_data = parse_mcp_result(list_result)
         assert list_data.get("success"), f"Failed to list areas: {list_data}"
 
-        areas = list_data.get("areas", [])
+        areas = _flatten_areas(list_data)
         found_area = next(
             (a for a in areas if a.get("area_id") == area_id),
             None,
@@ -89,10 +99,10 @@ class TestAreaLifecycle:
         logger.info(f"Deleted area: {area_id}")
 
         # 4. VERIFY: Area no longer in list
-        verify_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        verify_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         verify_data = parse_mcp_result(verify_result)
 
-        areas_after = verify_data.get("areas", [])
+        areas_after = _flatten_areas(verify_data)
         found_after = next(
             (a for a in areas_after if a.get("area_id") == area_id),
             None,
@@ -143,10 +153,10 @@ class TestAreaLifecycle:
         logger.info(f"Updated area: {area_id}")
 
         # 3. VERIFY: Check changes in list
-        list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
-        areas = list_data.get("areas", [])
+        areas = _flatten_areas(list_data)
         found_area = next(
             (a for a in areas if a.get("area_id") == area_id),
             None,
@@ -199,10 +209,10 @@ class TestAreaLifecycle:
         logger.info(f"Created area with aliases: {area_id}")
 
         # 2. VERIFY: Check aliases in list
-        list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
-        areas = list_data.get("areas", [])
+        areas = _flatten_areas(list_data)
         found_area = next(
             (a for a in areas if a.get("area_id") == area_id),
             None,
@@ -257,7 +267,7 @@ class TestFloorLifecycle:
         logger.info(f"Created floor: {floor_name} (ID: {floor_id})")
 
         # 2. LIST: Verify floor exists in list
-        list_result = await mcp_client.call_tool("ha_config_list_floors", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
 
         list_data = parse_mcp_result(list_result)
         assert list_data.get("success"), f"Failed to list floors: {list_data}"
@@ -287,7 +297,7 @@ class TestFloorLifecycle:
         logger.info(f"Deleted floor: {floor_id}")
 
         # 4. VERIFY: Floor no longer in list
-        verify_result = await mcp_client.call_tool("ha_config_list_floors", {})
+        verify_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         verify_data = parse_mcp_result(verify_result)
 
         floors_after = verify_data.get("floors", [])
@@ -343,7 +353,7 @@ class TestFloorLifecycle:
         logger.info(f"Updated floor: {floor_id}")
 
         # 3. VERIFY: Check changes in list
-        list_result = await mcp_client.call_tool("ha_config_list_floors", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
         floors = list_data.get("floors", [])
@@ -403,7 +413,7 @@ class TestFloorLifecycle:
         logger.info(f"Created floor with aliases: {floor_id}")
 
         # 2. VERIFY: Check aliases in list
-        list_result = await mcp_client.call_tool("ha_config_list_floors", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
         floors = list_data.get("floors", [])
@@ -415,7 +425,9 @@ class TestFloorLifecycle:
         assert found_floor is not None, f"Floor not found: {floor_id}"
         floor_aliases = found_floor.get("aliases", [])
         for alias in aliases:
-            assert alias in floor_aliases, f"Alias '{alias}' not found in {floor_aliases}"
+            assert alias in floor_aliases, (
+                f"Alias '{alias}' not found in {floor_aliases}"
+            )
         logger.info(f"Verified aliases: {floor_aliases}")
 
         # 3. CLEANUP
@@ -479,10 +491,10 @@ class TestAreaFloorIntegration:
         logger.info(f"Created area on floor: {area_id}")
 
         # 3. VERIFY: Check floor assignment in list
-        list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
-        areas = list_data.get("areas", [])
+        areas = _flatten_areas(list_data)
         found_area = next(
             (a for a in areas if a.get("area_id") == area_id),
             None,
@@ -509,10 +521,10 @@ class TestAreaFloorIntegration:
         logger.info("Removed floor assignment")
 
         # 5. VERIFY: Floor assignment removed
-        verify_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        verify_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         verify_data = parse_mcp_result(verify_result)
 
-        areas_after = verify_data.get("areas", [])
+        areas_after = _flatten_areas(verify_data)
         found_after = next(
             (a for a in areas_after if a.get("area_id") == area_id),
             None,
@@ -696,7 +708,9 @@ class TestAreaFloorIntegration:
               insertion order within the tie).
         """
         prefix = generate_unique_name("test_topo_sort")
-        logger.info(f"Testing topology sort order with levels [-1, 0, None, 2]: {prefix}")
+        logger.info(
+            f"Testing topology sort order with levels [-1, 0, None, 2]: {prefix}"
+        )
 
         levels = [-1, 0, None, 2]
         floor_ids_by_level: dict[str, Any] = {}
@@ -737,16 +751,17 @@ class TestAreaFloorIntegration:
             f"Last floor should be level=2, got: {returned_order[3]}"
         )
 
-        middle_ids = {returned_order[1].get("floor_id"), returned_order[2].get("floor_id")}
+        middle_ids = {
+            returned_order[1].get("floor_id"),
+            returned_order[2].get("floor_id"),
+        }
         expected_middle = {floor_ids_by_level["0"], floor_ids_by_level["None"]}
         assert middle_ids == expected_middle, (
             f"Middle positions should contain level=0 and level=None floors, "
             f"got: {middle_ids} vs expected {expected_middle}"
         )
 
-        logger.info(
-            "Verified sort order: -1 first, 2 last, 0/None tied in middle"
-        )
+        logger.info("Verified sort order: -1 first, 2 last, 0/None tied in middle")
 
         for fid in floor_ids_by_level.values():
             await mcp_client.call_tool(
@@ -799,19 +814,20 @@ class TestAreaFloorIntegration:
             )
 
             area_data = parse_mcp_result(area_result)
-            assert area_data.get("success"), f"Failed to create area {name}: {area_data}"
+            assert area_data.get("success"), (
+                f"Failed to create area {name}: {area_data}"
+            )
 
             area_id = area_data.get("area_id")
             area_ids.append(area_id)
             cleanup_tracker.track("area", area_id)
             logger.info(f"Created area: {name} (ID: {area_id})")
 
-
         # 3. VERIFY: All areas on floor
-        list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+        list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
         list_data = parse_mcp_result(list_result)
 
-        areas = list_data.get("areas", [])
+        areas = _flatten_areas(list_data)
         floor_areas = [a for a in areas if a.get("floor_id") == floor_id]
 
         assert len(floor_areas) >= len(area_ids), (
@@ -848,19 +864,17 @@ async def test_area_list_empty_or_populated(mcp_client):
 
     Basic validation that the list endpoint works.
     """
-    logger.info("Testing ha_list_areas functionality")
+    logger.info("Testing ha_list_floors_areas functionality")
 
-    list_result = await mcp_client.call_tool("ha_config_list_areas", {})
+    list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
     list_data = parse_mcp_result(list_result)
 
     assert list_data.get("success"), f"Failed to list areas: {list_data}"
-    assert "count" in list_data, f"Missing count in response: {list_data}"
-    assert "areas" in list_data, f"Missing areas in response: {list_data}"
-    assert isinstance(list_data["areas"], list), (
-        f"Areas should be a list: {type(list_data['areas'])}"
-    )
+    assert "area_count" in list_data, f"Missing area_count in response: {list_data}"
+    areas = _flatten_areas(list_data)
+    assert isinstance(areas, list), f"Flattened areas should be a list: {type(areas)}"
 
-    logger.info(f"Found {list_data['count']} existing area(s)")
+    logger.info(f"Found {list_data['area_count']} existing area(s)")
 
 
 @pytest.mark.floor
@@ -870,19 +884,19 @@ async def test_floor_list_empty_or_populated(mcp_client):
 
     Basic validation that the list endpoint works.
     """
-    logger.info("Testing ha_list_floors functionality")
+    logger.info("Testing ha_list_floors_areas functionality")
 
-    list_result = await mcp_client.call_tool("ha_config_list_floors", {})
+    list_result = await mcp_client.call_tool("ha_list_floors_areas", {})
     list_data = parse_mcp_result(list_result)
 
     assert list_data.get("success"), f"Failed to list floors: {list_data}"
-    assert "count" in list_data, f"Missing count in response: {list_data}"
+    assert "floor_count" in list_data, f"Missing floor_count in response: {list_data}"
     assert "floors" in list_data, f"Missing floors in response: {list_data}"
     assert isinstance(list_data["floors"], list), (
         f"Floors should be a list: {type(list_data['floors'])}"
     )
 
-    logger.info(f"Found {list_data['count']} existing floor(s)")
+    logger.info(f"Found {list_data['floor_count']} existing floor(s)")
 
 
 @pytest.mark.area

--- a/tests/src/unit/test_fields_projection_docstring_completeness.py
+++ b/tests/src/unit/test_fields_projection_docstring_completeness.py
@@ -130,10 +130,10 @@ TOOL_SPECS: list[dict[str, Any]] = [
         "return_harvest": [],
     },
     {
-        "tool": "ha_config_list_areas",
-        "docstring": ("tools/tools_areas.py", "ha_config_list_areas"),
+        "tool": "ha_list_floors_areas",
+        "docstring": ("tools/tools_areas.py", "ha_list_floors_areas"),
         "var_harvest": [
-            ("tools/tools_areas.py", "ha_config_list_areas", "response"),
+            ("tools/tools_areas.py", "ha_list_floors_areas", "response"),
         ],
         "return_harvest": [],
     },

--- a/tests/src/unit/test_tools_areas.py
+++ b/tests/src/unit/test_tools_areas.py
@@ -208,106 +208,146 @@ class TestSetAreaOrFloorCrossKindRejection:
         tools._client.send_websocket_message.assert_not_called()
 
 
-class TestHaConfigListAreasFieldsProjection:
-    """Unit tests for fields= projection in ha_config_list_areas."""
+class TestListFloorsAreasFieldsProjection:
+    """Unit tests for fields= top-level projection in ha_list_floors_areas."""
 
     @pytest.fixture
     def tools(self):
         client = MagicMock()
-        client.send_websocket_message = AsyncMock(
-            return_value={
-                "success": True,
-                "result": [
-                    {"area_id": "kitchen", "name": "Kitchen"},
-                    {"area_id": "bedroom", "name": "Bedroom"},
-                ],
-            }
-        )
+
+        def _route(msg):
+            return {
+                "config/area_registry/list": {
+                    "success": True,
+                    "result": [
+                        {"area_id": "kitchen", "name": "Kitchen", "floor_id": "ground"},
+                        {"area_id": "garage", "name": "Garage", "floor_id": None},
+                    ],
+                },
+                "config/floor_registry/list": {
+                    "success": True,
+                    "result": [{"floor_id": "ground", "name": "Ground", "level": 0}],
+                },
+            }[msg["type"]]
+
+        client.send_websocket_message = AsyncMock(side_effect=_route)
         return AreaTools(client)
 
     async def test_no_fields_returns_full_response(self, tools):
-        result = await tools.ha_config_list_areas()
-        assert set(result.keys()) == {"success", "count", "areas", "message"}
+        result = await tools.ha_list_floors_areas()
+        assert set(result.keys()) == {
+            "success",
+            "floor_count",
+            "area_count",
+            "unassigned_count",
+            "orphaned_count",
+            "floors",
+            "unassigned_areas",
+            "orphaned_areas",
+            "message",
+        }
 
-    async def test_single_field_projects_to_that_key_plus_success(self, tools):
-        result = await tools.ha_config_list_areas(fields=["areas"])
-        assert set(result.keys()) == {"success", "areas"}
-        assert len(result["areas"]) == 2
+    async def test_fields_projects_top_level(self, tools):
+        result = await tools.ha_list_floors_areas(fields=["floors"])
+        assert set(result.keys()) == {"success", "floors"}
 
     async def test_multiple_fields_projects_correctly(self, tools):
-        result = await tools.ha_config_list_areas(fields=["count", "areas"])
-        assert set(result.keys()) == {"success", "count", "areas"}
-        assert result["count"] == 2
+        result = await tools.ha_list_floors_areas(fields=["floor_count", "area_count"])
+        assert set(result.keys()) == {"success", "floor_count", "area_count"}
 
-    async def test_success_always_included_regardless_of_fields(self, tools):
-        result = await tools.ha_config_list_areas(fields=["count"])
-        assert "success" in result
+    async def test_success_always_retained(self, tools):
+        result = await tools.ha_list_floors_areas(fields=["floor_count"])
         assert result["success"] is True
 
     async def test_unknown_field_emits_warning(self, tools):
-        """Unknown fields key emits a diagnostic warning instead of being silently dropped."""
-        result = await tools.ha_config_list_areas(fields=["nonexistent_key"])
+        result = await tools.ha_list_floors_areas(fields=["nonexistent_key"])
         assert result["success"] is True
         assert "warnings" in result
         assert any("nonexistent_key" in w for w in result["warnings"])
 
     async def test_bad_fields_integer_raises_tool_error(self, tools):
-        """fields=123 raises ToolError with VALIDATION_FAILED + parameter='fields'.
-
-        Covers the early-validate raise path in ``ha_config_list_areas`` so a
-        regression dropping the try/except still surfaces.
-        """
         with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_list_areas(fields=123)
+            await tools.ha_list_floors_areas(fields=123)
         error = json.loads(str(exc_info.value))
         assert error["error"]["code"] == "VALIDATION_FAILED"
         assert error.get("parameter") == "fields"
 
     async def test_bad_json_fields_raises_tool_error(self, tools):
-        """fields='[\"' (malformed JSON) raises ToolError."""
         with pytest.raises(ToolError):
-            await tools.ha_config_list_areas(fields='["')
+            await tools.ha_list_floors_areas(fields='["')
 
 
-class TestHaConfigListAreasAreaFieldsProjection:
-    """Unit tests for area_fields= per-record projection in ha_config_list_areas."""
+class TestListFloorsAreasAreaFieldsProjection:
+    """Unit tests for area_fields= per-record projection across all 3 area buckets."""
 
     @pytest.fixture
     def tools(self):
         client = MagicMock()
-        client.send_websocket_message = AsyncMock(
-            return_value={
-                "success": True,
-                "result": [
-                    {"area_id": "kitchen", "name": "Kitchen", "icon": "mdi:home"},
-                    {"area_id": "bedroom", "name": "Bedroom", "icon": None},
-                ],
-            }
-        )
+
+        def _route(msg):
+            return {
+                "config/area_registry/list": {
+                    "success": True,
+                    "result": [
+                        {
+                            "area_id": "kitchen",
+                            "name": "Kitchen",
+                            "icon": "mdi:silverware",
+                            "floor_id": "ground",
+                        },
+                        {
+                            "area_id": "garage",
+                            "name": "Garage",
+                            "icon": None,
+                            "floor_id": None,
+                        },
+                        {
+                            "area_id": "ghost",
+                            "name": "Ghost",
+                            "icon": None,
+                            "floor_id": "deleted_floor_id",
+                        },
+                    ],
+                },
+                "config/floor_registry/list": {
+                    "success": True,
+                    "result": [{"floor_id": "ground", "name": "Ground", "level": 0}],
+                },
+            }[msg["type"]]
+
+        client.send_websocket_message = AsyncMock(side_effect=_route)
         return AreaTools(client)
 
-    async def test_area_fields_projects_each_record(self, tools):
-        """area_fields=['area_id'] returns records with only that key."""
-        result = await tools.ha_config_list_areas(area_fields=["area_id"])
-        assert all(set(a.keys()) == {"area_id"} for a in result["areas"])
+    async def test_area_fields_projects_nested_areas(self, tools):
+        """Areas nested under floors are projected to only the requested keys."""
+        result = await tools.ha_list_floors_areas(area_fields=["area_id"])
+        ground = next(f for f in result["floors"] if f["floor_id"] == "ground")
+        assert all(set(a.keys()) == {"area_id"} for a in ground["areas"])
+
+    async def test_area_fields_projects_unassigned_areas(self, tools):
+        result = await tools.ha_list_floors_areas(area_fields=["area_id"])
+        assert all(set(a.keys()) == {"area_id"} for a in result["unassigned_areas"])
+
+    async def test_area_fields_projects_orphaned_areas(self, tools):
+        result = await tools.ha_list_floors_areas(area_fields=["area_id"])
+        assert all(set(a.keys()) == {"area_id"} for a in result["orphaned_areas"])
+
+    async def test_area_fields_does_not_affect_floor_records(self, tools):
+        """Floor metadata (name, level, etc.) is untouched — only area records project."""
+        result = await tools.ha_list_floors_areas(area_fields=["area_id"])
+        ground = next(f for f in result["floors"] if f["floor_id"] == "ground")
+        assert "name" in ground
+        assert "level" in ground
 
     async def test_area_fields_multiple_keys(self, tools):
-        """area_fields=['area_id','name'] returns both keys per record."""
-        result = await tools.ha_config_list_areas(area_fields=["area_id", "name"])
-        for area in result["areas"]:
+        result = await tools.ha_list_floors_areas(area_fields=["area_id", "name"])
+        ground = next(f for f in result["floors"] if f["floor_id"] == "ground")
+        for area in ground["areas"]:
             assert set(area.keys()) == {"area_id", "name"}
 
     async def test_area_fields_unknown_key_emits_warning(self, tools):
-        """area_fields with only unknown keys emits a diagnostic in warnings[].
-
-        Pins the typo-footgun guard: area_fields=["are_id"] (typo for "area_id")
-        silently produced [{}, {}] before this fix.
-        """
-        result = await tools.ha_config_list_areas(area_fields=["are_id"])
-        # Every projected record is empty
-        for area in result["areas"]:
-            assert area == {}
-        # Diagnostic warning is present and names the wrong parameter
+        """area_fields with only unknown keys emits the typo-guard warning."""
+        result = await tools.ha_list_floors_areas(area_fields=["are_id"])
         assert "warnings" in result, (
             "Expected warnings key when all projected records are empty"
         )
@@ -316,8 +356,11 @@ class TestHaConfigListAreasAreaFieldsProjection:
         )
 
     async def test_area_fields_does_not_affect_outer_response_keys(self, tools):
-        """area_fields only projects inside areas[]; top-level keys are unchanged."""
-        result = await tools.ha_config_list_areas(area_fields=["area_id"])
+        """area_fields only projects inside area records; top-level keys are unchanged."""
+        result = await tools.ha_list_floors_areas(area_fields=["area_id"])
         assert "success" in result
-        assert "count" in result
-        assert "areas" in result
+        assert "floor_count" in result
+        assert "area_count" in result
+        assert "floors" in result
+        assert "unassigned_areas" in result
+        assert "orphaned_areas" in result

--- a/tests/src/unit/test_tools_areas.py
+++ b/tests/src/unit/test_tools_areas.py
@@ -222,6 +222,11 @@ class TestListFloorsAreasFieldsProjection:
                     "result": [
                         {"area_id": "kitchen", "name": "Kitchen", "floor_id": "ground"},
                         {"area_id": "garage", "name": "Garage", "floor_id": None},
+                        {
+                            "area_id": "ghost",
+                            "name": "Ghost",
+                            "floor_id": "deleted_floor_id",
+                        },
                     ],
                 },
                 "config/floor_registry/list": {
@@ -275,6 +280,14 @@ class TestListFloorsAreasFieldsProjection:
     async def test_bad_json_fields_raises_tool_error(self, tools):
         with pytest.raises(ToolError):
             await tools.ha_list_floors_areas(fields='["')
+
+    async def test_empty_fields_list_raises_tool_error(self, tools):
+        """fields=[] is rejected with VALIDATION_FAILED, mirroring area_fields=[]."""
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_list_floors_areas(fields=[])
+        error = json.loads(str(exc_info.value))
+        assert error["error"]["code"] == "VALIDATION_FAILED"
+        assert error.get("parameter") == "fields"
 
 
 class TestListFloorsAreasAreaFieldsProjection:
@@ -346,8 +359,21 @@ class TestListFloorsAreasAreaFieldsProjection:
             assert set(area.keys()) == {"area_id", "name"}
 
     async def test_area_fields_unknown_key_emits_warning(self, tools):
-        """area_fields with only unknown keys emits the typo-guard warning."""
+        """area_fields with only unknown keys projects records to {} and emits the typo-guard warning across all 3 buckets."""
         result = await tools.ha_list_floors_areas(area_fields=["are_id"])
+        # Every projected area record is empty, regardless of bucket
+        for floor in result["floors"]:
+            for area in floor["areas"]:
+                assert area == {}, (
+                    f"Expected empty record in nested bucket, got: {area}"
+                )
+        for area in result["unassigned_areas"]:
+            assert area == {}, (
+                f"Expected empty record in unassigned bucket, got: {area}"
+            )
+        for area in result["orphaned_areas"]:
+            assert area == {}, f"Expected empty record in orphaned bucket, got: {area}"
+        # Diagnostic warning is present and names the typo'd key
         assert "warnings" in result, (
             "Expected warnings key when all projected records are empty"
         )

--- a/tests/uat/stories/catalog/s05_entity_discovery.yaml
+++ b/tests/uat/stories/catalog/s05_entity_discovery.yaml
@@ -40,7 +40,7 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_config_list_areas
+    - ha_list_floors_areas
     - ha_search_entities
   description: >
     Agent should use area listing and entity search to build a comprehensive

--- a/tests/uat/stories/catalog/s10_area_organization.yaml
+++ b/tests/uat/stories/catalog/s10_area_organization.yaml
@@ -40,7 +40,7 @@ expected:
   tools_should_use:
     - ha_set_area_or_floor
     - ha_search_entities
-    - ha_config_list_areas
+    - ha_list_floors_areas
   description: >
     Agent should create the three areas, then search for light entities,
     and present a recommendation mapping. Should use entity names to infer

--- a/tests/uat/stories/scripts/verify_story.py
+++ b/tests/uat/stories/scripts/verify_story.py
@@ -167,7 +167,7 @@ async def _mcp_call(mcp_client, tool_name: str, args: dict | None = None) -> str
 async def _check_area_exists(mcp_client, check: dict) -> dict:
     name = check["name"]
     try:
-        text = await _mcp_call(mcp_client, "ha_config_list_areas")
+        text = await _mcp_call(mcp_client, "ha_list_floors_areas")
         if name.lower() in text.lower():
             return {**check, "type": "area_exists", "passed": True, "detail": f"Found area '{name}'"}
     except Exception as e:

--- a/tests/uat/stories/scripts/verify_story.py
+++ b/tests/uat/stories/scripts/verify_story.py
@@ -40,7 +40,12 @@ async def _check_entity_exists(client: httpx.AsyncClient, check: dict) -> dict:
     result = await _retry(attempt)
     if result is not None:
         return {**check, "type": "entity_exists", **result}
-    return {**check, "type": "entity_exists", "passed": False, "detail": f"{entity_id} not found"}
+    return {
+        **check,
+        "type": "entity_exists",
+        "passed": False,
+        "detail": f"{entity_id} not found",
+    }
 
 
 async def _check_entity_state(client: httpx.AsyncClient, check: dict) -> dict:
@@ -63,10 +68,17 @@ async def _check_entity_state(client: httpx.AsyncClient, check: dict) -> dict:
         actual = r.json().get("state") if r.status_code == 200 else "not found"
     except Exception:
         actual = "not found"
-    return {**check, "type": "entity_state", "passed": False, "detail": f"expected={expected}, actual={actual}"}
+    return {
+        **check,
+        "type": "entity_state",
+        "passed": False,
+        "detail": f"expected={expected}, actual={actual}",
+    }
 
 
-async def _find_in_states(client: httpx.AsyncClient, domain: str, alias: str) -> dict | None:
+async def _find_in_states(
+    client: httpx.AsyncClient, domain: str, alias: str
+) -> dict | None:
     """Search /api/states for entity in domain whose friendly_name contains alias. Returns state dict or None."""
     r = await client.get("/api/states")
     if r.status_code != 200:
@@ -97,11 +109,18 @@ async def _check_domain_entity_exists(
     result = await _retry(attempt)
     if result is not None:
         return {**check, "type": check_type, **result}
-    return {**check, "type": check_type, "passed": False, "detail": f"No {domain} matching '{alias}'"}
+    return {
+        **check,
+        "type": check_type,
+        "passed": False,
+        "detail": f"No {domain} matching '{alias}'",
+    }
 
 
 async def _check_automation_exists(client: httpx.AsyncClient, check: dict) -> dict:
-    return await _check_domain_entity_exists(client, check, "automation", "automation_exists")
+    return await _check_domain_entity_exists(
+        client, check, "automation", "automation_exists"
+    )
 
 
 async def _check_script_exists(client: httpx.AsyncClient, check: dict) -> dict:
@@ -113,7 +132,9 @@ async def _check_script_exists(client: httpx.AsyncClient, check: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-async def _find_in_automation_config(client: httpx.AsyncClient, alias: str) -> dict | None:
+async def _find_in_automation_config(
+    client: httpx.AsyncClient, alias: str
+) -> dict | None:
     """Return the automation config dict whose alias matches, or None."""
     # Find entity via states; unique_id is in the 'id' attribute of the same state dict.
     state = await _find_in_states(client, "automation", alias)
@@ -131,26 +152,58 @@ async def _find_in_automation_config(client: httpx.AsyncClient, alias: str) -> d
         return None
 
 
-async def _check_automation_has_condition(client: httpx.AsyncClient, check: dict) -> dict:
+async def _check_automation_has_condition(
+    client: httpx.AsyncClient, check: dict
+) -> dict:
     alias = check["alias"]
     auto = await _find_in_automation_config(client, alias)
     if auto is None:
-        return {**check, "type": "automation_has_condition", "passed": False, "detail": f"Automation '{alias}' not found"}
+        return {
+            **check,
+            "type": "automation_has_condition",
+            "passed": False,
+            "detail": f"Automation '{alias}' not found",
+        }
     conditions = auto.get("condition", auto.get("conditions", []))
     if conditions:
-        return {**check, "type": "automation_has_condition", "passed": True, "detail": f"{len(conditions)} condition(s)"}
-    return {**check, "type": "automation_has_condition", "passed": False, "detail": "No conditions found"}
+        return {
+            **check,
+            "type": "automation_has_condition",
+            "passed": True,
+            "detail": f"{len(conditions)} condition(s)",
+        }
+    return {
+        **check,
+        "type": "automation_has_condition",
+        "passed": False,
+        "detail": "No conditions found",
+    }
 
 
 async def _check_automation_has_trigger(client: httpx.AsyncClient, check: dict) -> dict:
     alias = check["alias"]
     auto = await _find_in_automation_config(client, alias)
     if auto is None:
-        return {**check, "type": "automation_has_trigger", "passed": False, "detail": f"Automation '{alias}' not found"}
+        return {
+            **check,
+            "type": "automation_has_trigger",
+            "passed": False,
+            "detail": f"Automation '{alias}' not found",
+        }
     triggers = auto.get("trigger", auto.get("triggers", []))
     if triggers:
-        return {**check, "type": "automation_has_trigger", "passed": True, "detail": f"{len(triggers)} trigger(s)"}
-    return {**check, "type": "automation_has_trigger", "passed": False, "detail": "No triggers found"}
+        return {
+            **check,
+            "type": "automation_has_trigger",
+            "passed": True,
+            "detail": f"{len(triggers)} trigger(s)",
+        }
+    return {
+        **check,
+        "type": "automation_has_trigger",
+        "passed": False,
+        "detail": "No triggers found",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -169,10 +222,25 @@ async def _check_area_exists(mcp_client, check: dict) -> dict:
     try:
         text = await _mcp_call(mcp_client, "ha_list_floors_areas")
         if name.lower() in text.lower():
-            return {**check, "type": "area_exists", "passed": True, "detail": f"Found area '{name}'"}
+            return {
+                **check,
+                "type": "area_exists",
+                "passed": True,
+                "detail": f"Found area '{name}'",
+            }
     except Exception as e:
-        return {**check, "type": "area_exists", "passed": False, "detail": f"Error: {e}"}
-    return {**check, "type": "area_exists", "passed": False, "detail": f"Area '{name}' not found"}
+        return {
+            **check,
+            "type": "area_exists",
+            "passed": False,
+            "detail": f"Error: {e}",
+        }
+    return {
+        **check,
+        "type": "area_exists",
+        "passed": False,
+        "detail": f"Area '{name}' not found",
+    }
 
 
 async def _check_label_exists(mcp_client, check: dict) -> dict:
@@ -180,21 +248,53 @@ async def _check_label_exists(mcp_client, check: dict) -> dict:
     try:
         text = await _mcp_call(mcp_client, "ha_config_get_label")
         if name.lower() in text.lower():
-            return {**check, "type": "label_exists", "passed": True, "detail": f"Found label '{name}'"}
+            return {
+                **check,
+                "type": "label_exists",
+                "passed": True,
+                "detail": f"Found label '{name}'",
+            }
     except Exception as e:
-        return {**check, "type": "label_exists", "passed": False, "detail": f"Error: {e}"}
-    return {**check, "type": "label_exists", "passed": False, "detail": f"Label '{name}' not found"}
+        return {
+            **check,
+            "type": "label_exists",
+            "passed": False,
+            "detail": f"Error: {e}",
+        }
+    return {
+        **check,
+        "type": "label_exists",
+        "passed": False,
+        "detail": f"Label '{name}' not found",
+    }
 
 
 async def _check_dashboard_exists(mcp_client, check: dict) -> dict:
     url_path = check["url_path"]
     try:
-        text = await _mcp_call(mcp_client, "ha_config_get_dashboard", {"list_only": True})
+        text = await _mcp_call(
+            mcp_client, "ha_config_get_dashboard", {"list_only": True}
+        )
         if url_path in text:
-            return {**check, "type": "dashboard_exists", "passed": True, "detail": f"Found dashboard '{url_path}'"}
+            return {
+                **check,
+                "type": "dashboard_exists",
+                "passed": True,
+                "detail": f"Found dashboard '{url_path}'",
+            }
     except Exception as e:
-        return {**check, "type": "dashboard_exists", "passed": False, "detail": f"Error: {e}"}
-    return {**check, "type": "dashboard_exists", "passed": False, "detail": f"No dashboard with url_path='{url_path}'"}
+        return {
+            **check,
+            "type": "dashboard_exists",
+            "passed": False,
+            "detail": f"Error: {e}",
+        }
+    return {
+        **check,
+        "type": "dashboard_exists",
+        "passed": False,
+        "detail": f"No dashboard with url_path='{url_path}'",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -205,15 +305,35 @@ async def _check_dashboard_exists(mcp_client, check: dict) -> dict:
 def _check_response_contains(check: dict, agent_output: str) -> dict:
     value = check["value"]
     if value.lower() in agent_output.lower():
-        return {**check, "type": "response_contains", "passed": True, "detail": f"Found '{value}'"}
-    return {**check, "type": "response_contains", "passed": False, "detail": f"'{value}' not in response"}
+        return {
+            **check,
+            "type": "response_contains",
+            "passed": True,
+            "detail": f"Found '{value}'",
+        }
+    return {
+        **check,
+        "type": "response_contains",
+        "passed": False,
+        "detail": f"'{value}' not in response",
+    }
 
 
 def _check_response_matches(check: dict, agent_output: str) -> dict:
     pattern = check["pattern"]
     if re.search(pattern, agent_output):
-        return {**check, "type": "response_matches", "passed": True, "detail": f"Pattern matched: {pattern}"}
-    return {**check, "type": "response_matches", "passed": False, "detail": f"Pattern not matched: {pattern}"}
+        return {
+            **check,
+            "type": "response_matches",
+            "passed": True,
+            "detail": f"Pattern matched: {pattern}",
+        }
+    return {
+        **check,
+        "type": "response_matches",
+        "passed": False,
+        "detail": f"Pattern not matched: {pattern}",
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Removes `ha_config_list_areas` and `ha_config_list_floors`. Their functionality is now fully covered by `ha_list_floors_areas`, with the `fields=` and `area_fields=` projection params ported across (the latter applies uniformly to area records in all three buckets — nested, unassigned, orphaned).

Finishes the consolidation that PR #1016's title promised but its implementation skipped — that PR was purely additive, leaving the two flat tools alongside the new nested-topology tool. Net: 3 tools → 1.

Not a breaking change per AGENTS.md (functionality fully achievable via the combined tool, no information loss).

### What changed

- `src/ha_mcp/tools/tools_areas.py` — delete the two flat tools; add `fields=` (top-level projection) and `area_fields=` (per-area-record projection across all 3 buckets) to `ha_list_floors_areas`. Preserves the existing typo-guard warning behavior.
- `src/ha_mcp/tools/tools_config_helpers.py`, `smart_search.py` — internal refs updated.
- `tests/src/unit/test_tools_areas.py` — delete two old projection test classes; add two new ones covering projection in all 3 area buckets.
- `tests/src/unit/test_fields_projection_docstring_completeness.py` — registry entry swapped.
- `tests/src/e2e/workflows/areas/test_lifecycle.py` — 13 verification reads migrated; small `_flatten_areas` helper added to recombine the 3-bucket area shape for area-presence assertions.
- `tests/src/e2e/tools/test_search_entities.py` — docstring updated.
- `tests/uat/stories/catalog/{s05_entity_discovery,s10_area_organization}.yaml` — `expected_tools` updated.
- `tests/uat/stories/scripts/verify_story.py` — call site updated.

README, `homeassistant-addon/DOCS.md`, and `site/src/data/tools.json` auto-regenerate on merge via `sync-tool-docs.yml`.

The second commit (`chore(internal): apply ruff format to changed files`) is a pure format pass on three files that had pre-existing master drift relative to the ruff version pinned in `uv.lock` (0.15.13). CI's format check runs on changed Python files, so any touched file with drift had to be formatted.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

BAT testing intentionally deferred to the PR author under the four-metric methodology (tokens · tool-calls · wall-time · success, tool_search OFF). Pytest not run locally — Termux dev environment cannot host uv (libc detection failure); CI is authoritative.

## Checklist
- [ ] I have updated documentation if needed

(Auto-regenerated docs handle this on merge.)