### PR TITLE
fix: surface the real reason a WebSocket connection failed

### DIFF
--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -235,6 +235,10 @@ class HomeAssistantWebSocketClient:
         self._send_lock: asyncio.Lock | None = None
         self._lock_loop: asyncio.AbstractEventLoop | None = None
         self._state = WebSocketConnectionState()
+        # Reason the most recent connect() attempt failed (exception text),
+        # or None. Surfaced by callers so the agent sees *why* a WebSocket
+        # connection failed instead of an opaque "Failed to connect" string.
+        self._last_connect_error: str | None = None
 
         # Parse URL to get WebSocket endpoint
         parsed = urlparse(self.base_url)
@@ -259,6 +263,7 @@ class HomeAssistantWebSocketClient:
         try:
             logger.info(f"Connecting to Home Assistant WebSocket: {self.ws_url}")
             self._state.reset_connection()
+            self._last_connect_error = None
 
             # Only configure an SSLContext for wss://; ws:// (Supervisor
             # proxy) doesn't use TLS and gets ssl=None.
@@ -326,6 +331,7 @@ class HomeAssistantWebSocketClient:
             return True
 
         except Exception as e:
+            self._last_connect_error = f"{type(e).__name__}: {e}"
             if _is_ssl_error(e) and self.verify_ssl:
                 logger.error(
                     "WebSocket TLS verification failed for %s: %s. "
@@ -925,6 +931,17 @@ class HomeAssistantWebSocketClient:
         """Check if WebSocket is connected and authenticated."""
         return self._state.is_ready
 
+    @property
+    def last_connect_error(self) -> str | None:
+        """Reason the most recent ``connect()`` attempt failed, or ``None``.
+
+        Captured from the underlying exception (e.g. an auth timeout, a
+        handshake HTTP/TLS error, or "Did not receive auth_required") so
+        callers can surface *why* the connection failed instead of an
+        opaque "Failed to connect to Home Assistant WebSocket".
+        """
+        return self._last_connect_error
+
 
 MAX_POOL_SIZE = 50
 
@@ -1059,7 +1076,14 @@ class WebSocketManager:
 
             connected = await client.connect()
             if not connected:
-                raise Exception("Failed to connect to Home Assistant WebSocket")
+                reason = getattr(client, "last_connect_error", None)
+                # Only append an actual string reason — a missing attribute or
+                # a non-str (e.g. a MagicMock in tests) must not pollute the
+                # message with a repr.
+                detail = f": {reason}" if isinstance(reason, str) else ""
+                raise Exception(
+                    "Failed to connect to Home Assistant WebSocket" + detail
+                )
 
             self._clients[key] = client
             self._last_used[key] = time.monotonic()

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -1076,10 +1076,10 @@ class WebSocketManager:
 
             connected = await client.connect()
             if not connected:
-                reason = getattr(client, "last_connect_error", None)
-                # Only append an actual string reason — a missing attribute or
-                # a non-str (e.g. a MagicMock in tests) must not pollute the
-                # message with a repr.
+                reason = client.last_connect_error
+                # Append only an actual string reason; the isinstance guard
+                # keeps a non-str (e.g. a MagicMock in tests) from polluting
+                # the message with a repr.
                 detail = f": {reason}" if isinstance(reason, str) else ""
                 raise Exception(
                     "Failed to connect to Home Assistant WebSocket" + detail

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -182,12 +182,17 @@ async def get_connected_ws_client(
     ws_client = HomeAssistantWebSocketClient(base_url, token, verify_ssl=verify_ssl)
     connected = await ws_client.connect()
     if not connected:
+        reason = ws_client.last_connect_error
+        details = (
+            reason
+            if isinstance(reason, str)
+            else "WebSocket connection could not be established"
+        )
         return None, create_connection_error(
             "Failed to connect to Home Assistant WebSocket",
-            details="WebSocket connection could not be established",
+            details=details,
         )
     return ws_client, None
-
 
 
 def _classify_api_status(
@@ -202,13 +207,17 @@ def _classify_api_status(
             if entity_id:
                 result = create_entity_not_found_error(entity_id, details=error_msg)
             else:
-                result = create_error_response(ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context)
+                result = create_error_response(
+                    ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context
+                )
         case 401 | 403:
             result = create_auth_error(error_msg, context=context)
         case 400:
             result = create_validation_error(error_msg, context=context)
         case _:
-            result = create_error_response(ErrorCode.SERVICE_CALL_FAILED, error_msg, context=context)
+            result = create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED, error_msg, context=context
+            )
     return result
 
 
@@ -244,7 +253,9 @@ def _classify_exception(
         case TimeoutError():
             operation = context.get("operation", "request") if context else "request"
             timeout_seconds = context.get("timeout_seconds", 30) if context else 30
-            result = create_timeout_error(operation, timeout_seconds, details=error_msg, context=context)
+            result = create_timeout_error(
+                operation, timeout_seconds, details=error_msg, context=context
+            )
         case ValueError():
             result = create_validation_error(error_msg, context=context)
 
@@ -276,7 +287,9 @@ def _classify_by_message(
                 "unknown type",
             )
         )
-        or re.search(r"expected (?:a |str|int|bool|dict|list|float|type|one of)", error_str)
+        or re.search(
+            r"expected (?:a |str|int|bool|dict|list|float|type|one of)", error_str
+        )
     ):
         # Supervisor schema validation: vol.Invalid message arriving as a
         # HomeAssistantCommandError via HA Core's hassio WS bridge. The
@@ -298,20 +311,27 @@ def _classify_by_message(
         if entity_id:
             result = create_entity_not_found_error(entity_id, details=error_msg)
         else:
-            result = create_error_response(ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context)
+            result = create_error_response(
+                ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context
+            )
     elif "timeout" in error_str:
-        result = create_timeout_error("operation", 30, details=error_msg, context=context)
+        result = create_timeout_error(
+            "operation", 30, details=error_msg, context=context
+        )
     elif "connection" in error_str or "connect" in error_str:
         result = create_connection_error(error_msg, context=context)
-    elif any(
-        phrase in error_str
-        for phrase in (
-            "unauthorized",
-            "authentication",
-            "invalid token",
-            "access denied",
+    elif (
+        any(
+            phrase in error_str
+            for phrase in (
+                "unauthorized",
+                "authentication",
+                "invalid token",
+                "access denied",
+            )
         )
-    ) or "401" in error_str:
+        or "401" in error_str
+    ):
         result = create_auth_error(error_msg, context=context)
     elif error_str.startswith("command failed:"):
         # HomeAssistantCommandError fallback: WS ``success=False`` with a
@@ -319,10 +339,15 @@ def _classify_by_message(
         # known failure mode (the WS command itself failed), not an
         # unexpected internal error — route to SERVICE_CALL_FAILED,
         # mirroring the 4xx fallback in _classify_api_status.
-        result = create_error_response(ErrorCode.SERVICE_CALL_FAILED, error_msg, context=context)
+        result = create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED, error_msg, context=context
+        )
     else:
         result = create_error_response(
-            ErrorCode.INTERNAL_ERROR, "An unexpected error occurred", details=error_msg, context=context
+            ErrorCode.INTERNAL_ERROR,
+            "An unexpected error occurred",
+            details=error_msg,
+            context=context,
         )
     return result
 
@@ -418,7 +443,11 @@ def exception_to_structured_error(
     ):
         logger.exception("Unclassified exception: %s", error_msg)
 
-    if suggestions and "error" in error_response and isinstance(error_response["error"], dict):
+    if (
+        suggestions
+        and "error" in error_response
+        and isinstance(error_response["error"], dict)
+    ):
         # Set both `suggestion` (singular, first item) and `suggestions`
         # (plural, full list). create_error_response (errors.py) sets the
         # singular key; existing tests for exception_to_structured_error
@@ -535,6 +564,4 @@ def register_tool_methods(mcp: Any, instance: Any) -> None:
             mcp.add_tool(method)
             count += 1
     if count == 0:
-        logger.warning(
-            f"No @tool-decorated methods found on {type(instance).__name__}"
-        )
+        logger.warning(f"No @tool-decorated methods found on {type(instance).__name__}")

--- a/tests/src/unit/test_ws_connect_error_detail.py
+++ b/tests/src/unit/test_ws_connect_error_detail.py
@@ -1,0 +1,246 @@
+"""Unit tests for surfacing *why* a WebSocket connection failed.
+
+Regression coverage for the opaque-error problem behind issue #1464: a failed
+``connect()`` used to bubble up only as "Failed to connect to Home Assistant
+WebSocket" with the real reason confined to a log line. These tests pin the
+reason being captured on the client and surfaced at both call sites (the
+pooled ``WebSocketManager.get_client`` path and the ``get_connected_ws_client``
+helper path).
+"""
+
+import json
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeWS:
+    """Minimal async-iterable websocket stand-in for connect() tests."""
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def close(self):
+        pass
+
+    async def send(self, *_args, **_kwargs):
+        pass
+
+
+class TestConnectCapturesReason:
+    """``connect()`` records the failure reason on ``last_connect_error``."""
+
+    def test_last_connect_error_is_none_before_any_connect(self):
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(url="http://supervisor/core", token="t")
+        assert client.last_connect_error is None
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_captures_exception_text(self):
+        """A transport-level failure is captured verbatim (type + message)."""
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(url="http://supervisor/core", token="t")
+
+        async def fake_connect(*_args, **_kwargs):
+            raise OSError("Connection refused")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert client.last_connect_error is not None
+        assert "OSError" in client.last_connect_error
+        assert "Connection refused" in client.last_connect_error
+
+    @pytest.mark.asyncio
+    async def test_missing_auth_required_is_captured(self):
+        """The 'Did not receive auth_required' handshake failure is captured.
+
+        This is the failure mode the issue bot hypothesised for Supervisor
+        proxy mode — the reason must reach the caller, not just the log.
+        """
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(url="http://supervisor/core", token="t")
+
+        async def fake_connect(*_args, **_kwargs):
+            return _FakeWS()
+
+        # No auth message ever arrives -> the auth_required wait returns None.
+        client._wait_for_auth_message = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert client.last_connect_error is not None
+        assert "Did not receive auth_required" in client.last_connect_error
+
+    @pytest.mark.asyncio
+    async def test_reason_is_cleared_on_a_fresh_attempt(self):
+        """A new connect() attempt resets the previous reason before running."""
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(url="http://supervisor/core", token="t")
+        client._last_connect_error = "stale: from a previous attempt"
+
+        async def fake_connect(*_args, **_kwargs):
+            raise OSError("brand new failure")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert "stale" not in (client.last_connect_error or "")
+        assert "brand new failure" in (client.last_connect_error or "")
+
+    @pytest.mark.asyncio
+    async def test_ssl_error_is_captured(self):
+        """A TLS verification failure is captured like any other reason.
+
+        Self-signed / hostname-mismatch certs are a common real-world cause,
+        so the surfaced reason must name the SSL error, not the opaque string.
+        """
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        client = HomeAssistantWebSocketClient(
+            url="https://ha.example.com:8123", token="t"
+        )
+
+        async def fake_connect(*_args, **_kwargs):
+            raise ssl.SSLCertVerificationError("self-signed certificate")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert client.last_connect_error is not None
+        assert "SSLCertVerificationError" in client.last_connect_error
+        assert "self-signed" in client.last_connect_error
+
+
+class TestManagerSurfacesReason:
+    """``WebSocketManager.get_client`` appends the reason to its raised error."""
+
+    @pytest.mark.asyncio
+    async def test_get_client_includes_reason_in_message(self):
+        from ha_mcp.client.websocket_client import (
+            HomeAssistantWebSocketClient,
+            WebSocketManager,
+        )
+
+        mock_client = MagicMock()
+        mock_client.is_connected = False
+        mock_client.connect = AsyncMock(return_value=False)
+        mock_client.disconnect = AsyncMock()
+        mock_client.last_connect_error = "OSError: [Errno 111] Connection refused"
+
+        manager = WebSocketManager()
+        # Isolate from any pooled state left by other tests.
+        manager._clients.clear()
+        manager._last_used.clear()
+        manager._current_loop = None
+        manager.configure(client_factory=lambda url, token: mock_client)
+        try:
+            with pytest.raises(Exception) as exc_info:
+                await manager.get_client(url="http://supervisor/core", token="t")
+            msg = str(exc_info.value)
+            assert "Failed to connect to Home Assistant WebSocket" in msg
+            assert "Connection refused" in msg
+        finally:
+            manager.configure(client_factory=HomeAssistantWebSocketClient)
+            manager._clients.clear()
+            manager._last_used.clear()
+            manager._current_loop = None
+
+    @pytest.mark.asyncio
+    async def test_get_client_omits_suffix_when_reason_absent(self):
+        """A client with no captured reason yields the bare message.
+
+        Also guards the MagicMock footgun: ``getattr(client,
+        "last_connect_error", None)`` on a bare mock returns a truthy mock,
+        and the ``isinstance`` guard must keep its repr out of the message.
+        """
+        from ha_mcp.client.websocket_client import (
+            HomeAssistantWebSocketClient,
+            WebSocketManager,
+        )
+
+        mock_client = MagicMock()  # last_connect_error left as an auto-mock
+        mock_client.is_connected = False
+        mock_client.connect = AsyncMock(return_value=False)
+        mock_client.disconnect = AsyncMock()
+
+        manager = WebSocketManager()
+        manager._clients.clear()
+        manager._last_used.clear()
+        manager._current_loop = None
+        manager.configure(client_factory=lambda url, token: mock_client)
+        try:
+            with pytest.raises(Exception) as exc_info:
+                await manager.get_client(url="http://supervisor/core", token="t")
+            assert (
+                str(exc_info.value) == "Failed to connect to Home Assistant WebSocket"
+            )
+        finally:
+            manager.configure(client_factory=HomeAssistantWebSocketClient)
+            manager._clients.clear()
+            manager._last_used.clear()
+            manager._current_loop = None
+
+
+class TestHelperSurfacesReason:
+    """``get_connected_ws_client`` puts the reason in the error ``details``."""
+
+    @pytest.mark.asyncio
+    async def test_helper_uses_reason_as_details(self):
+        from ha_mcp.tools import helpers
+
+        fake = MagicMock()
+        fake.connect = AsyncMock(return_value=False)
+        fake.last_connect_error = (
+            "HomeAssistantConnectionError: Did not receive auth_required message"
+        )
+
+        with patch.object(helpers, "HomeAssistantWebSocketClient", return_value=fake):
+            ws_client, error = await helpers.get_connected_ws_client(
+                "http://supervisor/core", "t"
+            )
+
+        assert ws_client is None
+        assert error is not None
+        # Robust to the exact key the reason lands under in the error dict.
+        assert "Did not receive auth_required" in json.dumps(error)
+
+    @pytest.mark.asyncio
+    async def test_helper_falls_back_when_reason_absent(self):
+        """No captured reason -> the generic default lands in details, no mock repr."""
+        from ha_mcp.tools import helpers
+
+        fake = MagicMock()  # last_connect_error left as an auto-mock
+        fake.connect = AsyncMock(return_value=False)
+
+        with patch.object(helpers, "HomeAssistantWebSocketClient", return_value=fake):
+            ws_client, error = await helpers.get_connected_ws_client(
+                "http://supervisor/core", "t"
+            )
+
+        assert ws_client is None
+        assert error is not None
+        blob = json.dumps(error)
+        assert "WebSocket connection could not be established" in blob
+        assert "MagicMock" not in blob

--- a/tests/src/unit/test_ws_connect_error_detail.py
+++ b/tests/src/unit/test_ws_connect_error_detail.py
@@ -132,6 +132,32 @@ class TestConnectCapturesReason:
         assert "SSLCertVerificationError" in client.last_connect_error
         assert "self-signed" in client.last_connect_error
 
+    @pytest.mark.asyncio
+    async def test_token_is_not_leaked_into_reason(self):
+        """The captured reason must never contain the access token.
+
+        The reason is built only from the exception text; the token travels
+        in the Authorization header / auth payload and is never echoed into a
+        connect exception. This pins that invariant against a future change
+        that captures more (repr(e), e.args, the URL, or request headers).
+        """
+        from ha_mcp.client.websocket_client import HomeAssistantWebSocketClient
+
+        token = "super-secret-token-DO-NOT-LEAK"
+        client = HomeAssistantWebSocketClient(url="http://supervisor/core", token=token)
+
+        async def fake_connect(*_args, **_kwargs):
+            raise OSError("[Errno 111] Connection refused")
+
+        with patch(
+            "ha_mcp.client.websocket_client.websockets.connect",
+            side_effect=fake_connect,
+        ):
+            assert await client.connect() is False
+
+        assert client.last_connect_error is not None
+        assert token not in client.last_connect_error
+
 
 class TestManagerSurfacesReason:
     """``WebSocketManager.get_client`` appends the reason to its raised error."""
@@ -169,21 +195,21 @@ class TestManagerSurfacesReason:
 
     @pytest.mark.asyncio
     async def test_get_client_omits_suffix_when_reason_absent(self):
-        """A client with no captured reason yields the bare message.
+        """A client whose connect() captured no reason yields the bare message.
 
-        Also guards the MagicMock footgun: ``getattr(client,
-        "last_connect_error", None)`` on a bare mock returns a truthy mock,
-        and the ``isinstance`` guard must keep its repr out of the message.
+        No trailing colon, no repr — the ``isinstance`` guard turns a ``None``
+        reason into an empty suffix.
         """
         from ha_mcp.client.websocket_client import (
             HomeAssistantWebSocketClient,
             WebSocketManager,
         )
 
-        mock_client = MagicMock()  # last_connect_error left as an auto-mock
+        mock_client = MagicMock()
         mock_client.is_connected = False
         mock_client.connect = AsyncMock(return_value=False)
         mock_client.disconnect = AsyncMock()
+        mock_client.last_connect_error = None
 
         manager = WebSocketManager()
         manager._clients.clear()


### PR DESCRIPTION
## What does this PR do?

When a WebSocket connection attempt fails, ha-mcp returned the opaque string
`Failed to connect to Home Assistant WebSocket` and kept the actual cause
(auth timeout, handshake HTTP/TLS error, `Did not receive auth_required`,
connection refused, …) in a WARNING log line only — `connect()` returns a bare
`bool`, so callers had nothing to surface. This makes connection failures like
#1464 effectively un-triageable from the agent/user side.

This captures the reason on the client and surfaces it everywhere that opaque
string is produced:

- `HomeAssistantWebSocketClient` records the underlying exception text in
  `last_connect_error` (set in `connect()`'s `except` block, cleared at the
  start of each attempt) and exposes it as a read-only property.
- `WebSocketManager.get_client` appends the reason to the error it raises.
- `get_connected_ws_client` passes it as the error `details` (used by the
  backup / calendar / history / traces / system tools).

Both surfacing sites guard the reason with `isinstance(reason, str)`, so a
missing or non-string value can never pollute the message with a repr.

No control-flow change, and no token is exposed — the handshake/auth exceptions
carry only the reason text (the token is sent as a header / `access_token`
field, never echoed back).

### Side effect worth noting

Because `get_client`'s raised message now contains the reason, a handshake-time
`403 Forbidden` (e.g. a reverse-proxy / rate-limit rejection during the WS
upgrade) will now match the **existing** 403-retry branch in
`send_websocket_message`, which previously only caught 403s that occurred
*after* the socket connected. This is a latent improvement — no new retry code —
but handshake-time 403s now get one retry.

### Context

Investigated for #1464 (WebSocket fails in Supervisor token mode). That report
isn't reproducible on demand — 150 sequential + concurrent WS dashboard calls
through the same webhook path on 7.6.0 stayed healthy — so the root cause looks
environmental. This does **not** claim to fix #1464; it makes that class of
failure self-diagnosing so the next occurrence reports *why* instead of the
opaque string.

## Type of change

- [x] 🐛 Bug fix

## Testing

New unit tests in `tests/src/unit/test_ws_connect_error_detail.py`:
- reason captured from a transport-level failure, the `Did not receive auth_required` handshake case, and a TLS failure (`SSLCertVerificationError`);
- the reason reset on a fresh attempt;
- `WebSocketManager.get_client` appending the reason, and omitting the suffix (no repr) when no reason is present;
- `get_connected_ws_client` surfacing the reason as `details`, and falling back to the generic default when none is present.

`ruff check`, `ruff format`, and `mypy` pass.

## Checklist

- [ ] I have updated documentation if needed
