### PR TITLE
ci: switch triage evaluate step to gpt-4o-mini (fixes 413 on large issues)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -747,13 +747,14 @@ jobs:
               return { status: resp.status, data };
             };
 
-            // Retry primary model on 5xx with exponential backoff; fall back to mini on 429.
+            // gpt-4o-mini: 16K input token free-tier limit (vs 8K for gpt-4.1).
+            // Retry on 5xx with exponential backoff; fall back to gpt-4o on 429.
             let result;
             for (let attempt = 1; attempt <= 3; attempt++) {
-              result = await call('openai/gpt-4.1');
+              result = await call('openai/gpt-4o-mini');
               if (result.status === 429) {
-                core.warning('gpt-4.1 rate limited, falling back to gpt-4.1-mini');
-                result = await call('openai/gpt-4.1-mini');
+                core.warning('gpt-4o-mini rate limited, falling back to gpt-4o');
+                result = await call('openai/gpt-4o');
                 break;
               }
               if (result.status < 500) break;


### PR DESCRIPTION
## Problem

The evaluate step uses `gpt-4.1` which has an **8K input token** free-tier limit on GitHub Models. Large issues exceed this and get HTTP 413:

```
Model call failed: HTTP 413 — tokens_limit_reached
"Request body too large for gpt-4.1 model. Max size: 8000 tokens."
```

## Fix

Switch to `openai/gpt-4o-mini` which has a **16K input token** free-tier limit — double the budget. The 429 fallback is updated to `gpt-4o`.

`gpt-4o-mini` is fully capable for structured JSON classification tasks like triage.

## Change

`gpt-4.1` → `gpt-4o-mini`, fallback `gpt-4.1-mini` → `gpt-4o`
