### PR TITLE
fix(security): narrow GHSA-mc92-ww4q-6fg4 to the masker and log redaction

### DIFF
--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -165,12 +165,11 @@ def maybe_persist_secret_path(
         )
         log_error(
             f"Failed to persist secret_path to addon options ({detail}). "
-            "This addon will still run, but other addons (e.g. the webhook "
-            "proxy) cannot auto-discover the secret path via Supervisor. "
-            "The secret path is not logged (it is the addon's only auth); "
-            "find it in /data/secret_path.txt. Workaround: open this addon's "
-            "Configuration tab, set the 'Secret path override' field to that "
-            "value, then save."
+            f"This addon will still run with secret_path={secret_path!r}, "
+            "but other addons (e.g. the webhook proxy) cannot auto-discover "
+            "it via Supervisor. Workaround: open this addon's Configuration "
+            "tab and paste the secret_path above into the 'Secret path override' "
+            "field, then save."
         )
 
 
@@ -611,12 +610,12 @@ def main() -> int:
 
     log_info("")
     log_info("=" * 80)
-    log_info("🔐 MCP Server URL: http://<home-assistant-ip>:9583<secret-path>")
+    log_info(f"🔐 MCP Server URL: http://<home-assistant-ip>:9583{secret_path}")
     log_info("")
-    log_info("   <secret-path> is this addon's only authentication, so it is")
-    log_info("   NOT logged here. Retrieve it from this addon's Configuration")
-    log_info("   tab ('Secret path override' field) or from /data/secret_path.txt,")
-    log_info("   then append it to the URL above.")
+    log_info(f"   Secret Path: {secret_path}")
+    log_info("")
+    log_info("   ⚠️  IMPORTANT: Copy this exact URL - the secret path is required!")
+    log_info("   💡 This path is auto-generated and persisted to /data/secret_path.txt")
     log_info("=" * 80)
     log_info("")
 

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -293,7 +293,8 @@ def _sanitize_log_text(text: str) -> str:
     review (see ``_generate_anonymization_guide``). Rules cover the most common
     leak shapes seen in HA add-on logs:
     JWTs, bearer tokens, long hex tokens, ``key=value`` style credentials,
