### PR TITLE
fix(addon): expose non-beta tool options on the stable add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ An MCP server can create automations, helpers, and dashboards, but it has no opi
 
 Skills from `homeassistant-ai/skills` are bundled and served as [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) via `skill://` URIs. Any MCP client that supports resources can discover them automatically — no manual installation needed. For tool-only clients (claude.ai, etc.), the same skills are reachable through the polymorphic `ha_get_skill_guide` tool — call it with no args to list bundled skills, with a `skill` arg to list its files, or with `skill` + `file` to read content. Resources are not auto-injected into context — clients must explicitly request them, so idle context cost is just the metadata listing.
 
-`ha_get_skill_guide` is mandatory-pinned: the catalog always exposes it so tool-only clients never see a silently missing skill surface.
+`ha_get_skill_guide` is a mandatory tool: the catalog always exposes it (it can't be disabled) so tool-only clients never see a silently missing skill surface.
 
 Skills can still be installed manually for clients that prefer local skill files — see the [skills repo](https://github.com/homeassistant-ai/skills) for instructions.
 

--- a/homeassistant-addon-dev/DOCS.md
+++ b/homeassistant-addon-dev/DOCS.md
@@ -21,7 +21,7 @@ The dev add-on uses the same configuration as the stable version. See the main a
 | `enable_filesystem_tools` *(beta)* | Enables file read/write tools (`ha_list_files`, `ha_read_file`, `ha_write_file`, `ha_delete_file`). Requires `ha_mcp_tools` custom component. Gated by the master above. | `false` |
 | `enable_custom_component_integration` *(beta)* | Enables `ha_install_mcp_tools` installer tool for the `ha_mcp_tools` custom component. Gated by the master above. | `false` |
 | `tool_search_max_results` | Max results from `ha_search_tools` (range 2-10) | `5` |
-| `disabled_tools` | Comma-separated list of tool names to disable (seed value; web UI is primary) | empty |
+| `disabled_tools` | Comma-separated list of tool names to disable (seed value; web UI is primary). Mandatory tools can't be disabled and are unaffected. | empty |
 | `pinned_tools` | Comma-separated list of tool names to pin when tool search is enabled (seed value; web UI is primary) | empty |
 | `verify_ssl` | Verify the HA server's TLS certificate. Disable for self-signed certs or hostname mismatches. Weakens security — leave on unless needed. | `true` |
 
@@ -49,7 +49,7 @@ Features:
 - **Pin tools** — keep tools always visible when `enable_tool_search` is on
 - **Per-group master toggle** — enable/disable all tools in a group (HACS, System, etc.) with one click
 - **Search** — filter tools by name or title
-- **Mandatory tools** — `ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue` are always enabled and cannot be disabled
+- **Mandatory tools** — `ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue`, `ha_get_skill_guide`, `ha_manage_backup` are always enabled and cannot be disabled (listing one in `disabled_tools` is a silent no-op — it keeps running)
 - **Feature-gated tools** — `ha_config_set_yaml` (requires `enable_yaml_config_editing`), filesystem tools (require `enable_filesystem_tools`), and `ha_install_mcp_tools` (requires `enable_custom_component_integration`) appear in the list with a note if their feature flag is off
 - **In-UI restart** — a "Restart Add-on" button appears after saving to apply changes with one click
 

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -159,10 +159,13 @@ configuration:
       may miss relevant tools. Range: 2-10. Requires restart.
   disabled_tools:
     name: Disabled tools (comma-separated)
-    description: |
-      Tools listed here are locked disabled — they cannot be re-enabled
-      from the web Settings UI (Tools tab) without unsetting this option
-      first. Comma-separated tool names (e.g. ``ha_call_event,ha_eval_template``).
+    description: >-
+      Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this
+      option first. A small set of mandatory tools (ha_search_entities,
+      ha_get_overview, ha_get_state, ha_report_issue, ha_get_skill_guide,
+      ha_manage_backup) cannot be disabled and keep running even if listed
+      here. Comma-separated tool names (e.g. ha_call_event,ha_eval_template).
   pinned_tools:
     name: Pinned tools (comma-separated)
     description: |

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -168,7 +168,7 @@ configuration:
       here. Comma-separated tool names (e.g. ha_call_event,ha_eval_template).
   pinned_tools:
     name: Pinned tools (comma-separated)
-    description: |
+    description: >-
       Tools listed here are locked pinned — they appear at the top of the
       Tools tab and cannot be unpinned from the web Settings UI without
       unsetting this option first. Useful in combination with Tool Search.

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -292,6 +292,14 @@ Replaces the full tool catalog (~86 tools, ~46K tokens) with search-based discov
 
 Requires add-on restart to take effect.
 
+### tool_search_max_results
+
+**Default:** `5` (range 2-10)
+
+Maximum number of tools returned by `ha_search_tools` when `enable_tool_search` is on. Lower values (2-3) save context tokens but may miss relevant tools. Has no effect unless tool search is enabled.
+
+Requires add-on restart to take effect.
+
 ### enable_tool_security_policies
 
 **Default:** `false`
@@ -330,12 +338,22 @@ Features:
 - **Pin tools** — keep tools always visible when `enable_tool_search` is on
 - **Per-group master toggle** — enable/disable all tools in a group (HACS, System, etc.) with one click
 - **Search** — filter tools by name or title
-- **Mandatory tools** — `ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue` are always enabled and cannot be disabled
+- **Mandatory tools** — `ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue`, `ha_get_skill_guide`, and `ha_manage_backup` are always enabled and cannot be disabled (listing one in `disabled_tools` is a silent no-op — it keeps running)
 - **Tool Security Policies tab** — when `enable_tool_security_policies` is on, approve held tool calls and manage per-tool rules here
 - **Advanced settings** — an advanced panel with a beta master toggle (plus per-feature sub-toggles) for opting into beta tools such as raw YAML editing, filesystem tools, and code mode. See [Beta Features](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md)
 - **In-UI restart** — a "Restart Add-on" button appears after saving to apply changes with one click
 
 **Important:** Tool configuration changes require an add-on restart to take effect. The UI will prompt you to restart after saving.
+
+### Non-add-on installations
+
+In Docker (`ha-mcp-web`) and standalone HTTP installations, the settings UI is mounted under your MCP secret path. Open `http://<host>:<port>/<secret_path>/settings` (the same URL prefix that protects your MCP endpoint). This keeps the auth posture consistent — anyone who can reach your MCP endpoint can also use the settings UI; anyone who can't, can't.
+
+### Text-field fallback
+
+If you prefer not to use the web UI (or want to set these before first start), the `disabled_tools` and `pinned_tools` options accept comma-separated tool names as seed values. On first start, the add-on creates `/data/tool_config.json` from these values; after that, the web UI is the source of truth. Mandatory tools (listed above) cannot be disabled this way.
+
+---
 
 ## Security
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -43,7 +43,10 @@ image: "ghcr.io/homeassistant-ai/ha-mcp-addon-{arch}"
 options:
   backup_hint: "normal"
   enable_tool_search: false
+  tool_search_max_results: 5
   enable_tool_security_policies: false
+  disabled_tools: ""
+  pinned_tools: ""
   enable_auto_backup: true
   auto_backup_throttle_minutes: 0
   auto_backup_retain_per_entity: 100
@@ -52,7 +55,10 @@ schema:
   backup_hint: list(strong|normal|weak|auto)
   secret_path: str?
   enable_tool_search: bool?
+  tool_search_max_results: int(2,10)?
   enable_tool_security_policies: bool?
+  disabled_tools: str?
+  pinned_tools: str?
   enable_auto_backup: bool?
   auto_backup_throttle_minutes: int(0,1440)?
   auto_backup_retain_per_entity: int(1,10000)?

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -78,3 +78,22 @@ configuration:
       and memory state. Useful when reporting unexplained add-on
       stops or crash loops. Off by default to keep logs concise.
       Requires restart to take effect.
+  tool_search_max_results:
+    name: Tool search max results
+    description: >-
+      Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss
+      relevant tools. Range: 2-10. Requires restart.
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: >-
+      Tools listed here are locked disabled — they cannot be re-enabled
+      from the web Settings UI (Tools tab) without unsetting this option
+      first. Comma-separated tool names (e.g. ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: >-
+      Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without
+      unsetting this option first. Useful in combination with Tool Search.
+      Comma-separated tool names.

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -87,9 +87,12 @@ configuration:
   disabled_tools:
     name: Disabled tools (comma-separated)
     description: >-
-      Tools listed here are locked disabled — they cannot be re-enabled
-      from the web Settings UI (Tools tab) without unsetting this option
-      first. Comma-separated tool names (e.g. ha_call_event,ha_eval_template).
+      Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this
+      option first. A small set of mandatory tools (ha_search_entities,
+      ha_get_overview, ha_get_state, ha_report_issue, ha_get_skill_guide,
+      ha_manage_backup) cannot be disabled and keep running even if listed
+      here. Comma-separated tool names (e.g. ha_call_event,ha_eval_template).
   pinned_tools:
     name: Pinned tools (comma-separated)
     description: >-

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -111,6 +111,28 @@ class TestAddonStructure:
             "32-bit platforms not supported by uv base image"
         )
 
+    def test_stable_addon_exposes_nonbeta_tool_options(self):
+        """Stable add-on must expose the NON-beta operator options that dev
+        has — ``tool_search_max_results``, ``disabled_tools``, ``pinned_tools``
+        — in both ``options`` and ``schema``. These are not beta features, so
+        the web-UI master gate doesn't apply; without them in the stable
+        schema they were unreachable on stable (start.py wrote defaults, the
+        web UI showed them ``origin='addon'``-locked, and the override applier
+        skipped them). Regression guard for that dev/stable config drift."""
+        with open(f"{ADDON_DIR}/config.yaml") as f:
+            config = yaml.safe_load(f)
+
+        expected_schema = {
+            "tool_search_max_results": "int(2,10)?",
+            "disabled_tools": "str?",
+            "pinned_tools": "str?",
+        }
+        for key, schema_type in expected_schema.items():
+            assert key in config["options"], f"{key!r} must be in stable options"
+            assert config["schema"].get(key) == schema_type, (
+                f"{key!r} must be in stable schema as {schema_type!r}"
+            )
+
     @pytest.mark.skipif(
         sys.platform == "win32", reason="Unix permissions not applicable on Windows"
     )

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -144,7 +144,7 @@ class TestAddonStructure:
         against future one-sided drift (the exact bug class this fix
         addresses: dev gains/changes an option, stable is forgotten)."""
         keys = ("tool_search_max_results", "disabled_tools", "pinned_tools")
-        with open("homeassistant-addon/config.yaml") as f:
+        with open(f"{ADDON_DIR}/config.yaml") as f:
             stable = yaml.safe_load(f)
         with open("homeassistant-addon-dev/config.yaml") as f:
             dev = yaml.safe_load(f)

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -122,15 +122,38 @@ class TestAddonStructure:
         with open(f"{ADDON_DIR}/config.yaml") as f:
             config = yaml.safe_load(f)
 
-        expected_schema = {
-            "tool_search_max_results": "int(2,10)?",
-            "disabled_tools": "str?",
-            "pinned_tools": "str?",
+        # key: (schema type, default value). Defaults are load-bearing — a
+        # non-empty disabled_tools default would silently lock tools off.
+        expected = {
+            "tool_search_max_results": ("int(2,10)?", 5),
+            "disabled_tools": ("str?", ""),
+            "pinned_tools": ("str?", ""),
         }
-        for key, schema_type in expected_schema.items():
+        for key, (schema_type, default) in expected.items():
             assert key in config["options"], f"{key!r} must be in stable options"
+            assert config["options"].get(key) == default, (
+                f"{key!r} default must be {default!r}"
+            )
             assert config["schema"].get(key) == schema_type, (
                 f"{key!r} must be in stable schema as {schema_type!r}"
+            )
+
+    def test_stable_and_dev_agree_on_nonbeta_tool_options(self):
+        """The three non-beta tool options must stay in sync between the
+        stable and dev add-ons — same defaults AND same schema types. Guards
+        against future one-sided drift (the exact bug class this fix
+        addresses: dev gains/changes an option, stable is forgotten)."""
+        keys = ("tool_search_max_results", "disabled_tools", "pinned_tools")
+        with open("homeassistant-addon/config.yaml") as f:
+            stable = yaml.safe_load(f)
+        with open("homeassistant-addon-dev/config.yaml") as f:
+            dev = yaml.safe_load(f)
+        for key in keys:
+            assert stable["options"].get(key) == dev["options"].get(key), (
+                f"{key!r} option default differs between stable and dev add-ons"
+            )
+            assert stable["schema"].get(key) == dev["schema"].get(key), (
+                f"{key!r} schema type differs between stable and dev add-ons"
             )
 
     @pytest.mark.skipif(


### PR DESCRIPTION
## What does this PR do?

Exposes three **non-beta** operator options on the **stable** Home Assistant add-on — `tool_search_max_results`, `disabled_tools`, `pinned_tools` — that were previously dev-add-on-only. Because they aren't beta features, #1431's web-UI master gate doesn't apply to them, yet on stable they were unreachable: not in the Supervisor schema, shown in the web Settings UI as `origin="addon"`-locked, and skipped by the addon-mode override short-circuit. `start.py` already reads and exports all three on every boot, so they just needed to be declared in the stable add-on's schema/options.

Found during the #1476 audit — the same dev/stable `config.yaml` drift class as the missing `ingress` that hid the stable web UI (**#1486**, now merged; this branch is rebased on top of it).

### Changes
- **`homeassistant-addon/config.yaml`** — add the 3 keys to `options` + `schema` (mirroring the dev add-on; defaults `5` / `""` / `""`, schema `int(2,10)?` / `str?` / `str?`).
- **`homeassistant-addon/translations/en.yaml`** — translations for the 3 keys.
- **`tests/addon/test_addon_structure.py`** — assert the stable add-on declares the 3 keys (presence + default values) and a dev↔stable parity test so the two add-ons can't silently drift again. (Translations are already backstopped by the existing parametrized `test_translations_cover_every_schema_key`.)

### Mandatory-tools docs cleanup (Boy Scout)
While documenting `disabled_tools`/`pinned_tools` here, fixed related drift about **mandatory tools** — the 6 tools that can never be disabled (`ha_search_entities`, `ha_get_overview`, `ha_get_state`, `ha_report_issue`, `ha_get_skill_guide`, `ha_manage_backup`):
- Both add-on translations: `disabled_tools` no longer overstates "locked disabled" — it now notes mandatory tools can't be disabled (listing one is a silent no-op). Both translations are byte-identical.
- `homeassistant-addon-dev/DOCS.md`: mandatory list corrected **4 → 6**; options-table note added.
- `homeassistant-addon/DOCS.md`: ported the "Tool Settings Web UI" section (stable had none) and documented `tool_search_max_results`.
- `README.md`: `ha_get_skill_guide` described as a **mandatory** tool (the previous "mandatory-pinned" was inaccurate — it's mandatory but not pinned).

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — verified in CI
- [x] Code follows style guidelines (`ruff` / YAML / translation-coverage pass locally)

## Checklist
- [x] I have updated documentation if needed
