### PR TITLE
deps(deps): bump jaraco-context from 6.0.1 to 6.1.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -614,11 +614,11 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.0.1"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Bumps `jaraco-context` 6.0.1 → 6.1.2 (lockfile only) to resolve **CVE-2026-23949 (GHSA-58pv-8j8x-9vj2)** — a Zip Slip path-traversal in `jaraco.context.tarball()` (affects 5.2.0–<6.1.0) that can extract files outside the target directory from a malicious tar archive.

`jaraco-context` is a transitive dependency (`py-key-value-aio` → `keyring` → `jaraco.context`); `keyring` sets no upper bound, so this is a lock-only minor bump with no `pyproject.toml` change. I confirmed the CVE via `pip-audit`/OSV.

Practical exposure in ha-mcp is nil — the codebase never calls the vulnerable `tarball()` helper — but bumping clears the CVE from the dependency tree. (The advisory is in GitHub's DB, but Dependabot does not auto-PR it since it's a transitive dep in the `uv` ecosystem.)

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] Tested with an LLM agent — N/A (lockfile-only transitive bump)
- [ ] `uv run pytest` (full suite) — not run locally (Alpine can't install `lefthook`; `skills-vendor` submodule uninitialised). **CI runs full suite + E2E.** Locally verified: `uv lock --check` passes and `jaraco.context`/`keyring`/`py-key-value-aio`/`ha_mcp` import cleanly under 6.1.2.
- [x] No Python source changed → `ruff` scope unaffected

## Checklist
- [x] No documentation changes needed (transitive lock pin)