-    URL userinfo, and IPv4 addresses with network context.
+    URL userinfo, IPv4 addresses with network context, and the MCP connect-URL
+    secret path (the add-on's LAN auth).
     """
     # JWT tokens (header.payload.signature)
     text = re.sub(
@@ -338,6 +339,14 @@ def _sanitize_log_text(text: str) -> str:
     text = _IPV4_WITH_PORT_OR_CIDR_RE.sub("[IP]", text)
     text = _IPV4_IN_URL_RE.sub(r"\1[IP]", text)
     text = _IPV4_AFTER_KEYWORD_RE.sub(r"\1[IP]", text)
+    # MCP connect-URL secret path — the add-on's LAN auth. Redact by the
+    # configured value (catches custom paths) and the generated
+    # ``/private_<token>`` convention. Only bug-report output is scrubbed here;
+    # the raw logs this text is copied from are left intact.
+    configured = os.getenv("MCP_SECRET_PATH", "").rstrip("/")
+    if configured and configured != "/mcp":
+        text = text.replace(configured, "[REDACTED_SECRET_PATH]")
+    text = re.sub(r"/private_[A-Za-z0-9_-]+", "[REDACTED_SECRET_PATH]", text)
     return text
 
 
@@ -623,7 +632,15 @@ class BugReportTools:
             "success": True,
             "diagnostic_info": diagnostic_info,
             "recent_logs": recent_logs,
-            "startup_logs": startup_logs,
+            # startup_logs is the only returned surface not already routed
+            # through _sanitize_log_text (the formatted_report summary and
+            # addon_logs are). Sanitize each message here so the connect-URL
+            # secret path and other secrets never reach a pasted report. This
+            # copies entries — the underlying log records stay raw.
+            "startup_logs": [
+                {**entry, "message": _sanitize_log_text(entry.get("message", ""))}
+                for entry in startup_logs
+            ],
             "addon_logs": addon_logs,
             "log_count": len(recent_logs),
             "startup_log_count": len(startup_logs),

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -345,7 +345,13 @@ def _sanitize_log_text(text: str) -> str:
     # the raw logs this text is copied from are left intact.
     configured = os.getenv("MCP_SECRET_PATH", "").rstrip("/")
     if configured and configured != "/mcp":
-        text = text.replace(configured, "[REDACTED_SECRET_PATH]")
+        # Anchor on a path-segment boundary so a short/substring-prone configured
+        # value (e.g. "/ha") cannot corrupt unrelated text (e.g. "/happy").
+        text = re.sub(
+            re.escape(configured) + r"(?![A-Za-z0-9_-])",
+            "[REDACTED_SECRET_PATH]",
+            text,
+        )
     text = re.sub(r"/private_[A-Za-z0-9_-]+", "[REDACTED_SECRET_PATH]", text)
     return text
 
@@ -632,11 +638,14 @@ class BugReportTools:
             "success": True,
             "diagnostic_info": diagnostic_info,
             "recent_logs": recent_logs,
-            # startup_logs is the only returned surface not already routed
-            # through _sanitize_log_text (the formatted_report summary and
-            # addon_logs are). Sanitize each message here so the connect-URL
-            # secret path and other secrets never reach a pasted report. This
-            # copies entries — the underlying log records stay raw.
+            # Scrub the startup-log *messages* — they aren't sanitized at source,
+            # so the connect-URL secret path can otherwise surface here.
+            # recent_logs is also returned, but its sensitive *parameters* are
+            # key-masked at the logging chokepoint and its error_message is
+            # returned as-is to the trusted client by design (see SECURITY.md);
+            # formatted_report and addon_logs already route through
+            # _sanitize_log_text. This copies entries — the underlying log
+            # records stay raw.
             "startup_logs": [
                 {**entry, "message": _sanitize_log_text(entry.get("message", ""))}
                 for entry in startup_logs

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -508,8 +508,7 @@ class BugReportTools:
         **OUTPUT:**
         Returns both templates plus diagnostic data. Key fields:
         - `runtime_bug_template`, `agent_behavior_template` — pick based on context
-        - `recent_logs` — recent ha-mcp tool calls (secret parameters redacted);
-          startup log entries are summarised in `formatted_report`, not returned raw
+        - `recent_logs`, `startup_logs` — captured ha-mcp tool/server log entries
         - `addon_logs` — addon container stdout/stderr (HA add-on installs only;
           empty string otherwise)
         - `suggested_title`, `duplicate_check_urls`, `anonymization_guide`
@@ -623,13 +622,8 @@ class BugReportTools:
         return {
             "success": True,
             "diagnostic_info": diagnostic_info,
-            # ``recent_logs`` entries are redacted at the logging chokepoint
-            # (UsageLogger.log_tool_usage), so the tool parameters here carry no
-            # secrets. ``startup_logs`` come from a separate StartupLogCollector
-            # that is NOT redacted at source, so the raw entries are
-            # intentionally omitted — the sanitized view lives in
-            # ``formatted_report`` (via ``_format_startup_logs``).
             "recent_logs": recent_logs,
+            "startup_logs": startup_logs,
             "addon_logs": addon_logs,
             "log_count": len(recent_logs),
             "startup_log_count": len(startup_logs),

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -290,26 +290,6 @@ class TestBugReportTool:
             assert len(result["recent_logs"]) == 2
 
     @pytest.mark.asyncio
-    async def test_startup_logs_not_returned_raw(self, registered_tools, mock_client):
-        """Regression (GHSA-mc92-ww4q-6fg4): raw ``startup_logs`` must not be in
-        the return. Unlike ``recent_logs`` (redacted at the logging chokepoint),
-        startup log entries are not sanitised at source; the sanitised startup
-        summary stays available via ``formatted_report``."""
-        mock_client.get_config.return_value = {"version": "2024.12.0"}
-        mock_client.get_states.return_value = []
-
-        ha_report_issue = registered_tools._tools["ha_report_issue"]
-        actual_func = ha_report_issue
-        while hasattr(actual_func, "__wrapped__"):
-            actual_func = actual_func.__wrapped__
-
-        result = await actual_func(tool_call_count=5)
-
-        assert "startup_logs" not in result
-        assert "recent_logs" in result
-        assert "formatted_report" in result
-
-    @pytest.mark.asyncio
     async def test_bug_report_log_formatting(self, registered_tools, mock_client):
         """Test that logs are properly formatted in the report."""
         mock_client.get_config.return_value = {"version": "2024.12.0"}

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -326,6 +326,74 @@ class TestBugReportTool:
         message = result["startup_logs"][0]["message"]
         assert "/private_T6tSJxqYuTESTtoken" not in message
         assert "[REDACTED_SECRET_PATH]" in message
+        # The same secret path must also be scrubbed from formatted_report,
+        # which embeds the startup-log summary.
+        assert "/private_T6tSJxqYuTESTtoken" not in result["formatted_report"]
+        assert "[REDACTED_SECRET_PATH]" in result["formatted_report"]
+
+    @pytest.mark.asyncio
+    async def test_startup_logs_configured_secret_path_redacted_in_output(
+        self, registered_tools, mock_client, monkeypatch
+    ):
+        """A custom configured ``MCP_SECRET_PATH`` is redacted end-to-end in
+        ``ha_report_issue`` output — the realistic worst case, since a custom
+        path has no ``/private_`` shape for the regex to fall back on."""
+        monkeypatch.setenv("MCP_SECRET_PATH", "/customhook")
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        ha_report_issue = registered_tools._tools["ha_report_issue"]
+        actual_func = ha_report_issue
+        while hasattr(actual_func, "__wrapped__"):
+            actual_func = actual_func.__wrapped__
+
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_startup_logs"
+        ) as mock_get_startup:
+            mock_get_startup.return_value = [
+                {
+                    "timestamp": "2024-12-01T10:00:00",
+                    "level": "INFO",
+                    "logger": "FastMCP",
+                    "message": "serving at http://ha.local:9583/customhook",
+                    "elapsed_seconds": 1.0,
+                }
+            ]
+            result = await actual_func(tool_call_count=5)
+
+        message = result["startup_logs"][0]["message"]
+        assert "/customhook" not in message
+        assert "[REDACTED_SECRET_PATH]" in message
+
+    @pytest.mark.asyncio
+    async def test_startup_logs_source_not_mutated(self, registered_tools, mock_client):
+        """The returned ``startup_logs`` is a sanitized copy; the underlying log
+        record handed to the tool must not be mutated."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        ha_report_issue = registered_tools._tools["ha_report_issue"]
+        actual_func = ha_report_issue
+        while hasattr(actual_func, "__wrapped__"):
+            actual_func = actual_func.__wrapped__
+
+        raw_message = "on http://0.0.0.0:9583/private_T6tSJxqYuTESTtoken"
+        raw_entry = {
+            "timestamp": "2024-12-01T10:00:00",
+            "level": "INFO",
+            "logger": "FastMCP",
+            "message": raw_message,
+            "elapsed_seconds": 1.0,
+        }
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_startup_logs"
+        ) as mock_get_startup:
+            mock_get_startup.return_value = [raw_entry]
+            result = await actual_func(tool_call_count=5)
+
+        assert "[REDACTED_SECRET_PATH]" in result["startup_logs"][0]["message"]
+        # The source record is untouched.
+        assert raw_entry["message"] == raw_message
 
     def test_sanitize_log_text_redacts_generated_secret_path(self):
         """The generated ``/private_<token>`` connect path is redacted."""
