### PR TITLE
fix: surface flow-helper config to agents reading UI-created templates

### DIFF
--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -2005,10 +2005,10 @@ class SmartSearchTools:
         entity, etc. — is searchable.
 
         Cost: 1 REST call + one options-flow probe per flow-helper config
-        entry, parallelised under ``semaphore``. The probe is skipped only
-        when the title alone already scores a perfect 100 (the deeper probe
-        can only raise the total, never lower it, so anything below 100 is
-        still worth probing for accurate scoring and ``match_in_config``).
+        entry, parallelised under ``semaphore``. The probe is skipped when
+        the title alone already scores the maximum (a deeper config match can
+        only raise the total, never lower it); any title that leaves headroom
+        is still probed for accurate scoring and ``match_in_config``.
         """
         try:
             response = await self.client._request("GET", "/config/config_entries/entry")
@@ -2112,7 +2112,12 @@ class SmartSearchTools:
             if isinstance(item, dict):
                 out.append(item)
             elif isinstance(item, Exception):
-                logger.debug(f"flow-helper scoring failed: {item}")
+                # The probe swallows its own transient/API errors, so anything
+                # reaching here is a scoring/extraction bug (e.g. a shape
+                # assumption breaking on a future HA version). Log at warning so
+                # it's discoverable — one bad entry must not sink the whole
+                # multi-source deep_search, so we drop it and keep going.
+                logger.warning(f"flow-helper scoring failed: {item!r}")
         return out
 
     def _score_deep_match(

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import random
+import re
 import time
 from typing import Any
 
@@ -2004,9 +2005,10 @@ class SmartSearchTools:
         entity, etc. — is searchable.
 
         Cost: 1 REST call + one options-flow probe per flow-helper config
-        entry, parallelised under ``semaphore``. Options probes are skipped
-        for entries whose title alone already exact-matches the query (no
-        added information from the deeper probe).
+        entry, parallelised under ``semaphore``. The probe is skipped only
+        when the title alone already scores a perfect 100 (the deeper probe
+        can only raise the total, never lower it, so anything below 100 is
+        still worth probing for accurate scoring and ``match_in_config``).
         """
         try:
             response = await self.client._request("GET", "/config/config_entries/entry")
@@ -2029,19 +2031,29 @@ class SmartSearchTools:
 
         async def score_entry(entry: dict[str, Any]) -> dict[str, Any] | None:
             entry_id = entry.get("entry_id")
-            domain = entry.get("domain", "")
-            title = entry.get("title") or entry_id or ""
             if not isinstance(entry_id, str):
                 return None
+            domain = entry.get("domain", "")
+            title = entry.get("title") or entry_id
 
-            # Title-only quick path: an exact title match doesn't need an
-            # options probe — the deeper config can't lower the score.
-            title_pseudo_eid = f"{domain}.{entry_id}"
+            # Score the name against a title-derived slug, never the opaque
+            # config-entry ULID: a random ULID substring would otherwise
+            # produce false-positive name matches (e.g. a 3-char query that
+            # happens to occur inside the base32 id). The slug mirrors the
+            # storage-helper path, which scores a name-derived id rather than
+            # an opaque key. entry_id is still returned to the caller; it just
+            # isn't a search target.
+            title_slug = re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")
+            title_pseudo_eid = f"{domain}.{title_slug}" if title_slug else domain
             name_score = self.fuzzy_searcher._calculate_entity_score(
                 title_pseudo_eid, title, domain, query_lower
             )
 
             options: dict[str, Any] = {}
+            # Only a perfect title match (score 100) makes the deeper options
+            # probe redundant — the probe can only raise the total, never lower
+            # it, so anything below 100 is worth probing (in both exact and
+            # fuzzy modes) for accurate scoring and ``match_in_config``.
             need_probe = include_config or (
                 self._score_deep_match(
                     title_pseudo_eid,
@@ -2051,16 +2063,20 @@ class SmartSearchTools:
                     query_lower,
                     exact_match,
                 )[0]
-                < (100 if exact_match else self.settings.fuzzy_threshold)
+                < 100
             )
             if need_probe:
                 async with semaphore:
-                    options = await fetch_entry_options(self.client, entry_id)
+                    options = await fetch_entry_options(
+                        self.client, entry_id, quiet=True
+                    )
 
+            # Search the title, domain, and probed options — but not the opaque
+            # entry_id (it would match random ULID substrings; it is returned
+            # in the result for the caller regardless).
             haystack: dict[str, Any] = {
                 "title": title,
                 "domain": domain,
-                "entry_id": entry_id,
                 "options": options,
             }
             config_score = self._search_in_dict(haystack, query_lower, exact_match)

--- a/src/ha_mcp/tools/smart_search.py
+++ b/src/ha_mcp/tools/smart_search.py
@@ -23,6 +23,8 @@ from ..utils.fuzzy_search import (
 )
 from .helpers import exception_to_structured_error, safe_info, safe_progress
 from .tools_config_dashboards import fetch_dashboards_list
+from .tools_config_entry_flow import FLOW_HELPER_TYPES
+from .tools_integrations import fetch_entry_options
 
 logger = logging.getLogger(__name__)
 
@@ -1755,6 +1757,22 @@ class SmartSearchTools:
                     elif isinstance(result, Exception):
                         logger.debug(f"Helper list fetch failed: {result}")
 
+                # Flow-based helpers (template, group, utility_meter,
+                # derivative, ...) are config entries, not storage records,
+                # and have no `<type>/list` WebSocket endpoint. Pull them via
+                # the standard /config/config_entries/entry REST surface and
+                # probe each entry's options flow so the helper's current
+                # config (template body, group members, source entity, ...)
+                # is searchable alongside the input_* helpers above.
+                results["helpers"].extend(
+                    await self._search_flow_helpers(
+                        query_lower,
+                        exact_match,
+                        semaphore,
+                        include_config=include_config,
+                    )
+                )
+
                 phase_done += 1
                 await safe_progress(
                     ctx,
@@ -1968,6 +1986,118 @@ class SmartSearchTools:
                     "helpers": [],
                 },
             )
