### PR TITLE
feat: convert Pydantic arg-validation errors to actionable ToolErrors

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -190,6 +190,12 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         # the skill guide tool are registered so it can wrap everything)
         self._apply_tool_search()
 
+        # Convert Pydantic type-validation errors to structured ToolErrors so
+        # models get actionable guidance instead of raw Pydantic messages.
+        from .tools.validation_middleware import ValidationErrorMiddleware
+
+        self.mcp.add_middleware(ValidationErrorMiddleware())
+
         # Wire tool security policies middleware (#966) — opt-in via
         # ENABLE_TOOL_SECURITY_POLICIES. Must come last so the middleware
         # wraps the final tool surface (including the search proxies).

--- a/src/ha_mcp/tools/validation_middleware.py
+++ b/src/ha_mcp/tools/validation_middleware.py
@@ -1,0 +1,57 @@
+"""FastMCP middleware that converts Pydantic validation errors to structured ToolErrors.
+
+When a model passes the wrong type for a tool parameter (e.g. a JSON string where
+a dict is required), FastMCP raises a PydanticValidationError with a raw message
+like "Input should be a valid dictionary". This middleware intercepts those errors
+and converts them to ha-mcp's structured format with actionable guidance.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
+from pydantic import ValidationError as PydanticValidationError
+
+from ..errors import create_validation_error
+from .helpers import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+# Maps Pydantic error types to model-readable fix hints.
+# FastMCP uses non-strict Pydantic: scalar mismatches (bool, int) are coerced
+# rather than rejected, so only dict_type and list_type fire in practice.
+_TYPE_HINTS: dict[str, str] = {
+    "dict_type": (
+        "expected a JSON object. "
+        'Pass {"key": "value"} directly, not a JSON-encoded string.'
+    ),
+    "list_type": (
+        "expected a JSON array. Pass [...] directly, not a JSON-encoded string."
+    ),
+}
+
+
+class ValidationErrorMiddleware(Middleware):
+    """Convert PydanticValidationError from argument validation into ToolErrors."""
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: CallNext
+    ) -> Any:
+        try:
+            return await call_next(context)
+        except PydanticValidationError as exc:
+            errors = exc.errors(include_url=False)
+            parts: list[str] = []
+            for err in errors:
+                loc = err.get("loc", ())
+                param = ".".join(str(p) for p in loc if p != "__root__")
+                hint = _TYPE_HINTS.get(err["type"], err["msg"])
+                parts.append(f"`{param}`: {hint}" if param else hint)
+            raise_tool_error(
+                create_validation_error(
+                    "; ".join(parts) if parts else "Invalid argument types.",
+                    details=", ".join(err["type"] for err in errors),
+                )
+            )

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -45,11 +45,14 @@ def _is_under(path: Path, root: Path) -> bool:
 def pytest_configure(config: pytest.Config) -> None:
     """Reject an invocation whose path args span both unit and e2e trees."""
     params = config.invocation_params
+    if params is None:
+        return
     base = Path(params.dir)
     touches_unit = touches_e2e = False
-    for arg in params.args:
-        if arg.startswith("-"):
-            continue
+    # ``config.args`` contains only the already-parsed positional path args,
+    # not option values (e.g. -k unit). Using invocation_params.args would
+    # misclassify option arguments as paths.
+    for arg in config.args:
         # Strip ``::node::ids`` and resolve relative to the invocation dir.
         target = (base / arg.split("::", 1)[0]).resolve()
         if _is_under(target, _UNIT):

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -1,0 +1,60 @@
+"""Session guard: unit and e2e tests must not run in the same pytest session.
+
+They share ``asyncio_default_test_loop_scope = session`` (one event loop per
+xdist worker). E2e tests leave Docker/HTTP state in that loop; unit tests
+using AsyncMock then behave non-deterministically.
+
+Run them separately:
+    cd tests && uv run pytest src/unit/ -n2
+    cd tests && uv run pytest src/e2e/ -n2 --dist loadscope
+
+The check runs in ``pytest_configure`` against the invocation path args
+(not collected items) so it fires on the xdist controller before any worker
+is spawned. Raising from a collection hook inside a worker crashes xdist with
+an opaque INTERNALERROR; ``pytest_configure`` on the controller exits cleanly.
+Only explicit path args are inspected: a bare ``pytest`` relying on
+``testpaths`` is left alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_UNIT = Path(__file__).parent / "unit"
+_E2E = Path(__file__).parent / "e2e"
+
+_MESSAGE = (
+    "Unit and e2e tests cannot run in the same pytest session. They share an "
+    "asyncio event loop per xdist worker, and e2e's Docker/HTTP state then "
+    "contaminates AsyncMock-based unit tests. Run them separately: "
+    "'uv run pytest src/unit/ -n2' and "
+    "'uv run pytest src/e2e/ -n2 --dist loadscope'."
+)
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Reject an invocation whose path args span both unit and e2e trees."""
+    params = config.invocation_params
+    base = Path(params.dir)
+    touches_unit = touches_e2e = False
+    for arg in params.args:
+        if arg.startswith("-"):
+            continue
+        # Strip ``::node::ids`` and resolve relative to the invocation dir.
+        target = (base / arg.split("::", 1)[0]).resolve()
+        if _is_under(target, _UNIT):
+            touches_unit = True
+        elif _is_under(target, _E2E):
+            touches_e2e = True
+    if touches_unit and touches_e2e:
+        raise pytest.UsageError(_MESSAGE)

--- a/tests/src/unit/test_validation_middleware.py
+++ b/tests/src/unit/test_validation_middleware.py
@@ -1,0 +1,123 @@
+"""Unit tests for ValidationErrorMiddleware."""
+
+import json
+
+import pytest
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.validation_middleware import ValidationErrorMiddleware
+
+
+def _make_mcp() -> FastMCP:
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_dict_param(config: dict) -> dict:
+        return {"ok": True}
+
+    @mcp.tool()
+    async def ha_test_list_param(items: list) -> dict:
+        return {"ok": True}
+
+    @mcp.tool()
+    async def ha_test_int_param(count: int) -> dict:
+        return {"count": count}
+
+    @mcp.tool()
+    async def ha_test_two_params(config: dict, items: list) -> dict:
+        return {"ok": True}
+
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_string_for_dict_gives_actionable_message():
+    """Passing a JSON string where a dict is expected raises a structured ToolError."""
+    mcp = _make_mcp()
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_dict_param", {"config": '{"key": "value"}'})
+
+    body = json.loads(str(exc_info.value))
+    assert body["success"] is False
+    msg = body["error"]["message"]
+    assert "config" in msg
+    assert "JSON object" in msg
+
+
+@pytest.mark.asyncio
+async def test_string_for_list_gives_actionable_message():
+    """Passing a JSON string where a list is expected names the array hint."""
+    mcp = _make_mcp()
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_list_param", {"items": "[1, 2, 3]"})
+
+    body = json.loads(str(exc_info.value))
+    msg = body["error"]["message"]
+    assert "items" in msg
+    assert "JSON array" in msg
+
+
+@pytest.mark.asyncio
+async def test_multiple_type_errors_are_joined():
+    """Multiple bad params surface together, joined by ';'."""
+    mcp = _make_mcp()
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool(
+            "ha_test_two_params", {"config": '{"a": 1}', "items": "[1]"}
+        )
+
+    msg = json.loads(str(exc_info.value))["error"]["message"]
+    assert "config" in msg
+    assert "items" in msg
+    assert ";" in msg
+
+
+@pytest.mark.asyncio
+async def test_scalar_string_is_coerced_not_wrapped():
+    """Tripwire for the design assumption: non-strict Pydantic coerces a
+    numeric string to int, so the middleware never sees an int error. If a
+    FastMCP upgrade flips to strict validation this test fails loudly,
+    signalling that int_type/bool_type hints would start mattering."""
+    mcp = _make_mcp()
+    result = await mcp.call_tool("ha_test_int_param", {"count": "42"})
+    assert result.structured_content == {"count": 42}
+
+
+@pytest.mark.asyncio
+async def test_dict_passes_through():
+    """Passing a proper dict round-trips through the middleware unchanged."""
+    mcp = _make_mcp()
+    result = await mcp.call_tool("ha_test_dict_param", {"config": {"key": "value"}})
+    assert result.structured_content == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_error_is_structured():
+    """Error follows ha-mcp's structured format with success/error fields."""
+    mcp = _make_mcp()
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_dict_param", {"config": "not a dict"})
+
+    body = json.loads(str(exc_info.value))
+    assert body["success"] is False
+    assert "code" in body["error"]
+    assert "message" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_error_from_tool_body_passes_through_unconverted():
+    """A ToolError raised inside the tool is NOT re-wrapped by the middleware."""
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_raises_tool_error(entity_id: str) -> dict:
+        raise ToolError('{"success": false, "error": {"code": "ENTITY_NOT_FOUND"}}')
+
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_raises_tool_error", {"entity_id": "light.x"})
+
+    body = json.loads(str(exc_info.value))
+    assert body["error"]["code"] == "ENTITY_NOT_FOUND"


