### PR TITLE
refactor: fold ha_check_config into ha_get_system_health include="config_check"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,7 +514,7 @@ src/ha_mcp/
 - `ha_config_<verb>_<noun>` — config-management tools (`ha_config_set_helper`, `ha_config_set_automation`, `ha_config_remove_automation`, `ha_config_delete_dashboard`)
 
 **Accepted exceptions**: A small set of tools name a single, distinct operation where forcing a `<verb>_<noun>` shape would read worse than the natural name. These are accepted as-is and should not be flagged:
-- `ha_restart`, `ha_reload_core`, `ha_check_config`, `ha_eval_template`
+- `ha_restart`, `ha_reload_core`, `ha_eval_template`
 - `ha_report_issue`, `ha_import_blueprint`
 - `ha_read_file`, `ha_write_file`, `ha_deep_search`, `ha_bulk_control`
 - `ha_install_mcp_tools`

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -51,7 +51,7 @@ ignored unless the master is also true.
 
 This tool edits `configuration.yaml` and package files directly, bypassing Home Assistant's config-entry flow. It includes safeguards (backup before every edit, YAML validation, key allowlist, path traversal blocking, post-edit config check), but operators should be aware of the following:
 
-**Config check has blind spots.** `ha_check_config` validates YAML syntax but does not catch all integration-level schema errors. An edit can pass validation, HA boots cleanly, but the target entity silently does not exist. Common LLM mistakes include mixing legacy and modern template sensor syntax, wrong field names (`value_template:` vs `state:`), and bad Jinja expressions.
+**Config check has blind spots.** HA's config check — run automatically post-edit, and available manually via `ha_get_system_health(include="config_check")` — validates YAML syntax but does not catch all integration-level schema errors. An edit can pass validation, HA boots cleanly, but the target entity silently does not exist. Common LLM mistakes include mixing legacy and modern template sensor syntax, wrong field names (`value_template:` vs `state:`), and bad Jinja expressions.
 
 **`action: remove` removes the entire top-level key.** Asking an LLM to remove a single sensor can result in the entire `template:` key being deleted, not just the intended entry.
 

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -399,18 +399,29 @@ class SystemTools:
             try:
                 ws_client, result = await self._fetch_health_info()
             except ToolError as health_err:
-                # The system_health/info baseline (WebSocket) is unavailable —
-                # degrade gracefully instead of sinking the whole tool, so the
-                # REST-based sections still return. WS-backed sections can't run
-                # without the connection and are reported as unavailable below.
-                # config_check is the pure-REST replacement for the removed
-                # ha_check_config tool, so it must not depend on the health
-                # WebSocket succeeding (the system_health/info command carries
-                # its own 10s timeout and can hang/be absent on some installs).
+                # The system_health/info baseline (WebSocket) is unavailable.
+                # Only ``await self._fetch_health_info()`` runs in this inner
+                # try, and it raises ToolError solely for baseline-unavailable
+                # conditions (connect failure / timeout / WS error), so this
+                # catch cannot swallow an unrelated ToolError.
+                #
+                # Degrade gracefully ONLY when the caller asked for a REST-based
+                # section (config_check / diagnostics) that can still be served
+                # without the WebSocket. config_check is the pure-REST
+                # replacement for the removed ha_check_config tool, so it must
+                # not depend on the health WebSocket (the system_health/info
+                # command carries its own 10s timeout and can hang/be absent on
+                # some installs). If the caller asked for nothing (the health
+                # baseline itself) or only WS-backed sections, the baseline WAS
+                # the deliverable: re-raise so the failure surfaces as
+                # isError=true, exactly as before this change.
+                if not (includes & {"config_check", "diagnostics"}):
+                    raise
                 logger.warning("system_health baseline unavailable: %s", health_err)
                 ws_client = None
                 result = {
                     "success": True,
+                    "baseline_available": False,
                     "health_info": {},
                     "component_count": 0,
                     "message": "System health baseline unavailable.",
@@ -452,8 +463,17 @@ class SystemTools:
 
             if ws_client is None:
                 # Health WebSocket unavailable: WS-backed sections can't run.
-                # Surface which requested sections were dropped, then skip them
-                # so the REST-based sections below still return.
+                # Give each requested WS-backed section a machine-readable error
+                # sub-dict under its own key (same shape the section carries when
+                # the baseline is up but the fetch fails), plus a summary
+                # warning, then skip them so the REST sections below still run.
+                ws_error = "requires the system_health WebSocket, which is unavailable"
+                if want_repairs:
+                    result["repairs"] = {"error": ws_error}
+                if want_zha:
+                    result["zha_network"] = {"error": ws_error}
+                if want_zwave:
+                    result["zwave_network"] = {"error": ws_error}
                 unavailable = sorted(includes & ws_backed)
                 if unavailable:
                     result.setdefault("warnings", []).append(
@@ -612,11 +632,7 @@ class SystemTools:
                 ],
             )
         finally:
