### PR TITLE
fix: refine last_changed/last_updated duration-math detector (#1157)

### DIFF
--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -85,8 +85,10 @@ _RE_DIRECT_STATE = re.compile(r"\bstates\.\w+\.\w+\.state\b")
 #       required — a bare ``X.last_changed < now()`` is *always* true and carries
 #       no duration, so it is intentionally NOT flagged: ``for:`` cannot express it)
 #   now() (<|<=|>|>=) X.last_changed + <delta>      (now() on the left)
+#   X.last_changed + <delta> (<|<=|>|>=) now()      (delta added to the attribute)
 #   now().timestamp() - X.last_changed.timestamp()  (epoch subtraction)
-#   as_timestamp(now()) - as_timestamp(X.last_changed)
+#   as_timestamp(now()) - as_timestamp(X.last_changed)        (function form)
+#   as_timestamp(now()) - X.last_changed | as_timestamp       (filter form)
 # Every alternation requires a dotted qualifier ending on a word boundary, so
 # bare Jinja variables literally named ``last_changed`` and longer look-alike
 # attributes (``last_changed_at``) are not falsely flagged; a leading ``word.``
@@ -100,8 +102,10 @@ _RE_DURATION_MATH = re.compile(
     r"\bnow\(\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\b"
     r"|\b(?:\w+\.)+last_(?:changed|updated)\b\s*[<>]=?\s*now\(\)\s*-"
     r"|\bnow\(\)\s*[<>]=?\s*(?:\w+\.)+last_(?:changed|updated)\b\s*\+"
+    r"|\b(?:\w+\.)+last_(?:changed|updated)\b\s*\+\s*[^<>{}]+?[<>]=?\s*now\(\)"
     r"|\bnow\(\)\.timestamp\(\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\.timestamp\(\)"
     r"|\bas_timestamp\(\s*now\(\)\s*\)\s*-\s*as_timestamp\([^)]*\.last_(?:changed|updated)\b"
+    r"|\bas_timestamp\(\s*now\(\)\s*\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\b\s*\|\s*as_timestamp\b"
 )
 # Motion entity pattern
 _RE_MOTION = re.compile(r"binary_sensor\.\w*motion", re.IGNORECASE)

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -78,11 +78,30 @@ _RE_STATE_IN = re.compile(r"states\s*\([^)]+\)\s+in\s+[\[(]")
 # Unsafe direct state access: states.sensor.x.state
 _RE_DIRECT_STATE = re.compile(r"\bstates\.\w+\.\w+\.state\b")
 # Duration/recency checks via last_changed or last_updated arithmetic.
-# Both alternations require at least one dotted qualifier (e.g. ``states.sensor.x.``)
-# so bare Jinja variables named ``last_changed`` are not falsely flagged.
+# Catches the shapes that compute "how long since X changed", all of which map
+# to the native ``for:`` field:
+#   now() - X.last_changed                          (forward subtraction)
+#   X.last_changed (<|<=|>|>=) now() - <delta>      (reversed; the subtraction is
+#       required — a bare ``X.last_changed < now()`` is *always* true and carries
+#       no duration, so it is intentionally NOT flagged: ``for:`` cannot express it)
+#   now() (<|<=|>|>=) X.last_changed + <delta>      (now() on the left)
+#   now().timestamp() - X.last_changed.timestamp()  (epoch subtraction)
+#   as_timestamp(now()) - as_timestamp(X.last_changed)
+# Every alternation requires a dotted qualifier ending on a word boundary, so
+# bare Jinja variables literally named ``last_changed`` and longer look-alike
+# attributes (``last_changed_at``) are not falsely flagged; a leading ``word.``
+# (``trigger.``, ``states.sensor.x.``) is the minimum.
+# Intentionally NOT matched (heuristic limits, low value): the reversed
+# as_timestamp operand order, the reversed ``.timestamp()`` order, and
+# ``state_attr(e, 'last_changed')`` / ``states('e').last_changed`` — the latter
+# two are not valid ways to read a state's ``last_changed`` in HA anyway. These
+# fall through to the generic template fallback in condition/trigger positions.
 _RE_DURATION_MATH = re.compile(
     r"\bnow\(\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\b"
-    r"|\b(?:\w+\.)+last_(?:changed|updated)\s*<\s*now\(\)"
+    r"|\b(?:\w+\.)+last_(?:changed|updated)\b\s*[<>]=?\s*now\(\)\s*-"
+    r"|\bnow\(\)\s*[<>]=?\s*(?:\w+\.)+last_(?:changed|updated)\b\s*\+"
+    r"|\bnow\(\)\.timestamp\(\)\s*-\s*(?:\w+\.)+last_(?:changed|updated)\.timestamp\(\)"
+    r"|\bas_timestamp\(\s*now\(\)\s*\)\s*-\s*as_timestamp\([^)]*\.last_(?:changed|updated)\b"
 )
 # Motion entity pattern
 _RE_MOTION = re.compile(r"binary_sensor\.\w*motion", re.IGNORECASE)
@@ -220,7 +239,15 @@ def _check_template_string(
     initial_count = len(warnings)
     label = position.capitalize()
 
-    if _RE_NUMERIC_CMP.search(template):
+    # Duration/recency math (e.g. `(now() - X.last_changed).total_seconds() > 300`)
+    # also contains a numeric comparison, so it matches `_RE_NUMERIC_CMP` too. But its
+    # correct native replacement is the `for:` field, NOT `numeric_state`. Suppress the
+    # numeric_state suggestion when duration math is present so the user isn't handed
+    # two conflicting native alternatives for one template (the duration warning below
+    # fires instead).
+    duration_match = _RE_DURATION_MATH.search(template)
+
+    if _RE_NUMERIC_CMP.search(template) and not duration_match:
         warnings.append(
             f"{label} uses template with float/int comparison — use native "
             f"`numeric_state` {position} instead "
@@ -280,7 +307,7 @@ def _check_template_string(
             "function instead (returns 'unknown' if missing rather than raising)."
             + _ref(skill_prefix, "template-guidelines.md#common-patterns")
         )
-    if _RE_DURATION_MATH.search(template):
+    if duration_match:
         warnings.append(
             f"{label} uses template for duration/recency check "
             "(`now() - X.last_changed/last_updated`) — use the native `for:` field "
@@ -502,7 +529,11 @@ def _check_triggers(
             vt = trigger.get("value_template", "")
             if isinstance(vt, str):
                 initial = len(warnings)
-                if _RE_NUMERIC_CMP.search(vt):
+                # See `_check_template_string`: duration math also trips the numeric
+                # comparison detector, but maps to `for:`, not `numeric_state`. Suppress
+                # the numeric_state suggestion when duration math is present.
+                duration_match = _RE_DURATION_MATH.search(vt)
+                if _RE_NUMERIC_CMP.search(vt) and not duration_match:
                     warnings.append(
                         "Trigger uses template with float/int comparison — "
                         "use native `numeric_state` trigger instead "
@@ -522,7 +553,7 @@ def _check_triggers(
                             "automation-patterns.md#trigger-types",
                         )
                     )
-                if _RE_DURATION_MATH.search(vt):
+                if duration_match:
                     warnings.append(
                         "Trigger uses template for duration/recency check "
                         "(`now() - X.last_changed/last_updated`) — use the native "

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -1597,7 +1597,14 @@ class TestSkillPrefixNoneNewDetectors:
 
 
 class TestDurationMathDetector:
-    """Detects now() - X.last_changed patterns and suggests native for:."""
+    """Detects duration/recency math on ``last_changed``/``last_updated`` and suggests ``for:``.
+
+    Covers every shape ``_RE_DURATION_MATH`` matches — forward (``now() - X.last_changed``),
+    reversed-with-subtraction (``X.last_changed < now() - <delta>`` and the ``>`` variants),
+    ``now()`` on the left, and ``as_timestamp(...)`` arithmetic — plus the deliberate
+    non-matches: bare Jinja variables, ``state_attr(...)`` strings, and the always-true bare
+    ``X.last_changed < now()`` (no duration → cannot map to ``for:``).
+    """
 
     def test_condition_last_changed_math(self):
         config = {
@@ -1626,6 +1633,7 @@ class TestDurationMathDetector:
         assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
 
     def test_trigger_template_last_changed_math(self):
+        """Template trigger using ``trigger.last_changed`` (single dotted qualifier) is flagged."""
         config = {
             "trigger": [
                 {
@@ -1656,6 +1664,7 @@ class TestDurationMathDetector:
         assert not _has_warning_containing(warnings, "last_changed", "for:")
 
     def test_warning_contains_skill_ref(self):
+        """Condition-path warning links to ``#native-conditions`` (cf. ``#trigger-types`` for triggers)."""
         config = {
             "condition": [
                 {
@@ -1742,12 +1751,43 @@ class TestDurationMathDetector:
         )
 
     def test_condition_reversed_comparison_last_changed_math(self):
-        """Reversed form ``X.last_changed < now()`` in a condition is flagged.
+        """Reversed form ``X.last_changed < now() - <delta>`` in a condition is flagged.
 
-        The regex's second alternation exists to catch the comparison written
-        the other way round; without a positive test a later refactor could
-        drop it silently. Asserting exactly one warning also guards against the
-        two alternations double-flagging the same template.
+        The reversed alternation catches the comparison written the other way
+        round, but it requires the ``- <delta>`` subtraction: that is what makes
+        it a genuine recency check (``last_changed < now() - 5min`` ⇒ "changed
+        more than 5 minutes ago"). Asserting exactly one warning also guards
+        against the alternations double-flagging the same template. The bare
+        ``X.last_changed < now()`` form is covered separately in
+        ``test_bare_reversed_comparison_not_flagged`` — it is always true and
+        intentionally NOT flagged.
+        """
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ states.binary_sensor.motion.last_changed < now() - timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        duration_warnings = [
+            w for w in warnings if "last_changed/last_updated" in w and "for:" in w
+        ]
+        assert len(duration_warnings) == 1, (
+            "Reversed-form duration math in a condition should fire exactly one warning"
+        )
+
+    def test_bare_reversed_comparison_not_flagged(self):
+        """Bare ``X.last_changed < now()`` (no subtraction) must NOT be flagged.
+
+        Without a ``- <delta>`` there is no duration threshold: an entity's
+        ``last_changed`` is by definition in the past, so the comparison is
+        always true and cannot be expressed with a native ``for:`` field.
+        Suggesting ``for:`` here would be incorrect advice, so the reversed
+        alternation deliberately requires the subtraction. (This corrects the
+        original #1264 behaviour, which flagged the bare form.)
         """
         config = {
             "condition": [
@@ -1759,11 +1799,16 @@ class TestDurationMathDetector:
             "action": [],
         }
         warnings = check_automation_config(config)
-        duration_warnings = [
-            w for w in warnings if "last_changed/last_updated" in w and "for:" in w
-        ]
-        assert len(duration_warnings) == 1, (
-            "Reversed-form duration math in a condition should fire exactly one warning"
+        assert not _has_warning_containing(
+            warnings, "last_changed/last_updated", "for:"
+        ), (
+            "Always-true bare `X.last_changed < now()` carries no duration and must "
+            "not get the `for:` suggestion"
+        )
+        # It is still a template in a logic position, so the generic fallback
+        # fires — confirming we drop only the (wrong) duration hint, not all output.
+        assert _has_warning_containing(warnings, "Template detected in condition"), (
+            "bare reversed form should still surface the generic template warning"
         )
 
     def test_trigger_reversed_comparison_last_updated_math(self):
@@ -1784,3 +1829,214 @@ class TestDurationMathDetector:
         assert len(duration_warnings) == 1, (
             "Reversed-form duration math in a trigger value_template should fire exactly one warning"
         )
+
+    def test_duration_math_suppresses_numeric_state_suggestion(self):
+        """Duration math with a numeric compare fires only the ``for:`` warning, not ``numeric_state``.
+
+        ``(now() - X.last_changed).total_seconds() | int > 300`` trips both the
+        numeric-comparison detector and the duration detector. The native fix is
+        ``for:`` (you cannot express "seconds since last_changed" as a
+        ``numeric_state``), so the conflicting ``numeric_state`` suggestion must
+        be suppressed — exactly one duration warning, and no float/int warning.
+        """
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ (now() - states.sensor.x.last_changed).total_seconds() | int > 300 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        duration_warnings = [
+            w for w in warnings if "last_changed/last_updated" in w and "for:" in w
+        ]
+        assert len(duration_warnings) == 1, "Should fire exactly one duration warning"
+        assert not _has_warning_containing(warnings, "float/int comparison"), (
+            "numeric_state suggestion must be suppressed when duration math is present"
+        )
+
+    def test_trigger_duration_math_suppresses_numeric_state_suggestion(self):
+        """Same numeric_state suppression applies on the template-trigger path."""
+        config = {
+            "trigger": [
+                {
+                    "platform": "template",
+                    "value_template": "{{ (now() - states.sensor.x.last_changed).total_seconds() | int > 300 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        duration_warnings = [
+            w for w in warnings if "last_changed/last_updated" in w and "for:" in w
+        ]
+        assert len(duration_warnings) == 1, "Should fire exactly one duration warning"
+        assert not _has_warning_containing(warnings, "float/int comparison"), (
+            "numeric_state suggestion must be suppressed when duration math is present"
+        )
+
+    def test_as_timestamp_recency_condition(self):
+        """``as_timestamp(now()) - as_timestamp(X.last_changed)`` recency math is flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ as_timestamp(now()) - as_timestamp(states.sensor.x.last_changed) > 300 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:"), (
+            "as_timestamp() recency form should be flagged"
+        )
+
+    def test_as_timestamp_recency_numeric_state_trigger(self):
+        """as_timestamp recency math inside a numeric_state value_template is flagged (no silent gap)."""
+        config = {
+            "trigger": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.x",
+                    "value_template": "{{ as_timestamp(now()) - as_timestamp(states.sensor.x.last_changed) }}",
+                    "above": 300,
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:"), (
+            "as_timestamp() duration math in a numeric_state value_template should be flagged, "
+            "not silently passed"
+        )
+
+    def test_greater_than_reversed_recency(self):
+        """``X.last_changed > now() - <delta>`` (changed within window) recency math is flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ states.sensor.x.last_changed > now() - timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_now_on_left_recency(self):
+        """``now() > X.last_changed + <delta>`` recency math is flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ now() > states.sensor.x.last_changed + timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_state_attr_last_changed_not_flagged(self):
+        """``state_attr('x', 'last_changed')`` (quoted attr string) must NOT be flagged.
+
+        The dotted-qualifier requirement means a ``last_changed`` passed as a
+        string argument to ``state_attr`` is not mistaken for an entity-attribute
+        access. Locks in the most likely future false positive.
+        """
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ now() - state_attr('sensor.x', 'last_changed') > timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert not _has_warning_containing(
+            warnings, "last_changed/last_updated", "for:"
+        ), "state_attr('x','last_changed') should not trigger the duration detector"
+
+    def test_comparator_variants_ge_le_flagged(self):
+        """``>=`` / ``<=`` recency comparisons are flagged like their strict ``>``/``<`` twins."""
+        for vt in (
+            "{{ states.sensor.x.last_changed <= now() - timedelta(minutes=5) }}",
+            "{{ states.sensor.x.last_changed >= now() - timedelta(minutes=5) }}",
+            "{{ now() >= states.sensor.x.last_changed + timedelta(minutes=5) }}",
+        ):
+            config = {
+                "condition": [{"condition": "template", "value_template": vt}],
+                "action": [],
+            }
+            warnings = check_automation_config(config)
+            assert _has_warning_containing(
+                warnings, "last_changed/last_updated", "for:"
+            ), f"{vt!r} should be flagged"
+
+    def test_timestamp_method_epoch_subtraction_flagged(self):
+        """``now().timestamp() - X.last_updated.timestamp()`` epoch recency math is flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ now().timestamp() - states.sensor.x.last_updated.timestamp() > 300 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_as_timestamp_last_updated_flagged(self):
+        """as_timestamp recency math covers ``last_updated`` too, not just ``last_changed``."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ as_timestamp(now()) - as_timestamp(states.sensor.x.last_updated) > 60 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_suffixed_attribute_name_not_flagged(self):
+        """Look-alike attributes (``last_changed_at``) must NOT match any alternation.
+
+        The trailing word boundary on every alternation — including the
+        ``as_timestamp`` path, which previously lacked it — keeps custom
+        attributes whose names merely start with ``last_changed``/``last_updated``
+        from being mistaken for the real state property.
+        """
+        for vt in (
+            "{{ now() - states.sensor.x.last_changed_at > timedelta(minutes=5) }}",
+            "{{ as_timestamp(now()) - as_timestamp(states.sensor.x.last_changed_at) }}",
+            "{{ states.sensor.x.last_updated_ts < now() - timedelta(minutes=5) }}",
+        ):
+            config = {
+                "condition": [{"condition": "template", "value_template": vt}],
+                "action": [],
+            }
+            warnings = check_automation_config(config)
+            assert not _has_warning_containing(
+                warnings, "last_changed/last_updated", "for:"
+            ), f"{vt!r} (look-alike attribute) must not be flagged as duration math"
+
+    def test_trigger_path_now_on_left_recency_flagged(self):
+        """The ``now() > X.last_changed + <delta>`` form also flows through the trigger path."""
+        config = {
+            "trigger": [
+                {
+                    "platform": "template",
+                    "value_template": "{{ now() > states.sensor.x.last_changed + timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -2040,3 +2040,53 @@ class TestDurationMathDetector:
         }
         warnings = check_automation_config(config)
         assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+    def test_attribute_plus_delta_compared_to_now_flagged(self):
+        """``X.last_changed + <delta> (<|<=|>|>=) now()`` (delta on the attribute) is flagged.
+
+        Mirror of the now()-on-the-left form. A no-comparison ``X.last_changed +
+        <delta>`` (just computing a future time) is NOT a recency check and stays
+        unflagged — the comparator-then-now() tail is required.
+        """
+        for vt in (
+            "{{ states.binary_sensor.motion.last_changed + timedelta(minutes=5) < now() }}",
+            "{{ states.sensor.x.last_updated + timedelta(hours=1) <= now() }}",
+        ):
+            config = {
+                "condition": [{"condition": "template", "value_template": vt}],
+                "action": [],
+            }
+            warnings = check_automation_config(config)
+            assert _has_warning_containing(
+                warnings, "last_changed/last_updated", "for:"
+            ), f"{vt!r} should be flagged"
+
+    def test_attribute_plus_delta_no_comparison_not_flagged(self):
+        """Bare ``X.last_changed + <delta>`` (computing a time, no comparison) is NOT flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ states.sensor.x.last_changed + timedelta(minutes=5) }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert not _has_warning_containing(
+            warnings, "last_changed/last_updated", "for:"
+        ), "computing a future time (no comparison to now()) is not a recency check"
+
+    def test_as_timestamp_filter_syntax_flagged(self):
+        """``as_timestamp(now()) - X.last_changed | as_timestamp`` (filter syntax) is flagged."""
+        config = {
+            "condition": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ as_timestamp(now()) - states.sensor.x.last_changed | as_timestamp > 300 }}",
+                }
+            ],
+            "action": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1264 (which partially closed #1157). A post-merge review of the
`now() - X.last_changed/last_updated` duration-math detector surfaced three issues;
this PR fixes them. The checker is **advisory** — it emits best-practice warnings to
the agent — so every change affects the *quality of suggestions*, never runtime behaviour.

**1. Contradictory double-warning (fix).**
A recency template that also contains a numeric comparison —
`{{ (now() - states.sensor.x.last_changed).total_seconds() | int > 300 }}` —
matched both `_RE_NUMERIC_CMP` and `_RE_DURATION_MATH`, emitting **two** warnings with
**conflicting** native advice: "use `numeric_state`" *and* "use `for:`". You cannot
express "seconds since `last_changed`" as a `numeric_state`, so the correct fix is `for:`.
The detectors now precompute `duration_match` and gate the `numeric_state` suggestion on
`not duration_match`, in both the condition path (`_check_template_string`) and the
template-trigger path (`_check_triggers`). Result: exactly one, correct warning.

**2. Always-true false positive (fix + corrected test).**
The reversed alternation matched the bare `{{ X.last_changed < now() }}`. That expression
is *always true* (an entity's `last_changed` is by definition in the past) and carries no
duration threshold, so the native `for:` field **cannot** express it — the suggestion was
incorrect advice. The reversed alternation now requires the subtraction
(`X.last_changed < now() - <delta>`), mirroring the forward form. This **corrects a test
added in #1264** (`test_condition_reversed_comparison_last_changed_math`) that asserted the
bare form should fire; it now uses the real recency form, and a new
`test_bare_reversed_comparison_not_flagged` locks in the corrected behaviour. The rationale
is documented inline in the test docstring.

**3. Missed recency forms incl. a fully-silent gap (coverage).**
`_RE_DURATION_MATH` only caught two narrow shapes. It now catches the common real-world
recency idioms below, with trailing word boundaries so look-alike attributes
(`last_changed_at`) are not falsely flagged:
- `X.last_changed (<|<=|>|>=) now() - <delta>`
- `now() (<|<=|>|>=) X.last_changed + <delta>`
- `X.last_changed + <delta> (<|<=|>|>=) now()`
- `now().timestamp() - X.last_changed.timestamp()`
- `as_timestamp(now()) - as_timestamp(X.last_changed)` (function form)
- `as_timestamp(now()) - X.last_changed | as_timestamp` (filter form)

The `as_timestamp(...)` form is the most important: in a `numeric_state` trigger
`value_template` it previously produced **zero** warnings (the only template-bearing
position with no generic fallback), silently passing a real anti-pattern. Because the
detector shares one regex, the `numeric_state` trigger path is fixed for free. The
dotted-qualifier guard is preserved, so bare Jinja variables and
`state_attr('x','last_changed')` strings are still **not** flagged (locked by tests). The
last two forms above were added in response to the Gemini Code Assist review; the regex
comment documents the intentional limits (reversed-operand / nested-call spellings, which
fall through to the generic template fallback).

**Changes:**
- `best_practice_checker.py`: gate `_RE_NUMERIC_CMP` on `not duration_match` (condition +
  template-trigger paths); rework `_RE_DURATION_MATH` (require subtraction on the reversed
  form; add `>=`/`<=`, both `now()`-on-left and attribute-`+`-delta shapes, `.timestamp()`,
  and both `as_timestamp()` function/filter shapes; trailing word boundaries); expand the
  comment to document every matched shape, the guard, and the deliberate non-matches.
- `test_best_practice_checker.py`: correct `test_condition_reversed_comparison_last_changed_math`;
  add 16 tests covering every new shape, both suppression paths, the numeric_state gap
  closure, and the false-positive guards (bare reversed, look-alike attribute, `state_attr`
  string, equality / no-comparison forms); add docstrings to two bare tests and the class.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

117 unit tests pass (was 101). `ruff format --check`, `ruff check`, and `mypy` clean.

## Checklist
- [x] I have updated documentation if needed
