### PR TITLE
test(haos-e2e): bake + install webhook-proxy addon and exercise its runtime

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -45,7 +45,7 @@ on:
       - 'tests/haos_image_build/**'
       - 'tests/initial_test_state/**'
       - 'custom_components/ha_mcp_tools/**'
-      - 'homeassistant-addon-webhook-proxy/mcp_proxy/**'
+      - 'homeassistant-addon-webhook-proxy/**'
       # The workflow itself — bumping the build script or env triggers a republish.
       - '.github/workflows/build-haos-test-image.yml'
   schedule:

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -83,7 +83,7 @@ jobs:
             tests/haos_image_build \
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
-            homeassistant-addon-webhook-proxy/mcp_proxy \
+            homeassistant-addon-webhook-proxy \
             | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
@@ -122,7 +122,7 @@ jobs:
         run: |
           if git diff --name-only \
               "origin/${{ github.base_ref }}...HEAD" \
-              | grep -qE '^(tests/haos_image_build/|tests/initial_test_state/|custom_components/ha_mcp_tools/|homeassistant-addon-webhook-proxy/mcp_proxy/)'; then
+              | grep -qE '^(tests/haos_image_build/|tests/initial_test_state/|custom_components/ha_mcp_tools/|homeassistant-addon-webhook-proxy/)'; then
             echo "bake_inputs_changed=true" >> "$GITHUB_OUTPUT"
             echo "PR modifies bake inputs; skipping GHCR fallback (would return stale master image)."
           fi

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -24,7 +24,7 @@ on:
       # these would otherwise skip HAOS E2E despite changing what gets
       # baked into the qcow2 the suite tests against.
       - 'custom_components/ha_mcp_tools/**'
-      - 'homeassistant-addon-webhook-proxy/mcp_proxy/**'
+      - 'homeassistant-addon-webhook-proxy/**'
       - '.github/workflows/haos-e2e-tests.yml'
       # Trigger on inaddon workflow changes too — both lanes share the
       # qcow2 cache key, so a change to either workflow's cache logic
@@ -88,7 +88,7 @@ jobs:
             tests/haos_image_build \
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
-            homeassistant-addon-webhook-proxy/mcp_proxy \
+            homeassistant-addon-webhook-proxy \
             | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
@@ -135,7 +135,7 @@ jobs:
         run: |
           if git diff --name-only \
               "origin/${{ github.base_ref }}...HEAD" \
-              | grep -qE '^(tests/haos_image_build/|tests/initial_test_state/|custom_components/ha_mcp_tools/|homeassistant-addon-webhook-proxy/mcp_proxy/)'; then
+              | grep -qE '^(tests/haos_image_build/|tests/initial_test_state/|custom_components/ha_mcp_tools/|homeassistant-addon-webhook-proxy/)'; then
             echo "bake_inputs_changed=true" >> "$GITHUB_OUTPUT"
             echo "PR modifies bake inputs; skipping GHCR fallback (would return stale master image)."
           fi

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -983,22 +983,29 @@ def stage_webhook_proxy_addon_source(qcow2: Path) -> None:
             f"checkout is incomplete; the image cannot be built."
         )
 
-    # Defensive guard against ``image:`` re-appearing in config.yaml.
-    # If addon-publish.yml ever starts writing one back (the production
-    # release sets ``image: ghcr.io/...`` and per-PR versions 404 from
-    # GHCR), the bake must strip it the same way ``stage_dev_addon_source``
-    # does. Fail fast here so the breakage is obvious rather than surfacing
-    # as a 5-minute install timeout downstream.
+    # Defensive guard against a TOP-LEVEL ``image:`` re-appearing in
+    # config.yaml. If addon-publish.yml ever starts writing one back
+    # (the production release sets ``image: ghcr.io/...`` and per-PR
+    # version bumps then 404 from GHCR), the bake must strip it the
+    # same way ``stage_dev_addon_source`` does. Fail fast here so the
+    # breakage is obvious rather than surfacing as a 5-minute install
+    # timeout downstream. Uses the same top-level-only test as
+    # ``stage_dev_addon_source``'s post-strip verification
+    # (``"\nimage:" in text or text.startswith("image:")``) so an
+    # indented nested key named ``image`` (e.g. under ``translations``)
+    # doesn't falsely trigger the guard.
     config_yaml = src_dir / "config.yaml"
     cfg_text = config_yaml.read_text()
-    if any(
-        ln.startswith("image:") or ln.lstrip().startswith("image:")
-        for ln in cfg_text.splitlines()
-    ):
+    if "\nimage:" in cfg_text or cfg_text.startswith("image:"):
+        offending = next(
+            (ln for ln in cfg_text.splitlines() if ln.startswith("image:")),
+            "<line not found>",
+        )
         raise RuntimeError(
-            f"{config_yaml} now declares an ``image:`` field. Supervisor "
-            f"will try to pull from GHCR instead of building locally, and "
-            f"per-PR version bumps will 404. Add an image-strip patch to "
+            f"{config_yaml} now declares a top-level ``image:`` field "
+            f"({offending!r}). Supervisor will try to pull from GHCR "
+            f"instead of building locally, and per-PR version bumps "
+            f"will 404. Add an image-strip patch to "
             f"stage_webhook_proxy_addon_source (mirror the one in "
             f"stage_dev_addon_source)."
         )
@@ -1198,11 +1205,14 @@ def install_webhook_proxy_addon(ws: HAWebSocket) -> str:
     set to ``manual`` so the cached qcow2 doesn't auto-start it on
     resume. Two reasons:
 
-    1. ``start.py`` writes ``/config/.mcp_proxy_config.json`` on every
-       run (target_url + a freshly-generated webhook_id). If the addon
-       runs during bake or on resume, it clobbers the deterministic
-       config the bake injected via ``bake_test_state`` and breaks
-       sibling tests that rely on the bake's webhook_id
+    1. ``start.py`` overwrites ``/config/.mcp_proxy_config.json`` on
+       every run with target_url + the addon's persisted webhook_id
+       (``/data/webhook_id.txt`` — generated on first-ever start,
+       reused on every subsequent run). The persisted id differs from
+       the deterministic value the bake injected via
+       ``bake_test_state``. If the addon runs during bake or on
+       resume, the overwrite clobbers the deterministic config and
+       breaks sibling tests that rely on the bake's webhook_id
        (``test_webhook_proxy.py`` in particular).
     2. On resume, the dev MCP addon and the webhook-proxy both
        auto-start in parallel; webhook-proxy's auto-discovery races

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -188,6 +188,19 @@ HA_MCP_ADDON_REPO = "https://github.com/homeassistant-ai/ha-mcp"
 # in homeassistant-addon/start.py).
 HA_MCP_DEV_ADDON_SLUG = "local_ha_mcp_dev"
 HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
+
+# Webhook-proxy addon baked into the qcow2 from local source so the addon's
+# ``start.py`` runtime (Supervisor auto-discovery of the MCP addon, webhook
+# registration, OAuth gate, webhook-ID persistence) gets real HAOS-tier
+# coverage. The addon's config.yaml lives at
+# ``homeassistant-addon-webhook-proxy/`` in the repo; we stage it under
+# ``/supervisor/addons/local/ha_mcp_webhook_proxy/`` and Supervisor picks it up
+# as a local addon (slug becomes ``local_<config-slug>`` → ``local_ha_mcp_webhook_proxy``).
+#
+# Auto-discovery in the webhook-proxy ``start.py`` matches slug suffixes
+# ``_ha_mcp`` / ``_ha_mcp_dev``, so the dev addon installed just before this
+# one (slug=``local_ha_mcp_dev``) is the discovery target.
+HA_MCP_WEBHOOK_PROXY_ADDON_SLUG = "local_ha_mcp_webhook_proxy"
 # Advanced SSH addon user/password set at install time so the runtime
 # helper (``haos_runtime.ssh_exec``) can authenticate non-interactively.
 # CI-test-only credential — overridable via env so the value never has
@@ -949,6 +962,98 @@ def stage_dev_addon_source(qcow2: Path) -> None:
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def stage_webhook_proxy_addon_source(qcow2: Path) -> None:
+    """Bake the webhook-proxy addon source into the qcow2 under /supervisor/addons/local/.
+
+    Mirrors ``stage_dev_addon_source`` but for the in-tree webhook-proxy
+    addon at ``homeassistant-addon-webhook-proxy/``. The webhook-proxy
+    Dockerfile is self-contained — ``COPY start.py /`` and
+    ``COPY mcp_proxy /opt/mcp_proxy`` both resolve inside the addon dir —
+    so no out-of-dir file copies and no Dockerfile patching are needed
+    (unlike the ha-mcp dev addon, which needs uv.lock / src/ pulled in
+    from the repo root). The addon also has no ``image:`` field in its
+    config.yaml, so Supervisor builds locally from the Dockerfile by
+    default and no strip is necessary.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    src_dir = repo_root / "homeassistant-addon-webhook-proxy"
+    if not src_dir.exists():
+        raise RuntimeError(
+            f"homeassistant-addon-webhook-proxy not found at {src_dir} — "
+            f"checkout is incomplete; the image cannot be built."
+        )
+
+    # Defensive guard against ``image:`` re-appearing in config.yaml.
+    # If addon-publish.yml ever starts writing one back (the production
+    # release sets ``image: ghcr.io/...`` and per-PR versions 404 from
+    # GHCR), the bake must strip it the same way ``stage_dev_addon_source``
+    # does. Fail fast here so the breakage is obvious rather than surfacing
+    # as a 5-minute install timeout downstream.
+    config_yaml = src_dir / "config.yaml"
+    cfg_text = config_yaml.read_text()
+    if any(
+        ln.startswith("image:") or ln.lstrip().startswith("image:")
+        for ln in cfg_text.splitlines()
+    ):
+        raise RuntimeError(
+            f"{config_yaml} now declares an ``image:`` field. Supervisor "
+            f"will try to pull from GHCR instead of building locally, and "
+            f"per-PR version bumps will 404. Add an image-strip patch to "
+            f"stage_webhook_proxy_addon_source (mirror the one in "
+            f"stage_dev_addon_source)."
+        )
+
+    LOG.info(
+        "Staging webhook-proxy addon source into qcow2 "
+        "/supervisor/addons/local/ha_mcp_webhook_proxy/"
+    )
+    workdir = Path(tempfile.mkdtemp(prefix="haos-webhook-proxy-addon-"))
+    try:
+        staging = workdir / "ha_mcp_webhook_proxy"
+        shutil.copytree(src_dir, staging)
+
+        seed_tar = workdir / "ha_mcp_webhook_proxy.tar"
+        _run(
+            [
+                "tar",
+                "--numeric-owner",
+                "--owner=0",
+                "--group=0",
+                "-C",
+                str(workdir),
+                "-cf",
+                str(seed_tar),
+                "ha_mcp_webhook_proxy",
+            ]
+        )
+        _run(
+            [
+                "guestfish",
+                "--rw",
+                "-a",
+                str(qcow2),
+                "run",
+                ":",
+                "mount",
+                "/dev/sda8",
+                "/",
+                ":",
+                "mkdir-p",
+                "/supervisor/addons/local",
+                ":",
+                "tar-in",
+                str(seed_tar),
+                "/supervisor/addons/local",
+            ]
+        )
+        LOG.info(
+            "Webhook-proxy addon source staged at "
+            "/supervisor/addons/local/ha_mcp_webhook_proxy/"
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
 def install_advanced_ssh(ws: HAWebSocket) -> str:
     """Install + configure Advanced SSH & Web Terminal for CI diagnostics.
 
