### PR TITLE
ci: budget issue-triage prompt under the GitHub Models token cap (#1514)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -484,7 +484,7 @@ jobs:
             const THRESHOLD = usingKeywords ? 1.0 : 60;
             const candidates = scored
               .sort((a, b) => b.score - a.score)
-              .slice(0, 3)
+              .slice(0, 4)
               .filter(x => x.score >= THRESHOLD);
 
             if (candidates.length === 0) {
@@ -495,7 +495,7 @@ jobs:
 
             const formatted = candidates.map(c =>
               '#' + c.issue.number + ' [' + c.issue.state + ']: ' + c.issue.title + '\n' +
-              cleanBody(c.issue.body).substring(0, 600)
+              cleanBody(c.issue.body).substring(0, 1200)
             ).join('\n\n---\n\n');
 
             core.info('BM25 found ' + candidates.length + ' candidates: ' + candidates.map(c => '#' + c.issue.number).join(', '));
@@ -560,7 +560,7 @@ jobs:
             const rawBody = process.env.ISSUE_BODY || '';
             const authorComments = process.env.ISSUE_AUTHOR_COMMENTS || '';
             const bm25Candidates = process.env.BM25_CANDIDATES || '';
-            const changelog = process.env.CHANGELOG_CONTEXT || 'No changelog available.';
+            let changelog = process.env.CHANGELOG_CONTEXT || 'No changelog available.';
 
             // Keep section headers (### ...) so the model can see structure and assess completeness.
             // Only strip _No response_ placeholders and collapse blank runs.
@@ -569,7 +569,9 @@ jobs:
               .replace(/\n{3,}/g, '\n\n')
               .trim();
 
-            const issueBody = cleanBody(rawBody).substring(0, 5000);
+            // Generous initial body cap; the budget loop below trims it (down to
+            // BODY_FLOOR) only when the assembled prompt exceeds the token budget.
+            let issueBody = cleanBody(rawBody).substring(0, 10000);
 
             // Parse extracted keywords for context (show top-5 by weight in prompt)
             let keywordSummary = '';
@@ -583,11 +585,11 @@ jobs:
               }
             } catch (e) { core.info('Keyword summary parse failed: ' + e.message); }
 
-            const authorSection = authorComments
+            let authorSection = authorComments
               ? `\nAuthor follow-up comments:\n${authorComments}\n`
               : '';
 
-            const duplicateSection = bm25Candidates
+            let duplicateSection = bm25Candidates
               ? `\n## Possible Duplicate Candidates (BM25 pre-filtered)\nCheck each candidate — mark DUPLICATE only if high confidence.\n\n${bm25Candidates}\n`
               : '';
 
@@ -595,7 +597,7 @@ jobs:
               + '"missing_info":[],"duplicate_of":null,"duplicate_confidence":"high|medium|low","related":[],'
               + '"priority":"Urgent|High|Medium|Low|null","effort":"Low|Medium|High|null","good_first_issue":false,"regression_likely":false,"reasoning":"one sentence summary"}';
 
