### PR TITLE
fix: add name attributes to generated settings-UI form controls (a11y)

### DIFF
--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -1614,7 +1614,7 @@ function render() {
       `<span class="group-count">${groupEnabled}/${tools.length} enabled</span>` +
       `</div>` +
       `<label class="switch group-master" title="Enable/disable all tools in this group">` +
-        `<input type="checkbox" ${anyEnabled ? 'checked' : ''} ${toggleable.length === 0 ? 'disabled' : ''}>` +
+        `<input type="checkbox" name="tool-group:${escapeHtml(tag)}" ${anyEnabled ? 'checked' : ''} ${toggleable.length === 0 ? 'disabled' : ''}>` +
         `<span class="slider"></span>` +
       `</label>`;
 
@@ -1718,20 +1718,20 @@ function render() {
         `</div>` +
         `<div class="tool-toggles">` +
           `<div class="toggle-group">` +
-            `<label class="switch"><input type="checkbox" data-tool="${escapeHtml(t.name)}" data-field="enabled" ` +
+            `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:enabled" data-tool="${escapeHtml(t.name)}" data-field="enabled" ` +
               `${isEnabled ? 'checked' : ''} ${lockEnabled ? 'disabled' : ''}>` +
               `<span class="slider"></span></label>` +
             `<span>enabled</span>` +
           `</div>` +
           `<div class="toggle-group ${!isEnabled ? 'disabled-toggle' : ''}">` +
-            `<label class="switch"><input type="checkbox" data-tool="${escapeHtml(t.name)}" data-field="pinned" ` +
+            `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:pinned" data-tool="${escapeHtml(t.name)}" data-field="pinned" ` +
               `${isPinned ? 'checked' : ''} ${lockPinned ? 'disabled' : ''}>` +
               `<span class="slider"></span></label>` +
             `<span>pinned</span>` +
           `</div>` +
           `<div class="toggle-group ${(policyState.enabled && isEnabled) ? '' : 'disabled-toggle'}" ` +
                `title="${policyState.enabled ? '' : 'Enable Tool Security Policies in addon config first.'}">` +
-            `<label class="switch"><input type="checkbox" data-tool="${escapeHtml(t.name)}" data-field="gated" ` +
+            `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:gated" data-tool="${escapeHtml(t.name)}" data-field="gated" ` +
               `${policyState.gatedTools.has(t.name) ? 'checked' : ''} ` +
               `${(policyState.enabled && isEnabled) ? '' : 'disabled'}>` +
               `<span class="slider"></span></label>` +
@@ -1922,16 +1922,16 @@ function renderBackupConfig() {
     row.className = 'backup-field';
     let controlHtml;
     if (typeof f.value === 'boolean') {
-      controlHtml = `<input type="checkbox" data-field="${escapeHtml(f.field)}" ${f.value ? 'checked' : ''} ${f.editable ? '' : 'disabled'}>`;
+      controlHtml = `<input type="checkbox" name="backup:${escapeHtml(f.field)}" data-field="${escapeHtml(f.field)}" ${f.value ? 'checked' : ''} ${f.editable ? '' : 'disabled'}>`;
     } else if (typeof f.value === 'string') {
       // Path / freeform string fields (auto_backup_dir).
-      controlHtml = `<input type="text" data-field="${escapeHtml(f.field)}" value="${escapeHtml(String(f.value ?? ''))}" ${f.editable ? '' : 'disabled'}>`;
+      controlHtml = `<input type="text" name="backup:${escapeHtml(f.field)}" data-field="${escapeHtml(f.field)}" value="${escapeHtml(String(f.value ?? ''))}" ${f.editable ? '' : 'disabled'}>`;
     } else {
       let min = 1;
       let max = 10000;
       if (f.field === 'auto_backup_throttle_minutes') { min = 0; max = 1440; }
       else if (f.field === 'auto_backup_calendar_lookahead_days') { min = 1; max = 365; }
-      controlHtml = `<input type="number" data-field="${escapeHtml(f.field)}" value="${Number(f.value)}" min="${min}" max="${max}" ${f.editable ? '' : 'disabled'}>`;
+      controlHtml = `<input type="number" name="backup:${escapeHtml(f.field)}" data-field="${escapeHtml(f.field)}" value="${Number(f.value)}" min="${min}" max="${max}" ${f.editable ? '' : 'disabled'}>`;
     }
     let originMsg;
     if (f.origin === 'env') {
@@ -2392,6 +2392,7 @@ function renderFeatureFlags(flags) {
       label.className = 'switch';
       const input = document.createElement('input');
       input.type = 'checkbox';
+      input.name = 'feature:' + fieldName;
       input.checked = !!f.value;
       input.disabled = !f.editable || lockedByMaster;
       input.addEventListener('change', () => {
@@ -2440,6 +2441,7 @@ function renderFeatureFlags(flags) {
     } else if (f.type === 'int') {
       const input = document.createElement('input');
       input.type = 'number';
+      input.name = 'feature:' + fieldName;
       input.value = f.value;
       if (typeof f.min === 'number') input.min = f.min;
       if (typeof f.max === 'number') input.max = f.max;
@@ -2510,6 +2512,7 @@ function renderYamlPackagesSubRows(flags, parentEl, masterOn, parentOn) {
     label.className = 'switch';
     const input = document.createElement('input');
     input.type = 'checkbox';
+    input.name = 'feature:' + fieldName;
     input.checked = !!f.value;
     input.disabled = !f.editable || lockedByGate;
     input.addEventListener('change', () => {
@@ -2574,6 +2577,7 @@ function renderCodeModeSubRows(parentEl, masterOn, codeModeOn) {
     }
     inputEl.disabled = disabled;
     inputEl.dataset.advField = f.field;
+    inputEl.name = 'adv:' + f.field;
     inputEl.addEventListener('change', () => {
       let v;
       if (f.type === 'int') v = parseInt(inputEl.value, 10);
@@ -2789,7 +2793,7 @@ function renderPolicyCard(toolName, rule) {
           '<select class="policy-predicate-path-select">' +
             '<option value="">(loading...)</option>' +
           '</select>' +
-          '<input type="text" class="policy-predicate-path-custom" ' +
+          '<input type="text" name="policy:predicate-path-custom" class="policy-predicate-path-custom" ' +
             'placeholder="e.g. args.color_temp" style="display:none">' +
         '</div>' +
         '<div class="policy-form-row">' +
@@ -2819,7 +2823,7 @@ function renderPolicyCard(toolName, rule) {
     '</div>' +
     '<div class="policy-rule-lifetime">' +
       '<label>Remember approval for:' +
-        '<input type="number" min="0" max="1440" class="policy-remember-minutes" ' +
+        '<input type="number" name="policy:remember-minutes" min="0" max="1440" class="policy-remember-minutes" ' +
           'value="' + (rule.remember_minutes || 0) + '">' +
         'minutes (0 = single-shot)' +
       '</label>' +
@@ -3083,7 +3087,7 @@ function renderPolicyCard(toolName, rule) {
     const initial = (existingValue === undefined || existingValue === null)
       ? ''
       : JSON.stringify(existingValue);
-    valueSlotEl.innerHTML = '<input type="text" ' +
+    valueSlotEl.innerHTML = '<input type="text" name="policy:predicate-value" ' +
       'class="policy-predicate-value-control policy-predicate-value" ' +
       'placeholder="' + escapeHtml(placeholder) + '" ' +
       'value="' + escapeHtml(initial) + '">';
@@ -3618,16 +3622,16 @@ function renderAdvancedSection(containerId, fields) {
         ).join('') +
         '</select>';
     } else if (f.type === 'bool') {
-      controlHtml = `<input type="checkbox" data-adv-field="${escapeHtml(f.field)}" ${f.value ? 'checked' : ''} ${f.editable ? '' : 'disabled'}>`;
+      controlHtml = `<input type="checkbox" name="adv:${escapeHtml(f.field)}" data-adv-field="${escapeHtml(f.field)}" ${f.value ? 'checked' : ''} ${f.editable ? '' : 'disabled'}>`;
     } else if (f.type === 'int' || f.type === 'float') {
-      controlHtml = `<input type="number" data-adv-field="${escapeHtml(f.field)}" value="${Number(f.value)}" ` +
+      controlHtml = `<input type="number" name="adv:${escapeHtml(f.field)}" data-adv-field="${escapeHtml(f.field)}" value="${Number(f.value)}" ` +
         (f.min !== undefined ? `min="${f.min}" ` : '') +
         (f.max !== undefined ? `max="${f.max}" ` : '') +
         (f.type === 'float' ? 'step="0.1" ' : '') +
         (f.editable ? '' : 'disabled') + '>';
     } else {
       // str
-      controlHtml = `<input type="text" data-adv-field="${escapeHtml(f.field)}" value="${escapeHtml(String(f.value ?? ''))}" ${f.editable ? '' : 'disabled'}>`;
+      controlHtml = `<input type="text" name="adv:${escapeHtml(f.field)}" data-adv-field="${escapeHtml(f.field)}" value="${escapeHtml(String(f.value ?? ''))}" ${f.editable ? '' : 'disabled'}>`;
     }
     let originMsg = '';
     if (f.origin === 'env') {

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -2790,7 +2790,7 @@ function renderPolicyCard(toolName, rule) {
       '<div class="policy-predicate-form" style="display:none;">' +
         '<div class="policy-form-row">' +
           '<label class="policy-form-label">Argument:</label>' +
-          '<select class="policy-predicate-path-select">' +
+          '<select name="policy:predicate-path" class="policy-predicate-path-select">' +
             '<option value="">(loading...)</option>' +
           '</select>' +
           '<input type="text" name="policy:predicate-path-custom" class="policy-predicate-path-custom" ' +
@@ -2798,7 +2798,7 @@ function renderPolicyCard(toolName, rule) {
         '</div>' +
         '<div class="policy-form-row">' +
           '<label class="policy-form-label">Match when:</label>' +
-          '<select class="policy-predicate-op">' +
+          '<select name="policy:predicate-op" class="policy-predicate-op">' +
             '<option value="exists">is present (any value)</option>' +
             '<option value="eq">equals</option>' +
             '<option value="neq">does NOT equal</option>' +
@@ -3057,7 +3057,7 @@ function renderPolicyCard(toolName, rule) {
     const existingArr = Array.isArray(existingValue)
       ? existingValue
       : (existingValue !== undefined && existingValue !== null ? [existingValue] : []);
-    let html = '<select class="policy-predicate-value-control"' +
+    let html = '<select name="policy:predicate-value" class="policy-predicate-value-control"' +
       (isMulti ? ' multiple size="6" style="min-width:220px"' : '') +
       '>';
     if (!isMulti) {
@@ -3616,7 +3616,7 @@ function renderAdvancedSection(containerId, fields) {
     const meta = ADVANCED_FIELD_META[f.field] || { label: f.field, help: '' };
     let controlHtml;
     if (f.choices) {
-      controlHtml = `<select data-adv-field="${escapeHtml(f.field)}" ${f.editable ? '' : 'disabled'}>` +
+      controlHtml = `<select name="adv:${escapeHtml(f.field)}" data-adv-field="${escapeHtml(f.field)}" ${f.editable ? '' : 'disabled'}>` +
         f.choices.map(c =>
           `<option value="${escapeHtml(c)}" ${String(f.value) === c ? 'selected' : ''}>${escapeHtml(c)}</option>`
         ).join('') +

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -962,7 +962,6 @@ class TestEnvPinnedToolRows:
         # the HTML `disabled` attribute. Coarse `"disabled" in result.dom`
         # would also pass on CSS class names elsewhere in the page; pin
         # the regex to the actual input element.
-        import re
 
         enabled_input_match = re.search(
             r'<input[^>]*data-field="enabled"[^>]*>',
@@ -1019,7 +1018,6 @@ class TestEnvPinnedToolRows:
             f"dom tail: {result.dom[-3000:]}"
         )
         # Pinned-toggle input for ha_bar must be disabled.
-        import re
 
         pin_input_match = re.search(
             r'<input[^>]*data-field="pinned"[^>]*>',
@@ -1119,7 +1117,6 @@ class TestAdvancedSectionRender:
             invoke="await new Promise(r => setTimeout(r, 200));",
         )
         _assert_clean_init(result)
-        import re
 
         select_match = re.search(
             r'<select[^>]*data-adv-field="log_level"[^>]*>(.*?)</select>',
@@ -1160,7 +1157,6 @@ class TestAdvancedSectionRender:
             invoke="await new Promise(r => setTimeout(r, 200));",
         )
         _assert_clean_init(result)
-        import re
 
         m = re.search(
             r'<input[^>]*data-adv-field="fuzzy_threshold"[^>]*>',
@@ -2426,7 +2422,6 @@ class TestBetaMasterToggleLiveRender:
         )
         _assert_clean_init(result)
         # Row has beta-sub class but NOT dimmed.
-        import re
 
         beta_sub_rows = re.findall(
             r'<div[^>]*class="[^"]*beta-sub[^"]*"[^>]*>',
@@ -2607,7 +2602,6 @@ class TestCodeModeNesting:
             invoke="await new Promise(r => setTimeout(r, 300));",
         )
         _assert_clean_init(result)
-        import re
 
         cm_rows = re.findall(
             r'<div[^>]*class="[^"]*codemode-sub[^"]*"[^>]*>',
@@ -2630,7 +2624,6 @@ class TestCodeModeNesting:
             invoke="await new Promise(r => setTimeout(r, 300));",
         )
         _assert_clean_init(result)
-        import re
 
         cm_rows = re.findall(
             r'<div[^>]*class="[^"]*codemode-sub[^"]*"[^>]*>',
@@ -2652,7 +2645,6 @@ class TestCodeModeNesting:
             invoke="await new Promise(r => setTimeout(r, 300));",
         )
         _assert_clean_init(result)
-        import re
 
         cm_rows = re.findall(
             r'<div[^>]*class="[^"]*codemode-sub[^"]*"[^>]*>',

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1178,9 +1178,7 @@ class TestFormControlAccessibility:
     (selection is via ``data-*`` attributes), so behaviour is unchanged.
     """
 
-    def test_tool_toggles_carry_name_attribute(
-        self, settings_script: str
-    ) -> None:
+    def test_tool_toggles_carry_name_attribute(self, settings_script: str) -> None:
         fetches = {
             **DEFAULT_FETCHES,
             "/api/settings/tools": {
@@ -1207,8 +1205,6 @@ class TestFormControlAccessibility:
             invoke="await new Promise(r => setTimeout(r, 200));",
         )
         _assert_clean_init(result)
-        import re
-
         for field in ("enabled", "pinned", "gated"):
             m = re.search(rf'<input[^>]*data-field="{field}"[^>]*>', result.dom)
             assert m is not None, f"expected {field} toggle in DOM"
@@ -1247,26 +1243,22 @@ class TestFormControlAccessibility:
             invoke="await new Promise(r => setTimeout(r, 200));",
         )
         _assert_clean_init(result)
-        import re
-
-        m = re.search(
-            r'<input[^>]*data-adv-field="fuzzy_threshold"[^>]*>', result.dom
-        )
+        m = re.search(r'<input[^>]*data-adv-field="fuzzy_threshold"[^>]*>', result.dom)
         assert m is not None, "expected advanced input for fuzzy_threshold"
         assert 'name="adv:fuzzy_threshold"' in m.group(0), (
             f"expected name on advanced input; got {m.group(0)}"
         )
 
-    def test_no_rendered_input_lacks_name_or_id(
-        self, settings_script: str
-    ) -> None:
+    def test_no_rendered_input_lacks_name_or_id(self, settings_script: str) -> None:
         """Holistic guard: render every page-load form surface — tool toggles
         + group master, feature flags, the yaml-packages sub-flags, the
-        code-mode numeric sub-rows and advanced fields — then assert every
-        rendered <input> carries a name or id, exactly the rule the
-        accessibility audit flags. (The backup-config and policy forms load
-        on tab activation, not at init — covered by their own tests below.)
+        code-mode numeric sub-rows, advanced fields and a choices dropdown —
+        then assert every rendered <input> AND <select> carries a name or id,
+        exactly the rule the accessibility audit flags. (The backup-config
+        and policy forms load on tab activation, not at init — covered by
+        their own tests below; the policy predicate <select>s render there.)
         """
+
         def flag(env: str) -> dict:
             return {
                 "value": True,
@@ -1346,6 +1338,18 @@ class TestFormControlAccessibility:
                             "min": 1.0,
                             "max": 300.0,
                         },
+                        {
+                            # choices -> renders a <select>, so the guard
+                            # also exercises the dropdown generator.
+                            "field": "log_level",
+                            "env_var": "LOG_LEVEL",
+                            "value": "INFO",
+                            "type": "str",
+                            "section": "diagnostics",
+                            "origin": "default",
+                            "editable": True,
+                            "choices": ["DEBUG", "INFO", "WARNING", "ERROR"],
+                        },
                     ]
                 },
             },
@@ -1357,13 +1361,11 @@ class TestFormControlAccessibility:
             invoke="await new Promise(r => setTimeout(r, 300));",
         )
         _assert_clean_init(result)
-        import re
-
-        inputs = re.findall(r"<input\b[^>]*>", result.dom)
-        assert inputs, "expected at least one rendered <input>"
-        missing = [i for i in inputs if "name=" not in i and "id=" not in i]
+        controls = re.findall(r"<(?:input|select)\b[^>]*>", result.dom)
+        assert controls, "expected at least one rendered form control"
+        missing = [c for c in controls if "name=" not in c and "id=" not in c]
         assert not missing, (
-            f"{len(missing)} rendered <input> lack name/id (a11y): {missing}"
+            f"{len(missing)} rendered form control(s) lack name/id (a11y): {missing}"
         )
         # Sanity: the expanded fixture really did exercise the extra
         # surfaces (code-mode sub-row + a yaml-packages sub-flag), not
@@ -1373,6 +1375,9 @@ class TestFormControlAccessibility:
         )
         assert 'name="feature:enable_yaml_packages_automation"' in result.dom, (
             "yaml-packages sub-row did not render — fixture/holistic-guard drift"
+        )
+        assert '<select name="adv:log_level"' in result.dom, (
+            "advanced choices <select> did not render — fixture/guard drift"
         )
 
     def test_backup_config_inputs_carry_name_attribute(
@@ -1419,8 +1424,7 @@ class TestFormControlAccessibility:
             initial_html=MIN_DOM,
             fetch_map=fetches,
             invoke=(
-                "await loadBackupConfig(); "
-                "await new Promise(r => setTimeout(r, 100));"
+                "await loadBackupConfig(); await new Promise(r => setTimeout(r, 100));"
             ),
         )
         _assert_clean_init(result)
@@ -1430,8 +1434,7 @@ class TestFormControlAccessibility:
             "auto_backup_throttle_minutes",
         ):
             assert f'name="backup:{field}"' in result.dom, (
-                f"expected name on backup input {field}; "
-                f"dom tail: {result.dom[-2000:]}"
+                f"expected name on backup input {field}; dom tail: {result.dom[-2000:]}"
             )
 
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1379,6 +1379,9 @@ class TestFormControlAccessibility:
         assert '<select name="adv:log_level"' in result.dom, (
             "advanced choices <select> did not render — fixture/guard drift"
         )
+        assert 'name="tool-group:' in result.dom, (
+            "tool group-master toggle did not render — fixture/guard drift"
+        )
 
     def test_backup_config_inputs_carry_name_attribute(
         self, settings_script: str
@@ -1435,6 +1438,68 @@ class TestFormControlAccessibility:
         ):
             assert f'name="backup:{field}"' in result.dom, (
                 f"expected name on backup input {field}; dom tail: {result.dom[-2000:]}"
+            )
+
+    def test_policy_predicate_controls_carry_name_attribute(
+        self, settings_script: str
+    ) -> None:
+        """The policy-rule editor renders on tab activation, not page init.
+        Drive ``policyLoadConfig()`` with one rule so ``renderPolicyCard``
+        emits the predicate form, and assert its always-rendered controls
+        carry a ``name``. (The predicate *value* control renders only on an
+        op-change — an async, fetch-backed path — so its name is covered by
+        review/code, not this render guard; it is set at both generator
+        sites.)
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {"enable_tool_security_policies": {"value": True}},
+                },
+            },
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "rules": [
+                        {
+                            "tool_name": "ha_config_set_helper",
+                            "when": [
+                                {
+                                    "path": "args.helper_type",
+                                    "op": "eq",
+                                    "value": "input_boolean",
+                                }
+                            ],
+                            "remember_minutes": 0,
+                        }
+                    ],
+                },
+            },
+            "/api/policy/pending": {
+                "status": 503,
+                "json": {"error": "irrelevant for this test"},
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="await window.policyLoadConfig();",
+        )
+        _assert_clean_init(result)
+        for nm in (
+            "policy:predicate-path",
+            "policy:predicate-op",
+            "policy:predicate-path-custom",
+            "policy:remember-minutes",
+        ):
+            assert f'name="{nm}"' in result.dom, (
+                f"expected policy control name={nm!r} in the rendered card; "
+                f"dom tail: {result.dom[-2500:]}"
             )
 
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1304,6 +1304,17 @@ class TestFormControlAccessibility:
                         "enable_yaml_packages_scene": flag(
                             "ENABLE_YAML_PACKAGES_SCENE"
                         ),
+                        # int-typed feature flag -> exercises the number-input
+                        # branch of the feature-flag generator.
+                        "tool_search_max_results": {
+                            "value": 50,
+                            "origin": "default",
+                            "editable": True,
+                            "type": "int",
+                            "env_var": "TOOL_SEARCH_MAX_RESULTS",
+                            "min": 1,
+                            "max": 200,
+                        },
                     },
                     "beta_sub_flags": [
                         "enable_code_mode",
@@ -1381,6 +1392,9 @@ class TestFormControlAccessibility:
         )
         assert 'name="tool-group:' in result.dom, (
             "tool group-master toggle did not render — fixture/guard drift"
+        )
+        assert 'name="feature:tool_search_max_results"' in result.dom, (
+            "int feature-flag input did not render — fixture/guard drift"
         )
 
     def test_backup_config_inputs_carry_name_attribute(

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1171,6 +1171,270 @@ class TestAdvancedSectionRender:
         assert 'max="100"' in m.group(0)
 
 
+class TestFormControlAccessibility:
+    """Every generated form control must carry a ``name`` (or ``id``) so it
+    is not flagged by the "form field should have an id or name attribute"
+    accessibility rule. ``name`` is additive — no JS selects on it
+    (selection is via ``data-*`` attributes), so behaviour is unchanged.
+    """
+
+    def test_tool_toggles_carry_name_attribute(
+        self, settings_script: str
+    ) -> None:
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {
+                    "tools": [
+                        {
+                            "name": "ha_foo",
+                            "title": "Foo",
+                            "primary_tag": "Utilities",
+                            "tags": ["Utilities"],
+                            "description": "Test tool",
+                            "annotations": {},
+                        }
+                    ],
+                    "states": {"ha_foo": "enabled"},
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        import re
+
+        for field in ("enabled", "pinned", "gated"):
+            m = re.search(rf'<input[^>]*data-field="{field}"[^>]*>', result.dom)
+            assert m is not None, f"expected {field} toggle in DOM"
+            assert f'name="tool:ha_foo:{field}"' in m.group(0), (
+                f"expected name on {field} toggle; got {m.group(0)}"
+            )
+
+    def test_advanced_field_input_carries_name_attribute(
+        self, settings_script: str
+    ) -> None:
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "fuzzy_threshold",
+                            "env_var": "FUZZY_THRESHOLD",
+                            "value": 70,
+                            "type": "int",
+                            "section": "search",
+                            "origin": "default",
+                            "editable": True,
+                            "min": 1,
+                            "max": 100,
+                        }
+                    ]
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        import re
+
+        m = re.search(
+            r'<input[^>]*data-adv-field="fuzzy_threshold"[^>]*>', result.dom
+        )
+        assert m is not None, "expected advanced input for fuzzy_threshold"
+        assert 'name="adv:fuzzy_threshold"' in m.group(0), (
+            f"expected name on advanced input; got {m.group(0)}"
+        )
+
+    def test_no_rendered_input_lacks_name_or_id(
+        self, settings_script: str
+    ) -> None:
+        """Holistic guard: render every page-load form surface — tool toggles
+        + group master, feature flags, the yaml-packages sub-flags, the
+        code-mode numeric sub-rows and advanced fields — then assert every
+        rendered <input> carries a name or id, exactly the rule the
+        accessibility audit flags. (The backup-config and policy forms load
+        on tab activation, not at init — covered by their own tests below.)
+        """
+        def flag(env: str) -> dict:
+            return {
+                "value": True,
+                "origin": "default",
+                "editable": True,
+                "type": "bool",
+                "env_var": env,
+            }
+
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {
+                    "tools": [
+                        {
+                            "name": "ha_foo",
+                            "title": "Foo",
+                            "primary_tag": "Utilities",
+                            "tags": ["Utilities"],
+                            "description": "Test tool",
+                            "annotations": {},
+                        }
+                    ],
+                    "states": {"ha_foo": "enabled"},
+                },
+            },
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {
+                        "enable_beta_features": flag("ENABLE_BETA_FEATURES"),
+                        "enable_code_mode": flag("ENABLE_CODE_MODE"),
+                        "enable_yaml_config_editing": flag(
+                            "ENABLE_YAML_CONFIG_EDITING"
+                        ),
+                        "enable_yaml_packages_automation": flag(
+                            "ENABLE_YAML_PACKAGES_AUTOMATION"
+                        ),
+                        "enable_yaml_packages_script": flag(
+                            "ENABLE_YAML_PACKAGES_SCRIPT"
+                        ),
+                        "enable_yaml_packages_scene": flag(
+                            "ENABLE_YAML_PACKAGES_SCENE"
+                        ),
+                    },
+                    "beta_sub_flags": [
+                        "enable_code_mode",
+                        "enable_yaml_config_editing",
+                    ],
+                    "is_addon": False,
+                },
+            },
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "fuzzy_threshold",
+                            "env_var": "FUZZY_THRESHOLD",
+                            "value": 70,
+                            "type": "int",
+                            "section": "search",
+                            "origin": "default",
+                            "editable": True,
+                            "min": 1,
+                            "max": 100,
+                        },
+                        {
+                            "field": "code_mode_max_duration",
+                            "env_var": "CODE_MODE_MAX_DURATION",
+                            "value": 30.0,
+                            "type": "float",
+                            "section": "beta_codemode",
+                            "origin": "default",
+                            "editable": True,
+                            "min": 1.0,
+                            "max": 300.0,
+                        },
+                    ]
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 300));",
+        )
+        _assert_clean_init(result)
+        import re
+
+        inputs = re.findall(r"<input\b[^>]*>", result.dom)
+        assert inputs, "expected at least one rendered <input>"
+        missing = [i for i in inputs if "name=" not in i and "id=" not in i]
+        assert not missing, (
+            f"{len(missing)} rendered <input> lack name/id (a11y): {missing}"
+        )
+        # Sanity: the expanded fixture really did exercise the extra
+        # surfaces (code-mode sub-row + a yaml-packages sub-flag), not
+        # silently render nothing.
+        assert 'name="adv:code_mode_max_duration"' in result.dom, (
+            "code-mode sub-row did not render — fixture/holistic-guard drift"
+        )
+        assert 'name="feature:enable_yaml_packages_automation"' in result.dom, (
+            "yaml-packages sub-row did not render — fixture/holistic-guard drift"
+        )
+
+    def test_backup_config_inputs_carry_name_attribute(
+        self, settings_script: str
+    ) -> None:
+        """The backup-config form loads on backups-tab activation (not at
+        page init), so drive ``loadBackupConfig()`` directly and assert its
+        bool / text / number inputs each carry a ``name``.
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/backup-config": {
+                "status": 200,
+                "json": {
+                    "fields": [
+                        {
+                            "field": "auto_backup_enabled",
+                            "env_var": "AUTO_BACKUP_ENABLED",
+                            "value": True,
+                            "origin": "default",
+                            "editable": True,
+                        },
+                        {
+                            "field": "auto_backup_dir",
+                            "env_var": "AUTO_BACKUP_DIR",
+                            "value": "/backups",
+                            "origin": "default",
+                            "editable": True,
+                        },
+                        {
+                            "field": "auto_backup_throttle_minutes",
+                            "env_var": "AUTO_BACKUP_THROTTLE_MINUTES",
+                            "value": 5,
+                            "origin": "default",
+                            "editable": True,
+                        },
+                    ],
+                    "is_addon": False,
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke=(
+                "await loadBackupConfig(); "
+                "await new Promise(r => setTimeout(r, 100));"
+            ),
+        )
+        _assert_clean_init(result)
+        for field in (
+            "auto_backup_enabled",
+            "auto_backup_dir",
+            "auto_backup_throttle_minutes",
+        ):
+            assert f'name="backup:{field}"' in result.dom, (
+                f"expected name on backup input {field}; "
+                f"dom tail: {result.dom[-2000:]}"
+            )
+
+
 class TestAddonModeLockedBannerCopy:
     """Locked-banner copy must avoid 'unset env var' wording in addon mode.
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1250,13 +1250,15 @@ class TestFormControlAccessibility:
         )
 
     def test_no_rendered_input_lacks_name_or_id(self, settings_script: str) -> None:
-        """Holistic guard: render every page-load form surface — tool toggles
-        + group master, feature flags, the yaml-packages sub-flags, the
-        code-mode numeric sub-rows, advanced fields and a choices dropdown —
-        then assert every rendered <input> AND <select> carries a name or id,
-        exactly the rule the accessibility audit flags. (The backup-config
-        and policy forms load on tab activation, not at init — covered by
-        their own tests below; the policy predicate <select>s render there.)
+        """Holistic guard: render every form surface present at default page
+        init — tool toggles + group master, feature flags, the yaml-packages
+        sub-flags, the code-mode numeric sub-rows, advanced fields and a
+        choices dropdown — then assert every rendered <input> AND <select>
+        carries a name or id, exactly the rule the accessibility audit flags.
+        (The backup-config and policy forms load on tab activation — including
+        via the ?tab= deep-link path — not at default init, so they are
+        covered by their own tests below; the policy predicate <select>s
+        render there.)
         """
 
         def flag(env: str) -> dict:
@@ -1379,10 +1381,14 @@ class TestFormControlAccessibility:
             f"{len(missing)} rendered form control(s) lack name/id (a11y): {missing}"
         )
         # Sanity: the expanded fixture really did exercise the extra
-        # surfaces (code-mode sub-row + a yaml-packages sub-flag), not
-        # silently render nothing.
+        # surfaces, not silently render nothing. `adv:code_mode_max_duration`
+        # is emitted by both the Advanced-panel field generator (the fixture
+        # lists it as an advanced field) and renderCodeModeSubRows, so this
+        # assert only proves *a* control with that name rendered — not the
+        # code-mode sub-row specifically.
         assert 'name="adv:code_mode_max_duration"' in result.dom, (
-            "code-mode sub-row did not render — fixture/holistic-guard drift"
+            "no control named adv:code_mode_max_duration rendered — "
+            "fixture/holistic-guard drift"
         )
         assert 'name="feature:enable_yaml_packages_automation"' in result.dom, (
             "yaml-packages sub-row did not render — fixture/holistic-guard drift"
@@ -1450,8 +1456,14 @@ class TestFormControlAccessibility:
             "auto_backup_dir",
             "auto_backup_throttle_minutes",
         ):
-            assert f'name="backup:{field}"' in result.dom, (
-                f"expected name on backup input {field}; dom tail: {result.dom[-2000:]}"
+            # Element-scoped: the name must sit on a single <input> tag, not
+            # merely appear somewhere in the whole-DOM string.
+            m = re.search(
+                rf'<input[^>]*name="backup:{re.escape(field)}"[^>]*>', result.dom
+            )
+            assert m is not None, (
+                f"expected backup <input> carrying name=backup:{field}; "
+                f"dom tail: {result.dom[-2000:]}"
             )
 
     def test_policy_predicate_controls_carry_name_attribute(
@@ -1460,10 +1472,11 @@ class TestFormControlAccessibility:
         """The policy-rule editor renders on tab activation, not page init.
         Drive ``policyLoadConfig()`` with one rule so ``renderPolicyCard``
         emits the predicate form, and assert its always-rendered controls
-        carry a ``name``. (The predicate *value* control renders only on an
-        op-change — an async, fetch-backed path — so its name is covered by
-        review/code, not this render guard; it is set at both generator
-        sites.)
+        carry a ``name``. (The predicate *value* control renders only after
+        the predicate form is opened, and re-renders on op/path edits, so it
+        has its own dedicated test below —
+        ``test_policy_predicate_value_control_carries_name_attribute`` —
+        which drives both generator sites.)
         """
         fetches = {
             **DEFAULT_FETCHES,
@@ -1511,10 +1524,140 @@ class TestFormControlAccessibility:
             "policy:predicate-path-custom",
             "policy:remember-minutes",
         ):
-            assert f'name="{nm}"' in result.dom, (
-                f"expected policy control name={nm!r} in the rendered card; "
-                f"dom tail: {result.dom[-2500:]}"
+            # Element-scoped: the name must sit on a single <input>/<select>
+            # tag, not merely appear somewhere in the whole-DOM string.
+            m = re.search(
+                rf'<(?:input|select)\b[^>]*name="{re.escape(nm)}"[^>]*>', result.dom
             )
+            assert m is not None, (
+                f"expected policy control element carrying name={nm!r} in the "
+                f"rendered card; dom tail: {result.dom[-2500:]}"
+            )
+
+    def test_policy_predicate_value_control_carries_name_attribute(
+        self, settings_script: str
+    ) -> None:
+        """The predicate *value* control is the last generated surface that
+        renders only after the predicate form is opened (click add-condition),
+        re-rendering on op/path edits. ``name="policy:predicate-value"`` is
+        emitted at both generator sites, so drive each through the JS harness:
+
+        - **Free-text branch** (``renderFreeTextValue`` -> ``<input>``): a
+          failed tool-schema fetch degrades gracefully to the free-text JSON
+          input, exactly the default path on form-open with no schema.
+        - **<select> branch** (``renderChoiceSelect`` -> ``<select>``): a
+          schema ``enum`` on the chosen path upgrades the value control to a
+          choice dropdown.
+
+        Opening the form is driven via ``policyLoadConfig()`` + a real click on
+        ``.policy-add-predicate`` (``openForm`` precedent already in this
+        class), so no internal function is poked directly.
+        """
+        base_fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/features": {
+                "status": 200,
+                "json": {
+                    "flags": {"enable_tool_security_policies": {"value": True}},
+                },
+            },
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "rules": [
+                        {
+                            "tool_name": "ha_config_set_helper",
+                            "when": [],
+                            "remember_minutes": 0,
+                        }
+                    ],
+                },
+            },
+            "/api/policy/pending": {
+                "status": 503,
+                "json": {"error": "irrelevant for this test"},
+            },
+        }
+
+        # --- Free-text branch: tool-schema 503 -> free-text <input> ---------
+        free_text = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map={
+                **base_fetches,
+                "/api/policy/tool-schema": {
+                    "status": 503,
+                    "json": {"error": "no schema available"},
+                },
+            },
+            invoke="""
+              await window.policyLoadConfig();
+              const card = document.querySelector('.policy-rule-card');
+              card.querySelector('.policy-add-predicate').click();
+              await new Promise(r => setTimeout(r, 100));
+            """,
+        )
+        _assert_clean_init(free_text)
+        m = re.search(
+            r'<input[^>]*class="[^"]*policy-predicate-value\b[^"]*"[^>]*>',
+            free_text.dom,
+        )
+        assert m is not None, (
+            "expected free-text value <input> after opening the predicate "
+            f"form; dom tail: {free_text.dom[-2500:]}"
+        )
+        assert 'name="policy:predicate-value"' in m.group(0), (
+            f"free-text value <input> missing name; got {m.group(0)}"
+        )
+
+        # --- <select> branch: schema enum on the chosen path -> <select> ----
+        select_branch = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map={
+                **base_fetches,
+                "/api/policy/tool-schema": {
+                    "status": 200,
+                    "json": {
+                        "paths": [
+                            {
+                                "path": "args.helper_type",
+                                "label": "Helper type",
+                                "type": "str",
+                                "enum": ["input_boolean", "input_number"],
+                            }
+                        ],
+                        "value_sources": {},
+                    },
+                },
+            },
+            invoke="""
+              await window.policyLoadConfig();
+              const card = document.querySelector('.policy-rule-card');
+              card.querySelector('.policy-add-predicate').click();
+              await new Promise(r => setTimeout(r, 100));
+              // op defaults to eq; pick the enum-backed path so the value
+              // control upgrades from free-text to a <select>.
+              const pathSel = card.querySelector('.policy-predicate-path-select');
+              pathSel.value = 'args.helper_type';
+              pathSel.dispatchEvent(new Event('change'));
+              await new Promise(r => setTimeout(r, 100));
+            """,
+        )
+        _assert_clean_init(select_branch)
+        m = re.search(
+            r'<select[^>]*class="[^"]*policy-predicate-value-control[^"]*"[^>]*>',
+            select_branch.dom,
+        )
+        assert m is not None, (
+            "expected choice <select> after selecting the enum-backed path; "
+            f"dom tail: {select_branch.dom[-2500:]}"
+        )
+        assert 'name="policy:predicate-value"' in m.group(0), (
+            f"choice <select> missing name; got {m.group(0)}"
+        )
 
 
 class TestAddonModeLockedBannerCopy:


### PR DESCRIPTION
## What does this PR do?

Accessibility fix for the settings UI: every JS-generated form control (`<input>` and `<select>`) now carries a `name` attribute, clearing the "form field should have an id or name attribute" audit rule (~100 warnings on a populated page). Follow-up to a finding from the visual review in #1431 (sibling of #1494, which addresses the other findings from that review).

The settings UI builds its form controls in JS without an id or name. This adds a derived, **additive** `name` to each generator:

| Surface | `name=` |
|---|---|
| Tool toggles / group master | `tool:<tool>:<field>` / `tool-group:<tag>` |
| Feature flags (bool + int) | `feature:<field>` |
| Advanced inputs / choices `<select>` / code-mode | `adv:<field>` |
| Backup config | `backup:<field>` |
| Policy predicate selects + inputs | `policy:<purpose>` |

No selector or event handler reads `name` (selection is via `data-*` / id), so behaviour — including the toggle / `disabled` / gate logic — is unchanged. Interpolated values are `escapeHtml`-escaped.

**Tests:** a holistic JS-harness guard renders every page-load form surface (tool toggles + group master, bool + int feature flags, yaml-packages sub-flags, code-mode sub-rows, advanced inputs + a choices `<select>`) and asserts every rendered `<input>`/`<select>` carries a name or id; plus targeted tests for tool toggles, advanced fields, the backup-config form, and the policy predicate controls (the on-demand surfaces driven directly via `loadBackupConfig()` / `policyLoadConfig()`). The only control not render-tested is the predicate-value control, which renders on an async op-change path — its name is set at both generator sites.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`) — full unit suite green locally (4017 passed, 1 skipped), ruff + mypy clean.
- [ ] I have tested these changes with a LLM agent

## Checklist
- [ ] I have updated documentation if needed — n/a (no user-facing docs affected)