@@ -1080,6 +1185,60 @@ def install_ha_mcp_dev_addon(ws: HAWebSocket) -> str:
     LOG.info("Starting ha-mcp dev addon")
     ws.supervisor_api(f"/addons/{slug}/start", method="post", timeout=120.0)
     LOG.info("ha-mcp dev addon installed + started; slug=%s", slug)
+    return slug
+
+
+def install_webhook_proxy_addon(ws: HAWebSocket) -> str:
+    """Install the local webhook-proxy addon during the bake's running phase.
+
+    Assumes ``stage_webhook_proxy_addon_source`` ran before start_qemu so
+    the source is at ``/supervisor/addons/local/ha_mcp_webhook_proxy/``.
+    Must run AFTER ``install_ha_mcp_dev_addon`` so the webhook-proxy's
+    Supervisor auto-discovery (slug-suffix match on ``_ha_mcp_dev``) has
+    a target to find when it first starts.
+
+    All option fields are optional in the schema (every entry is
+    ``str?`` / ``bool?`` / ``port?``), so the options POST below can pass
+    only the fields we care to seed; missing fields fall back to the
+    config.yaml defaults. We leave ``mcp_server_url`` empty deliberately
+    so the addon exercises the auto-discovery code path on first boot
+    (which is the production happy path), and we leave OAuth off so the
+    addon starts cleanly — individual e2e tests flip OAuth on when
+    exercising the gate.
+
+    Returns the installed slug (``local_ha_mcp_webhook_proxy``).
+    """
+    _reload_store(ws)
+    slug = HA_MCP_WEBHOOK_PROXY_ADDON_SLUG
+    LOG.info(
+        "Installing webhook-proxy addon (slug=%s) — building Docker image...", slug
+    )
+    # 900s matches the dev-addon timeout. Webhook-proxy build is much
+    # cheaper (no uv sync, stdlib-only start.py) but keep the headroom in
+    # case the python:3.13-slim base layer pull is slow on first install.
+    ws.supervisor_api(f"/store/addons/{slug}/install", method="post", timeout=900.0)
+
+    LOG.info("Setting webhook-proxy addon options (defaults; OAuth off)")
+    ws.supervisor_api(
+        f"/addons/{slug}/options",
+        method="post",
+        data={
+            "options": {
+                "remote_url": "",
+                "mcp_server_url": "",
+                "mcp_port": 9583,
+                "enable_oauth": False,
+                "oauth_client_id": "",
+                "oauth_client_secret": "",
+                "regenerate_oauth_creds": False,
+            },
+            "boot": "auto",
+        },
+        timeout=60.0,
+    )
+    LOG.info("Starting webhook-proxy addon")
+    ws.supervisor_api(f"/addons/{slug}/start", method="post", timeout=120.0)
+    LOG.info("webhook-proxy addon installed + started; slug=%s", slug)
     return slug
 
 
@@ -1364,6 +1523,11 @@ def build(work_dir: Path, output: Path) -> None:
     # Docker image while HAOS is up — that built image stays in the cached
     # qcow2 so subsequent CI runs only need a quick ``addons/{slug}/update``.
     stage_dev_addon_source(qcow2)
+    # Stage the webhook-proxy addon source alongside the dev addon. Order
+    # within the staging phase doesn't matter (guestfish tar-in is
+    # independent), but the install order below DOES — the webhook-proxy's
+    # auto-discovery needs the dev addon present at first start.
+    stage_webhook_proxy_addon_source(qcow2)
     qemu = start_qemu(qcow2, work_dir)
     base_url = f"http://127.0.0.1:{HA_HOST_PORT}"
     try:
@@ -1375,6 +1539,10 @@ def build(work_dir: Path, output: Path) -> None:
             install_addons(ws)
             install_hacs(ws, base_url)
             install_ha_mcp_dev_addon(ws)
+            # Webhook-proxy must install AFTER the dev addon so its
+            # Supervisor auto-discovery (slug-suffix match on _ha_mcp_dev)
+            # finds a target on first start.
+            install_webhook_proxy_addon(ws)
             install_advanced_ssh(ws)
             # TODO(#1281 follow-up): integrations (ESPHome companion, Node-RED
             # companion, Local Calendar, Sun verification) and mock RTSP/MQTT

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -1193,18 +1193,33 @@ def install_webhook_proxy_addon(ws: HAWebSocket) -> str:
 
     Assumes ``stage_webhook_proxy_addon_source`` ran before start_qemu so
     the source is at ``/supervisor/addons/local/ha_mcp_webhook_proxy/``.
-    Must run AFTER ``install_ha_mcp_dev_addon`` so the webhook-proxy's
-    Supervisor auto-discovery (slug-suffix match on ``_ha_mcp_dev``) has
-    a target to find when it first starts.
 
-    All option fields are optional in the schema (every entry is
-    ``str?`` / ``bool?`` / ``port?``), so the options POST below can pass
-    only the fields we care to seed; missing fields fall back to the
-    config.yaml defaults. We leave ``mcp_server_url`` empty deliberately
-    so the addon exercises the auto-discovery code path on first boot
-    (which is the production happy path), and we leave OAuth off so the
-    addon starts cleanly — individual e2e tests flip OAuth on when
-    exercising the gate.
+    Install-only — the addon is NOT started during bake and ``boot`` is
+    set to ``manual`` so the cached qcow2 doesn't auto-start it on
+    resume. Two reasons:
+
+    1. ``start.py`` writes ``/config/.mcp_proxy_config.json`` on every
+       run (target_url + a freshly-generated webhook_id). If the addon
+       runs during bake or on resume, it clobbers the deterministic
+       config the bake injected via ``bake_test_state`` and breaks
+       sibling tests that rely on the bake's webhook_id
+       (``test_webhook_proxy.py`` in particular).
+    2. On resume, the dev MCP addon and the webhook-proxy both
+       auto-start in parallel; webhook-proxy's auto-discovery races
+       the dev addon's startup and fails on first attempt, then
+       Supervisor escalates to ``boot_fail`` before the dev addon is
+       ready.
+
+    A session-scoped pytest fixture in
+    ``tests/src/e2e/haos_only/test_webhook_proxy_addon.py`` starts the
+    addon for the duration of its tests, then stops it. Sibling test
+    files don't see the addon running.
+
+    ``mcp_server_url`` is pinned to the dev addon's host-network URL so
+    the addon-runtime tests don't depend on auto-discovery timing.
+    Auto-discovery itself remains in the start.py code path; a dedicated
+    test in the haos_only module clears this field, restarts, and
+    asserts the discovery log appears.
 
     Returns the installed slug (``local_ha_mcp_webhook_proxy``).
     """
@@ -1218,27 +1233,34 @@ def install_webhook_proxy_addon(ws: HAWebSocket) -> str:
     # case the python:3.13-slim base layer pull is slow on first install.
     ws.supervisor_api(f"/store/addons/{slug}/install", method="post", timeout=900.0)
 
-    LOG.info("Setting webhook-proxy addon options (defaults; OAuth off)")
+    # Pin mcp_server_url to the dev addon's host-network URL so the
+    # addon skips auto-discovery on subsequent starts (no race against
+    # dev-addon startup on resume / restart). Both addons run on
+    # host_network so 127.0.0.1 is reachable from the webhook-proxy
+    # container to the dev MCP server's listening port.
+    pinned_mcp_url = f"http://127.0.0.1:9583{HA_MCP_TEST_SECRET_PATH}"
+    LOG.info(
+        "Setting webhook-proxy addon options (mcp_server_url=%s, boot=manual)",
+        pinned_mcp_url,
+    )
     ws.supervisor_api(
         f"/addons/{slug}/options",
         method="post",
         data={
             "options": {
                 "remote_url": "",
-                "mcp_server_url": "",
+                "mcp_server_url": pinned_mcp_url,
                 "mcp_port": 9583,
                 "enable_oauth": False,
                 "oauth_client_id": "",
                 "oauth_client_secret": "",
                 "regenerate_oauth_creds": False,
             },
-            "boot": "auto",
+            "boot": "manual",
         },
         timeout=60.0,
     )
-    LOG.info("Starting webhook-proxy addon")
-    ws.supervisor_api(f"/addons/{slug}/start", method="post", timeout=120.0)
-    LOG.info("webhook-proxy addon installed + started; slug=%s", slug)
+    LOG.info("webhook-proxy addon installed (not started); slug=%s", slug)
     return slug
 
 

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -47,6 +47,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))  # tests/src/ for haos_run
 from fastmcp import Client
 from haos_runtime import (
     HA_MCP_DEV_ADDON_SLUG,
+    HA_MCP_WEBHOOK_PROXY_ADDON_SLUG,
     HAOS_IMAGE_ENV,
     boot_haos_qemu,
     is_haos_backend_selected,
@@ -1377,6 +1378,20 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                             f"{base_url}/api/hassio/addons/{HA_MCP_DEV_ADDON_SLUG}/logs?lines=20000",
                         ),
                     )
+                # Always grab the webhook-proxy addon's stdout — it's
+                # installed by the bake (boot=manual) and started by the
+                # haos_only test module's session fixture. When tests in
+                # that module fail, the addon's own logs are the only
+                # place start.py's failure mode is visible (Supervisor's
+                # log only shows container lifecycle events, not addon
+                # stdout).
+                log_endpoints.append(
+                    (
+                        "webhook-proxy-addon.log",
+                        f"{base_url}/api/hassio/addons/"
+                        f"{HA_MCP_WEBHOOK_PROXY_ADDON_SLUG}/logs?lines=20000",
+                    ),
+                )
                 # Narrow except: any non-network error (NameError, KeyError
                 # from a future refactor) should propagate instead of being
                 # misreported as "Failed to dump". Per-endpoint network

--- a/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
+++ b/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
@@ -1,34 +1,45 @@
 """Webhook-proxy addon runtime E2E for the HAOS test tier.
 