+
+    async def _search_flow_helpers(
+        self,
+        query_lower: str,
+        exact_match: bool,
+        semaphore: asyncio.Semaphore,
+        *,
+        include_config: bool,
+    ) -> list[dict[str, Any]]:
+        """Search UI-created flow-based helpers (template, group, …).
+
+        Flow-helpers live as config entries (not storage records) and have
+        no ``<type>/list`` endpoint. Lists them via the standard config
+        entries REST endpoint, then probes each entry's options flow so the
+        helper's current config — template body, group members, source
+        entity, etc. — is searchable.
+
+        Cost: 1 REST call + one options-flow probe per flow-helper config
+        entry, parallelised under ``semaphore``. Options probes are skipped
+        for entries whose title alone already exact-matches the query (no
+        added information from the deeper probe).
+        """
+        try:
+            response = await self.client._request("GET", "/config/config_entries/entry")
+        except Exception as exc:
+            logger.debug(f"flow-helper search: list_entries failed: {exc}")
+            return []
+
+        if not isinstance(response, list):
+            return []
+
+        flow_entries = [
+            e
+            for e in response
+            if isinstance(e, dict)
+            and e.get("domain") in FLOW_HELPER_TYPES
+            and e.get("supports_options")
+        ]
+        if not flow_entries:
+            return []
+
+        async def score_entry(entry: dict[str, Any]) -> dict[str, Any] | None:
+            entry_id = entry.get("entry_id")
+            domain = entry.get("domain", "")
+            title = entry.get("title") or entry_id or ""
+            if not isinstance(entry_id, str):
+                return None
+
+            # Title-only quick path: an exact title match doesn't need an
+            # options probe — the deeper config can't lower the score.
+            title_pseudo_eid = f"{domain}.{entry_id}"
+            name_score = self.fuzzy_searcher._calculate_entity_score(
+                title_pseudo_eid, title, domain, query_lower
+            )
+
+            options: dict[str, Any] = {}
+            need_probe = include_config or (
+                self._score_deep_match(
+                    title_pseudo_eid,
+                    title,
+                    name_score,
+                    0,
+                    query_lower,
+                    exact_match,
+                )[0]
+                < (100 if exact_match else self.settings.fuzzy_threshold)
+            )
+            if need_probe:
+                async with semaphore:
+                    options = await fetch_entry_options(self.client, entry_id)
+
+            haystack: dict[str, Any] = {
+                "title": title,
+                "domain": domain,
+                "entry_id": entry_id,
+                "options": options,
+            }
+            config_score = self._search_in_dict(haystack, query_lower, exact_match)
+            total_score, threshold, match_in_name = self._score_deep_match(
+                title_pseudo_eid,
+                title,
+                name_score,
+                config_score,
+                query_lower,
+                exact_match,
+            )
+            if total_score < threshold:
+                return None
+
+            result: dict[str, Any] = {
+                "entry_id": entry_id,
+                "helper_type": domain,
+                "name": title,
+                "score": total_score,
+                "match_in_name": match_in_name,
+                "match_in_config": config_score >= threshold,
+            }
+            if include_config:
+                result["config"] = options
+            return result
+
+        scored = await asyncio.gather(
+            *(score_entry(e) for e in flow_entries),
+            return_exceptions=True,
+        )
+        out: list[dict[str, Any]] = []
+        for item in scored:
+            if isinstance(item, dict):
+                out.append(item)
+            elif isinstance(item, Exception):
+                logger.debug(f"flow-helper scoring failed: {item}")
+        return out
 
     def _score_deep_match(
         self,

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1189,6 +1189,11 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
           via the ha_set_entity(expose_to=...) parameter, not the options dict.
         - platform: Integration platform (e.g., "hue", "zwave_js")
         - device_id: Associated device ID (null if standalone)
+        - config_entry_id: Parent config entry's ID (null for YAML-only
+          entities). For UI-created template/group/utility_meter/derivative/
+          ... helpers, pass this to ``ha_get_integration(entry_id=...,
+          include_options=True)`` to read the helper's current config (template
+          body, group members, etc.) without scanning a domain list.
         - unique_id: Integration's unique identifier
         """
         try:
@@ -1254,6 +1259,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "options": entry.get("options", {}),
                     "platform": entry.get("platform"),
                     "device_id": entry.get("device_id"),
+                    "config_entry_id": entry.get("config_entry_id"),
                     "unique_id": entry.get("unique_id"),
                 }
 

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1190,10 +1190,11 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - platform: Integration platform (e.g., "hue", "zwave_js")
         - device_id: Associated device ID (null if standalone)
         - config_entry_id: Parent config entry's ID (null for YAML-only
-          entities). For UI-created template/group/utility_meter/derivative/
-          ... helpers, pass this to ``ha_get_integration(entry_id=...,
-          include_options=True)`` to read the helper's current config (template
-          body, group members, etc.) without scanning a domain list.
+          entities). When non-null — e.g. for UI-created template/group/
+          utility_meter/derivative/... helpers — pass it to
+          ``ha_get_integration(entry_id=..., include_options=True)`` to read the
+          helper's current config (template body, group members, etc.) without
+          scanning a domain list.
         - unique_id: Integration's unique identifier
         """
         try:

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -113,7 +113,15 @@ def options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
     a missing or ``None`` value are skipped.
     """
     out: dict[str, Any] = {}
-    for field in flow.get("data_schema") or []:
+    # Defensive: HA should always return a list of dict fields, but guard
+    # against malformed shapes so a bad response degrades to {} instead of
+    # raising AttributeError (e.g. a string data_schema would iterate chars).
+    data_schema = flow.get("data_schema")
+    if not isinstance(data_schema, list):
+        return out
+    for field in data_schema:
+        if not isinstance(field, dict):
+            continue
         name = field.get("name")
         if name is None:
             continue
@@ -163,7 +171,7 @@ async def fetch_entry_options(
         flow_id = flow.get("flow_id")
         flow_type = flow.get("type")
         if flow_type != "form":
-            logger.debug(
+            log_probe_failure(
                 f"OptionsFlow for {entry_id} returned type={flow_type!r}, "
                 f"not a form — cannot extract option defaults"
             )

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -101,6 +101,62 @@ assert set(get_args(HelperTypeLiteral)) == (
 )
 
 
+def options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
+    """Extract ``{field_name: current_value}`` from a form-type OptionsFlow.
+
+    Reads each ``data_schema`` entry's ``default`` key, falling back to
+    ``value`` (constant-type fields ship ``value`` instead of ``default``)
+    and then ``description.suggested_value`` (UI-created template, group,
+    utility_meter, and other flow-based helpers stash the current value
+    there — voluptuous renders ``suggested_value=...`` into the
+    ``description`` sub-object, not as a top-level field key). Fields with
+    a missing or ``None`` value are skipped.
+    """
+    out: dict[str, Any] = {}
+    for field in flow.get("data_schema") or []:
+        name = field.get("name")
+        if name is None:
+            continue
+        value = field.get("default", field.get("value"))
+        if value is None:
+            description = field.get("description")
+            if isinstance(description, dict):
+                value = description.get("suggested_value")
+        if value is not None:
+            out[name] = value
+    return out
+
+
+async def fetch_entry_options(client: Any, entry_id: str) -> dict[str, Any]:
+    """Probe an integration's options flow and return the persisted options.
+
+    See :meth:`IntegrationTools._fetch_entry_options` for full rationale.
+    Module-level form so non-class callers (e.g. ``smart_search``) can
+    surface flow-helper config without going through the tool class.
+    """
+    flow_id: str | None = None
+    try:
+        flow = await client.start_options_flow(entry_id)
+        flow_id = flow.get("flow_id")
+        if flow.get("type") != "form":
+            return {}
+        return options_from_form_flow(flow)
+    except Exception as exc:
+        logger.warning(
+            f"Failed to fetch options for {entry_id}: {type(exc).__name__}: {exc}"
+        )
+        return {}
+    finally:
+        if flow_id:
+            try:
+                await client.abort_options_flow(flow_id)
+            except Exception as abort_err:
+                logger.warning(
+                    f"Failed to abort options flow {flow_id}: "
+                    f"{type(abort_err).__name__}: {abort_err}"
+                )
+
+
 async def _get_entry_id_for_flow_helper(
     client: Any,
     helper_type: str,
@@ -213,7 +269,13 @@ class IntegrationTools:
             Field(
                 description="Include the options object for each entry. "
                 "Automatically enabled when domain filter is set. "
-                "Useful for auditing template definitions and helper configurations.",
+                "For UI-created flow-based helpers (template, group, "
+                "utility_meter, derivative, ...), the current config — "
+                "template body, group members, source entity, etc. — is "
+                "surfaced here by probing the options flow. Prefer this over "
+                "include_schema when you only need to read the current values; "
+                "use include_schema when you also need the field types or "
+                "selector metadata.",
                 default=False,
             ),
         ] = False,
@@ -758,22 +820,8 @@ class IntegrationTools:
 
     @staticmethod
     def _options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
-        """Extract ``{field_name: current_value}`` from a form-type OptionsFlow.
-
-        Reads each ``data_schema`` entry's ``default`` key, falling back to
-        ``value`` only when the ``default`` key is absent (constant-type
-        fields ship ``value`` instead of ``default``). Fields with a missing
-        or ``None`` value are skipped.
-        """
-        out: dict[str, Any] = {}
-        for field in flow.get("data_schema") or []:
-            name = field.get("name")
-            if name is None:
-                continue
-            value = field.get("default", field.get("value"))
-            if value is not None:
-                out[name] = value
-        return out
+        """Class-method alias for :func:`options_from_form_flow`."""
+        return options_from_form_flow(flow)
 
     async def _fetch_entry_options(self, entry_id: str) -> dict[str, Any]:
         """Read the current ``options`` for a config entry via its OptionsFlow.

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -127,22 +127,50 @@ def options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-async def fetch_entry_options(client: Any, entry_id: str) -> dict[str, Any]:
-    """Probe an integration's options flow and return the persisted options.
+async def fetch_entry_options(
+    client: Any, entry_id: str, *, quiet: bool = False
+) -> dict[str, Any]:
+    """Read the current ``options`` for a config entry via its OptionsFlow.
 