-            if ws_client:
-                try:
-                    await ws_client.disconnect()
-                except Exception:
-                    pass
+            await self._safe_disconnect(ws_client)
 
     @staticmethod
     def _parse_includes(include: str | None) -> set[str]:
@@ -624,6 +640,16 @@ class SystemTools:
         if not include:
             return set()
         return {s.strip().lower() for s in include.split(",") if s.strip()}
+
+    @staticmethod
+    async def _safe_disconnect(ws_client: Any) -> None:
+        """Best-effort WebSocket disconnect; never raises."""
+        if ws_client is None:
+            return
+        try:
+            await ws_client.disconnect()
+        except Exception:
+            pass
 
     async def _fetch_health_info(self) -> tuple[Any, dict[str, Any]]:
         """Connect to WebSocket and retrieve system health info.
@@ -651,6 +677,9 @@ class SystemTools:
                 "system_health/info", wait_timeout=10.0
             )
         except TimeoutError:
+            # The connection opened but the command stalled — disconnect it
+            # before raising so we don't leak the socket.
+            await self._safe_disconnect(ws_client)
             raise_tool_error(
                 create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
@@ -658,6 +687,7 @@ class SystemTools:
                 )
             )
         except Exception as e:
+            await self._safe_disconnect(ws_client)
             raise_tool_error(
                 create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
@@ -832,7 +862,8 @@ class SystemTools:
         an ``error`` field on backend failure. Never raises, so a config-check
         failure surfaces as ``result["config_check"]["error"]`` without sinking
         the rest of ha_get_system_health. Instance method (not @staticmethod)
-        because it calls the REST client, mirroring the diagnostics path.
+        because it calls the REST client (``self._client``), like the
+        diagnostics path.
         """
         config_check: dict[str, Any] = {
             "result": "unknown",

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -61,51 +61,6 @@ class SystemTools:
         self._client = client
 
     @tool(
-        name="ha_check_config",
-        tags={"System"},
-        annotations={
-            "idempotentHint": True,
-            "readOnlyHint": True,
-            "title": "Check Configuration",
-        },
-    )
-    @log_tool_usage
-    async def ha_check_config(self) -> dict[str, Any]:
-        """
-        Check Home Assistant configuration for errors.
-
-        Validates configuration files without applying changes.
-        Always run this before ha_restart() to ensure configuration is valid.
-        """
-        try:
-            config_result = await self._client.check_config()
-
-            # The API returns {"result": "valid"} or {"result": "invalid", "errors": [...]}
-            is_valid = config_result.get("result") == "valid"
-            errors = config_result.get("errors") or []  # Handle None case
-
-            return {
-                "success": True,
-                "result": "valid" if is_valid else "invalid",
-                "is_valid": is_valid,
-                "errors": errors,
-                "message": (
-                    "Configuration is valid"
-                    if is_valid
-                    else f"Configuration has {len(errors)} error(s)"
-                ),
-            }
-
-        except Exception as e:
-            exception_to_structured_error(
-                e,
-                suggestions=[
-                    "Ensure Home Assistant is running and accessible",
-                    "Check your connection settings",
-                ],
-            )
-
-    @tool(
         name="ha_restart",
         tags={"System"},
         annotations={"destructiveHint": True, "title": "Restart Home Assistant"},
@@ -127,15 +82,16 @@ class SystemTools:
                    measure to prevent accidental restarts.
 
         **Best Practices:**
-        1. Always run ha_check_config() first to ensure configuration is valid
+        1. Config is validated automatically before the restart proceeds; to
+           pre-check, call ha_get_system_health(include="config_check")
         2. Notify users before restarting (if applicable)
         3. Schedule restarts during low-activity periods
 
         **Example Usage:**
         ```python
-        # Always check config first
-        config = ha_check_config()
-        if config["result"] == "valid":
+        # Optional pre-check (ha_restart also validates config automatically)
+        health = ha_get_system_health(include="config_check")
+        if health["config_check"]["is_valid"]:
             # Restart with confirmation
             result = ha_restart(confirm=True)
         ```
@@ -153,7 +109,7 @@ class SystemTools:
                         "This is a safety measure to prevent accidental restarts."
                     ),
                     suggestions=[
-                        "Run ha_check_config() first to validate configuration",
+                        'Pre-check config via ha_get_system_health(include="config_check")',
                         "Call ha_restart(confirm=True) to proceed with restart",
                         "Consider using ha_reload_core() for config-only changes",
                     ],
@@ -391,7 +347,10 @@ class SystemTools:
             be large (Hue ~290 KB, ZHA/MQTT/ESPHome several MB) — pair with
             ``diagnostics_fields`` or ``diagnostics_truncate_at_bytes`` to fit the LLM
             context budget.
-          - Example: include="repairs,zha_network,zwave_network"
+          - "config_check": Validate HA configuration via POST /config/core/check_config
+            (the pre-restart safety check; ha_restart runs it automatically). Returns
+            {result: valid|invalid, is_valid, errors}; read-only/idempotent, takes no args.
+          - Example: include="repairs,zha_network,zwave_network,config_check"
           - Example: include="diagnostics", config_entry_id="abc123..."
         - include_dismissed_repairs: Include user-dismissed/ignored repairs (default: False). Only meaningful when "repairs" is in `include`.
         - config_entry_id: Required when ``include`` contains ``diagnostics``. The config
@@ -430,10 +389,36 @@ class SystemTools:
         includes = self._parse_includes(include)
         include_dismissed_repairs_bool = bool(include_dismissed_repairs)
 
+        # Sections that require the system_health WebSocket connection; the
+        # REST-based sections (config_check, diagnostics) do not.
+        ws_backed = {"repairs", "zha_network", "zha_network_full", "zwave_network"}
+
         ws_client = None
 
         try:
-            ws_client, result = await self._fetch_health_info()
+            try:
+                ws_client, result = await self._fetch_health_info()
+            except ToolError as health_err:
+                # The system_health/info baseline (WebSocket) is unavailable —
+                # degrade gracefully instead of sinking the whole tool, so the
+                # REST-based sections still return. WS-backed sections can't run
+                # without the connection and are reported as unavailable below.
+                # config_check is the pure-REST replacement for the removed
+                # ha_check_config tool, so it must not depend on the health
+                # WebSocket succeeding (the system_health/info command carries
+                # its own 10s timeout and can hang/be absent on some installs).
+                logger.warning("system_health baseline unavailable: %s", health_err)
+                ws_client = None
+                result = {
+                    "success": True,
+                    "health_info": {},
+                    "component_count": 0,
+                    "message": "System health baseline unavailable.",
+                    "warnings": [
+                        "system_health baseline unavailable; "
+                        "returning REST-based sections only."
+                    ],
+                }
 
             # Warn about unrecognized include values
             VALID_INCLUDES = {
@@ -442,6 +427,7 @@ class SystemTools:
                 "zha_network_full",
                 "zwave_network",
                 "diagnostics",
+                "config_check",
             }
             unknown = includes - VALID_INCLUDES
             if unknown:
@@ -463,6 +449,18 @@ class SystemTools:
             want_repairs = "repairs" in includes
             want_zha = zha_full or zha_summary
             want_zwave = "zwave_network" in includes
+
+            if ws_client is None:
+                # Health WebSocket unavailable: WS-backed sections can't run.
+                # Surface which requested sections were dropped, then skip them
+                # so the REST-based sections below still return.
+                unavailable = sorted(includes & ws_backed)
+                if unavailable:
+                    result.setdefault("warnings", []).append(
+                        "These sections require the system_health WebSocket, "
+                        f"which is unavailable: {', '.join(unavailable)}"
+                    )
+                want_repairs = want_zha = want_zwave = False
 
             sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]] = []
             if want_repairs:
