### PR TITLE
refactor(hacs): consolidate HACS tools into ha_get_hacs + ha_manage_hacs (#1045)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -664,7 +664,6 @@ These feed the picker tiles in the markup section AND the wizard `<script>` bloc
 - `ha_report_issue`, `ha_import_blueprint`
 - `ha_read_file`, `ha_write_file`, `ha_deep_search`, `ha_bulk_control`
 - `ha_install_mcp_tools`
-- `ha_hacs_*` family (`ha_hacs_search`, `ha_hacs_download`, `ha_hacs_add_repository`, `ha_hacs_repository_info`) — grandfathered; pre-dates this convention
 
 **Adding new verbs**: When no existing verb fits a new tool's purpose, add the verb to the approved-verbs list above rather than forcing a poor fit. `.gemini/styleguide.md` points back to this section as the single source of truth, so updates here propagate automatically.
 

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -100,7 +100,7 @@ class HacsTools:
     Two action-based tools split along the read/write boundary so the
     read path keeps ``readOnlyHint`` and is never flagged ``destructive``:
 
-    - ``ha_get_hacs`` (read): ``search`` the store / ``info`` for one repo.
+    - ``ha_get_hacs_info`` (read): ``search`` the store / ``info`` for one repo.
     - ``ha_manage_hacs`` (write): ``download`` install/update / ``add_repository``.
     """
 
@@ -108,16 +108,16 @@ class HacsTools:
         self._client = client
 
     @tool(
-        name="ha_get_hacs",
+        name="ha_get_hacs_info",
         tags={"HACS"},
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "Get HACS",
+            "title": "Get HACS Info",
         },
     )
     @log_tool_usage
-    async def ha_get_hacs(
+    async def ha_get_hacs_info(
         self,
         action: Annotated[
             Literal["search", "info"],
@@ -164,9 +164,9 @@ class HacsTools:
         discovers installed custom cards to wire into ``ha_config_set_dashboard()``.
 
         **Examples:**
-        - Search the store: ha_get_hacs(action="search", query="mushroom", category="lovelace")
-        - List installed: ha_get_hacs(action="search", installed_only=True)
-        - Repository details: ha_get_hacs(action="info", repository_id="441028036")
+        - Search the store: ha_get_hacs_info(action="search", query="mushroom", category="lovelace")
+        - List installed: ha_get_hacs_info(action="search", installed_only=True)
+        - Repository details: ha_get_hacs_info(action="info", repository_id="441028036")
 
         **Caveats:** ``info`` fetches full repository detail from GitHub, so it can hit GitHub
         rate limits / needs HACS's configured GitHub token; ``search`` reads HACS's locally
@@ -196,7 +196,7 @@ class HacsTools:
         except Exception as e:
             exception_to_structured_error(
                 e,
-                context={"tool": "ha_get_hacs", "action": action},
+                context={"tool": "ha_get_hacs_info", "action": action},
                 suggestions=[
                     "Verify HACS is installed: https://hacs.xyz/",
                     "For action='search', try a simpler query or a valid category",
@@ -246,7 +246,7 @@ class HacsTools:
         Use ``action="download"`` to install or update a repository, or
         ``action="add_repository"`` to register a custom GitHub repository with HACS. This
         tool performs writes; to search the store or read repository details use
-        ``ha_get_hacs``.
+        ``ha_get_hacs_info``.
 
         **Examples:**
         - Install latest: ha_manage_hacs(action="download", repository_id="441028036")
@@ -287,7 +287,7 @@ class HacsTools:
                 context={"tool": "ha_manage_hacs", "action": action},
                 suggestions=[
                     "Verify HACS is installed: https://hacs.xyz/",
-                    "For action='download', pass a valid repository_id (use ha_get_hacs(action='search') to find it)",
+                    "For action='download', pass a valid repository_id (use ha_get_hacs_info(action='search') to find it)",
                     "For action='add_repository', use 'owner/repo' format and a matching category",
                 ],
             )
@@ -307,7 +307,7 @@ class HacsTools:
     ) -> dict[str, Any]:
         await safe_info(
             ctx,
-            f"ha_get_hacs search starting: query={query!r} "
+            f"ha_get_hacs_info search starting: query={query!r} "
             f"category={category} installed_only={installed_only}",
         )
         await safe_progress(
@@ -445,7 +445,7 @@ class HacsTools:
             repository_id,
             "repository_id",
             suggestions=[
-                "Use ha_get_hacs(action='search') to find valid repository IDs",
+                "Use ha_get_hacs_info(action='search') to find valid repository IDs",
                 "Or pass a GitHub path like 'owner/repo' to install by name",
             ],
         )
@@ -883,7 +883,7 @@ async def _resolve_hacs_repo_id(ws_client: Any, repository_id: str) -> tuple[str
             ErrorCode.RESOURCE_NOT_FOUND,
             f"Repository '{repository_id}' not found in HACS",
             suggestions=[
-                "Use ha_get_hacs(action='search') to find the repository",
+                "Use ha_get_hacs_info(action='search') to find the repository",
                 "Check the repository name is correct (case-insensitive)",
                 "The repository may need to be added to HACS first",
             ],

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -133,19 +133,24 @@ class HacsTools:
         ] = None,
         installed_only: Annotated[
             bool,
-            Field(description="Only return installed repositories (action='search')"),
+            Field(
+                description="Only return installed repositories (action='search', default: False)"
+            ),
         ] = False,
         max_results: Annotated[
             int,
             Field(
                 ge=1,
                 le=100,
-                description="Maximum number of results (action='search', max: 100)",
+                description="Maximum number of results (action='search', default: 10, max: 100)",
             ),
         ] = 10,
         offset: Annotated[
             int,
-            Field(ge=0, description="Results to skip for pagination (action='search')"),
+            Field(
+                ge=0,
+                description="Results to skip for pagination (action='search', default: 0)",
+            ),
         ] = 0,
         repository_id: Annotated[
             str | None,
@@ -545,7 +550,9 @@ class HacsTools:
         # actually registered (mirroring the download path) — an accepted-but-
         # never-registered add (archived repo, bad structure, wrong category)
         # would otherwise report a misleading "Successfully added".
-        repo = await wait_for_repo_registration(ws_client, repository)
+        repo = await wait_for_repo_registration(
+            ws_client, repository, timeout=HACS_ADD_REGISTRATION_TIMEOUT
+        )
         if repo is None:
             raise_tool_error(
                 create_error_response(
@@ -676,6 +683,15 @@ HACS_SUBSCRIBE_TIMEOUT = 10.0
 # lossy for any reason. Larger than the old 1.0 s because we expect
 # the nudge to do the heavy lifting; this is belt-and-braces only.
 HACS_REPO_BACKSTOP_POLL_INTERVAL = 5.0
+
+# Wall-clock budget for confirming a custom repository registered after an
+# ``hacs/repositories/add``. Shorter than the resolve/download budget: a valid
+# repo registers in seconds, and failing fast turns an accepted-but-never-
+# registered add (archived/invalid repo, wrong category) into a prompt error
+# instead of a 30 s stall. Not exercised by the e2e suite (the only e2e add
+# fails at the owner/repo format guard), so the HAOS-load tuning behind the
+# 30 s resolve budget does not apply here.
+HACS_ADD_REGISTRATION_TIMEOUT = 10.0
 
 
 async def _find_repo_in_list_by_full_name(

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -95,543 +95,462 @@ async def _assert_hacs_available() -> None:
 
 
 class HacsTools:
-    """HACS integration tools for Home Assistant."""
+    """HACS integration tools for Home Assistant.
+
+    Two action-based tools split along the read/write boundary so the
+    read path keeps ``readOnlyHint`` and is never flagged ``destructive``:
+
+    - ``ha_get_hacs`` (read): ``search`` the store / ``info`` for one repo.
+    - ``ha_manage_hacs`` (write): ``download`` install/update / ``add_repository``.
+    """
 
     def __init__(self, client: Any) -> None:
         self._client = client
 
     @tool(
-        name="ha_hacs_search",
+        name="ha_get_hacs",
         tags={"HACS"},
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "Search HACS Store",
+            "title": "Get HACS",
         },
     )
     @log_tool_usage
-    async def ha_hacs_search(
+    async def ha_get_hacs(
         self,
-        query: str = "",
+        action: Annotated[
+            Literal["search", "info"],
+            Field(description="'search' the store, or 'info' for one repository"),
+        ],
+        query: Annotated[
+            str, Field(description="Search keyword (action='search')")
+        ] = "",
         category: Annotated[
             Literal["integration", "lovelace", "theme", "appdaemon", "python_script"]
             | None,
-            Field(
-                default=None,
-                description="Filter by category (optional)",
-            ),
+            Field(description="Filter by category (action='search')"),
         ] = None,
         installed_only: Annotated[
             bool,
-            Field(
-                default=False,
-                description="Only return installed repositories (default: False)",
-            ),
+            Field(description="Only return installed repositories (action='search')"),
         ] = False,
         max_results: Annotated[
             int,
             Field(
-                default=10,
                 ge=1,
                 le=100,
-                description="Maximum number of results to return (default: 10, max: 100)",
+                description="Maximum number of results (action='search', max: 100)",
             ),
         ] = 10,
         offset: Annotated[
             int,
-            Field(
-                default=0,
-                ge=0,
-                description="Number of results to skip for pagination (default: 0)",
-            ),
+            Field(ge=0, description="Results to skip for pagination (action='search')"),
         ] = 0,
+        repository_id: Annotated[
+            str | None,
+            Field(description="Numeric HACS ID or 'owner/repo' path (action='info')"),
+        ] = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
-        """Search HACS store for repositories, or list installed repositories.
+        """Get HACS (Home Assistant Community Store) data — search the store or fetch repository details.
 
-        **Search mode** (default): Searches by keyword across name, description, and authors.
-        **Browse mode** (no query, `installed_only=False`): Returns all HACS store repos
-        sorted alphabetically, paginated by `max_results` and `offset`.
-        **Installed mode** (`installed_only=True`): Lists installed repos (no query needed).
+        Use ``action="search"`` to search/browse/list store repositories, or
+        ``action="info"`` for one repository's full details (README, versions, GitHub
+        stats). This tool is read-only; to install or add repositories use
+        ``ha_manage_hacs``, and for non-HACS entities/config use the domain-specific tools.
 
-        **DASHBOARD TIP:** Use `installed_only=True, category="lovelace"` to discover
-        installed custom cards for use with `ha_config_set_dashboard()`.
-
-        **Examples:**
-        - Find custom cards: `ha_hacs_search("mushroom", category="lovelace")`
-        - Find integrations: `ha_hacs_search("nest", category="integration")`
-        - List installed: `ha_hacs_search(installed_only=True)`
-        - Installed by category: `ha_hacs_search(installed_only=True, category="lovelace")`
-
-        Args:
-            query: Search query (repository name, description, author). Empty string with
-                  installed_only=True lists all installed repos.
-            category: Filter by category (optional)
-            installed_only: Only return installed repositories (default: False)
-            max_results: Maximum results to return (default: 10, max: 100)
-            offset: Number of results to skip for pagination (default: 0)
-        """
-        try:
-            await safe_info(
-                ctx,
-                f"ha_hacs_search starting: query={query!r} "
-                f"category={category} installed_only={installed_only}",
-            )
-            await safe_progress(
-                ctx,
-                progress=0,
-                total=3,
-                message="checking HACS availability",
-            )
-
-            # Check if HACS is available
-            await _assert_hacs_available()
-
-            # Get all repositories via WebSocket
-            from ..client.websocket_client import get_websocket_client
-
-            ws_client = await get_websocket_client()
-
-            # Build command parameters - map user-friendly category to HACS internal name
-            kwargs_cmd: dict[str, Any] = {}
-            if category:
-                hacs_category = CATEGORY_MAP.get(category, category)
-                kwargs_cmd["categories"] = [hacs_category]
-
-            await safe_progress(
-                ctx,
-                progress=1,
-                total=3,
-                message="fetching HACS repository list",
-            )
-
-            response = await ws_client.send_command(
-                "hacs/repositories/list", **kwargs_cmd
-            )
-
-            if not response.get("success"):
-                exception_to_structured_error(
-                    Exception(f"HACS search request failed: {response}"),
-                    context={
-                        "command": "hacs/repositories/list",
-                        "query": query,
-                        "category": category,
-                    },
-                    raise_error=True,
-                )
-
-            all_repositories = response.get("result", [])
-            await safe_progress(
-                ctx,
-                progress=2,
-                total=3,
-                message=f"filtering {len(all_repositories)} repositories",
-            )
-            matches = _filter_and_score_repos(all_repositories, query, installed_only)
-            await safe_progress(
-                ctx,
-                progress=3,
-                total=3,
-                message=f"matched {len(matches)} repositories",
-            )
-
-            limited_matches = matches[offset : offset + max_results]
-            has_more = (offset + len(limited_matches)) < len(matches)
-
-            return await add_timezone_metadata(
-                self._client,
-                {
-                    "success": True,
-                    "query": query if query.strip() else None,
-                    "category_filter": category,
-                    "installed_only": installed_only,
-                    "total_matches": len(matches),
-                    "offset": offset,
-                    "limit": max_results,
-                    "count": len(limited_matches),
-                    "has_more": has_more,
-                    "next_offset": offset + max_results if has_more else None,
-                    "results": limited_matches,
-                },
-            )
-
-        except ToolError:
-            raise
-        except Exception as e:
-            exception_to_structured_error(
-                e,
-                context={
-                    "tool": "ha_hacs_search",
-                    "query": query,
-                    "category": category,
-                },
-                suggestions=[
-                    "Verify HACS is installed: https://hacs.xyz/",
-                    "Try a simpler search query",
-                    "Check category name is valid: integration, lovelace, theme, appdaemon, python_script",
-                ],
-            )
-
-    @tool(
-        name="ha_hacs_repository_info",
-        tags={"HACS"},
-        annotations={
-            "idempotentHint": True,
-            "readOnlyHint": True,
-            "title": "Get HACS Repository Info",
-        },
-    )
-    @log_tool_usage
-    async def ha_hacs_repository_info(self, repository_id: str) -> dict[str, Any]:
-        """Get detailed repository information including README and documentation.
-
-        Returns comprehensive information about a HACS repository:
-        - Basic info (name, description, category, authors)
-        - Installation status and versions
-        - README content (useful for configuration examples)
-        - Available releases and versions
-        - GitHub stats (stars, issues)
-        - Configuration examples (if available)
-
-        **Use Cases:**
-        - Get card configuration examples: `ha_hacs_repository_info("441028036")`
-        - Check integration setup instructions
-        - Find theme customization options
-
-        **Note:** The repository_id is the numeric ID from HACS, not the GitHub path.
-        Use `ha_hacs_search()` to find the numeric ID.
-
-        Args:
-            repository_id: Repository numeric ID (e.g., "441028036") or GitHub path (e.g., "dvd-dev/hilo")
-
-        Returns:
-            Detailed repository information or error if not found.
-        """
-        try:
-            # Check if HACS is available
-            await _assert_hacs_available()
-
-            from ..client.websocket_client import get_websocket_client
-
-            ws_client = await get_websocket_client()
-
-            # If repository_id contains a slash, it's a GitHub path - need to look up numeric ID
-            actual_id, _ = await _resolve_hacs_repo_id(ws_client, repository_id)
-
-            # Get repository info via WebSocket using numeric ID
-            response = await ws_client.send_command(
-                "hacs/repository/info", repository_id=actual_id
-            )
-
-            if not response.get("success"):
-                exception_to_structured_error(
-                    Exception(f"HACS repository info request failed: {response}"),
-                    context={
-                        "command": "hacs/repository/info",
-                        "repository_id": repository_id,
-                    },
-                    raise_error=True,
-                )
-
-            result = response.get("result", {})
-
-            # Extract and structure the most useful information
-            return await add_timezone_metadata(
-                self._client,
-                {
-                    "success": True,
-                    "repository_id": repository_id,
-                    "name": result.get("name"),
-                    "full_name": result.get("full_name"),
-                    "description": result.get("description"),
-                    "category": result.get("category"),
-                    "authors": result.get("authors", []),
-                    "domain": result.get("domain"),  # For integrations
-                    "installed": result.get("installed", False),
-                    "installed_version": result.get("installed_version"),
-                    "available_version": result.get("available_version"),
-                    "pending_update": result.get("pending_upgrade", False),
-                    "stars": result.get("stars", 0),
-                    "downloads": result.get("downloads", 0),
-                    "topics": result.get("topics", []),
-                    "releases": result.get("releases", []),
-                    "default_branch": result.get("default_branch"),
-                    "readme": result.get("readme"),  # Full README content
-                    "data": result,  # Full response for advanced use
-                },
-            )
-
-        except ToolError:
-            raise
-        except Exception as e:
-            exception_to_structured_error(
-                e,
-                context={
-                    "tool": "ha_hacs_repository_info",
-                    "repository_id": repository_id,
-                },
-                suggestions=[
-                    "Verify HACS is installed: https://hacs.xyz/",
-                    "Check repository ID format (e.g., 'hacs/integration' or 'owner/repo')",
-                    "Use ha_hacs_search() to find the correct repository ID",
-                ],
-            )
-
-    @tool(
-        name="ha_hacs_add_repository",
-        tags={"HACS"},
-        annotations={"destructiveHint": True, "title": "Add HACS Repository"},
-    )
-    @log_tool_usage
-    async def ha_hacs_add_repository(
-        self,
-        repository: str,
-        category: Annotated[
-            Literal["integration", "lovelace", "theme", "appdaemon", "python_script"],
-            Field(
-                description="Repository category (required)",
-            ),
-        ],
-    ) -> dict[str, Any]:
-        """Add a custom GitHub repository to HACS.
-
-        Allows adding custom repositories that are not in the default HACS store.
-        This is useful for:
-        - Adding custom integrations from GitHub
-        - Installing custom Lovelace cards
-        - Adding custom themes
-        - Installing beta/development versions
-
-        **Requirements:**
-        - Repository must be a valid GitHub repository
-        - Repository must follow HACS structure guidelines
-        - Category must match the repository type
+        **DASHBOARD TIP:** ``action="search", installed_only=True, category="lovelace"``
+        discovers installed custom cards to wire into ``ha_config_set_dashboard()``.
 
         **Examples:**
-        ```python
-        # Add custom integration
-        ha_hacs_add_repository("owner/custom-integration", category="integration")
+        - Search the store: ha_get_hacs(action="search", query="mushroom", category="lovelace")
+        - List installed: ha_get_hacs(action="search", installed_only=True)
+        - Repository details: ha_get_hacs(action="info", repository_id="441028036")
 
-        # Add custom card
-        ha_hacs_add_repository("owner/custom-card", category="lovelace")
-
-        # Add custom theme
-        ha_hacs_add_repository("owner/custom-theme", category="theme")
-        ```
-
-        Args:
-            repository: GitHub repository in format "owner/repo"
-            category: Repository category (integration, lovelace, theme, appdaemon, python_script)
-
-        Returns:
-            Success status and repository ID if added successfully.
+        **Caveats:** ``search``/``info`` proxy the GitHub API, so they are subject to GitHub
+        rate limits and need HACS's configured GitHub token; ``repository_id`` accepts a
+        numeric HACS ID or an ``owner/repo`` path.
         """
         try:
-            # Check if HACS is available
-            await _assert_hacs_available()
+            if action == "search":
+                return await self._hacs_search(
+                    query, category, installed_only, max_results, offset, ctx
+                )
 
-            # Validate repository format
-            if "/" not in repository:
+            # action == "info"
+            if not repository_id:
                 raise_tool_error(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "Invalid repository format. Must be 'owner/repo'",
+                        "repository_id is required for action='info'",
                         suggestions=[
-                            "Use format: 'owner/repo' (e.g., 'hacs/integration')",
-                            "Check the repository exists on GitHub",
+                            "Pass repository_id (numeric HACS ID or 'owner/repo')",
+                            "Use action='search' to find the repository first",
                         ],
                     )
                 )