### PR DESCRIPTION
## What does this PR do?

### Problem: models loop on raw Pydantic type errors

When a model passes the wrong type for a tool parameter (e.g. a JSON string where a dict is required), FastMCP surfaces a raw Pydantic error:

```
Input should be a valid dictionary [type=dict_type, input_value='{"alias": "..."}', input_type=str]
```

This is not actionable. Models see it, can't identify what they did wrong, and retry with the same bad payload -- burning tokens without making progress. In the BAT run that exposed this (#s02, previously #s09), the model retried the same JSON-string config 5+ times in a row before giving up.

### Fix: structured, model-readable error messages

This adds a `ValidationErrorMiddleware` that catches `PydanticValidationError` on any tool call and re-raises a structured `ToolError` with a clear hint:

**Before:**
```
1 validation error for call[ha_config_set_automation]
config
  Input should be a valid dictionary [type=dict_type, ...]
```

**After:**
```json
{"success": false, "error": {"code": "VALIDATION_FAILED",
  "message": "`config`: expected a JSON object. Pass {...} directly, not a JSON-encoded string.",
  "details": "dict_type"}}
```

The model sees the parameter name, what it should be, and a concrete corrective action -- the same structured format all other tool errors use. It works for all tools, including those behind the tool-search transform (verified with `ENABLE_TOOL_SEARCH=true`).