@@ -592,6 +590,14 @@ class SystemTools:
                     "were provided but ignored because 'diagnostics' is not "
                     "in include"
                 )
+
+            if "config_check" in includes:
+                # REST call on self._client (POST /config/core/check_config),
+                # not a ws_client command — so it runs inline like diagnostics
+                # rather than in the ws ``sections`` gather above. Standalone
+                # ``if`` (not chained to diagnostics) so both can be requested
+                # in one call.
+                result["config_check"] = await self._fetch_config_check()
 
             return result
 
@@ -817,6 +823,37 @@ class SystemTools:
                 f"Z-Wave JS integration not available or error: {e}"
             )
         return zwave_network
+
+    async def _fetch_config_check(self) -> dict[str, Any]:
+        """Validate HA configuration via POST /config/core/check_config.
+
+        Returns an embeddable sub-dict (matching the ``_fetch_repairs`` /
+        ``_fetch_zha_network`` convention): baseline keys always present, with
+        an ``error`` field on backend failure. Never raises, so a config-check
+        failure surfaces as ``result["config_check"]["error"]`` without sinking
+        the rest of ha_get_system_health. Instance method (not @staticmethod)
+        because it calls the REST client, mirroring the diagnostics path.
+        """
+        config_check: dict[str, Any] = {
+            "result": "unknown",
+            "is_valid": False,
+            "errors": [],
+        }
+        try:
+            config_result = await self._client.check_config()
+            # The API returns {"result": "valid"} or
+            # {"result": "invalid", "errors": [...]}.
+            is_valid = config_result.get("result") == "valid"
+            errors = config_result.get("errors") or []  # Handle None case
+            config_check = {
+                "result": "valid" if is_valid else "invalid",
+                "is_valid": is_valid,
+                "errors": errors,
+            }
+        except Exception as e:
+            logger.warning("Failed to check config: %s", e)
+            config_check["error"] = f"Config check not available: {e}"
+        return config_check
 
 
 def register_system_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -5,11 +5,10 @@ NOTE: Run these tests with the Docker test environment:
     HAMCP_ENV_FILE=tests/.env.test uv run pytest tests/src/e2e/workflows/system/test_system_tools.py -v
 
 Tests for system management MCP tools:
-- ha_check_config: Configuration validation
 - ha_restart: Home Assistant restart (with safety measures)
 - ha_reload_core: Reload specific configuration components
 - ha_get_overview: Get system information and entity overview
-- ha_get_system_health: Get system health data
+- ha_get_system_health: System health data + config validation (include="config_check")
 
 Note: ha_restart is tested carefully to avoid disrupting the test environment.
 We verify the safety mechanisms work but do not actually restart HA during tests.
@@ -29,37 +28,41 @@ class TestSystemTools:
     """Test system management tools."""
 
     @pytest.mark.asyncio
-    async def test_check_config_valid(self, mcp_client):
+    async def test_config_check_via_system_health(self, mcp_client):
         """
-        Test: Check Home Assistant configuration for errors.
+        Test: Validate HA configuration via ha_get_system_health(include="config_check").
 
-        This test validates that we can check the HA configuration
-        and that the test environment has valid configuration.
+        The standalone ha_check_config tool was folded into ha_get_system_health;
+        configuration validation now lives under the "config_check" include section.
         """
-        logger.info("Checking Home Assistant configuration...")
+        logger.info("Checking Home Assistant configuration via system health...")
 
-        result = await mcp_client.call_tool("ha_check_config", {})
+        result = await mcp_client.call_tool(
+            "ha_get_system_health", {"include": "config_check"}
+        )
         data = parse_mcp_result(result)
 
-        logger.info(f"Config check result: {data}")
+        logger.info(f"System health (config_check) result: {data}")
 
         # Verify the tool executed successfully