-
-            # Add repository via WebSocket
-            from ..client.websocket_client import get_websocket_client
-
-            ws_client = await get_websocket_client()
-
-            # Map user-friendly category to HACS internal name
-            hacs_category = CATEGORY_MAP.get(category, category)
-
-            response = await ws_client.send_command(
-                "hacs/repositories/add",
-                repository=repository,
-                category=hacs_category,
-            )
-
-            if not response.get("success"):
-                exception_to_structured_error(
-                    Exception(f"HACS add repository request failed: {response}"),
-                    context={
-                        "command": "hacs/repositories/add",
-                        "repository": repository,
-                        "category": category,
-                    },
-                    raise_error=True,
-                )
-
-            result = response.get("result", {})
-
-            return await add_timezone_metadata(
-                self._client,
-                {
-                    "success": True,
-                    "repository": repository,
-                    "category": category,
-                    "repository_id": result.get("id"),
-                    "message": f"Successfully added {repository} to HACS",
-                    "data": result,
-                },
-            )
+            return await self._hacs_info(repository_id)
 
         except ToolError:
             raise
         except Exception as e:
             exception_to_structured_error(
                 e,
-                context={
-                    "tool": "ha_hacs_add_repository",
-                    "repository": repository,
-                    "category": category,
-                },
+                context={"tool": "ha_get_hacs", "action": action},
                 suggestions=[
                     "Verify HACS is installed: https://hacs.xyz/",
-                    "Check repository format: 'owner/repo'",
-                    "Verify the repository exists on GitHub",
-                    "Ensure category matches repository type",
-                    "Check repository follows HACS guidelines: https://hacs.xyz/docs/publish/start",
+                    "For action='search', try a simpler query or a valid category",
+                    "For action='info', pass a valid repository_id (numeric ID or 'owner/repo')",
                 ],
             )
 
     @tool(
-        name="ha_hacs_download",
+        name="ha_manage_hacs",
         tags={"HACS"},
         annotations={
             "destructiveHint": True,
-            "title": "Download/Install HACS Repository",
+            "title": "Manage HACS",
         },
     )
     @log_tool_usage
