### PR TITLE
fix: reject python_transform while loops

### DIFF
--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -62,7 +62,6 @@ SAFE_NODES = {
     # Control flow
     ast.If,
     ast.For,
-    ast.While,
     ast.Break,
     ast.Continue,
     ast.IfExp,  # ternary: x if c else y
@@ -144,6 +143,7 @@ _NODE_SUGGESTIONS: dict[str, str] = {
     "AsyncWith": "perform the inner logic directly; with-blocks aren't supported",
     "FunctionDef": "use a list comprehension or inline the logic",
     "AsyncFunctionDef": "use a list comprehension or inline the logic",
+    "While": "use a for-loop or list comprehension instead of while-loops to ensure termination",
     "ClassDef": "use a dict literal instead of defining a class",
     "Yield": "build a list with a comprehension or for-loop append",
     "YieldFrom": "build a list with a comprehension or for-loop append",
@@ -508,7 +508,7 @@ PYTHON TRANSFORM SECURITY:
 - Deletion: del config['key'] or config.pop('key')
 - List methods: append, insert, pop, remove, clear, extend
 - Dict methods: update, get, setdefault, keys, values, items
-- Loops: for, while, if/else, pass, break, continue
+- Loops: for, if/else, pass, break, continue
 - Comprehensions: [x for x in ...], {k: v for ...}, (x for x in ...)
 - Ternary: x if condition else y
 - Iterable unpacking (* in calls/literals): f(*xs), [*xs, y]
@@ -527,6 +527,7 @@ PYTHON TRANSFORM SECURITY:
 - Dangerous builtins: eval, exec, compile, getattr, setattr, delattr, hasattr
 - Function definitions: def, class
 - Exception handling: try/except (validate with isinstance/in/.get() instead)
+- While loops: use bounded for loops or comprehensions instead
 
 🎯 PATTERNS:
 - Filter cards: cards = [c for c in cards if keep(c)]

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -144,6 +144,7 @@ _NODE_SUGGESTIONS: dict[str, str] = {
     "FunctionDef": "use a list comprehension or inline the logic",
     "AsyncFunctionDef": "use a list comprehension or inline the logic",
     "While": "use a for-loop or list comprehension instead of while-loops to ensure termination",
+    "AsyncFor": "use a regular for-loop over a synchronous iterable",
     "ClassDef": "use a dict literal instead of defining a class",
     "Yield": "build a list with a comprehension or for-loop append",
     "YieldFrom": "build a list with a comprehension or for-loop append",

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -164,6 +164,8 @@ _NODE_SUGGESTIONS: dict[str, str] = {
     "MatchStar": "use if/elif/else or a dict lookup instead of match/case",
 }
 
+_INTERPRETER_INTERNAL_NAMES = frozenset({"__builtins__", "__name__", "__doc__"})
+
 # Whitelist of safe methods that can be called
 SAFE_METHODS = {
     # List methods
@@ -299,6 +301,9 @@ def _validate_node(node: ast.AST) -> str | None:
             return f"Forbidden node type: {name} — {hint}"
         return f"Forbidden node type: {name}"
 
+    if isinstance(node, ast.Name) and node.id in _INTERPRETER_INTERNAL_NAMES:
+        return f"Forbidden: direct access to interpreter internals ({node.id})"
+
     if isinstance(node, ast.Attribute):
         if node.attr.startswith("__") and node.attr.endswith("__"):
             return f"Forbidden: dunder attribute access ({node.attr})"
@@ -369,7 +374,7 @@ def safe_execute_expression(
         )
 
     safe_globals: dict[str, Any] = {
-        "__builtins__": _SAFE_BUILTINS,
+        "__builtins__": dict(_SAFE_BUILTINS),
         "__name__": "__main__",
         "__doc__": None,
     }

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -740,7 +740,9 @@ class TestBuiltinsIsolation:
 
         try:
             with patch("ha_mcp.utils.python_sandbox.exec", mutate_execution_builtins):
-                safe_execute_expression("response = response", {"response": []}, "response")
+                safe_execute_expression(
+                    "response = response", {"response": []}, "response"
+                )
         finally:
             _SAFE_BUILTINS.clear()
             _SAFE_BUILTINS.update(original_builtins)

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -719,13 +719,38 @@ class TestSandboxErrorSubclasses:
 class TestBuiltinsIsolation:
     """Regression tests for GHSA-6w5w-h7g8-gm26."""
 
-    @pytest.mark.parametrize("name", ("__builtins__", "__name__", "__doc__"))
-    def test_direct_interpreter_internal_names_rejected(self, name):
-        valid, error = validate_expression(f"config['x'] = {name}")
+    @pytest.mark.parametrize(
+        ("name", "expr"),
+        [
+            ("__builtins__", "config['x'] = __builtins__"),
+            ("__name__", "config['x'] = __name__"),
+            ("__doc__", "config['x'] = __doc__"),
+            ("__builtins__", "__builtins__ = {}"),
+            ("__name__", "__name__ = 'x'"),
+            ("__doc__", "__doc__ = 'x'"),
+            ("__builtins__", "del __builtins__"),
+            ("__name__", "del __name__"),
+            ("__doc__", "del __doc__"),
+        ],
+    )
+    def test_direct_interpreter_internal_names_rejected(self, name, expr):
+        valid, error = validate_expression(expr)
 
         assert valid is False
         assert name in error
         assert "interpreter internals" in error
+
+    def test_subsequent_real_execution_sees_pristine_builtins(self):
+        """After a per-call copy is mutated, real executions still resolve
+        len/range/etc. from the unmodified _SAFE_BUILTINS source — guards
+        against a shallow-copy regression.
+        """
+        result = safe_execute_expression(
+            "response = len(items)",
+            {"items": [1, 2, 3], "response": 0},
+            "response",
+        )
+        assert result == 3
 
     def test_builtin_replacement_does_not_persist_between_executions(self):
         from unittest.mock import patch

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -8,6 +8,7 @@ from ha_mcp.utils.python_sandbox import (
     PythonSandboxExecutionError,
     PythonSandboxValidationError,
     format_sandbox_error,
+    get_security_documentation,
     safe_execute,
     safe_execute_expression,
     validate_expression,
@@ -47,11 +48,33 @@ for view in config['views']:
         valid, error = validate_expression(expr)
         assert valid is True
 
+    def test_while_loop_rejected(self):
+        """Regression for issue #1461: while loops can hang in-process exec."""
+        expr = """
+while True:
+    pass
+"""
+        valid, error = validate_expression(expr)
+        assert valid is False
+        assert "While" in error
+        assert "for-loop" in error
+
     def test_list_comprehension(self):
         """Test list comprehension."""
         expr = "config['entities'] = [e for e in config.get('entities', []) if 'light' in e]"
         valid, error = validate_expression(expr)
         assert valid is True
+
+
+class TestSecurityDocumentation:
+    """Test sandbox documentation shown to agents."""
+
+    def test_while_loop_not_documented_as_allowed(self):
+        docs = get_security_documentation()
+        allowed_section = docs.split("FORBIDDEN:", 1)[0]
+
+        assert "while" not in allowed_section.lower()
+        assert "- Loops: for, if/else, pass, break, continue" in docs
 
 
 class TestUnaryOperators:

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -4,6 +4,7 @@ import pytest
 
 from ha_mcp.utils.python_sandbox import (
     _EXECUTION_ERROR_TEXT_LIMIT,
+    _SAFE_BUILTINS,
     PythonSandboxError,
     PythonSandboxExecutionError,
     PythonSandboxValidationError,
@@ -713,6 +714,40 @@ class TestSandboxErrorSubclasses:
                 pytest.raises(type(infra_exc)),
             ):
                 safe_execute_expression("response = 1", {"response": 0}, "response")
+
+
+class TestBuiltinsIsolation:
+    """Regression tests for GHSA-6w5w-h7g8-gm26."""
+
+    @pytest.mark.parametrize("name", ("__builtins__", "__name__", "__doc__"))
+    def test_direct_interpreter_internal_names_rejected(self, name):
+        valid, error = validate_expression(f"config['x'] = {name}")
+
+        assert valid is False
+        assert name in error
+        assert "interpreter internals" in error
+
+    def test_builtin_replacement_does_not_persist_between_executions(self):
+        from unittest.mock import patch
+
+        original_builtins = dict(_SAFE_BUILTINS)
+        mutated_builtins = None
+
+        def mutate_execution_builtins(_expr, safe_globals, safe_locals):
+            nonlocal mutated_builtins
+            mutated_builtins = safe_globals["__builtins__"]
+            mutated_builtins["len"] = lambda value: 999
+
+        try:
+            with patch("ha_mcp.utils.python_sandbox.exec", mutate_execution_builtins):
+                safe_execute_expression("response = response", {"response": []}, "response")
+        finally:
+            _SAFE_BUILTINS.clear()
+            _SAFE_BUILTINS.update(original_builtins)
+
+        assert mutated_builtins is not _SAFE_BUILTINS
+        assert mutated_builtins["len"] is not len
+        assert _SAFE_BUILTINS["len"] is len
 
 
 class TestFormatSandboxError:


### PR DESCRIPTION
## What does this PR do?

Closes #1461.

Rejects Python `while` statements in `python_transform` validation because transforms execute synchronously in-process and an unbounded loop can hang the MCP server. Adds a targeted validation hint, removes `while` from generated sandbox documentation, and covers both with regression tests.

Also applies the reporter-recommended direct builtins isolation hardening: direct access to interpreter internals like `__builtins__`, `__name__`, and `__doc__` is rejected during AST validation, and each execution receives a fresh copy of `_SAFE_BUILTINS` so mutations cannot persist across transform calls.

`python_transform` can still edit Home Assistant `repeat.while` data because that is a dict key, not a Python `while` statement.

Thanks to @bharat and @lavkumarv for their responsible disclosures of the transform hang and builtins isolation issues.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Focused verification run locally:
- `PYTHONPATH=src pytest tests/src/unit/test_python_sandbox.py -q` (`80 passed`)
- `ruff check src/ha_mcp/utils/python_sandbox.py tests/src/unit/test_python_sandbox.py`
- `ruff format --check src/ha_mcp/utils/python_sandbox.py tests/src/unit/test_python_sandbox.py`
- `.venv\Scripts\python.exe -m compileall src\ha_mcp\utils\python_sandbox.py tests\src\unit\test_python_sandbox.py`
- `git diff --check`

Note: `uv run pytest ...` timed out while setting up/running in this Windows worktree, so the template `uv run` checkboxes are left unchecked.

## Checklist
- [x] I have updated documentation if needed