### PR TITLE
docs: telemetry wording — follow HA analytics setting, not opt-in-only

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** May 2026
+**Last updated:** June 2026
 
 ## Scope
 
@@ -12,7 +12,7 @@ Ha-mcp runs on your local machine and communicates with your own Home Assistant 
 
 ## Anonymous Usage Statistics
 
-Anonymous usage statistics are a planned future feature and are **not currently collected or transmitted** as of May 2026. When this feature is implemented, it will respect your Home Assistant analytics/telemetry setting by default, and you will be able to override that choice (opt out). Users will be notified in the release notes — and through a prominent in-app notice — before it becomes active.
+Anonymous usage statistics are a planned future feature and are **not currently collected or transmitted** as of June 2026. When this feature is implemented, it will respect your Home Assistant analytics/telemetry setting by default, and you will be able to override that choice (opt out). The change will be announced prominently in the release notes — shown in the README, on the GitHub releases page, and in the web Settings UI — at least one month before it takes effect.
 
 When enabled in a future release, anonymous usage statistics would include:
 
@@ -59,7 +59,7 @@ When you use ha-mcp, your MCP client accesses data from your Home Assistant inst
 
 ## Changes to This Policy
 
-We may update this privacy policy to reflect changes in our practices. Significant changes will be noted in release notes.
+We may update this privacy policy to reflect changes in our practices. Any change that affects what data is collected or transmitted will be announced prominently in the release notes — shown in the README, on the GitHub releases page, and in the web Settings UI — at least one month before it takes effect.
 
 ## Contact
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,7 +12,7 @@ Ha-mcp runs on your local machine and communicates with your own Home Assistant 
 
 ## Anonymous Usage Statistics
 
-Anonymous usage statistics are a planned future feature and are **not currently collected or transmitted** as of May 2026. When this feature is implemented, users will be notified in the release notes and it will be **opt-in only**.
+Anonymous usage statistics are a planned future feature and are **not currently collected or transmitted** as of May 2026. When this feature is implemented, it will respect your Home Assistant analytics/telemetry setting by default, and you will be able to override that choice (opt out). Users will be notified in the release notes — and through a prominent in-app notice — before it becomes active.
 
 When enabled in a future release, anonymous usage statistics would include:
 
@@ -49,7 +49,7 @@ When you use ha-mcp, your MCP client accesses data from your Home Assistant inst
 
 - **Your Home Assistant instance** — via the URL and token you provide
 - **Your MCP client** — the application that runs ha-mcp
-- **A telemetry server** — *planned future feature, not currently active*; would only receive data if you opt in
+- **A telemetry server** — *planned future feature, not currently active*; when active it would follow your Home Assistant analytics/telemetry setting, which you can override (opt out)
 
 ## Data Security
 
@@ -72,7 +72,7 @@ For privacy-related questions or concerns:
 
 | Aspect | Status |
 |--------|--------|
-| Anonymous telemetry | Not currently implemented (planned future feature, opt-in only) |
+| Anonymous telemetry | Not currently implemented (planned; will follow your Home Assistant analytics/telemetry setting, override-able) |
 | Personal data collected | None |
 | Bug reports | User-approved only |
 | Local processing | Yes |

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ For comprehensive testing documentation, see **[tests/README.md](tests/README.md
 
 Ha-mcp runs **locally** on your machine. Your smart home data stays on your network.
 
-- **No telemetry today** — anonymous usage stats are a planned future feature (as of May 2026); when it lands it will follow your Home Assistant analytics/telemetry setting (which you can override), and users will be notified beforehand
+- **No telemetry today** — anonymous usage stats are a planned future feature (as of June 2026); when it lands it will follow your Home Assistant analytics/telemetry setting (which you can override), announced prominently in the release notes and the web Settings UI at least one month beforehand
 - **No personal data collection** — we never collect entity names, configs, or device data
 - **User-controlled bug reports** — only sent with your explicit approval
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ For comprehensive testing documentation, see **[tests/README.md](tests/README.md
 
 Ha-mcp runs **locally** on your machine. Your smart home data stays on your network.
 
-- **No telemetry today** — anonymous usage stats are a planned future feature (as of May 2026); users will be notified when it lands and it will be opt-in only
+- **No telemetry today** — anonymous usage stats are a planned future feature (as of May 2026); when it lands it will follow your Home Assistant analytics/telemetry setting (which you can override), and users will be notified beforehand
 - **No personal data collection** — we never collect entity names, configs, or device data
 - **User-controlled bug reports** — only sent with your explicit approval
 


### PR DESCRIPTION
## What does this PR do?

Updates the future-telemetry wording in `PRIVACY.md` and `README.md`. Drops the
"opt-in only" promise — when telemetry is implemented it will follow your Home
Assistant analytics/telemetry setting by default, with the ability to override
(opt out). Keeps the existing "not currently implemented" framing. Docs only.

## Type of change
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent — N/A (docs-only)
- [ ] All automated tests pass (`uv run pytest`) — N/A (no code changed)
- [ ] Code follows style guidelines (`uv run ruff check`) — N/A (no Python changed)

## Checklist
- [x] I have updated documentation if needed
