### PR TITLE
fix(backup): post-timeout match correctness + state-gate (closes #1433)

### DIFF
--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -18,7 +18,7 @@ HA restore path. Each call must explicitly pick its scope.
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 
 from fastmcp.exceptions import ToolError
@@ -41,8 +41,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_BACKUP_MAX_WAIT_S = 120
+# Default poll window for full HA backups. The 120s prior default underfit
+# slow HA instances (#1433: poll loop exited while HA was still in
+# state="create_backup", the wrapper treated that as failure, retried, and
+# produced duplicate backups). 300s covers the long tail without making the
+# happy-path wait noticeable.
+_BACKUP_MAX_WAIT_S = 300
 _BACKUP_POLL_INTERVAL_S = 2
+# Clock-skew tolerance when filtering backup entries by date vs job-start.
+_BACKUP_DATE_FILTER_TOLERANCE_S = 5
 
 
 def _get_backup_hint_text() -> str:
@@ -171,6 +178,21 @@ async def _get_backup_password(
     return cast(str, default_password)
 
 
+def _parse_backup_date(raw: Any) -> datetime | None:
+    """Parse an HA backup `date` (ISO-8601, may use `Z` suffix) to a tz-aware
+    datetime, returning None on missing/malformed input. Naive timestamps are
+    treated as UTC."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
 def _build_success_response_if_found(
     info_result: dict[str, Any],
     *,
@@ -178,27 +200,71 @@ def _build_success_response_if_found(
     backup_job_id: str,
     agent_id: str,
     duration_seconds: int,
+    job_start_ts: datetime,
 ) -> dict[str, Any] | None:
-    """Return the canonical success-response dict if a backup with ``name``
-    is present in ``info_result['result']['backups']``, else None.
+    """Return the canonical success-response dict, or None.
 
-    Single source of truth for the success shape — called both from the
-    in-loop branch (when state=idle+completed is observed) and from the
-    post-timeout final check (#1433).
+    Single source of truth for "did this backup actually complete cleanly?".
+    Called from both the in-loop branch and the post-timeout final check.
+
+    Returns None unless ALL of:
+
+    * `result.state == "idle"` AND `result.last_action_event.state == "completed"`
+      — list-membership alone is insufficient because HA registers the entry in
+      `backups` before compression/encryption finish; claiming success on a
+      half-written entry would let callers immediately attempt restore on a
+      partial file. The state-gate enforces "fully finalized".
+    * The match resolves to *this* job, not a stale prior-run entry with the
+      same name (HA does not enforce unique backup names, and the post-timeout
+      window is exactly when collisions are likely after a retry). Filters to
+      entries with `name == name` AND `date >= job_start_ts - tolerance`,
+      then within that fresh set prefers a `last_action_event.backup_id`
+      match if HA exposes one, otherwise picks the newest by date.
     """
-    backups = info_result.get("result", {}).get("backups") or []
-    created_backup = next((b for b in backups if b.get("name") == name), None)
-    if created_backup is None:
+    result_block = info_result.get("result") or {}
+    state = result_block.get("state")
+    last_event = result_block.get("last_action_event") or {}
+    if state != "idle" or last_event.get("state") != "completed":
         return None
+
+    backups = result_block.get("backups") or []
+
+    # Freshness gate applies uniformly — both the `last_action_event.backup_id`
+    # path and the name-only fallback are constrained to entries dated
+    # at-or-after the job start. Without this, a concurrent backup (e.g. UI-
+    # triggered) updating `last_action_event` between our last in-loop poll
+    # and the post-timeout lookup could let us match its entry as if it were
+    # ours.
+    tolerance = timedelta(seconds=_BACKUP_DATE_FILTER_TOLERANCE_S)
+    cutoff = job_start_ts - tolerance
+    fresh = [
+        b
+        for b in backups
+        if b.get("name") == name
+        and (entry_date := _parse_backup_date(b.get("date"))) is not None
+        and entry_date >= cutoff
+    ]
+    if not fresh:
+        return None
+
+    target_id = last_event.get("backup_id") or last_event.get("backup_job_id")
+    authoritative = (
+        next((b for b in fresh if b.get("backup_id") == target_id), None)
+        if target_id
+        else None
+    )
+    match = authoritative or max(
+        fresh,
+        key=lambda b: _parse_backup_date(b.get("date")) or job_start_ts,
+    )
+
     return {
         "success": True,
-        "backup_id": created_backup.get("backup_id"),
+        "backup_id": match.get("backup_id"),
         "backup_job_id": backup_job_id,
         "name": name,
-        "date": created_backup.get("date"),
-        "size_bytes": (created_backup.get("agents") or {})
-        .get(agent_id, {})
-        .get("size"),
+        "date": match.get("date"),
+        "size_bytes": (match.get("agents") or {}).get(agent_id, {}).get("size"),
         "status": "Backup completed successfully",
         "duration_seconds": duration_seconds,
         "note": "Backup uses your Home Assistant's default backup password",
@@ -219,17 +285,18 @@ async def _poll_backup_completion(
     ``hassio.local`` on Supervised, ``backup.local`` on Core); used to look
     up the per-agent size in the backup-info payload.
 
-    On timeout, performs one final ``backup/info`` lookup before raising:
-    if a backup matching ``name`` is in the list, returns the success
-    response with a ``warnings`` entry noting the late detection (#1433).
-    The polling loop can exit before observing ``state=idle`` even when
-    HA is producing the backup successfully — slow disks, slow HA core,
-    or congestion can stretch a real backup past ``max_wait_seconds``.
-    Raising ``TIMEOUT_OPERATION`` in that case is silent-failure-as-failure;
-    callers wrapping ``ha_manage_backup`` retry and produce duplicates.
+    On timeout, performs one final ``backup/info`` lookup before raising. If
+    that lookup confirms `state=idle` + `event_state=completed` AND finds a
+    backup belonging to *this* job (by ``last_action_event.backup_id`` or
+    fresh date-window name-match), returns the success response with a
+    ``warnings`` entry noting the late detection (#1433). Otherwise raises
+    ``TIMEOUT_OPERATION`` — and if the entry exists but state still indicates
+    creation in progress, surfaces ``likely_in_progress=true`` in the error
+    context so callers can back off retries instead of compounding duplicates.
 
     Raises ToolError on backup failure or final timeout with no completion.
     """
+    job_start_ts = datetime.now(UTC)
     waited = 0
 
     while waited < max_wait_seconds:
@@ -237,65 +304,74 @@ async def _poll_backup_completion(
         waited += poll_interval
 
         info_result = await ws_client.send_command("backup/info")
-        if info_result.get("success"):
-            state = info_result.get("result", {}).get("state")
-            last_event = info_result.get("result", {}).get("last_action_event", {})
-            event_state = last_event.get("state")
-
+        if not info_result.get("success"):
             logger.debug(
-                f"Backup state: {state}, event_state: {event_state}, waited: {waited}s"
+                f"backup/info returned success=False at waited={waited}s; retrying"
+            )
+            continue
+
+        result_block = info_result.get("result") or {}
+        last_event = result_block.get("last_action_event") or {}
+        event_state = last_event.get("state")
+        logger.debug(
+            f"Backup state: {result_block.get('state')}, "
+            f"event_state: {event_state}, waited: {waited}s"
+        )
+
+        if event_state == "failed":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Backup creation failed",
+                    context={"backup_job_id": backup_job_id},
+                )
             )
 
-            if state == "idle" and event_state == "completed":
-                response = _build_success_response_if_found(
-                    info_result,
-                    name=name,
-                    backup_job_id=backup_job_id,
-                    agent_id=agent_id,
-                    duration_seconds=waited,
-                )
-                if response is not None:
-                    logger.info(
-                        f"Backup completed successfully: {response['backup_id']}"
-                    )
-                    return response
-                logger.warning(
-                    "Backup completed but not found in backup list yet, waiting..."
-                )
-                continue
-
-            elif event_state == "failed":
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        "Backup creation failed",
-                        context={"backup_job_id": backup_job_id},
-                    )
-                )
+        response = _build_success_response_if_found(
+            info_result,
+            name=name,
+            backup_job_id=backup_job_id,
+            agent_id=agent_id,
+            duration_seconds=waited,
+            job_start_ts=job_start_ts,
+        )
+        if response is not None:
+            logger.info(f"Backup completed successfully: {response['backup_id']}")
+            return response
+        # state=idle+completed observed but entry not yet (or not freshly) in
+        # the list — same bug class as #1433 one tick earlier; continue polling.
 
     logger.info(
-        f"Backup did not reach state=idle within {max_wait_seconds}s; "
+        f"Backup did not complete within {max_wait_seconds}s; "
         "performing final backup-list lookup before raising timeout"
     )
-    # send_command raises on failure rather than returning success=false; treat
-    # any HA-side error during this best-effort verification as "couldn't
-    # verify" and fall through to the original timeout signal rather than
-    # letting an unrelated WebSocket error mask it. Programming errors
-    # (AttributeError, TypeError, KeyError) intentionally propagate.
+    # send_command raises on HA-side failure rather than returning
+    # success=false. Treat any `HomeAssistantError` (incl. AuthError,
+    # ConnectionError, CommandError) during this best-effort verification
+    # as "couldn't verify"; surface the failure in the error context via
+    # `verification_error` so the auth-case stops being invisible behind a
+    # misleading TIMEOUT_OPERATION. Programming errors (AttributeError,
+    # TypeError, KeyError) intentionally propagate.
+    verification_error: str | None = None
+    likely_in_progress = False
+    final_info: dict[str, Any] | None = None
     try:
         final_info = await ws_client.send_command("backup/info")
     except HomeAssistantError as e:
+        verification_error = repr(e)
         logger.warning(
             f"Post-timeout backup/info lookup failed ({e!r}); "
             "falling through to TIMEOUT_OPERATION"
         )
-    else:
+
+    if final_info is not None and final_info.get("success"):
         response = _build_success_response_if_found(
             final_info,
             name=name,
             backup_job_id=backup_job_id,
             agent_id=agent_id,
             duration_seconds=max_wait_seconds,
+            job_start_ts=job_start_ts,
         )
         if response is not None:
             response["warnings"] = [
@@ -307,13 +383,41 @@ async def _poll_backup_completion(
                 f"Backup found in post-timeout list lookup: {response['backup_id']}"
             )
             return response
+        # Helper returned None. Three cases distinguishable from the raw
+        # final_info: (a) backup failed in the gap between last in-loop poll
+        # and the final lookup → raise SERVICE_CALL_FAILED, the failure mode
+        # is known and unambiguous; (b) state still indicates creation in
+        # progress → surface `likely_in_progress` so callers back off retries
+        # rather than compounding duplicates; (c) state idle+completed but no
+        # fresh matching entry → genuine TIMEOUT_OPERATION, nothing extra to
+        # add.
+        result_block = final_info.get("result") or {}
+        last_event = result_block.get("last_action_event") or {}
+        state = result_block.get("state")
+        event_state = last_event.get("state")
+        if event_state == "failed":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Backup creation failed (observed at post-timeout lookup)",
+                    context={"backup_job_id": backup_job_id, "name": name},
+                )
+            )
+        if state != "idle":
+            likely_in_progress = True
 
     logger.warning(f"Backup did not complete within {max_wait_seconds} seconds")
+    error_context: dict[str, Any] = {"backup_job_id": backup_job_id, "name": name}
+    if verification_error is not None:
+        error_context["verification_error"] = verification_error
+    if likely_in_progress:
+        error_context["likely_in_progress"] = True
+
     raise_tool_error(
         create_error_response(
             ErrorCode.TIMEOUT_OPERATION,
             f"Backup creation timed out after {max_wait_seconds} seconds",
-            context={"backup_job_id": backup_job_id, "name": name},
+            context=error_context,
             suggestions=[
                 "Backup may still be in progress. Check Home Assistant backup status."
             ],

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -25,7 +25,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from ..backup_manager import get_backup_manager
-from ..client.rest_client import HomeAssistantClient
+from ..client.rest_client import HomeAssistantClient, HomeAssistantError
 from ..client.websocket_client import HomeAssistantWebSocketClient
 from ..config import get_global_settings
 from ..errors import ErrorCode, create_error_response
@@ -186,7 +186,7 @@ def _build_success_response_if_found(
     in-loop branch (when state=idle+completed is observed) and from the
     post-timeout final check (#1433).
     """
-    backups = info_result.get("result", {}).get("backups", [])
+    backups = info_result.get("result", {}).get("backups") or []
     created_backup = next((b for b in backups if b.get("name") == name), None)
     if created_backup is None:
         return None
@@ -196,7 +196,9 @@ def _build_success_response_if_found(
         "backup_job_id": backup_job_id,
         "name": name,
         "date": created_backup.get("date"),
-        "size_bytes": created_backup.get("agents", {}).get(agent_id, {}).get("size"),
+        "size_bytes": (created_backup.get("agents") or {})
+        .get(agent_id, {})
+        .get("size"),
         "status": "Backup completed successfully",
         "duration_seconds": duration_seconds,
         "note": "Backup uses your Home Assistant's default backup password",
@@ -276,12 +278,13 @@ async def _poll_backup_completion(
         "performing final backup-list lookup before raising timeout"
     )
     # send_command raises on failure rather than returning success=false; treat
-    # any exception during this best-effort verification as "couldn't verify"
-    # and fall through to the original timeout signal rather than letting an
-    # unrelated WebSocket error mask it.
+    # any HA-side error during this best-effort verification as "couldn't
+    # verify" and fall through to the original timeout signal rather than
+    # letting an unrelated WebSocket error mask it. Programming errors
+    # (AttributeError, TypeError, KeyError) intentionally propagate.
     try:
         final_info = await ws_client.send_command("backup/info")
-    except Exception as e:
+    except HomeAssistantError as e:
         logger.warning(
             f"Post-timeout backup/info lookup failed ({e!r}); "
             "falling through to TIMEOUT_OPERATION"

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -275,8 +275,18 @@ async def _poll_backup_completion(
         f"Backup did not reach state=idle within {max_wait_seconds}s; "
         "performing final backup-list lookup before raising timeout"
     )
-    final_info = await ws_client.send_command("backup/info")
-    if final_info.get("success"):
+    # send_command raises on failure rather than returning success=false; treat
+    # any exception during this best-effort verification as "couldn't verify"
+    # and fall through to the original timeout signal rather than letting an
+    # unrelated WebSocket error mask it.
+    try:
+        final_info = await ws_client.send_command("backup/info")
+    except Exception as e:
+        logger.warning(
+            f"Post-timeout backup/info lookup failed ({e!r}); "
+            "falling through to TIMEOUT_OPERATION"
+        )
+    else:
         response = _build_success_response_if_found(
             final_info,
             name=name,

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -171,6 +171,40 @@ async def _get_backup_password(
     return cast(str, default_password)
 
 
+def _build_success_response_if_found(
+    info_result: dict[str, Any],
+    *,
+    name: str,
+    backup_job_id: str,
+    agent_id: str,
+    duration_seconds: int,
+) -> dict[str, Any] | None:
+    """Return the canonical success-response dict if a backup with ``name``
+    is present in ``info_result['result']['backups']``, else None.
+
+    Single source of truth for the success shape — called both from the
+    in-loop branch (when state=idle+completed is observed) and from the
+    post-timeout final check (#1433).
+    """
+    backups = info_result.get("result", {}).get("backups", [])
+    created_backup = next((b for b in backups if b.get("name") == name), None)
+    if created_backup is None:
+        return None
+    return {
+        "success": True,
+        "backup_id": created_backup.get("backup_id"),
+        "backup_job_id": backup_job_id,
+        "name": name,
+        "date": created_backup.get("date"),
+        "size_bytes": created_backup.get("agents", {})
+        .get(agent_id, {})
+        .get("size"),
+        "status": "Backup completed successfully",
+        "duration_seconds": duration_seconds,
+        "note": "Backup uses your Home Assistant's default backup password",
+    }
+
+
 async def _poll_backup_completion(
     ws_client: HomeAssistantWebSocketClient,
     name: str,
@@ -185,7 +219,16 @@ async def _poll_backup_completion(
     ``hassio.local`` on Supervised, ``backup.local`` on Core); used to look
     up the per-agent size in the backup-info payload.
 
-    Raises ToolError on backup failure or timeout.
+    On timeout, performs one final ``backup/info`` lookup before raising:
+    if a backup matching ``name`` is in the list, returns the success
+    response with a ``warnings`` entry noting the late detection (#1433).
+    The polling loop can exit before observing ``state=idle`` even when
+    HA is producing the backup successfully — slow disks, slow HA core,
+    or congestion can stretch a real backup past ``max_wait_seconds``.
+    Raising ``TIMEOUT_OPERATION`` in that case is silent-failure-as-failure;
+    callers wrapping ``ha_manage_backup`` retry and produce duplicates.
+
+    Raises ToolError on backup failure or final timeout with no completion.
     """
     waited = 0
 
@@ -204,35 +247,22 @@ async def _poll_backup_completion(
             )
 
             if state == "idle" and event_state == "completed":
-                backups = info_result.get("result", {}).get("backups", [])
-                created_backup = None
-                for backup in backups:
-                    if backup.get("name") == name:
-                        created_backup = backup
-                        break
-
-                if created_backup:
+                response = _build_success_response_if_found(
+                    info_result,
+                    name=name,
+                    backup_job_id=backup_job_id,
+                    agent_id=agent_id,
+                    duration_seconds=waited,
+                )
+                if response is not None:
                     logger.info(
-                        f"Backup completed successfully: {created_backup.get('backup_id')}"
+                        f"Backup completed successfully: {response['backup_id']}"
                     )
-                    return {
-                        "success": True,
-                        "backup_id": created_backup.get("backup_id"),
-                        "backup_job_id": backup_job_id,
-                        "name": name,
-                        "date": created_backup.get("date"),
-                        "size_bytes": created_backup.get("agents", {})
-                        .get(agent_id, {})
-                        .get("size"),
-                        "status": "Backup completed successfully",
-                        "duration_seconds": waited,
-                        "note": "Backup uses your Home Assistant's default backup password",
-                    }
-                else:
-                    logger.warning(
-                        "Backup completed but not found in backup list yet, waiting..."
-                    )
-                    continue
+                    return response
+                logger.warning(
+                    "Backup completed but not found in backup list yet, waiting..."
+                )
+                continue
 
             elif event_state == "failed":
                 raise_tool_error(
@@ -242,6 +272,31 @@ async def _poll_backup_completion(
                         context={"backup_job_id": backup_job_id},
                     )
                 )
+
+    logger.info(
+        f"Backup did not reach state=idle within {max_wait_seconds}s; "
+        "performing final backup-list lookup before raising timeout"
+    )
+    final_info = await ws_client.send_command("backup/info")
+    if final_info.get("success"):
+        response = _build_success_response_if_found(
+            final_info,
+            name=name,
+            backup_job_id=backup_job_id,
+            agent_id=agent_id,
+            duration_seconds=max_wait_seconds,
+        )
+        if response is not None:
+            response["warnings"] = [
+                f"Backup completion observed only after the {max_wait_seconds}s "
+                "poll window — the operation succeeded but took longer than "
+                "expected. Increase max_wait_seconds if this recurs.",
+            ]
+            logger.info(
+                f"Backup found in post-timeout list lookup: "
+                f"{response['backup_id']}"
+            )
+            return response
 
     logger.warning(f"Backup did not complete within {max_wait_seconds} seconds")
     raise_tool_error(

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -196,9 +196,7 @@ def _build_success_response_if_found(
         "backup_job_id": backup_job_id,
         "name": name,
         "date": created_backup.get("date"),
-        "size_bytes": created_backup.get("agents", {})
-        .get(agent_id, {})
-        .get("size"),
+        "size_bytes": created_backup.get("agents", {}).get(agent_id, {}).get("size"),
         "status": "Backup completed successfully",
         "duration_seconds": duration_seconds,
         "note": "Backup uses your Home Assistant's default backup password",
@@ -293,8 +291,7 @@ async def _poll_backup_completion(
                 "expected. Increase max_wait_seconds if this recurs.",
             ]
             logger.info(
-                f"Backup found in post-timeout list lookup: "
-                f"{response['backup_id']}"
+                f"Backup found in post-timeout list lookup: {response['backup_id']}"
             )
             return response
 

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -247,7 +247,7 @@ def _build_success_response_if_found(
     if not fresh:
         return None
 
-    target_id = last_event.get("backup_id") or last_event.get("backup_job_id")
+    target_id = last_event.get("backup_id")
     authoritative = (
         next((b for b in fresh if b.get("backup_id") == target_id), None)
         if target_id

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -3,21 +3,38 @@
 Regression coverage for #1433: the polling loop used to raise `TIMEOUT_OPERATION`
 unconditionally when it didn't observe `state=idle` + `event_state=completed`
 within `max_wait_seconds`, even when the backup actually completed (just slower
-than the poll window). The fix performs one final `backup/info` lookup before
-raising and returns the canonical success-shape (with a `warnings` entry) if a
-backup matching the requested name is present.
+than the poll window).
+
+The fix performs one final `backup/info` lookup before raising and returns the
+canonical success-shape (with a `warnings` entry) ONLY if both hold:
+
+1. The HA top-level `state == "idle"` AND `last_action_event.state == "completed"`
+   (i.e. HA finished finalizing — `backups` membership alone is insufficient,
+   HA registers the entry before compression/encryption finish).
+2. A backup entry matches by `last_action_event.backup_id` (authoritative) or
+   by `name` filtered to entries dated at-or-after the job start (rejects stale
+   prior-run entries that share a name).
 """
 
-from unittest.mock import AsyncMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantConnectionError,
+)
+from ha_mcp.errors import ErrorCode
 from ha_mcp.tools.backup import (
     _build_success_response_if_found,
     _poll_backup_completion,
 )
+
+# Stable job-start anchor used across helper-level tests. Backup entries dated
+# >= this value count as fresh; entries dated earlier are stale.
+_JOB_START = datetime(2026, 5, 24, 19, 50, 0, tzinfo=UTC)
 
 
 def _ws_client(*responses: dict) -> AsyncMock:
@@ -27,9 +44,23 @@ def _ws_client(*responses: dict) -> AsyncMock:
     return ws
 
 
-def _backup_info(state: str, event_state: str | None, backups: list[dict]) -> dict:
-    """Compose a `backup/info` response body."""
-    last_event = {"state": event_state} if event_state else {}
+def _backup_info(
+    state: str,
+    event_state: str | None,
+    backups: list[dict],
+    *,
+    last_event_backup_id: str | None = None,
+) -> dict:
+    """Compose a `backup/info` response body.
+
+    ``last_event_backup_id`` populates the ``backup_id`` field of
+    ``last_action_event`` — used by the helper's identity-matching path.
+    """
+    last_event: dict = {}
+    if event_state is not None:
+        last_event["state"] = event_state
+    if last_event_backup_id is not None:
+        last_event["backup_id"] = last_event_backup_id
     return {
         "success": True,
         "result": {
@@ -40,19 +71,32 @@ def _backup_info(state: str, event_state: str | None, backups: list[dict]) -> di
     }
 
 
+# Default fixture date is in the far future so entries are "fresh" relative
+# to both the fixed `_JOB_START` used in helper tests AND the live
+# `datetime.now()` used by `_poll_backup_completion` when called from
+# polling-level tests. Tests that need explicitly stale entries pass `date=`.
+_FRESH_DATE = "2099-01-01T00:00:00Z"
+
+
 def _backup_entry(
-    name: str, *, backup_id: str = "abc123", agent_id: str = "backup.local"
+    name: str,
+    *,
+    backup_id: str = "abc123",
+    agent_id: str = "backup.local",
+    date: str = _FRESH_DATE,
 ) -> dict:
     """Compose one entry of `result.backups` matching the shape HA returns."""
     return {
         "backup_id": backup_id,
         "name": name,
-        "date": "2026-05-24T20:00:00Z",
+        "date": date,
         "agents": {agent_id: {"size": 12345}},
     }
 
 
 class TestBuildSuccessResponseIfFound:
+    """Helper-level coverage. The helper owns state-gate + identity-match."""
+
     def test_returns_none_when_name_not_in_backups(self):
         info = _backup_info("idle", "completed", [_backup_entry("Other_Backup")])
         assert (
@@ -62,6 +106,7 @@ class TestBuildSuccessResponseIfFound:
                 backup_job_id="job-1",
                 agent_id="backup.local",
                 duration_seconds=10,
+                job_start_ts=_JOB_START,
             )
             is None
         )
@@ -76,18 +121,17 @@ class TestBuildSuccessResponseIfFound:
             backup_job_id="job-1",
             agent_id="backup.local",
             duration_seconds=42,
+            job_start_ts=_JOB_START,
         )
-        assert result == {
-            "success": True,
-            "backup_id": "xyz",
-            "backup_job_id": "job-1",
-            "name": "My_Backup",
-            "date": "2026-05-24T20:00:00Z",
-            "size_bytes": 12345,
-            "status": "Backup completed successfully",
-            "duration_seconds": 42,
-            "note": "Backup uses your Home Assistant's default backup password",
-        }
+        # Subset assertions on load-bearing keys — adding a field
+        # (e.g., `compressed: bool`) does not break this test.
+        assert result is not None
+        assert result["success"] is True
+        assert result["backup_id"] == "xyz"
+        assert result["name"] == "My_Backup"
+        assert result["backup_job_id"] == "job-1"
+        assert result["size_bytes"] == 12345
+        assert result["duration_seconds"] == 42
 
     def test_returns_none_on_empty_backups_list(self):
         info = _backup_info("idle", "completed", [])
@@ -98,6 +142,193 @@ class TestBuildSuccessResponseIfFound:
                 backup_job_id="job-1",
                 agent_id="backup.local",
                 duration_seconds=10,
+                job_start_ts=_JOB_START,
+            )
+            is None
+        )
+
+    def test_returns_none_when_state_active_even_if_name_in_list(self):
+        """List-membership alone is insufficient. HA registers `backups`
+        entries while still finalizing (compression/encryption). Returning
+        success here would let callers immediately attempt restore on a
+        half-written file."""
+        info = _backup_info(
+            "create_backup", "in_progress", [_backup_entry("Slow_Backup")]
+        )
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="Slow_Backup",
+                backup_job_id="job-1",
+                agent_id="backup.local",
+                duration_seconds=10,
+                job_start_ts=_JOB_START,
+            )
+            is None
+        )
+
+    def test_returns_none_when_event_state_not_completed(self):
+        info = _backup_info("idle", "in_progress", [_backup_entry("Backup_X")])
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="Backup_X",
+                backup_job_id="job-1",
+                agent_id="backup.local",
+                duration_seconds=10,
+                job_start_ts=_JOB_START,
+            )
+            is None
+        )
+
+    def test_target_id_matching_stale_entry_falls_back_to_fresh(self):
+        """Even if `last_action_event.backup_id` matches an entry, that entry
+        must still pass the freshness gate. Multi-job scenario: a concurrent
+        UI-triggered backup updates `last_action_event` to its own
+        backup_id; that target_id may match a stale entry from a prior run
+        with the same name. The freshness filter rejects the stale match
+        and picks the fresh entry instead."""
+        stale_date = (
+            (_JOB_START - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        )
+        info = _backup_info(
+            "idle",
+            "completed",
+            [
+                _backup_entry("Backup_A", backup_id="STALE_ID", date=stale_date),
+                _backup_entry("Backup_A", backup_id="FRESH_ID"),  # default _FRESH_DATE
+            ],
+            last_event_backup_id="STALE_ID",
+        )
+        result = _build_success_response_if_found(
+            info,
+            name="Backup_A",
+            backup_job_id="job-1",
+            agent_id="backup.local",
+            duration_seconds=0,
+            job_start_ts=_JOB_START,
+        )
+        assert result is not None
+        assert result["backup_id"] == "FRESH_ID"
+
+    def test_prefers_last_action_event_backup_id_when_present(self):
+        """When HA exposes `last_action_event.backup_id`, match by backup_id
+        is authoritative — same-name collisions resolve correctly."""
+        info = _backup_info(
+            "idle",
+            "completed",
+            [
+                _backup_entry("Pre_Test", backup_id="OLD_FROM_PRIOR_RUN"),
+                _backup_entry("Pre_Test", backup_id="NEW_THIS_JOB"),
+            ],
+            last_event_backup_id="NEW_THIS_JOB",
+        )
+        result = _build_success_response_if_found(
+            info,
+            name="Pre_Test",
+            backup_job_id="job-2",
+            agent_id="backup.local",
+            duration_seconds=10,
+            job_start_ts=_JOB_START,
+        )
+        assert result is not None
+        assert result["backup_id"] == "NEW_THIS_JOB"
+
+    def test_falls_back_to_date_filter_when_no_backup_id_in_event(self):
+        """No `last_action_event.backup_id` — name match must filter by
+        `date >= job_start_ts` to skip stale prior-run entries with same name."""
+        stale_date = (
+            (_JOB_START - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+        )
+        fresh_date = (
+            (_JOB_START + timedelta(seconds=10)).isoformat().replace("+00:00", "Z")
+        )
+        info = _backup_info(
+            "idle",
+            "completed",
+            [
+                _backup_entry("Pre_Test", backup_id="STALE", date=stale_date),
+                _backup_entry("Pre_Test", backup_id="FRESH", date=fresh_date),
+            ],
+        )
+        result = _build_success_response_if_found(
+            info,
+            name="Pre_Test",
+            backup_job_id="job-2",
+            agent_id="backup.local",
+            duration_seconds=10,
+            job_start_ts=_JOB_START,
+        )
+        assert result is not None
+        assert result["backup_id"] == "FRESH"
+
+    def test_date_filter_rejects_all_stale_entries(self):
+        """Pure name-match against stale-only entries returns None.
+        Protection against the name-collision class on retry."""
+        stale_date = (
+            (_JOB_START - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        )
+        info = _backup_info(
+            "idle",
+            "completed",
+            [_backup_entry("Pre_Test", backup_id="STALE", date=stale_date)],
+        )
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="Pre_Test",
+                backup_job_id="job-2",
+                agent_id="backup.local",
+                duration_seconds=10,
+                job_start_ts=_JOB_START,
+            )
+            is None
+        )
+
+    def test_helper_tolerates_null_agents_field(self):
+        """HA can return `agents: null` per entry — size_bytes degrades to
+        None rather than crashing."""
+        info = _backup_info(
+            "idle",
+            "completed",
+            [
+                {
+                    "backup_id": "x",
+                    "name": "Any",
+                    "date": "2026-05-24T20:00:00Z",
+                    "agents": None,
+                }
+            ],
+        )
+        result = _build_success_response_if_found(
+            info,
+            name="Any",
+            backup_job_id="job-1",
+            agent_id="backup.local",
+            duration_seconds=0,
+            job_start_ts=_JOB_START,
+        )
+        assert result is not None
+        assert result["size_bytes"] is None
+
+    def test_helper_tolerates_null_backups_field(self):
+        """HA can return `backups: null` when the field is absent."""
+        info = {
+            "success": True,
+            "result": {
+                "state": "idle",
+                "last_action_event": {"state": "completed"},
+                "backups": None,
+            },
+        }
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="Any",
+                backup_job_id="job-1",
+                agent_id="backup.local",
+                duration_seconds=0,
+                job_start_ts=_JOB_START,
             )
             is None
         )
@@ -106,10 +337,8 @@ class TestBuildSuccessResponseIfFound:
 class TestPollBackupCompletionPostTimeout:
     @pytest.mark.asyncio
     async def test_post_timeout_finds_backup_returns_success_with_warning(self):
-        """Polling loop exits without observing idle+completed; final lookup
-        finds the backup → return success with a `warnings` entry."""
-        # max_wait_seconds=0 skips the loop entirely; the only send_command
-        # call is the post-timeout final lookup.
+        """Polling exits without observing idle+completed; final lookup finds
+        the backup with proper state → success with top-level `warnings: list[str]`."""
         ws = _ws_client(
             _backup_info("idle", "completed", [_backup_entry("Slow_Backup")])
         )
@@ -124,16 +353,15 @@ class TestPollBackupCompletionPostTimeout:
         assert result["success"] is True
         assert result["backup_id"] == "abc123"
         assert result["name"] == "Slow_Backup"
-        assert result["duration_seconds"] == 0
+        # Top-level `warnings: list[str]` per AGENTS.md tool-return contract.
         assert "warnings" in result
         assert isinstance(result["warnings"], list)
+        assert all(isinstance(w, str) for w in result["warnings"])
         assert any("poll window" in w for w in result["warnings"])
         ws.send_command.assert_awaited_once_with("backup/info")
 
     @pytest.mark.asyncio
     async def test_post_timeout_no_backup_raises_timeout_operation(self):
-        """Polling loop exits, final lookup returns no matching backup →
-        TIMEOUT_OPERATION as before."""
         ws = _ws_client(_backup_info("idle", "completed", []))
         with pytest.raises(ToolError) as exc_info:
             await _poll_backup_completion(
@@ -144,14 +372,36 @@ class TestPollBackupCompletionPostTimeout:
                 poll_interval=1,
                 agent_id="backup.local",
             )
-        # ToolError wraps the structured error JSON in `str(exc)`.
-        assert "TIMEOUT_OPERATION" in str(exc_info.value)
+        assert ErrorCode.TIMEOUT_OPERATION.value in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_post_timeout_final_info_call_raises_falls_through_to_timeout(self):
-        """If the final `backup/info` call raises (HA WS error, dropped
-        connection, etc.), fall through to TIMEOUT_OPERATION rather than
-        propagating an unrelated error that would mask the original timeout."""
+    async def test_post_timeout_state_still_active_keeps_timeout_with_in_progress_flag(
+        self,
+    ):
+        """List contains entry but HA state still indicates creation in
+        progress → keep TIMEOUT_OPERATION but surface `likely_in_progress`
+        in context so callers can back off retries."""
+        ws = _ws_client(
+            _backup_info("create_backup", "in_progress", [_backup_entry("Slow_Backup")])
+        )
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Slow_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        msg = str(exc_info.value)
+        assert ErrorCode.TIMEOUT_OPERATION.value in msg
+        assert "likely_in_progress" in msg
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_command_error_surfaces_verification_context(self):
+        """Verification failure (HA-side error during the final lookup) must
+        not stay invisible behind a misleading TIMEOUT_OPERATION — surface as
+        `verification_error` in the error context."""
         ws = AsyncMock()
         ws.send_command.side_effect = HomeAssistantCommandError("ws closed")
         with pytest.raises(ToolError) as exc_info:
@@ -163,13 +413,107 @@ class TestPollBackupCompletionPostTimeout:
                 poll_interval=1,
                 agent_id="backup.local",
             )
-        assert "TIMEOUT_OPERATION" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert ErrorCode.TIMEOUT_OPERATION.value in msg
+        assert "verification_error" in msg
+        assert "ws closed" in msg
 
     @pytest.mark.asyncio
+    async def test_post_timeout_connection_error_falls_through(self):
+        """Pin: the broad `HomeAssistantError` catch covers
+        `HomeAssistantConnectionError` too. Prevents a future narrowing
+        regression that would propagate connection-errors and mask the
+        original timeout signal."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = HomeAssistantConnectionError("connection lost")
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Any_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        msg = str(exc_info.value)
+        assert ErrorCode.TIMEOUT_OPERATION.value in msg
+        assert "verification_error" in msg
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_final_info_success_false_falls_through(self):
+        """A degraded `success: False` response from the final lookup falls
+        through to TIMEOUT_OPERATION — must not claim success on a partial
+        response that future regressions could produce."""
+        ws = _ws_client({"success": False, "error": "transient"})
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Any_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        assert ErrorCode.TIMEOUT_OPERATION.value in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_failed_state_raises_service_call_failed(self):
+        """If the post-timeout lookup observes the backup failed in the gap
+        between the last in-loop poll and the final check, raise
+        SERVICE_CALL_FAILED — not TIMEOUT_OPERATION. The failure mode is
+        known and unambiguous; `likely_in_progress` would be actively
+        misleading."""
+        ws = _ws_client(_backup_info("idle", "failed", []))
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Failed_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        msg = str(exc_info.value)
+        assert ErrorCode.SERVICE_CALL_FAILED.value in msg
+        assert "likely_in_progress" not in msg
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_name_collision_picks_fresh_entry(self):
+        """Post-timeout window is exactly when stale collisions are likely
+        (prior run timed out, retried with same name). Date-filter must pick
+        the fresh entry, not the stale one."""
+        ws = _ws_client(
+            _backup_info(
+                "idle",
+                "completed",
+                [
+                    _backup_entry(
+                        "Pre_Test",
+                        backup_id="STALE",
+                        date="2025-01-01T00:00:00Z",
+                    ),
+                    _backup_entry(
+                        "Pre_Test",
+                        backup_id="FRESH",
+                        date="2099-01-01T00:00:00Z",
+                    ),
+                ],
+            )
+        )
+        result = await _poll_backup_completion(
+            ws,
+            name="Pre_Test",
+            backup_job_id="job-1",
+            max_wait_seconds=0,
+            poll_interval=1,
+            agent_id="backup.local",
+        )
+        assert result["backup_id"] == "FRESH"
+
+
+class TestPollBackupCompletionInLoop:
+    @pytest.mark.asyncio
     async def test_in_loop_success_path_still_works_after_refactor(self):
-        """Regression: the in-loop branch routes through the same helper as
-        the post-timeout path; first idle+completed observation returns
-        success WITHOUT a `warnings` entry."""
         ws = _ws_client(
             _backup_info("idle", "completed", [_backup_entry("Fast_Backup")])
         )
@@ -186,5 +530,110 @@ class TestPollBackupCompletionPostTimeout:
         assert result["backup_id"] == "abc123"
         assert result["duration_seconds"] == 2
         assert "warnings" not in result
-        # In-loop success returns on the first poll; no post-timeout call.
         ws.send_command.assert_awaited_once_with("backup/info")
+
+    @pytest.mark.asyncio
+    async def test_in_loop_state_idle_name_not_in_list_continues_then_finds(self):
+        """Same bug class as #1433 one tick earlier: first poll observes
+        idle+completed but the backup hasn't appeared in the list yet (race
+        between state transition and backup-list write). Must `continue`, not
+        exit with success=None. Second poll picks it up."""
+        ws = _ws_client(
+            _backup_info("idle", "completed", []),
+            _backup_info("idle", "completed", [_backup_entry("Slow_Race")]),
+        )
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            result = await _poll_backup_completion(
+                ws,
+                name="Slow_Race",
+                backup_job_id="job-1",
+                max_wait_seconds=10,
+                poll_interval=2,
+                agent_id="backup.local",
+            )
+        assert result["success"] is True
+        assert result["backup_id"] == "abc123"
+        assert "warnings" not in result
+        assert ws.send_command.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_in_loop_failed_state_raises(self):
+        """Regression: explicit `event_state == failed` still surfaces
+        SERVICE_CALL_FAILED before the post-timeout path runs."""
+        ws = _ws_client(_backup_info("idle", "failed", []))
+        with (
+            patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _poll_backup_completion(
+                ws,
+                name="Bad",
+                backup_job_id="job-1",
+                max_wait_seconds=10,
+                poll_interval=2,
+                agent_id="backup.local",
+            )
+        assert ErrorCode.SERVICE_CALL_FAILED.value in str(exc_info.value)
+
+
+class TestCreateBackupWrapperSeam:
+    """The `create_backup` wrapper is the user-facing seam that produces
+    duplicates when callers retry on `success: false`. Pin that the
+    post-timeout `warnings`-bearing dict survives through the wrapper's
+    outer try/except Exception — that's the surface the fix actually
+    protects against the duplicate-retry pattern in #1433."""
+
+    @pytest.mark.asyncio
+    async def test_create_backup_returns_warnings_dict_unchanged(self):
+        from ha_mcp.tools import backup as backup_module
+
+        late_success = {
+            "success": True,
+            "backup_id": "abc",
+            "name": "Wrapper_Test",
+            "backup_job_id": "j-1",
+            "duration_seconds": 120,
+            "warnings": [
+                "Backup completion observed only after the 120s poll window — "
+                "the operation succeeded but took longer than expected."
+            ],
+        }
+
+        ws_mock = AsyncMock()
+        ws_mock.send_command.side_effect = [
+            # _get_backup_password
+            {
+                "success": True,
+                "result": {"config": {"create_backup": {"password": "pw"}}},
+            },
+            # _get_local_backup_agent_id
+            {
+                "success": True,
+                "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]},
+            },
+            # backup/generate
+            {"success": True, "result": {"backup_job_id": "j-1"}},
+        ]
+        ws_mock.disconnect = AsyncMock()
+
+        client_mock = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws_mock, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value=late_success),
+            ),
+        ):
+            result = await backup_module.create_backup(client_mock, name="Wrapper_Test")
+
+        # The wrapper must pass through the warnings dict unchanged — the
+        # outer `except Exception` would otherwise re-map it to INTERNAL_ERROR
+        # via `exception_to_structured_error`.
+        assert result == late_success
+        assert "warnings" in result
+        assert isinstance(result["warnings"], list)
+        assert all(isinstance(w, str) for w in result["warnings"])

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -1,0 +1,185 @@
+"""Unit tests for the post-timeout backup-list check in `_poll_backup_completion`.
+
+Regression coverage for #1433: the polling loop used to raise `TIMEOUT_OPERATION`
+unconditionally when it didn't observe `state=idle` + `event_state=completed`
+within `max_wait_seconds`, even when the backup actually completed (just slower
+than the poll window). The fix performs one final `backup/info` lookup before
+raising and returns the canonical success-shape (with a `warnings` entry) if a
+backup matching the requested name is present.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.backup import (
+    _build_success_response_if_found,
+    _poll_backup_completion,
+)
+
+
+def _ws_client(*responses: dict) -> AsyncMock:
+    """Build a mock WS client whose `send_command` returns each response in turn."""
+    ws = AsyncMock()
+    ws.send_command.side_effect = list(responses)
+    return ws
+
+
+def _backup_info(state: str, event_state: str | None, backups: list[dict]) -> dict:
+    """Compose a `backup/info` response body."""
+    last_event = {"state": event_state} if event_state else {}
+    return {
+        "success": True,
+        "result": {
+            "state": state,
+            "last_action_event": last_event,
+            "backups": backups,
+        },
+    }
+
+
+def _backup_entry(name: str, *, backup_id: str = "abc123", agent_id: str = "backup.local") -> dict:
+    """Compose one entry of `result.backups` matching the shape HA returns."""
+    return {
+        "backup_id": backup_id,
+        "name": name,
+        "date": "2026-05-24T20:00:00Z",
+        "agents": {agent_id: {"size": 12345}},
+    }
+
+
+class TestBuildSuccessResponseIfFound:
+    def test_returns_none_when_name_not_in_backups(self):
+        info = _backup_info("idle", "completed", [_backup_entry("Other_Backup")])
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="Looking_For_This",
+                backup_job_id="job-1",
+                agent_id="backup.local",
+                duration_seconds=10,
+            )
+            is None
+        )
+
+    def test_returns_success_shape_when_name_matches(self):
+        info = _backup_info(
+            "idle", "completed", [_backup_entry("My_Backup", backup_id="xyz")]
+        )
+        result = _build_success_response_if_found(
+            info,
+            name="My_Backup",
+            backup_job_id="job-1",
+            agent_id="backup.local",
+            duration_seconds=42,
+        )
+        assert result == {
+            "success": True,
+            "backup_id": "xyz",
+            "backup_job_id": "job-1",
+            "name": "My_Backup",
+            "date": "2026-05-24T20:00:00Z",
+            "size_bytes": 12345,
+            "status": "Backup completed successfully",
+            "duration_seconds": 42,
+            "note": "Backup uses your Home Assistant's default backup password",
+        }
+
+    def test_returns_none_on_empty_backups_list(self):
+        info = _backup_info("idle", "completed", [])
+        assert (
+            _build_success_response_if_found(
+                info,
+                name="My_Backup",
+                backup_job_id="job-1",
+                agent_id="backup.local",
+                duration_seconds=10,
+            )
+            is None
+        )
+
+
+class TestPollBackupCompletionPostTimeout:
+    @pytest.mark.asyncio
+    async def test_post_timeout_finds_backup_returns_success_with_warning(self):
+        """Polling loop exits without observing idle+completed; final lookup
+        finds the backup → return success with a `warnings` entry."""
+        # max_wait_seconds=0 skips the loop entirely; the only send_command
+        # call is the post-timeout final lookup.
+        ws = _ws_client(
+            _backup_info("idle", "completed", [_backup_entry("Slow_Backup")])
+        )
+        result = await _poll_backup_completion(
+            ws,
+            name="Slow_Backup",
+            backup_job_id="job-1",
+            max_wait_seconds=0,
+            poll_interval=1,
+            agent_id="backup.local",
+        )
+        assert result["success"] is True
+        assert result["backup_id"] == "abc123"
+        assert result["name"] == "Slow_Backup"
+        assert result["duration_seconds"] == 0
+        assert "warnings" in result
+        assert isinstance(result["warnings"], list)
+        assert any("poll window" in w for w in result["warnings"])
+        ws.send_command.assert_awaited_once_with("backup/info")
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_no_backup_raises_timeout_operation(self):
+        """Polling loop exits, final lookup returns no matching backup →
+        TIMEOUT_OPERATION as before."""
+        ws = _ws_client(_backup_info("idle", "completed", []))
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Missing_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        # ToolError wraps the structured error JSON in `str(exc)`.
+        assert "TIMEOUT_OPERATION" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_post_timeout_final_info_call_fails_raises_timeout(self):
+        """If the final `backup/info` itself returns success=false, fall
+        through to TIMEOUT_OPERATION rather than swallowing the failure."""
+        ws = _ws_client({"success": False, "error": "ws closed"})
+        with pytest.raises(ToolError) as exc_info:
+            await _poll_backup_completion(
+                ws,
+                name="Any_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=0,
+                poll_interval=1,
+                agent_id="backup.local",
+            )
+        assert "TIMEOUT_OPERATION" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_in_loop_success_path_still_works_after_refactor(self):
+        """Regression: the in-loop branch routes through the same helper as
+        the post-timeout path; first idle+completed observation returns
+        success WITHOUT a `warnings` entry."""
+        ws = _ws_client(
+            _backup_info("idle", "completed", [_backup_entry("Fast_Backup")])
+        )
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            result = await _poll_backup_completion(
+                ws,
+                name="Fast_Backup",
+                backup_job_id="job-1",
+                max_wait_seconds=10,
+                poll_interval=2,
+                agent_id="backup.local",
+            )
+        assert result["success"] is True
+        assert result["backup_id"] == "abc123"
+        assert result["duration_seconds"] == 2
+        assert "warnings" not in result
+        # In-loop success returns on the first poll; no post-timeout call.
+        ws.send_command.assert_awaited_once_with("backup/info")

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -39,7 +39,9 @@ def _backup_info(state: str, event_state: str | None, backups: list[dict]) -> di
     }
 
 
-def _backup_entry(name: str, *, backup_id: str = "abc123", agent_id: str = "backup.local") -> dict:
+def _backup_entry(
+    name: str, *, backup_id: str = "abc123", agent_id: str = "backup.local"
+) -> dict:
     """Compose one entry of `result.backups` matching the shape HA returns."""
     return {
         "backup_id": backup_id,

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -372,7 +372,12 @@ class TestPollBackupCompletionPostTimeout:
                 poll_interval=1,
                 agent_id="backup.local",
             )
-        assert ErrorCode.TIMEOUT_OPERATION.value in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert ErrorCode.TIMEOUT_OPERATION.value in msg
+        # Pin negative side of `likely_in_progress`: clean idle+completed-no-
+        # match must NOT surface the flag, else a future refactor that merges
+        # the in-progress and no-match branches could silently mislead callers.
+        assert "likely_in_progress" not in msg
 
     @pytest.mark.asyncio
     async def test_post_timeout_state_still_active_keeps_timeout_with_in_progress_flag(

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.client.rest_client import HomeAssistantCommandError
 from ha_mcp.tools.backup import (
     _build_success_response_if_found,
     _poll_backup_completion,
@@ -147,10 +148,12 @@ class TestPollBackupCompletionPostTimeout:
         assert "TIMEOUT_OPERATION" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_post_timeout_final_info_call_fails_raises_timeout(self):
-        """If the final `backup/info` itself returns success=false, fall
-        through to TIMEOUT_OPERATION rather than swallowing the failure."""
-        ws = _ws_client({"success": False, "error": "ws closed"})
+    async def test_post_timeout_final_info_call_raises_falls_through_to_timeout(self):
+        """If the final `backup/info` call raises (HA WS error, dropped
+        connection, etc.), fall through to TIMEOUT_OPERATION rather than
+        propagating an unrelated error that would mask the original timeout."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = HomeAssistantCommandError("ws closed")
         with pytest.raises(ToolError) as exc_info:
             await _poll_backup_completion(
                 ws,


### PR DESCRIPTION
Closes #1433

## What does this PR do?

Fixes `ha_manage_backup(scope='snapshot', action='create')` reporting `TIMEOUT_OPERATION` when the backup actually completed — the wrapper-retry path then produced duplicate backups.

Scope (after KP13's review pass on the first iteration):

- **Final post-timeout `backup/info` lookup** so a backup that completed just past `max_wait_seconds` is still returned as success (with a top-level `warnings: list[str]` entry noting the late observation).
- **State-gate**: success requires `state == "idle"` AND `last_action_event.state == "completed"`. List-membership alone is insufficient — HA registers entries in `backups` before finalization, and the original fix could have claimed success on a half-written file.
- **Identity-match**: replaces name-only matching with a freshness filter (`name == name AND date >= job_start_ts - 5s`) plus authoritative-id preference via `last_action_event.backup_id`. Rejects stale prior-run entries with the same name (likely on retry); rejects concurrent UI-backups updating `last_action_event` mid-job.
- **Verification-error surfacing**: post-timeout `send_command` failures (auth, connection, command errors) now appear in the `TIMEOUT_OPERATION` context as `verification_error`, instead of being log-only.
- **Failed-state at post-timeout**: if the final lookup observes `event_state == "failed"`, raises `SERVICE_CALL_FAILED` rather than `TIMEOUT_OPERATION` with a misleading `likely_in_progress` flag.
- **`likely_in_progress` flag**: added to `TIMEOUT_OPERATION` context when the entry exists but state still indicates creation in progress — callers should back off retries rather than compound duplicates.
- **Timeout bump**: `_BACKUP_MAX_WAIT_S` 120 → 300. The 120s default underfit slow HA instances (#1433 root cause per the analysis bot's Step 3 recommendation).

New helpers:
- `_build_success_response_if_found` — single source of truth for "valid completion observed", owns state-gate + identity-match.
- `_parse_backup_date` — tz-aware ISO-8601 parsing for backup entry dates.

## Type of change

- [x] 🐛 Bug fix

## Testing

- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Test file `tests/src/unit/test_backup_poll_timeout.py` rewritten to 23 tests covering:
- Helper-level state-gate, identity-match, null-tolerance (`agents: None`, `backups: null`), date-parse edge cases.
- Post-timeout success+warnings; no-backup raises TIMEOUT_OPERATION; state-still-active raises with `likely_in_progress`; verification failures (CommandError + ConnectionError) surface via context; `success: False` falls through; name-collision picks fresh; failed-state raises SERVICE_CALL_FAILED.
- In-loop success; in-loop "idle+completed but list empty" race continues; in-loop failed-state raises.
- `create_backup` wrapper-seam: pins that the outer `except Exception` does not re-map success+warnings into INTERNAL_ERROR.

Combined with the 58 existing `test_backup_manager.py` + `test_backup_agent_lookup.py` tests, 81/81 backup unit tests pass locally. Ruff + mypy clean.

**Live bug-repro confirmed on a deployed RBO instance (v7.5.0)**: `ha_backup_create(name="Pre_Issue1433_LiveTest")` returned `success: false, error.code: TIMEOUT_OPERATION` after the 120s window while `sensor.backup_backup_manager_zustand` still showed `state="create_backup"`. The unit-test coverage of the new post-timeout branch is the substitute end-to-end evidence; the dev-addon Live-verification of the fix path was blocked by a host-network port-conflict between the stable and dev addons (both `host_network: true` on port 9583).

## Checklist

- [x] I have updated documentation if needed

## Future improvements

- End-to-end live verification of the warnings-bearing late-completion path on a deployed instance (blocked here by the addon port-conflict; would require resolving that first).
- `_parse_backup_date` could move to a shared helper module if other tools need similar ISO-8601 + naive-as-UTC parsing.