-        assert data.get("success") is True, f"Config check failed: {data.get('error')}"
+        assert data.get("success") is True, f"Health check failed: {data.get('error')}"
 
-        # Verify we got the expected fields
-        assert "result" in data, "Missing 'result' field"
-        assert "is_valid" in data, "Missing 'is_valid' field"
-        assert "errors" in data, "Missing 'errors' field"
+        # Verify the folded config_check section is present with expected fields
+        assert "config_check" in data, "Missing 'config_check' section"
+        config_check = data["config_check"]
+        assert "result" in config_check, "Missing 'result' field"
+        assert "is_valid" in config_check, "Missing 'is_valid' field"
+        assert "errors" in config_check, "Missing 'errors' field"
 
         # The test environment should have valid config
-        if data.get("is_valid"):
+        if config_check.get("is_valid"):
             logger.info("Configuration is valid")
-            assert data["result"] == "valid"
-            errors = data.get("errors") or []
+            assert config_check["result"] == "valid"
+            errors = config_check.get("errors") or []
             assert len(errors) == 0, f"Valid config should have no errors: {errors}"
         else:
             # Log errors if config is invalid (unexpected in test env)
-            logger.warning(f"Configuration has errors: {data['errors']}")
+            logger.warning(f"Configuration has errors: {config_check['errors']}")
 
         logger.info("Config check test completed successfully")
 
