### PR TITLE
test(config-subentry): mark forecast_solar e2e as known flaky + relative-import sweep

### DIFF
--- a/tests/src/e2e/workflows/automation/test_python_transform.py
+++ b/tests/src/e2e/workflows/automation/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
+from ...utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -66,9 +66,24 @@ async def test_python_transform_pattern_update(mcp_client, ha_client):
                 "alias": "Test Pattern Transform",
                 "trigger": [{"platform": "time", "at": "08:00:00"}],
                 "action": [
-                    {"alias": "Step A", "action": "light.turn_on", "target": {"entity_id": "light.a"}, "data": {"brightness": 50}},
-                    {"alias": "Step B", "action": "light.turn_on", "target": {"entity_id": "light.b"}, "data": {"brightness": 50}},
-                    {"alias": "Step C", "action": "climate.set_temperature", "target": {"entity_id": "climate.test"}, "data": {"temperature": 22}},
+                    {
+                        "alias": "Step A",
+                        "action": "light.turn_on",
+                        "target": {"entity_id": "light.a"},
+                        "data": {"brightness": 50},
+                    },
+                    {
+                        "alias": "Step B",
+                        "action": "light.turn_on",
+                        "target": {"entity_id": "light.b"},
+                        "data": {"brightness": 50},
+                    },
+                    {
+                        "alias": "Step C",
+                        "action": "climate.set_temperature",
+                        "target": {"entity_id": "climate.test"},
+                        "data": {"temperature": 22},
+                    },
                 ],
             }
         },
