### PR TITLE
fix(addon): restrict settings UI root routes to HA ingress

### DIFF
--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -5957,6 +5958,59 @@ def build_settings_handlers(
     return handlers
 
 
+# Home Assistant proxies every ingress request ("Open Web UI") from the
+# Supervisor's fixed network address. Per the add-on ingress contract
+# (https://developers.home-assistant.io/docs/add-ons/presentation/#ingress —
+# "Only connections from 172.30.32.2 must be allowed") the app must reject
+# every other source. This holds under host_network too: the Supervisor
+# reaches a host-network add-on by connecting to the hassio bridge gateway
+# from its own 172.30.32.2 address (supervisor/docker/app.py ip_address():
+# host_network -> network.gateway), so the transport peer the add-on sees is
+# 172.30.32.2 for genuine ingress and some other address (a LAN host, the
+# cloudflared tunnel, another add-on) for a direct port-9583 hit.
+SUPERVISOR_INGRESS_IP = "172.30.32.2"
+
+
+def _ingress_only(handler):
+    """Wrap a root-mounted add-on route so only HA ingress can reach it.
+
+    Add-on root routes carry no MCP secret, so without this guard a direct
+    caller on the published port — a LAN peer, a reverse proxy / tunnel
+    forwarding the bare root, or a CSRF POST from a LAN browser — could
+    rewrite tool config, flip the tool-security-policy, or restart the
+    add-on with no authentication. We gate on the *transport* peer
+    (``request.client.host``), never ``X-Forwarded-For`` (which a caller can
+    forge). The same handlers stay reachable under ``secret_prefix``, where
+    the MCP secret path is the auth for direct/remote access.
+    """
+
+    @functools.wraps(handler)
+    async def _guarded(request: Request) -> JSONResponse:
+        peer = request.client.host if request.client else None
+        if peer != SUPERVISOR_INGRESS_IP:
+            logger.warning(
+                "Blocked non-ingress request to add-on root route %s from "
+                "peer %r (only the Supervisor at %s may reach root routes; "
+                "use the MCP secret path for direct/remote access).",
+                request.url.path,
+                peer,
+                SUPERVISOR_INGRESS_IP,
+            )
+            return JSONResponse(
+                {
+                    "error": (
+                        "This endpoint is only reachable through Home "
+                        "Assistant ingress. For direct or remote access, use "
+                        "the settings UI under your MCP secret path."
+                    )
+                },
+                status_code=403,
+            )
+        return await handler(request)
+
+    return _guarded
+
+
 def register_settings_routes(
     mcp: FastMCP,
     server: HomeAssistantSmartMCPServer,
@@ -6031,18 +6085,26 @@ def register_settings_routes(
         ("/api/policy/value-source", ["GET"], "policy_get_value_source"),
     ]
 
-    def _mount(prefix: str) -> None:
+    def _mount(prefix: str, *, guard: bool = False) -> None:
+        # guard=True wraps each handler in _ingress_only so the route only
+        # answers HA ingress (the Supervisor) — used for the add-on root
+        # mount, whose port 9583 is reachable without the MCP secret.
         for path, methods, handler_key in routes:
-            mcp.custom_route(f"{prefix}{path}", methods=methods)(handlers[handler_key])
+            handler = handlers[handler_key]
+            if guard:
+                handler = _ingress_only(handler)
+            mcp.custom_route(f"{prefix}{path}", methods=methods)(handler)
 
     if is_addon:
-        # Root mount lets HA ingress proxy localhost:9583/ → settings UI.
-        # Direct port 9583 LAN access also reaches these routes; in this
-        # respect they share the existing add-on networking model where
-        # port 9583 is exposed via host_network and the secret path is
-        # the auth for direct access. Document this in DOCS.md.
-        mcp.custom_route("/", methods=["GET"])(handlers["root_page"])
-        _mount("")
+        # Root mount lets HA ingress proxy localhost:9583/ → the settings UI
+        # ("Open Web UI" button). The published port 9583 also makes these
+        # routes reachable by direct callers that present no MCP secret, so
+        # the root mount is gated with _ingress_only: only the Supervisor
+        # (HA ingress, 172.30.32.2) may reach root; every other caller gets
+        # 403 and must use the secret-path mount below. The "Open Web UI"
+        # button is unaffected — its traffic arrives from the Supervisor.
+        mcp.custom_route("/", methods=["GET"])(_ingress_only(handlers["root_page"]))
+        _mount("", guard=True)
 
     if secret_prefix:
         # Mount under the MCP secret path so Docker / standalone clients

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -5963,12 +5963,15 @@ def build_settings_handlers(
 # Supervisor's fixed network address. Per the add-on ingress contract
 # (https://developers.home-assistant.io/docs/add-ons/presentation/#ingress —
 # "Only connections from 172.30.32.2 must be allowed") the app must reject
-# every other source. This holds under host_network too: the Supervisor
-# reaches a host-network add-on by connecting to the hassio bridge gateway
-# from its own 172.30.32.2 address (supervisor/docker/app.py ip_address():
-# host_network -> network.gateway), so the transport peer the add-on sees is
-# 172.30.32.2 for genuine ingress and some other address (a LAN host, the
-# cloudflared tunnel, another add-on) for a direct port-9583 hit.
+# every other source. This holds under host_network too: ingress proxies to
+# http://{app.ip_address}:{ingress_port}/, and for a host-network add-on
+# app.ip_address is the hassio bridge gateway 172.30.32.1 — the DESTINATION the
+# Supervisor dials (supervisor/docker/app.py ip_address(): host_network ->
+# network.gateway). The Supervisor opens that connection from its own container
+# address 172.30.32.2, so the transport peer the add-on sees is 172.30.32.2 for
+# genuine ingress and some other address (a LAN host, the cloudflared tunnel at
+# 172.30.33.x, another add-on) for a direct port-9583 hit. Verified live via
+# netstat during an "Open Web UI" click.
 SUPERVISOR_INGRESS_IP = "172.30.32.2"
 
 # A settings-UI route handler: async (Request) -> Response.

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -17,12 +17,13 @@ import logging
 import os
 import time
 import uuid
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, TypedDict
 
 import httpx
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse
+from starlette.responses import HTMLResponse, JSONResponse, Response
 
 from ._version import get_version, is_running_in_addon
 from .backup_manager import get_backup_manager
@@ -5970,8 +5971,11 @@ def build_settings_handlers(
 # cloudflared tunnel, another add-on) for a direct port-9583 hit.
 SUPERVISOR_INGRESS_IP = "172.30.32.2"
 
+# A settings-UI route handler: async (Request) -> Response.
+_SettingsRoute = Callable[[Request], Awaitable[Response]]
 
-def _ingress_only(handler):
+
+def _ingress_only(handler: _SettingsRoute) -> _SettingsRoute:
     """Wrap a root-mounted add-on route so only HA ingress can reach it.
 
     Add-on root routes carry no MCP secret, so without this guard a direct
@@ -5985,7 +5989,7 @@ def _ingress_only(handler):
     """
 
     @functools.wraps(handler)
-    async def _guarded(request: Request) -> JSONResponse:
+    async def _guarded(request: Request) -> Response:
         peer = request.client.host if request.client else None
         if peer != SUPERVISOR_INGRESS_IP:
             logger.warning(

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3158,18 +3158,24 @@ class TestBetaMasterGateInSave:
         _reset_global_settings()
 
 
-def _http_request(peer_ip: str | None, path: str = "/api/policy/config") -> Request:
+def _http_request(
+    peer_ip: str | None,
+    path: str = "/api/policy/config",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Request:
     """Build a minimal Starlette Request with a controllable transport peer.
 
     ``client`` is the ASGI peer tuple uvicorn fills from the real TCP
-    connection — the unspoofable signal the ingress guard checks. ``None``
-    models a connection with no peer info.
+    connection — the transport-level signal the ingress guard checks (the real
+    TCP peer, not ``X-Forwarded-For``-forgeable). ``None`` models a connection
+    with no peer info. ``headers`` lets a test attach request headers (e.g. a
+    forged ``X-Forwarded-For``) to prove they cannot influence the gate.
     """
     scope = {
         "type": "http",
         "method": "GET",
         "path": path,
-        "headers": [],
+        "headers": headers or [],
         "query_string": b"",
         "client": (peer_ip, 51234) if peer_ip is not None else None,
     }
@@ -3209,6 +3215,26 @@ class TestIngressOnlyGuard:
 
         resp = await _ingress_only(inner)(_http_request(None))
         assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_forged_xff_does_not_bypass_guard(self):
+        # The gate keys on the transport peer, never on headers. A forged
+        # X-Forwarded-For claiming the Supervisor IP, from a non-Supervisor
+        # peer, must still be blocked.
+        called = False
+
+        async def inner(_request):
+            nonlocal called
+            called = True
+            return JSONResponse({"ok": True})
+
+        req = _http_request(
+            "192.168.1.50",
+            headers=[(b"x-forwarded-for", SUPERVISOR_INGRESS_IP.encode())],
+        )
+        resp = await _ingress_only(inner)(req)
+        assert resp.status_code == 403
+        assert called is False
 
 
 class TestIngressGateApplied:
@@ -3256,4 +3282,38 @@ class TestIngressGateApplied:
         captured = self._capture(monkeypatch)
         secret = captured[("/private_x/api/policy/config", ("PUT",))]
         # Secret-path route is the bare handler — no ingress IP gate.
+        assert not hasattr(secret, "__wrapped__")
+
+    @pytest.mark.asyncio
+    async def test_root_page_route_is_ingress_guarded(self, monkeypatch):
+        # The "/" front door is wrapped separately from the routes table, so
+        # pin it explicitly: a refactor dropping that one wrap would otherwise
+        # silently un-gate the entry point with every other test still green.
+        captured = self._capture(monkeypatch)
+        root_page = captured[("/", ("GET",))]
+        assert getattr(root_page, "__wrapped__", None) is not None
+        resp = await root_page(_http_request("10.0.0.9", path="/"))
+        assert resp.status_code == 403
+
+    def test_secret_routes_unguarded_in_non_addon_mode(self, monkeypatch):
+        # Non-add-on (Docker/standalone, secret-only): no bare-root mount, and
+        # the secret-path handlers must stay raw — the secret is the only auth
+        # there, so a stray guard would 403 legitimate direct clients.
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        captured: dict = {}
+
+        def factory(path, methods):
+            def decorator(fn):
+                captured[(path, tuple(methods))] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=factory)
+        register_settings_routes(mcp, MagicMock(), secret_path="/private_x")
+        # No bare-root mount when not in add-on mode.
+        assert ("/", ("GET",)) not in captured
+        # Secret-path handlers are raw (no ingress IP gate).
+        secret = captured[("/private_x/api/policy/config", ("PUT",))]
         assert not hasattr(secret, "__wrapped__")

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -441,7 +441,11 @@ class TestSaveToolsValidation:
 
         def custom_route_factory(path, methods):
             def decorator(fn):
-                if path == "/api/settings/tools" and "POST" in methods:
+                # Match both the root and secret-path mounts; the secret mount
+                # registers last, so `captured["save"]` ends up the unguarded
+                # handler (the root mount is wrapped in _ingress_only). This
+                # test exercises body validation, not the ingress gate.
+                if path.endswith("/api/settings/tools") and "POST" in methods:
                     captured["save"] = fn
                 return fn
 

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -19,9 +19,11 @@ from ha_mcp.settings_ui import (
     _SETTINGS_HTML,
     FEATURE_GATED_TOOLS,
     MANDATORY_TOOLS,
+    SUPERVISOR_INGRESS_IP,
     TRANSFORM_GENERATED_TOOLS,
     _get_config_path,
     _get_tool_metadata,
+    _ingress_only,
     apply_tool_visibility,
     load_tool_config,
     register_settings_routes,
@@ -3150,3 +3152,104 @@ class TestBetaMasterGateInSave:
             assert sub not in applied
         get_data_dir.cache_clear()
         _reset_global_settings()
+
+
+def _http_request(peer_ip: str | None, path: str = "/api/policy/config") -> Request:
+    """Build a minimal Starlette Request with a controllable transport peer.
+
+    ``client`` is the ASGI peer tuple uvicorn fills from the real TCP
+    connection — the unspoofable signal the ingress guard checks. ``None``
+    models a connection with no peer info.
+    """
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "client": (peer_ip, 51234) if peer_ip is not None else None,
+    }
+    return Request(scope)
+
+
+class TestIngressOnlyGuard:
+    """`_ingress_only` admits only the Supervisor (HA ingress) source IP."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_non_supervisor_peer(self):
+        called = False
+
+        async def inner(_request):
+            nonlocal called
+            called = True
+            return JSONResponse({"ok": True})
+
+        resp = await _ingress_only(inner)(_http_request("192.168.1.50"))
+        assert resp.status_code == 403
+        # The wrapped handler must never run for a rejected peer.
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_allows_supervisor_peer(self):
+        async def inner(_request):
+            return JSONResponse({"ok": True}, status_code=200)
+
+        resp = await _ingress_only(inner)(_http_request(SUPERVISOR_INGRESS_IP))
+        assert resp.status_code == 200
+        assert json.loads(resp.body) == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_blocks_missing_client(self):
+        async def inner(_request):
+            return JSONResponse({"ok": True})
+
+        resp = await _ingress_only(inner)(_http_request(None))
+        assert resp.status_code == 403
+
+
+class TestIngressGateApplied:
+    """register_settings_routes wraps the add-on root mount in the ingress
+    guard, while the secret-path twins stay raw (the secret is the auth there).
+    """
+
+    def _capture(self, monkeypatch) -> dict:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "fake")
+        captured: dict = {}
+
+        def factory(path, methods):
+            def decorator(fn):
+                captured[(path, tuple(methods))] = fn
+                return fn
+
+            return decorator
+
+        mcp = MagicMock()
+        mcp.custom_route = MagicMock(side_effect=factory)
+        register_settings_routes(mcp, MagicMock(), secret_path="/private_x")
+        return captured
+
+    def test_root_handler_wraps_the_same_handler_mounted_raw_under_secret(
+        self, monkeypatch
+    ):
+        captured = self._capture(monkeypatch)
+        root = captured[("/api/settings/tools", ("GET",))]
+        secret = captured[("/private_x/api/settings/tools", ("GET",))]
+        # Root is the ingress-guarded wrapper; the secret-path twin is the raw
+        # handler. functools.wraps records the original on `__wrapped__`.
+        assert root is not secret
+        assert getattr(root, "__wrapped__", None) is secret
+
+    @pytest.mark.asyncio
+    async def test_root_write_route_403_for_non_supervisor(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        # The policy-config write — the highest-stakes root route — must reject
+        # a direct (non-ingress) caller.
+        root_put = captured[("/api/policy/config", ("PUT",))]
+        resp = await root_put(_http_request("10.0.0.9", path="/api/policy/config"))
+        assert resp.status_code == 403
+
+    def test_secret_routes_present_and_unguarded(self, monkeypatch):
+        captured = self._capture(monkeypatch)
+        secret = captured[("/private_x/api/policy/config", ("PUT",))]
+        # Secret-path route is the bare handler — no ingress IP gate.
+        assert not hasattr(secret, "__wrapped__")


### PR DESCRIPTION
> Security advisory: **GHSA-q855-8rh5-jfgq** (reported by @bharat) — to be published as Moderate alongside the next release.

## What does this PR do?

In add-on mode the settings UI routes are mounted twice: under the MCP secret path (for direct/remote access) and at the bare root `/` so Home Assistant ingress can serve the "Open Web UI" button. The root mount performs no authentication, so any caller that can reach the published port `9583` without the MCP secret — a LAN peer, a reverse proxy/tunnel forwarding the bare root, or a CSRF `POST` from a LAN browser — could read or change which MCP tools are exposed, toggle feature flags, manage backups (including restore/delete), restart the add-on, or — with the opt-in Tool Security Policies feature enabled — read and rewrite the approval policy. (`/api/settings/advanced` is additionally exposed on dev builds.)

This wraps every root-mounted add-on route in an ingress guard. Genuine ingress always arrives from the Supervisor at `172.30.32.2` — verified live, and it holds under `host_network` because the Supervisor connects to the hassio bridge gateway from its own address (`supervisor/docker/app.py` `ip_address()` → `network.gateway`). The guard checks the transport peer (`request.client.host`), never the forgeable `X-Forwarded-For`, and returns `403` to anything else (logging the rejected peer). The `secret_prefix` mount is untouched, so the MCP secret path remains the auth for direct/remote access — the "Open Web UI" button, cloudflared, and the webhook-proxy add-on are all unaffected; only unauthenticated bare-root access is closed.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — settings_ui unit + route-registration suite green locally; full suite via CI
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed — existing add-on DOCS already direct users to "Open Web UI" / the secret path; no change needed