-    See :meth:`IntegrationTools._fetch_entry_options` for full rationale.
-    Module-level form so non-class callers (e.g. ``smart_search``) can
-    surface flow-helper config without going through the tool class.
+    Home Assistant does not expose ``ConfigEntry.options`` through any
+    read-only REST or WebSocket endpoint — ``/api/config/config_entries/entry``
+    deliberately omits the field. The closest approximation that the HA UI
+    itself uses is the ``default`` values populated into the OptionsFlow's
+    first-step ``data_schema``: integrations build that schema from the
+    existing options dict, so the defaults match the persisted state.
+
+    Starts the flow, harvests ``{name: default}`` from the first step, and
+    aborts the flow in ``finally`` so it doesn't sit half-open.
+
+    Returns ``{}`` on any failure (unsupported entry, non-form first step
+    such as a menu, init/abort errors) so callers can treat the return as
+    the canonical "options" field without further checks.
+
+    Probe failures log at ``warning`` (so breakage of a deliberate
+    single-entry probe is discoverable) unless ``quiet=True``, which demotes
+    them to ``debug`` for bulk fan-out callers (e.g. ``smart_search`` probes
+    one entry per flow-helper on every ``ha_deep_search``; a per-entry
+    warning there would spam the log on routine searches).
+
+    Exposed at module level (not as a method) so non-class callers such as
+    ``smart_search._search_flow_helpers`` can probe flow-helper config
+    without instantiating ``IntegrationTools``.
     """
+    log_probe_failure = logger.debug if quiet else logger.warning
     flow_id: str | None = None
     try:
         flow = await client.start_options_flow(entry_id)
         flow_id = flow.get("flow_id")
-        if flow.get("type") != "form":
+        flow_type = flow.get("type")
+        if flow_type != "form":
+            logger.debug(
+                f"OptionsFlow for {entry_id} returned type={flow_type!r}, "
+                f"not a form — cannot extract option defaults"
+            )
             return {}
         return options_from_form_flow(flow)
     except Exception as exc:
-        logger.warning(
+        log_probe_failure(
             f"Failed to fetch options for {entry_id}: {type(exc).__name__}: {exc}"
         )
         return {}
@@ -151,7 +179,7 @@ async def fetch_entry_options(client: Any, entry_id: str) -> dict[str, Any]:
             try:
                 await client.abort_options_flow(flow_id)
             except Exception as abort_err:
-                logger.warning(
+                log_probe_failure(
                     f"Failed to abort options flow {flow_id}: "
                     f"{type(abort_err).__name__}: {abort_err}"
                 )
@@ -676,7 +704,7 @@ class IntegrationTools:
 
             # Surface `options` on every per-entry response (HA's REST endpoint
             # omits the field). For entries with supports_options=True we probe
-            # via OptionsFlow — see `_fetch_entry_options`. When include_schema
+            # via OptionsFlow — see `fetch_entry_options`. When include_schema
             # is also requested, `_fetch_options_schema` below populates options
             # from the same flow init so we don't pay for two round-trips.
             if isinstance(result, dict):
@@ -824,50 +852,13 @@ class IntegrationTools:
         return options_from_form_flow(flow)
 
     async def _fetch_entry_options(self, entry_id: str) -> dict[str, Any]:
-        """Read the current ``options`` for a config entry via its OptionsFlow.
+        """Instance wrapper around :func:`fetch_entry_options`.
 
-        Home Assistant does not expose ``ConfigEntry.options`` through any
-        read-only REST or WebSocket endpoint — ``/api/config/config_entries/entry``
-        deliberately omits the field. The closest approximation that the HA UI
-        itself uses is the ``default`` values populated into the OptionsFlow's
-        first-step ``data_schema``: integrations build that schema from the
-        existing options dict, so the defaults match the persisted state.
-
-        Starts the flow, harvests ``{name: default}`` from the first step,
-        and aborts the flow in ``finally`` so it doesn't sit half-open.
-
-        Returns ``{}`` on any failure (unsupported entry, non-form first step
-        such as a menu, init/abort errors) so callers can treat the return as
-        the canonical "options" field without further checks. Unexpected
-        exception types are logged at ``warning`` so probe breakage is
-        discoverable.
+        Kept so existing call sites (and the ``include_schema`` path) read
+        naturally as ``self._fetch_entry_options(...)``; the probe logic and
+        full rationale live on the module-level function.
         """
