### PR TITLE
docs: add Codex low-token prompt guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository uses a worktree-based development workflow.
 - `CLAUDE.md` is a symlink pointing to `AGENTS.md`
 - Read either file - they're the same content
 - Commit changes to `AGENTS.md`, the symlink will automatically reflect them
+- Codex low-token delta: `prompts/PROJECT_CODEX_LOW_TOKEN_MODE_PROMPT.md`
 
 **Directory Structure:**
 ```

--- a/prompts/PROJECT_CODEX_LOW_TOKEN_MODE_PROMPT.md
+++ b/prompts/PROJECT_CODEX_LOW_TOKEN_MODE_PROMPT.md
@@ -1,0 +1,10 @@
+# Project Codex Low-Token Mode Prompt
+
+Используй этот prompt, когда работа идёт внутри `!projects/ha-mcp/`.
+
+- Базовый режим наследуется от root `prompts/CODEX_LOW_TOKEN_MODE_PROMPT.md`.
+- Для search-budget задач дополнительно используй root `prompts/CODEX_LOW_TOKEN_SEARCH_BUDGET_PROMPT.md`.
+- Сначала читай только `AGENTS.md`, `README.md`, `SECURITY.md`, `docs/FAQ.md` и минимальный набор runtime/build файлов: `pyproject.toml`, `src/`, `tests/`, `homeassistant-addon/`, `homeassistant-addon-dev/`.
+- Для кода открывай самый узкий нужный срез: сначала манифесты и entrypoints, затем только релевантные модули и тесты.
+- Для поиска используй `rg --files` и `rg -n`, доверяй `.rgignore`; `rg -uu` используй только если задача явно требует ignored paths.
+- Ответы и промежуточные апдейты держи компактными, если пользователь не запросил детальный разбор.


### PR DESCRIPTION
## Summary
- add a project-local `prompts/PROJECT_CODEX_LOW_TOKEN_MODE_PROMPT.md`
- reference that prompt from `AGENTS.md`
- document a small low-token read/search path for Codex inside `ha-mcp`

## Why
This brings `ha-mcp` in line with the workspace prompt-surface checks and gives Codex a minimal project-local delta before broad repository scans.

## Scope
- docs only
- no runtime or code-path changes