-    async def ha_hacs_download(
+    async def ha_manage_hacs(
         self,
-        repository_id: str,
-        version: Annotated[
+        action: Annotated[
+            Literal["download", "add_repository"],
+            Field(description="'download' to install/update, or 'add_repository'"),
+        ],
+        repository_id: Annotated[
             str | None,
             Field(
-                default=None,
-                description="Specific version to install (e.g., 'v1.2.3'). If not specified, installs the latest version.",
+                description="Numeric HACS ID or 'owner/repo' path (action='download')"
             ),
         ] = None,
+        version: Annotated[
+            str | None,
+            Field(description="Specific version to install (action='download')"),
+        ] = None,
+        repository: Annotated[
+            str | None,
+            Field(
+                description="GitHub repo 'owner/repo' to add (action='add_repository')"
+            ),
+        ] = None,
+        category: Annotated[
+            Literal["integration", "lovelace", "theme", "appdaemon", "python_script"]
+            | None,
+            Field(description="Repository category (action='add_repository')"),
+        ] = None,
     ) -> dict[str, Any]:
-        """Download and install a HACS repository.
+        """Manage HACS (Home Assistant Community Store) — install/update or add custom repositories.
 
-        This installs a repository from HACS to your Home Assistant instance.
-        For integrations, a restart of Home Assistant may be required after installation.
-
-        **Prerequisites:**
-        - The repository must already be in HACS (either from the default store or added via `ha_hacs_add_repository`)
-        - Use `ha_hacs_search()` to find the repository ID
+        Use ``action="download"`` to install or update a repository, or
+        ``action="add_repository"`` to register a custom GitHub repository with HACS. This
+        tool performs writes; to search the store or read repository details use
+        ``ha_get_hacs``.
 
         **Examples:**
-        ```python
-        # Install latest version of a repository
-        ha_hacs_download("441028036")
+        - Install latest: ha_manage_hacs(action="download", repository_id="441028036")
+        - Install a version: ha_manage_hacs(action="download", repository_id="piitaya/lovelace-mushroom", version="v4.0.0")
+        - Add a custom repo: ha_manage_hacs(action="add_repository", repository="owner/repo", category="lovelace")
 
-        # Install specific version
-        ha_hacs_download("441028036", version="v2.0.0")
-
-        # Install by GitHub path (will look up the numeric ID)
-        ha_hacs_download("piitaya/lovelace-mushroom", version="v4.0.0")
-        ```
-
-        **Note:** For integrations, you may need to restart Home Assistant after installation.
-        For Lovelace cards, clear your browser cache to see the new card.
-
-        Args:
-            repository_id: Repository numeric ID or GitHub path (e.g., "441028036" or "owner/repo")
-            version: Specific version to install (optional, defaults to latest)
-
-        Returns:
-            Success status and installation details.
+        **Caveats:** Installing an integration usually needs a Home Assistant restart to
+        activate; new Lovelace cards need a browser cache clear. ``repository_id`` accepts a
+        numeric HACS ID or an ``owner/repo`` path; ``add_repository`` requires ``owner/repo``
+        format plus a matching ``category``.
         """
         try:
-            # Empty/whitespace repository_id would either be passed straight
-            # into ``_resolve_hacs_repo_id`` (which has no empty-check and
-            # would fall through to a HACS lookup miss) or — for a numeric
-            # candidate — reach ``hacs/repository/download`` with an empty
-            # repository field. Same destructive-WS-call class as
-            # ``ha_manage_addon``: guard up-front so the caller learns the
-            # identifier was unusable before any backend call.
-            validate_identifier_not_empty(
-                repository_id,
-                "repository_id",
-                suggestions=[
-                    "Use ha_hacs_search() to find valid repository IDs",
-                    "Or pass a GitHub path like 'owner/repo' to install by name",
-                ],
-            )
-            # Check if HACS is available
-            await _assert_hacs_available()
+            if action == "download":
+                return await self._hacs_download(repository_id, version)
 
-            from ..client.websocket_client import get_websocket_client
-
-            ws_client = await get_websocket_client()
-
-            # Resolve GitHub path to numeric ID if needed
-            actual_id, repo_name = await _resolve_hacs_repo_id(ws_client, repository_id)
-
-            # Build download command parameters
-            download_kwargs: dict[str, Any] = {"repository": actual_id}
-            if version:
-                download_kwargs["version"] = version
-
-            # Download/install the repository
-            response = await ws_client.send_command(
-                "hacs/repository/download", **download_kwargs
-            )
-
-            if not response.get("success"):
-                exception_to_structured_error(
-                    Exception(f"HACS download request failed: {response}"),
-                    context={
-                        "command": "hacs/repository/download",
-                        "repository_id": repository_id,
-                        "version": version,
-                    },
-                    raise_error=True,
+            # action == "add_repository"
+            if repository is None or category is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "repository and category are required for action='add_repository'",
+                        suggestions=[
+                            "Pass repository in 'owner/repo' format",
+                            "Pass category (integration, lovelace, theme, appdaemon, python_script)",
+                        ],
+                    )
                 )
-
-            result = response.get("result", {})
-
-            return await add_timezone_metadata(
-                self._client,
-                {
-                    "success": True,
-                    "repository_id": actual_id,
-                    "repository": repo_name,
-                    "version": version or "latest",
-                    "message": f"Successfully installed {repo_name}"
-                    + (f" version {version}" if version else ""),
-                    "note": "For integrations, restart Home Assistant to activate. For Lovelace cards, clear browser cache.",
-                    "data": result,
-                },
-            )
+            return await self._hacs_add_repository(repository, category)
 
         except ToolError:
             raise
         except Exception as e:
             exception_to_structured_error(
                 e,
+                context={"tool": "ha_manage_hacs", "action": action},
+                suggestions=[
+                    "Verify HACS is installed: https://hacs.xyz/",
+                    "For action='download', pass a valid repository_id (use ha_get_hacs(action='search') to find it)",
+                    "For action='add_repository', use 'owner/repo' format and a matching category",
+                ],
+            )
+
+    # --- Private action handlers ------------------------------------------
+    # The public tools above are thin dispatchers; each handler raises a
+    # structured ToolError on failure, caught by the dispatcher's wrapper.
+
+    async def _hacs_search(
+        self,
+        query: str,
+        category: str | None,
+        installed_only: bool,
+        max_results: int,
+        offset: int,
+        ctx: Context | None,
+    ) -> dict[str, Any]:
+        await safe_info(
+            ctx,
+            f"ha_get_hacs search starting: query={query!r} "
+            f"category={category} installed_only={installed_only}",
+        )
+        await safe_progress(
+            ctx, progress=0, total=3, message="checking HACS availability"
+        )
+
+        # Check if HACS is available
+        await _assert_hacs_available()
+
+        # Get all repositories via WebSocket
+        from ..client.websocket_client import get_websocket_client
+
+        ws_client = await get_websocket_client()
+
+        # Build command parameters - map user-friendly category to HACS internal name
+        kwargs_cmd: dict[str, Any] = {}
+        if category:
+            hacs_category = CATEGORY_MAP.get(category, category)
+            kwargs_cmd["categories"] = [hacs_category]
+
+        await safe_progress(
+            ctx, progress=1, total=3, message="fetching HACS repository list"
+        )
+
+        response = await ws_client.send_command("hacs/repositories/list", **kwargs_cmd)
+
+        if not response.get("success"):
+            exception_to_structured_error(
+                Exception(f"HACS search request failed: {response}"),
                 context={
-                    "tool": "ha_hacs_download",
+                    "command": "hacs/repositories/list",
+                    "query": query,
+                    "category": category,
+                },
+                raise_error=True,
+            )
+
+        all_repositories = response.get("result", [])
+        await safe_progress(
+            ctx,
+            progress=2,
+            total=3,
+            message=f"filtering {len(all_repositories)} repositories",
+        )
+        matches = _filter_and_score_repos(all_repositories, query, installed_only)
+        await safe_progress(
+            ctx, progress=3, total=3, message=f"matched {len(matches)} repositories"
+        )
+
+        limited_matches = matches[offset : offset + max_results]
+        has_more = (offset + len(limited_matches)) < len(matches)
+
+        return await add_timezone_metadata(
+            self._client,
+            {
+                "success": True,
+                "query": query if query.strip() else None,
+                "category_filter": category,
+                "installed_only": installed_only,
+                "total_matches": len(matches),
+                "offset": offset,
+                "limit": max_results,
+                "count": len(limited_matches),
+                "has_more": has_more,
+                "next_offset": offset + max_results if has_more else None,
+                "results": limited_matches,
+            },
+        )
+
+    async def _hacs_info(self, repository_id: str) -> dict[str, Any]:
+        # Check if HACS is available
+        await _assert_hacs_available()
+
+        from ..client.websocket_client import get_websocket_client
+
+        ws_client = await get_websocket_client()
+
+        # If repository_id contains a slash, it's a GitHub path - look up numeric ID
+        actual_id, _ = await _resolve_hacs_repo_id(ws_client, repository_id)
+
+        # Get repository info via WebSocket using numeric ID
+        response = await ws_client.send_command(
+            "hacs/repository/info", repository_id=actual_id
+        )
+
+        if not response.get("success"):
+            exception_to_structured_error(
+                Exception(f"HACS repository info request failed: {response}"),
+                context={
+                    "command": "hacs/repository/info",
+                    "repository_id": repository_id,
+                },
+                raise_error=True,
+            )
+
+        result = response.get("result", {})
+
+        # Extract and structure the most useful information
+        return await add_timezone_metadata(
+            self._client,
+            {
+                "success": True,
+                "repository_id": repository_id,
+                "name": result.get("name"),
+                "full_name": result.get("full_name"),
+                "description": result.get("description"),
+                "category": result.get("category"),
+                "authors": result.get("authors", []),
+                "domain": result.get("domain"),  # For integrations
+                "installed": result.get("installed", False),
+                "installed_version": result.get("installed_version"),
+                "available_version": result.get("available_version"),
+                "pending_update": result.get("pending_upgrade", False),
+                "stars": result.get("stars", 0),
+                "downloads": result.get("downloads", 0),
+                "topics": result.get("topics", []),
+                "releases": result.get("releases", []),
+                "default_branch": result.get("default_branch"),
+                "readme": result.get("readme"),  # Full README content
+                "data": result,  # Full response for advanced use
+            },
+        )
+
+    async def _hacs_download(
+        self, repository_id: str | None, version: str | None
+    ) -> dict[str, Any]:
+        # Empty/whitespace repository_id would either be passed straight
+        # into ``_resolve_hacs_repo_id`` (which has no empty-check and
+        # would fall through to a HACS lookup miss) or — for a numeric
+        # candidate — reach ``hacs/repository/download`` with an empty
+        # repository field. Same destructive-WS-call class as
+        # ``ha_manage_addon``: guard up-front so the caller learns the
+        # identifier was unusable before any backend call.
+        repository_id = validate_identifier_not_empty(
+            repository_id,
+            "repository_id",
+            suggestions=[
+                "Use ha_get_hacs(action='search') to find valid repository IDs",
+                "Or pass a GitHub path like 'owner/repo' to install by name",
+            ],
+        )
+        # Check if HACS is available
+        await _assert_hacs_available()
+
+        from ..client.websocket_client import get_websocket_client
+
+        ws_client = await get_websocket_client()
+
+        # Resolve GitHub path to numeric ID if needed
+        actual_id, repo_name = await _resolve_hacs_repo_id(ws_client, repository_id)
+
+        # Build download command parameters
+        download_kwargs: dict[str, Any] = {"repository": actual_id}
+        if version:
+            download_kwargs["version"] = version
+
+        # Download/install the repository
+        response = await ws_client.send_command(
+            "hacs/repository/download", **download_kwargs
+        )
+
+        if not response.get("success"):
+            exception_to_structured_error(
+                Exception(f"HACS download request failed: {response}"),
+                context={
+                    "command": "hacs/repository/download",
                     "repository_id": repository_id,
                     "version": version,
                 },
-                suggestions=[
-                    "Verify HACS is installed: https://hacs.xyz/",
-                    "Check repository ID is valid (use ha_hacs_search() to find it)",
-                    "Ensure the repository is in HACS (use ha_hacs_add_repository() if needed)",
-                    "Check version format (e.g., 'v1.2.3' or '1.2.3')",
-                ],
+                raise_error=True,
             )
+
+        result = response.get("result", {})
+
+        return await add_timezone_metadata(
+            self._client,
+            {
+                "success": True,
+                "repository_id": actual_id,
+                "repository": repo_name,
+                "version": version or "latest",
+                "message": f"Successfully installed {repo_name}"
+                + (f" version {version}" if version else ""),
+                "note": "For integrations, restart Home Assistant to activate. For Lovelace cards, clear browser cache.",
+                "data": result,
+            },
+        )
+
+    async def _hacs_add_repository(
+        self, repository: str, category: str
+    ) -> dict[str, Any]:
+        # Check if HACS is available
+        await _assert_hacs_available()
+
+        # Validate repository format
+        if "/" not in repository:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Invalid repository format. Must be 'owner/repo'",
+                    suggestions=[
+                        "Use format: 'owner/repo' (e.g., 'hacs/integration')",
+                        "Check the repository exists on GitHub",
+                    ],
+                )
+            )
+
+        # Add repository via WebSocket
+        from ..client.websocket_client import get_websocket_client
+
+        ws_client = await get_websocket_client()
+
+        # Map user-friendly category to HACS internal name
+        hacs_category = CATEGORY_MAP.get(category, category)
+
+        response = await ws_client.send_command(
+            "hacs/repositories/add",
+            repository=repository,
+            category=hacs_category,
+        )
+
+        if not response.get("success"):
+            exception_to_structured_error(
+                Exception(f"HACS add repository request failed: {response}"),
+                context={
+                    "command": "hacs/repositories/add",
+                    "repository": repository,
+                    "category": category,
+                },
+                raise_error=True,
+            )
+
+        result = response.get("result", {})
+
+        return await add_timezone_metadata(
+            self._client,
+            {
+                "success": True,
+                "repository": repository,
+                "category": category,
+                "repository_id": result.get("id"),
+                "message": f"Successfully added {repository} to HACS",
+                "data": result,
+            },
+        )
 
 
 def register_hacs_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
@@ -945,8 +864,8 @@ async def _resolve_hacs_repo_id(ws_client: Any, repository_id: str) -> tuple[str
 
     For GitHub-path identifiers, this uses the HACS dispatch-signal
     waiter so that a caller running immediately after
-    ``ha_hacs_add_repository`` doesn't race against HACS' internal
-    registration — the same flake class that affected
+    ``ha_manage_hacs(action="add_repository")`` doesn't race against
+    HACS' internal registration — the same flake class that affected
     ``ha_install_mcp_tools``.
     """
     if "/" not in repository_id:
@@ -962,10 +881,9 @@ async def _resolve_hacs_repo_id(ws_client: Any, repository_id: str) -> tuple[str
             ErrorCode.RESOURCE_NOT_FOUND,
             f"Repository '{repository_id}' not found in HACS",
             suggestions=[
-                "Use ha_hacs_search() to find the repository",
+                "Use ha_get_hacs(action='search') to find the repository",
                 "Check the repository name is correct (case-insensitive)",
                 "The repository may need to be added to HACS first",
             ],
         )
     )
-    return repository_id, repository_id  # unreachable, but satisfies type checker

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -540,17 +540,36 @@ class HacsTools:
                 raise_error=True,
             )
 
