### PR TITLE
fix: stop dev builds from publishing the :latest Docker tag

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -129,9 +129,13 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          # Do NOT push :latest from dev builds. :latest is reserved for stable
+          # releases (release-publish.yml pushes :latest + :stable together).
+          # Dev builds run on every push to master, so tagging :latest here
+          # clobbers the default tag with bleeding-edge dev between the biweekly
+          # stable releases. The dev channel is :dev (rolling) + :dev-<sha>. (#1475)
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}:dev
-            ${{ env.REGISTRY }}/${{ github.repository }}:latest
             ${{ env.REGISTRY }}/${{ github.repository }}:dev-${{ needs.prepare.outputs.short_sha }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,11 +415,14 @@ On merge, `hotfix-release.yml` runs semantic-release, creates GitHub release, sy
 | `e2e-tests.yml` | PR to master | Full E2E tests (~3 min) |
 | `publish-dev.yml` | Push to master | Dev release `.devN` |
 | `notify-dev-channel.yml` | Push to master (src/) | Comment on PRs/issues with dev testing instructions |
-| `semver-release.yml` | Biweekly Wed 10:00 UTC | Stable release |
+| `semver-release.yml` | Biweekly Wed 10:00 UTC | Stable release (cuts version tag + GitHub release) |
+| `release-publish.yml` | After SemVer Release (`workflow_run`) or manual dispatch | Publish stable Docker image (`:latest` + `:stable` + semver) + MCP registry |
 | `hotfix-release.yml` | Hotfix PR merged | Immediate patch release |
 | `build-binary.yml` | Release | Linux/macOS/Windows binaries |
 | `addon-publish.yml` | Release | HA add-on update |
 | `sync-tool-docs.yml` | Push to master (`src/ha_mcp/tools/`, `scripts/extract_tools.py`) | Regenerate `tools.json`, README, DOCS.md |
+
+**Docker image tags** (`ghcr.io/homeassistant-ai/ha-mcp`): stable releases push `:latest` + `:stable` + semver tags (`release-publish.yml`); dev builds push only `:dev` + `:dev-<sha>` (`publish-dev.yml`) — **never `:latest`**, which is reserved for stable. The HA add-on images live in separate repos (`-addon-{arch}`, `-addon-dev-{arch}`) and are selected by an explicit `version:` pin, not by `:latest`.
 
 ## Development Commands
 

--- a/docs/dev-channel.md
+++ b/docs/dev-channel.md
@@ -16,7 +16,13 @@ Want to test the latest changes before the biweekly stable release? The dev chan
 | **Dev** | Every push to master | `ha-mcp-dev` / `:dev` |
 | **Stable** | Biweekly (Wednesday 10:00 UTC) | `ha-mcp` / `:latest` |
 
-> **Docker tags:** Each stable release publishes the same image under both `:latest` (the default tag pulled when none is specified) and `:stable`. They point at identical bits — use `:stable` if you want "stable only" to be unambiguous in a compose file or config. The dev channel is `:dev` (rolling, every master push) plus `:dev-<sha>` (pinned to one dev build). `:latest` only ever tracks stable, never dev.
+**Docker tags at a glance** (image `ghcr.io/homeassistant-ai/ha-mcp`):
+
+- `:latest` / `:stable` — the most recent stable release; both point at identical bits. `:latest` is the default tag pulled when none is given; use `:stable` to make "stable only" explicit in a compose file or config.
+- `:dev` — the rolling dev channel, rebuilt on every push to master.
+- `:dev-<sha>` — an immutable tag pinned to one specific dev build (see the Docker section below).
+
+`:latest` only ever tracks stable, never dev.
 
 ## Installation Methods
 
@@ -99,6 +105,13 @@ Dev images are published to GitHub Container Registry with the `dev` tag.
 **Pull the dev image:**
 ```bash
 docker pull ghcr.io/homeassistant-ai/ha-mcp:dev
+```
+
+**Pin a specific dev build:**
+
+Every dev build is also published under an immutable `:dev-<sha>` tag (the short commit SHA), so you can pin to one exact build — handy when verifying a fix on a specific commit. Unlike `:dev`, a `:dev-<sha>` tag never moves:
+```bash
+docker pull ghcr.io/homeassistant-ai/ha-mcp:dev-a1b2c3d
 ```
 
 **Run in stdio mode (Claude Desktop):**

--- a/docs/dev-channel.md
+++ b/docs/dev-channel.md
@@ -16,6 +16,8 @@ Want to test the latest changes before the biweekly stable release? The dev chan
 | **Dev** | Every push to master | `ha-mcp-dev` / `:dev` |
 | **Stable** | Biweekly (Wednesday 10:00 UTC) | `ha-mcp` / `:latest` |
 
+> **Docker tags:** Each stable release publishes the same image under both `:latest` (the default tag pulled when none is specified) and `:stable`. They point at identical bits — use `:stable` if you want "stable only" to be unambiguous in a compose file or config. The dev channel is `:dev` (rolling, every master push) plus `:dev-<sha>` (pinned to one dev build). `:latest` only ever tracks stable, never dev.
+
 ## Installation Methods
 
 ### uvx (Recommended)


### PR DESCRIPTION
## What does this PR do?

Fixes #1475: `ghcr.io/homeassistant-ai/ha-mcp:latest` was tracking dev builds instead of stable.

`publish-dev.yml` tagged every dev build (one per master push) with `:latest` on top of `:dev`/`:dev-<sha>`. Because dev publishes far outnumber the biweekly stable release (`release-publish.yml`, which also pushes `:latest`), the dev workflow won the tag race almost always — so the default `docker pull ghcr.io/homeassistant-ai/ha-mcp` resolved to a dev build flagged "use at your own risk."

This removes the `:latest` push from the dev workflow (keeping `:dev` + `:dev-<sha>`) and adds a comment so it isn't reinstated. `:latest` is now published only by stable releases, alongside `:stable`. `docs/dev-channel.md` now documents the full scheme.

**Verified unaffected:** the e2e/HAOS flows never pull the published ha-mcp image (they run ha-mcp in-process against upstream HA Core, or rebuild the add-on from source in-VM); the HA add-on selects images by an explicit `version:` pin in separate namespaces, not `:latest`.

**Note:** this prevents future clobbering but does not move the tag already live in GHCR. The next biweekly stable release re-points `:latest`; a manual `release-publish.yml` `workflow_dispatch` corrects it immediately.

## Type of change
- [x] 🐛 Bug fix
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

CI publish-workflow + docs only — no application code, and a tag-list edit can't be exercised without actually publishing. YAML structure unchanged.

## Checklist
- [x] I have updated documentation if needed