@@ -347,6 +415,16 @@ class TestBugReportTool:
         monkeypatch.delenv("MCP_SECRET_PATH", raising=False)
         out = _sanitize_log_text("on http://0.0.0.0:9583/mcp")
         assert "/mcp" in out
+
+    def test_sanitize_log_text_short_configured_path_does_not_corrupt(
+        self, monkeypatch
+    ):
+        """A short configured secret path must redact only its own path segment,
+        not unrelated text that happens to share the prefix."""
+        monkeypatch.setenv("MCP_SECRET_PATH", "/ha")
+        out = _sanitize_log_text("Connecting to /happy/path via /ha")
+        assert "/happy/path" in out
+        assert out.count("[REDACTED_SECRET_PATH]") == 1
 
     @pytest.mark.asyncio
     async def test_bug_report_log_formatting(self, registered_tools, mock_client):

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -290,6 +290,65 @@ class TestBugReportTool:
             assert len(result["recent_logs"]) == 2
 
     @pytest.mark.asyncio
+    async def test_startup_logs_secret_path_redacted_in_output(
+        self, registered_tools, mock_client
+    ):
+        """Regression (GHSA-mc92-ww4q-6fg4): ``ha_report_issue`` must scrub the
+        connect-URL secret path from the returned ``startup_logs`` so it cannot
+        leak into a pasted public report. The field stays present; only the
+        tool's output copy is sanitized — the underlying logs are untouched."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        ha_report_issue = registered_tools._tools["ha_report_issue"]
+        actual_func = ha_report_issue
+        while hasattr(actual_func, "__wrapped__"):
+            actual_func = actual_func.__wrapped__
+
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_startup_logs"
+        ) as mock_get_startup:
+            mock_get_startup.return_value = [
+                {
+                    "timestamp": "2024-12-01T10:00:00",
+                    "level": "INFO",
+                    "logger": "FastMCP",
+                    "message": (
+                        "Starting MCP server 'ha-mcp' on "
+                        "http://0.0.0.0:9583/private_T6tSJxqYuTESTtoken"
+                    ),
+                    "elapsed_seconds": 1.0,
+                }
+            ]
+            result = await actual_func(tool_call_count=5)
+
+        assert "startup_logs" in result
+        message = result["startup_logs"][0]["message"]
+        assert "/private_T6tSJxqYuTESTtoken" not in message
+        assert "[REDACTED_SECRET_PATH]" in message
+
+    def test_sanitize_log_text_redacts_generated_secret_path(self):
+        """The generated ``/private_<token>`` connect path is redacted."""
+        out = _sanitize_log_text(
+            "on http://0.0.0.0:9583/private_T6tSJxqYuTESTtoken/mcp"
+        )
+        assert "/private_T6tSJxqYuTESTtoken" not in out
+        assert "[REDACTED_SECRET_PATH]" in out
+
+    def test_sanitize_log_text_redacts_configured_secret_path(self, monkeypatch):
+        """A custom configured ``MCP_SECRET_PATH`` is redacted by value."""
+        monkeypatch.setenv("MCP_SECRET_PATH", "/customhook")
+        out = _sanitize_log_text("connect at http://ha.local:9583/customhook/mcp")
+        assert "/customhook" not in out
+        assert "[REDACTED_SECRET_PATH]" in out
+
+    def test_sanitize_log_text_keeps_default_mcp_path(self, monkeypatch):
+        """The low-entropy ``/mcp`` default is left intact (avoids noise)."""
+        monkeypatch.delenv("MCP_SECRET_PATH", raising=False)
+        out = _sanitize_log_text("on http://0.0.0.0:9583/mcp")
+        assert "/mcp" in out
+
+    @pytest.mark.asyncio
     async def test_bug_report_log_formatting(self, registered_tools, mock_client):
         """Test that logs are properly formatted in the report."""
         mock_client.get_config.return_value = {"version": "2024.12.0"}


### PR DESCRIPTION
## What does this PR do?

Re-scopes the GHSA-mc92-ww4q-6fg4 merge (`4a047102`): keeps the parts that are
genuine hardening, drops the part that isn't a vulnerability under our
SECURITY.md threat model, and replaces the `ha_report_issue` change with a
narrower fix that sanitizes the tool's *output* (not the logs).

### Kept
- `custom_components/ha_mcp_tools/__init__.py` — `secrets.yaml` masker parses
  structurally and masks every top-level key, closing the block-scalar (`|`, `>`)
  gap (SSH keys, TLS, service-account JSON). Fails closed.
- `src/ha_mcp/utils/usage_logger.py` — parameter redaction at the logging
  chokepoint (sensitive key names only). Keeps `recent_logs` redacted at source.

### ha_report_issue output sanitization (replaces the original startup_logs change)
The original merge dropped the raw `startup_logs` field. Instead, this PR keeps
the field and sanitizes it at the tool-output boundary:
- `_sanitize_log_text` now also redacts the MCP connect-URL **secret path** — by
  the configured `MCP_SECRET_PATH` value (catches custom paths) and the generated
  `/private_<token>` convention; the low-entropy `/mcp` default is left intact.
- The configured-value redaction is matched as a full path segment (so a short
  `MCP_SECRET_PATH` can't corrupt unrelated text).
- The returned `startup_logs` messages are routed through `_sanitize_log_text`;
  `formatted_report` and `addon_logs` already route through it, so all three
  carry the secret-path redaction.

Scope (deliberate): sanitization runs only on the report tool's *output*, and
only on free-text log *messages*. `recent_logs` is returned with its sensitive
*parameters* key-masked at the logging chokepoint; its `error_message` is
returned as-is, since `ha_report_issue` output goes to the trusted MCP client
(SECURITY.md), which already holds the LLAT. The underlying logs (`ha_get_logs`,
the add-on log, the startup collector) are left raw — operators need the real
connect URL there — and manual review before posting remains the operator's
responsibility, per the tool's privacy reminder.

### Reverted (not a vulnerability under SECURITY.md)
- `homeassistant-addon/start.py` — restores `secret_path` in the connect-URL
  banner and persist-failure message. It's the add-on's own LAN auth in the
  operator's own log; standard-mode LAN is the trusted zone (SECURITY.md).
  Removing the banner is a usability regression and it broke the add-on startup
  tests on `master`.

### CI impact
`master` is red on Docker & Add-on Validation: `start.py` stopped printing
`secret_path` but `tests/addon/test_addon_startup.py` still asserts the old
output. Reverting `start.py` turns the job green.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit tests cover the secret-path redaction (configured value, generated
`/private_*`, `/mcp`-kept, and a short configured value that must not corrupt
adjacent text) and verify end-to-end that `ha_report_issue` scrubs the secret
path from `startup_logs` and `formatted_report`, handles a custom configured
path, and does not mutate the underlying log records. Reverting `start.py`
restores `tests/addon/test_addon_startup.py`; full suite runs in CI.

## Checklist
- [ ] I have updated documentation if needed

### Operator responsibility
`ha_report_issue` assembles a report for the operator to review and paste into a
public issue. Server-side sanitization (secret path, tokens) is defense-in-depth;
the final review before posting remains the operator's responsibility, per the
tool's privacy reminder and anonymization guidance.

### Credits
Thanks to @bharat for the report (GHSA-mc92-ww4q-6fg4) and for flagging the
`secrets.yaml` masker as the highest-value fix — which this PR keeps.