-        flow_id: str | None = None
-        try:
-            flow = await self._client.start_options_flow(entry_id)
-            flow_id = flow.get("flow_id")
-            flow_type = flow.get("type")
-            if flow_type != "form":
-                logger.debug(
-                    f"OptionsFlow for {entry_id} returned type={flow_type!r}, "
-                    f"not a form — cannot extract option defaults"
-                )
-                return {}
-            return self._options_from_form_flow(flow)
-        except Exception as exc:
-            logger.warning(
-                f"Failed to fetch options for {entry_id}: {type(exc).__name__}: {exc}"
-            )
-            return {}
-        finally:
-            if flow_id:
-                try:
-                    await self._client.abort_options_flow(flow_id)
-                except Exception as abort_err:
-                    logger.warning(
-                        f"Failed to abort options flow {flow_id}: "
-                        f"{type(abort_err).__name__}: {abort_err}"
-                    )
+        return await fetch_entry_options(self._client, entry_id)
 
     async def _fetch_options_schema(self, entry_id: str, resp: dict[str, Any]) -> None:
         """Start an options flow to read the schema, then abort it.
@@ -947,7 +938,7 @@ class IntegrationTools:
 
         # `_format_entry` is sync and cannot probe the OptionsFlow; options
         # are filled in by a second async pass below for entries that
-        # advertise supports_options=True. See `_fetch_entry_options`.
+        # advertise supports_options=True. See `fetch_entry_options`.
         formatted_entries = [
             self._format_entry(entry, include_opts, logger_levels) for entry in entries
         ]

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1475,9 +1475,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         The 'helper' search covers both input_* helpers (input_boolean, input_number, ...)
         and UI-created flow-based helpers (template, group, utility_meter, derivative, ...).
-        For flow-helpers, results carry the parent config entry id under ``entry_id`` —
-        pair with ``ha_get_integration(entry_id=..., include_options=True)`` for the full
-        config when ``include_config=False``.
+        For flow-helpers, results carry the parent config entry id under ``entry_id``.
+        When ``include_config=False`` (the default), pair with
+        ``ha_get_integration(entry_id=..., include_options=True)`` to retrieve the full
+        config; set ``include_config=True`` to get it inline in one call.
 
         Args:
             query: Search query (exact substring by default, or fuzzy with exact_match=False)

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1473,6 +1473,12 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         **NOTE:** Dashboards and badges are NOT searched by default. Add 'dashboard' to
         search_types to include them.
 
+        The 'helper' search covers both input_* helpers (input_boolean, input_number, ...)
+        and UI-created flow-based helpers (template, group, utility_meter, derivative, ...).
+        For flow-helpers, results carry the parent config entry id under ``entry_id`` —
+        pair with ``ha_get_integration(entry_id=..., include_options=True)`` for the full
+        config when ``include_config=False``.
+
         Args:
             query: Search query (exact substring by default, or fuzzy with exact_match=False)
             search_types: Types to search (default: ["automation", "script", "scene", "helper"])

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -268,6 +268,116 @@ async def test_deep_search_helper(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_deep_search_finds_ui_template_helper(mcp_client):
+    """Deep search must surface UI-created flow-based (template) helpers.
+
+    Regression for issue #1457: template/group/utility_meter/... helpers live
+    as config entries, not storage records, so the helper search used to miss
+    them entirely. They are now listed via the config-entries endpoint and the
+    options flow is probed so the template body is searchable. This exercises
+    the full chain end-to-end (deep_search → flow-helper probe →
+    fetch_entry_options → description.suggested_value extraction):
+
+    1. found by helper name,
+    2. found by a token inside the template body (the headline fix), and
+    3. include_config=True attaches the probed config.
+    """
+    logger.info("🔍 Testing deep search for UI template helpers")
+
+    # Distinctive token embedded in the template body (not in the name), so a
+    # match on it can only come from probing the options flow config.
+    body_marker = "deepsearchtemplatebody4471"
+    config = {
+        "next_step_id": "sensor",
+        "name": "Deep Search Template Helper",
+        "state": "{{ states('sensor." + body_marker + "') }}",
+    }
+
+    create_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "template", "name": config["name"], "config": config},
+    )
+    create_data = assert_mcp_success(create_result, "Create template helper")
+    entry_id = create_data.get("entry_id")
+    assert entry_id, "Create should return the config entry_id"
+    logger.info(f"✅ Created template helper: {entry_id}")
+
+    try:
+        # 1) Findable by name. Flow-helper results carry the parent config
+        #    entry id under `entry_id` (storage helpers use `entity_id`).
+        data = await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_deep_search",
+            arguments={
+                "query": "Deep Search Template Helper",
+                "search_types": ["helper"],
+                "limit": 10,
+            },
+            predicate=lambda d: any(
+                h.get("entry_id") == entry_id for h in d.get("helpers", [])
+            ),
+            description="deep search finds template helper by name",
+        )
+        assert_deep_search_keys(data)
+        match = next(h for h in data["helpers"] if h.get("entry_id") == entry_id)
+        assert match.get("helper_type") == "template", (
+            f"helper_type should be 'template', got {match.get('helper_type')!r}"
+        )
+        assert match.get("match_in_name") is True, "should match on the name"
+        logger.info(f"✅ Found template helper by name (score {match.get('score')})")
+
+        # 2) Findable by a token inside the template body — only possible if the
+        #    options flow was probed and the template surfaced. This is the
+        #    core of issue #1457.
+        data2 = await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_deep_search",
+            arguments={
+                "query": body_marker,
+                "search_types": ["helper"],
+                "limit": 10,
+            },
+            predicate=lambda d: any(
+                h.get("entry_id") == entry_id for h in d.get("helpers", [])
+            ),
+            description="deep search finds template helper by template body",
+        )
+        match2 = next(h for h in data2["helpers"] if h.get("entry_id") == entry_id)
+        assert match2.get("match_in_config") is True, (
+            "template body must be searchable via the options-flow probe"
+        )
+        logger.info("✅ Found template helper by template body content")
+
+        # 3) include_config=True attaches the probed options (template body).
+        result3 = await mcp_client.call_tool(
+            "ha_deep_search",
+            {
+                "query": body_marker,
+                "search_types": ["helper"],
+                "include_config": True,
+                "limit": 10,
+            },
+        )
+        data3 = assert_mcp_success(result3, "Deep search with include_config")
+        match3 = next(
+            h for h in data3.get("helpers", []) if h.get("entry_id") == entry_id
+        )
+        assert "config" in match3, "include_config=True should attach the helper config"
+        assert body_marker in str(match3["config"]), (
+            "attached config should contain the template body"
+        )
+        logger.info("✅ include_config attached the template body")
+
+    finally:
+        await safe_call_tool(
+            mcp_client,
+            "ha_remove_helpers_integrations",
+            {"target": entry_id, "confirm": True},
+        )
+        logger.info("🧹 Cleaned up template helper")
+
+
+@pytest.mark.asyncio
 async def test_deep_search_all_types(mcp_client):
     """Test deep search across all types simultaneously."""
     logger.info("🔍 Testing deep search across all types")

--- a/tests/src/e2e/tools/test_deep_search.py
+++ b/tests/src/e2e/tools/test_deep_search.py
@@ -378,6 +378,133 @@ async def test_deep_search_finds_ui_template_helper(mcp_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "helper_type,name,config",
+    [
+        pytest.param(
+            "group",
+            "Deep Search Group E2E",
+            {
+                "group_type": "light",
+                "name": "Deep Search Group E2E",
+                "entities": [],
+                "hide_members": False,
+            },
+            id="group",
+        ),
+        pytest.param(
+            "min_max",
+            "Deep Search MinMax E2E",
+            {
+                "name": "Deep Search MinMax E2E",
+                "entity_ids": [
+                    "sensor.demo_temperature",
+                    "sensor.demo_outside_temperature",
+                ],
+                "type": "min",
+            },
+            id="min_max",
+        ),
+    ],
+)
+async def test_deep_search_finds_non_template_flow_helpers(
+    mcp_client, helper_type, name, config
+):
+    """deep_search surfaces non-template flow-based helpers too (issue #1457).
+
+    The flow-helper branch lists config entries for every domain in
+    ``FLOW_HELPER_TYPES``, so a group (menu-rooted flow) and a min_max (single
+    form) must be findable by name alongside template helpers — not just the
+    ``template`` domain.
+    """
+    logger.info(f"🔍 Testing deep search for {helper_type} flow-helper")
+
+    create_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": helper_type, "name": name, "config": config},
+    )
+    create_data = assert_mcp_success(create_result, f"Create {helper_type} helper")
+    entry_id = create_data.get("entry_id")
+    assert entry_id, f"Create should return entry_id for {helper_type}"
+
+    try:
+        data = await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_deep_search",
+            arguments={"query": name, "search_types": ["helper"], "limit": 10},
+            predicate=lambda d: any(
+                h.get("entry_id") == entry_id for h in d.get("helpers", [])
+            ),
+            description=f"deep search finds {helper_type} helper",
+        )
+        match = next(h for h in data["helpers"] if h.get("entry_id") == entry_id)
+        assert match.get("helper_type") == helper_type, (
+            f"helper_type should be {helper_type!r}, got {match.get('helper_type')!r}"
+        )
+        assert match.get("match_in_name") is True, "should match on the name"
+        logger.info(f"✅ Found {helper_type} flow-helper via deep_search")
+    finally:
+        await safe_call_tool(
+            mcp_client,
+            "ha_remove_helpers_integrations",
+            {"target": entry_id, "confirm": True},
+        )
+
+
+@pytest.mark.asyncio
+async def test_deep_search_flow_helper_fuzzy_probes_config(mcp_client):
+    """Fuzzy (``exact_match=False``) deep_search still probes flow-helper config.
+
+    The query is a token inside the template body but NOT the name, so the name
+    scores below 100 and — even in fuzzy mode — the options flow must be probed
+    for the body to be searchable. Exercises the fuzzy branch of the flow-helper
+    search end-to-end (only the exact-match path had E2E coverage before).
+    """
+    logger.info("🔍 Testing fuzzy deep search probes flow-helper config")
+
+    body_marker = "fuzzyflowbodymarker7788"
+    config = {
+        "next_step_id": "sensor",
+        "name": "Deep Search Fuzzy Template",
+        "state": "{{ states('sensor." + body_marker + "') }}",
+    }
+    create_result = await mcp_client.call_tool(
+        "ha_config_set_helper",
+        {"helper_type": "template", "name": config["name"], "config": config},
+    )
+    create_data = assert_mcp_success(create_result, "Create fuzzy template helper")
+    entry_id = create_data.get("entry_id")
+    assert entry_id, "Create should return the config entry_id"
+
+    try:
+        data = await wait_for_tool_result(
+            mcp_client,
+            tool_name="ha_deep_search",
+            arguments={
+                "query": body_marker,
+                "search_types": ["helper"],
+                "exact_match": False,
+                "limit": 10,
+            },
+            predicate=lambda d: any(
+                h.get("entry_id") == entry_id for h in d.get("helpers", [])
+            ),
+            description="fuzzy deep search finds template helper by body",
+        )
+        match = next(h for h in data["helpers"] if h.get("entry_id") == entry_id)
+        assert match.get("match_in_config") is True, (
+            "fuzzy search must surface the template body via the options probe"
+        )
+        logger.info("✅ Fuzzy deep search found template helper by body content")
+    finally:
+        await safe_call_tool(
+            mcp_client,
+            "ha_remove_helpers_integrations",
+            {"target": entry_id, "confirm": True},
+        )
+
+
+@pytest.mark.asyncio
 async def test_deep_search_all_types(mcp_client):
     """Test deep search across all types simultaneously."""
     logger.info("🔍 Testing deep search across all types")

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -126,6 +126,76 @@ class TestConfigEntryFlow:
             {"target": entry_id, "confirm": True},
         )
 
+    async def test_get_entity_config_entry_id_and_options_optimal_path(
+        self, mcp_client
+    ):
+        """End-to-end of the issue #1457 optimal read sequence:
+
+            ha_get_entity(entity_id)                  -> config_entry_id
+            ha_get_integration(entry_id,
+                               include_options=True)  -> template body
+
+        Covers the two read paths that previously had only unit coverage:
+        ``ha_get_entity`` surfacing ``config_entry_id``, and
+        ``include_options`` surfacing a UI template helper's body via
+        ``description.suggested_value``.
+        """
+        body_marker = "optimalpathtemplatebody8829"
+        name = "e2e optimal path template"
+        config = {
+            "next_step_id": "sensor",
+            "name": name,
+            "state": "{{ states('sensor." + body_marker + "') }}",
+        }
+        entry_id = await _create_config_entry_helper(
+            mcp_client, "template", config, "template sensor (optimal path)"
+        )
+        try:
+            # Locate the created template sensor entity.
+            search = await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_search_entities",
+                arguments={"query": name, "limit": 10},
+                predicate=lambda d: any(
+                    r.get("entity_id", "").startswith("sensor.")
+                    for r in d.get("results", [])
+                ),
+                description="created template sensor is searchable",
+            )
+            entity_id = next(
+                r["entity_id"]
+                for r in search["results"]
+                if r.get("entity_id", "").startswith("sensor.")
+            )
+
+            # Change #2: ha_get_entity surfaces the parent config_entry_id, so
+            # an agent can jump straight to ha_get_integration without scanning
+            # a domain list.
+            ge = await mcp_client.call_tool("ha_get_entity", {"entity_id": entity_id})
+            ge_data = assert_mcp_success(ge, "get entity")
+            assert ge_data["entity_entry"]["config_entry_id"] == entry_id, (
+                "ha_get_entity must surface the parent config_entry_id"
+            )
+
+            # Optimal read path: include_options surfaces the template body via
+            # the options-flow probe (description.suggested_value).
+            gi = await mcp_client.call_tool(
+                "ha_get_integration",
+                {"entry_id": entry_id, "include_options": True},
+            )
+            gi_data = assert_mcp_success(gi, "get integration include_options")
+            assert body_marker in str(gi_data), (
+                "include_options should surface the template body for a "
+                "UI-created template helper"
+            )
+            logger.info("✅ optimal read sequence verified end-to-end")
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
+
     async def test_update_min_max_helper(self, mcp_client):
         """Update an existing min_max helper via options flow (upsert with entry_id)."""
         config = {

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -142,6 +142,9 @@ class TestConfigEntryFlow:
         """
         body_marker = "optimalpathtemplatebody8829"
         name = "e2e optimal path template"
+        # HA derives a template helper's entity_id from its name (slugified),
+        # e.g. "Weather Message" -> sensor.weather_message (issue #1457).
+        entity_id = "sensor.e2e_optimal_path_template"
         config = {
             "next_step_id": "sensor",
             "name": name,
@@ -151,28 +154,20 @@ class TestConfigEntryFlow:
             mcp_client, "template", config, "template sensor (optimal path)"
         )
         try:
-            # Locate the created template sensor entity.
-            search = await wait_for_tool_result(
-                mcp_client,
-                tool_name="ha_search_entities",
-                arguments={"query": name, "limit": 10},
-                predicate=lambda d: any(
-                    r.get("entity_id", "").startswith("sensor.")
-                    for r in d.get("results", [])
-                ),
-                description="created template sensor is searchable",
-            )
-            entity_id = next(
-                r["entity_id"]
-                for r in search["results"]
-                if r.get("entity_id", "").startswith("sensor.")
-            )
-
             # Change #2: ha_get_entity surfaces the parent config_entry_id, so
             # an agent can jump straight to ha_get_integration without scanning
-            # a domain list.
-            ge = await mcp_client.call_tool("ha_get_entity", {"entity_id": entity_id})
-            ge_data = assert_mcp_success(ge, "get entity")
+            # a domain list. Poll because the template entity registers shortly
+            # after its config entry; the predicate also asserts the field.
+            ge_data = await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_entity",
+                arguments={"entity_id": entity_id},
+                predicate=lambda d: (
+                    (d.get("entity_entry") or {}).get("config_entry_id") == entry_id
+                ),
+                timeout=60,
+                description="ha_get_entity surfaces config_entry_id",
+            )
             assert ge_data["entity_entry"]["config_entry_id"] == entry_id, (
                 "ha_get_entity must surface the parent config_entry_id"
             )