-        result = response.get("result", {})
+        # HACS' add command returns ``success`` on acceptance but registers the
+        # repository asynchronously and returns no id in the ack. Confirm it
+        # actually registered (mirroring the download path) — an accepted-but-
+        # never-registered add (archived repo, bad structure, wrong category)
+        # would otherwise report a misleading "Successfully added".
+        repo = await wait_for_repo_registration(ws_client, repository)
+        if repo is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"HACS accepted the request but '{repository}' did not "
+                    "register as a custom repository.",
+                    suggestions=[
+                        "Verify the repository exists and follows HACS structure (e.g. has hacs.json)",
+                        "Check that the repository is not archived",
+                        "Ensure the category matches the repository type",
+                    ],
+                )
+            )
 
+        repo_id = repo.get("id")
         return await add_timezone_metadata(
             self._client,
             {
                 "success": True,
                 "repository": repository,
                 "category": category,
-                "repository_id": result.get("id"),
+                "repository_id": str(repo_id) if repo_id is not None else None,
                 "message": f"Successfully added {repository} to HACS",
-                "data": result,
+                "data": repo,
             },
         )
 

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -168,9 +168,10 @@ class HacsTools:
         - List installed: ha_get_hacs(action="search", installed_only=True)
         - Repository details: ha_get_hacs(action="info", repository_id="441028036")
 
-        **Caveats:** ``search``/``info`` proxy the GitHub API, so they are subject to GitHub
-        rate limits and need HACS's configured GitHub token; ``repository_id`` accepts a
-        numeric HACS ID or an ``owner/repo`` path.
+        **Caveats:** ``info`` fetches full repository detail from GitHub, so it can hit GitHub
+        rate limits / needs HACS's configured GitHub token; ``search`` reads HACS's locally
+        cached repository index. ``repository_id`` accepts a numeric HACS ID or an
+        ``owner/repo`` path.
         """
         try:
             if action == "search":
@@ -179,17 +180,15 @@ class HacsTools:
                 )
 
             # action == "info"
-            if not repository_id:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "repository_id is required for action='info'",
-                        suggestions=[
-                            "Pass repository_id (numeric HACS ID or 'owner/repo')",
-                            "Use action='search' to find the repository first",
-                        ],
-                    )
-                )
+            repository_id = validate_identifier_not_empty(
+                repository_id,
+                "repository_id",
+                message="repository_id is required for action='info'",
+                suggestions=[
+                    "Pass repository_id (numeric HACS ID or 'owner/repo')",
+                    "Use action='search' to find the repository first",
+                ],
+            )
             return await self._hacs_info(repository_id)
 
         except ToolError:
@@ -264,18 +263,21 @@ class HacsTools:
                 return await self._hacs_download(repository_id, version)
 
             # action == "add_repository"
-            if repository is None or category is None:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "repository and category are required for action='add_repository'",
-                        suggestions=[
-                            "Pass repository in 'owner/repo' format",
-                            "Pass category (integration, lovelace, theme, appdaemon, python_script)",
-                        ],
-                    )
-                )
-            return await self._hacs_add_repository(repository, category)
+            repository = validate_identifier_not_empty(
+                repository,
+                "repository",
+                suggestions=["Pass repository in 'owner/repo' format"],
+            )
+            # ``category`` is a Literal param, so bind the validated value to a
+            # new ``str`` name rather than reassigning (str is wider than the Literal).
+            valid_category = validate_identifier_not_empty(
+                category,
+                "category",
+                suggestions=[
+                    "Pass category (integration, lovelace, theme, appdaemon, python_script)"
+                ],
+            )
+            return await self._hacs_add_repository(repository, valid_category)
 
         except ToolError:
             raise

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -330,7 +330,7 @@ class ResourceTools:
             resource_type="module"
         )
 
-        Add HACS card (after installing via ha_hacs_download):
+        Add HACS card (after installing via ha_manage_hacs(action='download')):
         ha_config_set_dashboard_resource(
             url="/hacsfiles/lovelace-mushroom/mushroom.js",
             resource_type="module"

--- a/tests/src/e2e/haos_only/test_canary_addons.py
+++ b/tests/src/e2e/haos_only/test_canary_addons.py
@@ -55,9 +55,7 @@ async def test_addons_installed_via_mcp(mcp_client: Any) -> None:
     installed_names = {a.get("name") for a in payload.get("addons", [])}
     LOG.info("Installed addons on booted HAOS: %s", sorted(installed_names))
 
-    missing = [
-        name for name in INSTALLED_ADDON_NAMES if name not in installed_names
-    ]
+    missing = [name for name in INSTALLED_ADDON_NAMES if name not in installed_names]
     if missing:
         pytest.fail(
             f"Expected addons missing from HAOS install: {missing}. "
@@ -78,7 +76,9 @@ async def test_supervisor_info_via_mcp(mcp_client: Any) -> None:
     detail = payload.get("addon") or payload.get("data") or payload
     # Mosquitto is install=true, start=False in the build — so it should
     # be installed but not started. Either field name HA returns is fine.
-    assert detail.get("name") == "Mosquitto broker", f"Unexpected addon detail: {detail}"
+    assert detail.get("name") == "Mosquitto broker", (
+        f"Unexpected addon detail: {detail}"
+    )
 
 
 async def test_hacs_bootstrap_completed(mcp_client: Any) -> None:
@@ -92,10 +92,10 @@ async def test_hacs_bootstrap_completed(mcp_client: Any) -> None:
     tool to confirm the integration is reachable.
     """
     raw = await mcp_client.call_tool(
-        "ha_hacs_search", {"installed_only": True, "max_results": 1}
+        "ha_get_hacs", {"action": "search", "installed_only": True, "max_results": 1}
     )
     payload = parse_mcp_result(raw)
-    # ha_hacs_search wraps the payload as {"data": {"success": True, ...}}
+    # ha_get_hacs wraps the payload as {"data": {"success": True, ...}}
     # — the nested ``data`` envelope is the post-tool-formatter shape,
     # and ``success`` lives inside it. If HACS isn't loaded, the tool
     # raises ToolError (parse_mcp_result then surfaces it as
@@ -103,7 +103,7 @@ async def test_hacs_bootstrap_completed(mcp_client: Any) -> None:
     # either shape and only fail when neither is present.
     inner = payload.get("data", payload)
     assert inner.get("success"), (
-        f"HACS integration not reachable via ha_hacs_search — "
+        f"HACS integration not reachable via ha_get_hacs — "
         f"bootstrap from 'Get HACS' addon may have silently failed. "
         f"Response: {payload}"
     )

--- a/tests/src/e2e/haos_only/test_canary_addons.py
+++ b/tests/src/e2e/haos_only/test_canary_addons.py
@@ -92,10 +92,11 @@ async def test_hacs_bootstrap_completed(mcp_client: Any) -> None:
     tool to confirm the integration is reachable.
     """
     raw = await mcp_client.call_tool(
-        "ha_get_hacs", {"action": "search", "installed_only": True, "max_results": 1}
+        "ha_get_hacs_info",
+        {"action": "search", "installed_only": True, "max_results": 1},
     )
     payload = parse_mcp_result(raw)
-    # ha_get_hacs wraps the payload as {"data": {"success": True, ...}}
+    # ha_get_hacs_info wraps the payload as {"data": {"success": True, ...}}
     # — the nested ``data`` envelope is the post-tool-formatter shape,
     # and ``success`` lives inside it. If HACS isn't loaded, the tool
     # raises ToolError (parse_mcp_result then surfaces it as
@@ -103,7 +104,7 @@ async def test_hacs_bootstrap_completed(mcp_client: Any) -> None:
     # either shape and only fail when neither is present.
     inner = payload.get("data", payload)
     assert inner.get("success"), (
-        f"HACS integration not reachable via ha_get_hacs — "
+        f"HACS integration not reachable via ha_get_hacs_info — "
         f"bootstrap from 'Get HACS' addon may have silently failed. "
         f"Response: {payload}"
     )

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -120,16 +120,16 @@ class TestHacsSearchInstalled:
 
     async def test_list_all_installed(self, mcp_client):
         """
-        Test: List all installed HACS repositories via ha_get_hacs
+        Test: List all installed HACS repositories via ha_get_hacs_info
 
         This test validates listing installed repositories using the
         installed_only parameter. In a fresh test environment, there
         should be no installed repos.
         """
-        logger.info("Testing ha_get_hacs with installed_only=True...")
+        logger.info("Testing ha_get_hacs_info with installed_only=True...")
 
         data = await safe_hacs_call(
-            mcp_client, "ha_get_hacs", {"action": "search", "installed_only": True}
+            mcp_client, "ha_get_hacs_info", {"action": "search", "installed_only": True}
         )
 
         if not data.get("success"):
@@ -168,11 +168,11 @@ class TestHacsSearchInstalled:
         Exercises the code path where installed_only=True AND query is non-empty,
         ensuring only installed repos are returned even when scoring by relevance.
         """
-        logger.info("Testing ha_get_hacs with installed_only=True and query...")
+        logger.info("Testing ha_get_hacs_info with installed_only=True and query...")
 
         data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "query": "hacs", "installed_only": True},
         )
 
@@ -195,16 +195,16 @@ class TestHacsSearchInstalled:
         """
         Test: List installed HACS repositories filtered by category
 
-        Test filtering by different categories using ha_get_hacs with installed_only.
+        Test filtering by different categories using ha_get_hacs_info with installed_only.
         """
-        logger.info("Testing ha_get_hacs installed_only with category filter...")
+        logger.info("Testing ha_get_hacs_info installed_only with category filter...")
 
         categories = ["integration", "lovelace", "theme"]
 
         for category in categories:
             data = await safe_hacs_call(
                 mcp_client,
-                "ha_get_hacs",
+                "ha_get_hacs_info",
                 {"action": "search", "installed_only": True, "category": category},
             )
 
@@ -242,11 +242,11 @@ class TestHacsSearch:
 
         Search for a common term that should return results.
         """
-        logger.info("Testing ha_get_hacs basic search...")
+        logger.info("Testing ha_get_hacs_info basic search...")
 
         # Search for something likely to exist in HACS
         data = await safe_hacs_call(
-            mcp_client, "ha_get_hacs", {"action": "search", "query": "mushroom"}
+            mcp_client, "ha_get_hacs_info", {"action": "search", "query": "mushroom"}
         )
 
         if not data.get("success"):
@@ -283,11 +283,11 @@ class TestHacsSearch:
 
         Search within a specific category.
         """
-        logger.info("Testing ha_get_hacs with category filter...")
+        logger.info("Testing ha_get_hacs_info with category filter...")
 
         data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "query": "card", "category": "lovelace"},
         )
 
@@ -317,11 +317,11 @@ class TestHacsSearch:
 
         Verify pagination/limiting works correctly.
         """
-        logger.info("Testing ha_get_hacs with max_results...")
+        logger.info("Testing ha_get_hacs_info with max_results...")
 
         data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "query": "integration", "max_results": 5},
         )
 
@@ -346,11 +346,11 @@ class TestHacsSearch:
 
         Search for something that shouldn't exist.
         """
-        logger.info("Testing ha_get_hacs with no results...")
+        logger.info("Testing ha_get_hacs_info with no results...")
 
         data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "query": "xyznonexistent12345abcdef"},
         )
 
