### PR TITLE
fix: remove str from ha_bulk_control.operations schema + fix wrong-reason test

### DIFF
--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -579,7 +579,8 @@ class ServiceTools:
         """Control multiple devices with bulk operation support and WebSocket tracking."""
         parallel_bool = parallel
 
-        # Parse JSON operations if provided as string
+        # FastMCP validates operations as list[dict] before this runs.
+        # parse_json_param is kept as a defensive passthrough for the list case.
         try:
             parsed_operations = parse_json_param(operations, "operations")
         except ValueError as e:
@@ -591,8 +592,7 @@ class ServiceTools:
                 )
             )
 
-        # Ensure operations is a list of dicts
-        if parsed_operations is None or not isinstance(parsed_operations, list):
+        if not isinstance(parsed_operations, list):
             raise_tool_error(
                 create_validation_error(
                     "Operations parameter must be a list",

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -572,7 +572,7 @@ class ServiceTools:
     @log_tool_usage
     async def ha_bulk_control(
         self,
-        operations: str | list[dict[str, Any]],
+        operations: list[dict[str, Any]],
         parallel: bool = True,
         ctx: Context | None = None,
     ) -> dict[str, Any]:

--- a/tests/src/e2e/tools/test_ha_call_event.py
+++ b/tests/src/e2e/tools/test_ha_call_event.py
@@ -46,11 +46,11 @@ async def test_call_event_with_dict_data(mcp_client):
 
 @pytest.mark.asyncio
 async def test_call_event_list_data_rejected(mcp_client):
-    """Event data must be a dict — a JSON array is rejected with ToolError."""
+    """Event data must be a dict — a native list is rejected with ToolError."""
     with pytest.raises(ToolError):
         await mcp_client.call_tool(
             "ha_call_event",
-            {"event_type": "test_mcp_event_bad_data", "data": "[1, 2, 3]"},
+            {"event_type": "test_mcp_event_bad_data", "data": [1, 2, 3]},
         )
 
 

--- a/tests/src/e2e/workflows/core/test_bulk.py
+++ b/tests/src/e2e/workflows/core/test_bulk.py
@@ -234,29 +234,26 @@ class TestBulkControl:
                     f"Brightness should be around 77: {brightness}"
                 )
 
-    async def test_bulk_control_json_string_operations(
+    async def test_bulk_control_json_string_operations_rejected(
         self, mcp_client, test_light_entity
     ):
-        """Test bulk_control accepts operations as JSON string."""
-        logger.info("Testing ha_bulk_control with JSON string operations")
+        """Test bulk_control rejects operations passed as a JSON string.
 
-        # First turn off the light
-        await mcp_client.call_tool(
-            "ha_call_service",
-            {"domain": "light", "service": "turn_off", "entity_id": test_light_entity},
-        )
+        operations must be a list[dict], not a JSON-encoded string.
+        FastMCP validates the type at the schema boundary.
+        """
+        logger.info("Testing ha_bulk_control rejects JSON string operations")
 
-        # Operations as JSON string
         operations_json = json.dumps([{"entity_id": test_light_entity, "action": "on"}])
-        result = await mcp_client.call_tool(
+        result = await safe_call_tool(
+            mcp_client,
             "ha_bulk_control",
             {"operations": operations_json},
         )
-
-        data = assert_mcp_success(result, "Bulk with JSON string operations")
-        logger.info(
-            f"JSON string operations accepted: successful={data.get('successful_commands')}"
+        assert result.get("success") is False, (
+            "ha_bulk_control should reject a JSON-encoded string for operations"
         )
+        logger.info("JSON string operations correctly rejected")
 
     async def test_bulk_control_empty_operations(self, mcp_client):
         """Test bulk_control with empty operations list."""

--- a/tests/src/e2e/workflows/core/test_bulk.py
+++ b/tests/src/e2e/workflows/core/test_bulk.py
@@ -8,7 +8,6 @@ Note: ha_bulk_control expects 'operations' parameter as a list of dicts,
 each containing 'entity_id' and 'action' keys.
 """
 
-import json
 import logging
 
 import pytest
@@ -233,27 +232,6 @@ class TestBulkControl:
                 assert 50 <= brightness <= 100, (
                     f"Brightness should be around 77: {brightness}"
                 )
-
-    async def test_bulk_control_json_string_operations_rejected(
-        self, mcp_client, test_light_entity
-    ):
-        """Test bulk_control rejects operations passed as a JSON string.
-
-        operations must be a list[dict], not a JSON-encoded string.
-        FastMCP validates the type at the schema boundary.
-        """
-        logger.info("Testing ha_bulk_control rejects JSON string operations")
-
-        operations_json = json.dumps([{"entity_id": test_light_entity, "action": "on"}])
-        result = await safe_call_tool(
-            mcp_client,
-            "ha_bulk_control",
-            {"operations": operations_json},
-        )
-        assert result.get("success") is False, (
-            "ha_bulk_control should reject a JSON-encoded string for operations"
-        )
-        logger.info("JSON string operations correctly rejected")
 
     async def test_bulk_control_empty_operations(self, mcp_client):
         """Test bulk_control with empty operations list."""

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -113,6 +113,19 @@ _SERVICE_AND_ENTITY_TOOLS = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# operations param on ha_bulk_control (list[dict], not dict)
+# ---------------------------------------------------------------------------
+
+_BULK_TOOLS = [
+    (
+        "ha_mcp.tools.tools_service",
+        "register_service_tools",
+        "ha_bulk_control",
+        "operations",
+    ),
+]
+
 _ALL_TOOLS = _CONFIG_TOOLS + _SERVICE_AND_ENTITY_TOOLS
 
 
@@ -148,4 +161,41 @@ def test_param_advertises_object(module, register_fn, tool_name, param_name):
     )
     assert has_object, (
         f"{tool_name}.{param_name}: schema does not include type:object. Schema: {schema}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _BULK_TOOLS,
+)
+def test_list_param_does_not_advertise_string(
+    module, register_fn, tool_name, param_name
+):
+    """List parameter schema must not include type:string."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    fn = getattr(mod, register_fn)
+    schema = _get_param_schema(fn, tool_name, param_name)
+    assert not _contains_string_type(schema), (
+        f"{tool_name}.{param_name}: schema still advertises string type. Schema: {schema}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _BULK_TOOLS,
+)
+def test_list_param_advertises_array(module, register_fn, tool_name, param_name):
+    """List parameter schema must include type:array."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    fn = getattr(mod, register_fn)
+    schema = _get_param_schema(fn, tool_name, param_name)
+    has_array = schema.get("type") == "array" or any(
+        v.get("type") == "array" for v in schema.get("anyOf", [])
+    )
+    assert has_array, (
+        f"{tool_name}.{param_name}: schema does not include type:array. Schema: {schema}"
     )


### PR DESCRIPTION
## What does this PR do?

Two follow-ups from the post-merge review of #1487 by @kingpanther13.

### 1. `ha_bulk_control.operations: str | list[dict]` -> `list[dict]`

Same class of fix as #1485 and #1487. With `str | list[dict]`, Pydantic accepts a JSON-encoded string and passes it to the function body, where `parse_json_param` was load-bearing to parse it. Removing `str |` from the annotation makes Pydantic reject the string at the schema boundary before the body runs, so the string-parsing path in `parse_json_param` becomes unreachable.

Empirically verified (both cases):
- Old `str | list[dict]`: JSON string reaches the body as `type=str`. `parse_json_param` runs.
- New `list[dict]`: FastMCP raises a `ValidationError` before the body executes. Body never reached.

The `parse_json_param` call is retained as a defensive passthrough for the `list` case. The now-unreachable `is None` guard and the stale "if provided as string" comment are removed.

### 2. `test_bulk_control_json_string_operations` removed; schema regression test added

The original test asserted success when `operations` is passed as a JSON string. After removing `str |`, that call is rejected at the schema boundary, so the test would have failed in CI.

Converting it to a "rejection test" was rejected: that would test FastMCP's runtime enforcement behavior, not ha-mcp logic. If FastMCP adds coercion, the test would break for unrelated reasons.

Instead, `ha_bulk_control.operations` is added to the unit schema regression test (`test_config_param_no_string_schema.py`), which pins the annotation at the right level:
- `test_list_param_does_not_advertise_string` — schema must not include `type:string`
- `test_list_param_advertises_array` — schema must include `type:array`

### 3. `test_call_event_list_data_rejected`: send a native list, not a JSON string

After PR #1487 narrowed `data: dict | None`, the test was sending `"[1, 2, 3]"` (a JSON-encoded string). With `dict | None`, that string is rejected by Pydantic's `dict_type` check (expected dict, got str) rather than the `list_type` check the test name describes. Fixed by sending a native list `[1, 2, 3]`, which hits the `list_type` path and correctly exercises the contract.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

All affected tests verified locally. The annotation behavior is proven empirically: with `str | list[dict]`, a JSON string reaches the body as `type=str`; with `list[dict]`, FastMCP raises a `ValidationError` before the body runs.

## Checklist
- [x] I have updated documentation if needed