### Measured impact

Isolated eval against qwen3.6-27b (N=12, temp=0.7): replaying the exact failure turn (model passed `config` as a JSON string, receives the error, what does it do next?):

- **~92% recovery rate**: model resends `config` as a proper dict on the next attempt
- **0% string-retry**: failures degrade to giving up (`no_call`), not re-sending a string -- the message stops the retry loop entirely
- Wording variants (terse / explicit / side-by-side) clustered 75--92%, so the default phrasing is kept

Three reasoning traces were examined: two showed the model reading the error and self-correcting ("The error says 'Remove the surrounding quotes' -- I will resend as a proper object"); one showed persistent confusion. The ~8% non-recovery floor represents the genuinely-confused case, where the model cannot perceive that it emitted a string at all.

### Session guard bonus

Also adds `tests/src/conftest.py`: a pytest guard that rejects `pytest src/unit/ src/e2e/` in one session. They share an asyncio event loop per xdist worker, and e2e's Docker/HTTP state contaminates AsyncMock-based unit tests, causing flaky failures. The guard inspects `config.args` (positional paths only, not option values) in `pytest_configure` and aborts with a clear `UsageError` before any worker spawns.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit tests cover: dict and list type errors produce actionable hints, multi-error joining with `;`, a scalar-coercion tripwire that fails loudly if a FastMCP upgrade flips to strict Pydantic mode, and that a `ToolError` raised inside a tool body passes through unconverted.

## Checklist
- [x] I have updated documentation if needed