### PR TITLE
fix: route malformed ha_mcp_tools version to a distinct reinstall error

### DIFF
--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -63,8 +63,9 @@ def _version_tuple(version: str) -> tuple[int, ...]:
     segment to ``0`` would not actually achieve the "fail closed"
     intent: a malformed high-order segment like ``"1.x.0"`` would
     still parse to ``(1, 0, 0)`` and pass a ``>= (0, 5, 1)`` gate.
-    Caller routes the ValueError through ``_raise_component_too_old``
-    so the actionable update prompt fires.
+    The caller surfaces the ValueError as a distinct "malformed version"
+    error (reinstall / file-issue remediation), separate from the
+    "too old" update prompt.
     """
     return tuple(int(segment) for segment in version.split("."))
 
@@ -175,7 +176,25 @@ async def _fetch_caller_token(client: Any) -> str:
     try:
         parsed = _version_tuple(version)
     except ValueError:
-        _raise_component_too_old(f"malformed version: {version!r}")
+        # A malformed version (non-numeric segment like "1.x.0", or a
+        # future suffixed/date scheme _version_tuple can't parse) is a
+        # different failure mode from "too old": a HACS update won't help
+        # if the reported version itself is wrong. Point at reinstall /
+        # issue-filing instead of the version-bump remediation.
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "The installed ha_mcp_tools custom component reports a "
+                f"malformed version: {version!r}, so ha-mcp can't verify it "
+                f"meets the required >= {MIN_COMPONENT_VERSION}.",
+                suggestions=[
+                    "Reinstall ha_mcp_tools via HACS",
+                    "Restart Home Assistant after reinstalling",
+                    "If the version is still malformed, file an issue at "
+                    "https://github.com/homeassistant-ai/ha-mcp/issues",
+                ],
+            )
+        )
     if parsed < _version_tuple(MIN_COMPONENT_VERSION):
         _raise_component_too_old(f"reported version is {version}")
     _CALLER_TOKEN_CACHE[client] = token

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -551,10 +551,12 @@ class TestCallMcpToolsServiceInjectsToken:
 
     @pytest.mark.asyncio
     async def test_malformed_version_string_rejected(self):
-        """A non-numeric version segment (e.g. ``'1.x.0'``) is treated
-        as "too old" — fail-closed rather than letting the integer
-        prefix sneak past the gate (``(1, 0, 0)`` would otherwise
-        compare ``>= (0, 5, 1)`` and falsely accept).
+        """A non-numeric version segment (e.g. ``'1.x.0'``) is rejected
+        fail-closed rather than letting the integer prefix sneak past the
+        gate (``(1, 0, 0)`` would otherwise compare ``>= (0, 5, 1)`` and
+        falsely accept). It routes to a distinct "malformed version" error
+        (reinstall / file-issue), NOT the "too old / update via HACS"
+        remediation — updating can't fix a manifest whose version is wrong.
         """
         client = AsyncMock()
         client.get_services.return_value = [
@@ -575,8 +577,11 @@ class TestCallMcpToolsServiceInjectsToken:
         with pytest.raises(ToolError) as exc_info:
             await call_mcp_tools_service(client, "list_files", {"path": "www"})
         msg = str(exc_info.value)
-        assert "too old" in msg
-        assert "malformed" in msg
+        assert "malformed version" in msg
+        assert "1.x.0" in msg
+        assert "Reinstall" in msg
+        # Must NOT route to the "too old / update" remediation.
+        assert "too old" not in msg
 
 
 # =============================================================================

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -550,13 +550,27 @@ class TestCallMcpToolsServiceInjectsToken:
         await call_mcp_tools_service(client, "list_files", {"path": "www"})
 
     @pytest.mark.asyncio
-    async def test_malformed_version_string_rejected(self):
-        """A non-numeric version segment (e.g. ``'1.x.0'``) is rejected
-        fail-closed rather than letting the integer prefix sneak past the
-        gate (``(1, 0, 0)`` would otherwise compare ``>= (0, 5, 1)`` and
-        falsely accept). It routes to a distinct "malformed version" error
-        (reinstall / file-issue), NOT the "too old / update via HACS"
-        remediation — updating can't fix a manifest whose version is wrong.
+    @pytest.mark.parametrize(
+        "bad_version",
+        [
+            "1.x.0",  # non-numeric segment
+            "1.2.3-beta",  # pre-release suffix (most likely real-world case)
+            "v1.2.3",  # git-tag prefix
+            "latest",  # non-numeric placeholder
+        ],
+    )
+    async def test_malformed_version_string_rejected(self, bad_version):
+        """A version _version_tuple can't parse (non-numeric segment like
+        ``'1.x.0'``, a pre-release suffix, a ``v`` prefix, a placeholder)
+        is rejected fail-closed rather than letting an integer prefix sneak
+        past the gate (``'1.x.0'`` → ``(1, 0, 0)`` would otherwise compare
+        ``>= (0, 5, 1)`` and falsely accept). It routes to a distinct
+        "malformed version" error (reinstall / file-issue), NOT the
+        "too old / update via HACS" remediation — updating can't fix a
+        manifest whose version is wrong.
+
+        (The empty string is handled one guard earlier as a missing-version
+        "too old" case, so it never reaches this branch.)
         """
         client = AsyncMock()
         client.get_services.return_value = [
@@ -570,7 +584,7 @@ class TestCallMcpToolsServiceInjectsToken:
                 "service_response": {
                     "success": True,
                     "token": "tok-bad-version",
-                    "version": "1.x.0",
+                    "version": bad_version,
                 }
             }
         )
@@ -578,7 +592,7 @@ class TestCallMcpToolsServiceInjectsToken:
             await call_mcp_tools_service(client, "list_files", {"path": "www"})
         msg = str(exc_info.value)
         assert "malformed version" in msg
-        assert "1.x.0" in msg
+        assert bad_version in msg
         assert "Reinstall" in msg
         # Must NOT route to the "too old / update" remediation.
         assert "too old" not in msg


### PR DESCRIPTION
Addresses #1473 — item 1 (malformed-version remediation). Item 2 (E2E entity-load verification) is deferred; see note below. #1473 stays open.

## What does this PR do?

Follow-up from the #1452 review: a malformed `ha_mcp_tools` manifest version routed to the wrong remediation.

A manifest version that `_version_tuple` can not parse (a non-numeric segment like `1.x.0`, a pre-release suffix, a `v`-prefix, a placeholder) was routed through `_raise_component_too_old`, telling the user to "update via HACS". Updating can not fix a version string that is itself malformed. The `ValueError` branch now raises a distinct `COMPONENT_NOT_INSTALLED` error with a malformed-specific message and reinstall / file-issue suggestions. Fail-closed behaviour (a non-numeric prefix never sneaks past the `>=` gate) is unchanged. The existing `test_malformed_version_string_rejected` is updated and parametrised across four malformed formats.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent — N/A (error-text change, no new tool surface)
- [x] All automated tests pass (`uv run pytest`) — full fast unit suite green locally (3729 passed, 54 skipped)
- [x] Code follows style guidelines (`uv run ruff check`)

## Item 2 deferred

The issue's second item (poll after a packages-only `ha_config_set_yaml` to confirm HA loads the entity) needs an HA-runtime investigation out of scope here: even with the test HA's `packages:` wired and the advertised reload service called, a runtime-added package file does not load via a domain `<x>.reload` — the entity stays unqueryable. The tool writes a valid domain-keyed package, so the open question is whether packages-only writes need `homeassistant.reload_core_config`/restart rather than a domain reload. Best settled with local E2E; tracked on #1473.

## Checklist
- [x] I have updated documentation if needed — N/A; updated an inline docstring + comments only