@@ -378,11 +378,11 @@ class TestHacsRepositoryInfo:
 
         Should return an appropriate error.
         """
-        logger.info("Testing ha_get_hacs with nonexistent repo...")
+        logger.info("Testing ha_get_hacs_info with nonexistent repo...")
 
         parsed = await safe_call_tool(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "info", "repository_id": "nonexistent/repo12345"},
         )
         data = parsed.get("data") if isinstance(parsed.get("data"), dict) else parsed
@@ -414,12 +414,12 @@ class TestHacsRepositoryInfo:
 
         First search for a repo, then get its details.
         """
-        logger.info("Testing ha_get_hacs with valid repo...")
+        logger.info("Testing ha_get_hacs_info with valid repo...")
 
         # First search for a popular repo
         search_data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "query": "hacs", "max_results": 1},
         )
 
@@ -446,7 +446,9 @@ class TestHacsRepositoryInfo:
         logger.info(f"Getting info for repository: {identifier}")
 
         info_data = await safe_hacs_call(
-            mcp_client, "ha_get_hacs", {"action": "info", "repository_id": identifier}
+            mcp_client,
+            "ha_get_hacs_info",
+            {"action": "info", "repository_id": identifier},
         )
 
         if not info_data.get("success"):
@@ -563,7 +565,7 @@ async def test_hacs_discovery(mcp_client):
 
     data = await safe_hacs_call(
         mcp_client,
-        "ha_get_hacs",
+        "ha_get_hacs_info",
         {"action": "search", "installed_only": True, "max_results": 1},
     )
 
@@ -604,7 +606,7 @@ class TestMcpToolsInstallation:
         logger.info("Pre-flight check: verifying HACS availability...")
         data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "installed_only": True, "max_results": 1},
         )
 
@@ -630,7 +632,7 @@ class TestMcpToolsInstallation:
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
@@ -692,7 +694,7 @@ class TestMcpToolsInstallation:
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
@@ -738,7 +740,7 @@ class TestMcpToolsInstallation:
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
@@ -762,7 +764,7 @@ class TestMcpToolsInstallation:
         # Now check HACS search for installed integrations
         list_data = await safe_hacs_call(
             mcp_client,
-            "ha_get_hacs",
+            "ha_get_hacs_info",
             {"action": "search", "installed_only": True, "category": "integration"},
         )
 

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -120,16 +120,16 @@ class TestHacsSearchInstalled:
 
     async def test_list_all_installed(self, mcp_client):
         """
-        Test: List all installed HACS repositories via ha_hacs_search
+        Test: List all installed HACS repositories via ha_get_hacs
 
         This test validates listing installed repositories using the
         installed_only parameter. In a fresh test environment, there
         should be no installed repos.
         """
-        logger.info("Testing ha_hacs_search with installed_only=True...")
+        logger.info("Testing ha_get_hacs with installed_only=True...")
 
         data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"installed_only": True}
+            mcp_client, "ha_get_hacs", {"action": "search", "installed_only": True}
         )
 
         if not data.get("success"):
@@ -168,12 +168,12 @@ class TestHacsSearchInstalled:
         Exercises the code path where installed_only=True AND query is non-empty,
         ensuring only installed repos are returned even when scoring by relevance.
         """
-        logger.info("Testing ha_hacs_search with installed_only=True and query...")
+        logger.info("Testing ha_get_hacs with installed_only=True and query...")
 
         data = await safe_hacs_call(
             mcp_client,
-            "ha_hacs_search",
-            {"query": "hacs", "installed_only": True},
+            "ha_get_hacs",
+            {"action": "search", "query": "hacs", "installed_only": True},
         )
 
         if not data.get("success"):
@@ -195,17 +195,17 @@ class TestHacsSearchInstalled:
         """
         Test: List installed HACS repositories filtered by category
 
-        Test filtering by different categories using ha_hacs_search with installed_only.
+        Test filtering by different categories using ha_get_hacs with installed_only.
         """
-        logger.info("Testing ha_hacs_search installed_only with category filter...")
+        logger.info("Testing ha_get_hacs installed_only with category filter...")
 
         categories = ["integration", "lovelace", "theme"]
 
         for category in categories:
             data = await safe_hacs_call(
                 mcp_client,
-                "ha_hacs_search",
-                {"installed_only": True, "category": category},
+                "ha_get_hacs",
+                {"action": "search", "installed_only": True, "category": category},
             )
 
             if not data.get("success"):
@@ -242,10 +242,12 @@ class TestHacsSearch:
 
         Search for a common term that should return results.
         """
-        logger.info("Testing ha_hacs_search basic search...")
+        logger.info("Testing ha_get_hacs basic search...")
 
         # Search for something likely to exist in HACS
-        data = await safe_hacs_call(mcp_client, "ha_hacs_search", {"query": "mushroom"})
+        data = await safe_hacs_call(
+            mcp_client, "ha_get_hacs", {"action": "search", "query": "mushroom"}
+        )
 
         if not data.get("success"):
             unavailable, reason = is_hacs_unavailable(data)
@@ -281,10 +283,12 @@ class TestHacsSearch:
 
         Search within a specific category.
         """
-        logger.info("Testing ha_hacs_search with category filter...")
+        logger.info("Testing ha_get_hacs with category filter...")
 
         data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"query": "card", "category": "lovelace"}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "query": "card", "category": "lovelace"},
         )
 
         if not data.get("success"):
@@ -313,10 +317,12 @@ class TestHacsSearch:
 
         Verify pagination/limiting works correctly.
         """
-        logger.info("Testing ha_hacs_search with max_results...")
+        logger.info("Testing ha_get_hacs with max_results...")
 
         data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"query": "integration", "max_results": 5}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "query": "integration", "max_results": 5},
         )
 
         if not data.get("success"):
@@ -340,10 +346,12 @@ class TestHacsSearch:
 
         Search for something that shouldn't exist.
         """
-        logger.info("Testing ha_hacs_search with no results...")
+        logger.info("Testing ha_get_hacs with no results...")
 
         data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"query": "xyznonexistent12345abcdef"}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "query": "xyznonexistent12345abcdef"},
         )
 
         if not data.get("success"):
@@ -370,12 +378,12 @@ class TestHacsRepositoryInfo:
 
         Should return an appropriate error.
         """
-        logger.info("Testing ha_hacs_repository_info with nonexistent repo...")
+        logger.info("Testing ha_get_hacs with nonexistent repo...")
 
         parsed = await safe_call_tool(
             mcp_client,
-            "ha_hacs_repository_info",
-            {"repository_id": "nonexistent/repo12345"},
+            "ha_get_hacs",
+            {"action": "info", "repository_id": "nonexistent/repo12345"},
         )
         data = parsed.get("data") if isinstance(parsed.get("data"), dict) else parsed
 
@@ -406,11 +414,13 @@ class TestHacsRepositoryInfo:
 
         First search for a repo, then get its details.
         """
-        logger.info("Testing ha_hacs_repository_info with valid repo...")
+        logger.info("Testing ha_get_hacs with valid repo...")
 
         # First search for a popular repo
         search_data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"query": "hacs", "max_results": 1}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "query": "hacs", "max_results": 1},
         )
 
         if not search_data.get("success"):
@@ -436,7 +446,7 @@ class TestHacsRepositoryInfo:
         logger.info(f"Getting info for repository: {identifier}")
 
         info_data = await safe_hacs_call(
-            mcp_client, "ha_hacs_repository_info", {"repository_id": identifier}
+            mcp_client, "ha_get_hacs", {"action": "info", "repository_id": identifier}
         )
 
         if not info_data.get("success"):
@@ -471,12 +481,16 @@ class TestHacsWriteOperations:
 
         Should fail with validation error.
         """
-        logger.info("Testing ha_hacs_add_repository with invalid format...")
+        logger.info("Testing ha_manage_hacs with invalid format...")
 
         parsed = await safe_call_tool(
             mcp_client,
-            "ha_hacs_add_repository",
-            {"repository": "invalid-format-no-slash", "category": "integration"},
+            "ha_manage_hacs",
+            {
+                "action": "add_repository",
+                "repository": "invalid-format-no-slash",
+                "category": "integration",
+            },
         )
         data = (
             parsed.get("data", parsed)
@@ -503,12 +517,12 @@ class TestHacsWriteOperations:
 
         Should fail with not found error.
         """
-        logger.info("Testing ha_hacs_download with nonexistent repo...")
+        logger.info("Testing ha_manage_hacs with nonexistent repo...")
 
         parsed = await safe_call_tool(
             mcp_client,
-            "ha_hacs_download",
-            {"repository_id": "nonexistent/fake-repo-12345"},
+            "ha_manage_hacs",
+            {"action": "download", "repository_id": "nonexistent/fake-repo-12345"},
         )
         data = (
             parsed.get("data", parsed)
@@ -548,7 +562,9 @@ async def test_hacs_discovery(mcp_client):
     logger.info("Testing basic HACS discovery...")
 
     data = await safe_hacs_call(
-        mcp_client, "ha_hacs_search", {"installed_only": True, "max_results": 1}
+        mcp_client,
+        "ha_get_hacs",
+        {"action": "search", "installed_only": True, "max_results": 1},
     )
 
     unavailable, reason = is_hacs_unavailable(data)
@@ -587,7 +603,9 @@ class TestMcpToolsInstallation:
         """
         logger.info("Pre-flight check: verifying HACS availability...")
         data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"installed_only": True, "max_results": 1}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "installed_only": True, "max_results": 1},
         )
 
         unavailable, reason = is_hacs_unavailable(data)
@@ -611,7 +629,9 @@ class TestMcpToolsInstallation:
 
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"installed_only": True, "max_results": 1}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
         if unavailable:
@@ -671,7 +691,9 @@ class TestMcpToolsInstallation:
 
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"installed_only": True, "max_results": 1}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
         if unavailable:
@@ -715,7 +737,9 @@ class TestMcpToolsInstallation:
 
         # Before installation, verify HACS is available and ready
         info_data = await safe_hacs_call(
-            mcp_client, "ha_hacs_search", {"installed_only": True, "max_results": 1}
+            mcp_client,
+            "ha_get_hacs",
+            {"action": "search", "installed_only": True, "max_results": 1},
         )
         unavailable, reason = is_hacs_unavailable(info_data)
         if unavailable:
@@ -738,8 +762,8 @@ class TestMcpToolsInstallation:
         # Now check HACS search for installed integrations
         list_data = await safe_hacs_call(
             mcp_client,
-            "ha_hacs_search",
-            {"installed_only": True, "category": "integration"},
+            "ha_get_hacs",
+            {"action": "search", "installed_only": True, "category": "integration"},
         )
 
         if not list_data.get("success"):

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -280,7 +280,7 @@ async def test_ha_get_automation_traces_emits_progress_with_ctx() -> None:
 
 
 # ---------------------------------------------------------------------------
-# tools_hacs.HacsTools.ha_hacs_search
+# tools_hacs.HacsTools.ha_get_hacs
 # ---------------------------------------------------------------------------
 
 
@@ -290,9 +290,9 @@ async def _identity_timezone(_client: Any, data: dict[str, Any]) -> dict[str, An
 
 
 @pytest.mark.asyncio
-async def test_ha_hacs_search_works_without_ctx() -> None:
+async def test_ha_get_hacs_search_works_without_ctx() -> None:
     client = _mock_ha_client()
-    hacs_tool = HacsTools(client).ha_hacs_search
+    hacs_tool = HacsTools(client).ha_get_hacs
 
     ws = AsyncMock()
     ws.send_command = AsyncMock(return_value={"success": True, "result": []})
@@ -311,16 +311,16 @@ async def test_ha_hacs_search_works_without_ctx() -> None:
             new=_identity_timezone,
         ),
     ):
-        result = await hacs_tool(query="anything")
+        result = await hacs_tool(action="search", query="anything")
 
     assert result["success"] is True
     assert result["total_matches"] == 0
 
 
 @pytest.mark.asyncio
-async def test_ha_hacs_search_emits_progress_with_ctx() -> None:
+async def test_ha_get_hacs_search_emits_progress_with_ctx() -> None:
     client = _mock_ha_client()
-    hacs_tool = HacsTools(client).ha_hacs_search
+    hacs_tool = HacsTools(client).ha_get_hacs
     ctx = _make_ctx()
 
     ws = AsyncMock()
@@ -340,7 +340,7 @@ async def test_ha_hacs_search_emits_progress_with_ctx() -> None:
             new=_identity_timezone,
         ),
     ):