--- a/tests/src/unit/test_smart_search_flow_helpers.py
+++ b/tests/src/unit/test_smart_search_flow_helpers.py
@@ -146,6 +146,9 @@ class TestFlowHelperDeepSearch:
             include_config=True,
         )
         assert results[0]["config"] == {"state": "{{ comfort_index() }}"}
+        # include_config=True forces the probe even though the title already
+        # exact-matches (the config body has to be fetched to attach it).
+        client.start_options_flow.assert_awaited_once_with("01HXTEMPLATEZ")
 
     async def test_skips_non_flow_helper_domains(self) -> None:
         # Mixed list: only the template entry should be considered.
@@ -212,3 +215,138 @@ class TestFlowHelperDeepSearch:
             include_config=False,
         )
         assert results == []
+
+    async def test_does_not_match_on_opaque_entry_id(self) -> None:
+        # Regression (issue #1457 review): the config-entry ULID must not be a
+        # search target. Here the entry_id contains "weather" but neither the
+        # title nor the template body does — the entry must NOT match "weather".
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXWEATHERZZZ",
+                    "domain": "template",
+                    "title": "Bedroom Light",
+                    "supports_options": True,
+                }
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ 1 + 1 }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "weather",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert results == []
+
+    async def test_skips_entry_with_non_string_entry_id(self) -> None:
+        # A malformed config entry (missing/None entry_id) is skipped without a
+        # probe; the valid sibling is still returned.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": None,
+                    "domain": "template",
+                    "title": "Match Me",
+                    "supports_options": True,
+                },
+                {
+                    "entry_id": "01HXTEMPLATEOK",
+                    "domain": "template",
+                    "title": "Match Me",
+                    "supports_options": True,
+                },
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ true }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "match",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert [r["entry_id"] for r in results] == ["01HXTEMPLATEOK"]
+
+    async def test_probe_failure_on_one_entry_does_not_break_search(self) -> None:
+        # One entry's options probe blowing up must not drop the healthy
+        # sibling (fetch_entry_options swallows to {}; gather isolates faults).
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXBAD",
+                    "domain": "template",
+                    "title": "Broken",
+                    "supports_options": True,
+                },
+                {
+                    "entry_id": "01HXGOOD",
+                    "domain": "template",
+                    "title": "Renamed Sensor",
+                    "supports_options": True,
+                },
+            ]
+        )
+
+        async def flaky_flow(entry_id: str) -> dict[str, Any]:
+            if entry_id == "01HXBAD":
+                raise RuntimeError("flow init exploded")
+            return _make_flow_form("{{ states('sensor.outside_temperature') }}")
+
+        client.start_options_flow = AsyncMock(side_effect=flaky_flow)
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "outside_temperature",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert [r["entry_id"] for r in results] == ["01HXGOOD"]
+
+    async def test_fuzzy_mode_probes_when_title_below_perfect_score(self) -> None:
+        # Regression guard for the probe-skip threshold. In fuzzy mode a title
+        # scoring below 100 (but above fuzzy_threshold) must STILL trigger the
+        # options probe — the config could score higher, and results sort by
+        # score. The earlier logic skipped the probe once the title cleared
+        # fuzzy_threshold, under-ranking such entries.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXFUZZY",
+                    "domain": "template",
+                    "title": "Weather Stuff",
+                    "supports_options": True,
+                }
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ true }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        # Force a mid-range title score: above fuzzy_threshold (60), below 100.
+        with patch.object(tools, "_score_deep_match", return_value=(70, 60, True)):
+            results = await tools._search_flow_helpers(
+                "weather",
+                exact_match=False,
+                semaphore=asyncio.Semaphore(8),
+                include_config=False,
+            )
+        client.start_options_flow.assert_awaited_once_with("01HXFUZZY")
+        assert [r["entry_id"] for r in results] == ["01HXFUZZY"]

