### PR TITLE
test(uat): log model and quantization in BAT story results

### DIFF
--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -274,11 +274,19 @@ Skipped: s02, s04, s06-s12 (tools unchanged)
 
 ### Pre-built Story Results
 
+Read the `model` and `quantization` fields from each JSONL record (written by
+`run_story.py`) and state them. Results vary by model, so a report naming only
+the agent is ambiguous after the fact, and the same base model at different
+quants behaves very differently, so the quant matters too. Put them in the run
+header (single-model runs) and as columns.
+
 ```
-| Story | Agent  | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
-|-------|--------|----------|--------|--------|-----------------|---------------|-------|
-| s01   | gemini | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
-| s03   | gemini | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
+Run: agent=openai model=<model> quant=<quant>   (baseline <vX> vs HEAD)
+
+| Story | Agent  | Model   | Quant  | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
+|-------|--------|---------|--------|----------|--------|--------|-----------------|---------------|-------|
+| s01   | openai | <model> | <quant>| pass     | pass   | stable | ...             | ...           | ...   |
+| s03   | openai | <model> | <quant>| pass     | pass   | stable | ...             | ...           | ...   |
 ```
 
 ### Custom Story Details

--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -281,10 +281,10 @@ the agent is ambiguous after the fact. (Quant is `-` for cloud backends that
 don't expose it.)
 
 ```
-| Story | Agent  | Model   | Quant | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
-|-------|--------|---------|-------|----------|--------|--------|-----------------|---------------|-------|
-| s01   | gemini | <model> | -     | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
-| s03   | gemini | <model> | -     | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
+| Story | Agent  | Model         | Quant | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
+|-------|--------|---------------|-------|----------|--------|--------|-----------------|---------------|-------|
+| s01   | gemini | gemini-2.5-pro| -     | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
+| s03   | gemini | gemini-2.5-pro| -     | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
 ```
 
 ### Custom Story Details

--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -274,19 +274,17 @@ Skipped: s02, s04, s06-s12 (tools unchanged)
 
 ### Pre-built Story Results
 
-Read the `model` and `quantization` fields from each JSONL record (written by
-`run_story.py`) and state them. Results vary by model, so a report naming only
-the agent is ambiguous after the fact, and the same base model at different
-quants behaves very differently, so the quant matters too. Put them in the run
-header (single-model runs) and as columns.
+Also read the `model` and `quantization` fields from each JSONL record (written
+by `run_story.py`) and show them as columns. Results vary by model, and the same
+base model at different quants behaves very differently, so a report naming only
+the agent is ambiguous after the fact. (Quant is `-` for cloud backends that
+don't expose it.)
 
 ```
-Run: agent=openai model=<model> quant=<quant>   (baseline <vX> vs HEAD)
-
-| Story | Agent  | Model   | Quant  | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
-|-------|--------|---------|--------|----------|--------|--------|-----------------|---------------|-------|
-| s01   | openai | <model> | <quant>| pass     | pass   | stable | ...             | ...           | ...   |
-| s03   | openai | <model> | <quant>| pass     | pass   | stable | ...             | ...           | ...   |
+| Story | Agent  | Model   | Quant | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
+|-------|--------|---------|-------|----------|--------|--------|-----------------|---------------|-------|
+| s01   | gemini | <model> | -     | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
+| s03   | gemini | <model> | -     | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
 ```
 
 ### Custom Story Details

--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -281,10 +281,10 @@ the agent is ambiguous after the fact. (Quant is `-` for cloud backends that
 don't expose it.)
 
 ```
-| Story | Agent  | Model         | Quant | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
-|-------|--------|---------------|-------|----------|--------|--------|-----------------|---------------|-------|
-| s01   | gemini | gemini-2.5-pro| -     | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
-| s03   | gemini | gemini-2.5-pro| -     | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
+| Story | Agent  | Model            | Quant | Baseline | Target | Trend  | Baseline Tokens | Target Tokens | Delta |
+|-------|--------|------------------|-------|----------|--------|--------|-----------------|---------------|-------|
+| s01   | claude | claude-sonnet-4-6| -     | pass     | pass   | stable | 36,262          | 34,100        | -6%   |
+| s03   | claude | claude-sonnet-4-6| -     | pass     | pass   | stable | 42,000          | 41,500        | -1%   |
 ```
 
 ### Custom Story Details

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -73,6 +73,34 @@ async def detect_model(client: openai.AsyncOpenAI) -> str:
     return model_id
 
 
+async def detect_quantization(base_url: str, model_id: str) -> str | None:
+    """Best-effort lookup of a model's quantization (e.g. ``IQ2_M``).
+
+    Reads LM Studio's native ``/api/v0/models`` endpoint, which exposes
+    ``quantization`` that the OpenAI-compatible ``/v1/models`` does not.
+    The same base model at full precision vs a heavy quant behaves very
+    differently, so the quant belongs in the result record. Returns
+    ``None`` for backends that don't expose it (Ollama, cloud) or on any
+    error.
+    """
+    import httpx
+
+    root = base_url.rsplit("/v1", 1)[0].rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=5) as http:
+            resp = await http.get(f"{root}/api/v0/models")
+            resp.raise_for_status()
+            for entry in resp.json().get("data", []):
+                if entry.get("id") == model_id:
+                    quant = entry.get("quantization")
+                    if quant:
+                        logger.info(f"Detected quantization: {quant}")
+                    return quant
+    except Exception as e:  # best-effort enrichment, never fatal
+        logger.debug(f"Quantization detection skipped: {type(e).__name__}: {e}")
+    return None
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="OpenAI-compatible UAT agent for MCP testing",
@@ -406,17 +434,20 @@ async def create_and_warm_openai_client(
     api_key: str = DEFAULT_API_KEY,
     timeout: int = DEFAULT_TIMEOUT,
     model: str | None = None,
-) -> tuple[openai.AsyncOpenAI, str]:
+) -> tuple[openai.AsyncOpenAI, str, str | None]:
     """Construct an OpenAI client, resolve the model, and warm it up once.
 
-    Returns ``(client, model)``. Issues a 1-token completion to force
-    backends like LM Studio and Ollama to load the model into VRAM
+    Returns ``(client, model, quantization)``. Issues a 1-token completion
+    to force backends like LM Studio and Ollama to load the model into VRAM
     before the first real request (otherwise that request can stall
-    30-120s while the model is copied in). Raises on failure.
+    30-120s while the model is copied in). ``quantization`` is best-effort
+    (``None`` when the backend doesn't expose it). Raises on failure.
     """
     client = openai.AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
     resolved_model = model or await detect_model(client)
-    logger.info(f"Using model: {resolved_model}")
+    quantization = await detect_quantization(base_url, resolved_model)
+    suffix = f" ({quantization})" if quantization else ""
+    logger.info(f"Using model: {resolved_model}{suffix}")
     logger.info("Warming up model (may take a minute if not loaded)...")
     await client.chat.completions.create(
         model=resolved_model,
@@ -424,12 +455,12 @@ async def create_and_warm_openai_client(
         max_tokens=1,
     )
     logger.info("Model ready")
-    return client, resolved_model
+    return client, resolved_model, quantization
 
 
 async def _main_async(args: argparse.Namespace) -> None:
     try:
-        client, model = await create_and_warm_openai_client(
+        client, model, _quant = await create_and_warm_openai_client(
             base_url=args.base_url,
             api_key=args.api_key,
             timeout=args.timeout,

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -421,6 +421,7 @@ async def _run_test_prompt_inline(
         "completed": True,
         "duration_ms": duration_ms,
         "exit_code": exit_code,
+        "model": result.get("model"),
         "output": result.get("result", ""),
         "num_turns": result.get("num_turns"),
         "tool_stats": result.get("tool_stats"),
@@ -583,6 +584,8 @@ def append_result(
     session_file: str | None = None,
     passed: bool = False,
     verify_results: list[dict] | None = None,
+    model: str | None = None,
+    quantization: str | None = None,
 ) -> None:
     """Append a single story result as one JSONL line."""
     agent_data = bat_summary.get("agents", {}).get(agent, {})
@@ -595,6 +598,8 @@ def append_result(
         "branch": branch,
         "timestamp": datetime.now(UTC).isoformat(),
         "agent": agent,
+        "model": model or test_phase.get("model"),
+        "quantization": quantization,
         "story": story["id"],
         "category": story["category"],
         "weight": story["weight"],
@@ -726,6 +731,7 @@ async def run_stories(
         inline_mcp_client: MCPClient | None = None
         openai_client: openai.AsyncOpenAI | None = None
         resolved_model: str | None = None
+        resolved_quant: str | None = None
         openai_tools: list[dict] = []
 
         async with contextlib.AsyncExitStack() as agent_stack:
@@ -743,7 +749,11 @@ async def run_stories(
                     ha_url, ha_token, args.branch, mcp_env_dict or None
                 )
                 try:
-                    openai_client, resolved_model = await create_and_warm_openai_client(
+                    (
+                        openai_client,
+                        resolved_model,
+                        resolved_quant,
+                    ) = await create_and_warm_openai_client(
                         base_url=args.base_url,
                         api_key=args.api_key,
                         model=args.model,
@@ -919,6 +929,8 @@ async def run_stories(
                         session_file,
                         passed=passed,
                         verify_results=verify_results,
+                        model=resolved_model or args.model,
+                        quantization=resolved_quant,
                     )
 
                 if session_file:

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -199,6 +199,32 @@ def _extract_tokens(session_file: str | None, agent: str) -> dict | None:
     return None
 
 
+def _extract_model(session_file: str | None, agent: str) -> str | None:
+    """Extract the resolved model id from a subprocess agent's session file.
+
+    Claude records the resolved id (e.g. ``claude-sonnet-4-6``) as
+    ``message.model`` on each assistant entry, so the recorded model is
+    accurate even on a bare ``--agents claude`` run with no ``--model``.
+    Returns None for agents whose session format does not expose it
+    (gemini) or on any error, so the caller falls back to None.
+    """
+    if not session_file or not Path(session_file).exists():
+        return None
+    try:
+        if agent == "claude":
+            for line in Path(session_file).read_text().splitlines():
+                entry = json.loads(line)
+                if entry.get("type") == "assistant":
+                    model = entry.get("message", {}).get("model")
+                    if model:
+                        return model
+    except Exception as exc:
+        logger.warning(f"  Model extraction failed: {exc}")
+        return None
+
+    return None
+
+
 def _extract_tool_calls(session_file: str | None, agent: str) -> int | None:
     """Count tool calls from an agent session file."""
     if not session_file or not Path(session_file).exists():
@@ -598,7 +624,9 @@ def append_result(
         "branch": branch,
         "timestamp": datetime.now(UTC).isoformat(),
         "agent": agent,
-        "model": model or test_phase.get("model"),
+        "model": model
+        or test_phase.get("model")
+        or _extract_model(session_file, agent),
         "quantization": quantization,
         "story": story["id"],
         "category": story["category"],

--- a/tests/uat/stories/test_run_story_record.py
+++ b/tests/uat/stories/test_run_story_record.py
@@ -5,36 +5,46 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from uat.stories.run_story import append_result
+from uat.stories.run_story import _extract_model, append_result
 
 _STORY = {"id": "s01", "category": "automation", "weight": 5}
 
 
-def _bat_summary(test_phase: dict) -> dict:
-    return {"agents": {"openai": {"test": test_phase, "aggregate": {}}}}
+def _bat_summary(test_phase: dict, agent: str = "openai") -> dict:
+    return {"agents": {agent: {"test": test_phase, "aggregate": {}}}}
 
 
 def _write_and_read(
     tmp_path: Path,
     test_phase: dict,
     *,
+    agent: str = "openai",
     model: str | None = None,
     quantization: str | None = None,
+    session_file: str | None = None,
 ) -> dict:
     results_file = tmp_path / "results.jsonl"
     append_result(
         results_file,
         _STORY,
-        "openai",
+        agent,
         sha="abc123",
         describe="test",
         branch=None,
-        bat_summary=_bat_summary(test_phase),
+        bat_summary=_bat_summary(test_phase, agent),
         passed=True,
         model=model,
         quantization=quantization,
+        session_file=session_file,
     )
     return json.loads(results_file.read_text().splitlines()[-1])
+
+
+def _write_claude_session(tmp_path: Path, model: str = "claude-sonnet-4-6") -> str:
+    """Write a minimal claude session JSONL with one assistant entry."""
+    sf = tmp_path / "session.jsonl"
+    sf.write_text(json.dumps({"type": "assistant", "message": {"model": model}}) + "\n")
+    return str(sf)
 
 
 def test_tokens_thoughts_threaded_into_record(tmp_path):
@@ -58,9 +68,15 @@ def test_tokens_thoughts_defaults_to_zero_when_absent(tmp_path):
 
 
 def test_model_from_call_site_param(tmp_path):
-    """An explicit model arg (subprocess agents) lands in the record."""
+    """An explicit model= argument lands in the record."""
     record = _write_and_read(tmp_path, {}, model="sonnet")
     assert record["model"] == "sonnet"
+
+
+def test_model_call_site_arg_wins_over_test_phase(tmp_path):
+    """Both present: the explicit arg wins, pinning the OR order (live inline case)."""
+    record = _write_and_read(tmp_path, {"model": "phase-model"}, model="arg-model")
+    assert record["model"] == "arg-model"
 
 
 def test_model_from_test_phase(tmp_path):
@@ -87,3 +103,23 @@ def test_quantization_defaults_to_none_when_absent(tmp_path):
     record = _write_and_read(tmp_path, {})
     assert "quantization" in record
     assert record["quantization"] is None
+
+
+def test_extract_model_reads_claude_session(tmp_path):
+    """Claude's resolved model id comes from message.model in the session file."""
+    sf = _write_claude_session(tmp_path, "claude-sonnet-4-6")
+    assert _extract_model(sf, "claude") == "claude-sonnet-4-6"
+
+
+def test_extract_model_none_on_malformed_session(tmp_path):
+    """A corrupt session line degrades to None, never aborting the record write."""
+    sf = tmp_path / "session.jsonl"
+    sf.write_text("{not valid json\n")
+    assert _extract_model(str(sf), "claude") is None
+
+
+def test_model_from_claude_session_fallback(tmp_path):
+    """Bare claude run (no model arg, no test_phase model) records the session id."""
+    sf = _write_claude_session(tmp_path, "claude-sonnet-4-6")
+    record = _write_and_read(tmp_path, {}, agent="claude", session_file=sf)
+    assert record["model"] == "claude-sonnet-4-6"

--- a/tests/uat/stories/test_run_story_record.py
+++ b/tests/uat/stories/test_run_story_record.py
@@ -14,7 +14,13 @@ def _bat_summary(test_phase: dict) -> dict:
     return {"agents": {"openai": {"test": test_phase, "aggregate": {}}}}
 
 
-def _write_and_read(tmp_path: Path, test_phase: dict) -> dict:
+def _write_and_read(
+    tmp_path: Path,
+    test_phase: dict,
+    *,
+    model: str | None = None,
+    quantization: str | None = None,
+) -> dict:
     results_file = tmp_path / "results.jsonl"
     append_result(
         results_file,
@@ -25,6 +31,8 @@ def _write_and_read(tmp_path: Path, test_phase: dict) -> dict:
         branch=None,
         bat_summary=_bat_summary(test_phase),
         passed=True,
+        model=model,
+        quantization=quantization,
     )
     return json.loads(results_file.read_text().splitlines()[-1])
 
@@ -47,3 +55,35 @@ def test_tokens_thoughts_defaults_to_zero_when_absent(tmp_path):
         {"tokens_input": 100, "tokens_output": 50},
     )
     assert record["tokens_thoughts"] == 0
+
+
+def test_model_from_call_site_param(tmp_path):
+    """An explicit model arg (subprocess agents) lands in the record."""
+    record = _write_and_read(tmp_path, {}, model="sonnet")
+    assert record["model"] == "sonnet"
+
+
+def test_model_from_test_phase(tmp_path):
+    """The inline path stamps the resolved model into test_phase; it is used."""
+    record = _write_and_read(tmp_path, {"model": "qwen3.6-27b"})
+    assert record["model"] == "qwen3.6-27b"
+
+
+def test_model_defaults_to_none_when_absent(tmp_path):
+    """No model anywhere records a present-but-None key, not a crash."""
+    record = _write_and_read(tmp_path, {})
+    assert "model" in record
+    assert record["model"] is None
+
+
+def test_quantization_threaded_into_record(tmp_path):
+    """An explicit quantization arg lands in the record."""
+    record = _write_and_read(tmp_path, {}, quantization="Q4_K_M")
+    assert record["quantization"] == "Q4_K_M"
+
+
+def test_quantization_defaults_to_none_when_absent(tmp_path):
+    """No quantization records a present-but-None key, not a crash."""
+    record = _write_and_read(tmp_path, {})
+    assert "quantization" in record
+    assert record["quantization"] is None

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -706,3 +706,86 @@ class TestDetectModel:
         client.models.list = AsyncMock(return_value=MagicMock(data=[]))
         with pytest.raises(RuntimeError, match="No models available"):
             await openai_agent.detect_model(client)
+
+
+class TestDetectQuantization:
+    """Test best-effort LM Studio quantization detection."""
+
+    @staticmethod
+    def _patch_client(monkeypatch, *, payload=None, get_exc=None, raise_status=False):
+        """Swap httpx.AsyncClient for a fake; returns a dict capturing the GET url."""
+        import httpx
+
+        captured: dict = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                if raise_status:
+                    raise httpx.HTTPError("500 Server Error")
+
+            def json(self):
+                return payload or {}
+
+        class _Client:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url):
+                captured["url"] = url
+                if get_exc:
+                    raise get_exc
+                return _Resp()
+
+        monkeypatch.setattr(httpx, "AsyncClient", _Client)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_returns_quant_and_strips_v1_suffix(self, monkeypatch):
+        """Happy path: returns the quant and queries /api/v0/models with /v1 stripped."""
+        captured = self._patch_client(
+            monkeypatch,
+            payload={"data": [{"id": "qwen3.6-27b", "quantization": "IQ2_M"}]},
+        )
+        result = await openai_agent.detect_quantization(
+            "http://172.19.0.1:1234/v1", "qwen3.6-27b"
+        )
+        assert result == "IQ2_M"
+        assert captured["url"] == "http://172.19.0.1:1234/api/v0/models"
+
+    @pytest.mark.asyncio
+    async def test_none_when_model_not_listed(self, monkeypatch):
+        """A model id absent from the listing yields None."""
+        self._patch_client(
+            monkeypatch, payload={"data": [{"id": "other", "quantization": "Q4_K_M"}]}
+        )
+        result = await openai_agent.detect_quantization("http://h/v1", "qwen3.6-27b")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_none_when_entry_has_no_quant(self, monkeypatch):
+        """A matching entry without a quantization key yields None."""
+        self._patch_client(monkeypatch, payload={"data": [{"id": "qwen3.6-27b"}]})
+        result = await openai_agent.detect_quantization("http://h/v1", "qwen3.6-27b")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_none_on_transport_error(self, monkeypatch):
+        """A transport error is swallowed (never fatal); returns None."""
+        import httpx
+
+        self._patch_client(monkeypatch, get_exc=httpx.ConnectError("boom"))
+        result = await openai_agent.detect_quantization("http://h/v1", "m")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_none_on_http_error_status(self, monkeypatch):
+        """A 5xx (raise_for_status) is swallowed; returns None."""
+        self._patch_client(monkeypatch, raise_status=True)
+        result = await openai_agent.detect_quantization("http://h/v1", "m")
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

BAT story results recorded only the `agent` ("openai"/"claude"), not which model (or quantization) produced them. Agent behavior varies heavily by model, and the same base model at different quants behaves very differently, so historical `local/uat-results.jsonl` data could not be sliced by model/quant and `bat-story-eval` reports were ambiguous after the fact.

This adds two fields to every result record:
- `model`: threaded from the resolved/`--model` value (the inline openai path also stamps it into `test_phase`).
- `quantization`: best-effort, read from LM Studio's native `/api/v0/models` (the OpenAI-compatible `/v1/models` does not expose it). `None` for backends that don't provide it (Ollama, cloud).

`create_and_warm_openai_client` now returns the resolved quantization alongside the model. The `bat-story-eval` report gains Model + Quant columns.

Records written before this change have no `model`/`quantization` keys, so older rows remain model-ambiguous; only new runs carry them.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran a discovery story against a local LM Studio model: passed, and the written record carries both `model` and `quantization` (auto-detected). Also verified the full resolve-to-record threading directly against the live endpoint without Docker. Unit tests in `test_run_story_record.py` cover both model and quantization sources (call-site arg and inline `test_phase`) plus the None defaults; 7 passed. Ran the touched module's unit tests and ruff locally; full e2e suite left to CI (BAT test-tooling, no `src/` impact).

## Checklist
- [x] I have updated documentation if needed