-        result = await hacs_tool(query="anything", ctx=ctx)
+        result = await hacs_tool(action="search", query="anything", ctx=ctx)
 
     assert result["success"] is True
     ctx.info.assert_awaited()

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -280,7 +280,7 @@ async def test_ha_get_automation_traces_emits_progress_with_ctx() -> None:
 
 
 # ---------------------------------------------------------------------------
-# tools_hacs.HacsTools.ha_get_hacs
+# tools_hacs.HacsTools.ha_get_hacs_info
 # ---------------------------------------------------------------------------
 
 
@@ -290,9 +290,9 @@ async def _identity_timezone(_client: Any, data: dict[str, Any]) -> dict[str, An
 
 
 @pytest.mark.asyncio
-async def test_ha_get_hacs_search_works_without_ctx() -> None:
+async def test_ha_get_hacs_info_search_works_without_ctx() -> None:
     client = _mock_ha_client()
-    hacs_tool = HacsTools(client).ha_get_hacs
+    hacs_tool = HacsTools(client).ha_get_hacs_info
 
     ws = AsyncMock()
     ws.send_command = AsyncMock(return_value={"success": True, "result": []})
@@ -318,9 +318,9 @@ async def test_ha_get_hacs_search_works_without_ctx() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ha_get_hacs_search_emits_progress_with_ctx() -> None:
+async def test_ha_get_hacs_info_search_emits_progress_with_ctx() -> None:
     client = _mock_ha_client()
-    hacs_tool = HacsTools(client).ha_get_hacs
+    hacs_tool = HacsTools(client).ha_get_hacs_info
     ctx = _make_ctx()
 
     ws = AsyncMock()

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -96,12 +96,21 @@ class TestManageHacsDownload:
 
 
 class TestManageHacsAddRepository:
-    async def test_add_repository_translates_category_to_hacs_internal(self, tools):
+    async def test_add_repository_translates_category_and_returns_registered_id(
+        self, tools
+    ):
         # The user-facing "lovelace" category must reach HACS as its internal
-        # name "plugin" (CATEGORY_MAP). A regression here would otherwise only
-        # surface against a live HACS backend.
-        ws = _ws({"id": "999"})
-        with _patched_hacs(ws):
+        # name "plugin" (CATEGORY_MAP), and the returned id comes from the repo
+        # that actually registers — the add ack itself carries no id.
+        ws = _ws({})
+        registered = {"id": "999", "full_name": "owner/my-card", "name": "My Card"}
+        with (
+            _patched_hacs(ws),
+            patch(
+                "ha_mcp.tools.tools_hacs.wait_for_repo_registration",
+                new=AsyncMock(return_value=registered),
+            ),
+        ):
             result = await tools.ha_manage_hacs(
                 action="add_repository",
                 repository="owner/my-card",
@@ -114,6 +123,27 @@ class TestManageHacsAddRepository:
         assert ws.send_command.await_args.args[0] == "hacs/repositories/add"
         assert ws.send_command.await_args.kwargs["category"] == "plugin"
         assert ws.send_command.await_args.kwargs["repository"] == "owner/my-card"
+
+    async def test_add_repository_errors_when_repo_never_registers(self, tools):
+        # HACS accepts the add command but the repository never appears in the
+        # list (archived / invalid / wrong category). The tool must surface an
+        # error rather than a false "Successfully added".
+        ws = _ws({})
+        with (
+            _patched_hacs(ws),
+            patch(
+                "ha_mcp.tools.tools_hacs.wait_for_repo_registration",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tools.ha_manage_hacs(
+                action="add_repository",
+                repository="owner/archived",
+                category="integration",
+            )
+        assert "SERVICE_CALL_FAILED" in str(excinfo.value)
+        assert "did not register" in str(excinfo.value)
 
     async def test_add_repository_rejects_slashless_format_before_ws(self, tools):
         # The "owner/repo" format guard lives after _assert_hacs_available but

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -65,7 +65,9 @@ class TestGetHacsInfo:
             }
         )
         with _patched_hacs(ws):
-            result = await tools.ha_get_hacs(action="info", repository_id="441028036")
+            result = await tools.ha_get_hacs_info(
+                action="info", repository_id="441028036"
+            )
 
         assert result["success"] is True
         # Echoes the caller's identifier and surfaces the structured fields.
@@ -141,9 +143,9 @@ class TestDispatcherErrorRouting:
             ),
             pytest.raises(ToolError) as excinfo,
         ):
-            await tools.ha_get_hacs(action="search")
+            await tools.ha_get_hacs_info(action="search")
         msg = str(excinfo.value)
-        assert "ha_get_hacs" in msg
+        assert "ha_get_hacs_info" in msg
         assert "search" in msg
 
     async def test_structured_toolerror_passes_through_unwrapped(self, tools):
@@ -154,6 +156,6 @@ class TestDispatcherErrorRouting:
             patch.object(HacsTools, "_hacs_info", new=AsyncMock(side_effect=sentinel)),
             pytest.raises(ToolError) as excinfo,
         ):
-            await tools.ha_get_hacs(action="info", repository_id="123")
+            await tools.ha_get_hacs_info(action="info", repository_id="123")
         assert "RESOURCE_NOT_FOUND" in str(excinfo.value)
         assert "INTERNAL_ERROR" not in str(excinfo.value)

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.tools_hacs import HacsTools
+from ha_mcp.tools.tools_hacs import HACS_ADD_REGISTRATION_TIMEOUT, HacsTools
 
 
 async def _identity_timezone(_client, data):
@@ -108,9 +108,10 @@ class TestManageHacsAddRepository:
             _patched_hacs(ws),
             patch(
                 "ha_mcp.tools.tools_hacs.wait_for_repo_registration",
-                new=AsyncMock(return_value=registered),
-            ),
+                new_callable=AsyncMock,
+            ) as wait_mock,
         ):