--- a/tests/src/unit/test_smart_search_flow_helpers.py
+++ b/tests/src/unit/test_smart_search_flow_helpers.py
@@ -173,7 +173,7 @@ class TestFlowHelperDeepSearch:
 
         tools = _make_tools(client)
         results = await tools._search_flow_helpers(
-            "Match",
+            "match",
             exact_match=True,
             semaphore=asyncio.Semaphore(8),
             include_config=False,

--- a/tests/src/unit/test_smart_search_flow_helpers.py
+++ b/tests/src/unit/test_smart_search_flow_helpers.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``ha_deep_search`` coverage of UI-created flow-based
+helpers (template, group, utility_meter, derivative, ...).
+
+Issue #1457: deep_search previously hard-coded the helper list to
+``input_*`` only, so config-entry helpers were invisible. The flow-helper
+branch now lists config entries for any domain in ``FLOW_HELPER_TYPES``
+and probes each entry's options flow so the helper's current config
+(template body, group members, etc.) is searchable alongside the
+storage-based helpers.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.tools.smart_search import SmartSearchTools
+
+
+def _make_tools(client: Any) -> SmartSearchTools:
+    """Construct SmartSearchTools without loading global settings."""
+    with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+        mock_settings.return_value.fuzzy_threshold = 60
+        return SmartSearchTools(client=client)
+
+
+def _make_flow_form(suggested_value: str) -> dict[str, Any]:
+    """Build the options-flow response shape HA returns for a template helper."""
+    return {
+        "flow_id": "flow-1",
+        "type": "form",
+        "step_id": "binary_sensor",
+        "data_schema": [
+            {
+                "name": "state",
+                "selector": {"template": {}},
+                "description": {"suggested_value": suggested_value},
+                "required": True,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+class TestFlowHelperDeepSearch:
+    """``_search_flow_helpers`` surfaces flow-helper config entries."""
+
+    async def test_template_helper_matches_on_title(self) -> None:
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXTEMPLATEWEATHER",
+                    "domain": "template",
+                    "title": "Weather Message",
+                    "supports_options": True,
+                },
+                {
+                    "entry_id": "01HXTEMPLATEOTHER",
+                    "domain": "template",
+                    "title": "Unrelated",
+                    "supports_options": True,
+                },
+            ]
+        )
+        # Title-only exact match — no probe needed for the matching entry.
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ states('sensor.x') }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        semaphore = asyncio.Semaphore(8)
+        results = await tools._search_flow_helpers(
+            "weather", exact_match=True, semaphore=semaphore, include_config=False
+        )
+
+        entry_ids = {r["entry_id"] for r in results}
+        assert "01HXTEMPLATEWEATHER" in entry_ids
+        assert "01HXTEMPLATEOTHER" not in entry_ids
+        match = next(r for r in results if r["entry_id"] == "01HXTEMPLATEWEATHER")
+        assert match["helper_type"] == "template"
+        assert match["name"] == "Weather Message"
+        assert match["match_in_name"] is True
+        # include_config=False → no config in result, no options probe needed.
+        assert "config" not in match
+
+    async def test_template_helper_matches_on_template_body(self) -> None:
+        # Query is a substring of the template body but NOT the title —
+        # forces the options-flow probe path.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXTEMPLATEX",
+                    "domain": "template",
+                    "title": "Renamed Sensor",
+                    "supports_options": True,
+                },
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form(
+                "{{ states('sensor.outside_temperature') | float }}"
+            )
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "outside_temperature",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+
+        assert len(results) == 1
+        assert results[0]["entry_id"] == "01HXTEMPLATEX"
+        assert results[0]["match_in_config"] is True
+        client.start_options_flow.assert_awaited_once_with("01HXTEMPLATEX")
+        client.abort_options_flow.assert_awaited_once_with("flow-1")
+
+    async def test_include_config_attaches_options_body(self) -> None:
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXTEMPLATEZ",
+                    "domain": "template",
+                    "title": "Comfort Index",
+                    "supports_options": True,
+                }
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ comfort_index() }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "comfort",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=True,
+        )
+        assert results[0]["config"] == {"state": "{{ comfort_index() }}"}
+
+    async def test_skips_non_flow_helper_domains(self) -> None:
+        # Mixed list: only the template entry should be considered.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXLIGHTHUE",
+                    "domain": "hue",
+                    "title": "Hue Bridge",
+                    "supports_options": True,
+                },
+                {
+                    "entry_id": "01HXTEMPLATEAA",
+                    "domain": "template",
+                    "title": "Match Me",
+                    "supports_options": True,
+                },
+            ]
+        )
+        client.start_options_flow = AsyncMock(
+            return_value=_make_flow_form("{{ true }}")
+        )
+        client.abort_options_flow = AsyncMock()
+
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "Match",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert [r["entry_id"] for r in results] == ["01HXTEMPLATEAA"]
+
+    async def test_skips_entries_without_supports_options(self) -> None:
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXNOOPTS",
+                    "domain": "template",
+                    "title": "Locked Template",
+                    "supports_options": False,
+                }
+            ]
+        )
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "locked",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert results == []
+
+    async def test_returns_empty_when_rest_call_fails(self) -> None:
+        client = MagicMock()
+        client._request = AsyncMock(side_effect=RuntimeError("REST down"))
+        tools = _make_tools(client)
+        results = await tools._search_flow_helpers(
+            "anything",
+            exact_match=True,
+            semaphore=asyncio.Semaphore(8),
+            include_config=False,
+        )
+        assert results == []

