### PR TITLE
deps(deps): bump starlette from 0.49.1 to 1.2.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1415,14 +1415,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Bumps `starlette` 0.49.1 → 1.2.0 (lockfile only) to resolve **PYSEC-2026-161 (CVE-2026-48710)** — "BadHost". starlette < 1.0.1 does not validate the `Host` header and reconstructs `request.url.path` from it, which can poison path-based security checks (potential auth bypass).

`starlette` is a transitive dependency via `mcp` (`starlette>=0.27`, no upper bound), so no `pyproject.toml` specifier change is needed — only the lock pin moves. I confirmed the CVE against the OSV database with `pip-audit`.

Practical exposure in ha-mcp is low: there is no `request.url`/`request.url.path` usage in auth paths (starlette routing matches on the real request path, not the reconstructed URL), and the OAuth base URL comes from `MCP_BASE_URL`. Removing the flagged CVE from the dependency tree is the correct hygiene fix.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] Tested with an LLM agent — N/A (lockfile-only dependency pin bump)
- [ ] `uv run pytest` (full suite) — not run locally; the Alpine dev env can't install `lefthook` (no musl wheel) and the `skills-vendor` submodule is uninitialised. **CI runs the full suite + E2E.** Locally verified: `uv lock --check` passes, import smoke for `mcp`/`fastmcp`/`ha_mcp` under starlette 1.2.0, and `test_ws_connect_error_detail.py` (10 tests, transport-adjacent) stay green.
- [x] No Python source changed → `ruff` scope unaffected

## Checklist
- [x] No documentation changes needed (transitive lock pin)