+            wait_mock.return_value = registered
             result = await tools.ha_manage_hacs(
                 action="add_repository",
                 repository="owner/my-card",
@@ -119,6 +120,11 @@ class TestManageHacsAddRepository:
 
         assert result["success"] is True
         assert result["repository_id"] == "999"
+        # The add path confirms registration with the fail-fast budget, not the
+        # 30 s resolve/download default.
+        assert (
+            wait_mock.await_args.kwargs.get("timeout") == HACS_ADD_REGISTRATION_TIMEOUT
+        )
         ws.send_command.assert_awaited_once()
         assert ws.send_command.await_args.args[0] == "hacs/repositories/add"
         assert ws.send_command.await_args.kwargs["category"] == "plugin"

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -1,0 +1,159 @@
+"""Unit tests for the consolidated HACS action tools.
+
+Exercise the per-action handler success paths (``_hacs_info`` /
+``_hacs_download`` / ``_hacs_add_repository``) and the dispatcher's
+error-routing with a mocked WebSocket client. Complements the
+validation-guard tests in ``test_identifier_validation_family.py`` and the
+ctx/progress test in ``test_context_injection.py``.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_hacs import HacsTools
+
+
+async def _identity_timezone(_client, data):
+    """Stand-in for add_timezone_metadata that returns data unchanged."""
+    return data
+
+
+def _ws(result):
+    """A WS client whose send_command returns a successful HACS response."""
+    ws = AsyncMock()
+    ws.send_command = AsyncMock(return_value={"success": True, "result": result})
+    return ws
+
+
+@contextmanager
+def _patched_hacs(ws):
+    """Patch HACS availability, the WS client factory, and tz metadata."""
+    with (
+        patch(
+            "ha_mcp.tools.tools_hacs._assert_hacs_available",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "ha_mcp.client.websocket_client.get_websocket_client",
+            new=AsyncMock(return_value=ws),
+        ),
+        patch(
+            "ha_mcp.tools.tools_hacs.add_timezone_metadata",
+            new=_identity_timezone,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def tools():
+    return HacsTools(MagicMock())
+
+
+class TestGetHacsInfo:
+    async def test_info_returns_repository_detail(self, tools):
+        ws = _ws(
+            {
+                "name": "Mushroom",
+                "full_name": "piitaya/lovelace-mushroom",
+                "category": "plugin",
+                "installed": True,
+                "installed_version": "4.0.0",
+            }
+        )
+        with _patched_hacs(ws):
+            result = await tools.ha_get_hacs(action="info", repository_id="441028036")
+
+        assert result["success"] is True
+        # Echoes the caller's identifier and surfaces the structured fields.
+        assert result["repository_id"] == "441028036"
+        assert result["name"] == "Mushroom"
+        assert result["installed"] is True
+        assert result["installed_version"] == "4.0.0"
+        # A numeric id needs no resolution round-trip — exactly one WS call.
+        ws.send_command.assert_awaited_once()
+        assert ws.send_command.await_args.args[0] == "hacs/repository/info"
+
+
+class TestManageHacsDownload:
+    async def test_download_defaults_version_to_latest(self, tools):
+        ws = _ws({"status": "ok"})
+        with _patched_hacs(ws):
+            result = await tools.ha_manage_hacs(
+                action="download", repository_id="441028036"
+            )
+
+        assert result["success"] is True
+        assert result["version"] == "latest"  # no version given -> "latest"
+        assert result["repository"] == "441028036"  # numeric id resolves to itself
+        assert "Successfully installed" in result["message"]
+        assert ws.send_command.await_args.args[0] == "hacs/repository/download"
+
+
+class TestManageHacsAddRepository:
+    async def test_add_repository_translates_category_to_hacs_internal(self, tools):
+        # The user-facing "lovelace" category must reach HACS as its internal
+        # name "plugin" (CATEGORY_MAP). A regression here would otherwise only
+        # surface against a live HACS backend.
+        ws = _ws({"id": "999"})
+        with _patched_hacs(ws):
+            result = await tools.ha_manage_hacs(
+                action="add_repository",
+                repository="owner/my-card",
+                category="lovelace",
+            )
+
+        assert result["success"] is True
+        assert result["repository_id"] == "999"
+        ws.send_command.assert_awaited_once()
+        assert ws.send_command.await_args.args[0] == "hacs/repositories/add"
+        assert ws.send_command.await_args.kwargs["category"] == "plugin"
+        assert ws.send_command.await_args.kwargs["repository"] == "owner/my-card"
+
+    async def test_add_repository_rejects_slashless_format_before_ws(self, tools):
+        # The "owner/repo" format guard lives after _assert_hacs_available but
+        # before the WS add; the e2e test for it skips when HACS is
+        # unavailable, so pin it deterministically here.
+        ws = _ws({})
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(
+                action="add_repository",
+                repository="no-slash",
+                category="integration",
+            )
+        assert "VALIDATION_INVALID_PARAMETER" in str(excinfo.value)
+        assert "format" in str(excinfo.value).lower()
+        ws.send_command.assert_not_awaited()
+
+
+class TestDispatcherErrorRouting:
+    async def test_unexpected_handler_error_is_wrapped_with_action_context(self, tools):
+        # A non-ToolError escaping a handler must be converted to a structured
+        # ToolError carrying the tool + action context (Pattern A wrap branch).
+        with (
+            patch.object(
+                HacsTools,
+                "_hacs_search",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tools.ha_get_hacs(action="search")
+        msg = str(excinfo.value)
+        assert "ha_get_hacs" in msg
+        assert "search" in msg
+
+    async def test_structured_toolerror_passes_through_unwrapped(self, tools):
+        # A structured ToolError raised inside a handler must propagate with its
+        # original error code intact, not be re-wrapped as INTERNAL_ERROR.
+        sentinel = ToolError('{"error": {"code": "RESOURCE_NOT_FOUND"}}')
+        with (
+            patch.object(HacsTools, "_hacs_info", new=AsyncMock(side_effect=sentinel)),
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tools.ha_get_hacs(action="info", repository_id="123")
+        assert "RESOURCE_NOT_FOUND" in str(excinfo.value)
+        assert "INTERNAL_ERROR" not in str(excinfo.value)

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1217,7 +1217,7 @@ class TestEnergyPrefsIdentifierValidation:
         tools._client.send_websocket_message.assert_not_called()
 
 
-# --- tools_hacs.py — ha_get_hacs / ha_manage_hacs action validation ------
+# --- tools_hacs.py — ha_get_hacs_info / ha_manage_hacs action validation ------
 
 
 class TestHacsActionValidation:
@@ -1251,7 +1251,7 @@ class TestHacsActionValidation:
         # on the download path above (both now share
         # ``validate_identifier_not_empty``).
         with pytest.raises(ToolError) as excinfo:
-            await tools.ha_get_hacs(action="info", repository_id=bad)
+            await tools.ha_get_hacs_info(action="info", repository_id=bad)
         _assert_invalid_param(excinfo)
         assert '"parameter": "repository_id"' in str(excinfo.value), str(excinfo.value)
         tools._client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1217,10 +1217,10 @@ class TestEnergyPrefsIdentifierValidation:
         tools._client.send_websocket_message.assert_not_called()
 
 
-# --- tools_hacs.py (Iter7 — ha_hacs_download repository_id) --------------
+# --- tools_hacs.py — ha_get_hacs / ha_manage_hacs action validation ------
 
 
-class TestHacsIdentifierValidation:
+class TestHacsActionValidation:
     @pytest.fixture
     def tools(self, mock_ws_client):
         from ha_mcp.tools.tools_hacs import HacsTools
@@ -1228,7 +1228,7 @@ class TestHacsIdentifierValidation:
         return HacsTools(mock_ws_client)
 
     @pytest.mark.parametrize("bad", ["", "   "])
-    async def test_hacs_download_rejects_empty_repository_id(self, tools, bad):
+    async def test_manage_hacs_download_rejects_empty_repository_id(self, tools, bad):
         # Empty/whitespace ``repository_id`` would either fall through
         # ``_resolve_hacs_repo_id`` (no empty-check) into a HACS lookup
         # miss, or — for a numeric-looking candidate — reach
@@ -1238,7 +1238,32 @@ class TestHacsIdentifierValidation:
         # availability check) so neither the supervisor nor HACS sees
         # the empty id.
         with pytest.raises(ToolError) as excinfo:
-            await tools.ha_hacs_download(repository_id=bad)
+            await tools.ha_manage_hacs(action="download", repository_id=bad)
         _assert_invalid_param(excinfo)
         assert '"parameter": "repository_id"' in str(excinfo.value), str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_called()
+
+    async def test_get_hacs_info_requires_repository_id(self, tools):
+        # ``info`` has nothing to act on without a repository_id — the
+        # dispatcher must reject before any HACS availability check or
+        # WS round-trip, mirroring the up-front guard on the download
+        # path above.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_hacs(action="info")
+        _assert_invalid_param(excinfo)
+        assert "repository_id" in str(excinfo.value), str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{}, {"repository": "owner/repo"}, {"category": "integration"}],
+        ids=["neither", "category-missing", "repository-missing"],
+    )
+    async def test_manage_hacs_add_repository_requires_both_fields(self, tools, kwargs):
+        # ``add_repository`` needs both ``repository`` and ``category``;
+        # a partial call must be rejected up-front rather than sending a
+        # malformed ``hacs/repositories/add`` to the backend.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="add_repository", **kwargs)
+        _assert_invalid_param(excinfo)
         tools._client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1243,27 +1243,39 @@ class TestHacsActionValidation:
         assert '"parameter": "repository_id"' in str(excinfo.value), str(excinfo.value)
         tools._client.send_websocket_message.assert_not_called()
 
-    async def test_get_hacs_info_requires_repository_id(self, tools):
+    @pytest.mark.parametrize("bad", [None, "", "   "])
+    async def test_get_hacs_info_requires_repository_id(self, tools, bad):
         # ``info`` has nothing to act on without a repository_id — the
-        # dispatcher must reject before any HACS availability check or
-        # WS round-trip, mirroring the up-front guard on the download
-        # path above.
+        # dispatcher must reject None / empty / whitespace before any HACS
+        # availability check or WS round-trip, mirroring the up-front guard
+        # on the download path above (both now share
+        # ``validate_identifier_not_empty``).
         with pytest.raises(ToolError) as excinfo:
-            await tools.ha_get_hacs(action="info")
+            await tools.ha_get_hacs(action="info", repository_id=bad)
         _assert_invalid_param(excinfo)
-        assert "repository_id" in str(excinfo.value), str(excinfo.value)
+        assert '"parameter": "repository_id"' in str(excinfo.value), str(excinfo.value)
         tools._client.send_websocket_message.assert_not_called()
 
     @pytest.mark.parametrize(
-        "kwargs",
-        [{}, {"repository": "owner/repo"}, {"category": "integration"}],
-        ids=["neither", "category-missing", "repository-missing"],
+        "kwargs, bad_param",
+        [
+            ({}, "repository"),
+            ({"category": "integration"}, "repository"),
+            ({"repository": "   ", "category": "integration"}, "repository"),
+            ({"repository": "owner/repo"}, "category"),
+            ({"repository": "owner/repo", "category": "   "}, "category"),
+        ],
+        ids=["both-missing", "repo-missing", "repo-blank", "cat-missing", "cat-blank"],
     )
-    async def test_manage_hacs_add_repository_requires_both_fields(self, tools, kwargs):
+    async def test_manage_hacs_add_repository_requires_both_fields(
+        self, tools, kwargs, bad_param
+    ):
         # ``add_repository`` needs both ``repository`` and ``category``;
-        # a partial call must be rejected up-front rather than sending a
-        # malformed ``hacs/repositories/add`` to the backend.
+        # a missing OR blank field must be rejected up-front (naming the
+        # offending parameter) rather than sending a malformed
+        # ``hacs/repositories/add`` to the backend.
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_manage_hacs(action="add_repository", **kwargs)
         _assert_invalid_param(excinfo)
+        assert f'"parameter": "{bad_param}"' in str(excinfo.value), str(excinfo.value)
         tools._client.send_websocket_message.assert_not_called()

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -54,7 +54,7 @@ class TestConfigPersistence:
     """Test load/save of tool_config.json."""
 
     def test_save_and_load(self, tmp_path: Path):
-        config = {"tools": {"ha_get_hacs": "disabled", "ha_restart": "pinned"}}
+        config = {"tools": {"ha_get_hacs_info": "disabled", "ha_restart": "pinned"}}
         config_path = tmp_path / "tool_config.json"
         with patch("ha_mcp.settings_ui._get_config_path", return_value=config_path):
             save_tool_config(config)
@@ -75,11 +75,11 @@ class TestConfigPersistence:
     def test_seed_from_env_vars(self, tmp_path: Path):
         config_path = tmp_path / "tool_config.json"
         settings = MagicMock()
-        settings.disabled_tools = "ha_get_hacs,ha_manage_hacs"
+        settings.disabled_tools = "ha_get_hacs_info,ha_manage_hacs"
         settings.pinned_tools = "ha_restart"
         with patch("ha_mcp.settings_ui._get_config_path", return_value=config_path):
             config = load_tool_config(settings)
-        assert config["tools"]["ha_get_hacs"] == "disabled"
+        assert config["tools"]["ha_get_hacs_info"] == "disabled"
         assert config["tools"]["ha_manage_hacs"] == "disabled"
         assert config["tools"]["ha_restart"] == "pinned"
         assert config_path.exists()
@@ -92,11 +92,11 @@ class TestApplyToolVisibility:
         mcp = MagicMock()
         settings = MagicMock()
         settings.enable_yaml_config_editing = True
-        config = {"tools": {"ha_get_hacs": "disabled", "ha_restart": "enabled"}}
+        config = {"tools": {"ha_get_hacs_info": "disabled", "ha_restart": "enabled"}}
         apply_tool_visibility(mcp, config, settings)
         mcp.disable.assert_called_once()
         disabled_names = mcp.disable.call_args[1]["names"]
-        assert "ha_get_hacs" in disabled_names
+        assert "ha_get_hacs_info" in disabled_names
         assert "ha_restart" not in disabled_names
 
     def test_mandatory_tools_not_disabled(self):
@@ -148,10 +148,10 @@ class TestApplyToolVisibility:
         mcp = MagicMock()
         settings = MagicMock()
         settings.enable_yaml_config_editing = True
-        config = {"tools": {"ha_restart": "pinned", "ha_get_hacs": "enabled"}}
+        config = {"tools": {"ha_restart": "pinned", "ha_get_hacs_info": "enabled"}}
         result = apply_tool_visibility(mcp, config, settings)
         assert "ha_restart" in result.pinned_names
-        assert "ha_get_hacs" not in result.pinned_names
+        assert "ha_get_hacs_info" not in result.pinned_names
 
     def test_returns_explicitly_enabled_names(self):
         """Tools toggled to ``"enabled"`` are surfaced so the server can
@@ -163,13 +163,13 @@ class TestApplyToolVisibility:
             "tools": {
                 "ha_manage_backup": "enabled",  # would otherwise be a default pin
                 "ha_restart": "pinned",
-                "ha_get_hacs": "disabled",
+                "ha_get_hacs_info": "disabled",
             }
         }
         result = apply_tool_visibility(mcp, config, settings)
         assert "ha_manage_backup" in result.enabled_names
         assert "ha_restart" not in result.enabled_names
-        assert "ha_get_hacs" not in result.enabled_names
+        assert "ha_get_hacs_info" not in result.enabled_names
 
     def test_empty_config_no_disable(self):
         mcp = MagicMock()

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -54,7 +54,7 @@ class TestConfigPersistence:
     """Test load/save of tool_config.json."""
 
     def test_save_and_load(self, tmp_path: Path):
-        config = {"tools": {"ha_hacs_info": "disabled", "ha_restart": "pinned"}}
+        config = {"tools": {"ha_get_hacs": "disabled", "ha_restart": "pinned"}}
         config_path = tmp_path / "tool_config.json"
         with patch("ha_mcp.settings_ui._get_config_path", return_value=config_path):
             save_tool_config(config)
@@ -75,12 +75,12 @@ class TestConfigPersistence:
     def test_seed_from_env_vars(self, tmp_path: Path):
         config_path = tmp_path / "tool_config.json"
         settings = MagicMock()
-        settings.disabled_tools = "ha_hacs_info,ha_hacs_download"
+        settings.disabled_tools = "ha_get_hacs,ha_manage_hacs"
         settings.pinned_tools = "ha_restart"
         with patch("ha_mcp.settings_ui._get_config_path", return_value=config_path):
             config = load_tool_config(settings)
-        assert config["tools"]["ha_hacs_info"] == "disabled"
-        assert config["tools"]["ha_hacs_download"] == "disabled"
+        assert config["tools"]["ha_get_hacs"] == "disabled"
+        assert config["tools"]["ha_manage_hacs"] == "disabled"
         assert config["tools"]["ha_restart"] == "pinned"
         assert config_path.exists()
 
@@ -92,11 +92,11 @@ class TestApplyToolVisibility:
         mcp = MagicMock()
         settings = MagicMock()
         settings.enable_yaml_config_editing = True
-        config = {"tools": {"ha_hacs_info": "disabled", "ha_restart": "enabled"}}
+        config = {"tools": {"ha_get_hacs": "disabled", "ha_restart": "enabled"}}
         apply_tool_visibility(mcp, config, settings)
         mcp.disable.assert_called_once()
         disabled_names = mcp.disable.call_args[1]["names"]
-        assert "ha_hacs_info" in disabled_names
+        assert "ha_get_hacs" in disabled_names
         assert "ha_restart" not in disabled_names
 
     def test_mandatory_tools_not_disabled(self):
@@ -148,10 +148,10 @@ class TestApplyToolVisibility:
         mcp = MagicMock()
         settings = MagicMock()
         settings.enable_yaml_config_editing = True
-        config = {"tools": {"ha_restart": "pinned", "ha_hacs_info": "enabled"}}
+        config = {"tools": {"ha_restart": "pinned", "ha_get_hacs": "enabled"}}
         result = apply_tool_visibility(mcp, config, settings)
         assert "ha_restart" in result.pinned_names