@@ -619,13 +622,16 @@ class TestSystemToolsIntegration:
         """
         logger.info("Testing check config -> reload workflow...")
 
-        # Step 1: Check configuration
-        config_result = await mcp_client.call_tool("ha_check_config", {})
+        # Step 1: Check configuration (folded into ha_get_system_health)
+        config_result = await mcp_client.call_tool(
+            "ha_get_system_health", {"include": "config_check"}
+        )
         config_data = parse_mcp_result(config_result)
 
         assert config_data.get("success") is True, "Config check should succeed"
+        config_check = config_data.get("config_check", {})
 
-        if config_data.get("is_valid"):
+        if config_check.get("is_valid"):
             logger.info("Config is valid, proceeding with reload...")
 
             # Step 2: Reload automations
@@ -658,19 +664,20 @@ class TestSystemToolsIntegration:
         info_result = await mcp_client.call_tool("ha_get_overview", {})
         info_data = parse_mcp_result(info_result)
 
-        # Get system health (may not be available in test environment)
-        health_result = await mcp_client.call_tool("ha_get_system_health", {})
+        # Get system health + config status. Config validation is folded into
+        # ha_get_system_health as the "config_check" include section, so one
+        # call covers both. (May not be available in minimal test containers.)
+        health_result = await mcp_client.call_tool(
+            "ha_get_system_health", {"include": "config_check"}
+        )
         health_data = parse_mcp_result(health_result)
-
-        # Get config status
-        config_result = await mcp_client.call_tool("ha_check_config", {})
-        config_data = parse_mcp_result(config_result)
 
         # Verify essential tools returned successfully
         assert info_data.get("success") is True, "System overview should succeed"
-        assert config_data.get("success") is True, "Config check should succeed"
-        # Health data might not be available in test containers - don't require it
+        # Health data (and the folded config_check) might not be available in
+        # test containers - don't require it
         health_available = health_data.get("success") is True
+        config_check = health_data.get("config_check", {}) if health_available else {}
 
         # Extract system_info from overview
         system_info = info_data.get("system_info", {})
@@ -683,7 +690,7 @@ class TestSystemToolsIntegration:
         logger.info(f"Location: {system_info.get('location_name')}")
         logger.info(f"Timezone: {system_info.get('time_zone')}")
         logger.info(f"Components: {system_info.get('components_loaded')}")
-        logger.info(f"Config Status: {config_data.get('result')}")
+        logger.info(f"Config Status: {config_check.get('result', 'not available')}")
         if health_available:
             logger.info(f"Health Components: {health_data.get('component_count')}")
         else:

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -666,7 +666,9 @@ class TestSystemToolsIntegration:
 
         # Get system health + config status. Config validation is folded into
         # ha_get_system_health as the "config_check" include section, so one
-        # call covers both. (May not be available in minimal test containers.)
+        # call covers both. config_check is REST-based, so this call succeeds
+        # (degrading gracefully) even if the system_health WebSocket baseline is
+        # unavailable.
         health_result = await mcp_client.call_tool(
             "ha_get_system_health", {"include": "config_check"}
         )
@@ -674,10 +676,15 @@ class TestSystemToolsIntegration:
 
         # Verify essential tools returned successfully
         assert info_data.get("success") is True, "System overview should succeed"
-        # Health data (and the folded config_check) might not be available in
-        # test containers - don't require it
-        health_available = health_data.get("success") is True
-        config_check = health_data.get("config_check", {}) if health_available else {}
+        assert health_data.get("success") is True, (
+            "ha_get_system_health(include='config_check') should always succeed "
+            "(REST config_check degrades gracefully if the WS baseline is down)"
+        )
+        config_check = health_data.get("config_check", {})
+        assert "is_valid" in config_check, "config_check section should be present"
+        # The WS health baseline may still be unavailable in minimal containers;
+        # config_check does not depend on it.
+        baseline_available = health_data.get("baseline_available", True)
 
         # Extract system_info from overview
         system_info = info_data.get("system_info", {})
@@ -690,11 +697,11 @@ class TestSystemToolsIntegration:
         logger.info(f"Location: {system_info.get('location_name')}")
         logger.info(f"Timezone: {system_info.get('time_zone')}")
         logger.info(f"Components: {system_info.get('components_loaded')}")
-        logger.info(f"Config Status: {config_check.get('result', 'not available')}")
-        if health_available:
+        logger.info(f"Config Status: {config_check.get('result', 'unknown')}")
+        if baseline_available:
             logger.info(f"Health Components: {health_data.get('component_count')}")
         else:
-            logger.info("Health: Not available in this environment")
+            logger.info("Health baseline: not available in this environment")
         logger.info("=" * 60)
 
         logger.info("System overview test completed successfully")

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -157,6 +157,20 @@ class TestToolAnnotations:
             + "\n\nAdd tags={'Category Name'} to each @mcp.tool() decorator."
         )
 
+    def test_ha_check_config_removed_and_folded(self):
+        """ha_check_config was removed and folded into ha_get_system_health
+        (include='config_check'). Lock the removal at the source registration so
+        a bad merge that re-adds the @tool block fails CI. (Checks the source
+        string directly rather than get_all_tools(), whose regex can't parse
+        ha_get_system_health's paren-containing title.)"""
+        system_src = (get_tools_dir() / "tools_system.py").read_text(encoding="utf-8")
+        assert 'name="ha_check_config"' not in system_src, (
+            "ha_check_config was removed in favor of "
+            "ha_get_system_health(include='config_check'); it must not be "
+            "re-registered."
+        )
+        assert 'name="ha_get_system_health"' in system_src
+
     def test_tool_count_sanity_check(self):
         """Sanity check that we're finding a reasonable number of tools."""
         tools = get_all_tools()

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -843,9 +843,10 @@ class TestGetSystemHealthConfigCheck:
 
     @pytest.mark.asyncio
     async def test_ws_backed_section_reported_unavailable_when_health_fails(self):
-        """When the health WS baseline fails, a requested WS-backed section
-        (repairs) is dropped with a warning rather than crashing the tool, while
-        the REST config_check still returns."""
+        """When the health WS baseline fails but a REST section is also
+        requested, a requested WS-backed section (repairs) is reported with a
+        machine-readable error sub-dict (and a summary warning) rather than
+        crashing the tool, while the REST config_check still returns."""
         client = MagicMock()
         client.check_config = AsyncMock(return_value={"result": "valid"})
         tools = SystemTools(client)
@@ -856,9 +857,72 @@ class TestGetSystemHealthConfigCheck:
         ):
             result = await tools.ha_get_system_health(include="repairs,config_check")
         assert result["success"] is True
+        assert result["baseline_available"] is False
         assert result["config_check"]["is_valid"] is True
