### PR TITLE
feat: restrict ha_mcp_tools services to ha-mcp callers (caller token + ha_call_service refusal)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -174,12 +174,31 @@ def _caller_token_ok(hass: HomeAssistant, call: ServiceCall) -> bool:
         domain_data.get(_HASS_DATA_TOKEN_KEY) if isinstance(domain_data, dict) else None
     )
     presented = call.data.get(CALLER_TOKEN_FIELD)
-    # Constant-time compare: token is low-entropy enough that timing leaks
-    # don't meaningfully affect the threat model, but secrets.compare_digest
-    # is free and the right reflex.
+    # token_urlsafe(32) is 256-bit; the timing-side-channel risk is already
+    # negligible, but secrets.compare_digest is the right reflex regardless.
     if not isinstance(expected, str) or not isinstance(presented, str):
         return False
     return secrets.compare_digest(expected, presented)
+
+
+async def _caller_is_admin(hass: HomeAssistant, call: ServiceCall) -> bool:
+    """Return True if the caller is an admin user (or a no-user-context call).
+
+    HA's service registry has no built-in admin requirement — `Service`
+    has no admin flag, `async_call` performs no permission check, and
+    WS / REST `call_service` lack `@require_admin`. Gate explicitly here.
+
+    Calls without `context.user_id` (system-internal events) are treated
+    as trusted, matching HA's `async_admin_handler_factory` convention.
+    The supported deployment shapes all use admin tokens: addon's
+    SUPERVISOR_TOKEN maps to HA's `hassio_user`, which HA force-promotes
+    into `GROUP_ID_ADMIN` (hassio/__init__.py); standalone Docker/pip
+    deployments use a user-supplied admin LLAT.
+    """
+    if not call.context.user_id:
+        return True
+    user = await hass.auth.async_get_user(call.context.user_id)
+    return user is not None and bool(user.is_admin)
 
 
 def _is_path_allowed_for_dir(
@@ -1200,11 +1219,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def handle_get_caller_token(call: ServiceCall) -> ServiceResponse:
         """Return the caller-auth token to the ha-mcp bootstrap caller.
 
-        Intentionally unauthenticated beyond HA's default admin requirement:
-        ha-mcp does not know the token on first run, so this is the bootstrap
-        surface. The dangerous services (read/write/delete/edit_yaml) require
-        the token to be presented; this one returns it.
+        Admin-gated explicitly (see `_caller_is_admin`): HA's service
+        registry has no built-in admin requirement, so the gate prevents
+        a non-admin caller from bootstrapping the token. The supported
+        deployments (addon supervisor user, standalone admin LLAT) all
+        pass this gate.
         """
+        if not await _caller_is_admin(hass, call):
+            return {
+                "success": False,
+                "error_code": "unauthorized",
+                "error": "ha_mcp_tools.get_caller_token requires admin auth.",
+            }
         domain_data = hass.data.get(DOMAIN)
         token = (
             domain_data.get(_HASS_DATA_TOKEN_KEY)
@@ -1214,6 +1240,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not isinstance(token, str) or not token:
             return {
                 "success": False,
+                "error_code": "not_initialized",
                 "error": (
                     "Caller token not initialized — integration may not have "
                     "completed setup. Reload the ha_mcp_tools integration."

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -11,6 +11,7 @@ import fnmatch
 import logging
 import os
 import re
+import secrets
 import shutil
 from datetime import datetime
 from io import StringIO
@@ -27,6 +28,7 @@ from homeassistant.core import (
     SupportsResponse,
 )
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.storage import Store
 from ruamel.yaml import YAMLError
 
 from .const import (
@@ -50,6 +52,16 @@ SERVICE_READ_FILE = "read_file"
 SERVICE_WRITE_FILE = "write_file"
 SERVICE_DELETE_FILE = "delete_file"
 SERVICE_EDIT_YAML_CONFIG = "edit_yaml_config"
+SERVICE_GET_CALLER_TOKEN = "get_caller_token"
+
+# Caller-token auth (PR: restrict ha_mcp_tools.* to ha-mcp callers).
+# ha-mcp injects this field in every service-call payload; non-ha-mcp callers
+# (HA UI, automations, other integrations, the ha_call_service LLM bypass)
+# omit it and are rejected with a structured unauthorized response.
+CALLER_TOKEN_FIELD = "_ha_mcp_token"
+_TOKEN_STORAGE_KEY = f"{DOMAIN}_auth"
+_TOKEN_STORAGE_VERSION = 1
+_HASS_DATA_TOKEN_KEY = "caller_token"
 
 # Service schemas
 SERVICE_EDIT_YAML_CONFIG_SCHEMA = vol.Schema(
@@ -59,6 +71,7 @@ SERVICE_EDIT_YAML_CONFIG_SCHEMA = vol.Schema(
         vol.Required("yaml_path"): cv.string,
         vol.Optional("content"): cv.string,
         vol.Optional("backup", default=True): cv.boolean,
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
 
@@ -66,6 +79,7 @@ SERVICE_LIST_FILES_SCHEMA = vol.Schema(
     {
         vol.Required("path"): cv.string,
         vol.Optional("pattern"): cv.string,
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
 
@@ -73,6 +87,7 @@ SERVICE_READ_FILE_SCHEMA = vol.Schema(
     {
         vol.Required("path"): cv.string,
         vol.Optional("tail_lines"): vol.Coerce(int),
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
 
@@ -82,12 +97,23 @@ SERVICE_WRITE_FILE_SCHEMA = vol.Schema(
         vol.Required("content"): cv.string,
         vol.Optional("overwrite", default=False): cv.boolean,
         vol.Optional("create_dirs", default=True): cv.boolean,
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
 
 SERVICE_DELETE_FILE_SCHEMA = vol.Schema(
     {
         vol.Required("path"): cv.string,
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
+    }
+)
+
+# get_caller_token is the bootstrap surface: ha-mcp does not know the token
+# yet on first run, so this service intentionally does NOT require the token
+# itself. HA's default admin-auth still applies to the service call.
+SERVICE_GET_CALLER_TOKEN_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
 
@@ -103,6 +129,54 @@ ALLOWED_READ_FILES = [
 
 # Default tail lines for log files
 DEFAULT_LOG_TAIL_LINES = 1000
+
+
+async def _load_or_create_caller_token(hass: HomeAssistant) -> str:
+    """Return the persisted caller token, generating + saving one on first use.
+
+    The token authorizes a caller as ha-mcp. It's stored under
+    ``.storage/ha_mcp_tools_auth`` and remains stable across restarts so the
+    ha-mcp server can re-bootstrap without user intervention.
+    """
+    store: Store = Store(hass, _TOKEN_STORAGE_VERSION, _TOKEN_STORAGE_KEY)
+    data = await store.async_load()
+    if isinstance(data, dict):
+        existing = data.get("token")
+        if isinstance(existing, str) and existing:
+            return existing
+    token = secrets.token_urlsafe(32)
+    await store.async_save({"token": token})
+    return token
+
+
+def _unauthorized_response(service_name: str, **extra: Any) -> dict[str, Any]:
+    """Structured 'unauthorized' response.
+
+    ha-mcp clients detect this via ``error_code == "unauthorized"`` and
+    re-fetch the token before retrying.
+    """
+    return {
+        "success": False,
+        "error": (
+            f"Unauthorized: caller token missing or invalid for "
+            f"{DOMAIN}.{service_name}. This service is restricted to the "
+            "ha-mcp server; other callers should not invoke it directly."
+        ),
+        "error_code": "unauthorized",
+        **extra,
+    }
+
+
+def _caller_token_ok(hass: HomeAssistant, call: ServiceCall) -> bool:
+    """Return True if the caller presented the configured token."""
+    expected = hass.data.get(DOMAIN, {}).get(_HASS_DATA_TOKEN_KEY)
+    presented = call.data.get(CALLER_TOKEN_FIELD)
+    # Constant-time compare: token is low-entropy enough that timing leaks
+    # don't meaningfully affect the threat model, but secrets.compare_digest
+    # is free and the right reflex.
+    if not isinstance(expected, str) or not isinstance(presented, str):
+        return False
+    return secrets.compare_digest(expected, presented)
 
 
 def _is_path_allowed_for_dir(
@@ -319,6 +393,8 @@ def _build_edit_yaml_config_handler(hass):
 
     async def handle_edit_yaml_config(call: ServiceCall) -> dict[str, Any]:
         """Handle the edit_yaml_config service call."""
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_EDIT_YAML_CONFIG)
         rel_path = call.data["file"]
         action = call.data["action"]
         yaml_path = call.data["yaml_path"]
@@ -767,6 +843,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HA MCP Tools from a config entry."""
     config_dir = Path(hass.config.config_dir)
 
+    # Bootstrap the caller-auth token. Generated on first setup, persisted
+    # to .storage/ha_mcp_tools_auth, cached in hass.data for fast handler
+    # access. ha-mcp fetches it via the get_caller_token service.
+    caller_token = await _load_or_create_caller_token(hass)
+    hass.data.setdefault(DOMAIN, {})[_HASS_DATA_TOKEN_KEY] = caller_token
+
     # One-time migration of pre-fix YAML backups out of the publicly-served
     # www/ directory (GHSA-g39v-cvjh-8fpf). Wrapped so a migration failure
     # cannot prevent the integration from loading — the integration's
@@ -830,6 +912,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_list_files(call: ServiceCall) -> ServiceResponse:
         """Handle the list_files service call."""
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_LIST_FILES, files=[])
         rel_path = call.data["path"]
         pattern = call.data.get("pattern")
 
@@ -888,6 +972,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_read_file(call: ServiceCall) -> ServiceResponse:
         """Handle the read_file service call."""
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_READ_FILE)
         rel_path = call.data["path"]
         tail_lines = call.data.get("tail_lines")
 
@@ -987,6 +1073,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_write_file(call: ServiceCall) -> ServiceResponse:
         """Handle the write_file service call."""
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_WRITE_FILE)
         rel_path = call.data["path"]
         content = call.data["content"]
         overwrite = call.data.get("overwrite", False)
@@ -1053,6 +1141,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_delete_file(call: ServiceCall) -> ServiceResponse:
         """Handle the delete_file service call."""
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_DELETE_FILE)
         rel_path = call.data["path"]
 
         # Security check - only allow deletes from specific directories
@@ -1104,6 +1194,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     handle_edit_yaml_config = _build_edit_yaml_config_handler(hass)
 
+    async def handle_get_caller_token(call: ServiceCall) -> ServiceResponse:
+        """Return the caller-auth token to the ha-mcp bootstrap caller.
+
+        Intentionally unauthenticated beyond HA's default admin requirement:
+        ha-mcp does not know the token on first run, so this is the bootstrap
+        surface. The dangerous services (read/write/delete/edit_yaml) require
+        the token to be presented; this one returns it.
+        """
+        token = hass.data.get(DOMAIN, {}).get(_HASS_DATA_TOKEN_KEY)
+        if not isinstance(token, str) or not token:
+            return {
+                "success": False,
+                "error": (
+                    "Caller token not initialized — integration may not have "
+                    "completed setup. Reload the ha_mcp_tools integration."
+                ),
+            }
+        return {"success": True, "token": token}
+
     # Register all services with response support
     hass.services.async_register(
         DOMAIN,
@@ -1145,6 +1254,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         supports_response=SupportsResponse.ONLY,
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_CALLER_TOKEN,
+        handle_get_caller_token,
+        schema=SERVICE_GET_CALLER_TOKEN_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
     _LOGGER.info("HA MCP Tools initialized with file management services")
     return True
 
@@ -1157,4 +1274,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_remove(DOMAIN, SERVICE_READ_FILE)
     hass.services.async_remove(DOMAIN, SERVICE_WRITE_FILE)
     hass.services.async_remove(DOMAIN, SERVICE_DELETE_FILE)
+    hass.services.async_remove(DOMAIN, SERVICE_GET_CALLER_TOKEN)
+
+    # Drop the cached token from hass.data so a subsequent setup_entry
+    # re-reads from storage (covers the reload-after-rotate path).
+    if DOMAIN in hass.data:
+        hass.data[DOMAIN].pop(_HASS_DATA_TOKEN_KEY, None)
     return True

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -169,7 +169,10 @@ def _unauthorized_response(service_name: str, **extra: Any) -> dict[str, Any]:
 
 def _caller_token_ok(hass: HomeAssistant, call: ServiceCall) -> bool:
     """Return True if the caller presented the configured token."""
-    expected = hass.data.get(DOMAIN, {}).get(_HASS_DATA_TOKEN_KEY)
+    domain_data = hass.data.get(DOMAIN)
+    expected = (
+        domain_data.get(_HASS_DATA_TOKEN_KEY) if isinstance(domain_data, dict) else None
+    )
     presented = call.data.get(CALLER_TOKEN_FIELD)
     # Constant-time compare: token is low-entropy enough that timing leaks
     # don't meaningfully affect the threat model, but secrets.compare_digest
@@ -1202,7 +1205,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         surface. The dangerous services (read/write/delete/edit_yaml) require
         the token to be presented; this one returns it.
         """
-        token = hass.data.get(DOMAIN, {}).get(_HASS_DATA_TOKEN_KEY)
+        domain_data = hass.data.get(DOMAIN)
+        token = (
+            domain_data.get(_HASS_DATA_TOKEN_KEY)
+            if isinstance(domain_data, dict)
+            else None
+        )
         if not isinstance(token, str) or not token:
             return {
                 "success": False,
@@ -1278,6 +1286,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Drop the cached token from hass.data so a subsequent setup_entry
     # re-reads from storage (covers the reload-after-rotate path).
-    if DOMAIN in hass.data:
-        hass.data[DOMAIN].pop(_HASS_DATA_TOKEN_KEY, None)
+    domain_data = hass.data.get(DOMAIN)
+    if isinstance(domain_data, dict):
+        domain_data.pop(_HASS_DATA_TOKEN_KEY, None)
     return True

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/homeassistant-ai/ha-mcp/issues",
     "requirements": ["ruamel.yaml>=0.18.0"],
-    "version": "0.5.0",
+    "version": "0.5.0"
 }

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/homeassistant-ai/ha-mcp/issues",
     "requirements": ["ruamel.yaml>=0.18.0"],
-    "version": "0.4.0"
+    "version": "0.5.0",
 }

--- a/custom_components/ha_mcp_tools/services.yaml
+++ b/custom_components/ha_mcp_tools/services.yaml
@@ -146,3 +146,13 @@ delete_file:
       example: "www/old-file.css"
       selector:
         text:
+
+get_caller_token:
+  name: Get Caller Token (Internal)
+  description: >-
+    Internal bootstrap service used by the ha-mcp server. Returns the auth
+    token that the other ha_mcp_tools.* services require in their
+    `_ha_mcp_token` field. The token is generated on first integration setup
+    and persisted to .storage. Not intended for direct invocation from
+    automations or scripts.
+  fields: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,13 @@ ignore_missing_imports = true
 [tool.ruff]
 target-version = "py313"
 line-length = 88
-extend-exclude = ["tests/initial_test_state"]
+extend-exclude = [
+    "tests/initial_test_state",
+    # HA integration manifests must be strict JSON (no trailing commas);
+    # ruff 0.15+ formats .json files as JSONC and inserts trailing commas
+    # which makes Python's json.load() reject the file at HA startup.
+    "custom_components/**/*.json",
+]
 
 [tool.ruff.lint]
 select = [

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -13,6 +13,7 @@ The tools will gracefully fail with installation instructions if the component i
 Feature Flag: Set HAMCP_ENABLE_FILESYSTEM_TOOLS=true to enable these tools.
 """
 
+import asyncio
 import json
 import logging
 from typing import Annotated, Any
@@ -37,6 +38,110 @@ FEATURE_FLAG = "HAMCP_ENABLE_FILESYSTEM_TOOLS"
 
 # Domain for the custom component
 MCP_TOOLS_DOMAIN = "ha_mcp_tools"
+
+# Caller-token auth (mirrors custom_components/ha_mcp_tools).
+# The custom component's handlers reject every call that doesn't present
+# this field with the matching token. ha-mcp fetches the token once via
+# the get_caller_token bootstrap service, caches it, and re-fetches if a
+# subsequent call comes back unauthorized (covers token rotation).
+CALLER_TOKEN_FIELD = "_ha_mcp_token"
+CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
+_CALLER_TOKEN_CACHE: dict[str, str] = {}  # keyed by id(client) to support multi-client
+_CALLER_TOKEN_LOCKS: dict[int, asyncio.Lock] = {}
+
+
+def _get_token_lock(client: Any) -> asyncio.Lock:
+    """Per-client lock so concurrent first-callers fetch the token once."""
+    key = id(client)
+    lock = _CALLER_TOKEN_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _CALLER_TOKEN_LOCKS[key] = lock
+    return lock
+
+
+async def _fetch_caller_token(client: Any) -> str:
+    """Call the bootstrap service and cache the returned token."""
+    result = await client.call_service(
+        MCP_TOOLS_DOMAIN,
+        CALLER_TOKEN_BOOTSTRAP_SERVICE,
+        {},
+        return_response=True,
+    )
+    unwrapped = unwrap_service_response(result) if isinstance(result, dict) else {}
+    token = unwrapped.get("token") if isinstance(unwrapped, dict) else None
+    if not isinstance(token, str) or not token:
+        raise RuntimeError(
+            "ha_mcp_tools.get_caller_token did not return a usable token. "
+            "Reload the ha_mcp_tools integration in Home Assistant."
+        )
+    _CALLER_TOKEN_CACHE[str(id(client))] = token
+    return token
+
+
+async def _ensure_caller_token(client: Any, *, force_refresh: bool = False) -> str:
+    """Return a cached or freshly-fetched caller token."""
+    key = str(id(client))
+    if not force_refresh:
+        cached = _CALLER_TOKEN_CACHE.get(key)
+        if cached:
+            return cached
+    async with _get_token_lock(client):
+        cached = _CALLER_TOKEN_CACHE.get(key)
+        if cached and not force_refresh:
+            return cached
+        return await _fetch_caller_token(client)
+
+
+def _is_unauthorized_response(response: Any) -> bool:
+    """Detect the custom component's structured 'unauthorized' reply."""
+    if not isinstance(response, dict):
+        return False
+    inner = unwrap_service_response(response) if response else None
+    if not isinstance(inner, dict):
+        return False
+    return inner.get("error_code") == "unauthorized"
+
+
+async def call_mcp_tools_service(
+    client: Any,
+    service: str,
+    service_data: dict[str, Any],
+    *,
+    return_response: bool = True,
+) -> Any:
+    """Call an ha_mcp_tools.* service with the caller token injected.
+
+    On `unauthorized` response (token rotation or stale cache): refetch the
+    token from the bootstrap service and retry once. Subsequent unauthorized
+    responses are returned as-is — the wrapper tool surfaces the error.
+    """
+    token = await _ensure_caller_token(client)
+    payload = dict(service_data)
+    payload[CALLER_TOKEN_FIELD] = token
+    result = await client.call_service(
+        MCP_TOOLS_DOMAIN,
+        service,
+        payload,
+        return_response=return_response,
+    )
+    if _is_unauthorized_response(result):
+        logger.info("ha_mcp_tools rejected cached token; refetching and retrying once")
+        token = await _ensure_caller_token(client, force_refresh=True)
+        payload[CALLER_TOKEN_FIELD] = token
+        result = await client.call_service(
+            MCP_TOOLS_DOMAIN,
+            service,
+            payload,
+            return_response=return_response,
+        )
+    return result
+
+
+def _reset_caller_token_cache() -> None:
+    """Test hook: clear the module-level token cache."""
+    _CALLER_TOKEN_CACHE.clear()
+    _CALLER_TOKEN_LOCKS.clear()
 
 # Security constants - mirrors the custom component config
 READABLE_PATTERNS = [
@@ -173,12 +278,11 @@ class FilesystemTools:
             if pattern:
                 service_data["pattern"] = pattern
 
-            # Call the custom component service
-            result = await self._client.call_service(
-                MCP_TOOLS_DOMAIN,
+            # Call the custom component service (token injected by helper)
+            result = await call_mcp_tools_service(
+                self._client,
                 "list_files",
                 service_data,
-                return_response=True,
             )
 
             # The service returns the response directly
@@ -288,11 +392,10 @@ class FilesystemTools:
                 service_data["tail_lines"] = tail_lines_int
 
             # Call the custom component service
-            result = await self._client.call_service(
-                MCP_TOOLS_DOMAIN,
+            result = await call_mcp_tools_service(
+                self._client,
                 "read_file",
                 service_data,
-                return_response=True,
             )
 
             if isinstance(result, dict):
@@ -422,11 +525,10 @@ class FilesystemTools:
             }
 
             # Call the custom component service
-            result = await self._client.call_service(
-                MCP_TOOLS_DOMAIN,
+            result = await call_mcp_tools_service(
+                self._client,
                 "write_file",
                 service_data,
-                return_response=True,
             )
 
             if isinstance(result, dict):
@@ -534,11 +636,10 @@ class FilesystemTools:
             service_data: dict[str, Any] = {"path": path}
 
             # Call the custom component service
-            result = await self._client.call_service(
-                MCP_TOOLS_DOMAIN,
+            result = await call_mcp_tools_service(
+                self._client,
                 "delete_file",
                 service_data,
-                return_response=True,
             )
 
             if isinstance(result, dict):

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -217,7 +217,7 @@ def is_filesystem_tools_enabled() -> bool:
 
     Reads through :func:`config.get_global_settings` so the same
     env-var / override-file / default precedence path applies as
-    every other runtime-editable Settings field (issue #863 web UI).
+    every other runtime-editable Settings field.
     """
     from ..config import get_global_settings
 

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -61,8 +61,46 @@ def _get_token_lock(client: Any) -> asyncio.Lock:
     return lock
 
 
+async def _is_bootstrap_service_registered(client: Any) -> bool:
+    """Returns True if ha_mcp_tools.get_caller_token is present in HA's
+    service registry. Old (<0.5.0) versions of the custom component
+    didn't ship this service; the bootstrap call would otherwise fail
+    with an opaque 400 from HA."""
+    services = await client.get_services()
+    for entry in services:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("domain") != MCP_TOOLS_DOMAIN:
+            continue
+        domain_services = entry.get("services") or {}
+        return CALLER_TOKEN_BOOTSTRAP_SERVICE in domain_services
+    return False
+
+
 async def _fetch_caller_token(client: Any) -> str:
-    """Call the bootstrap service and cache the returned token."""
+    """Call the bootstrap service and cache the returned token.
+
+    Old custom-component versions (<0.5.0) don't register get_caller_token.
+    We detect that explicitly and surface an actionable "update component"
+    error rather than a generic "no usable token" string, which would
+    otherwise be the symptom for both (a) old component installed and
+    (b) a race condition during integration setup.
+    """
+    if not await _is_bootstrap_service_registered(client):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "The installed ha_mcp_tools custom component is too old "
+                "(pre-0.5.0) — it does not register the get_caller_token "
+                "bootstrap service that this ha-mcp version requires. "
+                "Update via HACS and restart Home Assistant.",
+                suggestions=[
+                    "HACS → Integrations → HA MCP Tools → Update",
+                    "Restart Home Assistant after update completes",
+                    "Then retry the operation",
+                ],
+            )
+        )
     result = await client.call_service(
         MCP_TOOLS_DOMAIN,
         CALLER_TOKEN_BOOTSTRAP_SERVICE,
@@ -287,9 +325,14 @@ class FilesystemTools:
                 service_data,
             )
 
-            # The service returns the response directly
+            # Mirror ha_config_set_yaml: raise on success=false so callers
+            # see a ToolError rather than a success-shaped response that
+            # carries an error payload.
             if isinstance(result, dict):
-                return unwrap_service_response(result)
+                result = unwrap_service_response(result)
+                if not result.get("success", True):
+                    raise_tool_error(result)
+                return result
 
             raise_tool_error(
                 create_error_response(
@@ -401,7 +444,10 @@ class FilesystemTools:
             )
 
             if isinstance(result, dict):
-                return unwrap_service_response(result)
+                result = unwrap_service_response(result)
+                if not result.get("success", True):
+                    raise_tool_error(result)
+                return result
 
             raise_tool_error(
                 create_error_response(
@@ -534,7 +580,10 @@ class FilesystemTools:
             )
 
             if isinstance(result, dict):
-                return unwrap_service_response(result)
+                result = unwrap_service_response(result)
+                if not result.get("success", True):
+                    raise_tool_error(result)
+                return result
 
             raise_tool_error(
                 create_error_response(
@@ -645,7 +694,10 @@ class FilesystemTools:
             )
 
             if isinstance(result, dict):
-                return unwrap_service_response(result)
+                result = unwrap_service_response(result)
+                if not result.get("success", True):
+                    raise_tool_error(result)
+                return result
 
             raise_tool_error(
                 create_error_response(

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -46,7 +46,8 @@ MCP_TOOLS_DOMAIN = "ha_mcp_tools"
 # subsequent call comes back unauthorized (covers token rotation).
 CALLER_TOKEN_FIELD = "_ha_mcp_token"
 CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
-_CALLER_TOKEN_CACHE: dict[str, str] = {}  # keyed by id(client) to support multi-client
+# Keyed by id(client) (int) to support multi-client setups.
+_CALLER_TOKEN_CACHE: dict[int, str] = {}
 _CALLER_TOKEN_LOCKS: dict[int, asyncio.Lock] = {}
 
 
@@ -75,13 +76,13 @@ async def _fetch_caller_token(client: Any) -> str:
             "ha_mcp_tools.get_caller_token did not return a usable token. "
             "Reload the ha_mcp_tools integration in Home Assistant."
         )
-    _CALLER_TOKEN_CACHE[str(id(client))] = token
+    _CALLER_TOKEN_CACHE[id(client)] = token
     return token
 
 
 async def _ensure_caller_token(client: Any, *, force_refresh: bool = False) -> str:
     """Return a cached or freshly-fetched caller token."""
-    key = str(id(client))
+    key = id(client)
     if not force_refresh:
         cached = _CALLER_TOKEN_CACHE.get(key)
         if cached:
@@ -142,6 +143,7 @@ def _reset_caller_token_cache() -> None:
     """Test hook: clear the module-level token cache."""
     _CALLER_TOKEN_CACHE.clear()
     _CALLER_TOKEN_LOCKS.clear()
+
 
 # Security constants - mirrors the custom component config
 READABLE_PATTERNS = [

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -16,6 +16,7 @@ Feature Flag: Set HAMCP_ENABLE_FILESYSTEM_TOOLS=true to enable these tools.
 import asyncio
 import json
 import logging
+import weakref
 from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
@@ -46,18 +47,21 @@ MCP_TOOLS_DOMAIN = "ha_mcp_tools"
 # subsequent call comes back unauthorized (covers token rotation).
 CALLER_TOKEN_FIELD = "_ha_mcp_token"
 CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
-# Keyed by id(client) (int) to support multi-client setups.
-_CALLER_TOKEN_CACHE: dict[int, str] = {}
-_CALLER_TOKEN_LOCKS: dict[int, asyncio.Lock] = {}
+# Weak-keyed by client object to support multi-client setups and self-evict
+# when a client is garbage-collected (avoids id() reuse if a freed client's
+# address gets recycled before the unauthorized-retry fires).
+_CALLER_TOKEN_CACHE: weakref.WeakKeyDictionary[Any, str] = weakref.WeakKeyDictionary()
+_CALLER_TOKEN_LOCKS: weakref.WeakKeyDictionary[Any, asyncio.Lock] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def _get_token_lock(client: Any) -> asyncio.Lock:
     """Per-client lock so concurrent first-callers fetch the token once."""
-    key = id(client)
-    lock = _CALLER_TOKEN_LOCKS.get(key)
+    lock = _CALLER_TOKEN_LOCKS.get(client)
     if lock is None:
         lock = asyncio.Lock()
-        _CALLER_TOKEN_LOCKS[key] = lock
+        _CALLER_TOKEN_LOCKS[client] = lock
     return lock
 
 
@@ -110,23 +114,29 @@ async def _fetch_caller_token(client: Any) -> str:
     unwrapped = unwrap_service_response(result) if isinstance(result, dict) else {}
     token = unwrapped.get("token") if isinstance(unwrapped, dict) else None
     if not isinstance(token, str) or not token:
-        raise RuntimeError(
-            "ha_mcp_tools.get_caller_token did not return a usable token. "
-            "Reload the ha_mcp_tools integration in Home Assistant."
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "ha_mcp_tools.get_caller_token did not return a usable token.",
+                suggestions=[
+                    "Reload the ha_mcp_tools integration in Home Assistant",
+                    "Verify the HA token used by ha-mcp has admin rights",
+                    "Then retry the operation",
+                ],
+            )
         )
-    _CALLER_TOKEN_CACHE[id(client)] = token
+    _CALLER_TOKEN_CACHE[client] = token
     return token
 
 
 async def _ensure_caller_token(client: Any, *, force_refresh: bool = False) -> str:
     """Return a cached or freshly-fetched caller token."""
-    key = id(client)
     if not force_refresh:
-        cached = _CALLER_TOKEN_CACHE.get(key)
+        cached = _CALLER_TOKEN_CACHE.get(client)
         if cached:
             return cached
     async with _get_token_lock(client):
-        cached = _CALLER_TOKEN_CACHE.get(key)
+        cached = _CALLER_TOKEN_CACHE.get(client)
         if cached and not force_refresh:
             return cached
         return await _fetch_caller_token(client)

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -371,7 +371,11 @@ class ServiceTools:
         # dedicated wrappers (which inject the required caller token). Block
         # ha_call_service from forwarding to that domain — it would otherwise
         # be a bypass path around the dedicated tools (see issue #1451).
-        if domain == "ha_mcp_tools":
+        # HA core's service registry lowercases the domain on fallback lookup
+        # (homeassistant/core.py ServiceRegistry.async_call), so normalise
+        # here to make sure a mixed-case `HA_MCP_TOOLS` can't slip past this
+        # exact-string check and still resolve downstream.
+        if isinstance(domain, str) and domain.strip().lower() == "ha_mcp_tools":
             raise_tool_error(
                 create_validation_error(
                     (

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -355,7 +355,7 @@ class ServiceTools:
         **Key behavior:**
         - **wait** (default True): wait for the entity state to change before
           returning. Only applies to state-changing services on a single entity.
-        - **Result compaction (issue #1446, default ON)**: ``result`` is trimmed
+        - **Result compaction (default ON)**: ``result`` is trimmed
           to the targeted entity's record (drops parent-group propagation) and
           stripped of ``context`` / ``last_*`` metadata and heavy attribute
           lists (``effect_list``, ``hue_scenes``). Escape hatches: ``verbose=True``

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -367,6 +367,22 @@ class ServiceTools:
         Common patterns: Use ha_get_state() to check current values before making changes.
         Use ha_search_entities() to find correct entity IDs.
         """
+        # ha_mcp_tools.* services are restricted to the ha-mcp server's
+        # dedicated wrappers (which inject the required caller token). Block
+        # ha_call_service from forwarding to that domain — it would otherwise
+        # be a bypass path around the dedicated tools (see issue #1451).
+        if domain == "ha_mcp_tools":
+            raise_tool_error(
+                create_validation_error(
+                    (
+                        "ha_call_service cannot invoke services in the "
+                        "'ha_mcp_tools' domain. Use the dedicated MCP tool "
+                        "instead: ha_list_files, ha_read_file, ha_write_file, "
+                        "ha_delete_file, or ha_config_set_yaml."
+                    ),
+                    parameter="domain",
+                )
+            )
         try:
             service_data = self._parse_service_data(data, entity_id)
 

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -370,7 +370,7 @@ class ServiceTools:
         # ha_mcp_tools.* services are restricted to the ha-mcp server's
         # dedicated wrappers (which inject the required caller token). Block
         # ha_call_service from forwarding to that domain — it would otherwise
-        # be a bypass path around the dedicated tools (see issue #1451).
+        # be a bypass path around the dedicated tools.
         # HA core's service registry lowercases the domain on fallback lookup
         # (homeassistant/core.py ServiceRegistry.async_call), so normalise
         # here to make sure a mixed-case `HA_MCP_TOOLS` can't slip past this

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -28,8 +28,8 @@ from .helpers import (
 )
 from .tools_config_dashboards import fetch_dashboards_list
 from .tools_filesystem import (
-    MCP_TOOLS_DOMAIN,
     _assert_mcp_tools_available,
+    call_mcp_tools_service,
 )
 from .util_helpers import coerce_bool_param, unwrap_service_response
 
@@ -231,12 +231,11 @@ class YamlConfigTools:
             if content is not None:
                 service_data["content"] = content
 
-            # Call the custom component service
-            result = await self._client.call_service(
-                MCP_TOOLS_DOMAIN,
+            # Call the custom component service (token injected by helper)
+            result = await call_mcp_tools_service(
+                self._client,
                 "edit_yaml_config",
                 service_data,
-                return_response=True,
             )
 
             if isinstance(result, dict):

--- a/tests/initial_test_state/.storage/auth
+++ b/tests/initial_test_state/.storage/auth
@@ -25,6 +25,17 @@
         "name": "mcp",
         "system_generated": false,
         "local_only": false
+      },
+      {
+        "id": "a5973d5989084a51c9639e88d98629dc",
+        "group_ids": [
+          "system-users"
+        ],
+        "is_owner": false,
+        "is_active": true,
+        "name": "non_admin_test",
+        "system_generated": false,
+        "local_only": false
       }
     ],
     "groups": [
@@ -116,6 +127,23 @@
         "token": "8d2988fa06656005d4285394c668e515124a3d466a30e7f7d11eb34c8c8c0b43fd1537be25c20618378f7ffc7360c9920219acec94f52e26ff444d0b054a8169",
         "jwt_key": "b9782f5628c972857d98ebe812da82c0410c6b3749b6f1e8b3b65c3f37ffacec952fd4216b45791ebec07181829cd2ade95ff16f273096096a23e6ab7f15ddd4",
         "last_used_at": "2025-09-08T00:03:16.685833+00:00",
+        "last_used_ip": null,
+        "expire_at": null,
+        "credential_id": null,
+        "version": "2025.9.1"
+      },
+      {
+        "id": "3792979c7ba7e60005662e22c7838cf8",
+        "user_id": "a5973d5989084a51c9639e88d98629dc",
+        "client_id": null,
+        "client_name": "non_admin_test",
+        "client_icon": null,
+        "token_type": "long_lived_access_token",
+        "created_at": "2025-09-08T00:03:16.685569+00:00",
+        "access_token_expiration": 315360000.0,
+        "token": "e1f927669b4593ebe5be69fa7286dd8bde98002ba66ac79f2cad2c92bcacefde776228c59606b06af4144e1658315bef437991c1282a78a833a565da143ba227",
+        "jwt_key": "39dd4df791517a1f3319519ca425410ffddf6b02c89136fe43de4d5622497f626745e1498341b50235c6b6eddfdc5700406851a60c9e9dc3d2801514f78bdaa5",
+        "last_used_at": null,
         "last_used_ip": null,
         "expire_at": null,
         "credential_id": null,

--- a/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
+++ b/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
@@ -1,29 +1,22 @@
-"""E2E coverage for the caller-token auth contract added in PR #1459.
+"""E2E coverage for the caller-token auth contract.
 
 Runs cross-lane (no backend marker) — the same assertions execute against
 the testcontainer backend, the HAOS external lane (``ha-mcp`` running
 externally against booted HAOS), and the HAOS inaddon lane (``ha-mcp``
 running inside the dev addon container with the supervisor token):
 
-* ``ha_call_service`` refuses ``domain == ha_mcp_tools`` — closes the
-  issue #1451 bypass at the wrapper layer. Verified across literal,
-  upper-case, mixed-case, and whitespace variants of the domain name so
-  the refusal cannot be sidestepped by HA core's domain-lowercasing
-  fallback (``homeassistant/core.py`` ``ServiceRegistry.async_call``).
+* ``ha_call_service`` refuses ``domain == ha_mcp_tools`` at the wrapper
+  layer. Verified across literal, upper-case, mixed-case, and
+  whitespace variants of the domain so the refusal cannot be
+  sidestepped by HA core's domain-lowercasing fallback
+  (``homeassistant/core.py`` ``ServiceRegistry.async_call``).
 * Positive smoke: ``ha_list_files`` round-trips successfully — implicit
   proof that ``call_mcp_tools_service`` bootstrap-fetches the caller
   token via ``ha_mcp_tools.get_caller_token``, injects it, and the
   handler accepts it. In addon mode the supervisor token maps to the
   admin-forced ``hassio_user`` and therefore passes the explicit admin
-  gate added to the bootstrap; in container / external HAOS mode the
-  user-supplied admin LLAT does the same.
-
-The negative branch of the admin gate (a non-admin caller is rejected
-by ``ha_mcp_tools.get_caller_token``) is covered by
-``test_caller_token_auth.py::TestCallerIsAdmin``. ``initial_test_state``
-ships only the system content user + the admin ``mcp`` user, so the
-positive admin path is the only one currently reachable at the E2E
-tier.
+  gate; in container / external HAOS mode the user-supplied admin LLAT
+  does the same.
 """
 
 from __future__ import annotations
@@ -86,7 +79,7 @@ async def mcp_client_for_refusal(
 
 
 # ---------------------------------------------------------------------------
-# ha_call_service refusal — issue #1451 bypass closure
+# ha_call_service refusal of the ha_mcp_tools domain
 # ---------------------------------------------------------------------------
 
 
@@ -169,7 +162,7 @@ class TestHaCallServiceRefusesMcpToolsDomain:
                 "service": "create",
                 "data": {
                     "message": f"caller-token-refusal-test {nonce}",
-                    "title": "PR #1459 refusal coverage",
+                    "title": "ha_mcp_tools refusal coverage",
                     "notification_id": f"pr1459_{nonce}",
                 },
             },
@@ -235,4 +228,68 @@ class TestCallerTokenBootstrapEndToEnd:
         assert data.get("success") is True, (
             f"ha_list_files must succeed once the bootstrap + token gate is "
             f"in place; got: {data!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Admin gate — non-admin caller is rejected at the bootstrap surface
+# ---------------------------------------------------------------------------
+
+
+class TestCallerTokenAdminGate:
+    """``ha_mcp_tools.get_caller_token`` is admin-gated explicitly.
+
+    The seeded non-admin user lives in ``tests/initial_test_state/.storage/auth``
+    (``a5973d59…``, ``system-users`` group). The matching LLAT is
+    ``NON_ADMIN_TEST_TOKEN`` in ``tests/test_constants.py``. We call the
+    HA REST endpoint directly with that token — no MCP wrapper, no
+    ``HOMEASSISTANT_TOKEN`` shadowing — and assert HA returns the
+    structured ``unauthorized`` reply emitted by the handler when
+    ``_caller_is_admin`` rejects.
+    """
+
+    async def test_non_admin_caller_rejected(
+        self,
+        _filesystem_feature_flag,
+        ha_container_with_fresh_config,
+    ):
+        import httpx
+
+        from tests.test_constants import NON_ADMIN_TEST_TOKEN
+
+        base_url = ha_container_with_fresh_config["base_url"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{base_url}/api/services/ha_mcp_tools/get_caller_token",
+                headers={
+                    "Authorization": f"Bearer {NON_ADMIN_TEST_TOKEN}",
+                    "Content-Type": "application/json",
+                },
+                params={"return_response": ""},
+                json={},
+            )
+
+        if response.status_code == 400 and "ServiceNotFound" in response.text:
+            pytest.skip(
+                "ha_mcp_tools.get_caller_token not registered in this lane "
+                "(custom component not installed); admin-gate coverage is "
+                "exercised in the lanes that pre-bake the component"
+            )
+
+        assert response.status_code == 200, (
+            f"HA must accept the non-admin LLAT at the auth layer (the "
+            f"admin gate fires inside the handler, not at the transport). "
+            f"Status={response.status_code}, body={response.text!r}"
+        )
+
+        body = response.json()
+        # HA wraps the service response under ``service_response``
+        service_response = body.get("service_response", body)
+        assert service_response.get("success") is False, (
+            f"Non-admin caller must be rejected by the admin gate; got: {body!r}"
+        )
+        assert service_response.get("error_code") == "unauthorized", (
+            f"Rejection must carry error_code='unauthorized' so clients can "
+            f"distinguish it from other failures; got: {body!r}"
         )

--- a/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
+++ b/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
@@ -18,16 +18,12 @@ running inside the dev addon container with the supervisor token):
   gate added to the bootstrap; in container / external HAOS mode the
   user-supplied admin LLAT does the same.
 
-The negative branch of the admin gate (a non-admin auth caller is
-rejected by ``ha_mcp_tools.get_caller_token``) is covered by
-``test_caller_token_auth.py::TestCallerIsAdmin`` at the unit layer — a
-real-user E2E exercise of it would require new non-admin-user fixture
-scaffolding (create user via ``config/auth/create``, register a
-homeassistant-auth-provider credential, log in to mint a refresh token,
-mint an LLAT, route an ``ha_mcp_tools.get_caller_token`` call through
-the non-admin LLAT). Out of scope for this PR; the unit-tier coverage
-plus the cross-lane positive-path E2E above pins both directions of
-the admin-gate behavior.
+The negative branch of the admin gate (a non-admin caller is rejected
+by ``ha_mcp_tools.get_caller_token``) is covered by
+``test_caller_token_auth.py::TestCallerIsAdmin``. ``initial_test_state``
+ships only the system content user + the admin ``mcp`` user, so the
+positive admin path is the only one currently reachable at the E2E
+tier.
 """
 
 from __future__ import annotations

--- a/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
+++ b/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
@@ -1,0 +1,242 @@
+"""E2E coverage for the caller-token auth contract added in PR #1459.
+
+Runs cross-lane (no backend marker) — the same assertions execute against
+the testcontainer backend, the HAOS external lane (``ha-mcp`` running
+externally against booted HAOS), and the HAOS inaddon lane (``ha-mcp``
+running inside the dev addon container with the supervisor token):
+
+* ``ha_call_service`` refuses ``domain == ha_mcp_tools`` — closes the
+  issue #1451 bypass at the wrapper layer. Verified across literal,
+  upper-case, mixed-case, and whitespace variants of the domain name so
+  the refusal cannot be sidestepped by HA core's domain-lowercasing
+  fallback (``homeassistant/core.py`` ``ServiceRegistry.async_call``).
+* Positive smoke: ``ha_list_files`` round-trips successfully — implicit
+  proof that ``call_mcp_tools_service`` bootstrap-fetches the caller
+  token via ``ha_mcp_tools.get_caller_token``, injects it, and the
+  handler accepts it. In addon mode the supervisor token maps to the
+  admin-forced ``hassio_user`` and therefore passes the explicit admin
+  gate added to the bootstrap; in container / external HAOS mode the
+  user-supplied admin LLAT does the same.
+
+The negative branch of the admin gate (a non-admin auth caller is
+rejected by ``ha_mcp_tools.get_caller_token``) is covered by
+``test_caller_token_auth.py::TestCallerIsAdmin`` at the unit layer — a
+real-user E2E exercise of it would require new non-admin-user fixture
+scaffolding (create user via ``config/auth/create``, register a
+homeassistant-auth-provider credential, log in to mint a refresh token,
+mint an LLAT, route an ``ha_mcp_tools.get_caller_token`` call through
+the non-admin LLAT). Out of scope for this PR; the unit-tier coverage
+plus the cross-lane positive-path E2E above pins both directions of
+the admin-gate behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import pytest
+
+from ...utilities.assertions import (
+    MCPAssertions,
+    extract_error_message,
+    safe_call_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+FEATURE_FLAG = "HAMCP_ENABLE_FILESYSTEM_TOOLS"
+
+
+@pytest.fixture(scope="module")
+def _filesystem_feature_flag(ha_container_with_fresh_config):
+    """Enable the filesystem feature flag for the bootstrap positive smoke.
+
+    Mirrors ``test_file_operations.py``'s ``filesystem_tools_enabled``
+    fixture; this is a thin local copy so this module stays independent
+    of the filesystem suite's imports.
+    """
+    os.environ[FEATURE_FLAG] = "true"
+    yield
+    os.environ.pop(FEATURE_FLAG, None)
+
+
+@pytest.fixture
+async def mcp_client_for_refusal(
+    _filesystem_feature_flag,
+    mcp_server,
+    mcp_client,
+    ha_container_with_fresh_config,
+):
+    """Yield an MCP client capable of exercising both the refusal and the
+    bootstrap-and-inject smoke.
+
+    In inaddon mode ``mcp_server`` is None (the addon is the server);
+    the session-scope ``mcp_client`` already speaks to the addon and is
+    handed back directly. Outside inaddon mode we wrap an in-process
+    FastMCP client around ``mcp_server.mcp`` exactly as the filesystem
+    suite does.
+    """
+    if mcp_server is None:
+        yield mcp_client
+        return
+
+    from fastmcp import Client
+
+    client = Client(mcp_server.mcp)
+    async with client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# ha_call_service refusal — issue #1451 bypass closure
+# ---------------------------------------------------------------------------
+
+
+class TestHaCallServiceRefusesMcpToolsDomain:
+    """Wrapper-layer refusal: ``ha_call_service(domain="ha_mcp_tools", …)``
+    must raise before the call is forwarded to HA's service registry."""
+
+    async def test_literal_domain_refused(self, mcp_client_for_refusal):
+        """The exact-string ``ha_mcp_tools`` is refused with a clear error
+        that points the LLM at the dedicated wrapper tools."""
+        result = await safe_call_tool(
+            mcp_client_for_refusal,
+            "ha_call_service",
+            {
+                "domain": "ha_mcp_tools",
+                "service": "write_file",
+                "data": {"path": "www/should-never-be-written.txt", "content": "x"},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "ha_mcp_tools" in error_msg, (
+            f"Refusal must name the blocked domain; got: {error_msg!r}"
+        )
+        assert any(
+            hint in error_msg
+            for hint in (
+                "ha_write_file",
+                "ha_list_files",
+                "ha_read_file",
+                "ha_delete_file",
+                "ha_config_set_yaml",
+            )
+        ), f"Refusal must hint at the dedicated tool; got: {error_msg!r}"
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "HA_MCP_TOOLS",
+            "Ha_Mcp_Tools",
+            "  ha_mcp_tools  ",
+            " HA_MCP_TOOLS ",
+        ],
+        ids=["upper", "mixed", "padded_lower", "padded_upper"],
+    )
+    async def test_case_and_whitespace_variants_refused(
+        self, mcp_client_for_refusal, variant
+    ):
+        """HA core's ``ServiceRegistry.async_call`` lowercases the domain
+        on its fallback lookup, so a mixed-case ``HA_MCP_TOOLS`` would
+        otherwise slip past an exact-string refusal and still resolve
+        downstream. Verify normalization closes that hole."""
+        result = await safe_call_tool(
+            mcp_client_for_refusal,
+            "ha_call_service",
+            {
+                "domain": variant,
+                "service": "write_file",
+                "data": {"path": "www/should-never-be-written.txt", "content": "x"},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "ha_mcp_tools" in error_msg, (
+            f"Variant {variant!r} must be refused with a ha_mcp_tools "
+            f"mention; got: {error_msg!r}"
+        )
+
+    async def test_unrelated_domain_not_refused(self, mcp_client_for_refusal):
+        """Refusal is narrow — ``persistent_notification`` (and any other
+        domain) must pass the refusal check and reach HA. We don't assert
+        success of the underlying call; we only assert the refusal text is
+        absent so we know the refusal didn't fire spuriously."""
+        nonce = uuid.uuid4().hex[:8]
+        result = await safe_call_tool(
+            mcp_client_for_refusal,
+            "ha_call_service",
+            {
+                "domain": "persistent_notification",
+                "service": "create",
+                "data": {
+                    "message": f"caller-token-refusal-test {nonce}",
+                    "title": "PR #1459 refusal coverage",
+                    "notification_id": f"pr1459_{nonce}",
+                },
+            },
+        )
+
+        # The refusal would mention ha_mcp_tools by name. Its absence is
+        # the load-bearing assertion. The call itself may succeed or fail
+        # for unrelated reasons; we don't care here.
+        if isinstance(result, dict):
+            error_msg = result.get("error")
+            if isinstance(error_msg, dict):
+                error_msg = error_msg.get("message", "")
+            elif not isinstance(error_msg, str):
+                error_msg = ""
+            assert "ha_mcp_tools" not in error_msg, (
+                f"Refusal must not fire for persistent_notification; got: {error_msg!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap-and-inject smoke — positive path of the gate
+# ---------------------------------------------------------------------------
+
+
+class TestCallerTokenBootstrapEndToEnd:
+    """Calling ``ha_list_files`` proves the full chain: ``ha-mcp`` fetches
+    the caller token via ``ha_mcp_tools.get_caller_token``, the handler's
+    admin gate accepts the supervisor user (addon mode) or the admin LLAT
+    (container / external HAOS mode), the wrapper injects ``_ha_mcp_token``,
+    and the dangerous-handler's ``_caller_token_ok`` check accepts it."""
+
+    async def test_list_files_round_trips(self, mcp_client_for_refusal):
+        """Implicit end-to-end coverage of bootstrap + admin gate + token
+        gate. Skips with a clear reason if the ha_mcp_tools custom
+        component isn't installed (testcontainer lanes without the
+        component baked in)."""
+        result = await safe_call_tool(
+            mcp_client_for_refusal,
+            "ha_list_files",
+            {"path": "www/"},
+        )
+
+        if isinstance(result, dict):
+            error = result.get("error") or {}
+            if (
+                isinstance(error, dict)
+                and error.get("code") == "COMPONENT_NOT_INSTALLED"
+            ):
+                pytest.skip(
+                    "ha_mcp_tools custom component not installed in this test "
+                    "config; bootstrap coverage is exercised in the lanes "
+                    "that pre-bake the component"
+                )
+
+        # If we got here the bootstrap + token gate must have worked end
+        # to end. The exact ``data`` shape isn't load-bearing for this
+        # test — we just need success.
+        async with MCPAssertions(mcp_client_for_refusal) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_list_files",
+                {"path": "www/"},
+            )
+        assert data.get("success") is True, (
+            f"ha_list_files must succeed once the bootstrap + token gate is "
+            f"in place; got: {data!r}"
+        )

--- a/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
+++ b/tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py
@@ -196,30 +196,12 @@ class TestCallerTokenBootstrapEndToEnd:
 
     async def test_list_files_round_trips(self, mcp_client_for_refusal):
         """Implicit end-to-end coverage of bootstrap + admin gate + token
-        gate. Skips with a clear reason if the ha_mcp_tools custom
-        component isn't installed (testcontainer lanes without the
-        component baked in)."""
-        result = await safe_call_tool(
-            mcp_client_for_refusal,
-            "ha_list_files",
-            {"path": "www/"},
-        )
-
-        if isinstance(result, dict):
-            error = result.get("error") or {}
-            if (
-                isinstance(error, dict)
-                and error.get("code") == "COMPONENT_NOT_INSTALLED"
-            ):
-                pytest.skip(
-                    "ha_mcp_tools custom component not installed in this test "
-                    "config; bootstrap coverage is exercised in the lanes "
-                    "that pre-bake the component"
-                )
-
-        # If we got here the bootstrap + token gate must have worked end
-        # to end. The exact ``data`` shape isn't load-bearing for this
-        # test — we just need success.
+        gate. Fails loudly if ha_mcp_tools is missing — the testcontainer
+        conftest auto-installs it and the HAOS lanes bake it in, so a
+        missing component means the install path regressed.
+        ``TestMcpToolsComponentNotInstalled`` in
+        ``workflows/filesystem/test_file_operations.py`` covers the
+        deliberate not-installed scenario; this test does not."""
         async with MCPAssertions(mcp_client_for_refusal) as mcp:
             data = await mcp.call_tool_success(
                 "ha_list_files",
@@ -270,13 +252,12 @@ class TestCallerTokenAdminGate:
                 json={},
             )
 
-        if response.status_code == 400 and "ServiceNotFound" in response.text:
-            pytest.skip(
-                "ha_mcp_tools.get_caller_token not registered in this lane "
-                "(custom component not installed); admin-gate coverage is "
-                "exercised in the lanes that pre-bake the component"
-            )
-
+        # No graceful skip on missing component: the testcontainer conftest
+        # auto-installs ha_mcp_tools and HAOS lanes bake it in, so a 400
+        # ServiceNotFound here means the install path regressed.
+        # TestMcpToolsComponentNotInstalled in
+        # workflows/filesystem/test_file_operations.py covers the
+        # deliberate not-installed scenario; this test does not.
         assert response.status_code == 200, (
             f"HA must accept the non-admin LLAT at the auth layer (the "
             f"admin gate fires inside the handler, not at the transport). "

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -36,6 +36,7 @@ sys.modules.setdefault("homeassistant.helpers.storage", MagicMock())
 
 from custom_components.ha_mcp_tools import (  # noqa: E402
     CALLER_TOKEN_FIELD,
+    _caller_is_admin,
     _caller_token_ok,
     _unauthorized_response,
 )
@@ -99,6 +100,59 @@ class TestCallerTokenOk:
         hass = _fake_hass("good-token-xyz")
         call = _fake_call("")
         assert _caller_token_ok(hass, call) is False
+
+    @pytest.mark.parametrize("bad_token", [123, ["good-token-xyz"], {"token": "x"}])
+    def test_rejects_non_string_presented_token(self, bad_token):
+        """isinstance guard must fail-closed on type confusion (the
+        ServiceCall.data dict can contain anything voluptuous coerced)."""
+        hass = _fake_hass("good-token-xyz")
+        call = MagicMock()
+        call.data = {CALLER_TOKEN_FIELD: bad_token}
+        assert _caller_token_ok(hass, call) is False
+
+
+class TestCallerIsAdmin:
+    """Bootstrap service is admin-gated explicitly (HA doesn't gate
+    service calls by default — verified against HA core)."""
+
+    @pytest.mark.asyncio
+    async def test_accepts_admin_user(self):
+        hass = MagicMock()
+        admin = MagicMock(is_admin=True)
+        hass.auth.async_get_user = AsyncMock(return_value=admin)
+        call = MagicMock()
+        call.context.user_id = "admin-uid"
+        assert await _caller_is_admin(hass, call) is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_admin_user(self):
+        hass = MagicMock()
+        non_admin = MagicMock(is_admin=False)
+        hass.auth.async_get_user = AsyncMock(return_value=non_admin)
+        call = MagicMock()
+        call.context.user_id = "non-admin-uid"
+        assert await _caller_is_admin(hass, call) is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_user_id(self):
+        """async_get_user returning None (deleted user, stale token) → reject."""
+        hass = MagicMock()
+        hass.auth.async_get_user = AsyncMock(return_value=None)
+        call = MagicMock()
+        call.context.user_id = "deleted-uid"
+        assert await _caller_is_admin(hass, call) is False
+
+    @pytest.mark.asyncio
+    async def test_no_user_context_is_trusted(self):
+        """call.context.user_id is None for system-internal events; HA's
+        own async_admin_handler_factory treats these as trusted, so we
+        match that convention rather than locking everyone out."""
+        hass = MagicMock()
+        hass.auth.async_get_user = AsyncMock()
+        call = MagicMock()
+        call.context.user_id = None
+        assert await _caller_is_admin(hass, call) is True
+        hass.auth.async_get_user.assert_not_awaited()
 
 
 class TestUnauthorizedResponse:
@@ -264,7 +318,7 @@ class TestCallMcpToolsServiceInjectsToken:
         # uses it, gets rejected, refetches, and retries.
         from ha_mcp.tools.tools_filesystem import _CALLER_TOKEN_CACHE
 
-        _CALLER_TOKEN_CACHE[id(client)] = "stale-token"
+        _CALLER_TOKEN_CACHE[client] = "stale-token"
 
         result = await call_mcp_tools_service(client, "write_file", {"path": "www/x"})
 
@@ -277,7 +331,9 @@ class TestCallMcpToolsServiceInjectsToken:
     @pytest.mark.asyncio
     async def test_raises_when_bootstrap_returns_no_token(self):
         """Service exists but returns a malformed response (race condition
-        during integration setup, etc.) → RuntimeError."""
+        during integration setup, etc.) → structured ToolError, not a bare
+        RuntimeError (which the wrapper's ``except Exception`` would
+        otherwise re-map to a generic INTERNAL_ERROR)."""
         client = AsyncMock()
         client.get_services.return_value = [
             {
@@ -287,8 +343,48 @@ class TestCallMcpToolsServiceInjectsToken:
         ]
         # Bootstrap returns a malformed response
         client.call_service.return_value = {"service_response": {"success": False}}
-        with pytest.raises(RuntimeError, match="did not return a usable token"):
+        with pytest.raises(ToolError, match="did not return a usable token"):
             await call_mcp_tools_service(client, "list_files", {"path": "www"})
+
+    @pytest.mark.asyncio
+    async def test_second_unauthorized_response_surfaces_no_further_retry(self):
+        """If the refetch+retry path also returns unauthorized (e.g. genuine
+        permanent rejection), the wrapper must NOT loop — it returns the
+        unauthorized response so the caller surfaces a real error rather
+        than spinning forever or silently succeeding."""
+        client = AsyncMock()
+        client.get_services.return_value = [
+            {
+                "domain": MCP_TOOLS_DOMAIN,
+                "services": {CALLER_TOKEN_BOOTSTRAP_SERVICE: {}, "write_file": {}},
+            }
+        ]
+        downstream_attempts = {"n": 0}
+
+        async def fake_call_service(domain, service, payload, **kwargs):
+            if domain == MCP_TOOLS_DOMAIN and service == CALLER_TOKEN_BOOTSTRAP_SERVICE:
+                return {
+                    "service_response": {"success": True, "token": "freshly-fetched"}
+                }
+            downstream_attempts["n"] += 1
+            return {
+                "service_response": {
+                    "success": False,
+                    "error_code": "unauthorized",
+                    "error": "still rejected",
+                }
+            }
+
+        client.call_service.side_effect = fake_call_service
+
+        result = await call_mcp_tools_service(client, "write_file", {"path": "www/x"})
+
+        # Exactly two downstream attempts — one cached, one after refetch.
+        # No third attempt; no silent success.
+        assert downstream_attempts["n"] == 2
+        inner = result["service_response"]
+        assert inner["error_code"] == "unauthorized"
+        assert inner["success"] is False
 
     @pytest.mark.asyncio
     async def test_raises_component_too_old_when_bootstrap_service_missing(self):
@@ -348,6 +444,29 @@ class TestHaCallServiceRefusesMcpToolsDomain:
             for name in ("ha_write_file", "ha_list_files", "ha_config_set_yaml")
         )
         # The downstream client was never touched.
+        tools._client.call_service.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "variant",
+        ["HA_MCP_TOOLS", "Ha_Mcp_Tools", "  ha_mcp_tools  ", " HA_MCP_TOOLS "],
+    )
+    @pytest.mark.asyncio
+    async def test_blocks_case_and_whitespace_variants(self, variant):
+        """HA core's ServiceRegistry.async_call lowercases the domain on its
+        fallback lookup, so a mixed-case `HA_MCP_TOOLS` would otherwise slip
+        past the exact-string refusal and still resolve downstream. The
+        refusal must normalize case + whitespace to match."""
+        from ha_mcp.tools.tools_service import ServiceTools
+
+        tools = ServiceTools.__new__(ServiceTools)
+        tools._client = AsyncMock()
+        tools._device_tools = AsyncMock()
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_call_service(
+                domain=variant, service="write_file", data={"path": "www/x"}
+            )
+        assert "ha_mcp_tools" in str(exc_info.value)
         tools._client.call_service.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -140,6 +140,24 @@ def _make_client_with_token(token: str) -> AsyncMock:
     that the token was injected."""
     client = AsyncMock()
 
+    # _fetch_caller_token now pre-flights via /api/services to detect old
+    # (pre-0.5.0) custom components that lack get_caller_token. The mock
+    # must report the bootstrap service as registered or the bootstrap
+    # path raises COMPONENT_NOT_INSTALLED before ever calling call_service.
+    client.get_services.return_value = [
+        {
+            "domain": MCP_TOOLS_DOMAIN,
+            "services": {
+                CALLER_TOKEN_BOOTSTRAP_SERVICE: {},
+                "list_files": {},
+                "read_file": {},
+                "write_file": {},
+                "delete_file": {},
+                "edit_yaml_config": {},
+            },
+        }
+    ]
+
     async def fake_call_service(domain, service, payload, **kwargs):
         if domain == MCP_TOOLS_DOMAIN and service == CALLER_TOKEN_BOOTSTRAP_SERVICE:
             # HA wraps response under "service_response" — mirror that so
@@ -204,6 +222,14 @@ class TestCallMcpToolsServiceInjectsToken:
     async def test_refetches_and_retries_once_on_unauthorized(self):
         """Token rotation flow: cached token is stale → refetch → succeed."""
         client = AsyncMock()
+        # Bootstrap service must appear registered or _fetch_caller_token
+        # short-circuits with COMPONENT_NOT_INSTALLED before retry happens.
+        client.get_services.return_value = [
+            {
+                "domain": MCP_TOOLS_DOMAIN,
+                "services": {CALLER_TOKEN_BOOTSTRAP_SERVICE: {}, "write_file": {}},
+            }
+        ]
         state = {"current_token": "fresh-token", "downstream_calls": 0}
 
         async def fake_call_service(domain, service, payload, **kwargs):
@@ -250,11 +276,44 @@ class TestCallMcpToolsServiceInjectsToken:
 
     @pytest.mark.asyncio
     async def test_raises_when_bootstrap_returns_no_token(self):
+        """Service exists but returns a malformed response (race condition
+        during integration setup, etc.) → RuntimeError."""
         client = AsyncMock()
+        client.get_services.return_value = [
+            {
+                "domain": MCP_TOOLS_DOMAIN,
+                "services": {CALLER_TOKEN_BOOTSTRAP_SERVICE: {}, "list_files": {}},
+            }
+        ]
         # Bootstrap returns a malformed response
         client.call_service.return_value = {"service_response": {"success": False}}
         with pytest.raises(RuntimeError, match="did not return a usable token"):
             await call_mcp_tools_service(client, "list_files", {"path": "www"})
+
+    @pytest.mark.asyncio
+    async def test_raises_component_too_old_when_bootstrap_service_missing(self):
+        """Old (pre-0.5.0) custom component lacks get_caller_token → actionable
+        COMPONENT_NOT_INSTALLED ToolError, not a generic 'no usable token' string.
+
+        This is the failure mode an upgrade-skipping user hits: ha-mcp updates
+        but the HACS integration doesn't, so the bootstrap call would otherwise
+        hit a 400 from HA. We pre-flight via /api/services to detect this
+        and surface a 'update via HACS' message instead.
+        """
+        client = AsyncMock()
+        # Component is installed, but get_caller_token is NOT registered
+        client.get_services.return_value = [
+            {
+                "domain": MCP_TOOLS_DOMAIN,
+                "services": {"list_files": {}, "write_file": {}},  # no get_caller_token
+            }
+        ]
+        with pytest.raises(ToolError) as exc_info:
+            await call_mcp_tools_service(client, "list_files", {"path": "www"})
+        msg = str(exc_info.value)
+        assert "too old" in msg or "pre-0.5.0" in msg
+        # call_service must NOT have been called — pre-flight rejected upstream
+        client.call_service.assert_not_called()
 
 
 # =============================================================================

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -7,7 +7,7 @@ Covers three layers:
 2. **ha-mcp wrapper helper** (``call_mcp_tools_service``) — fetches and
    caches the token, injects it on every call, refetches on unauthorized.
 3. **ha_call_service refusal** — the wrapper-layer block on the
-   ``ha_mcp_tools`` domain (closes the issue #1451 bypass).
+   ``ha_mcp_tools`` domain.
 
 Custom-component tests stub the homeassistant.* imports the same way
 ``test_custom_component_filesystem.py`` does so they can run without
@@ -413,13 +413,13 @@ class TestCallMcpToolsServiceInjectsToken:
 
 
 # =============================================================================
-# ha_call_service refusal of the ha_mcp_tools domain (issue #1451)
+# ha_call_service refusal of the ha_mcp_tools domain
 # =============================================================================
 
 
 class TestHaCallServiceRefusesMcpToolsDomain:
-    """ha_call_service must not forward to ha_mcp_tools — that's the bypass
-    skialpine's LLM used in issue #1451 to land yaml edits on stable."""
+    """ha_call_service must not forward to ha_mcp_tools — the dedicated
+    wrapper tools are the only supported path into that domain."""
 
     @pytest.mark.asyncio
     async def test_blocks_ha_mcp_tools_domain(self):

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -188,7 +188,9 @@ class TestCallMcpToolsServiceInjectsToken:
         client = _make_client_with_token("server-token-B")
 
         await call_mcp_tools_service(client, "list_files", {"path": "www"})
-        await call_mcp_tools_service(client, "read_file", {"path": "configuration.yaml"})
+        await call_mcp_tools_service(
+            client, "read_file", {"path": "configuration.yaml"}
+        )
 
         # Bootstrap should fire exactly once — second call reuses cached token.
         bootstrap_calls = [
@@ -206,7 +208,12 @@ class TestCallMcpToolsServiceInjectsToken:
 
         async def fake_call_service(domain, service, payload, **kwargs):
             if domain == MCP_TOOLS_DOMAIN and service == CALLER_TOKEN_BOOTSTRAP_SERVICE:
-                return {"service_response": {"success": True, "token": state["current_token"]}}
+                return {
+                    "service_response": {
+                        "success": True,
+                        "token": state["current_token"],
+                    }
+                }
             state["downstream_calls"] += 1
             # First downstream call: simulate stale-cache rejection
             if state["downstream_calls"] == 1:
@@ -230,7 +237,8 @@ class TestCallMcpToolsServiceInjectsToken:
         # Pre-seed the cache with a stale token so the first downstream call
         # uses it, gets rejected, refetches, and retries.
         from ha_mcp.tools.tools_filesystem import _CALLER_TOKEN_CACHE
-        _CALLER_TOKEN_CACHE[str(id(client))] = "stale-token"
+
+        _CALLER_TOKEN_CACHE[id(client)] = "stale-token"
 
         result = await call_mcp_tools_service(client, "write_file", {"path": "www/x"})
 

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -1,0 +1,311 @@
+"""Tests for the ha_mcp_tools caller-token auth path.
+
+Covers three layers:
+
+1. **Custom component handlers** — token check, unauthorized response shape,
+   get_caller_token bootstrap surface.
+2. **ha-mcp wrapper helper** (``call_mcp_tools_service``) — fetches and
+   caches the token, injects it on every call, refetches on unauthorized.
+3. **ha_call_service refusal** — the wrapper-layer block on the
+   ``ha_mcp_tools`` domain (closes the issue #1451 bypass).
+
+Custom-component tests stub the homeassistant.* imports the same way
+``test_custom_component_filesystem.py`` does so they can run without
+the real HA package available.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+# --- Custom-component-side imports (must stub HA first) ---------------------
+
+sys.modules.setdefault("voluptuous", MagicMock())
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.components", MagicMock())
+sys.modules.setdefault("homeassistant.components.persistent_notification", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.config_validation", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.storage", MagicMock())
+
+from custom_components.ha_mcp_tools import (  # noqa: E402
+    CALLER_TOKEN_FIELD,
+    _caller_token_ok,
+    _unauthorized_response,
+)
+from custom_components.ha_mcp_tools.const import DOMAIN  # noqa: E402
+
+# --- ha-mcp wrapper-side imports --------------------------------------------
+from ha_mcp.tools.tools_filesystem import (  # noqa: E402
+    CALLER_TOKEN_BOOTSTRAP_SERVICE,
+    MCP_TOOLS_DOMAIN,
+    _reset_caller_token_cache,
+    call_mcp_tools_service,
+)
+
+# =============================================================================
+# Custom-component side: handler-level token check
+# =============================================================================
+
+
+def _fake_hass(token: str | None) -> MagicMock:
+    """Build a hass stand-in whose .data carries the expected caller token."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"caller_token": token}} if token is not None else {}
+    return hass
+
+
+def _fake_call(presented_token: str | None, **extra: str) -> MagicMock:
+    """Build a ServiceCall stand-in with .data containing the presented token."""
+    call = MagicMock()
+    payload: dict[str, str] = dict(extra)
+    if presented_token is not None:
+        payload[CALLER_TOKEN_FIELD] = presented_token
+    call.data = payload
+    return call
+
+
+class TestCallerTokenOk:
+    """The handler's pre-flight check that gates all dangerous services."""
+
+    def test_accepts_matching_token(self):
+        hass = _fake_hass("good-token-xyz")
+        call = _fake_call("good-token-xyz")
+        assert _caller_token_ok(hass, call) is True
+
+    def test_rejects_missing_token(self):
+        hass = _fake_hass("good-token-xyz")
+        call = _fake_call(None)
+        assert _caller_token_ok(hass, call) is False
+
+    def test_rejects_mismatched_token(self):
+        hass = _fake_hass("good-token-xyz")
+        call = _fake_call("not-the-right-one")
+        assert _caller_token_ok(hass, call) is False
+
+    def test_rejects_when_hass_data_missing_token(self):
+        """If setup_entry hasn't run, no caller is authorized."""
+        hass = _fake_hass(None)
+        call = _fake_call("anything")
+        assert _caller_token_ok(hass, call) is False
+
+    def test_rejects_empty_string_token(self):
+        hass = _fake_hass("good-token-xyz")
+        call = _fake_call("")
+        assert _caller_token_ok(hass, call) is False
+
+
+class TestUnauthorizedResponse:
+    """The structured 'unauthorized' reply the helper emits."""
+
+    def test_has_error_code_unauthorized(self):
+        """Clients detect via error_code, not by string-matching error text."""
+        resp = _unauthorized_response("write_file")
+        assert resp["error_code"] == "unauthorized"
+        assert resp["success"] is False
+
+    def test_mentions_service_name_in_error(self):
+        resp = _unauthorized_response("delete_file")
+        assert "delete_file" in resp["error"]
+
+    def test_extra_kwargs_merged(self):
+        """list_files expects a 'files' key even on error — extras propagate."""
+        resp = _unauthorized_response("list_files", files=[])
+        assert resp["files"] == []
+        assert resp["error_code"] == "unauthorized"
+
+
+# =============================================================================
+# ha-mcp wrapper side: bootstrap + injection + refetch
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_cache_between_tests():
+    """Each test starts with an empty per-client token cache."""
+    _reset_caller_token_cache()
+    yield
+    _reset_caller_token_cache()
+
+
+def _make_client_with_token(token: str) -> AsyncMock:
+    """Client that returns ``token`` from the get_caller_token bootstrap and
+    echoes payload back for downstream service calls so tests can assert
+    that the token was injected."""
+    client = AsyncMock()
+
+    async def fake_call_service(domain, service, payload, **kwargs):
+        if domain == MCP_TOOLS_DOMAIN and service == CALLER_TOKEN_BOOTSTRAP_SERVICE:
+            # HA wraps response under "service_response" — mirror that so
+            # unwrap_service_response finds the token.
+            return {"service_response": {"success": True, "token": token}}
+        # Echo the payload so the test can verify token injection.
+        return {
+            "service_response": {
+                "success": True,
+                "received_payload": dict(payload),
+                "domain": domain,
+                "service": service,
+            }
+        }
+
+    client.call_service.side_effect = fake_call_service
+    return client
+
+
+class TestCallMcpToolsServiceInjectsToken:
+    """call_mcp_tools_service must always pass the cached/fetched token."""
+
+    @pytest.mark.asyncio
+    async def test_bootstraps_token_on_first_call(self):
+        client = _make_client_with_token("server-token-A")
+        result = await call_mcp_tools_service(client, "list_files", {"path": "www"})
+
+        # First call to client.call_service should be the bootstrap
+        first_call = client.call_service.await_args_list[0]
+        assert first_call.args[1] == CALLER_TOKEN_BOOTSTRAP_SERVICE
+
+        # The downstream call_service was invoked with the token in payload
+        downstream = client.call_service.await_args_list[1]
+        downstream_payload = downstream.args[2]
+        assert downstream_payload[CALLER_TOKEN_FIELD] == "server-token-A"
+        assert downstream_payload["path"] == "www"
+
+        # And the result came back wrapped — the helper does not unwrap
+        # itself; that's the caller's job to keep parity with the prior
+        # behavior of self._client.call_service(...).
+        echoed = result["service_response"]
+        assert echoed["received_payload"][CALLER_TOKEN_FIELD] == "server-token-A"
+
+    @pytest.mark.asyncio
+    async def test_caches_token_across_calls(self):
+        client = _make_client_with_token("server-token-B")
+
+        await call_mcp_tools_service(client, "list_files", {"path": "www"})
+        await call_mcp_tools_service(client, "read_file", {"path": "configuration.yaml"})
+
+        # Bootstrap should fire exactly once — second call reuses cached token.
+        bootstrap_calls = [
+            c
+            for c in client.call_service.await_args_list
+            if c.args[1] == CALLER_TOKEN_BOOTSTRAP_SERVICE
+        ]
+        assert len(bootstrap_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_refetches_and_retries_once_on_unauthorized(self):
+        """Token rotation flow: cached token is stale → refetch → succeed."""
+        client = AsyncMock()
+        state = {"current_token": "fresh-token", "downstream_calls": 0}
+
+        async def fake_call_service(domain, service, payload, **kwargs):
+            if domain == MCP_TOOLS_DOMAIN and service == CALLER_TOKEN_BOOTSTRAP_SERVICE:
+                return {"service_response": {"success": True, "token": state["current_token"]}}
+            state["downstream_calls"] += 1
+            # First downstream call: simulate stale-cache rejection
+            if state["downstream_calls"] == 1:
+                return {
+                    "service_response": {
+                        "success": False,
+                        "error_code": "unauthorized",
+                        "error": "stale",
+                    }
+                }
+            # Second downstream call: accept
+            return {
+                "service_response": {
+                    "success": True,
+                    "received_payload": dict(payload),
+                }
+            }
+
+        client.call_service.side_effect = fake_call_service
+
+        # Pre-seed the cache with a stale token so the first downstream call
+        # uses it, gets rejected, refetches, and retries.
+        from ha_mcp.tools.tools_filesystem import _CALLER_TOKEN_CACHE
+        _CALLER_TOKEN_CACHE[str(id(client))] = "stale-token"
+
+        result = await call_mcp_tools_service(client, "write_file", {"path": "www/x"})
+
+        # Two downstream attempts were made
+        assert state["downstream_calls"] == 2
+        # Second succeeded with the freshly-fetched token
+        echoed = result["service_response"]
+        assert echoed["received_payload"][CALLER_TOKEN_FIELD] == "fresh-token"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_bootstrap_returns_no_token(self):
+        client = AsyncMock()
+        # Bootstrap returns a malformed response
+        client.call_service.return_value = {"service_response": {"success": False}}
+        with pytest.raises(RuntimeError, match="did not return a usable token"):
+            await call_mcp_tools_service(client, "list_files", {"path": "www"})
+
+
+# =============================================================================
+# ha_call_service refusal of the ha_mcp_tools domain (issue #1451)
+# =============================================================================
+
+
+class TestHaCallServiceRefusesMcpToolsDomain:
+    """ha_call_service must not forward to ha_mcp_tools — that's the bypass
+    skialpine's LLM used in issue #1451 to land yaml edits on stable."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_ha_mcp_tools_domain(self):
+        from ha_mcp.tools.tools_service import ServiceTools
+
+        # Use a real ServiceTools instance with a mocked client — we never
+        # reach the client because the refusal is the first check.
+        tools = ServiceTools.__new__(ServiceTools)
+        tools._client = AsyncMock()
+        tools._device_tools = AsyncMock()
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_call_service(
+                domain="ha_mcp_tools", service="write_file", data={"path": "www/x"}
+            )
+
+        # Error message should point the LLM at the dedicated tool.
+        msg = str(exc_info.value)
+        assert "ha_mcp_tools" in msg
+        assert any(
+            name in msg
+            for name in ("ha_write_file", "ha_list_files", "ha_config_set_yaml")
+        )
+        # The downstream client was never touched.
+        tools._client.call_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_block_other_domains(self):
+        """light.turn_on must still pass the refusal gate — only ha_mcp_tools is refused."""
+        from ha_mcp.tools.tools_service import ServiceTools
+
+        tools = ServiceTools.__new__(ServiceTools)
+        client = AsyncMock()
+        client.call_service.return_value = {"context": {"id": "ctx"}, "result": []}
+        tools._client = client
+        tools._device_tools = AsyncMock()
+
+        # Should NOT raise the domain-refusal ToolError. (May still raise
+        # downstream for unrelated reasons; we just assert we got past
+        # the refusal gate.) wait=False skips the state-change-verification
+        # path so this test focuses on the refusal logic alone.
+        try:
+            await tools.ha_call_service(
+                domain="light",
+                service="turn_on",
+                entity_id="light.kitchen",
+                wait=False,
+            )
+        except ToolError as exc:
+            assert "ha_mcp_tools" not in str(exc), (
+                "Refusal incorrectly triggered for non-ha_mcp_tools domain"
+            )

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -13,15 +13,15 @@ from unittest.mock import MagicMock
 import pytest
 
 # Mock the Home Assistant imports before importing the module
-sys.modules['voluptuous'] = MagicMock()
-sys.modules['homeassistant'] = MagicMock()
-sys.modules['homeassistant.components'] = MagicMock()
-sys.modules['homeassistant.components.persistent_notification'] = MagicMock()
-sys.modules['homeassistant.config_entries'] = MagicMock()
-sys.modules['homeassistant.core'] = MagicMock()
-sys.modules['homeassistant.helpers'] = MagicMock()
-sys.modules['homeassistant.helpers.config_validation'] = MagicMock()
-sys.modules['homeassistant.helpers.storage'] = MagicMock()
+sys.modules["voluptuous"] = MagicMock()
+sys.modules["homeassistant"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
+sys.modules["homeassistant.helpers.storage"] = MagicMock()
 
 
 # Now we can import the functions
@@ -47,50 +47,113 @@ class TestIsPathAllowedForDir:
     def test_allows_www_directory(self, tmp_path):
         """Should allow paths in www/ directory."""
         assert _is_path_allowed_for_dir(tmp_path, "www/", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "www/test.css", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "www/subdir/test.js", ALLOWED_READ_DIRS) is True
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "www/test.css", ALLOWED_READ_DIRS)
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "www/subdir/test.js", ALLOWED_READ_DIRS)
+            is True
+        )
 
     def test_allows_themes_directory(self, tmp_path):
         """Should allow paths in themes/ directory."""
         assert _is_path_allowed_for_dir(tmp_path, "themes/", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "themes/dark.yaml", ALLOWED_READ_DIRS) is True
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "themes/dark.yaml", ALLOWED_READ_DIRS)
+            is True
+        )
 
     def test_allows_custom_templates_directory(self, tmp_path):
         """Should allow paths in custom_templates/ directory."""
-        assert _is_path_allowed_for_dir(tmp_path, "custom_templates/", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "custom_templates/test.jinja2", ALLOWED_READ_DIRS) is True
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "custom_templates/", ALLOWED_READ_DIRS)
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "custom_templates/test.jinja2", ALLOWED_READ_DIRS
+            )
+            is True
+        )
 
     def test_blocks_config_root_files(self, tmp_path):
         """Should block access to files in config root (not in allowed dirs)."""
-        assert _is_path_allowed_for_dir(tmp_path, "configuration.yaml", ALLOWED_READ_DIRS) is False
-        assert _is_path_allowed_for_dir(tmp_path, "secrets.yaml", ALLOWED_READ_DIRS) is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "configuration.yaml", ALLOWED_READ_DIRS)
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "secrets.yaml", ALLOWED_READ_DIRS)
+            is False
+        )
 
     def test_blocks_path_traversal_with_dotdot(self, tmp_path):
         """Should block path traversal with '..'."""
-        assert _is_path_allowed_for_dir(tmp_path, "../etc/passwd", ALLOWED_READ_DIRS) is False
-        assert _is_path_allowed_for_dir(tmp_path, "www/../secrets.yaml", ALLOWED_READ_DIRS) is False
-        assert _is_path_allowed_for_dir(tmp_path, "www/../../etc/passwd", ALLOWED_READ_DIRS) is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "../etc/passwd", ALLOWED_READ_DIRS)
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "www/../secrets.yaml", ALLOWED_READ_DIRS)
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "www/../../etc/passwd", ALLOWED_READ_DIRS
+            )
+            is False
+        )
 
     def test_blocks_absolute_paths(self, tmp_path):
         """Should block absolute paths."""
-        assert _is_path_allowed_for_dir(tmp_path, "/etc/passwd", ALLOWED_READ_DIRS) is False
-        assert _is_path_allowed_for_dir(tmp_path, "/www/test.css", ALLOWED_READ_DIRS) is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "/etc/passwd", ALLOWED_READ_DIRS)
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "/www/test.css", ALLOWED_READ_DIRS)
+            is False
+        )
 
     def test_blocks_storage_directory(self, tmp_path):
         """Should block .storage directory."""
-        assert _is_path_allowed_for_dir(tmp_path, ".storage/", ALLOWED_READ_DIRS) is False
-        assert _is_path_allowed_for_dir(tmp_path, ".storage/auth", ALLOWED_READ_DIRS) is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, ".storage/", ALLOWED_READ_DIRS) is False
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, ".storage/auth", ALLOWED_READ_DIRS)
+            is False
+        )
 
     def test_blocks_custom_components_directory(self, tmp_path):
         """Should block custom_components directory for writes."""
-        assert _is_path_allowed_for_dir(tmp_path, "custom_components/", ALLOWED_WRITE_DIRS) is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "custom_components/", ALLOWED_WRITE_DIRS)
+            is False
+        )
 
     def test_allows_dashboards_directory(self, tmp_path):
         """Should allow paths in dashboards/ directory (YAML-mode dashboards)."""
-        assert _is_path_allowed_for_dir(tmp_path, "dashboards/", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "dashboards/main.yaml", ALLOWED_READ_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "dashboards/", ALLOWED_WRITE_DIRS) is True
-        assert _is_path_allowed_for_dir(tmp_path, "dashboards/main.yaml", ALLOWED_WRITE_DIRS) is True
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "dashboards/", ALLOWED_READ_DIRS) is True
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "dashboards/main.yaml", ALLOWED_READ_DIRS
+            )
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "dashboards/", ALLOWED_WRITE_DIRS)
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "dashboards/main.yaml", ALLOWED_WRITE_DIRS
+            )
+            is True
+        )
 
 
 class TestIsPathAllowedForRead:
@@ -135,8 +198,18 @@ class TestIsPathAllowedForRead:
 
     def test_allows_custom_components_py_files(self, tmp_path):
         """Should allow reading custom_components/**/*.py files."""
-        assert _is_path_allowed_for_read(tmp_path, "custom_components/my_integration/init.py") is True
-        assert _is_path_allowed_for_read(tmp_path, "custom_components/my_integration/__init__.py") is True
+        assert (
+            _is_path_allowed_for_read(
+                tmp_path, "custom_components/my_integration/init.py"
+            )
+            is True
+        )
+        assert (
+            _is_path_allowed_for_read(
+                tmp_path, "custom_components/my_integration/__init__.py"
+            )
+            is True
+        )
 
     def test_blocks_path_traversal(self, tmp_path):
         """Should block path traversal attempts outside config dir."""
@@ -280,7 +353,9 @@ class TestFileOperationsIntegration:
 
         # Create config files
         (config_path / "configuration.yaml").write_text("homeassistant:\n  name: Test")
-        (config_path / "secrets.yaml").write_text("api_key: secret123\npassword: pass456")
+        (config_path / "secrets.yaml").write_text(
+            "api_key: secret123\npassword: pass456"
+        )
         (config_path / "automations.yaml").write_text("- alias: Test\n  trigger: []")
 
         yield config_path
@@ -308,12 +383,18 @@ class TestFileOperationsIntegration:
 
     def test_write_to_www_allowed(self, config_dir):
         """Should allow writing to www directory."""
-        assert _is_path_allowed_for_dir(config_dir, "www/new_file.css", ALLOWED_WRITE_DIRS)
+        assert _is_path_allowed_for_dir(
+            config_dir, "www/new_file.css", ALLOWED_WRITE_DIRS
+        )
 
     def test_write_to_config_root_blocked(self, config_dir):
         """Should block writing to config root."""
-        assert not _is_path_allowed_for_dir(config_dir, "configuration.yaml", ALLOWED_WRITE_DIRS)
-        assert not _is_path_allowed_for_dir(config_dir, "new_file.yaml", ALLOWED_WRITE_DIRS)
+        assert not _is_path_allowed_for_dir(
+            config_dir, "configuration.yaml", ALLOWED_WRITE_DIRS
+        )
+        assert not _is_path_allowed_for_dir(
+            config_dir, "new_file.yaml", ALLOWED_WRITE_DIRS
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +480,9 @@ class TestWriteFileSync:
     def test_creates_new_file(self, tmp_path):
         target = tmp_path / "sub" / "x.txt"
 
-        result = _write_file_sync(target, "hello", overwrite=False, create_dirs=True, config_dir=tmp_path)
+        result = _write_file_sync(
+            target, "hello", overwrite=False, create_dirs=True, config_dir=tmp_path
+        )
 
         assert "_error" not in result
         assert result["is_new"] is True
@@ -410,7 +493,9 @@ class TestWriteFileSync:
         target = tmp_path / "x.txt"
         target.write_text("original")
 
-        result = _write_file_sync(target, "new", overwrite=False, create_dirs=False, config_dir=tmp_path)
+        result = _write_file_sync(
+            target, "new", overwrite=False, create_dirs=False, config_dir=tmp_path
+        )
 
         assert result == {"_error": "exists_no_overwrite"}
         assert target.read_text() == "original"
@@ -419,7 +504,9 @@ class TestWriteFileSync:
         target = tmp_path / "x.txt"
         target.write_text("original")
 
-        result = _write_file_sync(target, "new", overwrite=True, create_dirs=False, config_dir=tmp_path)
+        result = _write_file_sync(
+            target, "new", overwrite=True, create_dirs=False, config_dir=tmp_path
+        )
 
         assert result["is_new"] is False
         assert target.read_text() == "new"
@@ -427,7 +514,9 @@ class TestWriteFileSync:
     def test_returns_no_parent_when_create_dirs_false(self, tmp_path):
         target = tmp_path / "missing_dir" / "x.txt"
 
-        result = _write_file_sync(target, "hi", overwrite=False, create_dirs=False, config_dir=tmp_path)
+        result = _write_file_sync(
+            target, "hi", overwrite=False, create_dirs=False, config_dir=tmp_path
+        )
 
         assert result["_error"] == "no_parent"
         assert result["parent"] == "missing_dir"

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -21,6 +21,7 @@ sys.modules['homeassistant.config_entries'] = MagicMock()
 sys.modules['homeassistant.core'] = MagicMock()
 sys.modules['homeassistant.helpers'] = MagicMock()
 sys.modules['homeassistant.helpers.config_validation'] = MagicMock()
+sys.modules['homeassistant.helpers.storage'] = MagicMock()
 
 
 # Now we can import the functions

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -153,26 +153,45 @@ class TestRegisterFilesystemTools:
         mcp.tool.assert_not_called()
 
     def test_registers_tools_when_enabled(self):
-        """Tools should be registered when feature flag is enabled."""
+        """Tools should be registered via mcp.add_tool when feature flag is enabled.
+
+        ``register_tool_methods`` (in helpers.py) discovers @tool-decorated
+        methods on the FilesystemTools instance and calls ``mcp.add_tool(...)``
+        for each. Earlier versions of this test mocked ``mcp.tool`` (the
+        legacy decorator path) and never inspected the call list, so the
+        guarded ``if registered_func:`` branches in production code could
+        silently skip without anyone noticing. Now we assert mcp.add_tool
+        fired the expected number of times (one per @tool method).
+        """
         from ha_mcp.tools.tools_filesystem import register_filesystem_tools
 
         mcp = MagicMock()
         client = MagicMock()
 
-        # Mock the tool decorator to return the function unchanged
-        def mock_tool(**kwargs):
-            def decorator(func):
-                return func
-
-            return decorator
-
-        mcp.tool = mock_tool
-
         with patch.dict(os.environ, {FEATURE_FLAG: "true"}):
             register_filesystem_tools(mcp, client)
 
-        # Since we're using a mock decorator, we just verify no exceptions occurred
-        # The actual registration happens via the @mcp.tool decorator
+        # FilesystemTools exposes 4 @tool methods: list_files, read_file,
+        # write_file, delete_file. Assert all four registered.
+        assert mcp.add_tool.call_count == 4, (
+            f"Expected 4 add_tool calls (one per @tool method on FilesystemTools), "
+            f"got {mcp.add_tool.call_count}"
+        )
+
+        # Tool functions are passed positionally — extract them and verify
+        # the names match the @tool(name=...) decorator values.
+        registered_names = {
+            call.args[0].__name__ for call in mcp.add_tool.call_args_list if call.args
+        }
+        expected_methods = {
+            "ha_list_files",
+            "ha_read_file",
+            "ha_write_file",
+            "ha_delete_file",
+        }
+        assert registered_names == expected_methods, (
+            f"Expected methods {expected_methods}, got {registered_names}"
+        )
 
 
 class TestHaListFilesTool:

--- a/tests/src/unit/test_yaml_config_tool.py
+++ b/tests/src/unit/test_yaml_config_tool.py
@@ -63,7 +63,20 @@ async def _make_tool():
             captured.setdefault("fns", []).append(method)
 
     client = MagicMock()
-    client.get_services = AsyncMock(return_value=[{"domain": "ha_mcp_tools"}])
+    # _fetch_caller_token pre-flights /api/services and requires
+    # get_caller_token to be registered — list it alongside the other
+    # services so the bootstrap doesn't trip COMPONENT_NOT_INSTALLED.
+    client.get_services = AsyncMock(
+        return_value=[
+            {
+                "domain": "ha_mcp_tools",
+                "services": {
+                    "get_caller_token": {},
+                    "edit_yaml_config": {},
+                },
+            }
+        ]
+    )
     client.send_websocket_message = AsyncMock()
     client.call_service = _build_call_service_mock()
 

--- a/tests/src/unit/test_yaml_config_tool.py
+++ b/tests/src/unit/test_yaml_config_tool.py
@@ -42,6 +42,7 @@ def _build_call_service_mock():
       1. ha_mcp_tools.get_caller_token → returns the token
       2. ha_mcp_tools.<actual_service> → returns the tool's response
     """
+
     async def fake_call_service(domain, service, payload, **kwargs):
         if service == "get_caller_token":
             return {"service_response": {"success": True, "token": "test-token"}}

--- a/tests/src/unit/test_yaml_config_tool.py
+++ b/tests/src/unit/test_yaml_config_tool.py
@@ -23,6 +23,34 @@ def enable_flag(monkeypatch):
     ha_mcp_config._settings = None
 
 
+@pytest.fixture(autouse=True)
+def _reset_caller_token_cache():
+    """The wrapper now caches the bootstrap token per-client. Each test gets
+    a fresh client, so the cache must be reset to avoid stale entries from
+    a previously-recycled id()."""
+    from ha_mcp.tools.tools_filesystem import _reset_caller_token_cache
+
+    _reset_caller_token_cache()
+    yield
+    _reset_caller_token_cache()
+
+
+def _build_call_service_mock():
+    """Make a call_service mock that satisfies the bootstrap fetch + dispatch.
+
+    The wrapper does two service calls per tool invocation now:
+      1. ha_mcp_tools.get_caller_token → returns the token
+      2. ha_mcp_tools.<actual_service> → returns the tool's response
+    """
+    async def fake_call_service(domain, service, payload, **kwargs):
+        if service == "get_caller_token":
+            return {"service_response": {"success": True, "token": "test-token"}}
+        return {"success": True, "file": "configuration.yaml"}
+
+    mock = AsyncMock(side_effect=fake_call_service)
+    return mock
+
+
 async def _make_tool():
     """Build a minimal mcp + client harness around register_yaml_config_tools."""
     from ha_mcp.tools.tools_yaml_config import register_yaml_config_tools
@@ -36,14 +64,26 @@ async def _make_tool():
     client = MagicMock()
     client.get_services = AsyncMock(return_value=[{"domain": "ha_mcp_tools"}])
     client.send_websocket_message = AsyncMock()
-    client.call_service = AsyncMock(
-        return_value={"success": True, "file": "configuration.yaml"}
-    )
+    client.call_service = _build_call_service_mock()
 
     mcp = FakeMCP()
     register_yaml_config_tools(mcp, client)
     # Find the ha_config_set_yaml fn — only one tool registered in this module
     return captured["fns"][0], client
+
+
+def _dispatch_call_count(client) -> int:
+    """Count call_service invocations that aren't the bootstrap fetch.
+
+    With caller-token auth, every tool invocation makes 2 calls (bootstrap +
+    actual service) on first use, 1 (just the actual) afterward. Tests want
+    to count just the dispatched-to-ha_mcp_tools.<dangerous-service> calls.
+    """
+    return sum(
+        1
+        for c in client.call_service.await_args_list
+        if c.args[1] != "get_caller_token"
+    )
 
 
 async def test_storage_collision_blocks_dispatch(monkeypatch):
@@ -81,7 +121,7 @@ async def test_no_collision_dispatches(monkeypatch):
         action="add",
         content="mode: yaml\ntitle: x\nfilename: dashboards/x.yaml\n",
     )
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1
 
 
 async def test_non_dashboard_path_skips_ws_check(monkeypatch):
@@ -93,7 +133,7 @@ async def test_non_dashboard_path_skips_ws_check(monkeypatch):
         content="- sensor: []\n",
     )
     client.send_websocket_message.assert_not_called()
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1
 
 
 async def test_ws_failure_skips_check_and_dispatches(monkeypatch):
@@ -105,7 +145,7 @@ async def test_ws_failure_skips_check_and_dispatches(monkeypatch):
         action="add",
         content="mode: yaml\ntitle: x\nfilename: dashboards/x.yaml\n",
     )
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1
 
 
 async def test_ws_returns_bare_list_blocks_collision(monkeypatch):
@@ -140,7 +180,7 @@ async def test_yaml_mode_existing_does_not_block(monkeypatch):
         action="add",
         content="mode: yaml\ntitle: x\nfilename: dashboards/x.yaml\n",
     )
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1
 
 
 async def test_ws_returns_unexpected_shape_warns_and_dispatches(monkeypatch):
@@ -152,7 +192,7 @@ async def test_ws_returns_unexpected_shape_warns_and_dispatches(monkeypatch):
         action="add",
         content="mode: yaml\ntitle: x\nfilename: dashboards/x.yaml\n",
     )
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1
 
 
 async def test_remove_action_skips_collision_check(monkeypatch):
@@ -171,4 +211,4 @@ async def test_remove_action_skips_collision_check(monkeypatch):
         action="remove",
     )
     client.send_websocket_message.assert_not_called()
-    client.call_service.assert_called_once()
+    assert _dispatch_call_count(client) == 1

--- a/tests/src/unit/test_yaml_dashboards.py
+++ b/tests/src/unit/test_yaml_dashboards.py
@@ -429,7 +429,7 @@ class TestHandleEditYamlConfigDashboards:
 
 class TestHandleEditYamlConfigSingleKey:
     """Single-key branch of _build_edit_yaml_config_handler must behave the same
-    after the factory refactor (regression guard for issue #1034)."""
+    after the factory refactor."""
 
     @pytest.fixture
     def hass(self, tmp_path):

--- a/tests/src/unit/test_yaml_dashboards.py
+++ b/tests/src/unit/test_yaml_dashboards.py
@@ -11,15 +11,26 @@ import pytest
 # Mock HA imports before importing the module
 sys.modules["voluptuous"] = MagicMock()
 sys.modules["homeassistant"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
 sys.modules["homeassistant.core"] = MagicMock()
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
+sys.modules["homeassistant.helpers.storage"] = MagicMock()
 
+from custom_components.ha_mcp_tools import CALLER_TOKEN_FIELD  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DASHBOARD_URL_PATH_PATTERN,
+    DOMAIN,
     RESERVED_DASHBOARD_URL_PATHS,
 )
+
+# Both handler fixtures below preload this token into hass.data and inject
+# it into every call_factory payload so the caller-token gate added by the
+# auth PR is transparent to these dashboard tests (which exercise the
+# yaml-editing logic, not the auth boundary).
+_TEST_CALLER_TOKEN = "test-caller-token-yaml-dashboards"
 
 
 class TestDashboardUrlPathPattern:
@@ -42,17 +53,17 @@ class TestDashboardUrlPathPattern:
     @pytest.mark.parametrize(
         "url_path",
         [
-            "",                     # empty
-            "no_underscore",        # underscores not allowed
-            "NoUpper",              # uppercase not allowed
-            "single",               # must contain a hyphen
-            "-leading-hyphen",      # cannot start with hyphen
-            "trailing-hyphen-",     # cannot end with hyphen
-            "double--hyphen",       # no consecutive hyphens
-            "has space",            # no spaces
-            "has/slash",            # no slashes
-            "has.dot",              # no dots
-            "..",                   # path traversal-ish
+            "",  # empty
+            "no_underscore",  # underscores not allowed
+            "NoUpper",  # uppercase not allowed
+            "single",  # must contain a hyphen
+            "-leading-hyphen",  # cannot start with hyphen
+            "trailing-hyphen-",  # cannot end with hyphen
+            "double--hyphen",  # no consecutive hyphens
+            "has space",  # no spaces
+            "has/slash",  # no slashes
+            "has.dot",  # no dots
+            "..",  # path traversal-ish
         ],
     )
     def test_rejects_invalid_url_paths(self, url_path):
@@ -91,6 +102,7 @@ class TestValidateDashboardFilename:
     @pytest.fixture(scope="class")
     def validate(self):
         from custom_components.ha_mcp_tools import _validate_dashboard_filename
+
         return _validate_dashboard_filename
 
     @pytest.mark.parametrize(
@@ -111,12 +123,12 @@ class TestValidateDashboardFilename:
             "../secrets.yaml",
             "/etc/passwd",
             "dashboards/../secrets.yaml",
-            "dashboards/main.yml",       # wrong extension
-            "main.yaml",                 # not under dashboards/
-            "www/dashboard.yaml",        # other allowlist dir, not dashboards
+            "dashboards/main.yml",  # wrong extension
+            "main.yaml",  # not under dashboards/
+            "www/dashboard.yaml",  # other allowlist dir, not dashboards
             "",
             "dashboards/",
-            "dashboards/main",           # no extension
+            "dashboards/main",  # no extension
         ],
     )
     def test_rejects_invalid_filenames(self, validate, filename):
@@ -132,6 +144,7 @@ class TestParseYamlPath:
     @pytest.fixture(scope="class")
     def parse(self):
         from custom_components.ha_mcp_tools import _parse_and_validate_yaml_path
+
         return _parse_and_validate_yaml_path
 
     def test_accepts_single_allowed_key(self, parse):
@@ -191,9 +204,13 @@ class TestHandleEditYamlConfigDashboards:
         h = MM()
         h.config = MM()
         h.config.config_dir = str(tmp_path)
+        # Seed the caller token so _caller_token_ok passes (auth PR).
+        h.data = {DOMAIN: {"caller_token": _TEST_CALLER_TOKEN}}
+
         # Run executor jobs inline so we can assert filesystem state
         async def _run(fn, *args):
             return fn(*args)
+
         h.async_add_executor_job = AsyncMock(side_effect=_run)
         # check_config service returns 'ok'
         h.services = MM()
@@ -202,11 +219,13 @@ class TestHandleEditYamlConfigDashboards:
 
     @pytest.fixture
     def call_factory(self):
-        """Build a ServiceCall-like object."""
+        """Build a ServiceCall-like object with the caller token pre-injected."""
+
         def _make(data):
             call = MM()
-            call.data = data
+            call.data = {**data, CALLER_TOKEN_FIELD: _TEST_CALLER_TOKEN}
             return call
+
         return _make
 
     def _run(self, coro):
@@ -249,6 +268,7 @@ class TestHandleEditYamlConfigDashboards:
         # Make sure 'mode:' isn't a sibling of 'dashboards:' under 'lovelace:'
         # (i.e., lovelace key should only contain 'dashboards')
         import yaml
+
         parsed = yaml.safe_load(text)
         assert set(parsed["lovelace"].keys()) == {"dashboards"}
 
@@ -267,9 +287,7 @@ class TestHandleEditYamlConfigDashboards:
                         "action": "add",
                         "yaml_path": "lovelace.dashboards.bad-dash",
                         "content": (
-                            "mode: yaml\n"
-                            "title: Bad\n"
-                            "filename: ../secrets.yaml\n"
+                            "mode: yaml\ntitle: Bad\nfilename: ../secrets.yaml\n"
                         ),
                         "backup": False,
                     }
@@ -335,6 +353,7 @@ class TestHandleEditYamlConfigDashboards:
         )
         assert result["success"] is True
         import yaml
+
         parsed = yaml.safe_load(cfg.read_text())
         assert "energy-dash" not in parsed["lovelace"]["dashboards"]
         assert "weather-dash" in parsed["lovelace"]["dashboards"]
@@ -399,6 +418,7 @@ class TestHandleEditYamlConfigDashboards:
         )
         assert result["success"] is True, result
         import yaml
+
         parsed = yaml.safe_load(cfg.read_text())
         entry = parsed["lovelace"]["dashboards"]["energy-dash"]
         # Old keys retained, overlapping keys overwritten, new keys added
@@ -416,8 +436,12 @@ class TestHandleEditYamlConfigSingleKey:
         h = MM()
         h.config = MM()
         h.config.config_dir = str(tmp_path)
+        # Seed the caller token so _caller_token_ok passes (auth PR).
+        h.data = {DOMAIN: {"caller_token": _TEST_CALLER_TOKEN}}
+
         async def _run(fn, *args):
             return fn(*args)
+
         h.async_add_executor_job = AsyncMock(side_effect=_run)
         h.services = MM()
         h.services.async_call = AsyncMock(return_value={"errors": None})
@@ -427,8 +451,9 @@ class TestHandleEditYamlConfigSingleKey:
     def call_factory(self):
         def _make(data):
             call = MM()
-            call.data = data
+            call.data = {**data, CALLER_TOKEN_FIELD: _TEST_CALLER_TOKEN}
             return call
+
         return _make
 
     def _run(self, coro):
@@ -456,6 +481,7 @@ class TestHandleEditYamlConfigSingleKey:
         )
         assert result["success"] is True, result
         import yaml
+
         parsed = yaml.safe_load(cfg.read_text())
         assert "command_line" in parsed
         assert parsed["default_config"] is None
@@ -464,10 +490,7 @@ class TestHandleEditYamlConfigSingleKey:
         from custom_components.ha_mcp_tools import _build_edit_yaml_config_handler
 
         cfg = Path(tmp_path) / "configuration.yaml"
-        cfg.write_text(
-            "shell_command:\n"
-            "  old_cmd: 'echo old'\n"
-        )
+        cfg.write_text("shell_command:\n  old_cmd: 'echo old'\n")
 
         handler = _build_edit_yaml_config_handler(hass)
         result = self._run(
@@ -485,6 +508,7 @@ class TestHandleEditYamlConfigSingleKey:
         )
         assert result["success"] is True, result
         import yaml
+
         parsed = yaml.safe_load(cfg.read_text())
         assert parsed["shell_command"] == {"new_cmd": "echo new"}
 
@@ -510,9 +534,7 @@ class TestHandleEditYamlConfigSingleKey:
         assert result["success"] is False
         assert "command_line" in result["error"]
 
-    def test_single_key_post_action_for_template(
-        self, tmp_path, hass, call_factory
-    ):
+    def test_single_key_post_action_for_template(self, tmp_path, hass, call_factory):
         """template -> reload_available; covers post-action lookup for single-key kind."""
         from custom_components.ha_mcp_tools import _build_edit_yaml_config_handler
 
@@ -527,11 +549,7 @@ class TestHandleEditYamlConfigSingleKey:
                         "file": "configuration.yaml",
                         "action": "add",
                         "yaml_path": "template",
-                        "content": (
-                            "- sensor:\n"
-                            "    - name: t\n"
-                            "      state: 'ok'\n"
-                        ),
+                        "content": ("- sensor:\n    - name: t\n      state: 'ok'\n"),
                         "backup": False,
                     }
                 )

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -10,6 +10,13 @@ across all test environments.
 # Expires: 2035 (10+ years from token creation)
 TEST_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxOTE5ZTZlMTVkYjI0Mzk2YTQ4YjFiZTI1MDM1YmU2YSIsImlhdCI6MTc1NzI4OTc5NiwiZXhwIjoyMDcyNjQ5Nzk2fQ.Yp9SSAjm2gvl9Xcu96FFxS8SapHxWAVzaI0E3cD9xac"
 
+# LLAT for a seeded non-admin user (``system-users`` group). Used to
+# verify the admin gate on ``ha_mcp_tools.get_caller_token`` rejects
+# non-admin callers end-to-end. The user, refresh_token, and jwt_key
+# entries that back this JWT live alongside the admin entries in
+# ``tests/initial_test_state/.storage/auth``.
+NON_ADMIN_TEST_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIzNzkyOTc5YzdiYTdlNjAwMDU2NjJlMjJjNzgzOGNmOCIsImlhdCI6MTc1NzI4OTc5NiwiZXhwIjoyMDcyNjQ5Nzk2fQ.LGH1CMs-3ML7YkY14FctNiHSenDGLjjW8wAB_MlZ7VU"
+
 # Home Assistant Docker image for E2E/performance/UAT tests.
 # Keep in sync with .github/workflows/e2e-tests.yml and pr.yml.
 # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant


### PR DESCRIPTION
## What does this PR do?

Closes the issue #1451 bypass and the broader exposure where the five
`ha_mcp_tools.*` services are callable by anything authenticated as HA admin
— Developer Tools, automations, scripts, REST API, other integrations,
conversation agents, and the `ha_call_service` MCP tool itself.

Two-part fix:

**Custom component (`custom_components/ha_mcp_tools/__init__.py`):**
- Each dangerous-service handler (`list_files`, `read_file`, `write_file`, `delete_file`, `edit_yaml_config`) now requires a `_ha_mcp_token` field in the service-call data and gates with `secrets.compare_digest`.
- Token generated by `secrets.token_urlsafe(32)` on first `async_setup_entry`, persisted via `Store(key="ha_mcp_tools_auth")`, cached in `hass.data` for handler access.
- New `ha_mcp_tools.get_caller_token` service exposes the token to the ha-mcp bootstrap (admin-auth-only, same as every other service).
- Unauthorized callers get a structured `{success: False, error_code: "unauthorized"}` reply.

**ha-mcp wrapper (`src/ha_mcp/tools/tools_filesystem.py`, `tools_yaml_config.py`, `tools_service.py`):**
- New `call_mcp_tools_service` helper: fetches + caches the token on first use, injects it on every call, refetches once on `error_code=unauthorized` (covers token rotation).
- All five wrapper tools route through it instead of calling `client.call_service(MCP_TOOLS_DOMAIN, …)` directly.
- `ha_call_service` itself rejects `domain == "ha_mcp_tools"` with a `ToolError` pointing the LLM at the dedicated wrappers. **This closes the #1451 bypass at the wrapper layer.**

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature

## Threat model

The token is **admin-readable** via `ha_mcp_tools.get_caller_token`, so this is not a defense against a compromised HA admin token. It is defense against the **casual-caller path**: callers that hit `ha_mcp_tools.*` directly without first fetching the token. Any caller that does the explicit two-step (fetch then inject) and has HA admin auth still works — that's by design, because ha-mcp itself uses exactly that flow.

| Caller | Before | Direct call (no token) | Deliberate fetch + inject (with admin auth) |
|---|---|---|---|
| ha-mcp's dedicated wrappers (filesystem.*, yaml_config) | worked | n/a — auto-bootstrap the token | ✅ works — this is the supported path |
| Automation / Script / Blueprint YAML | worked | **rejected** | possible in principle, but no real automation does this |
| Lovelace / Developer Tools UI | worked | **rejected** | possible from Dev Tools as a deliberate two-step, never a casual mis-click |
| Built-in HA Assist / conversation agent | worked | **rejected** | not a flow these clients implement |
| Other integrations / other MCP servers | worked | **rejected** | possible if they implement the bootstrap explicitly — again, deliberate |
| `ha_call_service` from any LLM (issue #1451 bypass) | **bypass** | **refused at the ha-mcp wrapper layer** *and* would be rejected downstream | also refused at the wrapper layer — the wrapper blocks `domain=ha_mcp_tools` outright |
| Direct REST/WS API call with admin LLAT, doing the two-step | worked | **rejected** | works (requires both admin auth and explicit fetch+inject) |

The goal isn't to prevent a determined HA admin from invoking these services — anyone with HA admin auth can also write to `/config/www` via the existing service registry and already has the keys to the house. The goal is to make sure **nothing reaches these handlers by accident or by drive-by LLM "creativity"** like the #1451 scenario.

Token leak is explicitly accepted: anyone with HA admin auth can already extract it, but the token's only value is being a deliberate step the casual paths don't take.

## Zero-config UX

No user-facing config required:
- Token auto-generated on integration setup, persisted across restarts.
- ha-mcp bootstraps via `get_caller_token` on first use, caches in memory, refetches on rotation.
- Works identically across deployment shapes (addon / container / stdio / HACS in-process).
- Rotation: delete the entry's `Store` data and reload — both sides re-sync on next call.

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — 96 tests covering this area pass (14 new + 82 affected existing). 2 pre-existing failures unrelated (Windows symlink permission + an unrelated unicode-decode case, both fail on clean upstream/master)
- [x] Code follows style guidelines (`uv run ruff check` + `uv run ruff format --check`)

New file `tests/src/unit/test_caller_token_auth.py` covers:
- handler-side `_caller_token_ok` (5 cases: match, missing, mismatch, no setup, empty)
- unauthorized response shape (3 cases including the `files=[]` extras path)
- wrapper-side `call_mcp_tools_service` bootstrap/cache/refetch (4 cases)
- `ha_call_service` refusal of `ha_mcp_tools` domain (2 cases)

`test_yaml_config_tool.py` updated to mock the new bootstrap fetch. `test_yaml_dashboards.py` and `test_custom_component_filesystem.py` gain the `homeassistant.helpers.storage` / `homeassistant.components.persistent_notification` stubs now needed for module import, and `test_yaml_dashboards.py` fixtures now seed the token transparently for the existing 13+ dashboard tests.

## Checklist
- [x] I have updated documentation if needed (services.yaml entry for `get_caller_token`)