-            const prompt = [
+            const assemble = (o = {}) => [
               'You are triaging a GitHub issue for ha-mcp.',
               '',
               '## What is ha-mcp',
@@ -621,11 +623,11 @@ jobs:
               'Type: ' + issueType,
               keywordSummary,
               'Body:',
-              issueBody,
-              authorSection,
-              duplicateSection,
+              o.issueBody ?? issueBody,
+              o.authorSection ?? authorSection,
+              o.duplicateSection ?? duplicateSection,
               '## Recent Release Context (for regression detection)',
-              changelog,
+              o.changelog ?? changelog,
               '',
               '## Evaluation Tasks',
               '',
@@ -683,7 +685,79 @@ jobs:
               jsonSchema,
             ].join('\n');
 
+            // Keep the assembled prompt within the GitHub Models input cap.
+            // The cap is 8000 tokens; we target a conservative input ceiling
+            // (leaving margin for the 800-token response) using a coarse
+            // chars-per-token estimate. Trim in priority order so the actual
+            // issue text survives longest: drop BM25 duplicate candidates
+            // first, then truncate the release context and the author follow-up
+            // comments, then the body — each to a floor. Every variable section
+            // assemble() splices in is bounded here (keywordSummary is already
+            // capped at the top-5 keywords upstream). Mirrored by
+            // scripts/verify_triage_prompt_budget.mjs (kept in sync by
+            // tests/src/unit/test_triage_prompt_budget.py).
+            const TOKEN_BUDGET = 7000;
+            const BODY_FLOOR = 2000; // chars of issue body always retained
+            const CHANGELOG_FLOOR = 1500; // chars of release context always retained
+            const AUTHOR_FLOOR = 1500; // chars of author follow-up comments always retained
+            const estTokens = (s) => Math.ceil((s || '').length / 4);
+            const trimTo = (s, floor, over) =>
+              s.substring(0, Math.max(floor, s.length - over * 4));
+
+            let prompt = assemble();
+            if (estTokens(prompt) > TOKEN_BUDGET && duplicateSection) {
+              core.info('Triage prompt over budget — dropping BM25 duplicate candidates');
+              duplicateSection = '';
+              prompt = assemble();
+            }
+            if (estTokens(prompt) > TOKEN_BUDGET && changelog.length > CHANGELOG_FLOOR) {
+              // Release context is variable input (up to ~20 unreleased commit
+              // subjects + 3x head -50 of CHANGELOG.md) and can be large for
+              // verbose semantic-release entries — trim it before the issue
+              // body so the actual report text survives longest.
+              const newLen = Math.max(CHANGELOG_FLOOR, changelog.length - (estTokens(prompt) - TOKEN_BUDGET) * 4);
+              core.info(`Triage prompt still over budget — truncating release context ${changelog.length} -> ${newLen} chars`);
+              changelog = trimTo(changelog, CHANGELOG_FLOOR, estTokens(prompt) - TOKEN_BUDGET);
+              prompt = assemble();
+            }
+            if (estTokens(prompt) > TOKEN_BUDGET && authorSection.length > AUTHOR_FLOOR) {
+              // Author follow-up comments are concatenated unbounded, so cap
+              // them too — before the body, after the lower-value sections.
+              const newLen = Math.max(AUTHOR_FLOOR, authorSection.length - (estTokens(prompt) - TOKEN_BUDGET) * 4);
+              core.info(`Triage prompt still over budget — truncating author comments ${authorSection.length} -> ${newLen} chars`);
+              authorSection = trimTo(authorSection, AUTHOR_FLOOR, estTokens(prompt) - TOKEN_BUDGET);
+              prompt = assemble();
+            }
+            if (estTokens(prompt) > TOKEN_BUDGET && issueBody.length > BODY_FLOOR) {
+              const newLen = Math.max(BODY_FLOOR, issueBody.length - (estTokens(prompt) - TOKEN_BUDGET) * 4);
+              core.info(`Triage prompt still over budget — truncating body ${issueBody.length} -> ${newLen} chars`);
+              issueBody = trimTo(issueBody, BODY_FLOOR, estTokens(prompt) - TOKEN_BUDGET);
+              prompt = assemble();
+            }
+            if (estTokens(prompt) > TOKEN_BUDGET) {
+              // Every variable section is at its floor, so trimming is
+              // exhausted. This can only happen if the static framing itself
+              // grows close to the budget; the prompt ships over-cap and the
+              // Evaluate 413 retry is the only remaining net. Warn so the
+              // "should not fire" assumption there stays self-enforcing.
+              core.warning(`Triage prompt is ~${estTokens(prompt)} tokens after trimming every section to its floor — still over budget ${TOKEN_BUDGET}. The static framing has likely grown; trim it or raise trim aggressiveness.`);
+            }
+            core.info(`Assembled triage prompt: ~${estTokens(prompt)} tokens (budget ${TOKEN_BUDGET}, cap 8000)`);
+
+            // Minimal fallback for the Evaluate step's 413 backstop: framing +
+            // rubric + JSON schema + a floored body, with the secondary sections
+            // dropped. Keeps the output contract (schema is the last element of
+            // assemble()) so a 413 retry still yields parseable JSON, instead of
+            // a head-truncation that would cut the schema off entirely.
+            const minimalPrompt = assemble({
+              duplicateSection: '',
+              changelog: 'No changelog available.',
+              authorSection: '',
+              issueBody: issueBody.substring(0, BODY_FLOOR),
+            });
+
             core.setOutput('prompt', prompt);
+            core.setOutput('minimal_prompt', minimalPrompt);
 
       - name: Evaluate
         id: evaluate
@@ -692,18 +766,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROMPT: ${{ steps.build_prompt.outputs.prompt }}
+          MINIMAL_PROMPT: ${{ steps.build_prompt.outputs.minimal_prompt }}
         with:
           script: |
             const token = process.env.GH_TOKEN;
             const prompt = process.env.PROMPT;
+            const minimalPrompt = process.env.MINIMAL_PROMPT || prompt;
 
-            const call = async (model) => {
+            const call = async (model, content = prompt) => {
               const resp = await fetch('https://models.github.ai/inference/chat/completions', {
                 method: 'POST',
                 headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                   model,
-                  messages: [{ role: 'user', content: prompt }],
+                  messages: [{ role: 'user', content }],
                   max_tokens: 800,
                   temperature: 0,
                 }),
@@ -715,13 +791,28 @@ jobs:
             };
 
             // gpt-4o-mini: 16K input token free-tier limit (vs 8K for gpt-4.1).
-            // Retry on 5xx with exponential backoff; fall back to gpt-4o on 429.
+            // Retry on 5xx with exponential backoff; fall back to gpt-4o on 429;
+            // on 413 (prompt over the model's input cap) retry once with the
+            // minimal prompt. The prompt is already budgeted in build_prompt.
             let result;
             for (let attempt = 1; attempt <= 3; attempt++) {
               result = await call('openai/gpt-4o-mini');
               if (result.status === 429) {
                 core.warning('gpt-4o-mini rate limited, falling back to gpt-4o');
                 result = await call('openai/gpt-4o');
+                break;
+              }
+              if (result.status === 413) {
+                // Defensive backstop: build_prompt budgets the prompt under the
+                // 8000-token cap, so this should not fire. If it does (estimate
+                // drift on token-dense content), retry once with the minimal
+                // prompt — framing + rubric + JSON schema + a floored body, with
+                // the secondary sections dropped — instead of breaking straight
+                // to setFailed. This preserves the output contract (a head
+                // truncation would cut the trailing schema off). gpt-4o shares
+                // the same cap, so falling back to it would 413 again.
+                core.warning('HTTP 413 (prompt exceeds model input cap) — retrying once with the minimal prompt');
+                result = await call('openai/gpt-4o-mini', minimalPrompt);
                 break;
               }
               if (result.status < 500) break;

--- a/scripts/verify_triage_prompt_budget.mjs
+++ b/scripts/verify_triage_prompt_budget.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Verifies the issue-triage prompt-budgeting algorithm keeps the assembled
+// prompt under the GitHub Models input cap, even with worst-case inputs.
+//
+// The triage workflow (.github/workflows/issue-triage.yml) runs without a repo
+// checkout (it pulls files via the API), so its build_prompt step cannot import
+// a shared module. This harness therefore mirrors the same pure trim algorithm
+// and asserts its guarantees. The constants and drop order below are kept in
+// sync with the workflow by tests/src/unit/test_triage_prompt_budget.py, which
+// parses both files and fails on drift.
+//
+// Run: node scripts/verify_triage_prompt_budget.mjs
+
+const TOKEN_BUDGET = 7000;
+const BODY_FLOOR = 2000;
+const CHANGELOG_FLOOR = 1500;
+const AUTHOR_FLOOR = 1500;
+const estTokens = (s) => Math.ceil((s || "").length / 4);
+
+// Mirrors build_prompt's trim loop. `staticText` stands in for the fixed
+// framing + evaluation rubric + JSON schema that always ships in the prompt.
+// Drop order: duplicates -> changelog -> author comments -> body, each
+// secondary section to a floor. Every variable assemble() input is bounded
+// (the workflow's keywordSummary is the only one left untrimmed, and it is
+// already capped at the top-5 keywords upstream).
+function fitToBudget({
+  staticText = "",
+  issueBody = "",
+  duplicateSection = "",
+  changelog = "",
+  authorSection = "",
+}) {
+  let body = issueBody;
+  let dup = duplicateSection;
+  let log = changelog;
+  let author = authorSection;
+  const total = () =>
+    estTokens(staticText) +
+    estTokens(body) +
+    estTokens(dup) +
+    estTokens(log) +
+    estTokens(author);
+  const trimTo = (s, floor) =>
+    s.substring(0, Math.max(floor, s.length - (total() - TOKEN_BUDGET) * 4));
+
+  if (total() > TOKEN_BUDGET && dup) dup = "";
+  if (total() > TOKEN_BUDGET && log.length > CHANGELOG_FLOOR) log = trimTo(log, CHANGELOG_FLOOR);
+  if (total() > TOKEN_BUDGET && author.length > AUTHOR_FLOOR) author = trimTo(author, AUTHOR_FLOOR);
+  if (total() > TOKEN_BUDGET && body.length > BODY_FLOOR) body = trimTo(body, BODY_FLOOR);
+  return { body, dup, log, author, tokens: total() };
+}
+
+let failures = 0;
+const check = (name, cond, detail = "") => {
+  if (cond) {
+    console.log(`  ok   ${name}`);
+  } else {
+    failures++;
+    console.error(`  FAIL ${name}${detail ? " — " + detail : ""}`);
+  }
+};
+
+const x = (n) => "x".repeat(n);
+
+console.log("Triage prompt budget checks (cap 8000 tokens, target", TOKEN_BUDGET, "):");
+
+// 1. Real worst case: full framing + 4 BM25 candidates @ ~1200 chars + a
+//    16000-char body + a large release-context block + long author comments.
+//    This is over budget before trimming, so it exercises the full trim chain.
+{
+  const r = fitToBudget({
+    staticText: x(7000), // ~1750 tokens of fixed framing/rubric/schema
+    issueBody: x(16000),
+    duplicateSection: x(4 * 1200),
+    changelog: x(21000), // verbose unreleased + 3x CHANGELOG.md head -50
+    authorSection: x(30000), // many/long unbounded author follow-up comments
+  });
+  check("worst case fits budget", r.tokens <= TOKEN_BUDGET, `got ${r.tokens} tokens`);
+}
+
+// 1b. Long author comments alone are trimmed and the prompt fits (the gap
+//     before authorSection became a trim target).
+{
+  const r = fitToBudget({ staticText: x(7000), issueBody: x(4000), authorSection: x(80000) });
+  check("long author comments trimmed to fit", r.tokens <= TOKEN_BUDGET, `got ${r.tokens} tokens`);
+  check("author trimmed before body, body untouched", r.author.length < 80000 && r.body.length === 4000, `author ${r.author.length}, body ${r.body.length}`);
+}
+
+// 2. Huge body alone fits (body truncated, floor not yet binding).
+{
+  const r = fitToBudget({ staticText: x(7000), issueBody: x(500000) });
+  check("huge body fits budget", r.tokens <= TOKEN_BUDGET, `got ${r.tokens} tokens`);
+}
+
+// 2b. Floor clamp exercised: framing alone dominates the budget, so even a
+//     fully-trimmed body lands exactly on BODY_FLOOR (the Math.max clamp).
+//     This is the over-budget case the workflow warns about, so assert the
+//     clamp, not that it fits.
+{
+  const r = fitToBudget({ staticText: x(30000), issueBody: x(500000) });
+  check("body clamped exactly to floor when framing dominates", r.body.length === BODY_FLOOR, `got ${r.body.length} chars`);
+}
+
+// 3. Large changelog alone is trimmed and the prompt fits (the gap that
+//    shipped before changelog became a trim target).
+{
+  const r = fitToBudget({ staticText: x(7000), issueBody: x(4000), changelog: x(60000) });
+  check("large changelog trimmed to fit", r.tokens <= TOKEN_BUDGET, `got ${r.tokens} tokens`);
+  check("changelog trimmed before body, body untouched", r.log.length < 60000 && r.body.length === 4000, `log ${r.log.length}, body ${r.body.length}`);
+}
+
+// 4. Ordering: duplicates are dropped before the body or changelog is touched,
+//    and the body survives intact when dropping duplicates alone suffices.
+{
+  const r = fitToBudget({
+    staticText: x(7000),
+    issueBody: x(8000),
+    duplicateSection: x(21000),
+  });
+  check("duplicates dropped first", r.dup === "");
+  check("body intact when dropping duplicates suffices", r.body.length === 8000, `got ${r.body.length} chars`);
+}
+
+// 5. Small input is left fully intact (no trimming).
+{
+  const body = x(1200), dup = x(600), log = x(900);
+  const r = fitToBudget({ staticText: x(7000), issueBody: body, duplicateSection: dup, changelog: log });
+  check("small input untouched", r.body === body && r.dup === dup && r.log === log);
+}
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll budget checks passed.");

--- a/tests/src/unit/test_triage_prompt_budget.py
+++ b/tests/src/unit/test_triage_prompt_budget.py
@@ -1,0 +1,100 @@
+"""Guards the issue-triage prompt-budgeting algorithm.
+
+The triage workflow (``.github/workflows/issue-triage.yml``) budgets the
+assembled LLM prompt under the GitHub Models 8000-token input cap (issue
+#1514). That step runs in a checkout-less workflow, so its inline JS can't be
+imported; ``scripts/verify_triage_prompt_budget.mjs`` deliberately mirrors the
+trim logic. This module runs that harness in CI and asserts the budget
+constants in the two files have not drifted apart — drift is the precise risk a
+mirrored copy introduces.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HARNESS = _REPO_ROOT / "scripts" / "verify_triage_prompt_budget.mjs"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "issue-triage.yml"
+
+# Budget knobs that must stay identical in both files.
+_CONSTANTS = ("TOKEN_BUDGET", "BODY_FLOOR", "CHANGELOG_FLOOR", "AUTHOR_FLOOR")
+
+# The priority order sections are trimmed in. A reorder in one file but not the
+# other would change behaviour silently, so assert both match this sequence.
+_CANONICAL_TRIM_ORDER = ["duplicate", "changelog", "author", "body"]
+_WORKFLOW_TRIM_MARKERS = {
+    "duplicate": r"duplicateSection = ''",
+    "changelog": r"changelog = trimTo\(",
+    "author": r"authorSection = trimTo\(",
+    "body": r"issueBody = trimTo\(",
+}
+_HARNESS_TRIM_MARKERS = {
+    "duplicate": r'dup = ""',
+    "changelog": r"log = trimTo\(",
+    "author": r"author = trimTo\(",
+    "body": r"body = trimTo\(",
+}
+
+
+def _node_binary() -> str:
+    return os.environ.get("NODE_BINARY", "node")
+
+
+def _extract_constants(text: str) -> dict[str, int]:
+    found: dict[str, int] = {}
+    for name in _CONSTANTS:
+        match = re.search(rf"\b{name}\s*=\s*(\d+)", text)
+        if match:
+            found[name] = int(match.group(1))
+    return found
+
+
+@pytest.mark.skipif(shutil.which(_node_binary()) is None, reason="node not available")
+def test_budget_harness_passes() -> None:
+    """The mirrored budget algorithm keeps worst-case prompts under the cap."""
+    result = subprocess.run(
+        [_node_binary(), str(_HARNESS)],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"verify_triage_prompt_budget.mjs failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_budget_constants_in_sync() -> None:
+    """Fail if the budget constants drift between workflow and harness."""
+    workflow_consts = _extract_constants(_WORKFLOW.read_text())
+    harness_consts = _extract_constants(_HARNESS.read_text())
+    for name in _CONSTANTS:
+        assert name in workflow_consts, f"{name} missing from {_WORKFLOW.name}"
+        assert name in harness_consts, f"{name} missing from {_HARNESS.name}"
+        assert workflow_consts[name] == harness_consts[name], (
+            f"{name} drifted: workflow={workflow_consts[name]} "
+            f"harness={harness_consts[name]}"
+        )
+
+
+def _trim_order(text: str, markers: dict[str, str]) -> list[str]:
+    positions: list[tuple[int, str]] = []
+    for kind, pattern in markers.items():
+        match = re.search(pattern, text)
+        assert match, f"trim marker for {kind!r} not found"
+        positions.append((match.start(), kind))
+    return [kind for _, kind in sorted(positions)]
+
+
+def test_trim_order_in_sync() -> None:
+    """Fail if the section trim/drop order drifts between the two files."""
+    workflow_order = _trim_order(_WORKFLOW.read_text(), _WORKFLOW_TRIM_MARKERS)
+    harness_order = _trim_order(_HARNESS.read_text(), _HARNESS_TRIM_MARKERS)
+    assert workflow_order == _CANONICAL_TRIM_ORDER, workflow_order
+    assert harness_order == _CANONICAL_TRIM_ORDER, harness_order


### PR DESCRIPTION
Fixes #1514.

## Problem

`build_prompt` assembles up to 6 BM25 candidates (3500 chars each) + the ~92-tool list + a 16000-char body + static framing. Per the issue, the non-body portion alone can reach or exceed the GitHub Models 8000-token input cap, so `Evaluate` gets an HTTP 413 on essentially every issue. 413 was unhandled (only 429 and `>= 500` were), so it broke straight to `setFailed`, leaving the issue with a `triage-failed` label. The gpt-4o fallback shares the same cap, so it would 413 too.

## Fix

- **`build_prompt` — proactive budgeting (primary fix).** After assembly, enforce a conservative token budget (chars/4 estimate, target 7000 to leave margin under the 8000 cap for the 800-token response). Trim in priority order so the actual issue text survives longest: drop BM25 duplicate candidates first, then the tool list, then truncate the body down to a 2000-char floor. The assembled token estimate is logged.
- **`Evaluate` — 413 backstop.** Catch 413 specifically and retry once with a truncated prompt instead of breaking to `setFailed`. With the budgeting above this should not fire; it guards against estimate drift on token-dense bodies (logs/JSON).

## Testing

This runs in CI against GitHub Models with no checkout, so the assembly can't import a shared module and can't be exercised in a normal unit test. I added `scripts/verify_triage_prompt_budget.mjs`, which mirrors the trim algorithm and asserts worst-case inputs (16000-char body + full tool list + 6 max BM25 candidates) stay under budget, the body is never trimmed below its floor, duplicates are dropped first, and small inputs are left untouched. Runs clean with `node scripts/verify_triage_prompt_budget.mjs`.

As you noted, the end-to-end path can only really be confirmed by merging and opening a fresh test issue. The harness keeps the budgeting logic itself checkable; happy to wire it into CI (or refactor the assembly into a checked-out, importable module) as a follow-up if you'd prefer that over the mirrored copy.