### PR TITLE
fix(addon): enable ingress so the stable add-on shows the Open Web UI / Settings UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -849,6 +849,21 @@ Before adding docs to tool descriptions, test what models already know using a n
 - `repository.yaml` (root) - For HA add-on store recognition
 - `homeassistant-addon/config.yaml` - Must match `pyproject.toml` version
 
+**Two add-on flavors:** `homeassistant-addon/` (stable, slug `ha_mcp`) and
+`homeassistant-addon-dev/` (dev channel, slug `ha_mcp_dev`) are *separate*
+add-ons with *separate* `config.yaml` files.
+
+**Functional config is NOT auto-synced between them.** The release pipeline
+(`semver-release.yml` → `update-addon-config`) only syncs the *version* and
+*changelog* into `homeassistant-addon/`. Functional keys — `ingress`, `ports`,
+`host_network`, `options`/`schema`, etc. — must be edited **by hand** in each
+flavor. When you add a non-beta capability to the dev add-on that should also
+ship on stable (e.g. `ingress` for the web Settings UI / "Open Web UI" button),
+mirror it into `homeassistant-addon/config.yaml` **in the same PR**. Assuming
+"the release pipeline handles it" is what kept `ingress` off the stable add-on.
+Beta-only keys are the deliberate exception — see the NOTE in
+`homeassistant-addon/config.yaml` and `docs/beta.md`.
+
 **Docs**: https://developers.home-assistant.io/docs/add-ons
 
 ## API Research

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -854,8 +854,9 @@ Before adding docs to tool descriptions, test what models already know using a n
 add-ons with *separate* `config.yaml` files.
 
 **Functional config is NOT auto-synced between them.** The release pipeline
