### PR TITLE
docs(security): explicit threat model for trusted clients, LAN, sandbox, and OAuth tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,14 @@ All workflow automation is implemented as skills in `.claude/skills/` and invoke
 - **Package**: `ha-mcp` on PyPI
 - **Python**: 3.13 only
 
+## Security
+
+See [SECURITY.md](SECURITY.md) for the threat model, scope, and reporting
+instructions. The threat model section documents the key design decisions that
+define what ha-mcp does and doesn't defend against (trusted MCP clients, local
+network boundary, OAuth Bearer token design, single-tenant standard mode, HA
+permission scope).
+
 ## External Documentation
 
 When implementing features or debugging, consult these resources:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,24 @@ By default the HTTP entrypoints bind to `0.0.0.0` so they are reachable from
 other machines on the LAN. To restrict to the local machine, set
 `MCP_HOST=127.0.0.1` (or use `-p 127.0.0.1:8086:8086` at the Docker layer).
 
+### Standard mode is single-tenant
+
+The secret-URL model (`ha-mcp-web`, `ha-mcp-sse`) assumes a single operator.
+All MCP clients that share the same `MCP_SECRET_PATH` get identical access —
+there is no per-client authorization or isolation. Reports that assume "client A
+shouldn't be able to see client B's data" don't apply to standard mode; that
+isolation model only exists in OAuth mode (scoped per HA token).
+
+### ha-mcp does not add or restrict Home Assistant permissions
+
+ha-mcp uses the long-lived access token the operator provides. That token's
+permissions in Home Assistant are what they are. If the configured token is an
+admin token, ha-mcp can perform admin-level operations. Reports stating "ha-mcp
+can do X" where X is permitted by the configured token are not vulnerabilities —
+they are the intended behavior. Restricting HA permissions is done in Home
+Assistant (e.g. by creating a non-admin user and generating a token for that
+user).
+
 ### OAuth Bearer token design
 
 In OAuth mode, access and refresh tokens are HMAC-signed, stateless Bearer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,10 @@ Consequences:
   vulnerability.
 - `python_transform` expressions are treated as **trusted code from a trusted
   client**. The sandbox exists to prevent accidental mistakes (e.g. a runaway
-  loop), not to sandbox an adversarial party. See
+  loop), not to sandbox an adversarial party. Additionally, `python_transform`
+  only ever receives data that ha-mcp fetched from the HA API and
+  JSON-deserialized — no Python callables can reach the expression's `config`
+  variable through any normal MCP or HA API call. See
   [python_sandbox.py](src/ha_mcp/utils/python_sandbox.py) for the explicit
   "not a security boundary" note.
 
@@ -73,8 +76,16 @@ token (LLAT). This is **by design**:
   immediately invalidates all derived tokens — that is the intended revocation
   path.
 - Tokens are HMAC-signed (preventing forgery and tampering) but not encrypted.
-  A party that captures a token can decode it to recover the LLAT. This is
-  equivalent to capturing any other Bearer token that grants the same access.
+  Encrypting the payload would not improve security: the LLAT must ultimately
+  be sent to Home Assistant in cleartext over HTTPS to authenticate API calls.
+  Anyone with access to the MCP server process can observe the LLAT regardless
+  of token format.
+- A party that captures a token can decode it to recover the LLAT. This is
+  equivalent to capturing any other Bearer token that grants the same access —
+  including the standard OAuth `client_credentials` model used by many MCP
+  clients, where a static `client_secret` stored at the AI provider grants
+  full service access. The trust boundary is identical; the only difference is
+  packaging.
 - Token revocation at the ha-mcp level is a no-op: there is no server-side
   token store. Revoke the LLAT in Home Assistant instead.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,16 +6,74 @@
 | ------- | --------- |
 | latest  | ✅        |
 
