### PR TITLE
docs(#1157): scripts native-for: guidance + fix numeric_state-condition for: overclaim

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -482,8 +482,8 @@ class AutomationConfigTools:
           `{{ states(x) in [...] }}`
         - `condition: time` instead of `{{ now().hour ... }}` or `{{ now().weekday() ... }}`
         - `condition: sun` instead of `{{ is_state('sun.sun', ...) }}`
-        - Native `for:` field on `state`/`numeric_state` triggers and conditions over
-          `{{ now() - X.last_changed > timedelta(...) }}` duration math.
+        - Native `for:` field on `state`/`numeric_state` triggers and `state`
+          conditions over `{{ now() - X.last_changed > timedelta(...) }}` duration math.
         - `wait_for_trigger` instead of `wait_template`
         - `choose` action instead of template-based service names
         - For one-shot date firing, use a `time` trigger plus `automation.turn_off` on a

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -436,8 +436,8 @@ class ConfigScriptTools:
         schema. Templates in logic positions fail silently and obscure intent.
         - `choose` / `if/then/else` instead of template-based service names
         - `wait_for_trigger` instead of `wait_template`
-        - Native `for:` field on `state`/`numeric_state` conditions inside
-          `choose`/`if` (and on `wait_for_trigger` triggers) instead of
+        - Native `for:` field on `state` conditions inside `choose`/`if`, and on
+          `state`/`numeric_state` triggers in `wait_for_trigger`, instead of
           `{{ now() - X.last_changed > timedelta(...) }}` duration math.
         - `repeat` with `for_each` instead of template loops
         - Hardcode `target.entity_id` literals — never `{{ this.entity_id }}`.

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -436,6 +436,9 @@ class ConfigScriptTools:
         schema. Templates in logic positions fail silently and obscure intent.
         - `choose` / `if/then/else` instead of template-based service names
         - `wait_for_trigger` instead of `wait_template`
+        - Native `for:` field on `state`/`numeric_state` conditions inside
+          `choose`/`if` (and on `wait_for_trigger` triggers) instead of
+          `{{ now() - X.last_changed > timedelta(...) }}` duration math.
         - `repeat` with `for_each` instead of template loops
         - Hardcode `target.entity_id` literals — never `{{ this.entity_id }}`.
         Templates are appropriate ONLY in `data.*` fields, notification message/title,

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1206,7 +1206,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - `condition: numeric_state` over `{{ states('x') | float > N }}`
         - `condition: state` over `{{ is_state(...) }}`
         - `condition: time` / `condition: sun` over `now().hour` / `is_state('sun.sun', ...)`
-        - Native `for:` field on state/numeric_state triggers and conditions over
+        - Native `for:` field on state/numeric_state triggers and state conditions over
           `{{ now() - X.last_changed > timedelta(...) }}` duration math
         - `choose` action over templated `service:` / `action:` strings
         See `ha_get_skill_guide` (best-practices skill) for the full anti-pattern list.


### PR DESCRIPTION
## What does this PR do?

Two related docs changes around the native `for:` field:

1. **Scripts gap (Area 1 of #1157):** adds a `for:` call-out to the `ha_config_set_script` "prefer native over templates" docstring — `for:` on `state` conditions inside `choose`/`if`, and on `state`/`numeric_state` triggers in `wait_for_trigger` — mirroring the guidance already on `ha_config_set_automation`.
2. **Correctness fix (web-doc fact-check):** the official docs (home-assistant.io/docs/scripts/conditions/) show the native `for:` field is on `state`/`numeric_state` *triggers* but only on `state` *conditions* — `numeric_state` conditions have no `for:`. The new bullet, plus the same pre-existing overclaim in the `ha_config_set_automation` and `ha_eval_template` docstrings (which read "`state`/`numeric_state` triggers *and conditions*"), are corrected to "... and `state` conditions".

This is **Part of #1157**, not a full close — the Area 4 template-function help surface is in progress as homeassistant-ai/skills#51 (see Future improvements). `site/src/data/tools.json`, the README table, and `homeassistant-addon/DOCS.md` regenerate post-merge via `sync-tool-docs.yml`, so no generated-doc edits are included here.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

Area 4 of #1157 (template-function help surface):
- **(a)** A curated reference is up as a draft PR on the skills repo (homeassistant-ai/skills#51); the ha-mcp side is a submodule bump once that merges.
- **(b)** Per-function-URL enrichment of `ha_eval_template` errors is not feasible: HA template render errors reach the tool as `Command failed: {}` with no function/filter name to parse.

## Checklist
- [x] I have updated documentation if needed