-(`semver-release.yml` → `update-addon-config`) only syncs the *version* and
-*changelog* into `homeassistant-addon/`. Functional keys — `ingress`, `ports`,
+only syncs the *version* (the `update-addon-config` job) and the *changelog*
+(the `Copy changelog to addon directory` step in `semver-release.yml`) into
+`homeassistant-addon/`. Functional keys — `ingress`, `ports`,
 `host_network`, `options`/`schema`, etc. — must be edited **by hand** in each
 flavor. When you add a non-beta capability to the dev add-on that should also
 ship on stable (e.g. `ingress` for the web Settings UI / "Open Web UI" button),

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -321,6 +321,22 @@ Per-tool rules (including argument conditions like `args.domain in ['lock', 'ala
 
 ---
 
+## Tool Settings Web UI
+
+The add-on exposes a web-based settings page for managing which tools are available to AI assistants. Click **"Open Web UI"** on the add-on info page to access it.
+
+Features:
+- **Enable/disable individual tools** — toggle each tool on or off
+- **Pin tools** — keep tools always visible when `enable_tool_search` is on
+- **Per-group master toggle** — enable/disable all tools in a group (HACS, System, etc.) with one click
+- **Search** — filter tools by name or title
+- **Mandatory tools** — `ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue` are always enabled and cannot be disabled
+- **Tool Security Policies tab** — when `enable_tool_security_policies` is on, approve held tool calls and manage per-tool rules here
+- **Advanced settings** — an advanced panel with a beta master toggle (plus per-feature sub-toggles) for opting into beta tools such as raw YAML editing, filesystem tools, and code mode. See [Beta Features](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md)
+- **In-UI restart** — a "Restart Add-on" button appears after saving to apply changes with one click
+
+**Important:** Tool configuration changes require an add-on restart to take effect. The UI will prompt you to restart after saving.
+
 ## Security
 
 ### Auto-Generated Secret Paths

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -14,6 +14,8 @@ boot: manual
 # Expose the web Settings UI via Supervisor ingress (the "Open Web UI" button).
 # start.py mounts the settings routes for the ingress proxy and binds 0.0.0.0;
 # this declaration is what makes Supervisor render the button and proxy to it.
+# ingress_stream keeps the proxy streaming responses (required for the
+# streamable-HTTP MCP transport / settings UI flush behaviour).
 # Must be set here too — the release pipeline syncs only version/changelog, not
 # functional config, so ingress is NOT auto-mirrored from
 # homeassistant-addon-dev/config.yaml.

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -11,6 +11,15 @@ arch:
 init: false
 startup: application
 boot: manual
+# Expose the web Settings UI via Supervisor ingress (the "Open Web UI" button).
+# start.py mounts the settings routes for the ingress proxy and binds 0.0.0.0;
+# this declaration is what makes Supervisor render the button and proxy to it.
+# Must be set here too — the release pipeline syncs only version/changelog, not
+# functional config, so ingress is NOT auto-mirrored from
+# homeassistant-addon-dev/config.yaml.
+ingress: true
+ingress_port: 9583
+ingress_stream: true
 # Enable access to Supervisor API for auto-discovery
 hassio_api: true
 # `manager` (not `default`) is required so the Supervisor token grants access

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -74,6 +74,10 @@ class TestAddonStructure:
         assert config.get("ingress_port") == 9583, (
             "ingress_port must be 9583 (the fixed internal MCP/web port)"
         )
+        assert config.get("ingress_stream") is True, (
+            "ingress_stream must be enabled so streamed responses flush through "
+            "the ingress proxy (streamable-HTTP MCP transport)"
+        )
 
         # Verify secret_path configuration (optional advanced override)
         assert "secret_path" not in config["options"], (

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -62,6 +62,19 @@ class TestAddonStructure:
         assert "ports" in config, "ports section required for HTTP transport"
         assert "9583/tcp" in config["ports"], "port 9583/tcp must be exposed"
 
+        # Verify ingress is enabled so the stable add-on exposes the web
+        # Settings UI ("Open Web UI" button). This must stay declared here —
+        # the release pipeline syncs version/changelog only, not functional
+        # config, so ingress is not auto-mirrored from the dev add-on. Locks
+        # the regression where stable shipped without the button.
+        assert config.get("ingress") is True, (
+            "ingress must be enabled so the 'Open Web UI' button / web Settings "
+            "UI is reachable on the stable add-on"
+        )
+        assert config.get("ingress_port") == 9583, (
+            "ingress_port must be 9583 (the fixed internal MCP/web port)"
+        )
+
         # Verify secret_path configuration (optional advanced override)
         assert "secret_path" not in config["options"], (
             "secret_path should be optional and omitted so Supervisor treats it as advanced"


### PR DESCRIPTION
## What does this PR do?

The stable Home Assistant add-on (`homeassistant-addon/`) never declared
`ingress`, so Home Assistant renders no **"Open Web UI"** button and the web
Settings UI is unreachable on stable — even though stable's `start.py` already
mounts the settings routes "for the HA ingress proxy" and binds `0.0.0.0`
(#960), and #1431 wired beta-feature access into stable's code. The dev add-on
(`homeassistant-addon-dev/`) has had `ingress: true` since #960, which is why
the button shows there but not on stable.

Root cause: functional add-on config is **not** auto-synced between the dev and
stable flavors — the release pipeline only syncs version + changelog — so
`ingress` had to be added to the stable `config.yaml` by hand and never was
("the release pipeline handles it" confusion).

### Changes
- **`homeassistant-addon/config.yaml`** — add `ingress: true` /
  `ingress_port: 9583` / `ingress_stream: true`, mirroring the dev add-on's
  proven block. No version bump (release pipeline owns it); no beta
  option/schema changes (beta access stays gated by the web-UI master toggle
  from #1431, per `docs/beta.md`).
- **`tests/addon/test_addon_structure.py`** — assert the stable add-on declares
  `ingress`/`ingress_port`, locking the regression.
- **`AGENTS.md`** — document that functional add-on config must be mirrored
  between flavors by hand, so this class of oversight can't recur.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — deferring to CI
- [ ] Code follows style guidelines (`uv run ruff check`) — deferring to CI

YAML validated locally (parses; `ingress` is top-level, no translation entry
needed). Full suite + lint left to CI.

## Checklist
- [x] I have updated documentation if needed