-        assert "repairs" not in result
+        # Dropped WS section carries the same {error} shape it would if the
+        # baseline were up and the fetch itself failed — not a vanished key.
+        assert "error" in result["repairs"]
         assert any("repairs" in w for w in result.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_bare_call_raises_when_health_ws_unavailable(self):
+        """A bare ha_get_system_health() (the health baseline IS the deliverable)
+        must still RAISE on a WS-baseline failure — degradation only applies when
+        a REST-only section was requested. Guards against regressing the tool's
+        primary mode into a misleading success."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with (
+            patch.object(
+                SystemTools,
+                "_fetch_health_info",
+                new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await tools.ha_get_system_health()
+
+    @pytest.mark.asyncio
+    async def test_ws_only_request_raises_when_health_ws_unavailable(self):
+        """include='repairs' (WS-only, no REST section) must RAISE on a
+        WS-baseline failure rather than degrade to success — the requested data
+        genuinely cannot be served without the WebSocket."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with (
+            patch.object(
+                SystemTools,
+                "_fetch_health_info",
+                new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await tools.ha_get_system_health(include="repairs")
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_returns_when_health_ws_unavailable(self):
+        """diagnostics is REST-based, so it too survives a WS-baseline failure —
+        the degradation guarantee is not specific to config_check."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with (
+            patch.object(
+                SystemTools,
+                "_fetch_health_info",
+                new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+            ),
+            patch(
+                "ha_mcp.tools.tools_system.fetch_integration_diagnostics",
+                new=AsyncMock(return_value={"data": {"ok": True}}),
+            ) as mock_diag,
+        ):
+            result = await tools.ha_get_system_health(
+                include="diagnostics", config_entry_id="entry_abc"
+            )
+        assert result["success"] is True
+        assert result["baseline_available"] is False
+        assert result["diagnostics"] == {"data": {"ok": True}}
+        mock_diag.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_config_check_combined_with_repairs(self):

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -744,3 +744,138 @@ class TestGetSystemHealthDiagnostics:
         err_payload = json.loads(str(excinfo.value))
         assert err_payload["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "diagnostics_data_path" in err_payload["error"]["message"]
+
+
+class TestGetSystemHealthConfigCheck:
+    """Wire-up tests for ha_get_system_health's include='config_check' branch —
+    the folded-in replacement for the removed standalone ha_check_config tool."""
+
+    @pytest.mark.asyncio
+    async def test_config_check_populates_section_when_valid(self):
+        """include='config_check' calls client.check_config() (REST) and embeds
+        the result/is_valid/errors sub-dict the old ha_check_config returned."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health(include="config_check")
+        assert "config_check" in result
+        assert result["config_check"]["is_valid"] is True
+        assert result["config_check"]["result"] == "valid"
+        assert result["config_check"]["errors"] == []
+        client.check_config.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_config_check_surfaces_invalid_with_errors(self):
+        client = MagicMock()
+        client.check_config = AsyncMock(
+            return_value={"result": "invalid", "errors": ["bad yaml at line 3"]}
+        )
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health(include="config_check")
+        assert result["config_check"]["is_valid"] is False
+        assert result["config_check"]["result"] == "invalid"
+        assert result["config_check"]["errors"] == ["bad yaml at line 3"]
+
+    @pytest.mark.asyncio
+    async def test_config_check_absent_when_not_requested(self):
+        """No include → config_check section absent and check_config not called
+        (parity with test_no_sections_when_include_omitted)."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health()
+        client.check_config.assert_not_awaited()
+        assert "config_check" not in result
+
+    @pytest.mark.asyncio
+    async def test_config_check_backend_failure_embeds_error_not_raises(self):
+        """A check_config backend failure surfaces as an embedded error sub-dict;
+        the parent tool still succeeds (the _fetch_* never-raise convention)."""
+        client = MagicMock()
+        client.check_config = AsyncMock(side_effect=RuntimeError("boom"))
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health(include="config_check")
+        assert result.get("success") is True
+        assert "error" in result["config_check"]
+        assert "boom" in result["config_check"]["error"]
+        # Pin the safe baseline contract: on failure config must read as
+        # NOT valid so a caller never mistakes a transient error for "config OK".
+        assert result["config_check"]["is_valid"] is False
+        assert result["config_check"]["result"] == "unknown"
+        assert result["config_check"]["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_config_check_non_dict_check_config_result_embeds_error(self):
+        """client.check_config() returning None (non-dict) is caught and embedded
+        as an error, not raised (defensive boundary the old tool also had)."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value=None)
+        tools = SystemTools(client)
+        with _patch_health_info_baseline():
+            result = await tools.ha_get_system_health(include="config_check")
+        assert result.get("success") is True
+        assert "error" in result["config_check"]
+        assert result["config_check"]["is_valid"] is False
+
+    @pytest.mark.asyncio
+    async def test_config_check_returns_even_when_health_ws_unavailable(self):
+        """If the system_health WebSocket baseline fails, config_check (pure REST)
+        must STILL return — it must not be sunk by the WS dependency. This is the
+        graceful-degradation guarantee that keeps config_check as robust as the
+        REST-only ha_check_config tool it replaced."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+        with patch.object(
+            SystemTools,
+            "_fetch_health_info",
+            new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+        ):
+            result = await tools.ha_get_system_health(include="config_check")
+        assert result["success"] is True
+        assert result["config_check"]["is_valid"] is True
+        assert result["config_check"]["result"] == "valid"
+        client.check_config.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ws_backed_section_reported_unavailable_when_health_fails(self):
+        """When the health WS baseline fails, a requested WS-backed section
+        (repairs) is dropped with a warning rather than crashing the tool, while
+        the REST config_check still returns."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+        with patch.object(
+            SystemTools,
+            "_fetch_health_info",
+            new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+        ):
+            result = await tools.ha_get_system_health(include="repairs,config_check")
+        assert result["success"] is True
+        assert result["config_check"]["is_valid"] is True
+        assert "repairs" not in result
+        assert any("repairs" in w for w in result.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_config_check_combined_with_repairs(self):
+        """include='repairs,config_check' populates both — proves the standalone
+        ``if`` is not mutually exclusive with the ws-gather sections."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_repairs",
+                new=AsyncMock(return_value={"issues": [], "count": 0}),
+            ),
+        ):
+            result = await tools.ha_get_system_health(include="repairs,config_check")
+        assert "repairs" in result
+        assert "config_check" in result
+        assert result["config_check"]["is_valid"] is True


### PR DESCRIPTION
## What does this PR do?

Removes the standalone `ha_check_config` tool and folds its capability into
`ha_get_system_health` as a new `include="config_check"` section, shrinking the
naming-convention exception list (#1175) by one.

`ha_check_config` was a thin wrapper over `POST /config/core/check_config`. Its
two real trigger points are already automatic — `ha_restart` validates config
internally before restarting (unchanged), and the beta YAML-edit path runs a
post-edit check — so what remained was a standalone "is my config valid?" probe,
which is a health signal and belongs in `ha_get_system_health`.

This PR also hardens `ha_get_system_health`: when the caller requests a
REST-based section (`config_check` or `diagnostics`) and the `system_health/info`
WebSocket baseline is unavailable, the tool degrades gracefully — it returns the
REST section(s) with `baseline_available: false` plus a warning, and marks any
co-requested WS-backed sections (repairs/zha/zwave) with an `{error}` sub-dict
instead of sinking the whole call. A bare `ha_get_system_health()` or a WS-only
request still raises on a baseline failure (unchanged from master), since the
baseline itself is the deliverable. This keeps `config_check` as robust as the
pure-REST tool it replaces.

`ha_restart`'s internal config-validation safety guard is untouched (it calls
the REST client directly, not the tool).

**Migration:** `ha_check_config()` → `ha_get_system_health(include="config_check")`;
read `result["config_check"]["is_valid"]` (plus `result` / `errors`). The response
moves from top-level `{result, is_valid, errors}` to nested `result["config_check"]`,
and clients with a cached tools/list should re-list. Per AGENTS.md this is a
consolidation (functionality preserved), not a breaking change.

The generated catalogs (`site/src/data/tools.json`, README tool table,
`homeassistant-addon/DOCS.md`) are intentionally not hand-edited — `sync-tool-docs.yml`
regenerates them on merge.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — changed unit suites pass locally; the full suite + `@pytest.mark.system` e2e run on CI (Linux/Docker)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