-        assert "ha_hacs_info" not in result.pinned_names
+        assert "ha_get_hacs" not in result.pinned_names
 
     def test_returns_explicitly_enabled_names(self):
         """Tools toggled to ``"enabled"`` are surfaced so the server can
@@ -163,13 +163,13 @@ class TestApplyToolVisibility:
             "tools": {
                 "ha_manage_backup": "enabled",  # would otherwise be a default pin
                 "ha_restart": "pinned",
-                "ha_hacs_info": "disabled",
+                "ha_get_hacs": "disabled",
             }
         }
         result = apply_tool_visibility(mcp, config, settings)
         assert "ha_manage_backup" in result.enabled_names
         assert "ha_restart" not in result.enabled_names
-        assert "ha_hacs_info" not in result.enabled_names
+        assert "ha_get_hacs" not in result.enabled_names
 
     def test_empty_config_no_disable(self):
         mcp = MagicMock()

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -18,19 +18,25 @@ def get_tools_dir() -> Path:
 
 def _parse_decorator_args(decorator_args: str, func_name: str, file_name: str) -> dict:
     """Parse decorator arguments into a tool info dict."""
-    has_read_only = 'readOnlyHint' in decorator_args and 'True' in decorator_args.split('readOnlyHint')[1][:20]
-    has_destructive = 'destructiveHint' in decorator_args and 'True' in decorator_args.split('destructiveHint')[1][:20]
-    has_title = 'title' in decorator_args
-    has_tags = 'tags=' in decorator_args or 'tags =' in decorator_args
+    has_read_only = (
+        "readOnlyHint" in decorator_args
+        and "True" in decorator_args.split("readOnlyHint")[1][:20]
+    )
+    has_destructive = (
+        "destructiveHint" in decorator_args
+        and "True" in decorator_args.split("destructiveHint")[1][:20]
+    )
+    has_title = "title" in decorator_args
+    has_tags = "tags=" in decorator_args or "tags =" in decorator_args
 
     return {
-        'file': file_name,
-        'function': func_name,
-        'has_read_only_hint': has_read_only,
-        'has_destructive_hint': has_destructive,
-        'has_title': has_title,
-        'has_tags': has_tags,
-        'decorator_args': decorator_args.strip(),
+        "file": file_name,
+        "function": func_name,
+        "has_read_only_hint": has_read_only,
+        "has_destructive_hint": has_destructive,
+        "has_title": has_title,
+        "has_tags": has_tags,
+        "decorator_args": decorator_args.strip(),
     }
 
 
@@ -38,31 +44,37 @@ def extract_tool_decorators(file_path: Path) -> list[dict]:
     """Extract @mcp.tool and @tool decorator information from a Python file."""
     content = file_path.read_text(encoding="utf-8")
     # Pattern 1: @mcp.tool(...) — closure pattern
-    pattern = r'@mcp\.tool\(([^)]*)\)\s*(?:@\w+\s*)*async def (\w+)'
+    pattern = r"@mcp\.tool\(([^)]*)\)\s*(?:@\w+\s*)*async def (\w+)"
     tools = [
         _parse_decorator_args(m.group(1), m.group(2), file_path.name)
         for m in re.finditer(pattern, content, re.DOTALL)
     ]
 
     # Pattern 2: @tool(name="ha_*", ...) — class method pattern
-    class_pattern = r'@tool\(\s*\n?\s*name="(ha_\w+)"[,\s]*([^)]*)\)\s*(?:@\w+\s*)*async def \w+'
+    class_pattern = (
+        r'@tool\(\s*\n?\s*name="(ha_\w+)"[,\s]*([^)]*)\)\s*(?:@\w+\s*)*async def \w+'
+    )
     tools.extend(
-        _parse_decorator_args(f'name="{m.group(1)}", {m.group(2)}', m.group(1), file_path.name)
+        _parse_decorator_args(
+            f'name="{m.group(1)}", {m.group(2)}', m.group(1), file_path.name
+        )
         for m in re.finditer(class_pattern, content, re.DOTALL)
     )
 
     # Also find bare @mcp.tool without arguments
-    bare_pattern = r'@mcp\.tool\s*\n\s*(?:@\w+\s*)*async def (\w+)'
+    bare_pattern = r"@mcp\.tool\s*\n\s*(?:@\w+\s*)*async def (\w+)"
     for match in re.finditer(bare_pattern, content):
         func_name = match.group(1)
-        tools.append({
-            'file': file_path.name,
-            'function': func_name,
-            'has_read_only_hint': False,
-            'has_destructive_hint': False,
-            'has_title': False,
-            'decorator_args': '',
-        })
+        tools.append(
+            {
+                "file": file_path.name,
+                "function": func_name,
+                "has_read_only_hint": False,
+                "has_destructive_hint": False,
+                "has_title": False,
+                "decorator_args": "",
+            }
+        )
 
     return tools
 
@@ -92,8 +104,8 @@ class TestToolAnnotations:
         both_hints = []
 
         for tool in tools:
-            has_read = tool['has_read_only_hint']
-            has_destructive = tool['has_destructive_hint']
+            has_read = tool["has_read_only_hint"]
+            has_destructive = tool["has_destructive_hint"]
 
             if not has_read and not has_destructive:
                 missing_hints.append(f"{tool['file']}:{tool['function']}")
@@ -121,7 +133,7 @@ class TestToolAnnotations:
         missing_titles = [
             f"{tool['file']}:{tool['function']}"
             for tool in tools
-            if not tool['has_title']
+            if not tool["has_title"]
         ]
 
         assert not missing_titles, (
@@ -136,7 +148,7 @@ class TestToolAnnotations:
         missing_tags = [
             f"{tool['file']}:{tool['function']}"
             for tool in tools
-            if not tool['has_tags']
+            if not tool["has_tags"]
         ]
 
         assert not missing_tags, (
@@ -153,11 +165,15 @@ class TestToolAnnotations:
         assert len(tools) >= 50, f"Only found {len(tools)} tools, expected at least 50"
 
         # We should have a mix of read-only and destructive tools
-        read_only_count = sum(1 for t in tools if t['has_read_only_hint'])
-        destructive_count = sum(1 for t in tools if t['has_destructive_hint'])
+        read_only_count = sum(1 for t in tools if t["has_read_only_hint"])
+        destructive_count = sum(1 for t in tools if t["has_destructive_hint"])
 
-        assert read_only_count >= 20, f"Only {read_only_count} read-only tools, expected at least 20"
-        assert destructive_count >= 20, f"Only {destructive_count} destructive tools, expected at least 20"
+        assert read_only_count >= 20, (
+            f"Only {read_only_count} read-only tools, expected at least 20"
+        )
+        assert destructive_count >= 19, (
+            f"Only {destructive_count} destructive tools, expected at least 19"
+        )
 
     def test_total_tool_count_limit(self):
         """Ensure total tool count doesn't exceed reasonable limits.
@@ -199,18 +215,31 @@ class TestToolAnnotations:
         """Tools with readOnlyHint should have read-only names (get, list, search, etc)."""
         tools = get_all_tools()
 
-        read_only_tools = [t for t in tools if t['has_read_only_hint']]
+        read_only_tools = [t for t in tools if t["has_read_only_hint"]]
 
         # These prefixes/patterns indicate read-only operations
-        read_only_patterns = ['get', 'list', 'search', 'check', 'eval', 'render']
+        read_only_patterns = ["get", "list", "search", "check", "eval", "render"]
 
         suspicious = []
         for tool in read_only_tools:
-            func = tool['function'].lower()
+            func = tool["function"].lower()
             # If it starts with a modifying verb, it's suspicious
             # Note: "list_updates" is OK (listing updates), "update_zone" is suspicious
-            modifying_prefixes = ['create_', 'set_', 'delete_', 'update_', 'add_', 'remove_', 'assign_', 'restart', 'reload']
-            if any(func.startswith(f'ha_{prefix}') or func.startswith(prefix) for prefix in modifying_prefixes):
+            modifying_prefixes = [
+                "create_",
+                "set_",
+                "delete_",
+                "update_",
+                "add_",
+                "remove_",
+                "assign_",
+                "restart",
+                "reload",
+            ]
+            if any(
+                func.startswith(f"ha_{prefix}") or func.startswith(prefix)
+                for prefix in modifying_prefixes
+            ):
                 suspicious.append(f"{tool['file']}:{tool['function']}")
 
         assert not suspicious, (
@@ -222,21 +251,41 @@ class TestToolAnnotations:
         """Tools with destructiveHint should have modifying names."""
         tools = get_all_tools()
 
-        destructive_tools = [t for t in tools if t['has_destructive_hint']]
+        destructive_tools = [t for t in tools if t["has_destructive_hint"]]
 
         # These patterns indicate destructive/modifying operations
-        destructive_patterns = ['create', 'set', 'delete', 'update', 'add', 'remove', 'assign', 'restart', 'reload', 'restore', 'import', 'rename', 'call', 'bulk', 'config_set', 'config_delete']
+        destructive_patterns = [
+            "create",
+            "set",
+            "delete",
+            "update",
+            "add",
+            "remove",
+            "assign",
+            "restart",
+            "reload",
+            "restore",
+            "import",
+            "rename",
+            "call",
+            "bulk",
+            "config_set",
+            "config_delete",
+        ]
 
         suspicious = []
         for tool in destructive_tools:
-            func = tool['function'].lower()
+            func = tool["function"].lower()
             # If it has only get/list/search patterns and destructiveHint, that's suspicious
             if not any(pattern in func for pattern in destructive_patterns):
                 # Exception: ha_call_service and ha_bulk_control are correctly destructive
-                if func not in ['ha_call_service', 'ha_bulk_control']:
+                if func not in ["ha_call_service", "ha_bulk_control"]:
                     suspicious.append(f"{tool['file']}:{tool['function']}")
 
         # This is a warning, not a hard failure - some tools might legitimately be destructive
         # even without obvious naming
         if suspicious:
-            print("\nNote: These destructive tools don't have typical modifying names:\n  " + "\n  ".join(suspicious))
+            print(
+                "\nNote: These destructive tools don't have typical modifying names:\n  "
+                + "\n  ".join(suspicious)
+            )

--- a/tests/src/unit/test_tools_mcp_component.py
+++ b/tests/src/unit/test_tools_mcp_component.py
@@ -106,7 +106,7 @@ class TestWaitForRepoRegistration:
 
     Lives in ``tools_hacs`` so both the installer flow
     (``ha_install_mcp_tools``) and the download flow
-    (``ha_hacs_download`` via ``_resolve_hacs_repo_id``) can share it.
+    (``ha_manage_hacs`` via ``_resolve_hacs_repo_id``) can share it.
     """
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Consolidates the four HACS tools into two action-based tools, split along the
read/write boundary so the read path keeps `readOnlyHint` and is never
mislabelled `destructive`:

| New tool | Annotations | Replaces | `action` |
|---|---|---|---|
| `ha_get_hacs_info` | `readOnlyHint`, `idempotentHint` | `ha_hacs_search`, `ha_hacs_repository_info` | `search`, `info` |
| `ha_manage_hacs` | `destructiveHint` | `ha_hacs_download`, `ha_hacs_add_repository` | `download`, `add_repository` |

HACS tool surface 4 → 2. Every operation and behaviour is preserved (progress
reporting, the empty-`repository_id` guard, the HACS dispatch-signal
registration waiter). Renaming is non-breaking per AGENTS.md — the same
outcomes remain achievable.

This redoes #1045 (closed unmerged because the requested changes were never
applied) with every review finding addressed:
- **No undefined `ErrorCode`** — keeps the structured `exception_to_structured_error`
  pattern, so the `INVALID_REQUEST` runtime crash that stalled #1045 is never introduced.
- **Read/write stay separate** (per the maintainer review on #1045) — not merged into one tool.
- Adds the missing **Caveats** docstring sections; keeps the high-value DASHBOARD TIP cross-tool hint.
- Removes a dead unreachable `return` in `_resolve_hacs_repo_id`.
- Adds unit regression tests for the action-validation paths.

Cross-references updated everywhere the rename reaches: `tools_resources.py` docstring,
the e2e HACS suite, the HAOS canary, and the unit tests (`test_context_injection`,
`test_identifier_validation_family`, `test_settings_ui`, `test_tools_mcp_component`).
Removes the grandfathered `ha_hacs_*` entry from the AGENTS.md naming-exception list,
shrinking the set tracked by #1175. `tools.json` / `README.md` / `DOCS.md` regenerate
on merge via `sync-tool-docs.yml`.

Original work by @Tipo-4ek, credited as co-author.

Refs #1045, #833, #1175

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

> **BAT (bot-acceptance) testing pending** — to be run manually to confirm no agent
> confusion from the action-based interface and that the consolidation measurably
> reduces token/tool count (the review ask on #1045).

## Checklist
- [x] I have updated documentation if needed

