### PR TITLE
fix: remove counter from ha_reload_core targets

### DIFF
--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -47,7 +47,6 @@ RELOAD_TARGETS = {
     "input_datetimes": ("input_datetime", "reload"),
     "input_buttons": ("input_button", "reload"),
     "timers": ("timer", "reload"),
-    "counters": ("counter", "reload"),
     "templates": ("template", "reload"),
     "persons": ("person", "reload"),
     "zones": ("zone", "reload"),
@@ -251,7 +250,6 @@ class SystemTools:
           - "input_datetimes": Reload input_datetime helpers
           - "input_buttons": Reload input_button helpers
           - "timers": Reload timer helpers
-          - "counters": Reload counter helpers
           - "templates": Reload template sensors/entities
           - "persons": Reload person configurations
           - "zones": Reload zone configurations

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -263,9 +263,11 @@ class TestSystemTools:
         # Some core components should always be reloadable
         assert len(reloaded) > 0, "Should have reloaded at least one component"
 
-        # Log any warnings
-        if data.get("warnings"):
-            logger.warning(f"Reload warnings: {data['warnings']}")
+        # A clean container should produce no reload warnings — any warning
+        # here means RELOAD_TARGETS lists a target whose reload service does
+        # not exist (e.g. issue #1453: `counter.reload`).
+        warnings = data.get("warnings") or []
+        assert not warnings, f"Reload all produced unexpected warnings: {warnings}"
 
         logger.info("Reload all test completed successfully")
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1453.

`ha_reload_core(target="all")` was emitting a spurious warning `counters: API error: 400 - 400: Bad Request` on every call. Root cause: the `counter` integration in HA Core does not register a `reload` service — it only exposes `increment`, `decrement`, `reset`, `set_value` (verified in `homeassistant/components/counter/__init__.py`). Counter helpers were never actually reloadable; the entry was wrong from the start.

Removes `"counters": ("counter", "reload")` from `RELOAD_TARGETS` and the matching docstring line. All other targets spot-checked against HA Core and confirmed to have a real reload service.

Also strengthens `test_reload_all` to **fail** on any warning instead of just logging it — that's why this regression slipped past CI. A clean test container should produce zero warnings.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed