### PR TITLE
fix: remove str from config param schema on service and entity tools

### DIFF
--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -613,12 +613,12 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = None,
         options: Annotated[
-            str | dict[str, dict[str, Any]] | None,
+            dict[str, dict[str, Any]] | None,
             Field(
                 description=(
                     "Per-domain entity registry options (e.g. sensor 'display_precision', "
                     "weather 'forecast_type'). Pass a dict mapping domain to a sub-dict, "
-                    'e.g. {"sensor": {"display_precision": 2}}. JSON-string form also accepted. '
+                    'e.g. {"sensor": {"display_precision": 2}}. '
                     "Multiple domains are sent as separate registry updates. "
                     "For 'Show As' use the dedicated `device_class` parameter — that is "
                     "what the HA UI Show As dropdown writes. Voice-assistant exposure is "
@@ -658,7 +658,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = None,
         categories: Annotated[
-            str | dict[str, str | None] | None,
+            dict[str, str | None] | None,
             Field(
                 description=(
                     "Category assignment as a dict mapping scope to category_id. "
@@ -684,7 +684,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             ),
         ] = "set",
         expose_to: Annotated[
-            str | dict[str, bool] | None,
+            dict[str, bool] | None,
             Field(
                 description=(
                     "Control voice assistant exposure. Pass a dict mapping assistant IDs to booleans. "

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -289,7 +289,7 @@ class ServiceTools:
         domain: str,
         service: str,
         entity_id: str | None = None,
-        data: str | dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
         return_response: bool | str = False,
         wait: bool | str = True,
         verbose: Annotated[
@@ -629,7 +629,7 @@ class ServiceTools:
     async def ha_call_event(
         self,
         event_type: str,
-        data: str | dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Execute a custom event on the Home Assistant event bus.
 

--- a/tests/src/e2e/tools/test_ha_call_event.py
+++ b/tests/src/e2e/tools/test_ha_call_event.py
@@ -45,19 +45,6 @@ async def test_call_event_with_dict_data(mcp_client):
 
 
 @pytest.mark.asyncio
-async def test_call_event_with_json_string_data(mcp_client):
-    """Publish a custom event with JSON-string event data (auto-parsed)."""
-    result = await mcp_client.call_tool(
-        "ha_call_event",
-        {"event_type": "test_mcp_event_json_str", "data": '{"source": "e2e_test"}'},
-    )
-    data = assert_mcp_success(result, "call event with JSON string data")
-    assert data["success"] is True
-    assert data["event_type"] == "test_mcp_event_json_str"
-    logger.info("Called event with JSON string data: %s", data)
-
-
-@pytest.mark.asyncio
 async def test_call_event_list_data_rejected(mcp_client):
     """Event data must be a dict — a JSON array is rejected with ToolError."""
     with pytest.raises(ToolError):

--- a/tests/src/e2e/workflows/categories/test_category_crud.py
+++ b/tests/src/e2e/workflows/categories/test_category_crud.py
@@ -304,7 +304,7 @@ class TestCategoryAssignment:
             "ha_set_entity",
             {
                 "entity_id": test_light_entity,
-                "categories": '{"automation": null}',  # JSON string format
+                "categories": {"automation": None},
             },
         )
         clear_data = assert_mcp_success(clear_result, "Clear category via null")

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -316,25 +316,6 @@ class TestCallService:
         data = assert_mcp_success(result, "Scene turn_on service call")
         logger.info(f"Scene activation executed: {data.get('message')}")
 
-    async def test_call_service_data_as_json_string(
-        self, mcp_client, test_light_entity
-    ):
-        """Test calling service with data provided as JSON string."""
-        logger.info("Testing ha_call_service with JSON string data")
-
-        result = await mcp_client.call_tool(
-            "ha_call_service",
-            {
-                "domain": "light",
-                "service": "turn_on",
-                "entity_id": test_light_entity,
-                "data": '{"brightness_pct": 75}',  # JSON string
-            },
-        )
-
-        data = assert_mcp_success(result, "Service with JSON string data")
-        logger.info(f"Service with JSON string executed: {data.get('message')}")
-
     async def test_call_service_without_entity_id(self, mcp_client):
         """Test calling domain-wide service without entity_id."""
         logger.info("Testing ha_call_service without entity_id")

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -1,12 +1,11 @@
-"""Schema regression test: config parameters must not advertise string type.
+"""Schema regression test: dict/object parameters must not advertise string type.
 
-Verifies that the MCP JSON schema for the `config` parameter on all five
-config-set tools is `{type: object}` (or `anyOf` containing only object/null),
-never `{type: string}` or an `anyOf` that includes string.
+Verifies that the MCP JSON schema for parameters that must be dicts/objects
+never includes type:string or an anyOf containing string. A string in the schema
+tells models that passing a JSON string is valid, causing retry loops when models
+pass strings that fail server-side parsing.
 
-A string in the schema tells models that passing a JSON string is valid.
-This causes retry loops when models pass strings that fail server-side
-parsing. The fix: annotate config as `dict | None`, not `str | dict | None`.
+Fix: annotate as `dict | None`, not `str | dict | None`.
 """
 
 from __future__ import annotations
@@ -19,16 +18,16 @@ from unittest.mock import MagicMock
 import pytest
 
 
-def _get_config_schema(
-    register_fn: Callable[..., Any], tool_name: str
+def _get_param_schema(
+    register_fn: Callable[..., Any], tool_name: str, param_name: str
 ) -> dict[str, Any]:
     from fastmcp import FastMCP
 
     async def _inner() -> dict[str, Any]:
         mcp = FastMCP("test")
-        register_fn(mcp, MagicMock())
+        register_fn(mcp, MagicMock(), device_tools=MagicMock())
         tool = await mcp.get_tool(tool_name)
-        return tool.parameters["properties"]["config"]  # type: ignore[no-any-return]
+        return tool.parameters["properties"][param_name]  # type: ignore[no-any-return]
 
     return asyncio.run(_inner())
 
@@ -40,93 +39,117 @@ def _contains_string_type(schema: dict[str, Any]) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# config param on set tools (PR #1485)
+# ---------------------------------------------------------------------------
+
+_CONFIG_TOOLS = [
+    (
+        "ha_mcp.tools.tools_config_automations",
+        "register_config_automation_tools",
+        "ha_config_set_automation",
+        "config",
+    ),
+    (
+        "ha_mcp.tools.tools_config_scripts",
+        "register_config_script_tools",
+        "ha_config_set_script",
+        "config",
+    ),
+    (
+        "ha_mcp.tools.tools_config_scenes",
+        "register_config_scene_tools",
+        "ha_config_set_scene",
+        "config",
+    ),
+    (
+        "ha_mcp.tools.tools_config_helpers",
+        "register_config_helper_tools",
+        "ha_config_set_helper",
+        "config",
+    ),
+    (
+        "ha_mcp.tools.tools_config_dashboards",
+        "register_config_dashboard_tools",
+        "ha_config_set_dashboard",
+        "config",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# data/options/categories/expose_to params on service & entity tools
+# ---------------------------------------------------------------------------
+
+_SERVICE_AND_ENTITY_TOOLS = [
+    (
+        "ha_mcp.tools.tools_service",
+        "register_service_tools",
+        "ha_call_service",
+        "data",
+    ),
+    (
+        "ha_mcp.tools.tools_service",
+        "register_service_tools",
+        "ha_call_event",
+        "data",
+    ),
+    (
+        "ha_mcp.tools.tools_entities",
+        "register_entity_tools",
+        "ha_set_entity",
+        "options",
+    ),
+    (
+        "ha_mcp.tools.tools_entities",
+        "register_entity_tools",
+        "ha_set_entity",
+        "categories",
+    ),
+    (
+        "ha_mcp.tools.tools_entities",
+        "register_entity_tools",
+        "ha_set_entity",
+        "expose_to",
+    ),
+]
+
+_ALL_TOOLS = _CONFIG_TOOLS + _SERVICE_AND_ENTITY_TOOLS
+
+
 @pytest.mark.parametrize(
-    ("module", "register_fn", "tool_name"),
-    [
-        (
-            "ha_mcp.tools.tools_config_automations",
-            "register_config_automation_tools",
-            "ha_config_set_automation",
-        ),
-        (
-            "ha_mcp.tools.tools_config_scripts",
-            "register_config_script_tools",
-            "ha_config_set_script",
-        ),
-        (
-            "ha_mcp.tools.tools_config_scenes",
-            "register_config_scene_tools",
-            "ha_config_set_scene",
-        ),
-        (
-            "ha_mcp.tools.tools_config_helpers",
-            "register_config_helper_tools",
-            "ha_config_set_helper",
-        ),
-        (
-            "ha_mcp.tools.tools_config_dashboards",
-            "register_config_dashboard_tools",
-            "ha_config_set_dashboard",
-        ),
-    ],
+    ("module", "register_fn", "tool_name", "param_name"),
+    _ALL_TOOLS,
 )
-def test_config_param_does_not_advertise_string(
-    module: str, register_fn: str, tool_name: str
+def test_param_does_not_advertise_string(
+    module: str, register_fn: str, tool_name: str, param_name: str
 ) -> None:
-    """config parameter schema must not include type:string."""
+    """Object/dict parameter schema must not include type:string."""
     import importlib
 
     mod = importlib.import_module(module)
     fn = getattr(mod, register_fn)
-    schema = _get_config_schema(fn, tool_name)
+    schema = _get_param_schema(fn, tool_name, param_name)
     assert not _contains_string_type(schema), (
-        f"{tool_name}: config schema still advertises string type. Schema: {schema}"
+        f"{tool_name}.{param_name}: schema still advertises string type. Schema: {schema}"
     )
 
 
 @pytest.mark.parametrize(
-    ("module", "register_fn", "tool_name"),
-    [
-        (
-            "ha_mcp.tools.tools_config_automations",
-            "register_config_automation_tools",
-            "ha_config_set_automation",
-        ),
-        (
-            "ha_mcp.tools.tools_config_scripts",
-            "register_config_script_tools",
-            "ha_config_set_script",
-        ),
-        (
-            "ha_mcp.tools.tools_config_scenes",
-            "register_config_scene_tools",
-            "ha_config_set_scene",
-        ),
-        (
-            "ha_mcp.tools.tools_config_helpers",
-            "register_config_helper_tools",
-            "ha_config_set_helper",
-        ),
-        (
-            "ha_mcp.tools.tools_config_dashboards",
-            "register_config_dashboard_tools",
-            "ha_config_set_dashboard",
-        ),
-    ],
+    ("module", "register_fn", "tool_name", "param_name"),
+    _ALL_TOOLS,
 )
-def test_config_param_advertises_object(
-    module: str, register_fn: str, tool_name: str
+def test_param_advertises_object(
+    module: str, register_fn: str, tool_name: str, param_name: str
 ) -> None:
-    """config parameter schema must include type:object."""
+    """Object/dict parameter schema must include type:object."""
     import importlib
 
     mod = importlib.import_module(module)
     fn = getattr(mod, register_fn)
-    schema = _get_config_schema(fn, tool_name)
-    # Either top-level type:object or anyOf containing {type:object}
+    schema = _get_param_schema(fn, tool_name, param_name)
     has_object = schema.get("type") == "object" or any(
         v.get("type") == "object" for v in schema.get("anyOf", [])
     )
     assert has_object, (
-        f"{tool_name}: config schema does not include type:object. Schema: {schema}"
+        f"{tool_name}.{param_name}: schema does not include type:object. Schema: {schema}"
     )

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -120,9 +120,7 @@ _ALL_TOOLS = _CONFIG_TOOLS + _SERVICE_AND_ENTITY_TOOLS
     ("module", "register_fn", "tool_name", "param_name"),
     _ALL_TOOLS,
 )
-def test_param_does_not_advertise_string(
-    module: str, register_fn: str, tool_name: str, param_name: str
-) -> None:
+def test_param_does_not_advertise_string(module, register_fn, tool_name, param_name):
     """Object/dict parameter schema must not include type:string."""
     import importlib
 
@@ -138,9 +136,7 @@ def test_param_does_not_advertise_string(
     ("module", "register_fn", "tool_name", "param_name"),
     _ALL_TOOLS,
 )
-def test_param_advertises_object(
-    module: str, register_fn: str, tool_name: str, param_name: str
-) -> None:
+def test_param_advertises_object(module, register_fn, tool_name, param_name):
     """Object/dict parameter schema must include type:object."""
     import importlib
 

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -312,50 +312,6 @@ class TestHaSetEntityExposeTo:
         )
 
     @pytest.mark.asyncio
-    async def test_expose_to_json_string(self, mock_mcp, mock_client):
-        """expose_to as JSON string should be parsed."""
-        entity_entry = {
-            "entity_id": "light.test",
-            "name": None,
-            "original_name": "Test",
-            "icon": None,
-            "area_id": None,
-            "disabled_by": None,
-            "hidden_by": None,
-            "aliases": [],
-            "labels": [],
-        }
-
-        mock_client.send_websocket_message = AsyncMock(
-            side_effect=[
-                {"success": True},  # expose call
-                {"success": True, "result": entity_entry},  # get entity call
-            ]
-        )
-        register_entity_tools(mock_mcp, mock_client)
-        tool = self.registered_tools["ha_set_entity"]
-
-        result = await tool(
-            entity_id="light.test",
-            expose_to=json.dumps({"conversation": True}),
-        )
-
-        assert result["success"] is True
-        assert result["exposure"] == {"conversation": True}
-
-    @pytest.mark.asyncio
-    async def test_expose_to_invalid_json_string(self, set_entity_tool):
-        """Invalid JSON string for expose_to should raise ToolError."""
-        with pytest.raises(ToolError) as exc_info:
-            await set_entity_tool(
-                entity_id="light.test",
-                expose_to="not valid json{",
-            )
-
-        error_data = json.loads(str(exc_info.value))
-        assert error_data["success"] is False
-
-    @pytest.mark.asyncio
     async def test_expose_to_none_not_triggered(self, mock_mcp, mock_client):
         """When expose_to is None, no exposure API call should be made."""
         mock_client.send_websocket_message = AsyncMock(
@@ -1612,24 +1568,6 @@ class TestHaSetEntityShowAs:
         assert body["options_domain"] == "weather"
         assert body["partial"] is True
         assert body["options_succeeded"] == {"sensor": {"display_precision": 1}}
-
-    @pytest.mark.asyncio
-    async def test_options_json_string_is_parsed(self, mock_mcp, mock_client):
-        """options as a JSON string should be parsed transparently."""
-        mock_client.send_websocket_message = AsyncMock(
-            return_value=self._registry_response()
-        )
-        register_entity_tools(mock_mcp, mock_client)
-        tool = self.registered_tools["ha_set_entity"]
-
-        await tool(
-            entity_id="sensor.temp",
-            options='{"sensor": {"display_precision": 0}}',
-        )
-
-        ws_msg = mock_client.send_websocket_message.call_args[0][0]
-        assert ws_msg["options_domain"] == "sensor"
-        assert ws_msg["options"] == {"display_precision": 0}
 
     @pytest.mark.asyncio
     async def test_options_invalid_shape_raises_validation_error(


### PR DESCRIPTION
## What does this PR do?

Extends #1485 — removes `str |` from five more MCP-exposed dict parameters across two tools.

`str | dict | None` generates `anyOf: [string, object, null]` in the MCP JSON schema, advertising to models that JSON-encoded strings are valid inputs. This misleads models into passing strings instead of dicts.

**Affected parameters (all changed from `str | dict | None` to `dict | None`):**
- `ha_call_service.data`
- `ha_call_event.data`
- `ha_set_entity.options`, `categories`, `expose_to`

**Root cause analysis:**
- `str |` was absent in the original v1.0.0 (human-authored, clean `dict | None`)
- Added by LLMs in later refactors, with LLM-written tests to match
- MCP uses JSON transport exclusively — string-coercion rationale ("XML-style callers") never applied here
- No BAT evidence of models passing strings for these params across 7 runs (27B + 9B models)
- Internal helpers (`_parse_json_dict_param`, `_parse_service_data`) retain `str | dict` — they are not MCP-exposed

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

**BAT results:** 14/14 stories pass (same as post-#1485 baseline, no regressions)

**Schema regression tests:** extended from 10 to 20 (5 new parameters x 2 assertions each)

**Removed 5 LLM-generated string-parsing tests** that tested invented behavior with no real-world use case:
- `test_call_event_with_json_string_data`
- `test_call_service_data_as_json_string`
- `test_expose_to_json_string`, `test_expose_to_invalid_json_string`
- `test_options_json_string_is_parsed`

## Checklist
- [x] I have updated documentation if needed