-The webhook-proxy addon (``homeassistant-addon-webhook-proxy/``) is now
-baked + installed during the HAOS image build (see
-``stage_webhook_proxy_addon_source`` and ``install_webhook_proxy_addon``
-in ``tests/haos_image_build/build_image.py``). The addon's ``start.py``
-runtime — Supervisor auto-discovery of the ha-mcp dev addon, webhook
-registration into HA Core, ``/data/webhook_id.txt`` persistence (#1020),
-the OAuth fail-closed gate (#1184), and the addon-options round-trip —
-cannot be exercised by the testcontainer suite (no Supervisor) and gets
-its first real coverage here.
+The webhook-proxy addon (``homeassistant-addon-webhook-proxy/``) is baked
+into the qcow2 with ``boot: manual`` (see
+``tests/haos_image_build/build_image.py::install_webhook_proxy_addon``).
+The bake validates that the addon installs cleanly and pre-builds its
+Docker image; tests in this module start the addon via a session
+fixture so the build's success acts as install coverage and the runtime
+tests only run once per session against a known-good container.
 
-Slugs:
+Why boot=manual + session fixture rather than boot=auto:
 
-- Webhook-proxy: ``local_ha_mcp_webhook_proxy`` (constant
-  ``HA_MCP_WEBHOOK_PROXY_ADDON_SLUG`` in build_image.py).
-- Dev addon (the discovery target): ``local_ha_mcp_dev``.
+- ``start.py`` writes ``/config/.mcp_proxy_config.json`` on every run
+  with a freshly-generated webhook_id. If the addon auto-started on
+  qcow2 resume, it would clobber the deterministic config that the
+  bake's ``bake_test_state`` step injected for sibling tests
+  (testcontainer-only ``test_webhook_proxy.py`` relies on the bake's
+  webhook_id ``mcp_e2e_test_webhook_proxy``).
+- The dev MCP addon and the webhook-proxy both have ``startup:
+  application`` and would race on parallel auto-start; webhook-proxy's
+  Supervisor auto-discovery is faster than the dev addon's MCP server
+  reaching ready, so auto-discovery returns "not running" and the
+  addon exits 1 → Supervisor escalates to boot_fail before the dev
+  addon stabilises.
 
-Tests interact with the addon through three observable surfaces:
+``mcp_server_url`` is pinned to ``http://127.0.0.1:9583<secret_path>``
+in the bake's options so the session fixture's start doesn't go through
+auto-discovery (both addons run on host_network so 127.0.0.1 reaches the
+dev addon's MCP server port from inside the webhook-proxy container).
+A dedicated test (``test_auto_discovery_finds_dev_addon_when_url_blank``)
+clears that option, restarts, and asserts auto-discovery still works —
+that path is exercised deliberately rather than relied on for setup.
+
+Tests exercise the addon's runtime through three observable surfaces:
 
 1. Supervisor / MCP tools (``ha_get_addon``, ``ha_manage_addon``,
-   ``ha_call_service`` with the ``hassio.addon_*`` services,
-   ``ha_get_logs``). Same shape as ``test_addon_lifecycle.py``.
-2. The HA Core webhook endpoint (``/api/webhook/<webhook_id>``) via
-   direct HTTP using the bearer token the conftest yields. The addon
-   registers this endpoint via the ``mcp_proxy`` custom integration
-   it installs into HA on first start.
-3. Addon stdout logs via ``ha_get_logs(source='supervisor', slug=...)``
-   — start.py logs the discovered MCP slug and the registered webhook
-   path on startup, which is what we pattern-match for the discovery
-   and webhook-ID persistence checks.
+   ``ha_call_service`` with ``hassio.addon_*``, ``ha_get_logs``).
+2. The HA Core webhook endpoint (``/api/webhook/<webhook_id>``) over
+   HTTP using the bearer token the conftest yields.
+3. Addon stdout via ``ha_get_logs(source='supervisor', slug=...)`` —
+   start.py logs the registered webhook path and the discovered MCP
+   slug on startup.
 """
 
 from __future__ import annotations
@@ -52,28 +63,22 @@ WEBHOOK_PROXY_NAME = "Nabu Casa / Webhook Proxy for HA MCP"
 WEBHOOK_PROXY_SLUG = "local_ha_mcp_webhook_proxy"
 DEV_ADDON_SLUG = "local_ha_mcp_dev"
 
-# Mirrors test_addon_lifecycle.py — Supervisor's "addon not running"
-# family. Used by lifecycle round-trip assertions.
 STOPPED_STATES: frozenset[str] = frozenset({"stopped", "boot_fail", "unknown", "error"})
 
-_STATE_POLL_TIMEOUT = 30.0
+_STATE_POLL_TIMEOUT = 60.0
 _STATE_POLL_INTERVAL = 0.5
 
 # start.py logs the registered webhook path as ``/api/webhook/<id>`` on
-# every startup (see homeassistant-addon-webhook-proxy/start.py:853 and
-# log lines around the proxy_config write). The ID is alphanumeric +
-# underscore + hyphen — match liberally rather than coupling to a
-# specific length, since the addon picks the format.
+# every startup. The ID is alphanumeric + underscore + hyphen; match
+# liberally rather than couple to a specific length.
 _WEBHOOK_PATH_RE = re.compile(r"/api/webhook/([A-Za-z0-9_-]+)")
-# start.py:247 logs "Discovered running MCP addon: <slug> at <ip>" on
-# successful auto-discovery. The MCP slug suffix match accepts
-# ``_ha_mcp_dev`` so the dev-channel addon is the expected target.
+# start.py logs "Discovered running MCP addon: <slug> at <ip>" on
+# successful auto-discovery.
 _DISCOVERY_RE = re.compile(r"Discovered running MCP addon:\s*(\S+)")
 
 
 # ---------------------------------------------------------------------------
-# Helpers — mirror test_addon_lifecycle.py shapes so future drift between
-# this module and the lifecycle suite stays visible.
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -124,24 +129,7 @@ async def _wait_for_state(
     )
 
 
-async def _ensure_started(mcp_client: Any, slug: str) -> None:
-    try:
-        detail = await _get_addon_detail(mcp_client, slug)
-        if detail.get("state") == "started":
-            return
-        result = await _addon_action(mcp_client, slug, "start")
-        if not result.get("success"):
-            LOG.warning(
-                "Cleanup: hassio.addon_start(%s) returned failure: %s", slug, result
-            )
-    except Exception:
-        LOG.exception(
-            "Cleanup of addon %s failed; original test exception preserved", slug
-        )
-
-
 async def _get_addon_logs(mcp_client: Any, slug: str) -> str:
-    """Fetch addon container stdout via ha_get_logs(source='supervisor')."""
     raw = await mcp_client.call_tool(
         "ha_get_logs", {"source": "supervisor", "slug": slug}
     )
@@ -155,104 +143,85 @@ async def _get_addon_logs(mcp_client: Any, slug: str) -> str:
 
 
 def _extract_webhook_id(log_text: str) -> str | None:
-    """Pull the most recent webhook ID start.py logged on startup, or None."""
+    """Pull the most recent webhook ID start.py logged on startup."""
     matches = _WEBHOOK_PATH_RE.findall(log_text)
     return matches[-1] if matches else None
 
 
-async def _restore_options(mcp_client: Any, slug: str, options: dict[str, Any]) -> None:
-    """Restore an options dict via ha_manage_addon. Logs and swallows failures."""
+async def _set_options(mcp_client: Any, slug: str, options: dict[str, Any]) -> None:
+    """Update addon options via ha_manage_addon, asserting success."""
+    raw = await mcp_client.call_tool(
+        "ha_manage_addon", {"slug": slug, "options": dict(options)}
+    )
+    payload = parse_mcp_result(raw)
+    ok = payload.get("success") is True or payload.get("status") == "pending_restart"
+    assert ok, f"ha_manage_addon options write failed: {payload}"
+
+
+# ---------------------------------------------------------------------------
+# Module-scope fixture: start the addon for this module's lifetime.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+async def webhook_proxy_started(mcp_client: Any) -> Any:
+    """Start the webhook-proxy addon for the duration of this module's tests.
+
+    The bake leaves the addon installed but not started (boot=manual).
+    This fixture brings it up at module scope so the per-test overhead
+    is bounded to "send hassio.addon_start once". On teardown, stop the
+    addon so sibling test modules that share the HAOS instance (only
+    a concern in inaddon-tier dispatch) see the addon back in stopped
+    state — preventing state contamination from start.py's writes to
+    /config/.mcp_proxy_config.json across module boundaries.
+    """
+    result = await _addon_action(mcp_client, WEBHOOK_PROXY_SLUG, "start")
+    assert result.get("success"), (
+        f"Fixture failed to start webhook-proxy addon: {result}"
+    )
+    await _wait_for_state(mcp_client, WEBHOOK_PROXY_SLUG, "started")
+    # start.py writes the webhook path to stdout on first start; give
+    # it a moment so the first test reads a populated log.
+    deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+        if _extract_webhook_id(log_text):
+            break
+        await asyncio.sleep(_STATE_POLL_INTERVAL)
     try:
-        await mcp_client.call_tool(
-            "ha_manage_addon", {"slug": slug, "options": dict(options)}
-        )
-    except Exception:
-        LOG.exception("Failed to restore webhook-proxy options to %s", options)
+        yield
+    finally:
+        try:
+            await _addon_action(mcp_client, WEBHOOK_PROXY_SLUG, "stop")
+            await _wait_for_state(
+                mcp_client, WEBHOOK_PROXY_SLUG, STOPPED_STATES, timeout=30.0
+            )
+        except Exception:
+            LOG.exception("Teardown stop of webhook-proxy addon failed")
 
 
 # ---------------------------------------------------------------------------
-# Installation + first-start contract
+# Post-start contract
 # ---------------------------------------------------------------------------
 
 
-async def test_addon_installed_and_running(mcp_client: Any) -> None:
-    """The bake-installed webhook-proxy addon resolves and is in ``started``."""
+async def test_addon_started_after_fixture(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
+    """Fixture brought the bake-installed addon to ``started``."""
     detail = await _get_addon_detail(mcp_client, WEBHOOK_PROXY_SLUG)
     assert detail.get("name") == WEBHOOK_PROXY_NAME, (
         f"Expected name {WEBHOOK_PROXY_NAME!r}, got {detail.get('name')!r}"
     )
     assert detail.get("state") == "started", (
-        f"Webhook-proxy addon should be ``started`` after bake; "
-        f"got state={detail.get('state')!r}. Full detail: {detail}"
+        f"Webhook-proxy addon should be ``started`` after fixture; "
+        f"got state={detail.get('state')!r}"
     )
 
 
-async def test_addon_supervisor_auto_discovery_logs_dev_slug(
-    mcp_client: Any,
+async def test_addon_logs_fetch_shape(
+    mcp_client: Any, webhook_proxy_started: Any
 ) -> None:
-    """``start.py`` auto-discovery finds and logs the dev MCP addon slug.
-
-    start.py:188-249 lists installed addons via the Supervisor API, matches
-    slug suffixes ``_ha_mcp`` / ``_ha_mcp_dev``, and logs the discovered
-    target before continuing. With ``mcp_server_url`` left empty in the
-    bake's options POST (see ``install_webhook_proxy_addon``), this is the
-    code path that runs on first start. A regression that breaks the slug
-    suffix match or the addon-listing call would show up here as the dev
-    slug failing to appear in the log.
-    """
-    log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
-    discovered = _DISCOVERY_RE.findall(log_text)
-    assert discovered, (
-        "Webhook-proxy logs do not contain "
-        '"Discovered running MCP addon: <slug>". Either the auto-discovery '
-        "code path regressed or the addon failed to reach it. "
-        f"Log tail: ...{log_text[-2000:]!r}"
-    )
-    assert DEV_ADDON_SLUG in discovered, (
-        f"Expected webhook-proxy to discover the dev addon "
-        f"({DEV_ADDON_SLUG!r}); observed discoveries: {discovered}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Lifecycle round-trip — mirror Matter Server's stop/start/restart test
-# ---------------------------------------------------------------------------
-
-
-async def test_addon_start_stop_restart_roundtrip(mcp_client: Any) -> None:
-    """Stop → start → restart cycles the webhook-proxy via Supervisor.
-
-    Mirrors ``test_matter_server_start_stop_restart_roundtrip``. Webhook-
-    proxy's startup is heavier than Matter Server (writes ``/data/webhook_id.txt``,
-    installs the mcp_proxy custom integration, registers the webhook with HA
-    Core) so the ``_STATE_POLL_TIMEOUT`` headroom matters more here than for
-    the lighter addons. Cleanup leaves it running so later tests observe a
-    started addon.
-    """
-    slug = WEBHOOK_PROXY_SLUG
-    try:
-        stop_result = await _addon_action(mcp_client, slug, "stop")
-        assert stop_result.get("success"), (
-            f"hassio.addon_stop({slug}) failed: {stop_result}"
-        )
-        await _wait_for_state(mcp_client, slug, STOPPED_STATES)
-
-        start_result = await _addon_action(mcp_client, slug, "start")
-        assert start_result.get("success"), (
-            f"hassio.addon_start({slug}) failed: {start_result}"
-        )
-        await _wait_for_state(mcp_client, slug, "started")
-
-        restart_result = await _addon_action(mcp_client, slug, "restart")
-        assert restart_result.get("success"), (
-            f"hassio.addon_restart({slug}) failed: {restart_result}"
-        )
-        await _wait_for_state(mcp_client, slug, "started")
-    finally:
-        await _ensure_started(mcp_client, slug)
-
-
-async def test_addon_logs_fetch_shape(mcp_client: Any) -> None:
     """``ha_get_logs(source='supervisor')`` returns substantial log text."""
     log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
     assert len(log_text.strip()) >= 100, (
@@ -261,12 +230,9 @@ async def test_addon_logs_fetch_shape(mcp_client: Any) -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Options round-trip — mirror Node-RED's options-persist pattern.
-# ---------------------------------------------------------------------------
-
-
-async def test_addon_options_get_returns_dict(mcp_client: Any) -> None:
+async def test_addon_options_get_returns_dict(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
     """``ha_get_addon`` exposes webhook-proxy options as a dict."""
     detail = await _get_addon_detail(mcp_client, WEBHOOK_PROXY_SLUG)
     options = detail.get("options")
@@ -276,14 +242,55 @@ async def test_addon_options_get_returns_dict(mcp_client: Any) -> None:
     )
 
 
-async def test_addon_remote_url_round_trip(mcp_client: Any) -> None:
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_start_stop_restart_roundtrip(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
+    """Stop → start → restart cycles via Supervisor.
+
+    Mirrors ``test_matter_server_start_stop_restart_roundtrip`` in
+    test_addon_lifecycle.py. Cleanup leaves the addon in ``started`` so
+    sibling tests in this module see it running. The fixture's teardown
+    is the durable stop.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    stop_result = await _addon_action(mcp_client, slug, "stop")
+    assert stop_result.get("success"), (
+        f"hassio.addon_stop({slug}) failed: {stop_result}"
+    )
+    await _wait_for_state(mcp_client, slug, STOPPED_STATES)
+
+    start_result = await _addon_action(mcp_client, slug, "start")
+    assert start_result.get("success"), (
+        f"hassio.addon_start({slug}) failed: {start_result}"
+    )
+    await _wait_for_state(mcp_client, slug, "started")
+
+    restart_result = await _addon_action(mcp_client, slug, "restart")
+    assert restart_result.get("success"), (
+        f"hassio.addon_restart({slug}) failed: {restart_result}"
+    )
+    await _wait_for_state(mcp_client, slug, "started")
+
+
+# ---------------------------------------------------------------------------
+# Options round-trip — mirror Node-RED's options-persist pattern.
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_remote_url_round_trip(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
     """``remote_url`` written via ha_manage_addon persists in Supervisor options.
 
     The addon's schema declares ``remote_url: str?``. Tests assert the
     write path round-trips through Supervisor; whether the addon actually
-    reaches the URL is a downstream concern (the addon doesn't try to
-    contact ``remote_url`` until something hits the webhook). Restored to
-    empty in ``finally`` so sibling tests aren't observably mutated.
+    reaches the URL is a downstream concern. Restored to empty in
+    ``finally`` so sibling tests aren't observably mutated.
     """
     slug = WEBHOOK_PROXY_SLUG
     detail = await _get_addon_detail(mcp_client, slug)
@@ -295,15 +302,7 @@ async def test_addon_remote_url_round_trip(mcp_client: Any) -> None:
     probe_options = dict(current_options)
     probe_options["remote_url"] = probe
     try:
-        write_raw = await mcp_client.call_tool(
-            "ha_manage_addon", {"slug": slug, "options": probe_options}
-        )
-        write_payload = parse_mcp_result(write_raw)
-        ok = write_payload.get("success") is True or (
-            write_payload.get("status") == "pending_restart"
-        )
-        assert ok, f"ha_manage_addon remote_url write failed: {write_payload}"
-
+        await _set_options(mcp_client, slug, probe_options)
         detail_after = await _get_addon_detail(mcp_client, slug)
         options_after = detail_after.get("options") or {}
         assert options_after.get("remote_url") == probe, (
@@ -313,8 +312,72 @@ async def test_addon_remote_url_round_trip(mcp_client: Any) -> None:
     finally:
         restore = dict(current_options)
         restore["remote_url"] = original_remote
-        await _restore_options(mcp_client, slug, restore)
-        await _ensure_started(mcp_client, slug)
+        try:
+            await _set_options(mcp_client, slug, restore)
+        except Exception:
+            LOG.exception("Failed to restore remote_url to %s", original_remote)
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery — deliberately exercised by clearing mcp_server_url + restart.
+# ---------------------------------------------------------------------------
+
+
+async def test_auto_discovery_finds_dev_addon_when_url_blank(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
+    """Clearing ``mcp_server_url`` forces start.py's auto-discovery.
+
+    The bake pins ``mcp_server_url`` to the dev addon's host-network URL
+    so the addon doesn't depend on auto-discovery timing during setup.
+    This test exercises the auto-discovery code path explicitly: clear
+    the field, restart the addon, assert the discovery log line names
+    the dev addon slug, then restore the pinned URL so subsequent tests
+    in this module use the reliable target.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    detail = await _get_addon_detail(mcp_client, slug)
+    current_options = detail.get("options") or {}
+    assert isinstance(current_options, dict)
+    pinned_url = current_options.get("mcp_server_url", "")
+
+    cleared_options = dict(current_options)
+    cleared_options["mcp_server_url"] = ""
+    try:
+        await _set_options(mcp_client, slug, cleared_options)
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        # Poll the log until the discovery line appears in the new run.
+        deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+        discovered: list[str] = []
+        while time.monotonic() < deadline:
+            log_text = await _get_addon_logs(mcp_client, slug)
+            discovered = _DISCOVERY_RE.findall(log_text)
+            if discovered:
+                break
+            await asyncio.sleep(_STATE_POLL_INTERVAL)
+        assert discovered, (
+            "Webhook-proxy did not log "
+            '"Discovered running MCP addon: <slug>" within '
+            f"{_STATE_POLL_TIMEOUT}s after restart with blank "
+            "mcp_server_url. Auto-discovery code path regressed."
+        )
+        assert DEV_ADDON_SLUG in discovered, (
+            f"Expected discovery target {DEV_ADDON_SLUG!r}; observed: {discovered}"
+        )
+    finally:
+        restore = dict(current_options)
+        restore["mcp_server_url"] = pinned_url
+        try:
+            await _set_options(mcp_client, slug, restore)
+            await _addon_action(mcp_client, slug, "restart")
+            await _wait_for_state(mcp_client, slug, "started")
+        except Exception:
+            LOG.exception("Failed to restore mcp_server_url + restart")
 
 
 # ---------------------------------------------------------------------------
@@ -322,85 +385,73 @@ async def test_addon_remote_url_round_trip(mcp_client: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_webhook_id_persists_across_restart(mcp_client: Any) -> None:
+async def test_webhook_id_persists_across_restart(
+    mcp_client: Any, webhook_proxy_started: Any
+) -> None:
     """The webhook ID survives an addon restart (PR #1020 regression).
 
-    start.py reads/writes ``/data/webhook_id.txt`` (see
-    ``_get_or_create_webhook_id``). ``/data`` is the Supervisor-mounted
-    persistent volume, so an ``addon_restart`` keeps the file and the URL
-    stays the same. A regression that re-generated the ID on every start
-    would break the contract that an MCP client's saved webhook URL
-    doesn't change unless the user explicitly rotates it.
-
-    Reads the most recent ``/api/webhook/<id>`` from the addon log,
-    restarts the addon, reads again, asserts the IDs match. ``-n2``
-    pytest-xdist scope is fine here because Supervisor logs accumulate
-    over the addon's whole life; each restart appends new lines without
-    truncating the file we read.
+    start.py reads/writes ``/data/webhook_id.txt`` — the Supervisor-
+    mounted persistent volume — so an ``addon_restart`` keeps the file
+    and the URL stays the same. A regression that re-generated the ID
+    on every start would break the contract that an MCP client's saved
+    webhook URL doesn't change unless the user explicitly rotates it.
     """
     slug = WEBHOOK_PROXY_SLUG
-    try:
-        pre_log = await _get_addon_logs(mcp_client, slug)
-        pre_id = _extract_webhook_id(pre_log)
-        assert pre_id, (
-            "Could not find ``/api/webhook/<id>`` line in webhook-proxy "
-            "logs before restart — start.py either didn't log it or the "
-            "log fetch returned an incomplete tail. "
-            f"Log tail: ...{pre_log[-2000:]!r}"
-        )
+    pre_log = await _get_addon_logs(mcp_client, slug)
+    pre_id = _extract_webhook_id(pre_log)
+    assert pre_id, (
+        "Could not find ``/api/webhook/<id>`` line in webhook-proxy "
+        "logs before restart. "
+        f"Log tail: ...{pre_log[-2000:]!r}"
+    )
 
-        restart_result = await _addon_action(mcp_client, slug, "restart")
-        assert restart_result.get("success"), (
-            f"hassio.addon_restart({slug}) failed: {restart_result}"
-        )
-        await _wait_for_state(mcp_client, slug, "started")
+    restart_result = await _addon_action(mcp_client, slug, "restart")
+    assert restart_result.get("success"), (
+        f"hassio.addon_restart({slug}) failed: {restart_result}"
+    )
+    await _wait_for_state(mcp_client, slug, "started")
 
-        # start.py logs the webhook path on every startup, but the
-        # Supervisor log endpoint races the addon's stdout buffer. Poll
-        # the log until a webhook-path line appears AFTER the restart.
-        deadline = time.monotonic() + _STATE_POLL_TIMEOUT
-        post_id: str | None = None
-        while time.monotonic() < deadline:
-            post_log = await _get_addon_logs(mcp_client, slug)
-            # Look at the suffix beyond pre_log's length so we only match
-            # lines emitted in the new (post-restart) run.
-            new_section = post_log[len(pre_log) :]
-            post_id = _extract_webhook_id(new_section)
-            if post_id:
-                break
-            await asyncio.sleep(_STATE_POLL_INTERVAL)
+    deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+    post_id: str | None = None
+    while time.monotonic() < deadline:
+        post_log = await _get_addon_logs(mcp_client, slug)
+        # Only consider log lines emitted after the pre-restart snapshot.
+        new_section = post_log[len(pre_log) :]
+        post_id = _extract_webhook_id(new_section)
+        if post_id:
+            break
+        await asyncio.sleep(_STATE_POLL_INTERVAL)
 
-        assert post_id, (
-            "Webhook-proxy did not re-log the webhook path within "
-            f"{_STATE_POLL_TIMEOUT}s of restart. Either the addon failed "
-            "to reach _register_webhook or stdout buffering is hiding "
-            "the line."
-        )
-        assert post_id == pre_id, (
-            f"Webhook ID changed across restart (pre={pre_id!r}, "
-            f"post={post_id!r}). #1020 regression — /data/webhook_id.txt "
-            "is no longer persisting the ID."
-        )
-    finally:
-        await _ensure_started(mcp_client, slug)
+    assert post_id, (
+        "Webhook-proxy did not re-log the webhook path within "
+        f"{_STATE_POLL_TIMEOUT}s of restart."
+    )
+    assert post_id == pre_id, (
+        f"Webhook ID changed across restart (pre={pre_id!r}, "
+        f"post={post_id!r}). #1020 regression — /data/webhook_id.txt "
+        "is no longer persisting the ID."
+    )
 
 
 # ---------------------------------------------------------------------------
-# Webhook endpoint reachability — addon-registered, not bake-injected.
+# Webhook endpoint registered in HA Core
 # ---------------------------------------------------------------------------
 
 
 async def test_webhook_endpoint_registered_in_ha_core(
-    mcp_client: Any, ha_container_with_fresh_config: dict[str, Any]
+    mcp_client: Any,
+    webhook_proxy_started: Any,
+    ha_container_with_fresh_config: dict[str, Any],
 ) -> None:
     """The webhook the addon registered is reachable on HA Core's HTTP API.
 
-    The addon's first-start flow installs the ``mcp_proxy`` custom
-    integration and creates a config entry that calls
-    ``webhook.async_register`` with the persisted webhook ID. A reachable
-    endpoint should NOT 404 — the integration replies with a structured
-    error or proxy response, not the generic HA "no such webhook" 404
-    that an unregistered ID returns.
+    The addon's start.py installs the ``mcp_proxy`` custom integration
+    and creates a config entry that calls ``webhook.async_register``
+    with the persisted webhook ID. HA returns 200 with an empty body
+    for any unregistered webhook ID (this is by design — webhook auth
+    is URL-secrecy). We assert the integration's response to the
+    registered URL differs from the unregistered baseline in at least
+    one of (status, body, content-type).
     """
     base_url = ha_container_with_fresh_config["base_url"]
     token = ha_container_with_fresh_config["token"]
@@ -408,62 +459,50 @@ async def test_webhook_endpoint_registered_in_ha_core(
 
     pre_log = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
     webhook_id = _extract_webhook_id(pre_log)
-    assert webhook_id, (
-        "Could not extract registered webhook ID from addon log. "
-        "test_webhook_id_persists_across_restart should be passing too — "
-        "fix that first if both fail."
-    )
+    assert webhook_id, "Could not extract registered webhook ID from addon log."
 
     registered_url = f"{base_url}/api/webhook/{webhook_id}"
-    unregistered_url = f"{base_url}/api/webhook/definitely-not-registered"
+    unregistered_url = f"{base_url}/api/webhook/definitely-not-registered-xyz"
 
-    # The HA Core webhook endpoint accepts POST without auth (webhooks
-    # are auth-by-URL-secrecy by design). GET with auth is also accepted
-    # for HA's own webhook handlers; mcp_proxy registers POST + GET. The
-    # raw status code suffices to distinguish "registered" (anything but
-    # 404) from "unregistered" (404). Failure mode we care about: a
-    # registration regression silently drops the webhook and BOTH URLs
-    # return 404 identically.
     registered_resp = await asyncio.to_thread(
         requests.post, registered_url, headers=headers, timeout=10
     )
     unregistered_resp = await asyncio.to_thread(
         requests.post, unregistered_url, headers=headers, timeout=10
     )
-    assert registered_resp.status_code != 404, (
-        f"Registered webhook URL returned 404 — addon's webhook "
-        f"registration did not take effect. "
-        f"URL: {registered_url}, body: {registered_resp.text[:300]!r}"
+
+    differs = (
+        registered_resp.status_code != unregistered_resp.status_code
+        or registered_resp.content != unregistered_resp.content
+        or registered_resp.headers.get("Content-Type")
+        != unregistered_resp.headers.get("Content-Type")
     )
-    # Sanity check: unknown ID returns the generic 404. If HA changes
-    # this to e.g. 401 for all webhook IDs the assertion above would
-    # pass falsely; pin the discrimination here.
-    assert unregistered_resp.status_code == 404, (
-        f"Unregistered webhook URL should return 404, got "
-        f"{unregistered_resp.status_code}: {unregistered_resp.text[:300]!r}"
+    assert differs, (
+        "Registered webhook response is identical to unregistered "
+        f"({registered_resp.status_code} == {unregistered_resp.status_code}, "
+        f"len={len(registered_resp.content)} == "
+        f"{len(unregistered_resp.content)}). mcp_proxy may not have "
+        "registered the webhook on first start."
     )
 
 
 # ---------------------------------------------------------------------------
-# OAuth gate (#1184): enabling enable_oauth must close the webhook to
-# unauthenticated callers.
+# OAuth gate (#1184)
 # ---------------------------------------------------------------------------
 
 
 async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
-    mcp_client: Any, ha_container_with_fresh_config: dict[str, Any]
+    mcp_client: Any,
+    webhook_proxy_started: Any,
+    ha_container_with_fresh_config: dict[str, Any],
 ) -> None:
     """Enabling ``enable_oauth`` makes the webhook reject unauth requests.
 
     PR #1184 added an OAuth fail-closed gate: when ``enable_oauth=true``
     the addon refuses to register the webhook (or unregisters it) until
-    the OAuth integration is verified loaded. The user-facing effect is
-    that previously-working POSTs to the webhook URL stop succeeding
-    with the same plain-status response. The exact failure mode depends
-    on whether the integration was successfully reloaded — accept either
-    a 4xx response OR an outright 404 (webhook unregistered while the
-    OAuth check ran), as long as it differs from the un-gated POST's
-    status. Restored to ``enable_oauth=false`` in ``finally``.
+    the OAuth integration is verified loaded. Accept either auth-
+    rejection (401/403) or unregistered-404 as evidence the gate
+    engaged. Restored to ``enable_oauth=false`` in ``finally``.
     """
     slug = WEBHOOK_PROXY_SLUG
     base_url = ha_container_with_fresh_config["base_url"]
@@ -479,7 +518,6 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
     assert webhook_id, "Could not extract webhook ID from addon log."
     webhook_url = f"{base_url}/api/webhook/{webhook_id}"
 
-    # Baseline: OAuth off, webhook endpoint accepts POST (status != 401/403).
     baseline_resp = await asyncio.to_thread(
         requests.post, webhook_url, headers=headers, timeout=10
     )
@@ -491,29 +529,13 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
     probe_options = dict(current_options)
     probe_options["enable_oauth"] = True
     try:
-        write_raw = await mcp_client.call_tool(
-            "ha_manage_addon", {"slug": slug, "options": probe_options}
-        )
-        write_payload = parse_mcp_result(write_raw)
-        ok = write_payload.get("success") is True or (
-            write_payload.get("status") == "pending_restart"
-        )
-        assert ok, f"enable_oauth=true write failed: {write_payload}"
-
-        # ha_manage_addon's options write reports ``pending_restart`` when
-        # the addon needs a restart to pick up runtime changes — the
-        # OAuth gate is a runtime concern, so kick the restart ourselves.
+        await _set_options(mcp_client, slug, probe_options)
         restart_result = await _addon_action(mcp_client, slug, "restart")
         assert restart_result.get("success"), (
             f"hassio.addon_restart({slug}) for OAuth toggle failed: {restart_result}"
         )
         await _wait_for_state(mcp_client, slug, "started")
 
-        # Poll until the post-restart webhook behavior diverges from
-        # baseline. start.py's OAuth gate is async (probes the
-        # /api/mcp_proxy/oauth endpoint with retries), so the close-down
-        # may not be observable for several seconds after the addon
-        # reports ``started``.
         deadline = time.monotonic() + _STATE_POLL_TIMEOUT
         last_status: int | None = None
         gated = False
@@ -522,9 +544,6 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
                 requests.post, webhook_url, headers=headers, timeout=10
             )
             last_status = resp.status_code
-            # Gate kicked in: either OAuth-rejected (401/403) or webhook
-            # unregistered (404). Anything else means the gate hasn't
-            # taken effect yet.
             if last_status in (401, 403, 404):
                 gated = True
                 break
@@ -537,12 +556,9 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
             "PR #1184 fail-closed gate may have regressed."
         )
     finally:
-        await _restore_options(mcp_client, slug, current_options)
-        # Restart so the restored OAuth-off state takes effect for sibling
-        # tests, then leave the addon running.
         try:
+            await _set_options(mcp_client, slug, current_options)
             await _addon_action(mcp_client, slug, "restart")
             await _wait_for_state(mcp_client, slug, "started")
         except Exception:
             LOG.exception("OAuth cleanup restart failed")
-        await _ensure_started(mcp_client, slug)

--- a/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
+++ b/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
@@ -10,12 +10,15 @@ tests only run once per session against a known-good container.
 
 Why boot=manual + session fixture rather than boot=auto:
 
-- ``start.py`` writes ``/config/.mcp_proxy_config.json`` on every run
-  with a freshly-generated webhook_id. If the addon auto-started on
-  qcow2 resume, it would clobber the deterministic config that the
-  bake's ``bake_test_state`` step injected for sibling tests
-  (testcontainer-only ``test_webhook_proxy.py`` relies on the bake's
-  webhook_id ``mcp_e2e_test_webhook_proxy``).
+- ``start.py`` overwrites ``/config/.mcp_proxy_config.json`` on every
+  run with the addon's persisted webhook_id (read from
+  ``/data/webhook_id.txt`` — generated on first-ever start, reused on
+  every subsequent run). That persisted id differs from the
+  deterministic value the bake's ``bake_test_state`` step injected
+  (``mcp_e2e_test_webhook_proxy``). If the addon auto-started on
+  qcow2 resume, the overwrite would happen before any test runs and
+  the testcontainer-only ``test_webhook_proxy.py`` (which still
+  expects the bake's id) would fail on identical-content checks.
 - The dev MCP addon and the webhook-proxy both have ``startup:
   application`` and would race on parallel auto-start; webhook-proxy's
   Supervisor auto-discovery is faster than the dev addon's MCP server
@@ -54,6 +57,7 @@ import pytest
 import requests
 
 from ..utilities.assertions import parse_mcp_result, safe_call_tool
+from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
 
@@ -143,7 +147,16 @@ async def _get_addon_logs(mcp_client: Any, slug: str) -> str:
 
 
 def _extract_webhook_id(log_text: str) -> str | None:
-    """Pull the most recent webhook ID start.py logged on startup."""
+    """Pull the most recent webhook ID start.py logged on startup.
+
+    Returns the LAST match in the supplied text. start.py logs the
+    webhook path once per run from ``_register_webhook``; on a
+    multi-start log (fixture start + intra-test restarts) every match
+    is the same persisted id (from ``/data/webhook_id.txt``), so
+    last-match is equivalent to any-match. Callers that need the id
+    from a SPECIFIC run (e.g. post-restart-only) should slice the log
+    before calling — see ``test_webhook_id_persists_across_restart``.
+    """
     matches = _WEBHOOK_PATH_RE.findall(log_text)
     return matches[-1] if matches else None
 
@@ -181,13 +194,30 @@ async def webhook_proxy_started(mcp_client: Any) -> Any:
     )
     await _wait_for_state(mcp_client, WEBHOOK_PROXY_SLUG, "started")
     # start.py writes the webhook path to stdout on first start; give
-    # it a moment so the first test reads a populated log.
+    # it a moment so the first test reads a populated log. Catch
+    # _POLLING_TRANSIENT_ERRORS so a momentary MCP transport blip
+    # during addon boot doesn't abort the fixture before the addon
+    # has had a chance to log the path.
     deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+    seen_webhook = False
     while time.monotonic() < deadline:
-        log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+        try:
+            log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+        except _POLLING_TRANSIENT_ERRORS as exc:
+            LOG.debug("Transient ha_get_logs error during fixture wait: %s", exc)
+            await asyncio.sleep(_STATE_POLL_INTERVAL)
+            continue
         if _extract_webhook_id(log_text):
+            seen_webhook = True
             break
         await asyncio.sleep(_STATE_POLL_INTERVAL)
+    assert seen_webhook, (
+        f"Webhook-proxy did not log ``/api/webhook/<id>`` within "
+        f"{_STATE_POLL_TIMEOUT}s of start. Either start.py failed to "
+        f"reach _register_webhook or it crashed before emitting the "
+        f"line. Check /tmp/haos-diagnostics/webhook-proxy-addon.log on "
+        f"the runner."
+    )
     try:
         yield
     finally:
@@ -196,7 +226,7 @@ async def webhook_proxy_started(mcp_client: Any) -> Any:
             await _wait_for_state(
                 mcp_client, WEBHOOK_PROXY_SLUG, STOPPED_STATES, timeout=30.0
             )
-        except Exception:
+        except Exception:  # pragma: no cover - cleanup best-effort
             LOG.exception("Teardown stop of webhook-proxy addon failed")
 
 
@@ -314,7 +344,7 @@ async def test_addon_remote_url_round_trip(
         restore["remote_url"] = original_remote
         try:
             await _set_options(mcp_client, slug, restore)
-        except Exception:
+        except Exception:  # pragma: no cover - cleanup best-effort
             LOG.exception("Failed to restore remote_url to %s", original_remote)
 
 
@@ -355,7 +385,16 @@ async def test_auto_discovery_finds_dev_addon_when_url_blank(
         deadline = time.monotonic() + _STATE_POLL_TIMEOUT
         discovered: list[str] = []
         while time.monotonic() < deadline:
-            log_text = await _get_addon_logs(mcp_client, slug)
+            try:
+                log_text = await _get_addon_logs(mcp_client, slug)
+            except _POLLING_TRANSIENT_ERRORS as exc:
+                LOG.debug(
+                    "Transient ha_get_logs error during discovery poll (slug=%s): %s",
+                    slug,
+                    exc,
+                )
+                await asyncio.sleep(_STATE_POLL_INTERVAL)
+                continue
             discovered = _DISCOVERY_RE.findall(log_text)
             if discovered:
                 break
@@ -376,7 +415,7 @@ async def test_auto_discovery_finds_dev_addon_when_url_blank(
             await _set_options(mcp_client, slug, restore)
             await _addon_action(mcp_client, slug, "restart")
             await _wait_for_state(mcp_client, slug, "started")
-        except Exception:
+        except Exception:  # pragma: no cover - cleanup best-effort
             LOG.exception("Failed to restore mcp_server_url + restart")
 
 
@@ -414,7 +453,16 @@ async def test_webhook_id_persists_across_restart(
     deadline = time.monotonic() + _STATE_POLL_TIMEOUT
     post_id: str | None = None
     while time.monotonic() < deadline:
-        post_log = await _get_addon_logs(mcp_client, slug)
+        try:
+            post_log = await _get_addon_logs(mcp_client, slug)
+        except _POLLING_TRANSIENT_ERRORS as exc:
+            LOG.debug(
+                "Transient ha_get_logs error during webhook-id poll (slug=%s): %s",
+                slug,
+                exc,
+            )
+            await asyncio.sleep(_STATE_POLL_INTERVAL)
+            continue
         # Only consider log lines emitted after the pre-restart snapshot.
         new_section = post_log[len(pre_log) :]
         post_id = _extract_webhook_id(new_section)
@@ -484,6 +532,17 @@ async def test_webhook_endpoint_registered_in_ha_core(
         f"{len(unregistered_resp.content)}). mcp_proxy may not have "
         "registered the webhook on first start."
     )
+    # Additional positive-signal check: HA's default-for-unregistered
+    # returns 200 with an empty body. If a future HA change starts
+    # returning a non-empty body for unknown webhooks (e.g. echoing the
+    # path), ``differs`` above could pass on incidental content drift
+    # without proving the integration actually handled the request.
+    # Anchor on registered-has-content as the positive signal.
+    assert len(registered_resp.content) > 0, (
+        f"Registered webhook returned an empty body ({registered_resp.status_code}). "
+        "mcp_proxy's handler should produce a response — empty body "
+        "suggests the integration's webhook isn't actually serving."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -525,6 +584,18 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
         f"Baseline (OAuth off) POST should not be auth-rejected; "
         f"got {baseline_resp.status_code}: {baseline_resp.text[:300]!r}"
     )
+    # The "gated" check below treats 404 as evidence the addon
+    # unregistered the webhook in response to enable_oauth=True. If the
+    # webhook were already unregistered at baseline (mcp_proxy never
+    # registered it on first start, say), the gate check would falsely
+    # pass with no actual contrast — pin the baseline as "registered"
+    # by requiring a non-404 here.
+    assert baseline_resp.status_code != 404, (
+        f"Baseline POST returned 404 — webhook is not registered before "
+        f"OAuth toggle. The gate test cannot distinguish gate-engaged "
+        f"from "
+        f"never-registered. Body: {baseline_resp.text[:300]!r}"
+    )
 
     probe_options = dict(current_options)
     probe_options["enable_oauth"] = True
@@ -540,9 +611,20 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
         last_status: int | None = None
         gated = False
         while time.monotonic() < deadline:
-            resp = await asyncio.to_thread(
-                requests.post, webhook_url, headers=headers, timeout=10
-            )
+            try:
+                resp = await asyncio.to_thread(
+                    requests.post, webhook_url, headers=headers, timeout=10
+                )
+            except requests.exceptions.RequestException as exc:
+                # Transient connection/timeout during addon restart and
+                # OAuth gate activation. Retry until the deadline.
+                LOG.debug(
+                    "Transient requests error during OAuth gate poll (url=%s): %s",
+                    webhook_url,
+                    exc,
+                )
+                await asyncio.sleep(_STATE_POLL_INTERVAL)
+                continue
             last_status = resp.status_code
             if last_status in (401, 403, 404):
                 gated = True
@@ -560,5 +642,5 @@ async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
             await _set_options(mcp_client, slug, current_options)
             await _addon_action(mcp_client, slug, "restart")
             await _wait_for_state(mcp_client, slug, "started")
-        except Exception:
+        except Exception:  # pragma: no cover - cleanup best-effort
             LOG.exception("OAuth cleanup restart failed")

--- a/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
+++ b/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
@@ -1,0 +1,548 @@
+"""Webhook-proxy addon runtime E2E for the HAOS test tier.
+
+The webhook-proxy addon (``homeassistant-addon-webhook-proxy/``) is now
+baked + installed during the HAOS image build (see
+``stage_webhook_proxy_addon_source`` and ``install_webhook_proxy_addon``
+in ``tests/haos_image_build/build_image.py``). The addon's ``start.py``
+runtime — Supervisor auto-discovery of the ha-mcp dev addon, webhook
+registration into HA Core, ``/data/webhook_id.txt`` persistence (#1020),
+the OAuth fail-closed gate (#1184), and the addon-options round-trip —
+cannot be exercised by the testcontainer suite (no Supervisor) and gets
+its first real coverage here.
+
+Slugs:
+
+- Webhook-proxy: ``local_ha_mcp_webhook_proxy`` (constant
+  ``HA_MCP_WEBHOOK_PROXY_ADDON_SLUG`` in build_image.py).
+- Dev addon (the discovery target): ``local_ha_mcp_dev``.
+
+Tests interact with the addon through three observable surfaces:
+
+1. Supervisor / MCP tools (``ha_get_addon``, ``ha_manage_addon``,
+   ``ha_call_service`` with the ``hassio.addon_*`` services,
+   ``ha_get_logs``). Same shape as ``test_addon_lifecycle.py``.
+2. The HA Core webhook endpoint (``/api/webhook/<webhook_id>``) via
+   direct HTTP using the bearer token the conftest yields. The addon
+   registers this endpoint via the ``mcp_proxy`` custom integration
+   it installs into HA on first start.
+3. Addon stdout logs via ``ha_get_logs(source='supervisor', slug=...)``
+   — start.py logs the discovered MCP slug and the registered webhook
+   path on startup, which is what we pattern-match for the discovery
+   and webhook-ID persistence checks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any
+
+import pytest
+import requests
+
+from ..utilities.assertions import parse_mcp_result, safe_call_tool
+
+LOG = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.haos_only]
+
+WEBHOOK_PROXY_NAME = "Nabu Casa / Webhook Proxy for HA MCP"
+WEBHOOK_PROXY_SLUG = "local_ha_mcp_webhook_proxy"
+DEV_ADDON_SLUG = "local_ha_mcp_dev"
+
+# Mirrors test_addon_lifecycle.py — Supervisor's "addon not running"
+# family. Used by lifecycle round-trip assertions.
+STOPPED_STATES: frozenset[str] = frozenset({"stopped", "boot_fail", "unknown", "error"})
+
+_STATE_POLL_TIMEOUT = 30.0
+_STATE_POLL_INTERVAL = 0.5
+
+# start.py logs the registered webhook path as ``/api/webhook/<id>`` on
+# every startup (see homeassistant-addon-webhook-proxy/start.py:853 and
+# log lines around the proxy_config write). The ID is alphanumeric +
+# underscore + hyphen — match liberally rather than coupling to a
+# specific length, since the addon picks the format.
+_WEBHOOK_PATH_RE = re.compile(r"/api/webhook/([A-Za-z0-9_-]+)")
+# start.py:247 logs "Discovered running MCP addon: <slug> at <ip>" on
+# successful auto-discovery. The MCP slug suffix match accepts
+# ``_ha_mcp_dev`` so the dev-channel addon is the expected target.
+_DISCOVERY_RE = re.compile(r"Discovered running MCP addon:\s*(\S+)")
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror test_addon_lifecycle.py shapes so future drift between
+# this module and the lifecycle suite stays visible.
+# ---------------------------------------------------------------------------
+
+
+async def _get_addon_detail(mcp_client: Any, slug: str) -> dict[str, Any]:
+    raw = await mcp_client.call_tool("ha_get_addon", {"slug": slug})
+    payload = parse_mcp_result(raw)
+    assert payload.get("success"), f"ha_get_addon({slug!r}) failed: {payload}"
+    detail = payload.get("addon")
+    assert isinstance(detail, dict), (
+        f"ha_get_addon({slug!r}) returned no addon dict: {payload}"
+    )
+    return detail
+
+
+async def _addon_action(mcp_client: Any, slug: str, action: str) -> dict[str, Any]:
+    return await safe_call_tool(
+        mcp_client,
+        "ha_call_service",
+        {
+            "domain": "hassio",
+            "service": f"addon_{action}",
+            "data": {"addon": slug},
+        },
+    )
+
+
+async def _wait_for_state(
+    mcp_client: Any,
+    slug: str,
+    expected: str | frozenset[str] | set[str],
+    *,
+    timeout: float = _STATE_POLL_TIMEOUT,
+) -> str:
+    expected_set: frozenset[str] = (
+        frozenset({expected}) if isinstance(expected, str) else frozenset(expected)
+    )
+    deadline = time.monotonic() + timeout
+    last_state: str | None = None
+    while time.monotonic() < deadline:
+        detail = await _get_addon_detail(mcp_client, slug)
+        last_state = detail.get("state")
+        if last_state in expected_set:
+            return str(last_state)
+        await asyncio.sleep(_STATE_POLL_INTERVAL)
+    raise AssertionError(
+        f"Addon {slug!r} state did not reach {sorted(expected_set)!r} "
+        f"within {timeout}s (last observed: {last_state!r})"
+    )
+
+
+async def _ensure_started(mcp_client: Any, slug: str) -> None:
+    try:
+        detail = await _get_addon_detail(mcp_client, slug)
+        if detail.get("state") == "started":
+            return
+        result = await _addon_action(mcp_client, slug, "start")
+        if not result.get("success"):
+            LOG.warning(
+                "Cleanup: hassio.addon_start(%s) returned failure: %s", slug, result
+            )
+    except Exception:
+        LOG.exception(
+            "Cleanup of addon %s failed; original test exception preserved", slug
+        )
+
+
+async def _get_addon_logs(mcp_client: Any, slug: str) -> str:
+    """Fetch addon container stdout via ha_get_logs(source='supervisor')."""
+    raw = await mcp_client.call_tool(
+        "ha_get_logs", {"source": "supervisor", "slug": slug}
+    )
+    payload = parse_mcp_result(raw)
+    assert payload.get("success"), f"ha_get_logs(supervisor, {slug}) failed: {payload}"
+    log_text = payload.get("log", "")
+    assert isinstance(log_text, str), (
+        f"ha_get_logs returned non-string log field: {type(log_text).__name__}"
+    )
+    return log_text
+
+
+def _extract_webhook_id(log_text: str) -> str | None:
+    """Pull the most recent webhook ID start.py logged on startup, or None."""
+    matches = _WEBHOOK_PATH_RE.findall(log_text)
+    return matches[-1] if matches else None
+
+
+async def _restore_options(mcp_client: Any, slug: str, options: dict[str, Any]) -> None:
+    """Restore an options dict via ha_manage_addon. Logs and swallows failures."""
+    try:
+        await mcp_client.call_tool(
+            "ha_manage_addon", {"slug": slug, "options": dict(options)}
+        )
+    except Exception:
+        LOG.exception("Failed to restore webhook-proxy options to %s", options)
+
+
+# ---------------------------------------------------------------------------
+# Installation + first-start contract
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_installed_and_running(mcp_client: Any) -> None:
+    """The bake-installed webhook-proxy addon resolves and is in ``started``."""
+    detail = await _get_addon_detail(mcp_client, WEBHOOK_PROXY_SLUG)
+    assert detail.get("name") == WEBHOOK_PROXY_NAME, (
+        f"Expected name {WEBHOOK_PROXY_NAME!r}, got {detail.get('name')!r}"
+    )
+    assert detail.get("state") == "started", (
+        f"Webhook-proxy addon should be ``started`` after bake; "
+        f"got state={detail.get('state')!r}. Full detail: {detail}"
+    )
+
+
+async def test_addon_supervisor_auto_discovery_logs_dev_slug(
+    mcp_client: Any,
+) -> None:
+    """``start.py`` auto-discovery finds and logs the dev MCP addon slug.
+
+    start.py:188-249 lists installed addons via the Supervisor API, matches
+    slug suffixes ``_ha_mcp`` / ``_ha_mcp_dev``, and logs the discovered
+    target before continuing. With ``mcp_server_url`` left empty in the
+    bake's options POST (see ``install_webhook_proxy_addon``), this is the
+    code path that runs on first start. A regression that breaks the slug
+    suffix match or the addon-listing call would show up here as the dev
+    slug failing to appear in the log.
+    """
+    log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+    discovered = _DISCOVERY_RE.findall(log_text)
+    assert discovered, (
+        "Webhook-proxy logs do not contain "
+        '"Discovered running MCP addon: <slug>". Either the auto-discovery '
+        "code path regressed or the addon failed to reach it. "
+        f"Log tail: ...{log_text[-2000:]!r}"
+    )
+    assert DEV_ADDON_SLUG in discovered, (
+        f"Expected webhook-proxy to discover the dev addon "
+        f"({DEV_ADDON_SLUG!r}); observed discoveries: {discovered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle round-trip — mirror Matter Server's stop/start/restart test
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_start_stop_restart_roundtrip(mcp_client: Any) -> None:
+    """Stop → start → restart cycles the webhook-proxy via Supervisor.
+
+    Mirrors ``test_matter_server_start_stop_restart_roundtrip``. Webhook-
+    proxy's startup is heavier than Matter Server (writes ``/data/webhook_id.txt``,
+    installs the mcp_proxy custom integration, registers the webhook with HA
+    Core) so the ``_STATE_POLL_TIMEOUT`` headroom matters more here than for
+    the lighter addons. Cleanup leaves it running so later tests observe a
+    started addon.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    try:
+        stop_result = await _addon_action(mcp_client, slug, "stop")
+        assert stop_result.get("success"), (
+            f"hassio.addon_stop({slug}) failed: {stop_result}"
+        )
+        await _wait_for_state(mcp_client, slug, STOPPED_STATES)
+
+        start_result = await _addon_action(mcp_client, slug, "start")
+        assert start_result.get("success"), (
+            f"hassio.addon_start({slug}) failed: {start_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+    finally:
+        await _ensure_started(mcp_client, slug)
+
+
+async def test_addon_logs_fetch_shape(mcp_client: Any) -> None:
+    """``ha_get_logs(source='supervisor')`` returns substantial log text."""
+    log_text = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+    assert len(log_text.strip()) >= 100, (
+        f"Webhook-proxy stdout should have substantial content "
+        f"(>=100 chars), got {len(log_text)} chars: {log_text[:200]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Options round-trip — mirror Node-RED's options-persist pattern.
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_options_get_returns_dict(mcp_client: Any) -> None:
+    """``ha_get_addon`` exposes webhook-proxy options as a dict."""
+    detail = await _get_addon_detail(mcp_client, WEBHOOK_PROXY_SLUG)
+    options = detail.get("options")
+    assert isinstance(options, dict), (
+        f"Webhook-proxy options field should be a dict, got "
+        f"{type(options).__name__}: {options!r}"
+    )
+
+
+async def test_addon_remote_url_round_trip(mcp_client: Any) -> None:
+    """``remote_url`` written via ha_manage_addon persists in Supervisor options.
+
+    The addon's schema declares ``remote_url: str?``. Tests assert the
+    write path round-trips through Supervisor; whether the addon actually
+    reaches the URL is a downstream concern (the addon doesn't try to
+    contact ``remote_url`` until something hits the webhook). Restored to
+    empty in ``finally`` so sibling tests aren't observably mutated.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    detail = await _get_addon_detail(mcp_client, slug)
+    current_options = detail.get("options") or {}
+    assert isinstance(current_options, dict)
+    original_remote = current_options.get("remote_url", "")
+
+    probe = "https://e2e-test.invalid/webhook-proxy-probe"
+    probe_options = dict(current_options)
+    probe_options["remote_url"] = probe
+    try:
+        write_raw = await mcp_client.call_tool(
+            "ha_manage_addon", {"slug": slug, "options": probe_options}
+        )
+        write_payload = parse_mcp_result(write_raw)
+        ok = write_payload.get("success") is True or (
+            write_payload.get("status") == "pending_restart"
+        )
+        assert ok, f"ha_manage_addon remote_url write failed: {write_payload}"
+
+        detail_after = await _get_addon_detail(mcp_client, slug)
+        options_after = detail_after.get("options") or {}
+        assert options_after.get("remote_url") == probe, (
+            f"remote_url probe={probe!r} did not persist. "
+            f"After-write options: {options_after}"
+        )
+    finally:
+        restore = dict(current_options)
+        restore["remote_url"] = original_remote
+        await _restore_options(mcp_client, slug, restore)
+        await _ensure_started(mcp_client, slug)
+
+
+# ---------------------------------------------------------------------------
+# Webhook-ID persistence (#1020 regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_webhook_id_persists_across_restart(mcp_client: Any) -> None:
+    """The webhook ID survives an addon restart (PR #1020 regression).
+
+    start.py reads/writes ``/data/webhook_id.txt`` (see
+    ``_get_or_create_webhook_id``). ``/data`` is the Supervisor-mounted
+    persistent volume, so an ``addon_restart`` keeps the file and the URL
+    stays the same. A regression that re-generated the ID on every start
+    would break the contract that an MCP client's saved webhook URL
+    doesn't change unless the user explicitly rotates it.
+
+    Reads the most recent ``/api/webhook/<id>`` from the addon log,
+    restarts the addon, reads again, asserts the IDs match. ``-n2``
+    pytest-xdist scope is fine here because Supervisor logs accumulate
+    over the addon's whole life; each restart appends new lines without
+    truncating the file we read.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    try:
+        pre_log = await _get_addon_logs(mcp_client, slug)
+        pre_id = _extract_webhook_id(pre_log)
+        assert pre_id, (
+            "Could not find ``/api/webhook/<id>`` line in webhook-proxy "
+            "logs before restart — start.py either didn't log it or the "
+            "log fetch returned an incomplete tail. "
+            f"Log tail: ...{pre_log[-2000:]!r}"
+        )
+
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        # start.py logs the webhook path on every startup, but the
+        # Supervisor log endpoint races the addon's stdout buffer. Poll
+        # the log until a webhook-path line appears AFTER the restart.
+        deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+        post_id: str | None = None
+        while time.monotonic() < deadline:
+            post_log = await _get_addon_logs(mcp_client, slug)
+            # Look at the suffix beyond pre_log's length so we only match
+            # lines emitted in the new (post-restart) run.
+            new_section = post_log[len(pre_log) :]
+            post_id = _extract_webhook_id(new_section)
+            if post_id:
+                break
+            await asyncio.sleep(_STATE_POLL_INTERVAL)
+
+        assert post_id, (
+            "Webhook-proxy did not re-log the webhook path within "
+            f"{_STATE_POLL_TIMEOUT}s of restart. Either the addon failed "
+            "to reach _register_webhook or stdout buffering is hiding "
+            "the line."
+        )
+        assert post_id == pre_id, (
+            f"Webhook ID changed across restart (pre={pre_id!r}, "
+            f"post={post_id!r}). #1020 regression — /data/webhook_id.txt "
+            "is no longer persisting the ID."
+        )
+    finally:
+        await _ensure_started(mcp_client, slug)
+
+
+# ---------------------------------------------------------------------------
+# Webhook endpoint reachability — addon-registered, not bake-injected.
+# ---------------------------------------------------------------------------
+
+
+async def test_webhook_endpoint_registered_in_ha_core(
+    mcp_client: Any, ha_container_with_fresh_config: dict[str, Any]
+) -> None:
+    """The webhook the addon registered is reachable on HA Core's HTTP API.
+
+    The addon's first-start flow installs the ``mcp_proxy`` custom
+    integration and creates a config entry that calls
+    ``webhook.async_register`` with the persisted webhook ID. A reachable
+    endpoint should NOT 404 — the integration replies with a structured
+    error or proxy response, not the generic HA "no such webhook" 404
+    that an unregistered ID returns.
+    """
+    base_url = ha_container_with_fresh_config["base_url"]
+    token = ha_container_with_fresh_config["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    pre_log = await _get_addon_logs(mcp_client, WEBHOOK_PROXY_SLUG)
+    webhook_id = _extract_webhook_id(pre_log)
+    assert webhook_id, (
+        "Could not extract registered webhook ID from addon log. "
+        "test_webhook_id_persists_across_restart should be passing too — "
+        "fix that first if both fail."
+    )
+
+    registered_url = f"{base_url}/api/webhook/{webhook_id}"
+    unregistered_url = f"{base_url}/api/webhook/definitely-not-registered"
+
+    # The HA Core webhook endpoint accepts POST without auth (webhooks
+    # are auth-by-URL-secrecy by design). GET with auth is also accepted
+    # for HA's own webhook handlers; mcp_proxy registers POST + GET. The
+    # raw status code suffices to distinguish "registered" (anything but
+    # 404) from "unregistered" (404). Failure mode we care about: a
+    # registration regression silently drops the webhook and BOTH URLs
+    # return 404 identically.
+    registered_resp = await asyncio.to_thread(
+        requests.post, registered_url, headers=headers, timeout=10
+    )
+    unregistered_resp = await asyncio.to_thread(
+        requests.post, unregistered_url, headers=headers, timeout=10
+    )
+    assert registered_resp.status_code != 404, (
+        f"Registered webhook URL returned 404 — addon's webhook "
+        f"registration did not take effect. "
+        f"URL: {registered_url}, body: {registered_resp.text[:300]!r}"
+    )
+    # Sanity check: unknown ID returns the generic 404. If HA changes
+    # this to e.g. 401 for all webhook IDs the assertion above would
+    # pass falsely; pin the discrimination here.
+    assert unregistered_resp.status_code == 404, (
+        f"Unregistered webhook URL should return 404, got "
+        f"{unregistered_resp.status_code}: {unregistered_resp.text[:300]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OAuth gate (#1184): enabling enable_oauth must close the webhook to
+# unauthenticated callers.
+# ---------------------------------------------------------------------------
+
+
+async def test_addon_oauth_toggle_blocks_unauthenticated_webhook(
+    mcp_client: Any, ha_container_with_fresh_config: dict[str, Any]
+) -> None:
+    """Enabling ``enable_oauth`` makes the webhook reject unauth requests.
+
+    PR #1184 added an OAuth fail-closed gate: when ``enable_oauth=true``
+    the addon refuses to register the webhook (or unregisters it) until
+    the OAuth integration is verified loaded. The user-facing effect is
+    that previously-working POSTs to the webhook URL stop succeeding
+    with the same plain-status response. The exact failure mode depends
+    on whether the integration was successfully reloaded — accept either
+    a 4xx response OR an outright 404 (webhook unregistered while the
+    OAuth check ran), as long as it differs from the un-gated POST's
+    status. Restored to ``enable_oauth=false`` in ``finally``.
+    """
+    slug = WEBHOOK_PROXY_SLUG
+    base_url = ha_container_with_fresh_config["base_url"]
+    token = ha_container_with_fresh_config["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    detail = await _get_addon_detail(mcp_client, slug)
+    current_options = detail.get("options") or {}
+    assert isinstance(current_options, dict)
+
+    pre_log = await _get_addon_logs(mcp_client, slug)
+    webhook_id = _extract_webhook_id(pre_log)
+    assert webhook_id, "Could not extract webhook ID from addon log."
+    webhook_url = f"{base_url}/api/webhook/{webhook_id}"
+
+    # Baseline: OAuth off, webhook endpoint accepts POST (status != 401/403).
+    baseline_resp = await asyncio.to_thread(
+        requests.post, webhook_url, headers=headers, timeout=10
+    )
+    assert baseline_resp.status_code not in (401, 403), (
+        f"Baseline (OAuth off) POST should not be auth-rejected; "
+        f"got {baseline_resp.status_code}: {baseline_resp.text[:300]!r}"
+    )
+
+    probe_options = dict(current_options)
+    probe_options["enable_oauth"] = True
+    try:
+        write_raw = await mcp_client.call_tool(
+            "ha_manage_addon", {"slug": slug, "options": probe_options}
+        )
+        write_payload = parse_mcp_result(write_raw)
+        ok = write_payload.get("success") is True or (
+            write_payload.get("status") == "pending_restart"
+        )
+        assert ok, f"enable_oauth=true write failed: {write_payload}"
+
+        # ha_manage_addon's options write reports ``pending_restart`` when
+        # the addon needs a restart to pick up runtime changes — the
+        # OAuth gate is a runtime concern, so kick the restart ourselves.
+        restart_result = await _addon_action(mcp_client, slug, "restart")
+        assert restart_result.get("success"), (
+            f"hassio.addon_restart({slug}) for OAuth toggle failed: {restart_result}"
+        )
+        await _wait_for_state(mcp_client, slug, "started")
+
+        # Poll until the post-restart webhook behavior diverges from
+        # baseline. start.py's OAuth gate is async (probes the
+        # /api/mcp_proxy/oauth endpoint with retries), so the close-down
+        # may not be observable for several seconds after the addon
+        # reports ``started``.
+        deadline = time.monotonic() + _STATE_POLL_TIMEOUT
+        last_status: int | None = None
+        gated = False
+        while time.monotonic() < deadline:
+            resp = await asyncio.to_thread(
+                requests.post, webhook_url, headers=headers, timeout=10
+            )
+            last_status = resp.status_code
+            # Gate kicked in: either OAuth-rejected (401/403) or webhook
+            # unregistered (404). Anything else means the gate hasn't
+            # taken effect yet.
+            if last_status in (401, 403, 404):
+                gated = True
+                break
+            await asyncio.sleep(_STATE_POLL_INTERVAL)
+
+        assert gated, (
+            "enable_oauth=true did not close the webhook within "
+            f"{_STATE_POLL_TIMEOUT}s of addon restart. Last status: "
+            f"{last_status} (baseline was {baseline_resp.status_code}). "
+            "PR #1184 fail-closed gate may have regressed."
+        )
+    finally:
+        await _restore_options(mcp_client, slug, current_options)
+        # Restart so the restored OAuth-off state takes effect for sibling
+        # tests, then leave the addon running.
+        try:
+            await _addon_action(mcp_client, slug, "restart")
+            await _wait_for_state(mcp_client, slug, "started")
+        except Exception:
+            LOG.exception("OAuth cleanup restart failed")
+        await _ensure_started(mcp_client, slug)

--- a/tests/src/e2e/workflows/webhook_proxy/test_webhook_proxy.py
+++ b/tests/src/e2e/workflows/webhook_proxy/test_webhook_proxy.py
@@ -17,9 +17,19 @@ infrastructure. We test the core integration mechanics only.
 import asyncio
 import logging
 
+import pytest
 import requests
 
 logger = logging.getLogger(__name__)
+
+# Testcontainer-only: in HAOS mode the webhook-proxy addon is installed
+# and ``start.py`` overwrites ``/config/.mcp_proxy_config.json`` whenever
+# the addon runs (rotating the webhook_id to a fresh value). These tests
+# rely on the deterministic bake-injected webhook_id
+# ``mcp_e2e_test_webhook_proxy``; the HAOS-tier equivalents live in
+# ``tests/src/e2e/haos_only/test_webhook_proxy_addon.py`` and use the
+# addon's actual runtime webhook_id.
+pytestmark = [pytest.mark.container_only]
 
 
 class TestWebhookProxyIntegration:

--- a/tests/src/e2e/workflows/webhook_proxy/test_webhook_proxy.py
+++ b/tests/src/e2e/workflows/webhook_proxy/test_webhook_proxy.py
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 
 # Testcontainer-only: in HAOS mode the webhook-proxy addon is installed
 # and ``start.py`` overwrites ``/config/.mcp_proxy_config.json`` whenever
-# the addon runs (rotating the webhook_id to a fresh value). These tests
-# rely on the deterministic bake-injected webhook_id
-# ``mcp_e2e_test_webhook_proxy``; the HAOS-tier equivalents live in
-# ``tests/src/e2e/haos_only/test_webhook_proxy_addon.py`` and use the
-# addon's actual runtime webhook_id.
+# the addon runs (replacing the bake's ``mcp_e2e_test_webhook_proxy`` id
+# with the addon's persisted id from ``/data/webhook_id.txt``). These
+# tests rely on the bake-injected deterministic id; the HAOS-tier
+# equivalents live in ``tests/src/e2e/haos_only/test_webhook_proxy_addon.py``
+# and read the addon's actual runtime id from its log on each run.
 pytestmark = [pytest.mark.container_only]
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -91,6 +91,10 @@ HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
 # with the ``local_`` prefix that Supervisor applies to local-store
 # addons.
 HA_MCP_DEV_ADDON_SLUG = "local_ha_mcp_dev"
+# Webhook-proxy addon's installed slug. Bake-installed (boot=manual; not
+# auto-started) by build_image.install_webhook_proxy_addon. The
+# haos_only test module's session fixture starts it on demand.
+HA_MCP_WEBHOOK_PROXY_ADDON_SLUG = "local_ha_mcp_webhook_proxy"
 # Advanced SSH Web Terminal addon's installed slug. Bake-installed by
 # build_image.install_advanced_ssh; available on host port
 # SSH_DEBUG_HOST_PORT (22222). User/password are CI-test-only and can


### PR DESCRIPTION
## What does this PR do?

Extends the HAOS e2e tier so the webhook-proxy addon's `start.py` runtime
(Supervisor auto-discovery of the dev MCP addon, webhook registration into
HA Core, `/data/webhook_id.txt` persistence, OAuth fail-closed gate, option
round-trips) is exercised against a real Supervisor. Previously only the
addon's `mcp_proxy` custom integration was injected into HA Core; the addon
process itself never ran in CI, so changes to `start.py` had no test
coverage.

The addon is **baked into the qcow2 (install-only, `boot: manual`)** so the
cached image ships with the Docker layer pre-built but the addon doesn't
auto-start on resume — that prevents `start.py` from overwriting the
deterministic `/config/.mcp_proxy_config.json` the bake injects for sibling
testcontainer tests. A module-scope pytest fixture starts the addon for
the haos_only tests, then stops it on teardown. `mcp_server_url` is pinned
in the bake's options to the dev addon's host-network URL so the fixture's
start path skips auto-discovery (avoids a race against the dev MCP addon
finishing its own boot); a dedicated test clears that pin, restarts, and
asserts the discovery log line appears.

### Tests added (`tests/src/e2e/haos_only/test_webhook_proxy_addon.py`)

- Addon resolves and is in `started` state under the module fixture
- `ha_get_logs(source='supervisor')` returns substantial stdout
- `ha_get_addon` exposes options as a dict
- Lifecycle round-trip (`addon_stop` / `addon_start` / `addon_restart`)
- `remote_url` round-trips through `ha_manage_addon` options write
- Auto-discovery: clear `mcp_server_url`, restart, assert discovery log
  names the dev addon slug (`local_ha_mcp_dev`)
- Webhook ID survives an addon restart (PR #1020 regression)
- Webhook endpoint registered in HA Core (registered response is
  non-empty and differs from unregistered ID's response)
- `enable_oauth=true` closes the webhook to unauthenticated requests
  (PR #1184 fail-closed gate)

### Pre-existing testcontainer suite

`tests/src/e2e/workflows/webhook_proxy/test_webhook_proxy.py` is now
marked `@pytest.mark.container_only`. In HAOS inaddon mode the
webhook-proxy addon runs and overwrites `/config/.mcp_proxy_config.json`
with its persisted webhook_id (from `/data/webhook_id.txt`, generated on
first-ever start), which doesn't match the bake's hardcoded
`mcp_e2e_test_webhook_proxy`. The HAOS-tier equivalents in the new
module read the addon's actual runtime id from its log on each run.

### CI coverage for future addon changes

All three HAOS workflows previously hashed only
`homeassistant-addon-webhook-proxy/mcp_proxy/` into the qcow2 cache key.
Expanded to the whole `homeassistant-addon-webhook-proxy/` directory so
PRs touching `start.py`, `Dockerfile`, `config.yaml`, or `translations/`
correctly invalidate the cache and trigger a fresh bake with the PR's
changes baked in.

### Diagnostics

The HAOS conftest's teardown now dumps the webhook-proxy addon's stdout
alongside HA Core and Supervisor logs (`webhook-proxy-addon.log` in
the run artifact), so future `start.py` failures surface the actual
error mode rather than just Supervisor's container-lifecycle events.

## Type of change
- [x] 🧪 Tests only

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed