### PR TITLE
docs(agents): drop ha_backup_create + ha_backup_restore from accepted exceptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,7 +652,7 @@ These feed the picker tiles in the markup section AND the wizard `<script>` bloc
 - `ha_restart`, `ha_reload_core`, `ha_check_config`, `ha_eval_template`
 - `ha_report_issue`, `ha_import_blueprint`
 - `ha_read_file`, `ha_write_file`, `ha_deep_search`, `ha_bulk_control`
-- `ha_backup_create`, `ha_backup_restore`, `ha_install_mcp_tools`
+- `ha_install_mcp_tools`
 - `ha_hacs_*` family (`ha_hacs_search`, `ha_hacs_download`, `ha_hacs_add_repository`, `ha_hacs_repository_info`) — grandfathered; pre-dates this convention
 
 **Adding new verbs**: When no existing verb fits a new tool's purpose, add the verb to the approved-verbs list above rather than forcing a poor fit. `.gemini/styleguide.md` points back to this section as the single source of truth, so updates here propagate automatically.


### PR DESCRIPTION
## What does this PR do?

Refs #1175.

Removes `ha_backup_create` and `ha_backup_restore` from the AGENTS.md "Accepted exceptions" list. Both were folded into `ha_manage_backup` via #1403 (commit `159a750`) and no longer exist as standalone registered tools, but the exception list still named them.

Docs-only, single line, no behaviour or code change.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`git grep "async def ha_backup_create\|async def ha_backup_restore" src/` returns zero matches at HEAD — only `ha_manage_backup` is registered in `src/ha_mcp/tools/backup.py`.

## Checklist
- [x] I have updated documentation if needed
