### PR TITLE
test: capture reasoning tokens and detect inert --no-think in BAT openai agent

### DIFF
--- a/tests/uat/AGENTS.md
+++ b/tests/uat/AGENTS.md
@@ -26,5 +26,5 @@ UV_CACHE_DIR=/tmp/claude-1000/uv-cache TMPDIR=/tmp/claude-1000 \
 
 Key flags:
 - `--mcp-env KEY=VALUE` — pass env vars to the MCP server (repeatable)
-- `--no-think` — disable reasoning mode for qwen3 and compatible models
+- `--no-think` disables reasoning: prepends /no_think (original Qwen3) and sends the enable_thinking=false chat-template kwarg (Qwen3.5/3.6)
 - `--results-file` — JSONL file to append results to (default: `local/uat-results.jsonl`)

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -96,7 +96,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-think",
         action="store_true",
-        help="Prepend /no_think to disable reasoning mode (qwen3 and compatible models)",
+        help=(
+            "Disable reasoning mode: prepends /no_think (original Qwen3) and "
+            "sends enable_thinking=false chat-template kwarg (Qwen3.5/3.6, "
+            "honored by vLLM/llama-server)"
+        ),
     )
     parser.add_argument(
         "--max-tokens",
@@ -127,6 +131,7 @@ async def tool_call_loop(
     tools: list[dict],
     mcp_client: MCPClient,
     max_tokens: int = DEFAULT_MAX_TOKENS,
+    no_think: bool = False,
     tool_trace_sink: list[str] | None = None,
 ) -> dict:
     """Run the LLM tool-call loop until a final text response or iteration limit.
@@ -142,12 +147,24 @@ async def tool_call_loop(
     total_fail = 0
     tokens_input = 0
     tokens_output = 0
+    tokens_thoughts = 0
     tokens_first_input: int | None = None
+    no_think_warned = False
 
     for _ in range(MAX_TOOL_LOOP_ITERATIONS):
         kwargs = {"model": model, "messages": messages, "max_tokens": max_tokens}
         if tools:
             kwargs["tools"] = tools
+        if no_think:
+            # Qwen3.5/3.6 dropped the in-band ``/no_think`` soft switch (still
+            # prepended below for older Qwen3) and moved reasoning control to
+            # the ``enable_thinking`` chat-template kwarg. Pass it via
+            # extra_body for servers that honor it (recent llama-server, vLLM).
+            # Servers that don't either silently ignore it (reasoning stays on)
+            # or reject the unknown field with HTTP 400; LM Studio's support
+            # varies by version. The reasoning-token check below warns when the
+            # model kept reasoning despite this request, so a no-op is visible.
+            kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
 
         response = await client.chat.completions.create(**kwargs)
         num_turns += 1
@@ -156,10 +173,18 @@ async def tool_call_loop(
         # idle context baseline.  If a turn's usage is None (some local servers
         # omit it), tokens_first_input stays None until the first turn that does
         # report usage — so it reflects "first available" rather than "turn 1".
+        reasoning_this_turn = 0
         if response.usage:
             prompt_toks = response.usage.prompt_tokens or 0
             tokens_input += prompt_toks
             tokens_output += response.usage.completion_tokens or 0
+            # reasoning_tokens (when reported, e.g. LM Studio / o1-style usage) is
+            # a subset of completion_tokens; track it so a run can show how much
+            # output was reasoning. Absent or null on backends that don't report.
+            details = getattr(response.usage, "completion_tokens_details", None)
+            raw_reasoning = getattr(details, "reasoning_tokens", None)
+            reasoning_this_turn = raw_reasoning if isinstance(raw_reasoning, int) else 0
+            tokens_thoughts += reasoning_this_turn
             if tokens_first_input is None:
                 tokens_first_input = prompt_toks
 
@@ -170,6 +195,32 @@ async def tool_call_loop(
             )
         choice = response.choices[0]
         message = choice.message
+
+        # If --no-think was requested but the model still reasoned, the backend
+        # didn't honor it (e.g. LM Studio can't map enable_thinking to some
+        # Qwen3.6 GGUFs). Warn once so the no-op is visible instead of silently
+        # paying full reasoning-decode cost. reasoning_tokens is the structured
+        # signal; reasoning_content and an inline <think> block in content cover
+        # servers that emit reasoning without a separate token detail.
+        if no_think and not no_think_warned:
+            still_reasoning = (
+                reasoning_this_turn
+                or getattr(message, "reasoning_content", None)
+                or "<think>" in (message.content or "")
+            )
+            if still_reasoning:
+                detail = (
+                    f"{reasoning_this_turn} reasoning tokens"
+                    if reasoning_this_turn
+                    else "reasoning in output, token count unavailable"
+                )
+                logger.warning(
+                    "--no-think requested but model %s still produced reasoning "
+                    "(%s); backend may not honor enable_thinking",
+                    model,
+                    detail,
+                )
+                no_think_warned = True
 
         # No tool calls — we have a final response
         if not message.tool_calls:
@@ -184,6 +235,7 @@ async def tool_call_loop(
                 "tokens_input": tokens_input,
                 "tokens_first_input": tokens_first_input,
                 "tokens_output": tokens_output,
+                "tokens_thoughts": tokens_thoughts,
                 "cost_usd": 0,
             }
 
@@ -245,9 +297,7 @@ async def tool_call_loop(
                 # Server-side WARNING log already shows the failure details;
                 # only record to the trace sink for test artifacts.
                 if tool_trace_sink is not None:
-                    tool_trace_sink.append(
-                        f"[tool] {tool_name} failed: {err_text}"
-                    )
+                    tool_trace_sink.append(f"[tool] {tool_name} failed: {err_text}")
 
             messages.append(
                 {
@@ -272,6 +322,7 @@ async def tool_call_loop(
         "tokens_input": tokens_input,
         "tokens_first_input": tokens_first_input,
         "tokens_output": tokens_output,
+        "tokens_thoughts": tokens_thoughts,
         "cost_usd": 0,
     }
 
@@ -343,6 +394,7 @@ async def run_scenario_inline(
         openai_tools,
         mcp_client,
         max_tokens=max_tokens,
+        no_think=no_think,
         tool_trace_sink=tool_trace_sink,
     )
     result["model"] = model

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -206,7 +206,7 @@ async def tool_call_loop(
             still_reasoning = (
                 reasoning_this_turn
                 or getattr(message, "reasoning_content", None)
-                or "<think>" in (message.content or "")
+                or "<think>" in (message.content or "").lower()
             )
             if still_reasoning:
                 detail = (

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -62,7 +62,9 @@ class SuggestingArgumentParser(argparse.ArgumentParser):
         match = re.search(r"unrecognized arguments?: (--\S+)", message)
         if match:
             known = [opt for opt in self._option_string_actions if opt.startswith("--")]
-            suggestions = difflib.get_close_matches(match.group(1), known, n=1, cutoff=0.6)
+            suggestions = difflib.get_close_matches(
+                match.group(1), known, n=1, cutoff=0.6
+            )
             if suggestions:
                 message = f"{message} (did you mean {suggestions[0]}?)"
         super().error(message)
@@ -341,6 +343,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
         cost_usd = None
         tokens_input = None
         tokens_output = None
+        tokens_thoughts = None
         tokens_first_input = None
         if raw_json and isinstance(raw_json, dict):
             # Claude JSON format
@@ -359,6 +362,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
             # OpenAI agent token counts and first-input baseline (included directly in JSON output)
             tokens_input = raw_json.get("tokens_input")
             tokens_output = raw_json.get("tokens_output")
+            tokens_thoughts = raw_json.get("tokens_thoughts")
             tokens_first_input = raw_json.get("tokens_first_input")
 
         result: dict = {
@@ -380,6 +384,8 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
             result["tokens_input"] = tokens_input
         if tokens_output is not None:
             result["tokens_output"] = tokens_output
+        if tokens_thoughts is not None:
+            result["tokens_thoughts"] = tokens_thoughts
         if tokens_first_input is not None:
             result["tokens_first_input"] = tokens_first_input
         if raw_json is not None:
@@ -597,6 +603,8 @@ def make_phase_summary(phase_key: str, phase_result: dict) -> dict:
         summary["tokens_input"] = phase_result["tokens_input"]
     if phase_result.get("tokens_output") is not None:
         summary["tokens_output"] = phase_result["tokens_output"]
+    if phase_result.get("tokens_thoughts") is not None:
+        summary["tokens_thoughts"] = phase_result["tokens_thoughts"]
     return summary
 
 
@@ -690,7 +698,7 @@ async def run(args: argparse.Namespace) -> dict:
         if sys.stdin.isatty():
             raise ValueError(
                 "No scenario provided. Pipe scenario JSON via stdin, or pass --scenario-file.\n"
-                "  echo '{\"test_prompt\":\"...\"}' | uv run python tests/uat/run_uat.py --agents gemini\n"
+                '  echo \'{"test_prompt":"..."}\' | uv run python tests/uat/run_uat.py --agents gemini\n'
                 "  uv run python tests/uat/run_uat.py --scenario-file scenario.json --agents gemini\n"
                 "For the pre-built story catalog, use tests/uat/stories/run_story.py --all."
             )
@@ -743,7 +751,9 @@ async def run(args: argparse.Namespace) -> dict:
 
     try:
         logger.info(f"HA: {ha_url}")
-        logger.info(f"MCP source: {mcp_source}" + (f" ({args.branch})" if args.branch else ""))
+        logger.info(
+            f"MCP source: {mcp_source}" + (f" ({args.branch})" if args.branch else "")
+        )
         logger.info(f"Agents: {', '.join(active_agents)}")
 
         extra_env = parse_mcp_env(
@@ -851,7 +861,11 @@ Examples:
     parser.add_argument(
         "--no-think",
         action="store_true",
-        help="Prepend /no_think to disable reasoning mode (qwen3 and compatible models)",
+        help=(
+            "Disable reasoning mode: prepends /no_think (original Qwen3) and "
+            "sends enable_thinking=false chat-template kwarg (Qwen3.5/3.6, "
+            "honored by vLLM/llama-server)"
+        ),
     )
     parser.add_argument(
         "--mcp-env",

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -273,9 +273,7 @@ def _find_latest_session_file(agent: str, after: float) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-async def _run_mcp_steps(
-    mcp_client: MCPClient, steps: list[dict], phase: str
-) -> None:
+async def _run_mcp_steps(mcp_client: MCPClient, steps: list[dict], phase: str) -> None:
     """Execute setup or teardown steps via a shared in-memory MCP client."""
     for step in steps:
         tool_name = step["tool"]
@@ -428,6 +426,7 @@ async def _run_test_prompt_inline(
         "tool_stats": result.get("tool_stats"),
         "tokens_input": result.get("tokens_input"),
         "tokens_output": result.get("tokens_output"),
+        "tokens_thoughts": result.get("tokens_thoughts"),
         "tool_trace": tool_trace,
         "cost_usd": result.get("cost_usd", 0),
     }
@@ -624,13 +623,22 @@ def append_result(
         ti = test_phase.get("tokens_input")
         to = test_phase.get("tokens_output")
         if ti is not None or to is not None:
-            tokens = {"input": ti or 0, "output": to or 0, "cached": 0, "thoughts": 0}
+            # reasoning_tokens are a subset of completion_tokens, so tokens_output
+            # already counts them; tokens_thoughts is the informational breakdown.
+            tokens = {
+                "input": ti or 0,
+                "output": to or 0,
+                "cached": 0,
+                "thoughts": test_phase.get("tokens_thoughts") or 0,
+            }
     if tokens:
         record["tokens_input"] = tokens["input"]
         record["tokens_output"] = tokens["output"]
         record["tokens_cached"] = tokens["cached"]
         record["tokens_thoughts"] = tokens["thoughts"]
-        record["tokens_billable"] = (tokens["input"] - tokens["cached"]) + tokens["output"]
+        record["tokens_billable"] = (tokens["input"] - tokens["cached"]) + tokens[
+            "output"
+        ]
 
     # First-turn input tokens: most direct measure of idle context size (openai agent only).
     # Comes from aggregate (not test_phase) since make_phase_summary doesn't propagate it.
@@ -742,7 +750,9 @@ async def run_stories(
                     )
                     agent_stack.push_async_callback(openai_client.close)
                 except Exception as e:
-                    error_msg = f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
+                    error_msg = (
+                        f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
+                    )
                     logger.error(f"[{agent}] {error_msg}")
                     _record_setup_failure(
                         filtered,
@@ -764,7 +774,9 @@ async def run_stories(
                     openai_tools = await fetch_openai_tools(
                         inline_mcp_client, max_tools=args.max_tools
                     )
-                    logger.info(f"[{agent}] MCP server ready ({len(openai_tools)} tools)")
+                    logger.info(
+                        f"[{agent}] MCP server ready ({len(openai_tools)} tools)"
+                    )
                 except Exception as e:
                     error_msg = f"Failed to start MCP server: {type(e).__name__}: {e}"
                     logger.error(f"[{agent}] {error_msg}")
@@ -814,7 +826,9 @@ async def run_stories(
                         openai_client is not None
                         and inline_mcp_client is not None
                         and resolved_model is not None
-                    ), "inline setup invariant: clients/model are populated when use_inline is True"
+                    ), (
+                        "inline setup invariant: clients/model are populated when use_inline is True"
+                    )
                     rc, summary = await _run_test_prompt_inline(
                         story["prompt"],
                         agent_name=agent,
@@ -862,7 +876,9 @@ async def run_stories(
                         .get("test", {})
                         .get("output", "")
                     )
-                    logger.info(f"[{agent}/{sid}] Verifying {len(ha_checks)} ha_check(s)...")
+                    logger.info(
+                        f"[{agent}/{sid}] Verifying {len(ha_checks)} ha_check(s)..."
+                    )
                     verify_results = await verify_ha_checks(
                         ha_url, ha_token, ha_checks, agent_output, shared_mcp
                     )
@@ -876,7 +892,12 @@ async def run_stories(
                     else:
                         logger.info(f"[{agent}/{sid}] All checks passed")
 
-                agg = (summary or {}).get("agents", {}).get(agent, {}).get("aggregate", {})
+                agg = (
+                    (summary or {})
+                    .get("agents", {})
+                    .get(agent, {})
+                    .get("aggregate", {})
+                )
                 passed = _compute_passed(
                     exit_code=rc,
                     tool_calls=agg.get("total_tool_calls"),
@@ -978,7 +999,11 @@ def main() -> None:
     parser.add_argument(
         "--no-think",
         action="store_true",
-        help="Prepend /no_think to disable reasoning mode (qwen3 and compatible models)",
+        help=(
+            "Disable reasoning mode: prepends /no_think (original Qwen3) and "
+            "sends enable_thinking=false chat-template kwarg (Qwen3.5/3.6, "
+            "honored by vLLM/llama-server)"
+        ),
     )
     parser.add_argument(
         "--max-tokens",

--- a/tests/uat/stories/test_run_story_record.py
+++ b/tests/uat/stories/test_run_story_record.py
@@ -1,0 +1,49 @@
+"""Unit tests for run_story.append_result token-record threading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from uat.stories.run_story import append_result
+
+_STORY = {"id": "s01", "category": "automation", "weight": 5}
+
+
+def _bat_summary(test_phase: dict) -> dict:
+    return {"agents": {"openai": {"test": test_phase, "aggregate": {}}}}
+
+
+def _write_and_read(tmp_path: Path, test_phase: dict) -> dict:
+    results_file = tmp_path / "results.jsonl"
+    append_result(
+        results_file,
+        _STORY,
+        "openai",
+        sha="abc123",
+        describe="test",
+        branch=None,
+        bat_summary=_bat_summary(test_phase),
+        passed=True,
+    )
+    return json.loads(results_file.read_text().splitlines()[-1])
+
+
+def test_tokens_thoughts_threaded_into_record(tmp_path):
+    """tokens_thoughts from the phase summary lands in the JSONL record."""
+    record = _write_and_read(
+        tmp_path,
+        {"tokens_input": 100, "tokens_output": 235, "tokens_thoughts": 220},
+    )
+    assert record["tokens_thoughts"] == 220
+    # reasoning is a subset of output, so billable must not double-count it.
+    assert record["tokens_billable"] == 100 + 235
+
+
+def test_tokens_thoughts_defaults_to_zero_when_absent(tmp_path):
+    """A phase summary without tokens_thoughts records 0, not a crash."""
+    record = _write_and_read(
+        tmp_path,
+        {"tokens_input": 100, "tokens_output": 50},
+    )
+    assert record["tokens_thoughts"] == 0

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -319,11 +319,14 @@ class TestToolCallLoop:
 
     @pytest.mark.asyncio
     async def test_no_think_warns_on_inline_think_block(self, caplog):
-        """Warn when reasoning is inlined as a <think> block with no structured signal."""
+        """Warn when reasoning is inlined as a <think> block with no structured signal.
+
+        Uses uppercase tags to also pin the case-insensitive detection.
+        """
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "<think>17*23</think>391."
+        mock_response.choices[0].message.content = "<THINK>17*23</THINK>391."
         mock_response.choices[0].message.tool_calls = None
         mock_response.choices[0].message.reasoning_content = None
         mock_response.usage = MagicMock(

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -104,7 +104,7 @@ class TestToolCallLoop:
         mock_response.choices[0].message.tool_calls = None
         mock_response.choices[0].finish_reason = "stop"
         mock_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50)
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         result = await openai_agent.tool_call_loop(
             client=mock_client,
@@ -120,6 +120,272 @@ class TestToolCallLoop:
         assert result["tokens_input"] == 100
         assert result["tokens_output"] == 50
         assert result["cost_usd"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_think_sends_enable_thinking_false(self):
+        """no_think=True sends the enable_thinking=false chat-template kwarg.
+
+        Qwen3.5/3.6 ignore the in-band ``/no_think`` token, so disabling
+        reasoning relies on this extra_body kwarg reaching the server.
+        """
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=5,
+            completion_tokens_details=MagicMock(reasoning_tokens=0),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        await openai_agent.tool_call_loop(
+            client=mock_client,
+            model="qwen3.6",
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=[],
+            mcp_client=AsyncMock(),
+            no_think=True,
+        )
+
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_think_default_omits_extra_body(self):
+        """Default (no_think=False) sends no extra_body, leaving other models untouched."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        await openai_agent.tool_call_loop(
+            client=mock_client,
+            model="some-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=[],
+            mcp_client=AsyncMock(),
+        )
+
+        _, kwargs = mock_client.chat.completions.create.call_args
+        assert "extra_body" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_think_warns_when_backend_still_reasons(self, caplog):
+        """Warn when --no-think is set but the model still returns reasoning tokens."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=235,
+            completion_tokens_details=MagicMock(reasoning_tokens=220),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with caplog.at_level("WARNING"):
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "Hello"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+                no_think=True,
+            )
+
+        assert any("still produced reasoning" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_think_silent_when_backend_honors_it(self, caplog):
+        """No warning when reasoning is actually suppressed (zero reasoning tokens)."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=5,
+            completion_tokens_details=MagicMock(reasoning_tokens=0),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with caplog.at_level("WARNING"):
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "Hello"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+                no_think=True,
+            )
+
+        assert not any("still produced reasoning" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_reasoning_tokens_captured_in_tokens_thoughts(self):
+        """reasoning_tokens from completion_tokens_details flows into tokens_thoughts."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "391."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=23,
+            completion_tokens=235,
+            completion_tokens_details=MagicMock(reasoning_tokens=220),
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        result = await openai_agent.tool_call_loop(
+            client=mock_client,
+            model="qwen3.6",
+            messages=[{"role": "user", "content": "17*23?"}],
+            tools=[],
+            mcp_client=AsyncMock(),
+        )
+
+        assert result["tokens_thoughts"] == 220
+        assert result["tokens_output"] == 235
+
+    @pytest.mark.asyncio
+    async def test_tokens_thoughts_zero_when_backend_omits_details(self):
+        """Backends without completion_tokens_details report zero thoughts, not a crash."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=5,
+            completion_tokens_details=None,
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        result = await openai_agent.tool_call_loop(
+            client=mock_client,
+            model="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            mcp_client=AsyncMock(),
+        )
+
+        assert result["tokens_thoughts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_no_think_warns_on_reasoning_content_without_token_detail(
+        self, caplog
+    ):
+        """Warn via reasoning_content when the backend reports no reasoning token count."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "391."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = "let me think..."
+        mock_response.usage = MagicMock(
+            prompt_tokens=10, completion_tokens=5, completion_tokens_details=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with caplog.at_level("WARNING"):
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+                no_think=True,
+            )
+
+        msgs = [
+            r.message for r in caplog.records if "still produced reasoning" in r.message
+        ]
+        assert len(msgs) == 1
+        assert "token count unavailable" in msgs[0]
+
+    @pytest.mark.asyncio
+    async def test_no_think_warns_on_inline_think_block(self, caplog):
+        """Warn when reasoning is inlined as a <think> block with no structured signal."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "<think>17*23</think>391."
+        mock_response.choices[0].message.tool_calls = None
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.usage = MagicMock(
+            prompt_tokens=10, completion_tokens=5, completion_tokens_details=None
+        )
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        with caplog.at_level("WARNING"):
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+                no_think=True,
+            )
+
+        assert any("still produced reasoning" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_think_warns_only_once_across_turns(self, caplog):
+        """The warning fires at most once even when every turn keeps reasoning."""
+
+        def _reasoning_resp(content, tool_calls):
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = content
+            resp.choices[0].message.tool_calls = tool_calls
+            resp.choices[0].message.reasoning_content = None
+            resp.usage = MagicMock(
+                prompt_tokens=10,
+                completion_tokens=60,
+                completion_tokens_details=MagicMock(reasoning_tokens=50),
+            )
+            return resp
+
+        tc = MagicMock()
+        tc.id = "call_1"
+        tc.function.name = "some_tool"
+        tc.function.arguments = "{}"
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_reasoning_resp(None, [tc]), _reasoning_resp("done", None)]
+        )
+        mock_mcp = AsyncMock()
+        mock_mcp.call_tool.return_value = MagicMock(content=[MagicMock(text="ok")])
+
+        with caplog.at_level("WARNING"):
+            result = await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=[],
+                mcp_client=mock_mcp,
+                no_think=True,
+            )
+
+        warnings = [
+            r for r in caplog.records if "still produced reasoning" in r.message
+        ]
+        assert len(warnings) == 1
+        assert result["tokens_thoughts"] == 100  # 50 per turn, accumulated
 
     @pytest.mark.asyncio
     async def test_single_tool_call(self):
@@ -147,7 +413,7 @@ class TestToolCallLoop:
         resp2.choices[0].finish_reason = "stop"
         resp2.usage = MagicMock(prompt_tokens=300, completion_tokens=20)
 
-        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_client.chat.completions.create = AsyncMock(side_effect=[resp1, resp2])
 
         # Mock MCP client
         mock_mcp = AsyncMock()
@@ -195,7 +461,7 @@ class TestToolCallLoop:
         resp2.choices[0].message.tool_calls = None
         resp2.usage = MagicMock(prompt_tokens=200, completion_tokens=10)
 
-        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_client.chat.completions.create = AsyncMock(side_effect=[resp1, resp2])
 
         mock_mcp = AsyncMock()
         mock_mcp.call_tool.side_effect = RuntimeError("Tool not found")
@@ -234,7 +500,7 @@ class TestToolCallLoop:
         resp2.choices[0].message.tool_calls = None
         resp2.usage = MagicMock(prompt_tokens=20, completion_tokens=5)
 
-        mock_client.chat.completions.create.side_effect = [resp1, resp2]
+        mock_client.chat.completions.create = AsyncMock(side_effect=[resp1, resp2])
 
         mock_mcp = AsyncMock()
 
@@ -267,9 +533,13 @@ class TestToolCallLoop:
         resp.choices = [MagicMock()]
         resp.choices[0].message.content = None
         resp.choices[0].message.tool_calls = [tool_call]
-        resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+        resp.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=15,
+            completion_tokens_details=MagicMock(reasoning_tokens=5),
+        )
 
-        mock_client.chat.completions.create.return_value = resp
+        mock_client.chat.completions.create = AsyncMock(return_value=resp)
 
         mock_mcp = AsyncMock()
         mock_mcp.call_tool.return_value = MagicMock(content=[MagicMock(text="ok")])
@@ -287,6 +557,9 @@ class TestToolCallLoop:
         assert (
             result["tool_stats"]["totalCalls"] == openai_agent.MAX_TOOL_LOOP_ITERATIONS
         )
+        # tokens_thoughts accumulates across every turn and is reported at the
+        # max-iterations exit too (not just the final-response exit).
+        assert result["tokens_thoughts"] == 5 * openai_agent.MAX_TOOL_LOOP_ITERATIONS
 
     @pytest.mark.asyncio
     async def test_null_usage_handled(self):
@@ -297,7 +570,7 @@ class TestToolCallLoop:
         mock_response.choices[0].message.content = "Result."
         mock_response.choices[0].message.tool_calls = None
         mock_response.usage = None
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         result = await openai_agent.tool_call_loop(
             client=mock_client,
@@ -318,7 +591,7 @@ class TestToolCallLoop:
         mock_response = MagicMock()
         mock_response.choices = []
         mock_response.usage = None
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with pytest.raises(RuntimeError, match="empty choices"):
             await openai_agent.tool_call_loop(
@@ -328,6 +601,59 @@ class TestToolCallLoop:
                 tools=[],
                 mcp_client=AsyncMock(),
             )
+
+
+class TestRunScenarioInline:
+    """Test the scenario wrapper that owns the /no_think prepend and threading."""
+
+    @staticmethod
+    def _mock_client():
+        client = MagicMock()
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "Done."
+        resp.choices[0].message.tool_calls = None
+        resp.choices[0].message.reasoning_content = None
+        resp.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=5,
+            completion_tokens_details=MagicMock(reasoning_tokens=0),
+        )
+        client.chat.completions.create = AsyncMock(return_value=resp)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_no_think_prepends_token_and_sends_kwarg(self):
+        """no_think=True both prepends /no_think and sends the enable_thinking kwarg."""
+        client = self._mock_client()
+        await openai_agent.run_scenario_inline(
+            client,
+            AsyncMock(),
+            "qwen3.6",
+            "Find lights",
+            no_think=True,
+            openai_tools=[],
+        )
+        _, kwargs = client.chat.completions.create.call_args
+        assert kwargs["messages"][0]["content"] == "/no_think\n\nFind lights"
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+
+    @pytest.mark.asyncio
+    async def test_default_omits_prepend_and_kwarg(self):
+        """Default leaves the prompt verbatim and sends no extra_body."""
+        client = self._mock_client()
+        await openai_agent.run_scenario_inline(
+            client,
+            AsyncMock(),
+            "some-model",
+            "Find lights",
+            openai_tools=[],
+        )
+        _, kwargs = client.chat.completions.create.call_args
+        assert kwargs["messages"][0]["content"] == "Find lights"
+        assert "extra_body" not in kwargs
 
 
 class TestExtractToolResultText:
@@ -361,17 +687,19 @@ class TestExtractToolResultText:
 class TestDetectModel:
     """Test model auto-detection."""
 
-    def test_returns_first_model_id(self):
+    @pytest.mark.asyncio
+    async def test_returns_first_model_id(self):
         """Returns the first model ID from the API."""
         client = MagicMock()
         model = MagicMock()
         model.id = "llama-3.1-8b"
-        client.models.list.return_value = MagicMock(data=[model])
-        assert openai_agent.detect_model(client) == "llama-3.1-8b"
+        client.models.list = AsyncMock(return_value=MagicMock(data=[model]))
+        assert await openai_agent.detect_model(client) == "llama-3.1-8b"
 
-    def test_raises_when_no_models(self):
+    @pytest.mark.asyncio
+    async def test_raises_when_no_models(self):
         """Raises RuntimeError when no models are available."""
         client = MagicMock()
-        client.models.list.return_value = MagicMock(data=[])
+        client.models.list = AsyncMock(return_value=MagicMock(data=[]))
         with pytest.raises(RuntimeError, match="No models available"):
-            openai_agent.detect_model(client)
+            await openai_agent.detect_model(client)


### PR DESCRIPTION
## What does this PR do?

Improves token accounting and reasoning-mode control in the BAT OpenAI-compatible agent (`tests/uat/`).

- **Capture reasoning tokens.** `tool_call_loop` now reads `usage.completion_tokens_details.reasoning_tokens` and reports it as `tokens_thoughts`, threaded through both the inline (`run_story.py`) and subprocess (`run_uat.py`) paths into the JSONL record. Previously hardcoded to `0` on the OpenAI path; this brings it to parity with the Gemini path. `tokens_billable` is intentionally unchanged (reasoning tokens are a subset of `completion_tokens`, already counted in `tokens_output`).
- **`--no-think` for Qwen3.5/3.6.** The flag now also sends `chat_template_kwargs={"enable_thinking": false}` via `extra_body`, since those models dropped the in-band `/no_think` soft switch. Honored by vLLM/llama-server; harmlessly ignored by servers that don't recognize it.
- **Detect an inert `--no-think`.** Warns once when `--no-think` was requested but the model still produced reasoning (via reasoning tokens, `reasoning_content`, or an inline `<think>` block). This surfaces the case where a backend (e.g. LM Studio with some Qwen3.6 GGUFs) silently ignores the request, instead of paying full reasoning-decode cost with no signal.
- **Fix broken test mocks.** Converted `MagicMock` to `AsyncMock` for the awaited `create()` / `models.list()` calls in `test_openai_agent.py` (5 pre-existing failing tests now pass).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified end-to-end by running the `s01` story against LM Studio (`qwen3.6-27b`, IQ2_M): story passed, and the JSONL record captured `tokens_thoughts: 1678` (44% of output), previously `0`. New unit tests cover the `enable_thinking` wiring, the warning's three detection branches, warn-once-across-turns, reasoning-token accumulation at both loop exits, and the `append_result` record threading.

## Checklist
- [x] I have updated documentation if needed
