### PR TITLE
docs: clarify telemetry is a planned future feature, not implemented

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** November 2024
+**Last updated:** May 2026
 
 ## Scope
 
@@ -12,20 +12,20 @@ Ha-mcp runs on your local machine and communicates with your own Home Assistant 
 
 ## Anonymous Usage Statistics
 
-Ha-mcp may collect anonymous usage statistics to help improve the server. If enabled, this includes:
+Anonymous usage statistics are a planned future feature and are **not currently collected or transmitted** as of May 2026. When this feature is implemented, users will be notified in the release notes and it will be **opt-in only**.
+
+When enabled in a future release, anonymous usage statistics would include:
 
 - **Tool usage counts** — which tools are used and how often
 - **Server version** — to understand adoption of updates
 - **Request/response sizes** — to optimize performance (not content)
 
-**What we do NOT collect:**
+**What would NOT be collected:**
 - Entity names or IDs
 - Home Assistant configuration
 - Personal information
 - Automation or script content
 - Any data from your smart home devices
-
-Telemetry is configurable in the settings.
 
 ## Bug Reports
 
@@ -49,13 +49,13 @@ When you use ha-mcp, your MCP client accesses data from your Home Assistant inst
 
 - **Your Home Assistant instance** — via the URL and token you provide
 - **Your MCP client** — the application that runs ha-mcp
-- **Our telemetry server** — for anonymous usage statistics (if enabled)
+- **A telemetry server** — *planned future feature, not currently active*; would only receive data if you opt in
 
 ## Data Security
 
 - Your Home Assistant credentials are stored locally by your MCP client
-- Anonymous telemetry contains no identifying information
 - Bug reports are only sent when you explicitly approve
+- Anonymous telemetry (when implemented) will contain no identifying information
 
 ## Changes to This Policy
 
@@ -72,7 +72,7 @@ For privacy-related questions or concerns:
 
 | Aspect | Status |
 |--------|--------|
-| Anonymous telemetry | Configurable |
+| Anonymous telemetry | Not currently implemented (planned future feature, opt-in only) |
 | Personal data collected | None |
 | Bug reports | User-approved only |
 | Local processing | Yes |

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ For comprehensive testing documentation, see **[tests/README.md](tests/README.md
 
 Ha-mcp runs **locally** on your machine. Your smart home data stays on your network.
 
-- **Configurable telemetry** — optional anonymous usage stats
+- **No telemetry today** — anonymous usage stats are a planned future feature (as of May 2026); users will be notified when it lands and it will be opt-in only
 - **No personal data collection** — we never collect entity names, configs, or device data
 - **User-controlled bug reports** — only sent with your explicit approval
 


### PR DESCRIPTION
## What does this PR do?

Updates README.md and PRIVACY.md to accurately reflect that telemetry / anonymous usage statistics are **not currently implemented**. The previous wording ("Configurable telemetry", "Our telemetry server", "Telemetry is configurable in the settings") described a feature that does not exist in the code — `src/ha_mcp/config.py` has no telemetry settings, and `src/ha_mcp/utils/usage_logger.py` only writes to a local file (`mcp_usage.jsonl`) with no networking. Originally flagged in #1468.

Wording now states it's a planned future feature as of May 2026, that users will be notified in release notes when it lands, and that it will be opt-in only. The existing description of what would be collected / not collected is preserved (reframed as "would" / "when implemented") so users still know what to expect.

## Type of change
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

(Docs-only change — no code paths touched.)

## Checklist
- [x] I have updated documentation if needed

Closes #1468