### PR TITLE
docs: clarify add-on vs uvx; add Codex + HTTP-native client setup

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -46,6 +46,8 @@ Full features and documentation: https://github.com/homeassistant-ai/ha-mcp
 
 ## Client Configuration
 
+> **You already have the add-on — connect your client to it.** The steps below point a client at this add-on's HTTP endpoint (ha-mcp running *inside* Home Assistant). You do **not** also need `uvx ha-mcp`: that starts a *separate* local copy of the server on your own machine and does **not** talk to this add-on, so running both side by side gives you two independent instances. `uvx` is the alternative for people *not* running the add-on (e.g. no Home Assistant OS) — see the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/) for that path.
+
 ### <details><summary><b>📱 Claude Desktop</b></summary>
 
 Claude Desktop requires a proxy to connect to HTTP MCP servers. Install **mcp-proxy** first:
@@ -100,6 +102,24 @@ claude mcp add-json home-assistant '{
 Replace the URL with the one from your add-on logs.
 
 **Restart Claude Code** after adding the configuration.
+
+</details>
+
+### <details><summary><b>📘 Codex</b></summary>
+
+Codex connects to HTTP MCP servers directly — use the URL from your add-on logs:
+
+```bash
+codex mcp add home-assistant --url http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw
+```
+
+**Heads-up:** as of early 2026, Codex's HTTP MCP support has a known initialization bug ([openai/codex#11284](https://github.com/openai/codex/issues/11284)) where the server connects but exposes **no tools**, even when the same endpoint works in other clients. If Codex shows no ha-mcp tools, run ha-mcp locally over stdio with `uvx` (see the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/)) instead.
+
+</details>
+
+### <details><summary><b>🧩 Cursor / Windsurf / other HTTP-native clients</b></summary>
+
+These connect to HTTP MCP servers directly: add a new HTTP MCP server pointing at the **MCP Server URL** from the add-on logs — no proxy needed. See your client's own MCP configuration docs for the exact field name.
 
 </details>
 

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -56,6 +56,7 @@ const withBase = (path: string) => {
         <div class="faq-item">
           <h3 class="text-lg font-medium text-white mb-2">Do I need the Home Assistant Add-on?</h3>
           <p class="text-slate-300"><strong class="text-green-400">No.</strong> The HA add-on is just one installation method. Most users run ha-mcp directly on their computer using <code class="bg-slate-800 px-1 rounded">uvx</code> (recommended for Claude Desktop). The add-on is only needed if you want to run ha-mcp inside your Home Assistant OS environment.</p>
+          <p class="text-slate-400 text-sm mt-2">If you <em>do</em> run the add-on, you don't also need <code class="bg-slate-800 px-1 rounded">uvx</code> — that would be a second, separate instance. HTTP-native clients (Codex, Cursor, Windsurf, Claude Code) connect straight to the add-on's URL, no proxy needed. One caveat: as of early 2026, Codex's HTTP MCP support has a <a href="https://github.com/openai/codex/issues/11284" class="text-blue-400 hover:underline">known initialization bug</a> where it loads no tools; if you hit that, run ha-mcp locally over stdio with <code class="bg-slate-800 px-1 rounded">uvx</code> instead.</p>
         </div>
 
         <div class="faq-item">


### PR DESCRIPTION
## What does this PR do?

Closes the documentation gap from #1470. The bundled add-on `DOCS.md` heavily featured `mcp-proxy` (correct for stdio-only Claude Desktop) but never told add-on users that HTTP-native clients connect to the add-on directly, or that `uvx` is a *separate* local deployment rather than something layered on the add-on. A Codex user followed the `mcp-proxy` path and lost hours.

- **Orientation note (add-on-centric):** you already have the add-on, connect to it; `uvx` is the alternative for people *not* running the add-on, not a second parallel instance.
- **Codex section:** connect via `codex mcp add --url` (matching the Setup Wizard's generated command), plus a heads-up that Codex's HTTP MCP support has a known init bug (openai/codex#11284) where it loads no tools — reliable fallback is `uvx` over stdio.
- **Cursor / Windsurf / HTTP-native section:** connect directly to the add-on URL, no proxy.
- **Site FAQ:** mirrors the add-on-vs-uvx and HTTP-native points.

## Type of change
- [x] 📚 Documentation

## Testing
Documentation-only (Markdown + one FAQ paragraph); no runtime code touched. CI validation (E2E + Docker/add-on) runs on this PR.

## Checklist
- [x] I have updated documentation if needed