--- a/tests/src/unit/test_smart_search_flow_helpers.py
+++ b/tests/src/unit/test_smart_search_flow_helpers.py
@@ -10,6 +10,7 @@ storage-based helpers.
 """
 
 import asyncio
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -279,9 +280,12 @@ class TestFlowHelperDeepSearch:
         )
         assert [r["entry_id"] for r in results] == ["01HXTEMPLATEOK"]
 
-    async def test_probe_failure_on_one_entry_does_not_break_search(self) -> None:
-        # One entry's options probe blowing up must not drop the healthy
-        # sibling (fetch_entry_options swallows to {}; gather isolates faults).
+    async def test_probe_swallow_does_not_drop_other_entries(self) -> None:
+        # start_options_flow raising for one entry is swallowed inside
+        # fetch_entry_options (→ {}) *before* score_entry runs, so that entry
+        # simply doesn't match while the healthy sibling is still returned.
+        # The gather-level isolation path (a bug inside score_entry) is covered
+        # by test_score_entry_crash_is_isolated_and_logged.
         client = MagicMock()
         client._request = AsyncMock(
             return_value=[
@@ -316,6 +320,78 @@ class TestFlowHelperDeepSearch:
             include_config=False,
         )
         assert [r["entry_id"] for r in results] == ["01HXGOOD"]
+
+    async def test_score_entry_crash_is_isolated_and_logged(self, caplog) -> None:
+        # A real bug inside score_entry (not a swallowed probe/API error) is
+        # isolated by gather: the bad entry is dropped and logged at WARNING
+        # (discoverable, per review), the healthy entry is still returned, and
+        # the multi-source search does not crash.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXGOOD",
+                    "domain": "template",
+                    "title": "Good",
+                    "supports_options": True,
+                },
+                {
+                    "entry_id": "01HXBOOM",
+                    "domain": "template",
+                    "title": "Boom",
+                    "supports_options": True,
+                },
+            ]
+        )
+        client.start_options_flow = AsyncMock(return_value=_make_flow_form("{{ x }}"))
+        client.abort_options_flow = AsyncMock()
+        tools = _make_tools(client)
+
+        def scorer(entity_id, friendly_name, *args, **kwargs):
+            if friendly_name == "Boom":
+                raise TypeError("scoring blew up")
+            return (100, 100, True)
+
+        with (
+            patch.object(tools, "_score_deep_match", side_effect=scorer),
+            caplog.at_level(logging.WARNING, logger="ha_mcp.tools.smart_search"),
+        ):
+            results = await tools._search_flow_helpers(
+                "good",
+                exact_match=True,
+                semaphore=asyncio.Semaphore(8),
+                include_config=False,
+            )
+
+        assert [r["entry_id"] for r in results] == ["01HXGOOD"]
+        assert "flow-helper scoring failed" in caplog.text
+
+    async def test_below_threshold_score_filters_entry(self) -> None:
+        # A non-zero score below the threshold is filtered via
+        # `if total_score < threshold: return None`.
+        client = MagicMock()
+        client._request = AsyncMock(
+            return_value=[
+                {
+                    "entry_id": "01HXLOW",
+                    "domain": "template",
+                    "title": "Low Score",
+                    "supports_options": True,
+                }
+            ]
+        )
+        client.start_options_flow = AsyncMock(return_value=_make_flow_form("{{ x }}"))
+        client.abort_options_flow = AsyncMock()
+        tools = _make_tools(client)
+
+        with patch.object(tools, "_score_deep_match", return_value=(50, 100, False)):
+            results = await tools._search_flow_helpers(
+                "x",
+                exact_match=True,
+                semaphore=asyncio.Semaphore(8),
+                include_config=False,
+            )
+        assert results == []
 
     async def test_fuzzy_mode_probes_when_title_below_perfect_score(self) -> None:
         # Regression guard for the probe-skip threshold. In fuzzy mode a title

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -788,8 +788,7 @@ class TestHaSetEntityCombined:
         device_rename = result["device_rename"]
         assert device_rename.get("lookup_failed") is None
         assert any(
-            "no associated device" in w
-            for w in device_rename.get("warnings", [])
+            "no associated device" in w for w in device_rename.get("warnings", [])
         )
 
 
@@ -1861,3 +1860,80 @@ class TestHaGetEntityRegistryOptions:
         assert entry["device_class"] == "window"
         assert entry["original_device_class"] is None
         assert entry["options"] == {"sensor": {"display_precision": 2}}
+
+    @pytest.mark.asyncio
+    async def test_get_entity_surfaces_config_entry_id(self, mock_mcp, mock_client):
+        # Issue #1457: agents trying to read a UI-created template helper
+        # need the parent config entry id to call ha_get_integration. Before
+        # this change the field was dropped from the response, forcing them
+        # to fall back to a domain-list scan.
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "entity_id": "sensor.weather_message",
+                    "name": None,
+                    "original_name": "Weather Message",
+                    "icon": None,
+                    "area_id": None,
+                    "disabled_by": None,
+                    "hidden_by": None,
+                    "aliases": [],
+                    "labels": [],
+                    "categories": {},
+                    "device_class": None,
+                    "original_device_class": None,
+                    "options": {},
+                    "platform": "template",
+                    "device_id": None,
+                    "config_entry_id": "01KB6B1Z1SA8B6AVAEMQ4FM8SD",
+                    "unique_id": "01KB6B1Z1SA8B6AVAEMQ4FM8SD",
+                },
+            }
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_get_entity"]
+
+        result = await tool(entity_id="sensor.weather_message")
+
+        entry = result["entity_entry"]
+        assert entry["config_entry_id"] == "01KB6B1Z1SA8B6AVAEMQ4FM8SD"
+        assert entry["platform"] == "template"
+
+    @pytest.mark.asyncio
+    async def test_config_entry_id_is_none_for_yaml_only_entity(
+        self, mock_mcp, mock_client
+    ):
+        # YAML-defined entities (e.g. legacy template platform) have no
+        # config entry — the field is surfaced as None rather than omitted
+        # so consumers can rely on a stable schema.
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "entity_id": "sensor.legacy",
+                    "name": None,
+                    "original_name": "Legacy",
+                    "icon": None,
+                    "area_id": None,
+                    "disabled_by": None,
+                    "hidden_by": None,
+                    "aliases": [],
+                    "labels": [],
+                    "categories": {},
+                    "device_class": None,
+                    "original_device_class": None,
+                    "options": {},
+                    "platform": "sensor",
+                    "device_id": None,
+                    # No config_entry_id key in HA's response.
+                    "unique_id": None,
+                },
+            }
+        )
+        register_entity_tools(mock_mcp, mock_client)
+        tool = self.registered_tools["ha_get_entity"]
+
+        result = await tool(entity_id="sensor.legacy")
+
+        assert result["entity_entry"]["config_entry_id"] is None

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1338,7 +1338,7 @@ class TestFetchEntryOptions:
         assert await fetch_entry_options(client, "entry_y") == {}
         client.abort_options_flow.assert_awaited_once_with("f2")
 
-    async def test_aborts_flow_even_when_extraction_raises(self) -> None:
+    async def test_skips_abort_when_start_raises_before_flow_id(self) -> None:
         client = MagicMock()
         client.start_options_flow = AsyncMock(side_effect=RuntimeError("init blew up"))
         client.abort_options_flow = AsyncMock()
@@ -1346,3 +1346,19 @@ class TestFetchEntryOptions:
         assert await fetch_entry_options(client, "entry_z") == {}
         # start raised before a flow_id existed → abort skipped (no leak)
         client.abort_options_flow.assert_not_awaited()
+
+    async def test_aborts_flow_when_extraction_raises_after_start(self) -> None:
+        # The flow starts (flow_id exists) but parsing the form blows up — the
+        # finally block must still abort so the flow doesn't sit half-open.
+        client = MagicMock()
+        client.start_options_flow = AsyncMock(
+            return_value={"flow_id": "f3", "type": "form", "data_schema": []}
+        )
+        client.abort_options_flow = AsyncMock()
+
+        with patch(
+            "ha_mcp.tools.tools_integrations.options_from_form_flow",
+            side_effect=RuntimeError("parse blew up"),
+        ):
+            assert await fetch_entry_options(client, "entry_w") == {}
+        client.abort_options_flow.assert_awaited_once_with("f3")

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1305,6 +1305,17 @@ class TestOptionsFromFormFlow:
             == {"state": "{{ 1 + 1 }}"}
         )
 
+    def test_malformed_data_schema_not_list_returns_empty(self) -> None:
+        # HA should never return a non-list data_schema, but a malformed
+        # response must degrade to {} rather than iterating a string
+        # character-by-character (which would AttributeError on str.get).
+        assert options_from_form_flow({"data_schema": "not-a-list"}) == {}
+
+    def test_malformed_field_not_dict_is_skipped(self) -> None:
+        # A non-dict entry inside data_schema is skipped, not crashed on.
+        flow = {"data_schema": ["garbage", {"name": "state", "default": "kept"}]}
+        assert options_from_form_flow(flow) == {"state": "kept"}
+
 
 class TestFetchEntryOptions:
     """``fetch_entry_options`` module-level probe (issue #1457)."""
@@ -1362,3 +1373,13 @@ class TestFetchEntryOptions:
         ):
             assert await fetch_entry_options(client, "entry_w") == {}
         client.abort_options_flow.assert_awaited_once_with("f3")
