### PR TITLE
fix: add-on-aware code-mode locked note + suppress settings-UI favicon 404

### DIFF
--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -590,8 +590,10 @@ def main() -> int:
     # this file out before reinstalling if they want to migrate).
     # Setting this unconditionally is safe: on the stable add-on the
     # tool isn't registered anyway, so the file is never read or
-    # written. Operators can override by setting CODE_MODE_SAVED_TOOLS_PATH
-    # in the add-on's environment if they want a different location.
+    # written. This path is hardcoded in add-on mode: it is not in the
+    # add-on config.yaml schema, so add-on operators have no surface to
+    # change it — and /data is the only location that survives add-on
+    # updates anyway.
     os.environ.setdefault("CODE_MODE_SAVED_TOOLS_PATH", "/data/saved_tools.json")
     os.environ["TOOL_SEARCH_MAX_RESULTS"] = str(tool_search_max_results)
     os.environ["DISABLED_TOOLS"] = disabled_tools_raw

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, TypedDi
 
 import httpx
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response
 
 from ._version import get_version, is_running_in_addon
 from .backup_manager import get_backup_manager
@@ -2548,8 +2548,15 @@ function renderCodeModeSubRows(parentEl, masterOn, codeModeOn) {
 
     const info = document.createElement('div');
     info.className = 'feature-info';
+    // Route through the shared addon-aware helper (same as the feature-
+    // flag and advanced-field locked rows). In addon mode an env-pinned
+    // field like CODE_MODE_SAVED_TOOLS_PATH is set by start.py via
+    // setdefault and, being absent from the addon config.yaml schema,
+    // cannot be unset by the user — so the standalone "unset it to edit
+    // here" copy is unactionable; envLockedNoteHtml swaps it for the
+    // addon-runtime wording. Standalone mode is unchanged.
     const lockedNote = f.origin === 'env'
-      ? `<div class="feature-locked-note">Set via env var <code>${escapeHtml(f.env_var)}</code> — unset it to edit here.</div>`
+      ? `<div class="feature-locked-note">${envLockedNoteHtml(f.env_var, f.field)}</div>`
       : '';
     info.innerHTML =
       `<div class="feature-name">${escapeHtml(meta.label)}</div>` +
@@ -4215,6 +4222,13 @@ def build_settings_handlers(
     async def _settings_page(_: Request) -> HTMLResponse:
         return HTMLResponse(_SETTINGS_HTML)
 
+    async def _favicon(_: Request) -> Response:
+        # The page ships no <link rel="icon">, so browsers request
+        # /favicon.ico at the origin root. Without this route that 404s
+        # and logs a red console error on every load. 204 No Content is
+        # the smallest correct answer ("no icon"), no body to serve.
+        return Response(status_code=204)
+
     async def _get_tools(_: Request) -> JSONResponse:
         if server is not None:
             tools = await _get_tool_metadata(server)
@@ -5860,6 +5874,7 @@ def build_settings_handlers(
 
     handlers: dict[str, Any] = {
         "root_page": _root_page,
+        "favicon": _favicon,
         "settings_page": _settings_page,
         "get_tools": _get_tools,
         "save_tools": _save_tools,
@@ -5949,6 +5964,7 @@ def register_settings_routes(
         # the auth for direct access. Document this in DOCS.md.
         mcp.custom_route("/", methods=["GET"])(handlers["root_page"])
         mcp.custom_route("/settings", methods=["GET"])(handlers["settings_page"])
+        mcp.custom_route("/favicon.ico", methods=["GET"])(handlers["favicon"])
         mcp.custom_route("/api/settings/tools", methods=["GET"])(handlers["get_tools"])
         mcp.custom_route("/api/settings/tools", methods=["POST"])(
             handlers["save_tools"]

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, TypedDi
 
 import httpx
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse
 
 from ._version import get_version, is_running_in_addon
 from .backup_manager import get_backup_manager
@@ -602,6 +602,10 @@ _SETTINGS_HTML = (
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>HA-MCP Tool Settings</title>
+<!-- Empty data URI: tells the browser "no favicon" so it never requests
+     /favicon.ico (which would 404 and log a console error, since the
+     settings server serves no such asset in any deployment mode). -->
+<link rel="icon" href="data:,">
 <style>
   :root {
     --bg: #1c1c1e; --surface: #2c2c2e; --surface-hover: #3a3a3c;
@@ -4222,13 +4226,6 @@ def build_settings_handlers(
     async def _settings_page(_: Request) -> HTMLResponse:
         return HTMLResponse(_SETTINGS_HTML)
 
-    async def _favicon(_: Request) -> Response:
-        # The page ships no <link rel="icon">, so browsers request
-        # /favicon.ico at the origin root. Without this route that 404s
-        # and logs a red console error on every load. 204 No Content is
-        # the smallest correct answer ("no icon"), no body to serve.
-        return Response(status_code=204)
-
     async def _get_tools(_: Request) -> JSONResponse:
         if server is not None:
             tools = await _get_tool_metadata(server)
@@ -5874,7 +5871,6 @@ def build_settings_handlers(
 
     handlers: dict[str, Any] = {
         "root_page": _root_page,
-        "favicon": _favicon,
         "settings_page": _settings_page,
         "get_tools": _get_tools,
         "save_tools": _save_tools,
@@ -5964,7 +5960,6 @@ def register_settings_routes(
         # the auth for direct access. Document this in DOCS.md.
         mcp.custom_route("/", methods=["GET"])(handlers["root_page"])
         mcp.custom_route("/settings", methods=["GET"])(handlers["settings_page"])
-        mcp.custom_route("/favicon.ico", methods=["GET"])(handlers["favicon"])
         mcp.custom_route("/api/settings/tools", methods=["GET"])(handlers["get_tools"])
         mcp.custom_route("/api/settings/tools", methods=["POST"])(
             handlers["save_tools"]

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -2552,16 +2552,36 @@ function renderCodeModeSubRows(parentEl, masterOn, codeModeOn) {
 
     const info = document.createElement('div');
     info.className = 'feature-info';
-    // Route through the shared addon-aware helper (same as the feature-
-    // flag and advanced-field locked rows). In addon mode an env-pinned
-    // field like CODE_MODE_SAVED_TOOLS_PATH is set by start.py via
-    // setdefault and, being absent from the addon config.yaml schema,
-    // cannot be unset by the user — so the standalone "unset it to edit
-    // here" copy is unactionable; envLockedNoteHtml swaps it for the
-    // addon-runtime wording. Standalone mode is unchanged.
-    const lockedNote = f.origin === 'env'
-      ? `<div class="feature-locked-note">${envLockedNoteHtml(f.env_var, f.field)}</div>`
-      : '';
+    // code_mode_saved_tools_path needs honest, field-specific copy:
+    //  - add-on mode: hardcoded by start.py (setdefault to /data); not
+    //    Supervisor-managed and absent from the addon schema, so it
+    //    genuinely can't be changed — don't imply a lever exists.
+    //  - standalone with the env var set: the "unset it" hint IS
+    //    actionable (the operator controls the env var), so keep it.
+    //  - standalone with no path: a blank path disables persistence —
+    //    warn that saved tools live in memory only.
+    // Other env-locked code-mode sub-fields keep the shared helper.
+    let lockedNote = '';
+    if (f.field === 'code_mode_saved_tools_path') {
+      if (IS_ADDON_MODE) {
+        lockedNote =
+          '<div class="feature-locked-note">Hardcoded to ' +
+          '<code>/data/saved_tools.json</code> in add-on mode and cannot ' +
+          'be changed (fixed here so saved tools survive add-on updates).' +
+          '</div>';
+      } else if (f.origin === 'env') {
+        lockedNote =
+          `<div class="feature-locked-note">${envLockedNoteHtml(f.env_var, f.field)}</div>`;
+      } else if (!f.value) {
+        lockedNote =
+          '<div class="feature-locked-note">If blank, custom tools are kept ' +
+          'in memory only and lost on restart. Set a path on persistent ' +
+          'storage to keep them.</div>';
+      }
+    } else if (f.origin === 'env') {
+      lockedNote =
+        `<div class="feature-locked-note">${envLockedNoteHtml(f.env_var, f.field)}</div>`;
+    }
     info.innerHTML =
       `<div class="feature-name">${escapeHtml(meta.label)}</div>` +
       `<div class="feature-help">${escapeHtml(meta.help)}</div>` +
@@ -5384,16 +5404,34 @@ def build_settings_handlers(
             if is_addon_synced:
                 addon_writes_present = True
             elif os.environ.get(env_name) is not None:
+                # Add-on mode has no env-var surface for non-schema keys
+                # (e.g. CODE_MODE_SAVED_TOOLS_PATH, set by start.py), so
+                # "unset it to edit here" is unactionable there — give
+                # add-on-aware copy instead of implying a lever exists.
+                if addon_mode:
+                    message = (
+                        f"{fname!r} is fixed by the add-on runtime and "
+                        "cannot be changed from the web UI."
+                    )
+                    suggestions = [
+                        "This value is baked into the add-on and is not "
+                        "exposed as an editable setting.",
+                    ]
+                else:
+                    message = (
+                        f"{fname!r} is set via {env_name} env var — "
+                        "unset it to edit here."
+                    )
+                    suggestions = [
+                        f"Unset the {env_name} environment variable (or "
+                        "remove it from your Docker config), then restart "
+                        "to edit this setting from the UI.",
+                    ]
                 return JSONResponse(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"{fname!r} is set via {env_name} env var — "
-                        "unset it to edit here.",
-                        suggestions=[
-                            f"Unset the {env_name} environment variable (or "
-                            "remove it from your addon/Docker config), then "
-                            "restart to edit this setting from the UI.",
-                        ],
+                        message,
+                        suggestions=suggestions,
                         context={"env_var": env_name},
                     ),
                     status_code=409,

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -1290,5 +1290,16 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "in-memory cache. Check operator logs for the "
                     "underlying I/O error."
                 )
+            elif not settings.code_mode_saved_tools_path:
+                # Blank path = persistence disabled: the in-memory save
+                # succeeded but is lost on restart. Surface a warning so
+                # the agent doesn't assume the entry is durable — mirrors
+                # the write-failure branch above.
+                response["data"]["save_warning"] = (
+                    f"save_as={save_as!r} is kept in memory only — "
+                    "code_mode_saved_tools_path is unset, so custom tools "
+                    "are not persisted and are lost on restart. Set a path "
+                    "on persistent storage to keep them."
+                )
 
         return response

--- a/tests/src/e2e/tools/test_create_custom_tool.py
+++ b/tests/src/e2e/tools/test_create_custom_tool.py
@@ -1989,13 +1989,49 @@ class TestCodeModeSavePersistenceFailure:
                 "save_as": "test_save_warning_restored",
             },
         )
-        assert data.get("success") is True, (
-            f"Post-restore save must succeed: {data}"
-        )
+        assert data.get("success") is True, f"Post-restore save must succeed: {data}"
         payload = data.get("data", {})
         assert payload.get("saved_as") == "test_save_warning_restored", (
             f"saved_as must reflect the persisted name after restore: {data}"
         )
         assert "save_warning" not in payload, (
             f"save_warning must not appear on a clean save: {data}"
+        )
+
+
+class TestCodeModeBlankPathWarning:
+    """A blank ``code_mode_saved_tools_path`` disables persistence — a
+    ``save_as`` succeeds in memory but isn't durable, so the response must
+    carry a ``save_warning``. The in-process ``mcp_client_with_code_mode``
+    server leaves the path unset (the standalone/Docker "forgot to
+    configure persistence" case), so any save through it exercises this.
+    Companion to the write-failure shape pinned above.
+    """
+
+    async def test_blank_path_save_warns_in_memory_only(
+        self, mcp_client_with_code_mode
+    ):
+        _skip_if_unavailable(
+            await _check_tool_available(mcp_client_with_code_mode),
+            "test_blank_path_save_warns_in_memory_only",
+        )
+        data = await safe_call_tool(
+            mcp_client_with_code_mode,
+            TOOL_NAME,
+            {
+                "code": "result = {'value': 1}\nresult",
+                "justification": "E2E test: blank-path persistence warning",
+                "save_as": "test_blank_path_warning",
+            },
+        )
+        assert data.get("success") is True, data
+        payload = data.get("data", {})
+        # The in-memory save succeeds, so saved_as stays set (unlike the
+        # write-failure rollback, which resets it to None).
+        assert payload.get("saved_as") == "test_blank_path_warning", data
+        # ...but the response must warn that the entry isn't persisted.
+        warning = payload.get("save_warning")
+        assert isinstance(warning, str) and "memory only" in warning, (
+            f"expected an in-memory-only persistence warning when the "
+            f"saved-tools path is unset: {data}"
         )

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -392,6 +392,50 @@ class TestRouteRegistration:
         assert "/private_x/settings" in paths
         assert "/private_x/api/settings/tools" in paths
 
+    def test_registers_favicon_in_addon_mode(self, monkeypatch):
+        # The settings page ships no <link rel="icon">, so browsers request
+        # /favicon.ico at the origin root and log a 404 on every load. A
+        # root favicon route (addon mode mounts root for ingress) silences it.
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(return_value=lambda fn: fn)
+        register_settings_routes(mcp, MagicMock(), secret_path="/private_x")
+        paths = self._collect_paths(mcp)
+        assert "/favicon.ico" in paths
+
+    @pytest.mark.asyncio
+    async def test_favicon_handler_returns_no_content(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict[str, Any] = {}
+
+        def custom_route_factory(path, methods):
+            def decorator(fn):
+                if path == "/favicon.ico":
+                    captured["favicon"] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
+        register_settings_routes(mcp, MagicMock(), secret_path="/x")
+        favicon = captured["favicon"]
+        resp = await favicon(MagicMock())
+        assert resp.status_code == 204
+
+    def test_favicon_not_registered_in_standalone_mode(self, monkeypatch):
+        # Favicon is addon-only: standalone/Docker mounts solely under the
+        # secret prefix, where the browser never requests a root
+        # /favicon.ico. Mounting it at root there would be an
+        # unauthenticated endpoint, so guard against the route leaking out
+        # of the `if is_addon:` block.
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(return_value=lambda fn: fn)
+        register_settings_routes(mcp, MagicMock(), secret_path="/mcp")
+        paths = self._collect_paths(mcp)
+        assert "/favicon.ico" not in paths
+
     def test_secret_path_only_when_not_addon(self, monkeypatch):
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         mcp = MagicMock()

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -16,6 +16,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from ha_mcp.settings_ui import (
+    _SETTINGS_HTML,
     FEATURE_GATED_TOOLS,
     MANDATORY_TOOLS,
     TRANSFORM_GENERATED_TOOLS,
@@ -392,50 +393,6 @@ class TestRouteRegistration:
         assert "/private_x/settings" in paths
         assert "/private_x/api/settings/tools" in paths
 
-    def test_registers_favicon_in_addon_mode(self, monkeypatch):
-        # The settings page ships no <link rel="icon">, so browsers request
-        # /favicon.ico at the origin root and log a 404 on every load. A
-        # root favicon route (addon mode mounts root for ingress) silences it.
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
-        mcp = MagicMock()
-        mcp.custom_route = MagicMock(return_value=lambda fn: fn)
-        register_settings_routes(mcp, MagicMock(), secret_path="/private_x")
-        paths = self._collect_paths(mcp)
-        assert "/favicon.ico" in paths
-
-    @pytest.mark.asyncio
-    async def test_favicon_handler_returns_no_content(self, monkeypatch):
-        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
-        captured: dict[str, Any] = {}
-
-        def custom_route_factory(path, methods):
-            def decorator(fn):
-                if path == "/favicon.ico":
-                    captured["favicon"] = fn
-                return fn
-
-            return decorator
-
-        mcp = MagicMock()
-        mcp.custom_route = MagicMock(side_effect=custom_route_factory)
-        register_settings_routes(mcp, MagicMock(), secret_path="/x")
-        favicon = captured["favicon"]
-        resp = await favicon(MagicMock())
-        assert resp.status_code == 204
-
-    def test_favicon_not_registered_in_standalone_mode(self, monkeypatch):
-        # Favicon is addon-only: standalone/Docker mounts solely under the
-        # secret prefix, where the browser never requests a root
-        # /favicon.ico. Mounting it at root there would be an
-        # unauthenticated endpoint, so guard against the route leaking out
-        # of the `if is_addon:` block.
-        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
-        mcp = MagicMock()
-        mcp.custom_route = MagicMock(return_value=lambda fn: fn)
-        register_settings_routes(mcp, MagicMock(), secret_path="/mcp")
-        paths = self._collect_paths(mcp)
-        assert "/favicon.ico" not in paths
-
     def test_secret_path_only_when_not_addon(self, monkeypatch):
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         mcp = MagicMock()
@@ -455,6 +412,20 @@ class TestRouteRegistration:
         mcp.custom_route = MagicMock(return_value=lambda fn: fn)
         register_settings_routes(mcp, MagicMock(), secret_path="")
         assert mcp.custom_route.call_count == 0
+
+
+class TestFaviconSuppression:
+    """The page suppresses the browser's automatic /favicon.ico request via
+    an empty-data-URI <link rel="icon">, so no 404 is logged in any
+    deployment mode (add-on, standalone, Docker, sidecar) — no backend
+    route required.
+    """
+
+    def test_settings_html_head_suppresses_favicon_request(self) -> None:
+        # `data:,` is an empty data URI: modern browsers read it as "no
+        # icon" and skip the default /favicon.ico request entirely, so the
+        # 404 console error never fires regardless of which routes mount.
+        assert '<link rel="icon" href="data:,">' in _SETTINGS_HTML
 
 
 class TestSaveToolsValidation:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -415,16 +415,11 @@ class TestRouteRegistration:
 
 
 class TestFaviconSuppression:
-    """The page suppresses the browser's automatic /favicon.ico request via
-    an empty-data-URI <link rel="icon">, so no 404 is logged in any
-    deployment mode (add-on, standalone, Docker, sidecar) — no backend
-    route required.
+    """The page carries an empty-data-URI `<link rel="icon">` so the browser
+    never requests /favicon.ico (rationale at the `<link>` in settings_ui.py).
     """
 
     def test_settings_html_head_suppresses_favicon_request(self) -> None:
-        # `data:,` is an empty data URI: modern browsers read it as "no
-        # icon" and skip the default /favicon.ico request entirely, so the
-        # 404 console error never fires regardless of which routes mount.
         assert '<link rel="icon" href="data:,">' in _SETTINGS_HTML
 
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1376,17 +1376,23 @@ class TestAddonModeLockedBannerCopy:
             invoke="await new Promise(r => setTimeout(r, 200));",
         )
         _assert_clean_init(result)
-        assert "CODE_MODE_SAVED_TOOLS_PATH" in result.dom, (
-            f"expected the code-mode sub-row to render with its env var; "
+        assert 'data-adv-field="code_mode_saved_tools_path"' in result.dom, (
+            f"expected the saved-tools code-mode sub-row to render; "
             f"dom tail: {result.dom[-2000:]}"
         )
         assert "unset it to edit here" not in result.dom, (
             "addon-mode code-mode sub-row still shows standalone "
             "'unset env var' copy the add-on user cannot act on"
         )
-        assert "addon runtime environment" in result.dom, (
-            f"expected addon-aware copy on the code-mode sub-row; "
+        # Field-specific, honest copy — NOT the generic "managed by
+        # Supervisor" helper text (Supervisor never sees this start.py
+        # setdefault value).
+        assert "Hardcoded to" in result.dom and "cannot be changed" in result.dom, (
+            f"expected field-specific 'hardcoded in add-on mode' copy; "
             f"dom tail: {result.dom[-2000:]}"
+        )
+        assert "managed by Home Assistant Supervisor" not in result.dom, (
+            "add-on copy must not imply Supervisor manages this hardcoded field"
         )
 
     def test_codemode_subrow_standalone_mode_still_uses_unset_copy(
@@ -1447,6 +1453,68 @@ class TestAddonModeLockedBannerCopy:
         _assert_clean_init(result)
         assert "unset it to edit here" in result.dom, (
             f"standalone code-mode sub-row copy regressed; "
+            f"dom tail: {result.dom[-2000:]}"
+        )
+
+    def test_codemode_saved_tools_path_blank_warns_persistence_off(
+        self, settings_script: str
+    ) -> None:
+        """Standalone with no path set: the saved-tools row must warn that
+        custom tools are kept in memory only and lost on restart — a blank
+        ``code_mode_saved_tools_path`` disables persistence.
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {
+                        "enable_beta_features": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_BETA_FEATURES",
+                        },
+                        "enable_code_mode": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_CODE_MODE",
+                        },
+                    },
+                    "beta_sub_flags": ["enable_code_mode"],
+                    "is_addon": False,
+                },
+            },
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "code_mode_saved_tools_path",
+                            "env_var": "CODE_MODE_SAVED_TOOLS_PATH",
+                            "value": "",
+                            "type": "str",
+                            "section": "beta_codemode",
+                            "origin": "default",
+                            "editable": True,
+                        }
+                    ],
+                    "is_addon": False,
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        assert "memory only" in result.dom and "lost on restart" in result.dom, (
+            f"expected blank-path persistence warning on saved-tools row; "
             f"dom tail: {result.dom[-2000:]}"
         )
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1310,6 +1310,146 @@ class TestAddonModeLockedBannerCopy:
             f"standalone-mode copy regressed; dom tail: {result.dom[-2000:]}"
         )
 
+    def test_codemode_subrow_locked_banner_in_addon_mode_avoids_unset_copy(
+        self, settings_script: str
+    ) -> None:
+        """Env-pinned code-mode sub-row in addon mode must use addon-runtime
+        copy, not the standalone "unset env var" instruction.
+
+        ``CODE_MODE_SAVED_TOOLS_PATH`` is set by the add-on's ``start.py``
+        via ``os.environ.setdefault`` and is absent from the add-on
+        ``config.yaml`` schema, so the Saved-tools-path row renders
+        env-pinned and read-only and the add-on user cannot unset it —
+        the standalone "unset it to edit here" copy is unactionable.
+        ``renderCodeModeSubRows`` was
+        overlooked when the addon-aware locked-note copy was added to
+        the other render paths (see the master/advanced banner tests
+        above); this pins the same rule for the code-mode sub-rows.
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {
+                        "enable_beta_features": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_BETA_FEATURES",
+                        },
+                        "enable_code_mode": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_CODE_MODE",
+                        },
+                    },
+                    "beta_sub_flags": ["enable_code_mode"],
+                    "is_addon": True,
+                },
+            },
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "code_mode_saved_tools_path",
+                            "env_var": "CODE_MODE_SAVED_TOOLS_PATH",
+                            "value": "/data/saved_tools.json",
+                            "type": "str",
+                            "section": "beta_codemode",
+                            "origin": "env",
+                            "editable": False,
+                        }
+                    ],
+                    "is_addon": True,
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        assert "CODE_MODE_SAVED_TOOLS_PATH" in result.dom, (
+            f"expected the code-mode sub-row to render with its env var; "
+            f"dom tail: {result.dom[-2000:]}"
+        )
+        assert "unset it to edit here" not in result.dom, (
+            "addon-mode code-mode sub-row still shows standalone "
+            "'unset env var' copy the add-on user cannot act on"
+        )
+        assert "addon runtime environment" in result.dom, (
+            f"expected addon-aware copy on the code-mode sub-row; "
+            f"dom tail: {result.dom[-2000:]}"
+        )
+
+    def test_codemode_subrow_standalone_mode_still_uses_unset_copy(
+        self, settings_script: str
+    ) -> None:
+        """Regression guard: outside addon mode the code-mode sub-row keeps
+        the standalone "unset env var" copy.
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {
+                        "enable_beta_features": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_BETA_FEATURES",
+                        },
+                        "enable_code_mode": {
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "bool",
+                            "env_var": "ENABLE_CODE_MODE",
+                        },
+                    },
+                    "beta_sub_flags": ["enable_code_mode"],
+                    "is_addon": False,
+                },
+            },
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "code_mode_saved_tools_path",
+                            "env_var": "CODE_MODE_SAVED_TOOLS_PATH",
+                            "value": "/srv/saved_tools.json",
+                            "type": "str",
+                            "section": "beta_codemode",
+                            "origin": "env",
+                            "editable": False,
+                        }
+                    ],
+                    "is_addon": False,
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        assert "unset it to edit here" in result.dom, (
+            f"standalone code-mode sub-row copy regressed; "
+            f"dom tail: {result.dom[-2000:]}"
+        )
+
 
 class TestBetaBlockRendersAtBottom:
     """Beta master + sub-flags render into the dedicated `betaBody` div,

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -75,10 +75,6 @@ class TestBuildSettingsHandlers:
         assert set(handlers.keys()) == {
             "root_page",
             "settings_page",
-            # Addon-root-only assets (like root_page, the sidecar does not
-            # mount these — register_settings_routes serves them at the
-            # ingress root).
-            "favicon",
             "get_tools",
             "save_tools",
             "restart_addon",

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -75,6 +75,10 @@ class TestBuildSettingsHandlers:
         assert set(handlers.keys()) == {
             "root_page",
             "settings_page",
+            # Addon-root-only assets (like root_page, the sidecar does not
+            # mount these — register_settings_routes serves them at the
+            # ingress root).
+            "favicon",
             "get_tools",
             "save_tools",
             "restart_addon",


### PR DESCRIPTION
## What does this PR do?

Two small settings-UI add-on-mode fixes found while exercising the merged Advanced-settings panel (#1431):

1. **Add-on-aware code-mode locked note.** `renderCodeModeSubRows` hardcoded `… — unset it to edit here.` for env-pinned code-mode fields, even in add-on mode. `CODE_MODE_SAVED_TOOLS_PATH` is set by the add-on's `start.py` via `os.environ.setdefault` and is absent from the add-on `config.yaml` schema, so the add-on user cannot unset it — the instruction is unactionable. The fix routes the note through the shared `envLockedNoteHtml` helper that the feature-flag and advanced-field locked rows already use, so add-on mode gets the add-on-runtime copy. Standalone-mode copy is byte-for-byte unchanged.

2. **Settings-UI favicon 404.** The page shipped no `<link rel="icon">`, so browsers request `/favicon.ico` at the origin root and log a red 404 console error on every load. Adds an empty-data-URI `<link rel="icon" href="data:,">` to the page `<head>` so the browser never requests `/favicon.ico` — in every deployment mode (add-on, standalone, Docker, sidecar). (Earlier revisions used a backend 204 route; switched to the `<link>` per review — mode-global and needs no route/handler/tests.)

A wording call for the shared add-on copy is flagged for @kingpanther13 in the Implementation Summary that will follow before this is marked ready.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`) — full unit suite green locally (4008 passed, 1 skipped), ruff + mypy clean, rendered-`<script>` parse test green. The full e2e suite runs in CI.
- [ ] I have tested these changes with a LLM agent

## Checklist
- [ ] I have updated documentation if needed — n/a (no user-facing docs affected)