@@ -115,7 +130,9 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
             "config": {
                 "alias": "Test Hash Required",
                 "trigger": [{"platform": "time", "at": "09:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -176,7 +193,9 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "config": {
                 "alias": "Test Conflict",
                 "trigger": [{"platform": "time", "at": "10:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -194,7 +213,9 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "config": {
                 "alias": "Test Conflict Modified",
                 "trigger": [{"platform": "time", "at": "11:00:00"}],
-                "action": [{"action": "light.turn_off", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_off", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -222,7 +243,9 @@ async def test_python_transform_blocked_import(mcp_client, ha_client):
             "config": {
                 "alias": "Test Security",
                 "trigger": [{"platform": "time", "at": "12:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -257,7 +280,11 @@ async def test_chained_transforms(mcp_client, ha_client):
                 "alias": "Test Chain",
                 "trigger": [{"platform": "time", "at": "13:00:00"}],
                 "action": [
-                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}, "data": {"brightness": 50}},
+                    {
+                        "action": "light.turn_on",
+                        "target": {"entity_id": "light.test"},
+                        "data": {"brightness": 50},
+                    },
                 ],
             }
         },
@@ -302,7 +329,9 @@ async def test_returned_hash_matches_next_get(mcp_client, ha_client):
             "config": {
                 "alias": "Test Hash Match",
                 "trigger": [{"platform": "time", "at": "14:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -339,7 +368,9 @@ async def test_transform_invalid_config_rejected(mcp_client, ha_client):
             "config": {
                 "alias": "Test Invalid Transform",
                 "trigger": [{"platform": "time", "at": "15:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -409,7 +440,9 @@ async def test_plural_key_hash_stability(mcp_client, ha_client):
             "config": {
                 "alias": "Test Plural Keys",
                 "triggers": [{"platform": "time", "at": "17:00:00"}],
-                "actions": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "actions": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -447,7 +480,9 @@ async def test_full_config_update_with_config_hash(mcp_client, ha_client):
             "config": {
                 "alias": "Test Full Hash",
                 "trigger": [{"platform": "time", "at": "18:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -466,7 +501,9 @@ async def test_full_config_update_with_config_hash(mcp_client, ha_client):
             "config": {
                 "alias": "Full Hash Updated",
                 "trigger": [{"platform": "time", "at": "18:30:00"}],
-                "action": [{"action": "light.turn_off", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_off", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -483,7 +520,9 @@ async def test_full_config_update_with_stale_hash(mcp_client, ha_client):
             "config": {
                 "alias": "Test Full Stale",
                 "trigger": [{"platform": "time", "at": "19:00:00"}],
-                "action": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "action": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             }
         },
     )
@@ -525,7 +564,9 @@ async def test_full_config_update_with_stale_hash(mcp_client, ha_client):
 
 
 @pytest.mark.asyncio
-async def test_categorized_automation_transform_preserves_category(mcp_client, ha_client):
+async def test_categorized_automation_transform_preserves_category(
+    mcp_client, ha_client
+):
     """Test that python_transform on a categorized automation preserves the category.
 
     Regression test for blocker #1: category must be popped before upsert
@@ -548,7 +589,11 @@ async def test_categorized_automation_transform_preserves_category(mcp_client, h
                 "alias": "Test Categorized Transform",
                 "trigger": [{"platform": "time", "at": "21:00:00"}],
                 "action": [
-                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}, "data": {"brightness": 50}},
+                    {
+                        "action": "light.turn_on",
+                        "target": {"entity_id": "light.test"},
+                        "data": {"brightness": 50},
+                    },
                 ],
             },
             "category": category_id,

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -13,8 +13,8 @@ import logging
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import assert_mcp_success, safe_call_tool
-from tests.src.e2e.utilities.wait_helpers import wait_for_tool_result
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +58,20 @@ class TestConfigEntryFlow:
         """Create a min_max helper (single form step, no menu)."""
         config = {
             "name": "test_min_max_e2e",
-            "entity_ids": ["sensor.demo_temperature", "sensor.demo_outside_temperature"],
+            "entity_ids": [
+                "sensor.demo_temperature",
+                "sensor.demo_outside_temperature",
+            ],
             "type": "min",
         }
-        entry_id = await _create_config_entry_helper(mcp_client, "min_max", config, "min_max helper")
+        entry_id = await _create_config_entry_helper(
+            mcp_client, "min_max", config, "min_max helper"
+        )
 
         await safe_call_tool(
-            mcp_client, "ha_delete_helpers_integrations", {"target": entry_id, "confirm": True}
+            mcp_client,
+            "ha_delete_helpers_integrations",
+            {"target": entry_id, "confirm": True},
         )
 
     async def test_create_group_helper_light(self, mcp_client):
@@ -75,10 +82,14 @@ class TestConfigEntryFlow:
             "entities": [],  # empty list is valid
             "hide_members": False,
         }
-        entry_id = await _create_config_entry_helper(mcp_client, "group", config, "light group helper")
+        entry_id = await _create_config_entry_helper(
+            mcp_client, "group", config, "light group helper"
+        )
 
         await safe_call_tool(
-            mcp_client, "ha_delete_helpers_integrations", {"target": entry_id, "confirm": True}
+            mcp_client,
+            "ha_delete_helpers_integrations",
+            {"target": entry_id, "confirm": True},
         )
 
     async def test_create_template_sensor(self, mcp_client):
@@ -88,10 +99,14 @@ class TestConfigEntryFlow:
             "name": "test_template_sensor_e2e",
             "state": "{{ states('sun.sun') }}",
         }
-        entry_id = await _create_config_entry_helper(mcp_client, "template", config, "template sensor")
+        entry_id = await _create_config_entry_helper(
+            mcp_client, "template", config, "template sensor"
+        )
 
         await safe_call_tool(
-            mcp_client, "ha_delete_helpers_integrations", {"target": entry_id, "confirm": True}
+            mcp_client,
+            "ha_delete_helpers_integrations",
+            {"target": entry_id, "confirm": True},
         )
 
     async def test_create_template_binary_sensor(self, mcp_client):
@@ -106,7 +121,9 @@ class TestConfigEntryFlow:
         )
 
         await safe_call_tool(
-            mcp_client, "ha_delete_helpers_integrations", {"target": entry_id, "confirm": True}
+            mcp_client,
+            "ha_delete_helpers_integrations",
+            {"target": entry_id, "confirm": True},
         )
 
     async def test_update_min_max_helper(self, mcp_client):
@@ -122,7 +139,10 @@ class TestConfigEntryFlow:
 
         # Update via options flow
         updated_config = {
-            "entity_ids": ["sensor.demo_temperature", "sensor.demo_outside_temperature"],
+            "entity_ids": [
+                "sensor.demo_temperature",
+                "sensor.demo_outside_temperature",
+            ],
             "type": "max",
         }
         update_result = await mcp_client.call_tool(
@@ -154,7 +174,9 @@ class TestConfigEntryFlow:
             None,
         )
         if entry is None:
-            pytest.skip("No config entries with supports_options=true in test environment")
+            pytest.skip(
+                "No config entries with supports_options=true in test environment"
+            )
 
         result = await mcp_client.call_tool(
             "ha_get_integration",
@@ -164,7 +186,9 @@ class TestConfigEntryFlow:
         assert "options_schema" in data, "Expected options_schema in response"
         schema = data["options_schema"]
         assert schema.get("flow_type") in ("form", "menu")
-        logger.info(f"options_schema flow_type={schema['flow_type']} for {entry['domain']}")
+        logger.info(
+            f"options_schema flow_type={schema['flow_type']} for {entry['domain']}"
+        )
 
     async def test_create_group_helper_missing_menu_selection(self, mcp_client):
         """Creating a group helper without group_type returns a helpful error

--- a/tests/src/e2e/workflows/config/test_config_subentries.py
+++ b/tests/src/e2e/workflows/config/test_config_subentries.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/src/e2e/workflows/config/test_config_subentries.py
+++ b/tests/src/e2e/workflows/config/test_config_subentries.py
@@ -40,11 +40,18 @@ def _find_forecast_plane(
 @pytest.mark.asyncio
 @pytest.mark.config
 @pytest.mark.slow
+@pytest.mark.flaky(reruns=2, reruns_delay=10)
 async def test_forecast_solar_config_subentry_create_list_delete(
     mcp_client: Any,
     ha_client: Any,
 ) -> None:
-    """Create, list, and delete a Forecast.Solar plane config subentry."""
+    """Create, list, and delete a Forecast.Solar plane config subentry.
+
+    Flaky on the inaddon HAOS runner: ``submit_config_flow_step`` for
+    the initial entry create has been observed hitting the 30s client
+    timeout. Retried up to 3x to absorb the transient; a genuine
+    regression will still fail all attempts.
+    """
     unique = uuid.uuid4().hex[:8]
     entry_id: str | None = None
     subentry_id: str | None = None
@@ -139,9 +146,9 @@ async def test_forecast_solar_config_subentry_create_list_delete(
         assert isinstance(after_subentries, list), (
             f"Expected subentries list after delete: {after_data}"
         )
-        assert _find_forecast_plane(
-            after_subentries, modules_power=modules_power
-        ) is None
+        assert (
+            _find_forecast_plane(after_subentries, modules_power=modules_power) is None
+        )
     finally:
         if entry_id and subentry_id:
             await safe_call_tool(

--- a/tests/src/e2e/workflows/dashboards/__init__.py
+++ b/tests/src/e2e/workflows/dashboards/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests for Home Assistant dashboard management tools."""

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 # Import test utilities
-from tests.src.e2e.utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.assertions import MCPAssertions, safe_call_tool
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -214,7 +214,11 @@ class TestDashboardLifecycle:
         # The key assertion: error must NOT be about hyphens
         if not data.get("success", False):
             error = data.get("error", {})
-            error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+            error_msg = (
+                error.get("message", str(error))
+                if isinstance(error, dict)
+                else str(error)
+            )
             assert "hyphen" not in error_msg.lower(), (
                 f"'lovelace' should not be rejected by hyphen validation, got: {error_msg}"
             )
@@ -227,7 +231,11 @@ class TestDashboardLifecycle:
         )
         if not data.get("success", False):
             error = data.get("error", {})
-            error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+            error_msg = (
+                error.get("message", str(error))
+                if isinstance(error, dict)
+                else str(error)
+            )
             assert "hyphen" not in error_msg.lower(), (
                 f"'default' should not be rejected by hyphen validation, got: {error_msg}"
             )
@@ -240,7 +248,9 @@ class TestDashboardLifecycle:
         )
         assert data["success"] is False
         error = data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "hyphen" in error_msg.lower()
 
         logger.info("Default dashboard hyphen validation test completed successfully")
@@ -405,7 +415,9 @@ class TestDashboardIdentifierResolution:
             {
                 "url_path": "test-981-get-by-id",
                 "title": "Get by id",
-                "config": {"views": [{"cards": [{"type": "markdown", "content": "hi"}]}]},
+                "config": {
+                    "views": [{"cards": [{"type": "markdown", "content": "hi"}]}]
+                },
             },
         )
         internal_id = create_data["dashboard_id"]
@@ -433,7 +445,9 @@ class TestDashboardIdentifierResolution:
             {
                 "url_path": "test-981-set-by-id",
                 "title": "Set by id",
-                "config": {"views": [{"cards": [{"type": "markdown", "content": "v1"}]}]},
+                "config": {
+                    "views": [{"cards": [{"type": "markdown", "content": "v1"}]}]
+                },
             },
         )
         internal_id = create_data["dashboard_id"]
@@ -477,7 +491,9 @@ class TestDashboardIdentifierResolution:
             {
                 "url_path": "test-981-mixed-hash",
                 "title": "Mixed identifier hash",
-                "config": {"views": [{"cards": [{"type": "markdown", "content": "x"}]}]},
+                "config": {
+                    "views": [{"cards": [{"type": "markdown", "content": "x"}]}]
+                },
             },
         )
         internal_id = create_data["dashboard_id"]
@@ -640,4 +656,3 @@ class TestFindCard:
                 "ha_config_delete_dashboard",
                 {"url_path": "test-find-type"},
             )
-

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 # Import test utilities
-from ...utilities.assertions import MCPAssertions, safe_call_tool
+from ...utilities.assertions import MCPAssertions, extract_error_message, safe_call_tool
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -213,12 +213,7 @@ class TestDashboardLifecycle:
         )
         # The key assertion: error must NOT be about hyphens
         if not data.get("success", False):
-            error = data.get("error", {})
-            error_msg = (
-                error.get("message", str(error))
-                if isinstance(error, dict)
-                else str(error)
-            )
+            error_msg = extract_error_message(data)
             assert "hyphen" not in error_msg.lower(), (
                 f"'lovelace' should not be rejected by hyphen validation, got: {error_msg}"
             )
@@ -230,12 +225,7 @@ class TestDashboardLifecycle:
             {"url_path": "default", "title": "Default Dashboard"},
         )
         if not data.get("success", False):
-            error = data.get("error", {})
-            error_msg = (
-                error.get("message", str(error))
-                if isinstance(error, dict)
-                else str(error)
-            )
+            error_msg = extract_error_message(data)
             assert "hyphen" not in error_msg.lower(), (
                 f"'default' should not be rejected by hyphen validation, got: {error_msg}"
             )
@@ -247,10 +237,7 @@ class TestDashboardLifecycle:
             {"url_path": "nodash", "title": "Invalid Dashboard"},
         )
         assert data["success"] is False
-        error = data.get("error", {})
-        error_msg = (
-            error.get("message", str(error)) if isinstance(error, dict) else str(error)
-        )
+        error_msg = extract_error_message(data)
         assert "hyphen" in error_msg.lower()
 
         logger.info("Default dashboard hyphen validation test completed successfully")

--- a/tests/src/e2e/workflows/dashboards/test_python_transform.py
+++ b/tests/src/e2e/workflows/dashboards/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
+from ...utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -19,7 +19,11 @@ async def test_python_transform_simple_update(mcp_client, ha_client):
                 "views": [
                     {
                         "cards": [
-                            {"type": "button", "entity": "light.test", "icon": "mdi:lamp"}
+                            {
+                                "type": "button",
+                                "entity": "light.test",
+                                "icon": "mdi:lamp",
+                            }
                         ]
                     }
                 ]
@@ -145,7 +149,8 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
     mcp = MCPAssertions(mcp_client)
 
     await mcp.call_tool_success(
-        "ha_config_set_dashboard", {"url_path": "test-python-hash", "config": {"views": []}}
+        "ha_config_set_dashboard",
+        {"url_path": "test-python-hash", "config": {"views": []}},
     )
 
     # Try without config_hash - should fail
@@ -174,7 +179,10 @@ async def test_python_transform_mutual_exclusivity(mcp_client, ha_client):
     )
     # Verify error message mentions mutual exclusivity
     error_msg = extract_error_message(result)
-    assert "cannot use both" in error_msg.lower() or "mutually exclusive" in error_msg.lower()
+    assert (
+        "cannot use both" in error_msg.lower()
+        or "mutually exclusive" in error_msg.lower()
+    )
 
 
 @pytest.mark.asyncio
@@ -334,8 +342,15 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
                     {
                         "title": "View 1",
                         "cards": [
-                            {"type": "button", "entity": "light.test_a", "icon": "mdi:lamp"},
-                            {"type": "entities", "entities": ["light.test_b", "switch.test_c"]},
+                            {
+                                "type": "button",
+                                "entity": "light.test_a",
+                                "icon": "mdi:lamp",
+                            },
+                            {
+                                "type": "entities",
+                                "entities": ["light.test_b", "switch.test_c"],
+                            },
                         ],
                     },
                     {
@@ -543,13 +558,7 @@ async def test_python_transform_returns_authoritative_post_save_hash(
             {
                 "url_path": url_path,
                 "config": {
-                    "views": [
-                        {
-                            "cards": [
-                                {"type": "markdown", "content": "v1"}
-                            ]
-                        }
-                    ]
+                    "views": [{"cards": [{"type": "markdown", "content": "v1"}]}]
                 },
             },
         )

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -18,6 +18,7 @@ import logging
 # Import test utilities
 from ...utilities.assertions import (
     MCPAssertions,
+    extract_error_message,
     safe_call_tool,
 )
 
@@ -521,10 +522,7 @@ class TestInlineDashboardResource:
             {"content": ""},
         )
         assert data["success"] is False
-        error = data.get("error", {})
-        error_msg = (
-            error.get("message", str(error)) if isinstance(error, dict) else str(error)
-        )
+        error_msg = extract_error_message(data)
         assert "empty" in error_msg.lower()
 
         logger.info("Inline empty content error test completed successfully")

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -16,7 +16,7 @@ production-level functionality and compatibility.
 import logging
 
 # Import test utilities
-from tests.src.e2e.utilities.assertions import (
+from ...utilities.assertions import (
     MCPAssertions,
     safe_call_tool,
 )
@@ -89,7 +89,6 @@ class TestDashboardResourceLifecycle:
         assert update_data["success"] is True
         assert update_data["action"] == "updated"
 
-
         # 5. Verify update was applied
         logger.info("Verifying resource update...")
         list_after_update = await mcp.call_tool_success(
@@ -114,7 +113,6 @@ class TestDashboardResourceLifecycle:
         )
         assert delete_data["success"] is True
         assert delete_data["action"] == "delete"
-
 
         # 7. Verify deletion
         logger.info("Verifying resource deletion...")
@@ -166,7 +164,6 @@ class TestDashboardResourceLifecycle:
             assert css_data["resource_type"] == "css"
             created_ids.append(css_data.get("resource_id"))
 
-
             # Verify by_type categorization
             list_data = await mcp.call_tool_success(
                 "ha_config_list_dashboard_resources", {}
@@ -200,7 +197,6 @@ class TestDashboardResourceLifecycle:
             resource_id = add_data.get("resource_id")
             assert resource_id is not None
 
-
             # Update to module type
             update_data = await mcp.call_tool_success(
                 "ha_config_set_dashboard_resource",
@@ -212,7 +208,6 @@ class TestDashboardResourceLifecycle:
             )
             assert update_data["success"] is True
             assert update_data["action"] == "updated"
-
 
             # Verify type was changed
             list_data = await mcp.call_tool_success(
@@ -319,7 +314,6 @@ class TestDashboardResourceList:
         resource_id = add_data.get("resource_id")
 
         try:
-
             list_data = await mcp.call_tool_success(
                 "ha_config_list_dashboard_resources", {}
             )
@@ -528,7 +522,9 @@ class TestInlineDashboardResource:
         )
         assert data["success"] is False
         error = data.get("error", {})
-        error_msg = error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg = (
+            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        )
         assert "empty" in error_msg.lower()
 
         logger.info("Inline empty content error test completed successfully")
@@ -548,7 +544,6 @@ class TestInlineDashboardResource:
 
         try:
             assert create_data["action"] == "created"
-
 
             # Update with new content
             content_v2 = "const VERSION = 2; // Updated"

--- a/tests/src/e2e/workflows/entities/__init__.py
+++ b/tests/src/e2e/workflows/entities/__init__.py
@@ -1,0 +1,1 @@
+"""E2E tests for Home Assistant entity management tools."""

--- a/tests/src/e2e/workflows/entities/test_entity_management.py
+++ b/tests/src/e2e/workflows/entities/test_entity_management.py
@@ -6,8 +6,8 @@ import logging
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import assert_mcp_success, safe_call_tool
-from tests.src.e2e.utilities.cleanup import (
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.cleanup import (
     TestEntityCleaner as EntityCleaner,
 )
 
@@ -469,8 +469,12 @@ class TestEntityManagement:
 
         # Verify both entities are present
         returned_entity_ids = {e.get("entity_id") for e in entity_entries}
-        assert entity_id1 in returned_entity_ids, f"entity_id1 missing: {entity_entries}"
-        assert entity_id2 in returned_entity_ids, f"entity_id2 missing: {entity_entries}"
+        assert entity_id1 in returned_entity_ids, (
+            f"entity_id1 missing: {entity_entries}"
+        )
+        assert entity_id2 in returned_entity_ids, (
+            f"entity_id2 missing: {entity_entries}"
+        )
 
         # Verify each entry has expected fields
         for entry in entity_entries:
@@ -499,7 +503,9 @@ class TestEntityManagement:
 
         assert not data.get("success", True), "Should fail for non-existent entity"
         assert "error" in data, f"Missing error field: {data}"
-        assert data.get("error", {}).get("suggestions"), f"Missing suggestions field: {data}"
+        assert data.get("error", {}).get("suggestions"), (
+            f"Missing suggestions field: {data}"
+        )
 
         logger.info("Non-existent entity error handling verified")
 
@@ -512,7 +518,9 @@ class TestEntityManagement:
         data = assert_mcp_success(result, "Get entity with empty list")
 
         assert data.get("count") == 0, f"Expected count=0, got: {data}"
-        assert data.get("entity_entries") == [], f"Expected empty entity_entries: {data}"
+        assert data.get("entity_entries") == [], (
+            f"Expected empty entity_entries: {data}"
+        )
         assert data.get("message") == "No entities requested", (
             f"Expected 'No entities requested' message: {data}"
         )
@@ -546,7 +554,9 @@ class TestEntityManagement:
         get_data = assert_mcp_success(get_result, "Get entity partial success")
 
         # Verify partial success
-        assert get_data.get("count") == 1, f"Expected count=1 (partial), got: {get_data}"
+        assert get_data.get("count") == 1, (
+            f"Expected count=1 (partial), got: {get_data}"
+        )
 
         entity_entries = get_data.get("entity_entries", [])
         assert len(entity_entries) == 1, f"Expected 1 entry: {entity_entries}"

--- a/tests/src/e2e/workflows/entities/test_entity_remove.py
+++ b/tests/src/e2e/workflows/entities/test_entity_remove.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.assertions import assert_mcp_success, safe_call_tool
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,9 @@ class TestEntityRemove:
             {"entity_id": entity_id},
         )
         remove_data = assert_mcp_success(remove_result, "Remove entity")
-        assert remove_data.get("success") is True, f"Expected success, got: {remove_data}"
+        assert remove_data.get("success") is True, (
+            f"Expected success, got: {remove_data}"
+        )
         assert remove_data.get("entity_id") == entity_id
 
         logger.info(f"Entity removed successfully: {entity_id}")

--- a/tests/src/e2e/workflows/entities/test_show_as.py
+++ b/tests/src/e2e/workflows/entities/test_show_as.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from fastmcp.exceptions import ToolError
 
-from tests.src.e2e.utilities.assertions import assert_mcp_success
+from ...utilities.assertions import assert_mcp_success
 
 logger = logging.getLogger(__name__)
 

--- a/tests/src/e2e/workflows/integrations/test_integration_management.py
+++ b/tests/src/e2e/workflows/integrations/test_integration_management.py
@@ -6,11 +6,11 @@ import logging
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import (
+from ...utilities.assertions import (
     assert_mcp_success,
     safe_call_tool,
 )
-from tests.src.e2e.utilities.wait_helpers import wait_for_tool_result
+from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
 

--- a/tests/src/e2e/workflows/scripts/test_python_transform.py
+++ b/tests/src/e2e/workflows/scripts/test_python_transform.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.src.e2e.utilities.assertions import MCPAssertions, extract_error_message
+from ...utilities.assertions import MCPAssertions, extract_error_message
 
 
 @pytest.mark.asyncio
@@ -65,7 +65,9 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
         {
             "script_id": "test_py_hash_req",
             "config": {
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -109,7 +111,9 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "script_id": "test_py_conflict",
             "config": {
                 "alias": "Test Conflict",
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -125,7 +129,9 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
             "script_id": "test_py_conflict",
             "config": {
                 "alias": "Test Conflict Modified",
-                "sequence": [{"action": "light.turn_off", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_off", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -152,7 +158,9 @@ async def test_python_transform_blocked_import(mcp_client, ha_client):
         {
             "script_id": "test_py_security",
             "config": {
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -221,7 +229,11 @@ async def test_chained_transforms(mcp_client, ha_client):
             "config": {
                 "alias": "Chain Test",
                 "sequence": [
-                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}, "data": {"brightness": 50}},
+                    {
+                        "action": "light.turn_on",
+                        "target": {"entity_id": "light.test"},
+                        "data": {"brightness": 50},
+                    },
                 ],
             },
         },
@@ -265,7 +277,9 @@ async def test_returned_hash_matches_next_get(mcp_client, ha_client):
             "script_id": "test_hash_match",
             "config": {
                 "alias": "Hash Match Test",
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -301,7 +315,9 @@ async def test_transform_invalid_config_rejected(mcp_client, ha_client):
             "script_id": "test_invalid_transform",
             "config": {
                 "alias": "Invalid Transform Test",
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -334,7 +350,9 @@ async def test_full_config_update_with_config_hash(mcp_client, ha_client):
             "script_id": "test_full_hash",
             "config": {
                 "alias": "Full Hash Test",
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -351,7 +369,9 @@ async def test_full_config_update_with_config_hash(mcp_client, ha_client):
             "config_hash": get_result["config_hash"],
             "config": {
                 "alias": "Full Hash Updated",
-                "sequence": [{"action": "light.turn_off", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_off", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )
@@ -368,7 +388,9 @@ async def test_full_config_update_with_stale_hash(mcp_client, ha_client):
             "script_id": "test_full_stale",
             "config": {
                 "alias": "Full Stale Test",
-                "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.test"}}],
+                "sequence": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.test"}}
+                ],
             },
         },
     )


### PR DESCRIPTION
## What does this PR do?

Primary: marks `test_forecast_solar_config_subentry_create_list_delete` as known flaky.

The test has been observed timing out at the 30s client budget on the inaddon HAOS runner during the initial `submit_config_flow_step` POST. Most recent occurrence: PR #1424 run 26365894260 (the non-inaddon HAOS E2E job passed on identical code).

Applies `@pytest.mark.flaky(reruns=2, reruns_delay=10)` to the test, matching the precedent from #1426. The test now gets 3 attempts with a 10s pause between — absorbs the transient, still surfaces a genuine persistent regression as a failure across all 3.

Boy-scouted along the way:

- **Relative-import sweep** (10 additional e2e test files): switched `from tests.src.e2e.utilities.X` to `from ...utilities.X` per AGENTS.md line 870. The absolute form only resolves under pytest's runtime sys.path manipulation, so pyright/pylance was flagging it as unresolved on every affected file — breaking IDE click-through, find-references, and autocomplete. CI was unaffected (mypy is `src/`-scoped, ruff doesn't enforce import style, no pyright job), but developer ergonomics were degraded across 10 files. Now consistent with the rest of the e2e suite.
- **Missing `__init__.py`** added to `tests/src/e2e/workflows/dashboards/` and `tests/src/e2e/workflows/entities/` — the only two `workflows/` subdirs missing it (22 others have one). The previous absolute imports were a workaround for these dirs not being proper packages; the relative-import sweep surfaced the latent bug as `ImportError: attempted relative import with no known parent package` in the first CI run.
- **ruff format drift** on 8 of the touched files, required by CI's per-file `ruff format --check` policy (mostly long-dict-literal expansion).
- **`extract_error_message` helper adoption** (`tests/src/e2e/workflows/dashboards/test_lifecycle.py` × 3 sites, `test_resources.py` × 1 site) replacing manual 4-line `error.get("message", str(error))` blocks with the project's existing helper from `tests/src/e2e/utilities/assertions.py:17`. Same pattern still exists in ~10 sites across 3 untouched files (`test_backup.py`, `test_device_registry.py`, `test_system_tools.py`) — separate cleanup.

## Type of change
- [x] 🧪 Tests only

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check` + `ruff format --check`)

## Checklist
- [x] I have updated documentation if needed