### PR TITLE
fix: remove str from config param schema on set tools

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -401,7 +401,7 @@ class AutomationConfigTools:
     async def ha_config_set_automation(
         self,
         config: Annotated[
-            str | dict[str, Any] | None,
+            dict[str, Any] | None,
             Field(
                 description="Complete automation configuration with required fields: 'alias', 'trigger', 'action'. "
                 "Optional: 'description', 'condition', 'mode', 'max', 'initial_state', 'variables'. "

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -847,10 +847,9 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             ),
         ],
         config: Annotated[
-            str | dict[str, Any] | None,
+            dict[str, Any] | None,
             Field(
                 description="Dashboard configuration with views and cards. "
-                "Can be dict or JSON string. "
                 "Omit or set to None to create dashboard without initial config. "
                 "Mutually exclusive with python_transform."
             ),

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2297,7 +2297,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = None,
         config: Annotated[
-            str | dict | None,
+            dict | None,
             Field(
                 description=(
                     "Config dict for flow-based helper types and "
@@ -2305,7 +2305,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "(template, group, utility_meter, derivative, min_max, threshold, "
                     "integration, statistics, trend, random, filter, tod, "
                     "generic_thermostat, switch_as_x, generic_hygrostat). "
-                    "Accepts JSON string or dict. Ignored for simple helper types. "
+                    "Ignored for simple helper types. "
                     "Field set is delivered as data_schema on the first validation error."
                 ),
                 default=None,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -2297,7 +2297,7 @@ def register_config_helper_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = None,
         config: Annotated[
-            dict | None,
+            dict[str, Any] | None,
             Field(
                 description=(
                     "Config dict for flow-based helper types and "

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -424,7 +424,7 @@ class ConfigSceneTools:
             str, Field(description="Scene identifier (e.g., 'movie_night')")
         ],
         config: Annotated[
-            str | dict[str, Any] | None,
+            dict[str, Any] | None,
             Field(
                 description=(
                     "Scene configuration dictionary. Must include 'entities' "

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -383,7 +383,7 @@ class ConfigScriptTools:
             ),
         ],
         config: Annotated[
-            str | dict[str, Any] | None,
+            dict[str, Any] | None,
             Field(
                 description="Script configuration dictionary. Must include EITHER 'sequence' (for regular scripts) OR 'use_blueprint' (for blueprint-based scripts). "
                 "Optional fields: 'alias', 'description', 'icon', 'mode', 'max', 'fields'. "

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -12,24 +12,28 @@ parsing. The fix: annotate config as `dict | None`, not `str | dict | None`.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 
-def _get_config_schema(register_fn, tool_name: str) -> dict:
+def _get_config_schema(
+    register_fn: Callable[..., Any], tool_name: str
+) -> dict[str, Any]:
     from fastmcp import FastMCP
 
-    async def _inner():
+    async def _inner() -> dict[str, Any]:
         mcp = FastMCP("test")
         register_fn(mcp, MagicMock())
         tool = await mcp.get_tool(tool_name)
-        return tool.parameters["properties"]["config"]
+        return tool.parameters["properties"]["config"]  # type: ignore[no-any-return]
 
     return asyncio.run(_inner())
 
 
-def _contains_string_type(schema: dict) -> bool:
+def _contains_string_type(schema: dict[str, Any]) -> bool:
     """Return True if the schema allows string values."""
     return schema.get("type") == "string" or any(
         variant.get("type") == "string" for variant in schema.get("anyOf", [])

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -1,0 +1,128 @@
+"""Schema regression test: config parameters must not advertise string type.
+
+Verifies that the MCP JSON schema for the `config` parameter on all five
+config-set tools is `{type: object}` (or `anyOf` containing only object/null),
+never `{type: string}` or an `anyOf` that includes string.
+
+A string in the schema tells models that passing a JSON string is valid.
+This causes retry loops when models pass strings that fail server-side
+parsing. The fix: annotate config as `dict | None`, not `str | dict | None`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _get_config_schema(register_fn, tool_name: str) -> dict:
+    from fastmcp import FastMCP
+
+    async def _inner():
+        mcp = FastMCP("test")
+        register_fn(mcp, MagicMock())
+        tool = await mcp.get_tool(tool_name)
+        return tool.parameters["properties"]["config"]
+
+    return asyncio.run(_inner())
+
+
+def _contains_string_type(schema: dict) -> bool:
+    """Return True if the schema allows string values."""
+    return schema.get("type") == "string" or any(
+        variant.get("type") == "string" for variant in schema.get("anyOf", [])
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name"),
+    [
+        (
+            "ha_mcp.tools.tools_config_automations",
+            "register_config_automation_tools",
+            "ha_config_set_automation",
+        ),
+        (
+            "ha_mcp.tools.tools_config_scripts",
+            "register_config_script_tools",
+            "ha_config_set_script",
+        ),
+        (
+            "ha_mcp.tools.tools_config_scenes",
+            "register_config_scene_tools",
+            "ha_config_set_scene",
+        ),
+        (
+            "ha_mcp.tools.tools_config_helpers",
+            "register_config_helper_tools",
+            "ha_config_set_helper",
+        ),
+        (
+            "ha_mcp.tools.tools_config_dashboards",
+            "register_config_dashboard_tools",
+            "ha_config_set_dashboard",
+        ),
+    ],
+)
+def test_config_param_does_not_advertise_string(
+    module: str, register_fn: str, tool_name: str
+) -> None:
+    """config parameter schema must not include type:string."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    fn = getattr(mod, register_fn)
+    schema = _get_config_schema(fn, tool_name)
+    assert not _contains_string_type(schema), (
+        f"{tool_name}: config schema still advertises string type. Schema: {schema}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name"),
+    [
+        (
+            "ha_mcp.tools.tools_config_automations",
+            "register_config_automation_tools",
+            "ha_config_set_automation",
+        ),
+        (
+            "ha_mcp.tools.tools_config_scripts",
+            "register_config_script_tools",
+            "ha_config_set_script",
+        ),
+        (
+            "ha_mcp.tools.tools_config_scenes",
+            "register_config_scene_tools",
+            "ha_config_set_scene",
+        ),
+        (
+            "ha_mcp.tools.tools_config_helpers",
+            "register_config_helper_tools",
+            "ha_config_set_helper",
+        ),
+        (
+            "ha_mcp.tools.tools_config_dashboards",
+            "register_config_dashboard_tools",
+            "ha_config_set_dashboard",
+        ),
+    ],
+)
+def test_config_param_advertises_object(
+    module: str, register_fn: str, tool_name: str
+) -> None:
+    """config parameter schema must include type:object."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    fn = getattr(mod, register_fn)
+    schema = _get_config_schema(fn, tool_name)
+    # Either top-level type:object or anyOf containing {type:object}
+    has_object = schema.get("type") == "object" or any(
+        v.get("type") == "object" for v in schema.get("anyOf", [])
+    )
+    assert has_object, (
+        f"{tool_name}: config schema does not include type:object. Schema: {schema}"
+    )

--- a/tests/uat/CLAUDE.md
+++ b/tests/uat/CLAUDE.md
@@ -1,0 +1,22 @@
+# UAT Testing
+
+UAT stories always use testcontainers — a fresh HA Docker container is spun up per agent run. Never use `--ha-url` pointing at a production HA instance.
+
+When testcontainers fails with an image error, diagnose Docker first (`docker images`, `docker info`) before suggesting alternatives. The HA test image is cached locally; a "No such image" error in WSL2 is usually a Docker context mismatch, not a missing image.
+
+## Running stories
+
+```bash
+# All stories, local model (LM Studio)
+UV_CACHE_DIR=/tmp/claude-1000/uv-cache TMPDIR=/tmp/claude-1000 \
+  uv run python tests/uat/stories/run_story.py --all --agents openai \
+  --base-url http://172.19.0.1:1234/v1 --model <model-id> --no-think
+
+# With a feature flag
+... --mcp-env ENABLE_LITE_DOCSTRINGS=true
+```
+
+Key flags:
+- `--mcp-env KEY=VALUE` — pass env vars to the MCP server (repeatable)
+- `--no-think` — disable reasoning mode for qwen3 and compatible models
+- `--results-file` — JSONL file to append results to (default: `local/uat-results.jsonl`)


### PR DESCRIPTION
## What does this PR do?

The `config` parameter on five tools was typed as `str | dict | None`:

- `ha_config_set_automation`
- `ha_config_set_script`
- `ha_config_set_scene`
- `ha_config_set_helper`
- `ha_config_set_dashboard`

This caused the MCP JSON schema to advertise `anyOf: [string, object, null]`, telling models that passing a JSON string is valid. Models would pass JSON strings instead of dicts, hit parse errors, and retry 2-3 times before self-correcting. The fix is to drop `str` from the type annotation so the schema becomes `anyOf: [object, null]`.

The runtime parser (`_parse_and_validate_config` and equivalents) still accepts strings as a safety net, but models no longer see string as a valid input.

Discovered while running UAT stories against a local model (qwen3.6-27b) and observing repeated `ha_config_set_automation` retries in the trace.

## UAT results

Tested with qwen3.6-27b, `--no-think`, tool_search enabled (14 stories):

| Story | Baseline | Schema fix | Billable (base) | Billable (fix) | Delta |
|---|---|---|---|---|---|
| s01 | PASS | PASS | 62,670 | 171,779 | +174% |
| s02 | PASS | PASS | 110,209 | 30,088 | -73% |
| s03 | PASS | PASS | 28,646 | 92,328 | +222% |
| s04 | PASS | PASS | 63,933 | 63,584 | -1% |
| s05 | PASS | PASS | 84,568 | 22,256 | -74% |
| s06 | PASS | PASS | 73,491 | 73,294 | -0% |
| s07 | PASS | PASS | 49,308 | 38,867 | -21% |
| s08 | PASS | PASS | 29,591 | 29,910 | +1% |
| s09 | FAIL | PASS | 19,062 | 187,763 | +885% |
| s10 | FAIL | PASS | 22,073 | 20,654 | -6% |
| s11 | PASS | PASS | 86,291 | 62,736 | -27% |
| s12 | PASS | PASS | 95,051 | 51,125 | -46% |
| s13 | PASS | PASS | 115,304 | 23,386 | -80% |
| s14 | FAIL | PASS | 50,399 | 36,477 | -28% |
| **TOTAL** | **11/14** | **14/14** | **890,596** | **904,247** | **+2%** |

14/14 had not been observed before with this model. The definitive validation is the unit test suite, which fails on master and passes on this branch.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New regression tests in `tests/src/unit/test_config_param_no_string_schema.py` verify the MCP schema for each affected tool:
- 5 tests assert `type:string` is absent from the `config` schema
- 5 tests assert `type:object` is present

These tests fail on master and pass on this branch, confirming the fix.

## Checklist
- [x] I have updated documentation if needed