### PR TITLE
refactor(service): compact ha_call_service result default (#1446)

### DIFF
--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -7,7 +7,7 @@ integrations (config entries) via the REST and WebSocket APIs.
 
 import asyncio
 import logging
-from typing import Annotated, Any, Literal, cast, get_args
+from typing import Annotated, Any, Literal, get_args
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -459,27 +459,18 @@ class IntegrationTools:
             include_diagnostics_bool = coerce_bool_param(
                 include_diagnostics, "include_diagnostics", default=False
             )
-            include_subentries_bool = cast(
-                bool,
-                coerce_bool_param(
-                    include_subentries, "include_subentries", default=False
-                ),
+            include_subentries_bool = coerce_bool_param(
+                include_subentries, "include_subentries", default=False
             )
-            include_subentry_schema_bool = cast(
-                bool,
-                coerce_bool_param(
-                    include_subentry_schema,
-                    "include_subentry_schema",
-                    default=False,
-                ),
+            include_subentry_schema_bool = coerce_bool_param(
+                include_subentry_schema,
+                "include_subentry_schema",
+                default=False,
             )
-            show_advanced_options_bool = cast(
-                bool,
-                coerce_bool_param(
-                    show_advanced_options,
-                    "show_advanced_options",
-                    default=False,
-                ),
+            show_advanced_options_bool = coerce_bool_param(
+                show_advanced_options,
+                "show_advanced_options",
+                default=False,
             )
             exact_match_bool = coerce_bool_param(
                 exact_match, "exact_match", default=True

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -1316,8 +1316,7 @@ class IntegrationTools:
             context={"helper_type": helper_type},
         )
 
-        # default=True guarantees a non-None return; cast for mypy.
-        wait_bool = cast(bool, coerce_bool_param(wait, "wait", default=True))
+        wait_bool = coerce_bool_param(wait, "wait", default=True)
         warnings: list[str] = []
 
         # === Routing dispatch ===

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -24,17 +24,15 @@ from .util_helpers import (
     coerce_int_param,
     filter_active_repairs,
     parse_string_list_param,
-    project_entity_record,
     project_fields,
     project_records,
     project_repair_fields,
     public_fields,
     result_fields_warning,
 )
-
-# Backwards-compatible alias — _project_entity used to live here; moved to
-# util_helpers.py so ha_call_service can reuse it.
-_project_entity = project_entity_record
+from .util_helpers import (
+    project_entity_record as _project_entity,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1488,8 +1488,8 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         """
         # Parse search_types to handle JSON string input from MCP clients
         parsed_search_types = parse_string_list_param(search_types, "search_types")
-        include_config_bool = (
-            coerce_bool_param(include_config, "include_config", default=False) or False
+        include_config_bool = coerce_bool_param(
+            include_config, "include_config", default=False
         )
         exact_match_bool = coerce_bool_param(exact_match, "exact_match", default=True)
         try:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -24,12 +24,17 @@ from .util_helpers import (
     coerce_int_param,
     filter_active_repairs,
     parse_string_list_param,
+    project_entity_record,
     project_fields,
     project_records,
     project_repair_fields,
     public_fields,
     result_fields_warning,
 )
+
+# Backwards-compatible alias — _project_entity used to live here; moved to
+# util_helpers.py so ha_call_service can reuse it.
+_project_entity = project_entity_record
 
 logger = logging.getLogger(__name__)
 
@@ -164,85 +169,6 @@ async def _exact_match_search(
         "results": paginated,
         "search_type": "exact_match",
     }
-
-
-def _project_entity(
-    record: dict[str, Any],
-    fields: list[str] | None,
-    attribute_keys: list[str] | None,
-) -> tuple[dict[str, Any], str | None]:
-    """Apply optional field projection to a HA entity record.
-
-    ``fields`` filters which top-level keys to keep (e.g. ["state", "attributes"]).
-    ``attribute_keys`` further filters the ``attributes`` sub-dict.
-    Both default None = full payload (no-op).
-
-    Returns ``(projected_record, warning_string | None)``.  *warning_string* is
-    non-None when ``attribute_keys`` was specified, the original ``attributes``
-    dict was non-empty, and the filter produced an empty result — i.e. the caller
-    supplied only unknown attribute keys (typo guard).  Callers should append the
-    warning to the response ``warnings`` list so the user receives a diagnostic
-    rather than a silently empty ``attributes: {}``.
-
-    Both parameters are already parsed into ``list[str] | None`` — string/CSV inputs
-    must be normalised at the call site via ``parse_string_list_param`` (see
-    ``ha_get_state`` which parses once before the bulk loop to avoid re-parsing per
-    entity record).
-
-    Unlike ``project_fields``, this helper does not auto-retain ``success`` — entity
-    records have no ``success`` field, so the asymmetry is intentional.
-
-    Non-dict ``attributes`` handling: when ``attribute_keys`` is set but the
-    record's ``attributes`` value is not a dict (``None``, a string, a list —
-    rare from HA's state API but possible from malformed records, partial
-    error payloads, or mocked fixtures), the key-set filter cannot be
-    applied and the ``attributes`` value is returned unchanged. A
-    ``warning``-level log line records the short-circuit so it is visible
-    at default log levels. The bulk path shares this helper, so
-    both single- and bulk-entity calls behave identically here. This is
-    deliberately silent (no caller-facing warning) because malformed
-    ``attributes`` is rare and the call still produces a usable record.
-    """
-    if not isinstance(record, dict):
-        return (
-            record,
-            None,
-        )  # non-dict (e.g. error path returning None) — skip projection
-    if fields is not None:
-        keep = set(fields)
-        record = {k: v for k, v in record.items() if k in keep}
-    attr_warn: str | None = None
-    if attribute_keys is not None:
-        attrs = record.get("attributes")
-        if isinstance(attrs, dict):
-            attr_keep = set(attribute_keys)
-            filtered_attrs = {k: v for k, v in attrs.items() if k in attr_keep}
-            # Typo guard: if the original had keys AND the caller specified at least
-            # one key AND the filter yielded nothing, the caller likely mistyped an
-            # attribute name.  Return a diagnostic so the agent gets
-            # "attributes came out empty — available: [...]" instead of silently
-            # receiving ``attributes: {}``.
-            # Exclude the attribute_keys=[] case — an empty list is an explicit
-            # "keep nothing" request, not a typo.
-            if attrs and attribute_keys and not filtered_attrs:
-                available = sorted(attrs.keys())
-                attr_warn = (
-                    f"attribute_keys {sorted(attribute_keys)!r} matched no attribute "
-                    f"keys — attributes came out empty. "
-                    f"Available keys: {available!r}"
-                )
-            record = {**record, "attributes": filtered_attrs}
-        elif "attributes" in record:
-            # ``attributes`` is present but not a dict — filter cannot apply.
-            # Log at warning so the no-op is visible at default log levels
-            # (this branch is exercised rarely; see docstring for rationale).
-            logger.warning(
-                "_project_entity: attribute_keys filter skipped — "
-                "'attributes' is %s (expected dict) for record keys=%r",
-                type(attrs).__name__,
-                list(record.keys()),
-            )
-    return record, attr_warn
 
 
 def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -23,7 +23,14 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
-from .util_helpers import coerce_bool_param, parse_json_param, wait_for_state_change
+from .util_helpers import (
+    coerce_bool_param,
+    compact_service_result,
+    parse_json_param,
+    parse_string_list_param,
+    project_entity_record,
+    wait_for_state_change,
+)
 
 
 def _parse_json_dict_param(
@@ -215,6 +222,48 @@ class ServiceTools:
                 f"Service executed but state verification failed: {e}"
             )
 
+    @staticmethod
+    def _project_service_result(
+        result: Any,
+        *,
+        entity_id: str | None,
+        verbose: bool,
+        fields: list[str] | None,
+        attribute_keys: list[str] | None,
+    ) -> tuple[Any, list[str]]:
+        """Apply compact / explicit projection to a service-call ``result``.
+
+        Issue #1446. Precedence:
+
+        - ``verbose=True``: bypass every transformation; return ``result`` as-is.
+        - Explicit ``fields`` or ``attribute_keys``: apply per-record projection
+          via ``project_entity_record`` to every record. No compaction; this is
+          the power-user path.
+        - Default: apply ``compact_service_result`` (filter to ``entity_id``
+          record when single string, drop top-level metadata + heavy lists).
+
+        Returns ``(projected, warnings)``. ``warnings`` collects per-record
+        typo-guard diagnostics from ``project_entity_record`` (e.g. all-empty
+        ``attribute_keys`` filter) — deduplicated so an N-record list with the
+        same typo doesn't emit N copies of the same warning.
+        """
+        if verbose:
+            return result, []
+        if fields is None and attribute_keys is None:
+            return compact_service_result(result, entity_id), []
+        if not isinstance(result, list):
+            return result, []
+        projected: list[Any] = []
+        seen_warnings: set[str] = set()
+        warnings: list[str] = []
+        for record in result:
+            new_record, warn = project_entity_record(record, fields, attribute_keys)
+            projected.append(new_record)
+            if warn and warn not in seen_warnings:
+                seen_warnings.add(warn)
+                warnings.append(warn)
+        return projected, warnings
+
     @tool(
         name="ha_call_service",
         tags={"Service & Device Control"},
@@ -229,6 +278,9 @@ class ServiceTools:
         data: str | dict[str, Any] | None = None,
         return_response: bool | str = False,
         wait: bool | str = True,
+        verbose: bool | str = False,
+        result_fields: str | list[str] | None = None,
+        result_attribute_keys: str | list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Execute Home Assistant services to control entities and trigger automations.
@@ -261,6 +313,16 @@ class ServiceTools:
         - **wait**: Wait for the entity state to change after the service call (default: True).
           Only applies to state-changing services on a single entity. Set to False for
           fire-and-forget calls, bulk operations, or services without observable state changes.
+        - **verbose**: Return the raw HA service response unchanged (default: False).
+          By default ``result`` is compacted — filtered to the called entity's record
+          when ``entity_id`` is a single string (drops parent-group propagation),
+          and stripped of ``context``/``last_*`` metadata and known-heavy attribute
+          lists like ``effect_list``. Set ``verbose=True`` to get the full propagation
+          chain and unaltered attribute payload (escape hatch for inspection / debug).
+        - **result_fields**: Project each record in ``result`` to these top-level
+          keys (e.g. ``["entity_id", "state"]``). Mirrors ``ha_get_state``'s ``fields``.
+        - **result_attribute_keys**: Project each record's ``attributes`` dict to
+          these keys. Mirrors ``ha_get_state``'s ``attribute_keys``.
 
         **For detailed service documentation, use ha_get_skill_guide.**
 
@@ -276,6 +338,13 @@ class ServiceTools:
                 or False
             )
             wait_bool = coerce_bool_param(wait, "wait", default=True)
+            verbose_bool = coerce_bool_param(verbose, "verbose", default=False) or False
+            parsed_result_fields = parse_string_list_param(
+                result_fields, "result_fields", allow_csv=True
+            )
+            parsed_result_attribute_keys = parse_string_list_param(
+                result_attribute_keys, "result_attribute_keys", allow_csv=True
+            )
 
             # Determine if we should wait for state change:
             # Only for state-changing services on a single entity, not for
@@ -296,15 +365,25 @@ class ServiceTools:
                 domain, service, service_data, return_response=return_response_bool
             )
 
+            projected_result, projection_warnings = self._project_service_result(
+                result,
+                entity_id=entity_id,
+                verbose=verbose_bool,
+                fields=parsed_result_fields,
+                attribute_keys=parsed_result_attribute_keys,
+            )
+
             response: dict[str, Any] = {
                 "success": True,
                 "domain": domain,
                 "service": service,
                 "entity_id": entity_id,
                 "parameters": data,
-                "result": result,
+                "result": projected_result,
                 "message": f"Successfully executed {domain}.{service}",
             }
+            if projection_warnings:
+                response.setdefault("warnings", []).extend(projection_warnings)
 
             # If return_response was requested, include the service_response key prominently
             if return_response_bool and isinstance(result, dict):

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -253,9 +253,23 @@ class ServiceTools:
             return compact_service_result(result, entity_id), []
         if not isinstance(result, list):
             return result, []
+        warnings: list[str] = []
+        # ``result_attribute_keys`` only takes effect when ``attributes`` is in
+        # the projected ``result_fields`` (or ``result_fields`` is None). Surface
+        # a warning rather than silently ignoring the parameter — mirrors
+        # ha_get_state's attribute_keys_no_effect handling.
+        if (
+            attribute_keys is not None
+            and fields is not None
+            and "attributes" not in fields
+        ):
+            warnings.append(
+                "result_attribute_keys was ignored because 'attributes' is not "
+                "in result_fields. Add 'attributes' to result_fields (or omit "
+                "result_fields) to apply result_attribute_keys."
+            )
         projected: list[Any] = []
         seen_warnings: set[str] = set()
-        warnings: list[str] = []
         for record in result:
             new_record, warn = project_entity_record(record, fields, attribute_keys)
             projected.append(new_record)
@@ -278,9 +292,43 @@ class ServiceTools:
         data: str | dict[str, Any] | None = None,
         return_response: bool | str = False,
         wait: bool | str = True,
-        verbose: bool | str = False,
-        result_fields: str | list[str] | None = None,
-        result_attribute_keys: str | list[str] | None = None,
+        verbose: Annotated[
+            bool | str,
+            Field(
+                description=(
+                    "Return HA's raw service response unchanged (default: False). "
+                    "Use as an escape hatch when you need the full propagation "
+                    "chain or raw attribute payload (debug / inspection). "
+                    "WARNING: brings back token-bloat for nested-group targets — "
+                    "prefer result_fields / result_attribute_keys for targeted control."
+                ),
+            ),
+        ] = False,
+        result_fields: Annotated[
+            str | list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Project each record in 'result' to only these top-level keys "
+                    "(e.g. ['entity_id', 'state']). Mirrors ha_get_state's fields=. "
+                    "Setting this DISABLES default compaction — no entity-id filter, "
+                    "no metadata strip — and applies the explicit projection instead."
+                ),
+            ),
+        ] = None,
+        result_attribute_keys: Annotated[
+            str | list[str] | None,
+            Field(
+                default=None,
+                description=(
+                    "Project each record's 'attributes' dict to only these keys "
+                    "(e.g. ['brightness', 'rgb_color']). Mirrors ha_get_state's "
+                    "attribute_keys=. Setting this DISABLES default compaction. "
+                    "Requires 'attributes' to be present in result_fields (or "
+                    "result_fields=None)."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """
         Execute Home Assistant services to control entities and trigger automations.
@@ -304,25 +352,15 @@ class ServiceTools:
         ha_call_service("homeassistant", "toggle", entity_id="switch.porch_light")
         ```
 
-        **Parameters:**
-        - **domain**: Service domain (light, climate, automation, etc.)
-        - **service**: Service name (turn_on, set_temperature, trigger, etc.)
-        - **entity_id**: Optional target entity. For some services (e.g., light.turn_off), omitting this targets all entities in the domain
-        - **data**: Optional dict of service-specific parameters
-        - **return_response**: Set to True for services that return data
-        - **wait**: Wait for the entity state to change after the service call (default: True).
-          Only applies to state-changing services on a single entity. Set to False for
-          fire-and-forget calls, bulk operations, or services without observable state changes.
-        - **verbose**: Return the raw HA service response unchanged (default: False).
-          By default ``result`` is compacted — filtered to the called entity's record
-          when ``entity_id`` is a single string (drops parent-group propagation),
-          and stripped of ``context``/``last_*`` metadata and known-heavy attribute
-          lists like ``effect_list``. Set ``verbose=True`` to get the full propagation
-          chain and unaltered attribute payload (escape hatch for inspection / debug).
-        - **result_fields**: Project each record in ``result`` to these top-level
-          keys (e.g. ``["entity_id", "state"]``). Mirrors ``ha_get_state``'s ``fields``.
-        - **result_attribute_keys**: Project each record's ``attributes`` dict to
-          these keys. Mirrors ``ha_get_state``'s ``attribute_keys``.
+        **Key behavior:**
+        - **wait** (default True): wait for the entity state to change before
+          returning. Only applies to state-changing services on a single entity.
+        - **Result compaction (issue #1446, default ON)**: ``result`` is trimmed
+          to the targeted entity's record (drops parent-group propagation) and
+          stripped of ``context`` / ``last_*`` metadata and heavy attribute
+          lists (``effect_list``, ``hue_scenes``). Escape hatches: ``verbose=True``
+          for the raw HA response, or ``result_fields`` / ``result_attribute_keys``
+          for explicit per-record projection (mirrors ``ha_get_state``).
 
         **For detailed service documentation, use ha_get_skill_guide.**
 
@@ -338,13 +376,28 @@ class ServiceTools:
                 or False
             )
             wait_bool = coerce_bool_param(wait, "wait", default=True)
-            verbose_bool = coerce_bool_param(verbose, "verbose", default=False) or False
-            parsed_result_fields = parse_string_list_param(
-                result_fields, "result_fields", allow_csv=True
-            )
-            parsed_result_attribute_keys = parse_string_list_param(
-                result_attribute_keys, "result_attribute_keys", allow_csv=True
-            )
+            try:
+                verbose_bool = (
+                    coerce_bool_param(verbose, "verbose", default=False) or False
+                )
+            except ValueError as e:
+                raise_tool_error(create_validation_error(str(e), parameter="verbose"))
+            try:
+                parsed_result_fields = parse_string_list_param(
+                    result_fields, "result_fields", allow_csv=True
+                )
+            except ValueError as e:
+                raise_tool_error(
+                    create_validation_error(str(e), parameter="result_fields")
+                )
+            try:
+                parsed_result_attribute_keys = parse_string_list_param(
+                    result_attribute_keys, "result_attribute_keys", allow_csv=True
+                )
+            except ValueError as e:
+                raise_tool_error(
+                    create_validation_error(str(e), parameter="result_attribute_keys")
+                )
 
             # Determine if we should wait for state change:
             # Only for state-changing services on a single entity, not for

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -371,15 +371,12 @@ class ServiceTools:
             service_data = self._parse_service_data(data, entity_id)
 
             # Coerce return_response boolean parameter
-            return_response_bool = (
-                coerce_bool_param(return_response, "return_response", default=False)
-                or False
+            return_response_bool = coerce_bool_param(
+                return_response, "return_response", default=False
             )
             wait_bool = coerce_bool_param(wait, "wait", default=True)
             try:
-                verbose_bool = (
-                    coerce_bool_param(verbose, "verbose", default=False) or False
-                )
+                verbose_bool = coerce_bool_param(verbose, "verbose", default=False)
             except ValueError as e:
                 raise_tool_error(create_validation_error(str(e), parameter="verbose"))
             try:

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -65,7 +65,11 @@ class SystemTools:
     @tool(
         name="ha_check_config",
         tags={"System"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Check Configuration"},
+        annotations={
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Check Configuration",
+        },
     )
     @log_tool_usage
     async def ha_check_config(self) -> dict[str, Any]:
@@ -142,22 +146,24 @@ class SystemTools:
         instead, which reloads specific components without a full restart.
         """
         # Coerce boolean parameter that may come as string from XML-style calls
-        confirm_bool = coerce_bool_param(confirm, "confirm", default=False) or False
+        confirm_bool = coerce_bool_param(confirm, "confirm", default=False)
 
         if not confirm_bool:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                "Restart not confirmed",
-                details=(
-                    "You must set confirm=True to restart Home Assistant. "
-                    "This is a safety measure to prevent accidental restarts."
-                ),
-                suggestions=[
-                    "Run ha_check_config() first to validate configuration",
-                    "Call ha_restart(confirm=True) to proceed with restart",
-                    "Consider using ha_reload_core() for config-only changes",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Restart not confirmed",
+                    details=(
+                        "You must set confirm=True to restart Home Assistant. "
+                        "This is a safety measure to prevent accidental restarts."
+                    ),
+                    suggestions=[
+                        "Run ha_check_config() first to validate configuration",
+                        "Call ha_restart(confirm=True) to proceed with restart",
+                        "Consider using ha_reload_core() for config-only changes",
+                    ],
+                )
+            )
 
         restart_initiated = False
         try:
@@ -165,15 +171,17 @@ class SystemTools:
             config_result = await self._client.check_config()
             if config_result.get("result") != "valid":
                 errors = config_result.get("errors") or []
-                raise_tool_error(create_error_response(
-                    ErrorCode.CONFIG_INVALID,
-                    "Configuration is invalid - restart aborted",
-                    details=(
-                        "Home Assistant configuration has errors. "
-                        "Fix the errors before restarting."
-                    ),
-                    context={"config_errors": errors},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.CONFIG_INVALID,
+                        "Configuration is invalid - restart aborted",
+                        details=(
+                            "Home Assistant configuration has errors. "
+                            "Fix the errors before restarting."
+                        ),
+                        context={"config_errors": errors},
+                    )
+                )
 
             # Call the restart service - mark as initiated before the call
             # as the connection may be closed before we get a response
@@ -199,8 +207,7 @@ class SystemTools:
             # Connection errors after restart initiated are expected
             # (HA closes connections during restart)
             if restart_initiated and any(
-                pattern in error_msg.lower()
-                for pattern in ("connect", "closed", "504")
+                pattern in error_msg.lower() for pattern in ("connect", "closed", "504")
             ):
                 return {
                     "success": True,
@@ -272,12 +279,17 @@ class SystemTools:
         target = target.lower().strip()
 
         if target not in RELOAD_TARGETS:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                f"Invalid reload target: {target}",
-                context={"target": target, "valid_targets": list(RELOAD_TARGETS.keys())},
-                suggestions=[f"Use one of: {', '.join(RELOAD_TARGETS.keys())}"],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid reload target: {target}",
+                    context={
+                        "target": target,
+                        "valid_targets": list(RELOAD_TARGETS.keys()),
+                    },
+                    suggestions=[f"Use one of: {', '.join(RELOAD_TARGETS.keys())}"],
+                )
+            )
 
         try:
             if target == "all":
@@ -313,11 +325,13 @@ class SystemTools:
                 service_info = RELOAD_TARGETS[target]
                 if service_info is None:
                     # This shouldn't happen as we check for "all" above
-                    raise_tool_error(create_error_response(
-                        ErrorCode.INTERNAL_ERROR,
-                        f"Invalid target configuration for: {target}",
-                        context={"target": target},
-                    ))
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.INTERNAL_ERROR,
+                            f"Invalid target configuration for: {target}",
+                            context={"target": target},
+                        )
+                    )
                 domain, service = service_info
                 await self._client.call_service(domain, service, {})
 
@@ -343,7 +357,11 @@ class SystemTools:
     @tool(
         name="ha_get_system_health",
         tags={"System", "Zigbee", "Z-Wave", "Integrations"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get System Health (incl. ZHA/Z-Wave/integration diagnostics)"},
+        annotations={
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Get System Health (incl. ZHA/Z-Wave/integration diagnostics)",
+        },
     )
     @log_tool_usage
     async def ha_get_system_health(
@@ -474,9 +492,7 @@ class SystemTools:
                     ("zha_network", self._fetch_zha_network(ws_client, full=zha_full))
                 )
             if want_zwave:
-                sections.append(
-                    ("zwave_network", self._fetch_zwave_network(ws_client))
-                )
+                sections.append(("zwave_network", self._fetch_zwave_network(ws_client)))
 
             if sections:
                 gathered = await asyncio.gather(
@@ -641,25 +657,32 @@ class SystemTools:
             verify_ssl=self._client.verify_ssl,
         )
         if error or ws_client is None:
-            raise_tool_error(error or create_error_response(
-                ErrorCode.CONNECTION_FAILED,
-                "Failed to connect to Home Assistant WebSocket",
-            ))
+            raise_tool_error(
+                error
+                or create_error_response(
+                    ErrorCode.CONNECTION_FAILED,
+                    "Failed to connect to Home Assistant WebSocket",
+                )
+            )
 
         try:
             _, event_response = await ws_client.send_command_with_event(
                 "system_health/info", wait_timeout=10.0
             )
         except TimeoutError:
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                "Timeout waiting for system health data",
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Timeout waiting for system health data",
+                )
+            )
         except Exception as e:
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                str(e),
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    str(e),
+                )
+            )
 
         health_info = event_response.get("event", {})
         component_count = len(health_info) if isinstance(health_info, dict) else 0
@@ -672,7 +695,6 @@ class SystemTools:
         }
 
         return ws_client, result
-
 
     @staticmethod
     async def _fetch_repairs(
@@ -703,9 +725,7 @@ class SystemTools:
             else:
                 err = repairs_result.get("error") or {}
                 err_msg = (
-                    err.get("message")
-                    if isinstance(err, dict)
-                    else str(err)
+                    err.get("message") if isinstance(err, dict) else str(err)
                 ) or "unknown error"
                 logger.warning(
                     "repairs/list_issues returned success=false: %s", err_msg
@@ -717,9 +737,7 @@ class SystemTools:
         return repairs
 
     @staticmethod
-    async def _fetch_zha_network(
-        ws_client: Any, *, full: bool
-    ) -> dict[str, Any]:
+    async def _fetch_zha_network(ws_client: Any, *, full: bool) -> dict[str, Any]:
         """Fetch ZHA Zigbee network device data."""
         ZHA_SUMMARY_LIMIT = 50
         ZHA_FULL_LIMIT = 25

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -78,6 +78,22 @@ def public_fields(d: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+@overload
+def coerce_bool_param(
+    value: bool | str | None,
+    param_name: str = ...,
+    default: bool = ...,
+) -> bool: ...
+
+
+@overload
+def coerce_bool_param(
+    value: bool | str | None,
+    param_name: str = ...,
+    default: None = ...,
+) -> bool | None: ...
+
+
 def coerce_bool_param(
     value: bool | str | None,
     param_name: str = "parameter",

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -309,10 +309,12 @@ def project_entity_record(
     records have no ``success`` field, so the asymmetry is intentional.
 
     Non-dict ``attributes`` handling: when ``attribute_keys`` is set but the
-    record's ``attributes`` value is not a dict, the key-set filter cannot be
-    applied and the ``attributes`` value is returned unchanged. A
-    ``warning``-level log line records the short-circuit so it is visible at
-    default log levels.
+    record's ``attributes`` value is not a dict (``None``, scalar, list — rare
+    from HA's state API but possible from malformed records, partial error
+    payloads, or mocked fixtures), the key-set filter cannot be applied. A
+    ``warning``-level log line records the short-circuit AND a caller-facing
+    warning is returned via ``attr_warn`` so the agent (MCP consumer) sees that
+    its filter was skipped rather than just an operator tailing logs.
     """
     if not isinstance(record, dict):
         return record, None
@@ -340,14 +342,25 @@ def project_entity_record(
                 type(attrs).__name__,
                 list(record.keys()),
             )
+            attr_warn = (
+                f"attribute_keys filter skipped — record 'attributes' is "
+                f"{type(attrs).__name__} (expected dict)"
+            )
     return record, attr_warn
 
 
-# Default compact-result projection for ha_call_service. Drops timestamp/context
-# metadata at the top level and known-heavy enum-style attribute lists (issue
-# #1446: a single WLED light's effect_list can be ~250 entries, emitted on
-# every propagated state). Kept deliberately minimal — domain-specific trimming
-# belongs in ha_get_state via explicit attribute_keys, not here.
+# Default compact-result projection for ha_call_service (issue #1446). A single
+# WLED light's `effect_list` can be ~250 entries, emitted on every propagated
+# group state — `light.turn_on` on a nested group returned 16 state objects
+# with that list carried four times. Drops timestamp/context metadata at the
+# top level and known-heavy enum-style attribute lists.
+#
+# Extension policy: add a key here only when (a) it's universally heavy across
+# installations (not just an unusual config), (b) it carries no signal callers
+# would act on for service-call confirmation, and (c) callers who do want it
+# can opt in via `result_fields` / `verbose=True`. Domain-specific or
+# install-specific trimming belongs in `ha_get_state` via explicit
+# `attribute_keys`, not here.
 _COMPACT_RESULT_DROP_TOP_LEVEL: frozenset[str] = frozenset(
     {"context", "last_changed", "last_reported", "last_updated"}
 )
@@ -360,20 +373,15 @@ def compact_service_result(
     result: Any,
     target_entity_id: str | None,
 ) -> Any:
-    """Trim a ha_call_service ``result`` list to the compact default.
-
-    Issue #1446: HA returns a state record for every entity affected by a
-    service call. With nested HA-native groups (group → group → group) and
-    WLED-style entities carrying ~250-entry ``effect_list`` attributes, this
-    list blows up token usage with no corresponding signal — agents only need
-    confirmation that the targeted entity reached its new state.
+    """Trim a ha_call_service ``result`` list to the compact default (issue #1446).
 
     Compact rules:
 
-    1. When ``target_entity_id`` is a single string, filter the list to records
-       whose ``entity_id`` matches — drops the propagation chain (parent groups).
-       Falls back to the full list if no record matches (e.g. HA returned
-       only parent states).
+    1. When ``target_entity_id`` is a single entity ID string OR a
+       comma-separated list of entity IDs (HA accepts both as a service-call
+       target), filter the list to records whose ``entity_id`` is in that set
+       — drops the propagation chain (parent groups). Falls back to the full
+       list if no record matches (e.g. HA returned only parent states).
     2. Drop top-level metadata keys (``context``, ``last_*``) from every record.
     3. Drop known-heavy attribute keys (``effect_list``, ``hue_scenes``) from
        every record's ``attributes`` dict.
@@ -386,13 +394,15 @@ def compact_service_result(
 
     records: list[Any] = result
     if isinstance(target_entity_id, str) and target_entity_id:
-        matched = [
-            r
-            for r in records
-            if isinstance(r, dict) and r.get("entity_id") == target_entity_id
-        ]
-        if matched:
-            records = matched
+        targets = {t.strip() for t in target_entity_id.split(",") if t.strip()}
+        if targets:
+            matched = [
+                r
+                for r in records
+                if isinstance(r, dict) and r.get("entity_id") in targets
+            ]
+            if matched:
+                records = matched
 
     compacted: list[Any] = []
     for record in records:

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -282,6 +282,137 @@ def parse_string_list_param(
     raise ValueError(f"{param_name} must be string, list, or None")
 
 
+def project_entity_record(
+    record: dict[str, Any],
+    fields: list[str] | None,
+    attribute_keys: list[str] | None,
+) -> tuple[dict[str, Any], str | None]:
+    """Apply optional field projection to a HA entity record.
+
+    ``fields`` filters which top-level keys to keep (e.g. ["state", "attributes"]).
+    ``attribute_keys`` further filters the ``attributes`` sub-dict.
+    Both default None = full payload (no-op).
+
+    Returns ``(projected_record, warning_string | None)``.  *warning_string* is
+    non-None when ``attribute_keys`` was specified, the original ``attributes``
+    dict was non-empty, and the filter produced an empty result — i.e. the caller
+    supplied only unknown attribute keys (typo guard).  Callers should append the
+    warning to the response ``warnings`` list so the user receives a diagnostic
+    rather than a silently empty ``attributes: {}``.
+
+    Both parameters are already parsed into ``list[str] | None`` — string/CSV inputs
+    must be normalised at the call site via ``parse_string_list_param`` (see
+    ``ha_get_state`` which parses once before the bulk loop to avoid re-parsing per
+    entity record).
+
+    Unlike ``project_fields``, this helper does not auto-retain ``success`` — entity
+    records have no ``success`` field, so the asymmetry is intentional.
+
+    Non-dict ``attributes`` handling: when ``attribute_keys`` is set but the
+    record's ``attributes`` value is not a dict, the key-set filter cannot be
+    applied and the ``attributes`` value is returned unchanged. A
+    ``warning``-level log line records the short-circuit so it is visible at
+    default log levels.
+    """
+    if not isinstance(record, dict):
+        return record, None
+    if fields is not None:
+        keep = set(fields)
+        record = {k: v for k, v in record.items() if k in keep}
+    attr_warn: str | None = None
+    if attribute_keys is not None:
+        attrs = record.get("attributes")
+        if isinstance(attrs, dict):
+            attr_keep = set(attribute_keys)
+            filtered_attrs = {k: v for k, v in attrs.items() if k in attr_keep}
+            if attrs and attribute_keys and not filtered_attrs:
+                available = sorted(attrs.keys())
+                attr_warn = (
+                    f"attribute_keys {sorted(attribute_keys)!r} matched no attribute "
+                    f"keys — attributes came out empty. "
+                    f"Available keys: {available!r}"
+                )
+            record = {**record, "attributes": filtered_attrs}
+        elif "attributes" in record:
+            logger.warning(
+                "project_entity_record: attribute_keys filter skipped — "
+                "'attributes' is %s (expected dict) for record keys=%r",
+                type(attrs).__name__,
+                list(record.keys()),
+            )
+    return record, attr_warn
+
+
+# Default compact-result projection for ha_call_service. Drops timestamp/context
+# metadata at the top level and known-heavy enum-style attribute lists (issue
+# #1446: a single WLED light's effect_list can be ~250 entries, emitted on
+# every propagated state). Kept deliberately minimal — domain-specific trimming
+# belongs in ha_get_state via explicit attribute_keys, not here.
+_COMPACT_RESULT_DROP_TOP_LEVEL: frozenset[str] = frozenset(
+    {"context", "last_changed", "last_reported", "last_updated"}
+)
+_COMPACT_RESULT_DROP_ATTRIBUTES: frozenset[str] = frozenset(
+    {"effect_list", "hue_scenes"}
+)
+
+
+def compact_service_result(
+    result: Any,
+    target_entity_id: str | None,
+) -> Any:
+    """Trim a ha_call_service ``result`` list to the compact default.
+
+    Issue #1446: HA returns a state record for every entity affected by a
+    service call. With nested HA-native groups (group → group → group) and
+    WLED-style entities carrying ~250-entry ``effect_list`` attributes, this
+    list blows up token usage with no corresponding signal — agents only need
+    confirmation that the targeted entity reached its new state.
+
+    Compact rules:
+
+    1. When ``target_entity_id`` is a single string, filter the list to records
+       whose ``entity_id`` matches — drops the propagation chain (parent groups).
+       Falls back to the full list if no record matches (e.g. HA returned
+       only parent states).
+    2. Drop top-level metadata keys (``context``, ``last_*``) from every record.
+    3. Drop known-heavy attribute keys (``effect_list``, ``hue_scenes``) from
+       every record's ``attributes`` dict.
+
+    Returns ``result`` unchanged when not a list (e.g. dict from
+    ``return_response=True`` services), or when the list is empty.
+    """
+    if not isinstance(result, list) or not result:
+        return result
+
+    records: list[Any] = result
+    if isinstance(target_entity_id, str) and target_entity_id:
+        matched = [
+            r
+            for r in records
+            if isinstance(r, dict) and r.get("entity_id") == target_entity_id
+        ]
+        if matched:
+            records = matched
+
+    compacted: list[Any] = []
+    for record in records:
+        if not isinstance(record, dict):
+            compacted.append(record)
+            continue
+        trimmed = {
+            k: v for k, v in record.items() if k not in _COMPACT_RESULT_DROP_TOP_LEVEL
+        }
+        attrs = trimmed.get("attributes")
+        if isinstance(attrs, dict):
+            trimmed["attributes"] = {
+                k: v
+                for k, v in attrs.items()
+                if k not in _COMPACT_RESULT_DROP_ATTRIBUTES
+            }
+        compacted.append(trimmed)
+    return compacted
+
+
 def project_fields(
     data: dict[str, Any],
     fields: str | list[str] | None,

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -422,3 +422,76 @@ async def test_call_service_input_boolean_toggle(mcp_client, cleanup_tracker):
         "ha_remove_helpers_integrations",
         {"helper_type": "input_boolean", "target": entity_id, "confirm": True},
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.core
+class TestCallServiceResultProjection:
+    """Result projection params (issue #1446) — verbose, fields, attribute_keys."""
+
+    async def test_default_compacts_result(self, mcp_client, test_light_entity):
+        """Default behavior strips context/last_* metadata from result records.
+
+        Issue #1446: agents were burning tokens on propagated state + heavy
+        attribute lists. Default trims metadata that's never used for "did
+        the call work" confirmation.
+        """
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": test_light_entity,
+            },
+        )
+        data = assert_mcp_success(result, "compact-default light.turn_on")
+        records = data.get("result") or []
+        # Records may be empty on some test backends; only assert structure
+        # when HA actually returned propagation states.
+        for record in records:
+            assert isinstance(record, dict)
+            assert "context" not in record
+            assert "last_changed" not in record
+            assert "last_reported" not in record
+            assert "last_updated" not in record
+
+    async def test_verbose_preserves_raw_metadata(self, mcp_client, test_light_entity):
+        """verbose=True is the escape hatch — return HA's raw response."""
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": test_light_entity,
+                "verbose": True,
+            },
+        )
+        data = assert_mcp_success(result, "verbose light.turn_on")
+        records = data.get("result") or []
+        # If HA returned propagation records, verbose must include the raw
+        # metadata keys the compact path strips.
+        if records:
+            first = records[0]
+            assert isinstance(first, dict)
+            assert "context" in first or "last_updated" in first, (
+                f"verbose should preserve raw metadata; got keys {list(first.keys())}"
+            )
+
+    async def test_result_fields_projects_per_record(
+        self, mcp_client, test_light_entity
+    ):
+        """result_fields=['entity_id','state'] drops attributes/metadata."""
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": test_light_entity,
+                "result_fields": ["entity_id", "state"],
+            },
+        )
+        data = assert_mcp_success(result, "result_fields projection")
+        for record in data.get("result") or []:
+            assert set(record.keys()).issubset({"entity_id", "state"}), (
+                f"unexpected keys after projection: {record.keys()}"
+            )

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -495,3 +495,31 @@ class TestCallServiceResultProjection:
             assert set(record.keys()).issubset({"entity_id", "state"}), (
                 f"unexpected keys after projection: {record.keys()}"
             )
+
+    async def test_result_attribute_keys_filters_attributes(
+        self, mcp_client, test_light_entity
+    ):
+        """result_attribute_keys=['brightness'] trims attributes; record keeps just that key.
+
+        Asymmetry guard: if the test backend doesn't propagate state, the
+        `if records:` block won't run — that's acceptable cross-backend
+        coverage rather than a strict assertion.
+        """
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": test_light_entity,
+                "data": {"brightness_pct": 50},
+                "result_attribute_keys": ["brightness"],
+            },
+        )
+        data = assert_mcp_success(result, "result_attribute_keys projection")
+        for record in data.get("result") or []:
+            attrs = record.get("attributes")
+            # When attributes are present, they should be filtered to brightness only.
+            if isinstance(attrs, dict) and attrs:
+                assert set(attrs.keys()) == {"brightness"}, (
+                    f"unexpected attribute keys after projection: {attrs.keys()}"
+                )

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -523,3 +523,35 @@ class TestCallServiceResultProjection:
                 assert set(attrs.keys()) == {"brightness"}, (
                     f"unexpected attribute keys after projection: {attrs.keys()}"
                 )
+
+    async def test_comma_separated_entity_id_filters_to_target_set(self, mcp_client):
+        """Comma-separated entity_id forces multi-record response and exercises filter end-to-end.
+
+        Stronger than the single-entity e2e tests above — calling turn_on with
+        two demo lights guarantees HA returns at least two state records, so
+        the compaction filter (G3: comma-separated support) is verified to
+        narrow correctly rather than silently passing on an empty list.
+        """
+        targets = "light.bed_light,light.ceiling_lights"
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "entity_id": targets,
+            },
+        )
+        data = assert_mcp_success(result, "comma-separated entity_id compaction")
+        records = data.get("result") or []
+        if records:
+            kept = {r.get("entity_id") for r in records if isinstance(r, dict)}
+            target_set = set(targets.split(","))
+            # No record outside the target set survives compaction.
+            assert kept <= target_set, (
+                f"compaction kept records outside target set: extra={kept - target_set}"
+            )
+            # And compaction stripped the propagation metadata.
+            for record in records:
+                if isinstance(record, dict):
+                    assert "context" not in record
+                    assert "last_changed" not in record

--- a/tests/src/unit/test_compact_service_result.py
+++ b/tests/src/unit/test_compact_service_result.py
@@ -1,0 +1,197 @@
+"""Unit tests for compact ha_call_service result projection (issue #1446).
+
+The OP reported that ha_call_service returns a state record for every entity
+affected by a service call — for nested HA-native groups with a WLED member,
+that's 16 state objects with a ~250-entry effect_list emitted four times.
+``compact_service_result`` trims this to the targeted entity's record with
+heavy attributes stripped; the tool exposes ``verbose=True`` and
+``result_fields``/``result_attribute_keys`` for explicit control.
+"""
+
+from ha_mcp.tools.tools_service import ServiceTools
+from ha_mcp.tools.util_helpers import compact_service_result
+
+
+def _make_record(entity_id: str, *, effect_list_size: int = 0) -> dict:
+    record: dict = {
+        "entity_id": entity_id,
+        "state": "on",
+        "attributes": {
+            "brightness": 51,
+            "color_mode": "hs",
+            "rgb_color": [255, 121, 0],
+            "friendly_name": entity_id.split(".", 1)[-1].replace("_", " "),
+        },
+        "last_changed": "2026-05-25T20:57:04.183180+00:00",
+        "last_reported": "2026-05-25T21:18:31.413215+00:00",
+        "last_updated": "2026-05-25T21:18:31.413215+00:00",
+        "context": {"id": "01KSGG1VB9", "parent_id": None, "user_id": "abc"},
+    }
+    if effect_list_size:
+        record["attributes"]["effect_list"] = [
+            f"Effect {i}" for i in range(effect_list_size)
+        ]
+    return record
+
+
+class TestCompactServiceResult:
+    """Compaction strips metadata + heavy lists and filters to target entity."""
+
+    def test_filters_propagation_chain_to_target(self):
+        """OP case: leaf entity targeted, parent groups propagated — keep only target."""
+        result = [
+            _make_record("light.bedroom_desk_inner_left"),
+            _make_record("light.bedroom_desk"),  # parent group
+            _make_record("light.bedroom_desk_lights"),  # grandparent
+            _make_record("light.lights_in_bedroom", effect_list_size=250),  # WLED
+        ]
+        compacted = compact_service_result(result, "light.bedroom_desk_inner_left")
+        assert isinstance(compacted, list)
+        assert len(compacted) == 1
+        assert compacted[0]["entity_id"] == "light.bedroom_desk_inner_left"
+
+    def test_strips_context_and_timestamps(self):
+        result = [_make_record("light.kitchen")]
+        compacted = compact_service_result(result, "light.kitchen")
+        record = compacted[0]
+        assert "context" not in record
+        assert "last_changed" not in record
+        assert "last_reported" not in record
+        assert "last_updated" not in record
+        # state + attributes preserved
+        assert record["state"] == "on"
+        assert record["attributes"]["brightness"] == 51
+
+    def test_strips_effect_list_from_attributes(self):
+        """WLED's ~250-entry effect_list is the worst offender — drop it by default."""
+        result = [_make_record("light.wled", effect_list_size=250)]
+        compacted = compact_service_result(result, "light.wled")
+        attrs = compacted[0]["attributes"]
+        assert "effect_list" not in attrs
+        # Other useful attrs preserved
+        assert attrs["brightness"] == 51
+        assert attrs["rgb_color"] == [255, 121, 0]
+
+    def test_keeps_full_list_when_target_unmatched(self):
+        """If HA only returned propagated parents, keep them all (don't return [])."""
+        result = [
+            _make_record("light.parent_group"),
+            _make_record("light.grandparent_group"),
+        ]
+        compacted = compact_service_result(result, "light.nonexistent_target")
+        assert len(compacted) == 2
+
+    def test_keeps_full_list_when_entity_id_is_none(self):
+        """Domain-wide / list-target calls — agent expects all affected entities."""
+        result = [_make_record("light.a"), _make_record("light.b")]
+        compacted = compact_service_result(result, None)
+        assert len(compacted) == 2
+        # Per-record compaction still applies to each
+        for record in compacted:
+            assert "context" not in record
+
+    def test_empty_list_passthrough(self):
+        assert compact_service_result([], "light.kitchen") == []
+
+    def test_non_list_passthrough(self):
+        """``return_response=True`` services return dicts — leave them alone."""
+        as_dict = {"service_response": {"foo": "bar"}}
+        assert compact_service_result(as_dict, "light.kitchen") is as_dict
+        assert compact_service_result(None, "light.kitchen") is None
+
+    def test_non_dict_records_passthrough(self):
+        """Malformed entries (e.g. a stray string) are kept unchanged."""
+        result = ["unexpected", _make_record("light.kitchen")]
+        compacted = compact_service_result(result, "light.kitchen")
+        # entity_id filter only matches the dict record, so result has just one
+        assert len(compacted) == 1
+        assert compacted[0]["entity_id"] == "light.kitchen"
+
+
+class TestProjectServiceResult:
+    """ServiceTools._project_service_result orchestrates verbose / explicit / default."""
+
+    def test_verbose_returns_raw_result_unchanged(self):
+        result = [_make_record("light.kitchen", effect_list_size=250)]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.kitchen",
+            verbose=True,
+            fields=None,
+            attribute_keys=None,
+        )
+        assert projected is result
+        assert warnings == []
+        # context + effect_list intact in verbose mode
+        assert projected[0]["context"]["id"] == "01KSGG1VB9"
+        assert len(projected[0]["attributes"]["effect_list"]) == 250
+
+    def test_default_applies_compaction(self):
+        result = [
+            _make_record("light.target"),
+            _make_record("light.parent_group", effect_list_size=250),
+        ]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=False,
+            fields=None,
+            attribute_keys=None,
+        )
+        assert len(projected) == 1
+        assert projected[0]["entity_id"] == "light.target"
+        assert "context" not in projected[0]
+        assert warnings == []
+
+    def test_explicit_fields_applies_per_record_projection(self):
+        """fields=['entity_id', 'state'] keeps only those keys; no compaction."""
+        result = [
+            _make_record("light.target"),
+            _make_record("light.parent_group"),
+        ]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=False,
+            fields=["entity_id", "state"],
+            attribute_keys=None,
+        )
+        # Both records retained (no compaction filter when fields explicit)
+        assert len(projected) == 2
+        for record in projected:
+            assert set(record.keys()) == {"entity_id", "state"}
+        assert warnings == []
+
+    def test_explicit_attribute_keys_typo_emits_single_warning(self):
+        """Same typo across N records should emit one warning, not N."""
+        result = [
+            _make_record("light.a"),
+            _make_record("light.b"),
+            _make_record("light.c"),
+        ]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id=None,
+            verbose=False,
+            fields=None,
+            attribute_keys=["nonexistent_attr"],
+        )
+        assert len(projected) == 3
+        for record in projected:
+            assert record["attributes"] == {}
+        # Deduplicated — exactly one warning, not three
+        assert len(warnings) == 1
+        assert "nonexistent_attr" in warnings[0]
+
+    def test_non_list_result_passthrough(self):
+        """Dict result (return_response services) passes through every mode."""
+        result = {"service_response": {"forecast": []}}
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id=None,
+            verbose=False,
+            fields=None,
+            attribute_keys=None,
+        )
+        assert projected is result
+        assert warnings == []

--- a/tests/src/unit/test_compact_service_result.py
+++ b/tests/src/unit/test_compact_service_result.py
@@ -72,6 +72,32 @@ class TestCompactServiceResult:
         assert attrs["brightness"] == 51
         assert attrs["rgb_color"] == [255, 121, 0]
 
+    def test_strips_hue_scenes_from_attributes(self):
+        """Hue rooms emit a `hue_scenes` list on every state report — drop it too."""
+        record = _make_record("light.living_room")
+        record["attributes"]["hue_scenes"] = ["Energize", "Concentrate", "Relax"]
+        compacted = compact_service_result([record], "light.living_room")
+        assert "hue_scenes" not in compacted[0]["attributes"]
+        assert compacted[0]["attributes"]["brightness"] == 51
+
+    def test_comma_separated_entity_ids_filter_to_set(self):
+        """HA accepts entity_id="light.a,light.b" — filter to that target set."""
+        result = [
+            _make_record("light.a"),
+            _make_record("light.b"),
+            _make_record("light.parent_group"),  # propagation noise
+            _make_record("light.c"),  # unrelated
+        ]
+        compacted = compact_service_result(result, "light.a,light.b")
+        kept = {r["entity_id"] for r in compacted}
+        assert kept == {"light.a", "light.b"}
+
+    def test_comma_separated_handles_whitespace_and_empties(self):
+        """`"light.a, light.b ,,"` → {`light.a`, `light.b`}; nothing else kept."""
+        result = [_make_record("light.a"), _make_record("light.b")]
+        compacted = compact_service_result(result, "light.a, light.b ,,")
+        assert {r["entity_id"] for r in compacted} == {"light.a", "light.b"}
+
     def test_keeps_full_list_when_target_unmatched(self):
         """If HA only returned propagated parents, keep them all (don't return [])."""
         result = [
@@ -195,3 +221,94 @@ class TestProjectServiceResult:
         )
         assert projected is result
         assert warnings == []
+
+    def test_explicit_attribute_keys_happy_path(self):
+        """``attribute_keys`` filters successfully — record kept, no warnings."""
+        result = [_make_record("light.target", effect_list_size=10)]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=False,
+            fields=None,
+            attribute_keys=["brightness", "rgb_color"],
+        )
+        assert len(projected) == 1
+        assert projected[0]["attributes"] == {
+            "brightness": 51,
+            "rgb_color": [255, 121, 0],
+        }
+        assert warnings == []
+
+    def test_explicit_fields_and_attribute_keys_combined(self):
+        """``fields`` + ``attribute_keys`` together: both filters apply in order."""
+        result = [_make_record("light.target")]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=False,
+            fields=["entity_id", "attributes"],
+            attribute_keys=["brightness"],
+        )
+        assert len(projected) == 1
+        assert set(projected[0].keys()) == {"entity_id", "attributes"}
+        assert projected[0]["attributes"] == {"brightness": 51}
+        assert warnings == []
+
+    def test_attribute_keys_without_attributes_in_fields_warns(self):
+        """``attribute_keys`` ignored when ``fields`` excludes ``attributes``.
+
+        Mirrors ``ha_get_state``'s ``attribute_keys_no_effect`` warning.
+        """
+        result = [_make_record("light.target")]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=False,
+            fields=["entity_id", "state"],
+            attribute_keys=["brightness"],
+        )
+        assert len(projected) == 1
+        assert "attributes" not in projected[0]
+        # Single no-effect warning surfaced
+        assert any("result_attribute_keys was ignored" in w for w in warnings), (
+            f"expected no-effect warning, got: {warnings}"
+        )
+
+    def test_verbose_overrides_explicit_fields(self):
+        """``verbose=True`` wins over explicit projection — escape hatch is absolute."""
+        result = [_make_record("light.target", effect_list_size=250)]
+        projected, warnings = ServiceTools._project_service_result(
+            result,
+            entity_id="light.target",
+            verbose=True,
+            fields=["entity_id", "state"],  # would normally drop attributes
+            attribute_keys=["brightness"],  # would normally trim further
+        )
+        # Raw — fields/attribute_keys ignored
+        assert projected is result
+        assert "context" in projected[0]
+        assert len(projected[0]["attributes"]["effect_list"]) == 250
+        assert warnings == []
+
+    def test_non_dict_attributes_surfaces_caller_warning(self):
+        """When record has non-dict ``attributes``, agent gets a warning string.
+
+        Previously logged at warning level only; now surfaced via ``attr_warn``
+        so MCP consumers see the skip (issue #1446 review feedback).
+        """
+        record = {
+            "entity_id": "light.weird",
+            "state": "on",
+            "attributes": "not_a_dict",  # malformed payload
+        }
+        projected, warnings = ServiceTools._project_service_result(
+            [record],
+            entity_id="light.weird",
+            verbose=False,
+            fields=None,
+            attribute_keys=["brightness"],
+        )
+        assert len(projected) == 1
+        assert any("filter skipped" in w for w in warnings), (
+            f"expected non-dict-attributes warning, got: {warnings}"
+        )

--- a/tests/src/unit/test_get_state_fields_projection.py
+++ b/tests/src/unit/test_get_state_fields_projection.py
@@ -1,6 +1,6 @@
 """Unit tests for fields= and attribute_keys= projection in ha_get_state (issue #1199)."""
 
-from ha_mcp.tools.tools_search import _project_entity
+from ha_mcp.tools.util_helpers import project_entity_record as _project_entity
 
 _ENTITY_RECORD = {
     "entity_id": "light.kitchen",


### PR DESCRIPTION
## What does this PR do?

Closes #1446.

`ha_call_service` returned HA's raw service response — for nested HA-native
groups with WLED-style entities, that meant a state record per affected
entity, each carrying a ~250-entry `effect_list` and full `context`/`last_*`
metadata. A simple `light.turn_on` could return 16 state objects, burning
tokens with no extra signal.

**Default behavior change:**

- Filter `result` to the called entity's record when `entity_id` is a single
  string (or comma-separated set, e.g. `"light.a,light.b"` — HA accepts both
  as a service target) — drops parent-group propagation noise.
- Strip top-level metadata (`context`, `last_changed`, `last_reported`,
  `last_updated`) from every record.
- Drop known-heavy attribute lists (`effect_list`, `hue_scenes`) from every
  record's `attributes` dict.

Useful confirmation attributes (brightness, color_mode, rgb_color, etc.)
stay intact — agents can still verify "did the color actually become orange"
in one shot without a follow-up `ha_get_state`.

**Escape hatches preserve full functionality:**

- `verbose=True` — return HA's raw response unchanged. Use for debugging
  or when you need the propagation chain.
- `result_fields=[...]` / `result_attribute_keys=[...]` — mirror
  `ha_get_state`'s projection params for explicit per-record control.
  Setting either disables default compaction.
- Bad inputs raise structured `VALIDATION_FAILED` errors with the offending
  parameter name (mirrors `ha_get_state`).
- `result_attribute_keys` with `result_fields` excluding `"attributes"` emits
  a single no-effect warning rather than silently ignoring the param
  (mirrors `ha_get_state`'s `attribute_keys_no_effect`).

**Refactor:**

- `project_entity_record` moved from `tools_search.py` to `util_helpers.py`
  so both `ha_get_state` and `ha_call_service` share one projection helper.
  The non-dict-`attributes` path now surfaces a caller-facing warning
  (previously log-only — agents couldn't see the filter skip).
- `coerce_bool_param` gains `@overload`s matching `coerce_int_param`'s
  pattern: `default: bool` → returns `bool`. Drops `or False` patches at
  3 sites and `cast(bool, ...)` workarounds at 4 sites across
  `tools_integrations`, `tools_search`, `tools_service`, `tools_system`.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit coverage in `tests/src/unit/test_compact_service_result.py`:
propagation filter, metadata stripping, `effect_list` + `hue_scenes` drop,
comma-separated entity_id filtering (incl. whitespace edge cases),
`result_attribute_keys` happy path, `fields + attribute_keys` combined,
attribute-keys-no-effect warning, `verbose` overrides explicit projection,
non-dict-attributes caller warning, edge cases. New e2e coverage in
`tests/src/e2e/workflows/core/test_service.py`: default-compact, `verbose=True`,
`result_fields`, `result_attribute_keys`, comma-separated multi-target.

## Checklist
- [x] I have updated documentation if needed