+## Threat Model
+
+Understanding what ha-mcp does and doesn't defend against helps you write
+accurate reports and helps us triage quickly.
+
+### MCP clients are trusted principals
+
+An authenticated MCP client (one that has the secret URL or completed the OAuth
+flow) is a **trusted principal**. ha-mcp does not attempt to defend against a
+malicious or compromised MCP client — that is equivalent to defending against a
+malicious user who has your Home Assistant long-lived access token.
+
+Consequences:
+- Prompt injection that reaches an MCP client is the **client's responsibility**
+  to defend against. If the LLM embedded in a client is tricked into calling a
+  tool it shouldn't, that is a client-side control issue, not a server-side
+  vulnerability.
+- `python_transform` expressions are treated as **trusted code from a trusted
+  client**. The sandbox exists to prevent accidental mistakes (e.g. a runaway
+  loop), not to sandbox an adversarial party. See
+  [python_sandbox.py](src/ha_mcp/utils/python_sandbox.py) for the explicit
+  "not a security boundary" note.
+
+### Local network is the trusted zone for standard mode
+
+The HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by URL-path
+secrecy and are designed for loopback HTTP or LAN HTTP with a high-entropy
+`MCP_SECRET_PATH`. Any peer that can reach the configured path is treated as
+trusted — securing the local network is outside ha-mcp's scope.
+
+For internet-facing deployments use the OAuth entrypoint (`ha-mcp-oauth`)
+behind a TLS-terminating reverse proxy (see
+[OAuth Mode](#oauth-mode--beta-warning) below). Deployment guidance:
+[AGENTS.md → Docker](AGENTS.md#docker).
+
+By default the HTTP entrypoints bind to `0.0.0.0` so they are reachable from
+other machines on the LAN. To restrict to the local machine, set
+`MCP_HOST=127.0.0.1` (or use `-p 127.0.0.1:8086:8086` at the Docker layer).
+
+### OAuth Bearer token design
+
+In OAuth mode, access and refresh tokens are HMAC-signed, stateless Bearer
+tokens. The token payload contains the user's Home Assistant long-lived access
+token (LLAT). This is **by design**:
+
+- The LLAT is the authorization boundary. Revoking it in Home Assistant
+  immediately invalidates all derived tokens — that is the intended revocation
+  path.
+- Tokens are HMAC-signed (preventing forgery and tampering) but not encrypted.
+  A party that captures a token can decode it to recover the LLAT. This is
+  equivalent to capturing any other Bearer token that grants the same access.
+- Token revocation at the ha-mcp level is a no-op: there is no server-side
+  token store. Revoke the LLAT in Home Assistant instead.
+
+The consent form explains this revocation path. Reports about token opacity
+(the LLAT being visible inside the token) will be closed as by-design.
+
 ## Scope
 
 **In scope** — please report these:
 
 - Authentication bypass in standard (LLAT) or OAuth mode
-- OAuth mode: XSS, SSRF, token leakage, open redirect
-- Prompt injection paths that circumvent tool-level safeguards
-  (e.g., HA entity data triggering unintended tool calls)
+- OAuth mode: XSS, SSRF, open redirect, or credential exfiltration via the
+  consent form or token endpoint (i.e. an unauthenticated party obtaining a
+  token or extracting credentials without completing the consent flow)
+- Unintended information disclosure via API responses (e.g. secrets returned to
+  a client that shouldn't have them)
 - Privilege escalation within the MCP tool surface
-- Unintended information disclosure via API responses
 - Dependency vulnerabilities with a credible exploit path
 
 **Out of scope** — these will not be actioned:
@@ -26,26 +84,23 @@
 - Attacks requiring physical access to the HA host
 - "The LLM performed a destructive action using valid, authorized tools" —
   this is a configuration or usage issue, not a security vulnerability.
-  Tool visibility controls (`ENABLED_TOOL_MODULES`, group toggles) exist for this purpose.
+  Tool visibility controls (`ENABLED_TOOL_MODULES`, group toggles) exist for
+  this purpose.
+- Prompt injection that only travels through read-only tool return values —
+  the MCP client controls what the LLM sees and acts on; hardening that path
+  is the client's responsibility (see [Threat Model](#threat-model) above).
+- `python_transform` issues: the sandbox is not a security boundary between
+  trusted and untrusted code. Problems with `python_transform` behavior are
+  bugs, not security vulnerabilities.
+- LAN-peer access to standard-mode HTTP endpoints: the local network is the
+  trusted zone (see [Threat Model](#threat-model) above).
+- OAuth token containing an encoded LLAT: this is the Bearer token design
+  (see [Threat Model](#threat-model) above).
+- OAuth token revocation not preventing further HA API access: revoke the LLAT
+  in Home Assistant instead.
 - Vulnerabilities that are only exploitable due to a misconfigured deployment
   (e.g., standard-mode instance exposed to the internet without TLS, or a
   network-reachable HTTP entrypoint using the default `MCP_SECRET_PATH`).
-
-### Standard-mode threat model
-
-The HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`) authenticate by URL-path
-secrecy and are designed for loopback HTTP or LAN HTTP with a high-entropy
-`MCP_SECRET_PATH`. For internet-facing deployments use the OAuth entrypoint
-(`ha-mcp-oauth`) behind a TLS-terminating reverse proxy (see
-[OAuth Mode](#oauth-mode--beta-warning) below). Deployment guidance:
-[AGENTS.md → Docker](AGENTS.md#docker).
-
-By default the HTTP entrypoints (`ha-mcp-web`, `ha-mcp-sse`,
-`ha-mcp-oauth`) bind to `0.0.0.0` so they are reachable from other
-machines on the LAN. To restrict the server to the local machine, set
-`MCP_HOST=127.0.0.1` before launching (the Docker snippet in AGENTS.md
-uses `-p 127.0.0.1:8086:8086` to achieve the same effect at the
-container level — either approach works).
 
 ## OAuth Mode — Beta Warning
 
@@ -57,15 +112,17 @@ and carries a larger attack surface than the standard LLAT setup.
 - CVEs were published and fixed in v7.x (XSS: GHSA-pf93-j98v-25pv;
   SSRF: GHSA-fmfg-9g7c-3vq7). Upgrade to the latest release before deploying.
 
-If you choose to run OAuth mode, restrict the consent endpoint to trusted networks
-and place it behind a TLS-terminating reverse proxy.
+If you choose to run OAuth mode, restrict the consent endpoint to trusted
+networks and place it behind a TLS-terminating reverse proxy.
 
 ## Reporting a Vulnerability
 
 Use the private reporting page at:
 **https://github.com/homeassistant-ai/ha-mcp/security/advisories/new**
 
-Reports are assessed within 48 hours; fixes may take an additional 24–48 hours. We aim for coordinated disclosure and will work with you to agree on a disclosure timeline, typically within 90 days of the initial report.
+Reports are assessed within 48 hours; fixes may take an additional 24–48 hours.
+We aim for coordinated disclosure and will work with you to agree on a
+disclosure timeline, typically within 90 days of the initial report.
 Severity is assessed using CVSS base scores where applicable.
 
 **Requirements for a valid report:**

--- a/src/ha_mcp/auth/provider.py
+++ b/src/ha_mcp/auth/provider.py
@@ -73,6 +73,8 @@ class HomeAssistantOAuthProvider(OAuthProvider):
     Security comes from HTTPS transport and the LLAT itself being the
     authorization boundary — revoking the LLAT in Home Assistant
     immediately invalidates all derived tokens.
+    See SECURITY.md § "OAuth Bearer token design" for the full rationale
+    and the intended revocation path.
     """
 
     def __init__(

--- a/src/ha_mcp/utils/python_sandbox.py
+++ b/src/ha_mcp/utils/python_sandbox.py
@@ -4,6 +4,7 @@ Python expression validation for dashboard transformations.
 Restricts expressions to a known-safe subset: dict/list operations,
 basic control flow, and whitelisted methods. Not a security boundary —
 callers are already authenticated MCP users with full HA access.
+See SECURITY.md § "MCP clients are trusted principals" for the rationale.
 """
 
 import ast


### PR DESCRIPTION
## Summary

Formalises the security threat model in \`SECURITY.md\` to reduce recurring
reports on design decisions that are intentional and out of scope.

**New Threat Model section** — five explicitly documented decisions:

- **MCP clients are trusted principals** — prompt injection via tool return values and \`python_transform\` issues are the client's responsibility, not server-side vulnerabilities.
- **Local network is the trusted zone** for standard mode — LAN-peer access is by design; securing the local network is out of scope.
- **Standard mode is single-tenant** — all clients sharing the same \`MCP_SECRET_PATH\` get identical access; per-client isolation only exists in OAuth mode.
- **ha-mcp does not add or restrict HA permissions** — the configured LLAT's scope is the permission boundary; reports about tools doing what the token allows are not vulnerabilities.
- **OAuth Bearer token design** — tokens carry the LLAT by design (HMAC-signed, not encrypted); the revocation path is revoking the LLAT in Home Assistant.

**Expanded Out of Scope list** — explicit entries for each of the above classes.

**Cross-references** added in:
- \`python_sandbox.py\` module docstring
- \`HomeAssistantOAuthProvider\` class docstring
- \`AGENTS.md\` — new \`## Security\` section pointing to \`SECURITY.md\`

No functional code changes.

## Test plan

- [ ] Review \`SECURITY.md\` threat model section for accuracy
- [ ] Confirm the Out of Scope entries match the threat model sections
- [ ] Check that code cross-references point to the correct section headings