+
+    async def test_returns_empty_when_form_has_no_flow_id(self) -> None:
+        # A form response missing flow_id yields {} and skips the abort —
+        # there's no flow_id to abort — without raising.
+        client = MagicMock()
+        client.start_options_flow = AsyncMock(return_value={"type": "form"})
+        client.abort_options_flow = AsyncMock()
+
+        assert await fetch_entry_options(client, "entry_nf") == {}
+        client.abort_options_flow.assert_not_awaited()

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -18,6 +18,8 @@ from ha_mcp.client.rest_client import (
 from ha_mcp.tools.tools_integrations import (
     IntegrationTools,
     _get_entry_id_for_flow_helper,
+    fetch_entry_options,
+    options_from_form_flow,
 )
 
 
@@ -1221,3 +1223,126 @@ class TestGetIntegrationDiagnostics:
         err_payload = json.loads(str(excinfo.value))
         assert err_payload["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "diagnostics_data_path" in err_payload["error"]["message"]
+
+
+class TestOptionsFromFormFlow:
+    """``options_from_form_flow`` field extraction (issue #1457)."""
+
+    def test_reads_default_when_present(self) -> None:
+        flow = {
+            "data_schema": [
+                {"name": "max_value", "default": 42},
+            ]
+        }
+        assert options_from_form_flow(flow) == {"max_value": 42}
+
+    def test_falls_back_to_value_for_constant_fields(self) -> None:
+        flow = {"data_schema": [{"name": "fixed", "value": "constant"}]}
+        assert options_from_form_flow(flow) == {"fixed": "constant"}
+
+    def test_falls_back_to_description_suggested_value_for_template(self) -> None:
+        # UI-created template helpers stash the current template body under
+        # description.suggested_value — not as a top-level field key.
+        # Before issue #1457 the extractor skipped this path, so options
+        # came back empty for template/group/utility_meter/derivative/...
+        flow = {
+            "data_schema": [
+                {
+                    "name": "state",
+                    "selector": {"template": {}},
+                    "description": {
+                        "suggested_value": "{{ states('sensor.x') | float }}",
+                    },
+                    "required": True,
+                },
+                {
+                    "name": "device_class",
+                    "selector": {"select": {"options": ["temperature"]}},
+                    "description": {"suggested_value": "temperature"},
+                },
+            ]
+        }
+        assert options_from_form_flow(flow) == {
+            "state": "{{ states('sensor.x') | float }}",
+            "device_class": "temperature",
+        }
+
+    def test_default_wins_over_description_suggested_value(self) -> None:
+        flow = {
+            "data_schema": [
+                {
+                    "name": "field",
+                    "default": "wins",
+                    "description": {"suggested_value": "loses"},
+                }
+            ]
+        }
+        assert options_from_form_flow(flow) == {"field": "wins"}
+
+    def test_skips_fields_with_no_value_anywhere(self) -> None:
+        flow = {
+            "data_schema": [
+                {"name": "optional_blank"},
+                {"name": "explicit_none", "default": None},
+            ]
+        }
+        assert options_from_form_flow(flow) == {}
+
+    def test_static_alias_on_class_calls_module_helper(self) -> None:
+        # Backwards-compatibility: callers still using the @staticmethod
+        # alias must get the same answer as the module-level helper.
+        flow = {
+            "data_schema": [
+                {
+                    "name": "state",
+                    "description": {"suggested_value": "{{ 1 + 1 }}"},
+                }
+            ]
+        }
+        assert (
+            IntegrationTools._options_from_form_flow(flow)
+            == options_from_form_flow(flow)
+            == {"state": "{{ 1 + 1 }}"}
+        )
+
+
+class TestFetchEntryOptions:
+    """``fetch_entry_options`` module-level probe (issue #1457)."""
+
+    async def test_returns_options_from_form_flow(self) -> None:
+        client = MagicMock()
+        client.start_options_flow = AsyncMock(
+            return_value={
+                "flow_id": "f1",
+                "type": "form",
+                "data_schema": [
+                    {
+                        "name": "state",
+                        "description": {"suggested_value": "{{ true }}"},
+                    }
+                ],
+            }
+        )
+        client.abort_options_flow = AsyncMock()
+
+        assert await fetch_entry_options(client, "entry_x") == {"state": "{{ true }}"}
+        client.abort_options_flow.assert_awaited_once_with("f1")
+
+    async def test_returns_empty_when_flow_is_a_menu(self) -> None:
+        client = MagicMock()
+        client.start_options_flow = AsyncMock(
+            return_value={"flow_id": "f2", "type": "menu", "menu_options": []}
+        )
+        client.abort_options_flow = AsyncMock()
+
+        assert await fetch_entry_options(client, "entry_y") == {}
+        client.abort_options_flow.assert_awaited_once_with("f2")
+
+    async def test_aborts_flow_even_when_extraction_raises(self) -> None:
+        client = MagicMock()
+        client.start_options_flow = AsyncMock(side_effect=RuntimeError("init blew up"))
+        client.abort_options_flow = AsyncMock()
+
+        assert await fetch_entry_options(client, "entry_z") == {}
+        # start raised before a flow_id existed → abort skipped (no leak)
+        client.abort_options_flow.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Closes #1457.

Reading or searching a UI-created flow-based helper (template / group /
utility_meter / derivative / ...) used to take 4–5 tool calls because every read
path agents naturally try failed: `ha_get_state` returns the rendered output, not
the template body; `ha_get_integration(domain="template")` returned `options:{}`
for every entry; `ha_deep_search` couldn't see config-entry helpers at all; only
`ha_get_integration(entry_id, include_schema=True)` worked.

### Root causes (all in ha-mcp, not HA core)

1. **`options_from_form_flow` only checked `default`/`value`.** UI flow-helpers
   stash the current value under `description.suggested_value` (voluptuous ships
   `suggested_value=...` into the field's `description` sub-object, not as a
   top-level field key). Now read as a third fallback, so `include_options=True`
   returns the template body, group members, source entity, etc.
2. **`ha_get_entity` dropped `config_entry_id`.** It's on every registry entry —
   surfaced so agents can map entity_id → entry_id without scanning a domain list.
3. **`ha_deep_search` hard-coded the helper list to `input_*`.** Added a
   flow-helper pass that lists config entries for any domain in
   `FLOW_HELPER_TYPES` and probes each entry's options flow so the helper's
   current config (template body, group members, ...) is searchable.

### Optimal sequence after this change

```
ha_get_entity(entity_id)                              → config_entry_id
ha_get_integration(entry_id=…, include_options=True)  → template body
ha_config_set_helper(helper_type="template", helper_id=…, config=…)
```

Docstrings on `ha_get_entity`, `ha_get_integration.include_options`, and
`ha_deep_search` point agents at this path.

### Review hardening (Gemini Code Assist + review pass)

- Flow-helper search scores a **title-derived slug**, not the opaque config-entry
  ULID, and excludes `entry_id` from the search haystack — prevents
  false-positive matches on random ULID substrings.
- The options probe is skipped **only when the title scores a perfect 100**
  (exact and fuzzy), so a fuzzy title match below 100 still probes — accurate
  ranking and `match_in_config`.
- `fetch_entry_options` logs probe failures at `debug` for the bulk `deep_search`
  caller (`quiet=True`) and `warning` for the single-entry `include_options` path.
- Instance `_fetch_entry_options` delegates to the module-level
  `fetch_entry_options` (single source of truth + rationale).

**Refactor:** extracted `options_from_form_flow` + `fetch_entry_options` to module
level so `smart_search` reuses the same probe.

## Type of change
- [x] 🐛 Bug fix
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

**Unit** — flow-helper scoring (slug vs opaque id, fuzzy probe threshold,
per-entry exception isolation, non-string entry_id), `options_from_form_flow`
precedence (`default` → `value` → `suggested_value`), `fetch_entry_options` abort
paths, and `ha_get_entity` `config_entry_id` (present + None).

**E2E** — deep_search finds UI template helpers (by name, by template body,
`include_config`), non-template flow helpers (group, min_max), the fuzzy-mode
probe path, and the full `ha_get_entity → config_entry_id →
ha_get_integration(include_options=True)` read sequence.

## Checklist
- [x] I have updated documentation if needed