### PR TITLE
ci: add CodeQL code-quality CI gate and clear all code-quality findings

### DIFF
--- a/.github/workflows/codeql-quality.yml
+++ b/.github/workflows/codeql-quality.yml
@@ -1,0 +1,84 @@
+name: CodeQL Code Quality
+
+# Runs the CodeQL "python-code-quality" suite and fails the PR on ANY finding.
+#
+# Why a custom workflow instead of GitHub's Code Quality page:
+#   - GitHub Code Quality (Preview) is gated to Team/Enterprise Cloud org plans;
+#     this repo's org is on the free plan, so the Settings → Security → Code
+#     quality toggle is unavailable.
+#   - We do NOT upload SARIF to code scanning: the repo already uses CodeQL
+#     *default setup* for security, and SARIF uploads are rejected while default
+#     setup is enabled. This workflow keeps the quality results out of the
+#     Security tab and gates purely on the job status + artifact/summary.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '**.py'
+      - '.github/workflows/codeql-quality.yml'
+      - 'scripts/codeql_quality_gate.py'
+  push:
+    branches: [ master ]
+    paths:
+      - '**.py'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: CodeQL Code Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install CodeQL CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extensions install github/gh-codeql
+          gh codeql set-version latest
+
+      - name: Create CodeQL database
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh codeql database create ha-mcp-db \
+            --language=python \
+            --build-mode=none \
+            --source-root . \
+            --overwrite
+
+      - name: Analyze with python-code-quality suite
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh codeql database analyze ha-mcp-db \
+            codeql/python-queries:codeql-suites/python-code-quality.qls \
+            --format=sarif-latest \
+            --output quality.sarif \
+            --download
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-quality-sarif
+          path: quality.sarif
+          if-no-files-found: warn
+
+      - name: Gate on findings
+        run: python scripts/codeql_quality_gate.py quality.sarif

--- a/homeassistant-addon-webhook-proxy/start.py
+++ b/homeassistant-addon-webhook-proxy/start.py
@@ -33,6 +33,7 @@ class IntegrationInstall(NamedTuple):
     first_install: bool
     version_changed: bool
 
+
 if TYPE_CHECKING:
     from typing import TextIO
 
@@ -83,7 +84,9 @@ def _supervisor_get(path: str) -> dict | None:
         with urllib.request.urlopen(req, timeout=10) as resp:
             response_data = json.loads(resp.read())
             if not isinstance(response_data, dict):
-                log_error(f"Supervisor API GET {path}: unexpected response type {type(response_data)}")
+                log_error(
+                    f"Supervisor API GET {path}: unexpected response type {type(response_data)}"
+                )
                 return None
             data = response_data.get("data", {})
             return data if isinstance(data, dict) else {}
@@ -116,10 +119,10 @@ def _supervisor_post(path: str, data: dict) -> bool:
         try:
             err_body = e.read().decode("utf-8", errors="replace")[:200]
         except Exception:
+            # Best-effort: the error body is optional diagnostic detail; if it
+            # can't be read/decoded we still log the HTTPError below.
             pass
-        log_error(
-            f"Supervisor API POST {path} ({type(e).__name__}): {e} — {err_body}"
-        )
+        log_error(f"Supervisor API POST {path} ({type(e).__name__}): {e} — {err_body}")
         return False
     except (urllib.error.URLError, TimeoutError) as e:
         log_error(f"Supervisor API POST {path} ({type(e).__name__}): {e}")
@@ -147,6 +150,8 @@ def _supervisor_get_text(path: str) -> str | None:
         try:
             body = e.read().decode("utf-8", errors="replace")[:200]
         except Exception:
+            # Best-effort: the error body is optional diagnostic detail; if it
+            # can't be read/decoded we still log the HTTPError below.
             pass
         log_error(f"Supervisor API GET text {path}: {e} — {body}")
         return None
@@ -155,7 +160,9 @@ def _supervisor_get_text(path: str) -> str | None:
         return None
 
 
-def _ha_core_api(method: str, path: str, data: dict | None = None) -> dict | list | None:
+def _ha_core_api(
+    method: str, path: str, data: dict | None = None
+) -> dict | list | None:
     """Request to HA Core API via Supervisor proxy. Returns parsed JSON."""
     token = os.environ.get("SUPERVISOR_TOKEN")
     if not token:
@@ -175,7 +182,12 @@ def _ha_core_api(method: str, path: str, data: dict | None = None) -> dict | lis
         with urllib.request.urlopen(req, timeout=15) as resp:
             result: dict | list = json.loads(resp.read())
             return result
-    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, json.JSONDecodeError) as e:
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        TimeoutError,
+        json.JSONDecodeError,
+    ) as e:
         log_error(f"HA Core API {method} {path}: {e}")
         return None
 
@@ -345,8 +357,7 @@ def _regenerate_oauth_creds(data_dir: Path) -> None:
             log_info("Wiped existing OAuth credentials per regenerate toggle")
     except OSError as e:
         log_error(
-            f"Failed to wipe OAuth creds for regeneration "
-            f"({type(e).__name__}): {e}"
+            f"Failed to wipe OAuth creds for regeneration ({type(e).__name__}): {e}"
         )
 
 
@@ -389,10 +400,7 @@ def _resolve_oauth_creds(
             if isinstance(loaded, dict):
                 stored = loaded
         except (OSError, json.JSONDecodeError) as e:
-            log_error(
-                f"Could not read existing OAuth creds "
-                f"({type(e).__name__}): {e}"
-            )
+            log_error(f"Could not read existing OAuth creds ({type(e).__name__}): {e}")
 
     final_id = configured_id.strip() or stored.get("client_id", "")
     final_secret = configured_secret.strip() or stored.get("client_secret", "")
@@ -417,18 +425,14 @@ def _resolve_oauth_creds(
         try:
             data_dir.mkdir(parents=True, exist_ok=True)
             creds_file.write_text(
-                json.dumps(
-                    {"client_id": final_id, "client_secret": final_secret}
-                )
+                json.dumps({"client_id": final_id, "client_secret": final_secret})
             )
             try:
                 creds_file.chmod(0o600)
             except OSError:
                 pass  # tmpfs / non-POSIX filesystems may not support chmod
         except OSError as e:
-            log_error(
-                f"Failed to persist OAuth creds ({type(e).__name__}): {e}"
-            )
+            log_error(f"Failed to persist OAuth creds ({type(e).__name__}): {e}")
             return "", ""
 
     return final_id, final_secret
@@ -443,6 +447,8 @@ def _get_or_create_webhook_id(data_dir: Path) -> str:
             if wid:
                 return wid
         except OSError:
+            # Existing file unreadable (permissions/corruption); fall through
+            # to generate and persist a fresh webhook ID below.
             pass
     wid = f"mcp_{secrets.token_hex(16)}"
     try:
@@ -468,9 +474,7 @@ def _read_integration_domain() -> str | None:
     try:
         domain = json.loads(src_manifest.read_text()).get("domain")
     except (OSError, json.JSONDecodeError) as e:
-        log_error(
-            f"Could not read integration manifest ({type(e).__name__}): {e}"
-        )
+        log_error(f"Could not read integration manifest ({type(e).__name__}): {e}")
         return None
     return domain if isinstance(domain, str) else None
 
@@ -491,9 +495,7 @@ def _probe_oauth_active() -> bool:
     domain = _read_integration_domain()
     if not domain:
         return False
-    result = _ha_core_api(
-        "GET", f"/{domain}/oauth/protected-resource"
-    )
+    result = _ha_core_api("GET", f"/{domain}/oauth/protected-resource")
     return isinstance(result, dict) and "authorization_servers" in result
 
 
@@ -586,7 +588,10 @@ def _ensure_config_entry(retries: int = 5, delay: int = 10) -> bool:
                 complete = _ha_core_api(
                     "POST", f"/config/config_entries/flow/{flow['flow_id']}", {}
                 )
-                if isinstance(complete, dict) and complete.get("type") == "create_entry":
+                if (
+                    isinstance(complete, dict)
+                    and complete.get("type") == "create_entry"
+                ):
                     log_info("Config entry created")
                     return True
 
@@ -747,9 +752,7 @@ def main() -> int:
             enable_oauth = bool(config.get("enable_oauth", False))
             oauth_client_id = config.get("oauth_client_id", "")
             oauth_client_secret = config.get("oauth_client_secret", "")
-            regenerate_oauth_creds = bool(
-                config.get("regenerate_oauth_creds", False)
-            )
+            regenerate_oauth_creds = bool(config.get("regenerate_oauth_creds", False))
         except (OSError, json.JSONDecodeError) as e:
             log_error(f"Failed to read config ({type(e).__name__}): {e}")
 
@@ -783,9 +786,7 @@ def main() -> int:
                     "POST",
                     "/services/persistent_notification/create",
                     {
-                        "title": (
-                            "MCP Webhook Proxy: manual action required"
-                        ),
+                        "title": ("MCP Webhook Proxy: manual action required"),
                         "message": (
                             "The Webhook Proxy addon could not "
                             "automatically clear the 'Regenerate OAuth "
@@ -947,9 +948,7 @@ def main() -> int:
                 "POST",
                 "/services/persistent_notification/create",
                 {
-                    "title": (
-                        "MCP Webhook Proxy: setup did not complete"
-                    ),
+                    "title": ("MCP Webhook Proxy: setup did not complete"),
                     "message": (
                         "After restarting Home Assistant, the addon "
                         "could not create the integration's config "
@@ -981,9 +980,7 @@ def main() -> int:
                 "POST",
                 "/services/persistent_notification/create",
                 {
-                    "title": (
-                        "MCP Webhook Proxy: webhook URL is not active"
-                    ),
+                    "title": ("MCP Webhook Proxy: webhook URL is not active"),
                     "message": (
                         "The addon could not create the integration's "
                         "config entry, so the webhook URL is currently "
@@ -1021,22 +1018,12 @@ def main() -> int:
     if enable_oauth and not _probe_oauth_active():
         log_error("")
         log_error("=" * 70)
-        log_error(
-            "  OAuth is enabled but the integration code currently loaded "
-            "in"
-        )
-        log_error(
-            "  Home Assistant does not enforce it (HA was not restarted "
-            "after"
-        )
+        log_error("  OAuth is enabled but the integration code currently loaded in")
+        log_error("  Home Assistant does not enforce it (HA was not restarted after")
         log_error("  the addon update).")
         log_error("")
-        log_error(
-            "  Disabling the webhook to prevent unauthenticated access."
-        )
-        log_error(
-            "  RESTART HOME ASSISTANT (Settings → System → Restart) — the"
-        )
+        log_error("  Disabling the webhook to prevent unauthenticated access.")
+        log_error("  RESTART HOME ASSISTANT (Settings → System → Restart) — the")
         log_error("  webhook will reactivate automatically afterwards.")
         log_error("=" * 70)
         log_error("")
@@ -1050,17 +1037,12 @@ def main() -> int:
                 json.dumps({"reason": "stale_integration_code"})
             )
         except OSError as e:
-            log_error(
-                f"Could not write OAuth restart marker "
-                f"({type(e).__name__}): {e}"
-            )
+            log_error(f"Could not write OAuth restart marker ({type(e).__name__}): {e}")
         _ha_core_api(
             "POST",
             "/services/persistent_notification/create",
             {
-                "title": (
-                    "MCP Webhook Proxy: HA restart required for OAuth"
-                ),
+                "title": ("MCP Webhook Proxy: HA restart required for OAuth"),
                 "message": (
                     "OAuth is enabled in the addon configuration, but "
                     "the new OAuth-enforcing integration code has not "
@@ -1098,10 +1080,11 @@ def main() -> int:
             try:
                 oauth_restart_marker.unlink(missing_ok=True)
             except OSError:
+                # Best-effort cleanup; the integration's async_setup_entry
+                # removes this marker on its next boot regardless.
                 pass
             log_info(
-                "OAuth-enforcing integration code is now active; "
-                "webhook re-enabled."
+                "OAuth-enforcing integration code is now active; webhook re-enabled."
             )
         else:
             # Re-probe failed AFTER HA was restarted and the config entry
@@ -1121,9 +1104,7 @@ def main() -> int:
                 "POST",
                 "/services/persistent_notification/create",
                 {
-                    "title": (
-                        "MCP Webhook Proxy: OAuth could not be enabled"
-                    ),
+                    "title": ("MCP Webhook Proxy: OAuth could not be enabled"),
                     "message": (
                         "After Home Assistant was restarted, the "
                         "OAuth-enforcing integration code still did "
@@ -1152,7 +1133,9 @@ def main() -> int:
     if resolved_remote:
         log_info(f"  MCP Server URL (remote): {resolved_remote}{webhook_path}")
     else:
-        log_info(f"  MCP Server URL (remote): https://<your-external-url>{webhook_path}")
+        log_info(
+            f"  MCP Server URL (remote): https://<your-external-url>{webhook_path}"
+        )
         log_info("    Set 'remote_url' in addon config, or enable Nabu Casa")
     log_info("")
     log_info("  Copy the remote URL above into your MCP client.")
@@ -1161,18 +1144,10 @@ def main() -> int:
         log_info("  OAuth (Beta) is ENABLED for this URL.")
         log_info(f"    OAuth Client ID:     {oauth_client_id}")
         log_info(f"    OAuth Client Secret: {oauth_client_secret}")
-        log_info(
-            "    Paste both into the OAuth fields of your MCP client's"
-        )
-        log_info(
-            "    connector setup (Claude.ai: connector → Advanced settings)."
-        )
-        log_info(
-            "    These values persist at /data/oauth_creds.json — same"
-        )
-        log_info(
-            "    values across addon restarts."
-        )
+        log_info("    Paste both into the OAuth fields of your MCP client's")
+        log_info("    connector setup (Claude.ai: connector → Advanced settings).")
+        log_info("    These values persist at /data/oauth_creds.json — same")
+        log_info("    values across addon restarts.")
     log_info("=" * 70)
     log_info("")
 
@@ -1196,8 +1171,7 @@ def main() -> int:
                 log_error(f"MCP server unreachable: {target_url}")
             elif consecutive_failures % 5 == 0:
                 log_error(
-                    f"MCP server still unreachable after "
-                    f"{consecutive_failures} checks"
+                    f"MCP server still unreachable after {consecutive_failures} checks"
                 )
 
     # Cleanup on stop: remove config entry to unregister the webhook (stops

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -703,6 +703,9 @@ def main() -> int:
         log_info("Interrupted, exiting")
         return 0
     except BaseException as e:
+        # Top-level crash handler: intentionally catch ANY exit (including
+        # SystemExit, translated to its code below) so the add-on supervisor
+        # always sees a clean process exit code instead of a traceback.
         import traceback
 
         log_error(f"MCP server crashed: {e}")

--- a/packaging/binary/pyinstaller_hooks/runtime_hook.py
+++ b/packaging/binary/pyinstaller_hooks/runtime_hook.py
@@ -1,14 +1,19 @@
 # Runtime hook to ensure codecs are registered before any imports
 # This runs before the main application starts
 
-# Register the idna codec (required for httpx URL parsing)
+# Register the idna codec (required for httpx URL parsing).
+# Imported purely for its registration side effect, not for any bound name.
 try:
     import idna.codec  # noqa: F401 - This registers the 'idna' codec
 except ImportError:
+    # idna may not be bundled in every build; httpx falls back to its own
+    # IDNA handling, so a missing codec here is non-fatal.
     pass
 
-# Ensure encodings are available
+# Ensure encodings are available (imported for its registration side effect).
 try:
     import encodings.idna  # noqa: F401
 except ImportError:
+    # encodings.idna is part of the stdlib but may be excluded by a trimmed
+    # PyInstaller build; absence is non-fatal for normal ASCII hostnames.
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ ignore = [
     "RUF001",  # ambiguous unicode — HA entity names use degree symbols etc
     "RUF003",  # ambiguous unicode in comments
     "RUF010",  # explicit f-string type conversion — str(x) is clearer than !s
-    "F841",    # unused variable — too many to fix now
     "RUF059",  # unused unpacked variable
     "SIM118",  # in-dict-keys — style preference
     "PIE810",  # multiple-starts-ends-with — style preference

--- a/scripts/bake_local_calendar.py
+++ b/scripts/bake_local_calendar.py
@@ -88,7 +88,10 @@ def create_local_calendar(base_url: str) -> str:
         timeout=15,
     )
     if not submit_r.ok:
-        print(f"  flow submit returned {submit_r.status_code}: {submit_r.text}", file=sys.stderr)
+        print(
+            f"  flow submit returned {submit_r.status_code}: {submit_r.text}",
+            file=sys.stderr,
+        )
         submit_r.raise_for_status()
     done = submit_r.json()
     if done.get("type") != "create_entry":
@@ -101,17 +104,17 @@ def create_local_calendar(base_url: str) -> str:
     # entity registry unwritten and the seed unusable.
     observed_calendars: list[str] = []
     for attempt in range(30):
-        states_r = requests.get(
-            f"{base_url}/api/states", timeout=5, headers=headers
-        )
+        states_r = requests.get(f"{base_url}/api/states", timeout=5, headers=headers)
         states_r.raise_for_status()
         states = states_r.json()
         observed_calendars = [
-            s["entity_id"] for s in states
+            s["entity_id"]
+            for s in states
             if s.get("entity_id", "").startswith("calendar.")
         ]
         local_cals = [
-            eid for eid in observed_calendars
+            eid
+            for eid in observed_calendars
             if "demo" not in eid
             and "calendar_" not in eid  # demo entities use this prefix
         ]
@@ -134,6 +137,7 @@ def wait_for_api(base_url: str, timeout_s: int = 90) -> None:
                 print(f"✓ HA API ready after {attempt + 1}s")
                 return
         except requests.exceptions.RequestException:
+            # API not up yet — expected while the container boots; retry next second.
             pass
         time.sleep(1)
     raise RuntimeError(f"HA API didn't become ready in {timeout_s}s")
@@ -198,6 +202,8 @@ def main() -> int:
             try:
                 _docker("stop", "-t", "5", container_name)
             except subprocess.CalledProcessError:
+                # Best-effort cleanup — container may already be gone; re-raise
+                # the original error below regardless.
                 pass
             raise
 

--- a/scripts/bake_pagination_seed.py
+++ b/scripts/bake_pagination_seed.py
@@ -127,6 +127,7 @@ def wait_for_api(base_url: str, timeout_s: int = 90) -> None:
                 print(f"✓ HA API ready after {attempt + 1}s")
                 return
         except requests.exceptions.RequestException:
+            # Expected while HA is still starting: keep polling until timeout.
             pass
         time.sleep(1)
     raise RuntimeError(f"HA API at {base_url} didn't become ready in {timeout_s}s")
@@ -143,6 +144,7 @@ def wait_for_entity(base_url: str, entity_id: str, timeout_s: int = 30) -> None:
                 print(f"✓ Entity {entity_id} registered after {attempt + 1}s")
                 return
         except requests.exceptions.RequestException:
+            # Expected until the entity is registered: keep polling until timeout.
             pass
         time.sleep(1)
     raise RuntimeError(

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Parse a CodeQL code-quality SARIF file, report findings, and gate on them.
+
+CodeQL's Code Quality preview (the GitHub Settings → Security → Code quality
+page) is only available to Team/Enterprise Cloud org plans, so it cannot be
+enabled on this repo's free org. This script provides an equivalent gate by
+running the ``python-code-quality.qls`` suite via the CodeQL CLI in CI and
+failing the job when any finding remains.
+
+Usage:
+    codeql_quality_gate.py <quality.sarif>
+
+Exits 1 if the SARIF contains any results, 0 otherwise. A grouped, sorted
+finding list is printed to stdout and (when running in Actions) appended to
+the job summary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def _rule_id(result: dict[str, Any], run: dict[str, Any]) -> str:
+    """Resolve a result's rule id, falling back to the rules table by index."""
+    if rule_id := result.get("ruleId"):
+        return rule_id
+    rule_index = result.get("rule", {}).get("index")
+    if rule_index is None:
+        return "<unknown>"
+    rules = run.get("tool", {}).get("driver", {}).get("rules", [])
+    if 0 <= rule_index < len(rules):
+        return rules[rule_index].get("id", "<unknown>")
+    return "<unknown>"
+
+
+def _location(result: dict[str, Any]) -> tuple[str, int]:
+    """Return (file, line) for a result's primary physical location."""
+    locations = result.get("locations") or []
+    if not locations:
+        return ("<no-location>", 0)
+    phys = locations[0].get("physicalLocation", {})
+    uri = phys.get("artifactLocation", {}).get("uri", "<no-file>")
+    line = phys.get("region", {}).get("startLine", 0)
+    return (uri, line)
+
+
+def load_findings(sarif_path: Path) -> list[tuple[str, int, str, str]]:
+    """Return a sorted list of (file, line, rule_id, message) findings."""
+    data = json.loads(sarif_path.read_text(encoding="utf-8"))
+    findings: list[tuple[str, int, str, str]] = []
+    for run in data.get("runs", []):
+        for result in run.get("results", []):
+            rule_id = _rule_id(result, run)
+            file, line = _location(result)
+            message = result.get("message", {}).get("text", "").strip()
+            findings.append((file, line, rule_id, message))
+    findings.sort(key=lambda f: (f[2], f[0], f[1]))
+    return findings
+
+
+def render(findings: list[tuple[str, int, str, str]]) -> str:
+    """Render a human-readable, grouped report of the findings."""
+    if not findings:
+        return "No CodeQL code-quality findings. ✅"
+    by_rule: dict[str, list[tuple[str, int, str, str]]] = defaultdict(list)
+    for f in findings:
+        by_rule[f[2]].append(f)
+    counts = Counter(f[2] for f in findings)
+
+    lines: list[str] = [f"CodeQL code-quality findings: {len(findings)}", ""]
+    lines.append("Count by rule:")
+    for rule, count in counts.most_common():
+        lines.append(f"  {count:>4}  {rule}")
+    lines.append("")
+    for rule in sorted(by_rule):
+        lines.append(f"## {rule} ({len(by_rule[rule])})")
+        for file, line, _, message in by_rule[rule]:
+            lines.append(f"  {file}:{line}  {message}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <quality.sarif>", file=sys.stderr)
+        return 2
+    sarif_path = Path(argv[1])
+    if not sarif_path.exists():
+        print(f"SARIF file not found: {sarif_path}", file=sys.stderr)
+        return 2
+
+    findings = load_findings(sarif_path)
+    report = render(findings)
+    print(report)
+
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(f"# CodeQL Code Quality\n\n```\n{report}\n```\n")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -181,7 +181,11 @@ def main(argv: list[str]) -> int:
         print(f"SARIF file not found: {sarif_path}", file=sys.stderr)
         return 2
 
-    findings, suppressed = classify(sarif_path)
+    try:
+        findings, suppressed = classify(sarif_path)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Could not read SARIF file {sarif_path}: {e}", file=sys.stderr)
+        return 2
     report = render(findings)
     if suppressed:
         lines = [f"\nSuppressed (allowlisted false positives): {len(suppressed)}"]

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -108,9 +108,9 @@ def _location(result: dict[str, Any]) -> tuple[str, int]:
     locations = result.get("locations") or []
     if not locations:
         return ("<no-location>", 0)
-    phys = locations[0].get("physicalLocation", {})
-    uri = phys.get("artifactLocation", {}).get("uri", "<no-file>")
-    line = phys.get("region", {}).get("startLine", 0)
+    phys = locations[0].get("physicalLocation") or {}
+    uri = (phys.get("artifactLocation") or {}).get("uri") or "<no-file>"
+    line = (phys.get("region") or {}).get("startLine") or 0
     return (uri, line)
 
 
@@ -135,7 +135,7 @@ def classify(
             file, line = _location(result)
             if any(file.startswith(prefix) for prefix in PATHS_IGNORE):
                 continue
-            message = result.get("message", {}).get("text", "").strip()
+            message = ((result.get("message") or {}).get("text") or "").strip()
             if reason := _allowlist_reason(file, rule_id, message):
                 suppressed.append((file, line, rule_id, message, reason))
                 continue

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -36,17 +36,70 @@ PATHS_IGNORE: tuple[str, ...] = ("tests/initial_test_state/",)
 # and cannot be fixed in our source.
 RULES_IGNORE: frozenset[str] = frozenset({"py/syntax-error"})
 
+# Per-finding allowlist for verified false positives and intentional patterns
+# that cannot be cleared without breaking or contorting correct code. Each entry
+# is (rule_id, path_fragment, message_substring, reason). A finding is suppressed
+# only when all three of rule/path/message match — keep this list tight and the
+# reason current. Suppressed findings are reported (not silently dropped).
+ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "py/unused-global-variable",
+        "src/ha_mcp/__main__.py",
+        "_shutdown_in_progress",
+        "Cross-invocation use: set True on the first signal, read on the next to "
+        "force-exit. CodeQL's single-pass dead-store analysis misses the "
+        "second-signal read, so the assignment looks dead.",
+    ),
+    (
+        "py/unused-global-variable",
+        "src/ha_mcp/tools/util_helpers.py",
+        "_SKILL_GUIDE_MANDATORYBPS_HINT",
+        "Used cross-module in server.py; CodeQL's unused-global check is "
+        "module-local and does not count the importing site.",
+    ),
+    (
+        "py/unused-import",
+        "packaging/binary/pyinstaller_hooks/runtime_hook.py",
+        "idna",
+        "Intentional side-effect import: registers the idna codec at startup and "
+        "forces PyInstaller to bundle it. Rewriting it risks the binary build.",
+    ),
+    (
+        "py/unused-import",
+        "packaging/binary/pyinstaller_hooks/runtime_hook.py",
+        "encodings",
+        "Intentional side-effect import: registers the stdlib encodings.idna "
+        "codec at startup. Rewriting it risks the binary build.",
+    ),
+    (
+        "py/catch-base-exception",
+        "homeassistant-addon/start.py",
+        "BaseException",
+        "Intentional top-level supervisor handler: must catch SystemExit to emit "
+        "a clean add-on exit code; KeyboardInterrupt is handled by the clause "
+        "above. Matches how the codebase suppresses other deliberate catches.",
+    ),
+)
+
+
+def _allowlist_reason(file: str, rule_id: str, message: str) -> str | None:
+    """Return the allowlist reason if this finding is a verified suppression."""
+    for rule, path, substr, reason in ALLOWLIST:
+        if rule_id == rule and path in file and substr in message:
+            return reason
+    return None
+
 
 def _rule_id(result: dict[str, Any], run: dict[str, Any]) -> str:
     """Resolve a result's rule id, falling back to the rules table by index."""
     if rule_id := result.get("ruleId"):
-        return rule_id
+        return str(rule_id)
     rule_index = result.get("rule", {}).get("index")
     if rule_index is None:
         return "<unknown>"
     rules = run.get("tool", {}).get("driver", {}).get("rules", [])
     if 0 <= rule_index < len(rules):
-        return rules[rule_index].get("id", "<unknown>")
+        return str(rules[rule_index].get("id", "<unknown>"))
     return "<unknown>"
 
 
@@ -61,10 +114,19 @@ def _location(result: dict[str, Any]) -> tuple[str, int]:
     return (uri, line)
 
 
-def load_findings(sarif_path: Path) -> list[tuple[str, int, str, str]]:
-    """Return a sorted list of (file, line, rule_id, message) findings."""
+def classify(
+    sarif_path: Path,
+) -> tuple[list[tuple[str, int, str, str]], list[tuple[str, int, str, str, str]]]:
+    """Return (gating_findings, suppressed) from a SARIF file.
+
+    ``gating_findings`` are (file, line, rule_id, message) tuples the gate fails
+    on. ``suppressed`` are (file, line, rule_id, message, reason) tuples dropped
+    by the allowlist (reported, never silent). Vendored paths and the
+    parser-diagnostic rule are dropped entirely.
+    """
     data = json.loads(sarif_path.read_text(encoding="utf-8"))
     findings: list[tuple[str, int, str, str]] = []
+    suppressed: list[tuple[str, int, str, str, str]] = []
     for run in data.get("runs", []):
         for result in run.get("results", []):
             rule_id = _rule_id(result, run)
@@ -74,9 +136,18 @@ def load_findings(sarif_path: Path) -> list[tuple[str, int, str, str]]:
             if any(file.startswith(prefix) for prefix in PATHS_IGNORE):
                 continue
             message = result.get("message", {}).get("text", "").strip()
+            if reason := _allowlist_reason(file, rule_id, message):
+                suppressed.append((file, line, rule_id, message, reason))
+                continue
             findings.append((file, line, rule_id, message))
     findings.sort(key=lambda f: (f[2], f[0], f[1]))
-    return findings
+    suppressed.sort(key=lambda f: (f[2], f[0], f[1]))
+    return findings, suppressed
+
+
+def load_findings(sarif_path: Path) -> list[tuple[str, int, str, str]]:
+    """Return the sorted list of gating (file, line, rule_id, message) findings."""
+    return classify(sarif_path)[0]
 
 
 def render(findings: list[tuple[str, int, str, str]]) -> str:
@@ -110,8 +181,13 @@ def main(argv: list[str]) -> int:
         print(f"SARIF file not found: {sarif_path}", file=sys.stderr)
         return 2
 
-    findings = load_findings(sarif_path)
+    findings, suppressed = classify(sarif_path)
     report = render(findings)
+    if suppressed:
+        lines = [f"\nSuppressed (allowlisted false positives): {len(suppressed)}"]
+        for file, line, rule_id, _msg, reason in suppressed:
+            lines.append(f"  {file}:{line}  {rule_id} — {reason}")
+        report += "\n".join(lines) + "\n"
     print(report)
 
     if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -29,18 +29,13 @@ from typing import Any
 # (see ``extend-exclude`` in pyproject.toml). Keep this in sync with that list.
 PATHS_IGNORE: tuple[str, ...] = ("tests/initial_test_state/",)
 
-# Rules dropped before gating. ``py/syntax-error`` here is not a real syntax
-# error: it is a ``tsg-python`` parser diagnostic that CodeQL's code-quality
-# engine emits when it cannot parse a (valid Python 3) construct such as a
-# percent-format string. It is a tool limitation, not a code-quality finding,
-# and cannot be fixed in our source.
-RULES_IGNORE: frozenset[str] = frozenset({"py/syntax-error"})
-
 # Per-finding allowlist for verified false positives and intentional patterns
 # that cannot be cleared without breaking or contorting correct code. Each entry
 # is (rule_id, path_fragment, message_substring, reason). A finding is suppressed
 # only when all three of rule/path/message match — keep this list tight and the
-# reason current. Suppressed findings are reported (not silently dropped).
+# reason current. Suppressed findings are reported (not silently dropped). Scope
+# every entry to a specific file + message signature so a genuinely new finding
+# of the same rule elsewhere still fails the gate.
 ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
     (
         "py/unused-global-variable",
@@ -49,13 +44,6 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "Cross-invocation use: set True on the first signal, read on the next to "
         "force-exit. CodeQL's single-pass dead-store analysis misses the "
         "second-signal read, so the assignment looks dead.",
-    ),
-    (
-        "py/unused-global-variable",
-        "src/ha_mcp/tools/util_helpers.py",
-        "_SKILL_GUIDE_MANDATORYBPS_HINT",
-        "Used cross-module in server.py; CodeQL's unused-global check is "
-        "module-local and does not count the importing site.",
     ),
     (
         "py/unused-import",
@@ -121,8 +109,8 @@ def classify(
 
     ``gating_findings`` are (file, line, rule_id, message) tuples the gate fails
     on. ``suppressed`` are (file, line, rule_id, message, reason) tuples dropped
-    by the allowlist (reported, never silent). Vendored paths and the
-    parser-diagnostic rule are dropped entirely.
+    by the allowlist (reported, never silent). Findings under vendored
+    ``PATHS_IGNORE`` prefixes are dropped entirely.
     """
     data = json.loads(sarif_path.read_text(encoding="utf-8"))
     findings: list[tuple[str, int, str, str]] = []
@@ -130,8 +118,6 @@ def classify(
     for run in data.get("runs", []):
         for result in run.get("results", []):
             rule_id = _rule_id(result, run)
-            if rule_id in RULES_IGNORE:
-                continue
             file, line = _location(result)
             if any(file.startswith(prefix) for prefix in PATHS_IGNORE):
                 continue

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -24,6 +24,18 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
+# Findings under these path prefixes are dropped before gating. These are
+# vendored / third-party trees we do not own and ruff already excludes them
+# (see ``extend-exclude`` in pyproject.toml). Keep this in sync with that list.
+PATHS_IGNORE: tuple[str, ...] = ("tests/initial_test_state/",)
+
+# Rules dropped before gating. ``py/syntax-error`` here is not a real syntax
+# error: it is a ``tsg-python`` parser diagnostic that CodeQL's code-quality
+# engine emits when it cannot parse a (valid Python 3) construct such as a
+# percent-format string. It is a tool limitation, not a code-quality finding,
+# and cannot be fixed in our source.
+RULES_IGNORE: frozenset[str] = frozenset({"py/syntax-error"})
+
 
 def _rule_id(result: dict[str, Any], run: dict[str, Any]) -> str:
     """Resolve a result's rule id, falling back to the rules table by index."""
@@ -56,7 +68,11 @@ def load_findings(sarif_path: Path) -> list[tuple[str, int, str, str]]:
     for run in data.get("runs", []):
         for result in run.get("results", []):
             rule_id = _rule_id(result, run)
+            if rule_id in RULES_IGNORE:
+                continue
             file, line = _location(result)
+            if any(file.startswith(prefix) for prefix in PATHS_IGNORE):
+                continue
             message = result.get("message", {}).get("text", "").strip()
             findings.append((file, line, rule_id, message))
     findings.sort(key=lambda f: (f[2], f[0], f[1]))

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -3,14 +3,15 @@
 import sys
 
 if sys.version_info < (3, 13):  # noqa: UP036 — uvx can bypass requires-python and run on 3.12
-    print(
+    # Write directly to stderr (not print) so this import-time version gate
+    # fires before any 3.13-only syntax in the rest of the module is parsed.
+    sys.stderr.write(
         f"ERROR: ha-mcp requires Python 3.13+, but you are running Python "
         f"{sys.version_info.major}.{sys.version_info.minor}.\n"
         "If using uvx, add '--python 3.13' to your config args:\n"
         '  "args": ["--python", "3.13", "--refresh", "ha-mcp@latest"]\n'
         "Or install Python 3.13: brew install python@3.13 (macOS) / "
-        "sudo apt install python3.13 (Linux)",
-        file=sys.stderr,
+        "sudo apt install python3.13 (Linux)\n"
     )
     sys.exit(1)
 
@@ -496,6 +497,8 @@ async def _cancel_tasks(*tasks: asyncio.Task) -> None:
             try:
                 await task
             except asyncio.CancelledError:
+                # Expected: we just cancelled this task, swallow its
+                # CancelledError so remaining tasks still get awaited.
                 pass
 
 
@@ -525,6 +528,8 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
             except TimeoutError:
                 logger.warning("Server did not stop within timeout")
             except asyncio.CancelledError:
+                # Expected: we just cancelled server_task above; swallow its
+                # CancelledError so shutdown can proceed to cleanup.
                 pass
 
     except asyncio.CancelledError:

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -711,6 +711,7 @@ class HomeAssistantClient:
                     if isinstance(msg, str) and msg:
                         message = msg
             except json.JSONDecodeError:
+                # Body wasn't a JSON envelope; fall back to raw text below.
                 pass
             if not message:
                 message = text_body.strip() or response.reason_phrase or "<empty body>"

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -352,6 +352,8 @@ class HomeAssistantWebSocketClient:
             try:
                 await self.background_task
             except asyncio.CancelledError:
+                # Expected: we just cancelled the task above; swallow the
+                # propagated CancelledError so disconnect can finish cleanly.
                 pass
             finally:
                 self.background_task = None

--- a/src/ha_mcp/client/websocket_listener.py
+++ b/src/ha_mcp/client/websocket_listener.py
@@ -87,6 +87,7 @@ class WebSocketListenerService:
             try:
                 await self.listener_task
             except asyncio.CancelledError:
+                # Expected: awaiting a cancelled task re-raises CancelledError.
                 pass
 
         if self.cleanup_task and not self.cleanup_task.done():
@@ -94,6 +95,7 @@ class WebSocketListenerService:
             try:
                 await self.cleanup_task
             except asyncio.CancelledError:
+                # Expected: awaiting a cancelled task re-raises CancelledError.
                 pass
 
         # Remove event handler if WebSocket client exists
@@ -164,7 +166,9 @@ class WebSocketListenerService:
             if updated_ops:
                 operations_updated = self.stats["operations_updated"]
                 if isinstance(operations_updated, int):
-                    self.stats["operations_updated"] = operations_updated + len(updated_ops)
+                    self.stats["operations_updated"] = operations_updated + len(
+                        updated_ops
+                    )
                 logger.info(f"Updated {len(updated_ops)} operations for {entity_id}")
 
         except (RuntimeError, ConnectionError, OSError) as e:
@@ -307,7 +311,6 @@ _listener_lock: asyncio.Lock | None = None
 async def get_listener_service() -> WebSocketListenerService:
     """Get the global WebSocket listener service instance."""
     global _listener_service, _listener_lock
-    import asyncio
 
     current_loop = asyncio.get_event_loop()
 
@@ -373,7 +376,12 @@ class WebSocketContextManager:
         self.service = service
         return service
 
-    async def __aexit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
         """Stop WebSocket listener."""
         if self.service:
             await self.service.stop()

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -142,14 +142,14 @@ async def capture_dashboard_png(
                 context={"engine_url": engine},
                 suggestions=[
                     "Ensure the Puppet screenshot add-on (or sidecar) is "
-                    "installed and running",
+                    + "installed and running",
                     # Puppet restarts itself when navigation fails, so a
                     # missing/invalid token shows up as a dropped connection
                     # rather than an HTTP error.
                     f"If it is running, its access token is likely missing or "
                     f"invalid — {TOKEN_HINT}",
                     "Check HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL on "
-                    "Docker/Container deployments",
+                    + "Docker/Container deployments",
                 ],
             )
         )

--- a/src/ha_mcp/dashboard_screenshot/provision.py
+++ b/src/ha_mcp/dashboard_screenshot/provision.py
@@ -96,10 +96,11 @@ async def resolve_engine_url() -> str:
             suggestions=[
                 "Use HA OS / Supervised and install the screenshot engine add-on",
                 "Or run the engine as a sidecar and set "
-                "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL",
+                + "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL",
             ],
         )
     )
+    raise AssertionError("unreachable: raise_tool_error always raises")
 
 
 async def _discover_engine_url_via_supervisor() -> str:

--- a/src/ha_mcp/policy/middleware.py
+++ b/src/ha_mcp/policy/middleware.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NoReturn
 
 import anyio
 from anyio.to_thread import run_sync as run_in_thread
@@ -176,7 +176,7 @@ class PolicyMiddleware(Middleware):
                 await pending.wait()
 
     @staticmethod
-    def _raise_denied_error() -> None:
+    def _raise_denied_error() -> NoReturn:
         raise_tool_error(
             create_error_response(
                 ErrorCode.USER_DENIED,
@@ -189,7 +189,7 @@ class PolicyMiddleware(Middleware):
 
     def _raise_pending_error(
         self, pending: PendingApproval, rule: Rule | None = None
-    ) -> None:
+    ) -> NoReturn:
         # Time-remaining, not total TTL: an LLM that re-calls a minute
         # before expiry should see "~60s left", not the original 300s.
         remaining = max(
@@ -216,9 +216,9 @@ class PolicyMiddleware(Middleware):
                 "with the same arguments after the user approves.",
                 suggestions=[
                     "Tell the user to open the Tool Security Policies tab in "
-                    "the ha-mcp settings UI and approve the pending request.",
+                    + "the ha-mcp settings UI and approve the pending request.",
                     "Re-call this tool with the same arguments after the user "
-                    "approves.",
+                    + "approves.",
                 ],
                 context=context,
             )

--- a/src/ha_mcp/policy/middleware.py
+++ b/src/ha_mcp/policy/middleware.py
@@ -149,6 +149,7 @@ class PolicyMiddleware(Middleware):
                 name,
             )
         self._raise_pending_error(pending, rule)
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     async def _wait_for_decision(
         self,

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -47,6 +47,20 @@ _OLD_SKILL_TOOL_ALIASES = (
     "If you were going to call any of those, call this instead."
 )
 
+# Hint shipped at the top of ha_get_skill_guide responses that deliver
+# best-practice skill content directly. Smart clients that fetch the reference
+# files proactively via this tool would otherwise still receive duplicate
+# canonical content from the per-call write-tool attach — this hint tells them
+# to opt out so the same body doesn't ride along again on every subsequent
+# write. Defined here (its only consumer) rather than in util_helpers.
+_SKILL_GUIDE_MANDATORYBPS_HINT = (
+    "You now have this best-practice reference in your context. "
+    "Pass `MandatoryBPS=false` on subsequent write-tool calls in this "
+    "session (ha_config_set_automation / _script / _scene / _helper / "
+    "_dashboard / _yaml) to avoid re-receiving the canonical reference "
+    "files inline."
+)
+
 
 # Server icon configuration using GitHub-hosted images
 # These icons are bundled in packaging/mcpb/ and also available via GitHub raw URLs
@@ -1447,10 +1461,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         # parsing the (potentially large) content body. Scoped to the
         # best-practice skill because that's the one the write-tool
         # MandatoryBPS param gates; other skills (if any) are unrelated.
-        from .tools.util_helpers import (
-            _HA_BEST_PRACTICES_SKILL_NAME,
-            _SKILL_GUIDE_MANDATORYBPS_HINT,
-        )
+        from .tools.util_helpers import _HA_BEST_PRACTICES_SKILL_NAME
 
         response: dict[str, Any] = {}
         if skill == _HA_BEST_PRACTICES_SKILL_NAME:

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -1703,9 +1703,9 @@ def build_settings_handlers(
                     ),
                     suggestions=[
                         "Include enable_beta_features=true in the same save "
-                        "payload as the sub-flag(s).",
+                        + "payload as the sub-flag(s).",
                         "Or turn on the master 'Enable beta features' toggle "
-                        "first, then enable the sub-flag(s).",
+                        + "first, then enable the sub-flag(s).",
                     ],
                     context={"rejected": beta_sub_writes},
                 ),
@@ -1874,10 +1874,10 @@ def build_settings_handlers(
                             "Supervisor helper returned ok=False with no error",
                             suggestions=[
                                 "Check the Home Assistant Supervisor logs and "
-                                "the add-on logs for the underlying failure.",
+                                + "the add-on logs for the underlying failure.",
                                 "Report this at "
-                                "https://github.com/homeassistant-ai/ha-mcp/issues "
-                                "if it persists — this indicates an internal bug.",
+                                + "https://github.com/homeassistant-ai/ha-mcp/issues "
+                                + "if it persists — this indicates an internal bug.",
                             ],
                         ),
                         status_code=500,
@@ -2575,10 +2575,10 @@ def build_settings_handlers(
                             "Supervisor helper returned ok=False with no error",
                             suggestions=[
                                 "Check the Home Assistant Supervisor logs and "
-                                "the add-on logs for the underlying failure.",
+                                + "the add-on logs for the underlying failure.",
                                 "Report this at "
-                                "https://github.com/homeassistant-ai/ha-mcp/issues "
-                                "if it persists — this indicates an internal bug.",
+                                + "https://github.com/homeassistant-ai/ha-mcp/issues "
+                                + "if it persists — this indicates an internal bug.",
                             ],
                         ),
                         status_code=500,

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -517,6 +517,7 @@ async def create_backup(
             context={"tool": "create_backup"},
             suggestions=["Check Home Assistant connection and backup configuration"],
         )
+        return None  # unreachable: exception_to_structured_error always raises
     finally:
         # Always disconnect WebSocket — narrow to transport errors; a
         # programming error during cleanup should still surface.
@@ -714,6 +715,7 @@ async def restore_backup(
             context={"tool": "restore_backup", "backup_id": backup_id},
             suggestions=["Check Home Assistant connection and backup availability"],
         )
+        return None  # unreachable: exception_to_structured_error always raises
     finally:
         # Always disconnect WebSocket — narrow to transport errors; a
         # programming error during cleanup should still surface.
@@ -953,11 +955,11 @@ def register_backup_tools(
                     create_error_response(
                         ErrorCode.RESOURCE_NOT_FOUND,
                         f"Could not snapshot {dom}:{eid} — entity not found "
-                        "or fetch returned no config",
+                        + "or fetch returned no config",
                         context={"domain": dom, "entity_id": eid},
                         suggestions=[
                             "Verify the entity exists via the matching "
-                            "ha_config_get_* tool first",
+                            + "ha_config_get_* tool first",
                             "For helpers, pass domain='helper_<helper_type>' "
                             "(e.g. 'helper_input_boolean')",
                         ],
@@ -1053,13 +1055,13 @@ def register_backup_tools(
                     context={"backup_name": bname, "action": "restore"},
                     suggestions=[
                         "Verify the entity referenced by the backup still "
-                        "exists; restore re-POSTs to its current registry "
-                        "key",
+                        + "exists; restore re-POSTs to its current registry "
+                        + "key",
                         "Compare the captured schema vs current HA — HA "
-                        "minor versions occasionally drop/rename fields",
+                        + "minor versions occasionally drop/rename fields",
                         "Inspect the snapshot YAML via "
-                        "ha_manage_backup(scope='edits', action='view', "
-                        "backup_name=...)",
+                        + "ha_manage_backup(scope='edits', action='view', "
+                        + "backup_name=...)",
                     ],
                 )
             return {

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -728,6 +728,7 @@ async def restore_backup(
                     type(err).__name__,
                     err,
                 )
+    return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 # Valid (scope, action) combinations. Anything outside this set is
@@ -961,7 +962,7 @@ def register_backup_tools(
                             "Verify the entity exists via the matching "
                             + "ha_config_get_* tool first",
                             "For helpers, pass domain='helper_<helper_type>' "
-                            "(e.g. 'helper_input_boolean')",
+                            + "(e.g. 'helper_input_boolean')",
                         ],
                     )
                 )

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -195,7 +195,7 @@ class DeviceControlTools:
             raise
         except Exception as e:
             logger.error(f"Error in control_device_smart: {e}")
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "action": action},
                 suggestions=[
@@ -204,6 +204,8 @@ class DeviceControlTools:
                     "Try simpler action like 'toggle'",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     def _parse_parameters(
         self,
@@ -655,11 +657,12 @@ class DeviceControlTools:
             raise
         except Exception as e:
             logger.error(f"Error in bulk_device_control: {e}")
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e,
                 context={"results": results},
                 suggestions=["Check operation parameters and try again"],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
     def _tool_error_to_dict(e: ToolError) -> dict[str, Any]:

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -90,15 +90,17 @@ class DeviceControlTools:
 
             # Parse domain from entity ID
             if "." not in entity_id:
-                raise_tool_error(create_error_response(
-                    ErrorCode.ENTITY_INVALID_ID,
-                    f"Invalid entity ID format: {entity_id}",
-                    suggestions=[
-                        "Entity ID must be in format 'domain.entity_name'",
-                        "Use smart_entity_search to find correct entity ID",
-                    ],
-                    context={"entity_id": entity_id, "action": action},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.ENTITY_INVALID_ID,
+                        f"Invalid entity ID format: {entity_id}",
+                        suggestions=[
+                            "Entity ID must be in format 'domain.entity_name'",
+                            "Use smart_entity_search to find correct entity ID",
+                        ],
+                        context={"entity_id": entity_id, "action": action},
+                    )
+                )
 
             domain = entity_id.split(".")[0]
             handler = get_domain_handler(domain)
@@ -111,15 +113,21 @@ class DeviceControlTools:
             # Validate action for domain
             valid_actions = handler.get("valid_actions", ["on", "off", "toggle"])
             if action not in valid_actions:
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_INVALID_ACTION,
-                    f"Invalid action '{action}' for domain '{domain}'",
-                    suggestions=[
-                        f"Valid actions for {domain}: {', '.join(valid_actions)}",
-                        "Use 'toggle' for simple on/off control",
-                    ],
-                    context={"entity_id": entity_id, "action": action, "valid_actions": valid_actions},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_INVALID_ACTION,
+                        f"Invalid action '{action}' for domain '{domain}'",
+                        suggestions=[
+                            f"Valid actions for {domain}: {', '.join(valid_actions)}",
+                            "Use 'toggle' for simple on/off control",
+                        ],
+                        context={
+                            "entity_id": entity_id,
+                            "action": action,
+                            "valid_actions": valid_actions,
+                        },
+                    )
+                )
 
             # Build service call
             service_call = self._build_service_call(
@@ -187,7 +195,7 @@ class DeviceControlTools:
             raise
         except Exception as e:
             logger.error(f"Error in control_device_smart: {e}")
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "action": action},
                 suggestions=[
@@ -207,15 +215,17 @@ class DeviceControlTools:
             try:
                 return json.loads(parameters)
             except json.JSONDecodeError:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_JSON,
-                    f"Invalid JSON in parameters: {parameters}",
-                    suggestions=[
-                        "Parameters should be a valid JSON object",
-                        "Example: {'brightness': 102, 'color_temp_kelvin': 4000}",
-                    ],
-                    context={"entity_id": entity_id, "action": action},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_JSON,
+                        f"Invalid JSON in parameters: {parameters}",
+                        suggestions=[
+                            "Parameters should be a valid JSON object",
+                            "Example: {'brightness': 102, 'color_temp_kelvin': 4000}",
+                        ],
+                        context={"entity_id": entity_id, "action": action},
+                    )
+                )
         return parameters
 
     async def _validate_entity_exists(
@@ -227,15 +237,17 @@ class DeviceControlTools:
         try:
             current_state = await self.client.get_entity_state(entity_id)
             if not current_state:
-                raise_tool_error(create_error_response(
-                    ErrorCode.ENTITY_NOT_FOUND,
-                    f"Entity not found: {entity_id}",
-                    suggestions=[
-                        "Use smart_entity_search to find the correct entity",
-                        "Check entity is not disabled in Home Assistant",
-                    ],
-                    context={"entity_id": entity_id, "action": action},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        f"Entity not found: {entity_id}",
+                        suggestions=[
+                            "Use smart_entity_search to find the correct entity",
+                            "Check entity is not disabled in Home Assistant",
+                        ],
+                        context={"entity_id": entity_id, "action": action},
+                    )
+                )
             return current_state
         except ToolError:
             raise
@@ -325,7 +337,9 @@ class DeviceControlTools:
         parameters: dict[str, Any] | None,
     ) -> dict[str, Any]:
         """Build Home Assistant service call from action and parameters."""
-        service_name, parameters = self._resolve_service_name(domain, action, parameters)
+        service_name, parameters = self._resolve_service_name(
+            domain, action, parameters
+        )
 
         service_data: dict[str, Any] = {"entity_id": entity_id}
 
@@ -411,16 +425,18 @@ class DeviceControlTools:
         operation = get_operation_from_memory(operation_id)
 
         if not operation:
-            raise_tool_error(create_error_response(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                "Operation not found or expired",
-                suggestions=[
-                    "Operation may have been cleaned up after completion",
-                    "Check operation ID spelling",
-                    "Use control_device_smart to start new operation",
-                ],
-                context={"operation_id": operation_id},
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    "Operation not found or expired",
+                    suggestions=[
+                        "Operation may have been cleaned up after completion",
+                        "Check operation ID spelling",
+                        "Use control_device_smart to start new operation",
+                    ],
+                    context={"operation_id": operation_id},
+                )
+            )
 
         # Wait up to timeout_seconds for the operation to leave the pending state.
         # The WebSocket listener mutates operation.status as state changes arrive,
@@ -434,16 +450,18 @@ class DeviceControlTools:
                 await asyncio.sleep(0.2)
                 refreshed = get_operation_from_memory(operation_id)
                 if refreshed is None:
-                    raise_tool_error(create_error_response(
-                        ErrorCode.RESOURCE_NOT_FOUND,
-                        "Operation cleaned up during status poll",
-                        suggestions=[
-                            "Operation may have completed and been purged before "
-                            "verification finished",
-                            "Use control_device_smart to start new operation",
-                        ],
-                        context={"operation_id": operation_id},
-                    ))
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.RESOURCE_NOT_FOUND,
+                            "Operation cleaned up during status poll",
+                            suggestions=[
+                                "Operation may have completed and been purged before "
+                                + "verification finished",
+                                "Use control_device_smart to start new operation",
+                            ],
+                            context={"operation_id": operation_id},
+                        )
+                    )
                 operation = refreshed
 
         # Check operation status
@@ -470,40 +488,44 @@ class DeviceControlTools:
             }
 
         elif operation.status.value == "failed":
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                operation.error_message or "Device operation failed",
-                context={
-                    "operation_id": operation_id,
-                    "entity_id": operation.entity_id,
-                    "action": operation.action,
-                    "duration_ms": operation.duration_ms,
-                },
-                suggestions=[
-                    "Check if device is available and responding",
-                    "Verify device supports the requested action",
-                    "Check Home Assistant logs for error details",
-                    "Try a simpler action like toggle",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    operation.error_message or "Device operation failed",
+                    context={
+                        "operation_id": operation_id,
+                        "entity_id": operation.entity_id,
+                        "action": operation.action,
+                        "duration_ms": operation.duration_ms,
+                    },
+                    suggestions=[
+                        "Check if device is available and responding",
+                        "Verify device supports the requested action",
+                        "Check Home Assistant logs for error details",
+                        "Try a simpler action like toggle",
+                    ],
+                )
+            )
 
         elif operation.status.value == "timeout":
-            raise_tool_error(create_error_response(
-                ErrorCode.TIMEOUT_OPERATION,
-                f"Operation timed out after {operation.timeout_ms}ms",
-                context={
-                    "operation_id": operation_id,
-                    "entity_id": operation.entity_id,
-                    "action": operation.action,
-                    "elapsed_ms": operation.elapsed_ms,
-                },
-                suggestions=[
-                    "Device may be slow to respond or offline",
-                    "Check device connectivity",
-                    "Try increasing timeout for slow devices",
-                    "Verify device is powered on",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.TIMEOUT_OPERATION,
+                    f"Operation timed out after {operation.timeout_ms}ms",
+                    context={
+                        "operation_id": operation_id,
+                        "entity_id": operation.entity_id,
+                        "action": operation.action,
+                        "elapsed_ms": operation.elapsed_ms,
+                    },
+                    suggestions=[
+                        "Device may be slow to respond or offline",
+                        "Check device connectivity",
+                        "Try increasing timeout for slow devices",
+                        "Verify device is powered on",
+                    ],
+                )
+            )
 
         else:  # pending
             return {
@@ -576,12 +598,14 @@ class DeviceControlTools:
             Bulk operation results
         """
         if not operations:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "No operations provided",
-                suggestions=["Provide a list of device control operations"],
-                context={"results": []},
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "No operations provided",
+                    suggestions=["Provide a list of device control operations"],
+                    context={"results": []},
+                )
+            )
 
         results: list[dict[str, Any]] = []
         operation_ids: list[str] = []
@@ -631,7 +655,7 @@ class DeviceControlTools:
             raise
         except Exception as e:
             logger.error(f"Error in bulk_device_control: {e}")
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e,
                 context={"results": results},
                 suggestions=["Check operation parameters and try again"],
@@ -671,10 +695,12 @@ class DeviceControlTools:
                 if isinstance(result, ToolError):
                     results.append(self._tool_error_to_dict(result))
                 elif isinstance(result, Exception):
-                    results.append(create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        f"Exception during execution: {result!s}",
-                    ))
+                    results.append(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            f"Exception during execution: {result!s}",
+                        )
+                    )
                 elif isinstance(result, dict):
                     results.append(result)
                     if "operation_id" in result:
@@ -703,10 +729,12 @@ class DeviceControlTools:
             except ToolError as e:
                 results.append(self._tool_error_to_dict(e))
             except Exception as e:
-                results.append(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Exception during execution: {e!s}",
-                ))
+                results.append(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Exception during execution: {e!s}",
+                    )
+                )
             await safe_progress(
                 ctx,
                 progress=i + 1,
@@ -775,11 +803,15 @@ class DeviceControlTools:
             Status summary for all operations
         """
         if not operation_ids:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "No operation IDs provided",
-                suggestions=["Provide a list of operation IDs from control_device_smart"],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "No operation IDs provided",
+                    suggestions=[
+                        "Provide a list of operation IDs from control_device_smart"
+                    ],
+                )
+            )
 
         # Check all operations
         statuses = []

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -363,9 +363,9 @@ def _append_macos_hints(error_response: dict[str, Any]) -> None:
         return
     macos_hints = [
         "macOS may block local network access for Claude Desktop subprocesses "
-        "(System Settings > Privacy & Security > Local Network)",
+        + "(System Settings > Privacy & Security > Local Network)",
         "Try an SSH tunnel: ssh -N -L 8123:localhost:8123 user@ha-server, "
-        "then use http://localhost:8123",
+        + "then use http://localhost:8123",
         "Ensure you are using http:// (not https://) unless SSL/TLS is configured",
     ]
     # Handle both "suggestions" (plural, 2+ items) and "suggestion" (singular, 1 item)
@@ -384,7 +384,8 @@ def exception_to_structured_error(
     *,
     raise_error: Literal[True] = True,
     suggestions: list[str] | None = None,
-) -> NoReturn: ...
+) -> NoReturn:
+    pass
 
 
 @overload
@@ -394,7 +395,8 @@ def exception_to_structured_error(
     *,
     raise_error: Literal[False],
     suggestions: list[str] | None = None,
-) -> dict[str, Any]: ...
+) -> dict[str, Any]:
+    pass
 
 
 def exception_to_structured_error(

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -203,6 +203,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     "helpers": [],
                 },
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     @staticmethod
     def _build_automation_uid_map(

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -90,6 +90,10 @@ class EntitySearchMixin(_SearchBase):
                     "error_source": "smart_entity_search",
                 },
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     @staticmethod
     def _build_registry_slim(reg_result: Any) -> dict[str, dict[str, Any]]:
@@ -340,6 +344,10 @@ class EntitySearchMixin(_SearchBase):
                 ],
                 context={"area_query": area_query},
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     @classmethod
     def _parse_area_registry(cls, result: Any) -> dict[str, dict[str, Any]]:

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -162,6 +162,9 @@ class SystemOverviewMixin(_SearchBase):
                     "controllable_devices": {},
                 },
             )
+            # exception_to_structured_error always raises; unreachable but makes
+            # every code path return explicitly (py/mixed-returns).
+            return None
 
     @staticmethod
     def _build_entity_area_map(

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -292,11 +292,14 @@ async def _supervisor_api_call(
             context={"endpoint": endpoint},
             suggestions=["Check Home Assistant connection and Supervisor availability"],
         )
+        return None  # unreachable: exception_to_structured_error always raises
     finally:
         if ws_client:
             try:
                 await ws_client.disconnect()
             except Exception:
+                # Best-effort cleanup: the WS connection is being torn down, so a
+                # disconnect failure is non-fatal and must not mask the real result.
                 pass
 
 
@@ -314,16 +317,16 @@ def _addon_connection_failure_suggestions(
         return [
             "Check that the add-on is running",
             "Direct-port access requires the MCP host to share Home "
-            "Assistant's container network. On PyPI/uvx installs, drop "
-            "the 'port' parameter to route through Ingress instead.",
+            + "Assistant's container network. On PyPI/uvx installs, drop "
+            + "the 'port' parameter to route through Ingress instead.",
         ]
     if is_running_in_addon():
         return [
             "The target add-on container may not be reachable from this "
-            "MCP add-on. Check that the target add-on is running.",
+            + "MCP add-on. Check that the target add-on is running.",
             "If the failure persists, the addon Docker network may be "
-            "unhealthy — try restarting the target add-on, then this "
-            "MCP add-on.",
+            + "unhealthy — try restarting the target add-on, then this "
+            + "MCP add-on.",
         ]
     return [
         f"Verify Home Assistant is reachable at {client.base_url}",
@@ -1903,6 +1906,7 @@ class AddOnTools:
             )
             return self._repo_noop_result(key, repository, noop)
         self._raise_repo_action_error(key, repository, error_text)
+        return None  # unreachable: _raise_repo_action_error always raises
 
     @staticmethod
     def _supervisor_error_text(error_text: str) -> str:
@@ -1971,9 +1975,9 @@ class AddOnTools:
         else:
             suggestions = [
                 "Verify the repository slug — list current repositories with "
-                "ha_get_addon(source='available')",
+                + "ha_get_addon(source='available')",
                 "A repository that still has installed add-ons can't be removed "
-                "until those add-ons are uninstalled",
+                + "until those add-ons are uninstalled",
             ]
         raise_tool_error(
             create_error_response(

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -377,6 +377,7 @@ class AreaTools:
                     "Verify WebSocket connection is active",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     # ============================================================
     # COMBINED SET / REMOVE
@@ -628,6 +629,7 @@ class AreaTools:
                 context={"operation": operation, "kind": kind, "name": name, "id": id},
                 suggestions=suggestions,
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_remove_area_or_floor",
@@ -717,6 +719,7 @@ class AreaTools:
                     f"Verify the {kind} id exists using ha_list_floors_areas()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -630,6 +630,7 @@ class AreaTools:
                 suggestions=suggestions,
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_remove_area_or_floor",
@@ -720,6 +721,7 @@ class AreaTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_area_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_blueprints.py
+++ b/src/ha_mcp/tools/tools_blueprints.py
@@ -30,7 +30,9 @@ class BlueprintTools:
         self._client = client
 
     @staticmethod
-    def _format_blueprint_list(blueprints_data: dict[str, Any], domain: str) -> dict[str, Any]:
+    def _format_blueprint_list(
+        blueprints_data: dict[str, Any], domain: str
+    ) -> dict[str, Any]:
         """Format blueprint data into list response structure.
 
         Args:
@@ -45,17 +47,21 @@ class BlueprintTools:
             blueprint_info = {
                 "path": bp_path,
                 "domain": domain,
-                "name": metadata.get("name", bp_path.split("/")[-1].replace(".yaml", "")),
+                "name": metadata.get(
+                    "name", bp_path.split("/")[-1].replace(".yaml", "")
+                ),
             }
 
             # Add optional metadata if available
             if "metadata" in metadata:
                 meta = metadata["metadata"]
-                blueprint_info.update({
-                    "description": meta.get("description"),
-                    "source_url": meta.get("source_url"),
-                    "author": meta.get("author"),
-                })
+                blueprint_info.update(
+                    {
+                        "description": meta.get("description"),
+                        "source_url": meta.get("source_url"),
+                        "author": meta.get("author"),
+                    }
+                )
 
             blueprints.append(blueprint_info)
 
@@ -69,7 +75,11 @@ class BlueprintTools:
     @tool(
         name="ha_get_blueprint",
         tags={"Blueprints"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Blueprint"},
+        annotations={
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Get Blueprint",
+        },
     )
     @log_tool_usage
     async def ha_get_blueprint(
@@ -115,11 +125,13 @@ class BlueprintTools:
             # Validate domain
             valid_domains = ["automation", "script"]
             if domain not in valid_domains:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"Invalid domain '{domain}'. Must be one of: {', '.join(valid_domains)}",
-                    context={"domain": domain, "valid_domains": valid_domains},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Invalid domain '{domain}'. Must be one of: {', '.join(valid_domains)}",
+                        context={"domain": domain, "valid_domains": valid_domains},
+                    )
+                )
 
             # Get list of blueprints
             list_response = await self._client.send_websocket_message(
@@ -127,11 +139,13 @@ class BlueprintTools:
             )
 
             if not list_response.get("success"):
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    list_response.get("error", "Failed to query blueprints"),
-                    context={"domain": domain},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        list_response.get("error", "Failed to query blueprints"),
+                        context={"domain": domain},
+                    )
+                )
 
             blueprints_data = list_response.get("result", {})
 
@@ -142,15 +156,21 @@ class BlueprintTools:
             # Path provided - get specific blueprint details
             if path not in blueprints_data:
                 available_paths = list(blueprints_data.keys())[:10]
-                raise_tool_error(create_error_response(
-                    ErrorCode.RESOURCE_NOT_FOUND,
-                    f"Blueprint not found: {path}",
-                    context={"path": path, "domain": domain, "available_blueprints": available_paths},
-                    suggestions=[
-                        "Use ha_get_blueprint() without path to see all available blueprints",
-                        "Check the path format (e.g., 'homeassistant/motion_light.yaml')",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"Blueprint not found: {path}",
+                        context={
+                            "path": path,
+                            "domain": domain,
+                            "available_blueprints": available_paths,
+                        },
+                        suggestions=[
+                            "Use ha_get_blueprint() without path to see all available blueprints",
+                            "Check the path format (e.g., 'homeassistant/motion_light.yaml')",
+                        ],
+                    )
+                )
 
             # Get the blueprint details from the list response
             blueprint_data = blueprints_data[path]
@@ -160,7 +180,9 @@ class BlueprintTools:
                 "success": True,
                 "path": path,
                 "domain": domain,
-                "name": blueprint_data.get("name", path.split("/")[-1].replace(".yaml", "")),
+                "name": blueprint_data.get(
+                    "name", path.split("/")[-1].replace(".yaml", "")
+                ),
             }
 
             # Add metadata if available
@@ -197,6 +219,7 @@ class BlueprintTools:
                     "Check Home Assistant connection",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_import_blueprint",
@@ -237,11 +260,13 @@ class BlueprintTools:
         try:
             # Validate URL format
             if not url.startswith(("http://", "https://")):
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "Invalid URL format. URL must start with http:// or https://",
-                    context={"url": url},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Invalid URL format. URL must start with http:// or https://",
+                        context={"url": url},
+                    )
+                )
 
             # Send WebSocket command to import blueprint
             response = await self._client.send_websocket_message(
@@ -259,14 +284,19 @@ class BlueprintTools:
                 ]
 
                 if "already exists" in str(error_msg).lower():
-                    suggestions.insert(0, "Blueprint already exists - use ha_get_blueprint() to see installed blueprints")
+                    suggestions.insert(
+                        0,
+                        "Blueprint already exists - use ha_get_blueprint() to see installed blueprints",
+                    )
 
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    error_msg,
-                    context={"url": url},
-                    suggestions=suggestions,
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        error_msg,
+                        context={"url": url},
+                        suggestions=suggestions,
+                    )
+                )
 
             # Extract import result (blueprint/import only validates, does not save)
             result_data = response.get("result", {})
@@ -276,15 +306,17 @@ class BlueprintTools:
             domain = blueprint_meta.get("domain", "automation")
 
             if not suggested_filename or not raw_data:
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    "Blueprint validated but no filename or YAML data was returned",
-                    context={"url": url},
-                    suggestions=[
-                        "This may indicate an incompatible blueprint format",
-                        "Try a different blueprint URL",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        "Blueprint validated but no filename or YAML data was returned",
+                        context={"url": url},
+                        suggestions=[
+                            "This may indicate an incompatible blueprint format",
+                            "Try a different blueprint URL",
+                        ],
+                    )
+                )
 
             # Ensure the path has a .yaml extension — HA's blueprint/import returns
             # suggested_filename without the extension (e.g. "user/blueprint_name")
@@ -318,12 +350,14 @@ class BlueprintTools:
                 if "already exists" in save_error.lower():
                     suggestions.insert(0, "A blueprint with this path already exists")
 
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    save_error,
-                    context={"url": url, "path": suggested_filename},
-                    suggestions=suggestions,
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        save_error,
+                        context={"url": url, "path": suggested_filename},
+                        suggestions=suggestions,
+                    )
+                )
 
             save_result = save_response.get("result") or {}
 
@@ -353,6 +387,7 @@ class BlueprintTools:
                     "Try importing from a different source (GitHub, Community, direct URL)",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_blueprint_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -87,6 +87,8 @@ def _detect_installation_method() -> str:
         if (project_root / ".git").exists():
             return "git"
     except Exception:
+        # Best-effort probe: path resolution may fail in unusual layouts;
+        # fall through to the next detection heuristic.
         pass
 
     # 5. PyPI install - marker file exists in package
@@ -95,6 +97,8 @@ def _detect_installation_method() -> str:
         if marker_path.exists():
             return "pypi"
     except Exception:
+        # Best-effort probe: marker lookup may fail in unusual layouts;
+        # fall through to the default "unknown" result.
         pass
 
     # 6. Default - unknown

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -168,6 +168,7 @@ class CalendarTools:
             exception_to_structured_error(
                 error, context={"entity_id": entity_id}, suggestions=suggestions
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_set_calendar_event",
@@ -309,6 +310,7 @@ class CalendarTools:
             exception_to_structured_error(
                 error, context={"entity_id": entity_id}, suggestions=suggestions
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_remove_calendar_event",
@@ -493,6 +495,7 @@ class CalendarTools:
                 context={"entity_id": entity_id, "uid": uid},
                 suggestions=suggestions,
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_calendar_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_categories.py
+++ b/src/ha_mcp/tools/tools_categories.py
@@ -165,6 +165,7 @@ class CategoryTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_config_set_category",
@@ -306,6 +307,7 @@ class CategoryTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_config_remove_category",
@@ -415,6 +417,7 @@ class CategoryTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_category_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_categories.py
+++ b/src/ha_mcp/tools/tools_categories.py
@@ -164,6 +164,7 @@ class CategoryTools:
                     "Ensure scope is valid (e.g., 'automation', 'script', 'scene', 'helpers')",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_set_category",
@@ -304,6 +305,7 @@ class CategoryTools:
                     "For updates, verify the category_id exists using ha_config_get_category()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_remove_category",
@@ -412,6 +414,7 @@ class CategoryTools:
                     "Verify the category_id exists using ha_config_get_category()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_category_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -237,9 +237,9 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
             f"Sandbox memory limit exceeded: {short}",
             [
                 "Reduce memory usage in your code (smaller intermediate "
-                "data structures, no large list accumulation).",
+                + "data structures, no large list accumulation).",
                 "Stream results via call_tool calls rather than building "
-                "them up in-process.",
+                + "them up in-process.",
                 "Operator can raise CODE_MODE_MAX_MEMORY (max 256 MB).",
             ],
         )
@@ -249,7 +249,7 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
             f"Sandbox recursion limit exceeded: {short}",
             [
                 "Convert deep recursion to iteration (while/for with an "
-                "explicit stack).",
+                + "explicit stack).",
                 "Operator can raise CODE_MODE_MAX_RECURSION (max 10000).",
             ],
         )
@@ -271,7 +271,7 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
             [
                 "Remove all 'import' / 'from ... import' statements.",
                 "Use the injected helpers instead: api_get, api_post, "
-                "ws_send, call_tool, delete_saved_tool.",
+                + "ws_send, call_tool, delete_saved_tool.",
             ],
         )
     if _matches("NotImplementedError", "does not yet support", "context manager"):
@@ -280,8 +280,8 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
             f"Sandbox does not support this Python feature: {short}",
             [
                 "Monty's sandboxed interpreter is a Python subset — "
-                "context managers (with), match statements, class "
-                "definitions, and some builtins are unavailable.",
+                + "context managers (with), match statements, class "
+                + "definitions, and some builtins are unavailable.",
                 "Rewrite using basic statements and the injected helpers.",
             ],
         )
@@ -292,7 +292,7 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
             [
                 "Fix the syntax error and retry.",
                 "Reminder: no class definitions, no imports, no 'with' "
-                "or 'match' statements.",
+                + "or 'match' statements.",
             ],
         )
 
@@ -302,7 +302,7 @@ def _classify_sandbox_error(exc: Exception) -> tuple[ErrorCode, str, list[str]]:
         [
             f"Exception type: {exc_type}",
             "Some Python builtins behave differently in Monty (e.g. "
-            "next() requires an iterator, not a list).",
+            + "next() requires an iterator, not a list).",
             "Check the values you're passing to api_get/api_post/ws_send/call_tool.",
             "Use 'await' before any call to api_get/api_post/ws_send/call_tool.",
         ],
@@ -1154,9 +1154,9 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                         message,
                         suggestions=[
                             "The saved code may no longer work in the "
-                            "current sandbox or HA configuration.",
+                            + "current sandbox or HA configuration.",
                             "Use ha_manage_custom_tool(code=...) to "
-                            "create an updated version.",
+                            + "create an updated version.",
                             *suggestions,
                         ],
                         context={

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -403,6 +403,7 @@ class AutomationConfigTools:
                     "Use ha_get_skill_guide for help",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_set_automation",
@@ -1296,6 +1297,7 @@ class AutomationConfigTools:
                     "Check Home Assistant connection",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_config_automation_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -926,7 +926,8 @@ class AutomationConfigTools:
             # automation_id omitted when all three fallbacks are falsy —
             # the create path is unguarded by validate_identifier_not_empty,
             # and surfacing automation_id=None would lie about resolvability.
-            # HA's upsert contract makes this branch unreachable in practice.
+            # Defensive: HA's upsert normally returns a usable id, so this
+            # fallback rarely triggers.
             **({"automation_id": automation_id} if automation_id else {}),
             **_strip_redundant_identifier_echo(result),
         }

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -435,7 +435,8 @@ async def _lazy_resolve_and_retry(
     url_path: str,
     ws_data: dict[str, Any],
     response: Any,
-) -> tuple[str, Any]: ...
+) -> tuple[str, Any]:
+    pass
 
 
 @overload
@@ -444,7 +445,8 @@ async def _lazy_resolve_and_retry(
     url_path: None,
     ws_data: dict[str, Any],
     response: Any,
-) -> tuple[None, Any]: ...
+) -> tuple[None, Any]:
+    pass
 
 
 async def _lazy_resolve_and_retry(
@@ -1000,6 +1002,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                 context=context,
                 suggestions=suggestions,
             )
+            return None
 
     @mcp.tool(
         tags={"Dashboards"},
@@ -1598,6 +1601,10 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                             existing_hash,
                         ) = await _get_dashboard_config_internal(client, url_path)
                     except ToolError:
+                        # Pre-read failure is non-fatal on the force-replace
+                        # path: skip the optimistic-lock check and large-config
+                        # warning and proceed with the replacement (see the
+                        # rationale above the try).
                         pass
 
                     if isinstance(existing_config, dict):
@@ -1696,6 +1703,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
             )
             augment_error_dict_with_skill_content(error, bp_warnings=None)
             raise_tool_error(error)
+            return None
 
     @mcp.tool(
         tags={"Dashboards"},

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1837,6 +1837,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
                     "Cannot delete YAML-mode or default dashboard",
                 ],
             )
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     # =========================================================================
     # Dashboard Resource Management Tools

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3375,6 +3375,7 @@ class HelperConfigTools:
             return (
                 None  # exception_to_structured_error always raises; explicit for CodeQL
             )
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_config_set_helper",

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3372,6 +3372,9 @@ class HelperConfigTools:
                     "Use ha_search_entities(domain_filter='input_*') as alternative",
                 ],
             )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
     @tool(
         name="ha_config_set_helper",

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -243,8 +243,7 @@ class ConfigSceneTools:
                 message="scene_id must not be empty",
                 suggestions=[
                     "Pass a non-empty scene identifier (e.g. 'movie_night')",
-                    "Use ha_search_entities(domain_filter='scene') "
-                    "to find existing scene_ids",
+                    "Use ha_search_entities(domain_filter='scene') to find existing scene_ids",
                 ],
                 context={"scene_id": scene_id},
             )
@@ -294,6 +293,10 @@ class ConfigSceneTools:
                     "Use ha_get_skill_guide for help",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     async def _get_scene_config_internal(
         self, scene_id: str
@@ -985,8 +988,7 @@ class ConfigSceneTools:
                 message="scene_id must not be empty",
                 suggestions=[
                     "Pass a non-empty scene identifier (e.g. 'old_scene')",
-                    "Use ha_search_entities(domain_filter='scene') "
-                    "to find existing scene_ids",
+                    "Use ha_search_entities(domain_filter='scene') to find existing scene_ids",
                 ],
                 context={"scene_id": scene_id},
             )
@@ -1035,6 +1037,10 @@ class ConfigSceneTools:
                     "Use ha_get_skill_guide for help",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
 
 def register_config_scene_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -201,6 +201,7 @@ class ConfigScriptTools:
                     "Use ha_get_skill_guide for help",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     async def _list_script_entity_ids(self) -> list[str]:
         """Best-effort list of bare script IDs (up to 10) from the entity registry.
@@ -917,6 +918,7 @@ class ConfigScriptTools:
                     "Use ha_get_skill_guide for help",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_config_script_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -1422,6 +1422,7 @@ class EnergyTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_energy_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -52,9 +52,7 @@ logger = logging.getLogger(__name__)
 # corresponding ``Literal`` alias so MCP-wire callers (Pydantic-validated)
 # get typo-rejection at the boundary; runtime guards in `_set_prefs` cover
 # the unit-test path that bypasses Pydantic.
-_PrefsKey = Literal[
-    "energy_sources", "device_consumption", "device_consumption_water"
-]
+_PrefsKey = Literal["energy_sources", "device_consumption", "device_consumption_water"]
 _PREFS_TOP_LEVEL_KEYS: tuple[_PrefsKey, ...] = (
     "energy_sources",
     "device_consumption",
@@ -622,6 +620,7 @@ class EnergyTools:
                     "Verify WebSocket connection is active",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     async def _dry_run(self, config: dict[str, Any]) -> dict[str, Any]:
         """Shape-check the proposed config and fetch current-state validate.
@@ -688,6 +687,7 @@ class EnergyTools:
                     "Verify config shape matches energy/get_prefs response",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     async def _set_prefs(
         self,
@@ -828,18 +828,12 @@ class EnergyTools:
                                 "mode": "set",
                                 "submitted_keys": sorted(submitted_keys),
                                 "hashed_keys": sorted(hashed_keys),
-                                "missing_in_hash": sorted(
-                                    submitted_keys - hashed_keys
-                                ),
-                                "extra_in_hash": sorted(
-                                    hashed_keys - submitted_keys
-                                ),
+                                "missing_in_hash": sorted(submitted_keys - hashed_keys),
+                                "extra_in_hash": sorted(hashed_keys - submitted_keys),
                             },
                             suggestions=[
-                                "Pass exactly one config_hash_per_key entry "
-                                "per top-level key in 'config'",
-                                "Use the str form of config_hash to lock "
-                                "the full prefs blob instead",
+                                "Pass exactly one config_hash_per_key entry per top-level key in 'config'",
+                                "Use the str form of config_hash to lock the full prefs blob instead",
                             ],
                         )
                     )
@@ -980,6 +974,7 @@ class EnergyTools:
                     "Re-read prefs and retry with a fresh config_hash",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     # ------------------------------------------------------------------
     # Convenience modes — atomic read-modify-write (no caller hash)
@@ -1138,13 +1133,13 @@ class EnergyTools:
                     suggestions=[
                         "Fix the listed errors and retry",
                         "solar/battery/gas need 'stat_energy_from'; grid needs "
-                        "only 'type' for the local check, but HA Core's voluptuous "
-                        "schema requires the full grid field set "
-                        "(cost_adjustment_day, stat_energy_to, stat_cost, "
-                        "entity_energy_price, number_energy_price, "
-                        "entity_energy_price_export, number_energy_price_export, "
-                        "stat_compensation) — pass them as None when unused or "
-                        "the post-save validate will surface them.",
+                        + "only 'type' for the local check, but HA Core's voluptuous "
+                        + "schema requires the full grid field set "
+                        + "(cost_adjustment_day, stat_energy_to, stat_cost, "
+                        + "entity_energy_price, number_energy_price, "
+                        + "entity_energy_price_export, number_energy_price_export, "
+                        + "stat_compensation) — pass them as None when unused or "
+                        + "the post-save validate will surface them.",
                     ],
                 )
             )
@@ -1426,6 +1421,7 @@ class EnergyTools:
                     "Verify WebSocket connection is active",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_energy_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1096,6 +1096,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             logger.error(f"Error updating entity: {e}")
             eid_context = entity_id if isinstance(entity_id, str) else entity_ids
             exception_to_structured_error(e, context={"entity_id": eid_context})
+            return None  # unreachable: exception_to_structured_error always raises
 
     @mcp.tool(
         tags={"Entity Registry"},
@@ -1294,6 +1295,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "entity_id": entity_id if isinstance(entity_id, str) else entity_ids
                 },
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @mcp.tool(
         tags={"Entity Registry"},
@@ -1387,3 +1389,4 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 e,
                 context={"entity_id": entity_id},
             )
+            return None  # unreachable: exception_to_structured_error always raises

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -191,7 +191,7 @@ async def _fetch_caller_token(client: Any) -> str:
                     "Reinstall ha_mcp_tools via HACS",
                     "Restart Home Assistant after reinstalling",
                     "If the version is still malformed, file an issue at "
-                    "https://github.com/homeassistant-ai/ha-mcp/issues",
+                    + "https://github.com/homeassistant-ai/ha-mcp/issues",
                 ],
             )
         )
@@ -431,6 +431,7 @@ class FilesystemTools:
                 e,
                 context={"tool": "ha_list_files", "path": path, "pattern": pattern},
             )
+            return None
 
     @tool(
         name="ha_read_file",
@@ -539,6 +540,7 @@ class FilesystemTools:
                 e,
                 context={"tool": "ha_read_file", "path": path},
             )
+            return None
 
     @tool(
         name="ha_write_file",
@@ -669,6 +671,7 @@ class FilesystemTools:
                 e,
                 context={"tool": "ha_write_file", "path": path},
             )
+            return None
 
     @tool(
         name="ha_delete_file",
@@ -780,6 +783,7 @@ class FilesystemTools:
                 e,
                 context={"tool": "ha_delete_file", "path": path},
             )
+            return None
 
 
 def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -432,6 +432,7 @@ class FilesystemTools:
                 context={"tool": "ha_list_files", "path": path, "pattern": pattern},
             )
             return None
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_read_file",
@@ -541,6 +542,7 @@ class FilesystemTools:
                 context={"tool": "ha_read_file", "path": path},
             )
             return None
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_write_file",
@@ -672,6 +674,7 @@ class FilesystemTools:
                 context={"tool": "ha_write_file", "path": path},
             )
             return None
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_delete_file",
@@ -784,6 +787,7 @@ class FilesystemTools:
                 context={"tool": "ha_delete_file", "path": path},
             )
             return None
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_filesystem_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -204,6 +204,7 @@ class GroupTools:
                     "Verify REST API is accessible",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_set_group",
@@ -379,6 +380,7 @@ class GroupTools:
                     "Use ha_config_list_groups() to see existing groups",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_config_remove_group",
@@ -493,6 +495,7 @@ class GroupTools:
                     "Groups defined in YAML cannot be permanently removed",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_group_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -208,6 +208,7 @@ class HacsTools:
                     "For action='info', pass a valid repository_id (numeric ID or 'owner/repo')",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     @tool(
         name="ha_manage_hacs",
@@ -296,6 +297,7 @@ class HacsTools:
                     "For action='add_repository', use 'owner/repo' format and a matching category",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     # --- Private action handlers ------------------------------------------
     # The public tools above are thin dispatchers; each handler raises a
@@ -933,3 +935,4 @@ async def _resolve_hacs_repo_id(ws_client: Any, repository_id: str) -> tuple[str
             ],
         )
     )
+    return None  # unreachable: raise_tool_error always raises

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -411,6 +411,9 @@ class HistoryTools:
                     "Ensure recorder component is enabled",
                 ]
             exception_to_structured_error(e, suggestions=suggestions)
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
 
 def register_history_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -664,6 +664,7 @@ class IntegrationTools:
                     "Ensure your token has sufficient permissions",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     async def _get_single_entry(
         self,
@@ -735,6 +736,7 @@ class IntegrationTools:
                     "config entries",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     async def _fetch_config_subentries(self, entry_id: str) -> list[dict[str, Any]]:
         """Fetch config subentries for a detailed entry response."""
@@ -1112,6 +1114,7 @@ class IntegrationTools:
         except Exception as e:
             logger.error(f"Failed to set integration enabled: {e}")
             exception_to_structured_error(e, context={"entry_id": entry_id})
+            return None  # unreachable: exception_to_structured_error raises
 
     @tool(
         name="ha_remove_helpers_integrations",
@@ -1429,6 +1432,7 @@ class IntegrationTools:
                     "see all config entries",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     # === Path 2: FLOW helper delete via entity_id → entry_id lookup ===
     async def _delete_flow_helper(
@@ -1668,9 +1672,10 @@ class IntegrationTools:
                 suggestions=[
                     "Check Home Assistant connection",
                     "Verify the target exists using ha_search_entities() "
-                    "or ha_get_integration()",
+                    + "or ha_get_integration()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     async def _delete_config_subentry(
         self, entry_id: str, subentry_id: str
@@ -1950,10 +1955,10 @@ class IntegrationTools:
                             ),
                             suggestions=[
                                 "Re-enable the entity via "
-                                "ha_set_entity(enabled=True), then retry "
-                                "deletion.",
+                                + "ha_set_entity(enabled=True), then retry "
+                                + "deletion.",
                                 "Or inspect the entity registry entry "
-                                "directly to confirm unique_id presence.",
+                                + "directly to confirm unique_id presence.",
                             ],
                             context={
                                 "target": target,
@@ -2050,6 +2055,7 @@ class IntegrationTools:
                     "Ensure helper is not used by automations or scripts",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
 
 def register_integration_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -1433,6 +1433,7 @@ class IntegrationTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     # === Path 2: FLOW helper delete via entity_id → entry_id lookup ===
     async def _delete_flow_helper(
@@ -2056,6 +2057,7 @@ class IntegrationTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_integration_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -146,6 +146,7 @@ class LabelTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_config_set_label",
@@ -282,6 +283,7 @@ class LabelTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_config_remove_label",
@@ -372,6 +374,7 @@ class LabelTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_label_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -145,6 +145,7 @@ class LabelTools:
                     "Verify WebSocket connection is active",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     @tool(
         name="ha_config_set_label",
@@ -280,6 +281,7 @@ class LabelTools:
                     "For updates, verify the label_id exists using ha_config_get_label()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     @tool(
         name="ha_config_remove_label",
@@ -369,6 +371,7 @@ class LabelTools:
                     "Verify the label_id exists using ha_config_get_label()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error raises
 
 
 def register_label_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -335,6 +335,9 @@ class McpComponentTools:
                     "Ensure GitHub is accessible",
                 ],
             )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
 
 def register_mcp_component_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -128,6 +128,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 context={"device_id": device_id},
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @mcp.tool(
         tags={"Device Registry", "Zigbee", "Z-Wave"},
@@ -851,3 +852,4 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 context={"device_id": device_id},
             )
             return None  # unreachable: exception_to_structured_error raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -127,6 +127,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 e,
                 context={"device_id": device_id},
             )
+            return None  # unreachable: exception_to_structured_error raises
 
     @mcp.tool(
         tags={"Device Registry", "Zigbee", "Z-Wave"},
@@ -590,6 +591,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         except Exception as e:
             logger.error(f"Error getting device: {e}")
             exception_to_structured_error(e)
+            return None  # unreachable: exception_to_structured_error raises
 
     @mcp.tool(
         tags={"Device Registry"},
@@ -848,3 +850,4 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 e,
                 context={"device_id": device_id},
             )
+            return None  # unreachable: exception_to_structured_error raises

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -237,6 +237,10 @@ class ResourceTools:
                     "Check that you have admin permissions",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     @tool(
         name="ha_config_set_dashboard_resource",
@@ -519,6 +523,10 @@ class ResourceTools:
                     "Check that you have admin permissions",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     async def _set_url_resource(
         self,
@@ -587,6 +595,10 @@ class ResourceTools:
                     "Verify the URL is correctly formatted",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
     async def _upsert_resource(
         self,
@@ -729,6 +741,10 @@ class ResourceTools:
                     "Check that you have admin permissions",
                 ],
             )
+            # ``exception_to_structured_error`` always raises (NoReturn); this
+            # explicit raise makes the function's exit unambiguous (no implicit
+            # ``return None`` fall-through) and is never reached at runtime.
+            raise
 
 
 def register_resources_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1033,6 +1033,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 ],
             )
             return None  # unreachable: error helpers above always raise
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @mcp.tool(
         tags={"Search & Discovery"},

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1032,6 +1032,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "Check area/domain filter spelling",
                 ],
             )
+            return None  # unreachable: error helpers above always raise
 
     @mcp.tool(
         tags={"Search & Discovery"},
@@ -1525,6 +1526,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "Try simpler search terms",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @mcp.tool(
         tags={"Search & Discovery"},
@@ -1794,3 +1796,4 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 e,
                 context={"entity_ids": entity_ids},
             )
+            return None  # unreachable: exception_to_structured_error always raises

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -500,6 +500,7 @@ class ServiceTools:
                 suggestions=suggestions,
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_get_operation_status",

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -499,6 +499,7 @@ class ServiceTools:
                 },
                 suggestions=suggestions,
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_get_operation_status",
@@ -563,6 +564,7 @@ class ServiceTools:
                     "Use ha_get_state() to check current entity states instead",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_bulk_control",

--- a/src/ha_mcp/tools/tools_services.py
+++ b/src/ha_mcp/tools/tools_services.py
@@ -203,6 +203,9 @@ class ServiceDiscoveryTools:
                     "Try with a specific domain filter",
                 ],
             )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
 
 def register_services_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -170,6 +170,7 @@ class SystemTools:
                 }
 
             exception_to_structured_error(e)
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_reload_core",
@@ -303,6 +304,7 @@ class SystemTools:
                     "Check Home Assistant logs for details",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_get_system_health",
@@ -631,6 +633,7 @@ class SystemTools:
                     "Try ha_get_overview() for basic system information",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
         finally:
             await self._safe_disconnect(ws_client)
 
@@ -649,6 +652,8 @@ class SystemTools:
         try:
             await ws_client.disconnect()
         except Exception:
+            # Best-effort cleanup: a disconnect failure on an already-closing
+            # socket is not actionable and must not mask the real result.
             pass
 
     async def _fetch_health_info(self) -> tuple[Any, dict[str, Any]]:

--- a/src/ha_mcp/tools/tools_todo.py
+++ b/src/ha_mcp/tools/tools_todo.py
@@ -200,9 +200,11 @@ class TodoTools:
                     "Verify todo integration is enabled",
                 ]
             )
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e, context=context or None, suggestions=suggestions
             )
+            raise  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_set_todo_item",
@@ -399,7 +401,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": summary},
                 suggestions=[
@@ -408,6 +410,7 @@ class TodoTools:
                     "Some todo lists may not support description or due dates",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     async def _update_item(
         self,
@@ -461,7 +464,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": item},
                 suggestions=[
@@ -470,6 +473,7 @@ class TodoTools:
                     "Some todo lists may not support all update operations",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
     def _build_update_service_data(
@@ -618,7 +622,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            return exception_to_structured_error(
+            exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": item},
                 suggestions=[
@@ -627,6 +631,7 @@ class TodoTools:
                     "Make sure the item hasn't already been removed",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
 
 def register_todo_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_todo.py
+++ b/src/ha_mcp/tools/tools_todo.py
@@ -200,7 +200,7 @@ class TodoTools:
                     "Verify todo integration is enabled",
                 ]
             )
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e, context=context or None, suggestions=suggestions
             )
 
@@ -399,7 +399,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": summary},
                 suggestions=[
@@ -461,7 +461,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": item},
                 suggestions=[
@@ -618,7 +618,7 @@ class TodoTools:
         except ToolError:
             raise
         except Exception as e:
-            exception_to_structured_error(
+            return exception_to_structured_error(
                 e,
                 context={"entity_id": entity_id, "item": item},
                 suggestions=[

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -176,12 +176,14 @@ class TraceTools:
             elif automation_id.startswith("script."):
                 domain = "script"
             else:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"Invalid entity_id format: {automation_id}",
-                    details="Entity ID must start with 'automation.' or 'script.'",
-                    context={"automation_id": automation_id},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Invalid entity_id format: {automation_id}",
+                        details="Entity ID must start with 'automation.' or 'script.'",
+                        context={"automation_id": automation_id},
+                    )
+                )
 
             # Extract the object_id (part after the domain) as fallback
             object_id = automation_id.split(".", 1)[1]
@@ -205,11 +207,14 @@ class TraceTools:
                 verify_ssl=self._client.verify_ssl,
             )
             if error or ws_client is None:
-                raise_tool_error(error or create_error_response(
-                    ErrorCode.CONNECTION_FAILED,
-                    "Failed to connect to Home Assistant WebSocket",
-                    context={"automation_id": automation_id},
-                ))
+                raise_tool_error(
+                    error
+                    or create_error_response(
+                        ErrorCode.CONNECTION_FAILED,
+                        "Failed to connect to Home Assistant WebSocket",
+                        context={"automation_id": automation_id},
+                    )
+                )
 
             try:
                 # Home Assistant stores traces by unique_id, not entity_id.
@@ -238,19 +243,24 @@ class TraceTools:
                         err_ctx: dict[str, str] = {"automation_id": automation_id}
                         if run_id:
                             err_ctx["run_id"] = run_id
-                        raise_tool_error(create_error_response(
-                            ErrorCode.SERVICE_CALL_FAILED,
-                            result.get("error", "Failed to retrieve trace"),
-                            context=err_ctx,
-                        ))
+                        raise_tool_error(
+                            create_error_response(
+                                ErrorCode.SERVICE_CALL_FAILED,
+                                result.get("error", "Failed to retrieve trace"),
+                                context=err_ctx,
+                            )
+                        )
 
                     trace_data = result.get("result", {})
                     await safe_progress(
                         ctx, progress=3, total=3, message="formatting trace"
                     )
                     return _format_detailed_trace(
-                        automation_id, run_id, trace_data,
-                        deduplicate=deduplicate, detailed=detailed,
+                        automation_id,
+                        run_id,
+                        trace_data,
+                        deduplicate=deduplicate,
+                        detailed=detailed,
                         sections=sections,
                     )
                 else:
@@ -262,11 +272,13 @@ class TraceTools:
                     )
 
                     if not result.get("success"):
-                        raise_tool_error(create_error_response(
-                            ErrorCode.SERVICE_CALL_FAILED,
-                            result.get("error", "Failed to list traces"),
-                            context={"automation_id": automation_id},
-                        ))
+                        raise_tool_error(
+                            create_error_response(
+                                ErrorCode.SERVICE_CALL_FAILED,
+                                result.get("error", "Failed to list traces"),
+                                context={"automation_id": automation_id},
+                            )
+                        )
 
                     traces_data = result.get("result", [])
 
@@ -323,6 +335,9 @@ class TraceTools:
                     "Ensure Home Assistant connection is working",
                 ],
             )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
 
 def register_trace_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
@@ -358,9 +373,7 @@ async def _resolve_trace_item_id(
         if result.get("success") and result.get("result"):
             unique_id = result["result"].get("unique_id")
             if unique_id:
-                logger.debug(
-                    f"Resolved {entity_id} to unique_id: {unique_id}"
-                )
+                logger.debug(f"Resolved {entity_id} to unique_id: {unique_id}")
                 return str(unique_id)
 
         # Fallback to object_id if no unique_id found
@@ -513,7 +526,7 @@ def _format_trace_list(
         start = max(end - limit, 0)
         window = list(reversed(traces[start:end])) if end > 0 else []
     else:
-        window = traces[offset:offset + limit]
+        window = traces[offset : offset + limit]
 
     formatted_traces = []
     for trace in window:
@@ -560,8 +573,12 @@ def _format_trace_list(
 
 
 def _format_detailed_trace(
-    automation_id: str, run_id: str, trace: dict[str, Any],
-    *, deduplicate: bool = True, detailed: bool = False,
+    automation_id: str,
+    run_id: str,
+    trace: dict[str, Any],
+    *,
+    deduplicate: bool = True,
+    detailed: bool = False,
     sections: str | None = None,
 ) -> dict[str, Any]:
     """Format detailed trace for AI consumption."""
@@ -597,7 +614,8 @@ def _format_detailed_trace(
             elif path == "condition" or path.startswith("condition/"):
                 conditions.append(step_info)
             elif (
-                path == "action" or path.startswith("action/")
+                path == "action"
+                or path.startswith("action/")
                 or path.startswith("sequence/")
                 or (domain == "script" and (path.split("/")[0].isdigit()))
             ):
@@ -655,7 +673,14 @@ def _format_detailed_trace(
         requested = {s.strip().lower() for s in sections.split(",")}
         keep_keys = {section_key_map[s] for s in requested if s in section_key_map}
         # Always keep metadata keys
-        keep_keys |= {"success", "automation_id", "run_id", "timestamp", "state", "script_execution"}
+        keep_keys |= {
+            "success",
+            "automation_id",
+            "run_id",
+            "timestamp",
+            "state",
+            "script_execution",
+        }
         result = {k: v for k, v in result.items() if k in keep_keys}
 
     return result
@@ -678,9 +703,13 @@ def _populate_trigger_info(
             "description": trigger_vars.get("description"),
         }
         if "to_state" in trigger_vars:
-            result["trigger"]["to_state"] = trigger_vars.get("to_state", {}).get("state")
+            result["trigger"]["to_state"] = trigger_vars.get("to_state", {}).get(
+                "state"
+            )
         if "from_state" in trigger_vars:
-            result["trigger"]["from_state"] = trigger_vars.get("from_state", {}).get("state")
+            result["trigger"]["from_state"] = trigger_vars.get("from_state", {}).get(
+                "state"
+            )
         if "entity_id" in trigger_vars:
             result["trigger"]["entity_id"] = trigger_vars["entity_id"]
 
@@ -738,7 +767,9 @@ def _populate_action_trace(
             if useful_vars:
                 if deduplicate:
                     try:
-                        fingerprint = json.dumps(useful_vars, sort_keys=True, default=str)
+                        fingerprint = json.dumps(
+                            useful_vars, sort_keys=True, default=str
+                        )
                     except (TypeError, ValueError):
                         fingerprint = str(useful_vars)
 

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -744,6 +744,9 @@ class UpdateTools:
                     "Verify API access permissions",
                 ],
             )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
 
 
 def register_update_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -778,6 +778,7 @@ class UtilityTools:
                 ],
             )
             raise  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @staticmethod
     def _addon_auth_error_suggestions() -> list[str]:
@@ -917,6 +918,7 @@ class UtilityTools:
                 ],
             )
             raise  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     async def eval_template(
         self, template: str, timeout: int, report_errors: bool
@@ -1005,6 +1007,7 @@ class UtilityTools:
                 suggestions=suggestions,
             )
             raise  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -172,7 +172,7 @@ class UtilityTools:
                         suggestions=[
                             "Pick a valid service name (e.g. 'supervisor', 'host')",
                             "For add-on container logs use source='supervisor' with "
-                            "the add-on slug instead",
+                            + "the add-on slug instead",
                         ],
                     )
                 )
@@ -414,6 +414,7 @@ class UtilityTools:
                 },
                 suggestions=suggestions,
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     async def _get_system_log(
         self,
@@ -492,6 +493,7 @@ class UtilityTools:
                     "Verify system_log integration is enabled",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     async def _get_error_log(
         self,
@@ -558,6 +560,7 @@ class UtilityTools:
                     "The error log may be empty if no errors have occurred",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
     def _parse_logger_entry(entry: Any) -> dict[str, Any] | None:
@@ -655,6 +658,7 @@ class UtilityTools:
                     "Verify the 'logger' integration is enabled",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     async def _get_supervisor_log(
         self,
@@ -773,6 +777,7 @@ class UtilityTools:
                     "Ensure Supervisor is available (HA OS or Supervised install)",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
     def _addon_auth_error_suggestions() -> list[str]:
@@ -863,16 +868,16 @@ class UtilityTools:
                 if is_running_in_addon():
                     suggestions = [
                         "Addon's hassio_role must be 'manager' or higher to "
-                        "read /<service>/logs",
+                        + "read /<service>/logs",
                         "Verify the addon was reinstalled after the role bump "
-                        "took effect",
+                        + "took effect",
                     ]
                 else:
                     suggestions = [
                         "The Long-Lived Access Token must belong to a user "
-                        "with admin privileges",
+                        + "with admin privileges",
                         "Generate a new LLAT under an admin account and set "
-                        "HOMEASSISTANT_TOKEN to it",
+                        + "HOMEASSISTANT_TOKEN to it",
                     ]
                 exception_to_structured_error(
                     e,
@@ -911,6 +916,7 @@ class UtilityTools:
                     "Ensure Supervisor is available (HA OS or Supervised install)",
                 ],
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
     async def eval_template(
         self, template: str, timeout: int, report_errors: bool
@@ -998,6 +1004,7 @@ class UtilityTools:
                 context={"template": template},
                 suggestions=suggestions,
             )
+            raise  # unreachable: exception_to_structured_error always raises
 
 
 def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_voice_assistant.py
+++ b/src/ha_mcp/tools/tools_voice_assistant.py
@@ -90,11 +90,13 @@ class VoiceAssistantTools:
 
         if not result.get("success"):
             error_msg = websocket_error_message(result.get("error", "Operation failed"))
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                f"Failed to {operation} Assist pipeline: {error_msg}",
-                context={"pipeline_id": pipeline_id, "operation": operation},
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to {operation} Assist pipeline: {error_msg}",
+                    context={"pipeline_id": pipeline_id, "operation": operation},
+                )
+            )
 
         return result.get("result")
 
@@ -111,20 +113,24 @@ class VoiceAssistantTools:
         )
         if not isinstance(pipeline, dict):
             if pipeline_id is None:
-                raise_tool_error(create_error_response(
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        "No preferred Assist pipeline is configured",
+                        context={"pipeline_id": pipeline_id, "details": pipeline},
+                        suggestions=[
+                            "Call ha_manage_pipeline(action='list') to find pipeline IDs.",
+                            "Pass base_pipeline_id explicitly when creating a pipeline.",
+                        ],
+                    )
+                )
+            raise_tool_error(
+                create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
-                    "No preferred Assist pipeline is configured",
+                    "Unexpected Assist pipeline response",
                     context={"pipeline_id": pipeline_id, "details": pipeline},
-                    suggestions=[
-                        "Call ha_manage_pipeline(action='list') to find pipeline IDs.",
-                        "Pass base_pipeline_id explicitly when creating a pipeline.",
-                    ],
-                ))
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                "Unexpected Assist pipeline response",
-                context={"pipeline_id": pipeline_id, "details": pipeline},
-            ))
+                )
+            )
         return pipeline
 
     @staticmethod
@@ -160,15 +166,17 @@ class VoiceAssistantTools:
         }
         for field, value in values.items():
             if value == "" and field not in _NULLABLE_PIPELINE_FIELDS:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"{field} cannot be an empty string",
-                    context={"field": field},
-                    suggestions=[
-                        f"Omit {field} to keep the existing or cloned value.",
-                        f"Pass a non-empty value for {field}.",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{field} cannot be an empty string",
+                        context={"field": field},
+                        suggestions=[
+                            f"Omit {field} to keep the existing or cloned value.",
+                            f"Pass a non-empty value for {field}.",
+                        ],
+                    )
+                )
         return {
             field: _normalize_pipeline_value(field, value)
             for field, value in values.items()
@@ -200,12 +208,16 @@ class VoiceAssistantTools:
             }
 
         if pipeline_id is None:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "action='get' requires pipeline_id",
-                context={"action": action},
-                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "action='get' requires pipeline_id",
+                    context={"action": action},
+                    suggestions=[
+                        "Call ha_manage_pipeline(action='list') first to find pipeline IDs."
+                    ],
+                )
+            )
 
         data = await self._send_pipeline_message(
             {"type": "assist_pipeline/pipeline/get", "pipeline_id": pipeline_id},
@@ -227,12 +239,16 @@ class VoiceAssistantTools:
     async def _set_preferred_pipeline(self, pipeline_id: str | None) -> dict[str, Any]:
         """Set the preferred Assist pipeline."""
         if pipeline_id is None:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "action='set_preferred' requires pipeline_id",
-                context={"action": "set_preferred"},
-                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "action='set_preferred' requires pipeline_id",
+                    context={"action": "set_preferred"},
+                    suggestions=[
+                        "Call ha_manage_pipeline(action='list') first to find pipeline IDs."
+                    ],
+                )
+            )
 
         await self._send_pipeline_message(
             {
@@ -262,34 +278,42 @@ class VoiceAssistantTools:
         if action == "create" and (
             updates.get("name") is None or updates.get("conversation_engine") is None
         ):
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "action='create' requires name and conversation_engine",
-                context={"action": action},
-                suggestions=[
-                    "Provide name and conversation_engine.",
-                    "Use ha_manage_pipeline(action='list') to inspect current pipeline values.",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "action='create' requires name and conversation_engine",
+                    context={"action": action},
+                    suggestions=[
+                        "Provide name and conversation_engine.",
+                        "Use ha_manage_pipeline(action='list') to inspect current pipeline values.",
+                    ],
+                )
+            )
 
         if action == "update" and pipeline_id is None:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_MISSING_PARAMETER,
-                "action='update' requires pipeline_id",
-                context={"action": action},
-                suggestions=["Call ha_manage_pipeline(action='list') first to find pipeline IDs."],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "action='update' requires pipeline_id",
+                    context={"action": action},
+                    suggestions=[
+                        "Call ha_manage_pipeline(action='list') first to find pipeline IDs."
+                    ],
+                )
+            )
 
         if not updates and not make_preferred:
-            raise_tool_error(create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                "No Assist pipeline changes requested",
-                context={"action": action, "pipeline_id": pipeline_id},
-                suggestions=[
-                    "Pass at least one pipeline field to update.",
-                    "Use action='set_preferred' to only change the preferred pipeline.",
-                ],
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "No Assist pipeline changes requested",
+                    context={"action": action, "pipeline_id": pipeline_id},
+                    suggestions=[
+                        "Pass at least one pipeline field to update.",
+                        "Use action='set_preferred' to only change the preferred pipeline.",
+                    ],
+                )
+            )
 
         source_pipeline_id = pipeline_id if action == "update" else base_pipeline_id
         pipeline = await self._get_pipeline_for_write(source_pipeline_id)
@@ -309,15 +333,17 @@ class VoiceAssistantTools:
             pipeline_id=pipeline_id,
         )
         if not isinstance(result_pipeline, dict):
-            raise_tool_error(create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                "Unexpected Assist pipeline write response",
-                context={
-                    "action": action,
-                    "pipeline_id": pipeline_id,
-                    "details": result_pipeline,
-                },
-            ))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Unexpected Assist pipeline write response",
+                    context={
+                        "action": action,
+                        "pipeline_id": pipeline_id,
+                        "details": result_pipeline,
+                    },
+                )
+            )
 
         result_pipeline_id = str(result_pipeline.get("id", pipeline_id))
         preferred_changed = False
@@ -432,15 +458,23 @@ class VoiceAssistantTools:
         ] = None,
         tts_voice: Annotated[
             str | None,
-            Field(description="Text-to-speech voice. Pass empty string to clear.", default=None),
+            Field(
+                description="Text-to-speech voice. Pass empty string to clear.",
+                default=None,
+            ),
         ] = None,
         wake_word_entity: Annotated[
             str | None,
-            Field(description="Wake-word entity ID. Pass empty string to clear.", default=None),
+            Field(
+                description="Wake-word entity ID. Pass empty string to clear.",
+                default=None,
+            ),
         ] = None,
         wake_word_id: Annotated[
             str | None,
-            Field(description="Wake-word ID. Pass empty string to clear.", default=None),
+            Field(
+                description="Wake-word ID. Pass empty string to clear.", default=None
+            ),
         ] = None,
         prefer_local_intents: Annotated[
             bool | None,
@@ -542,9 +576,12 @@ class VoiceAssistantTools:
                     "Use ha_search_entities(domain_filter='conversation') to find conversation agent IDs",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
-    def _get_entity_exposure(entity_id: str, exposed_entities: dict[str, Any]) -> dict[str, Any]:
+    def _get_entity_exposure(
+        entity_id: str, exposed_entities: dict[str, Any]
+    ) -> dict[str, Any]:
         """Build response for a specific entity's exposure settings."""
         entity_settings = exposed_entities.get(entity_id, {})
         is_exposed = any(entity_settings.get(asst) for asst in KNOWN_ASSISTANTS)
@@ -552,8 +589,7 @@ class VoiceAssistantTools:
             "success": True,
             "entity_id": entity_id,
             "exposed_to": {
-                asst: entity_settings.get(asst, False)
-                for asst in KNOWN_ASSISTANTS
+                asst: entity_settings.get(asst, False) for asst in KNOWN_ASSISTANTS
             },
             "is_exposed_anywhere": is_exposed,
             "has_custom_settings": entity_id in exposed_entities,
@@ -565,7 +601,9 @@ class VoiceAssistantTools:
         }
 
     @staticmethod
-    def _list_exposures(exposed_entities: dict[str, Any], assistant: str | None) -> dict[str, Any]:
+    def _list_exposures(
+        exposed_entities: dict[str, Any], assistant: str | None
+    ) -> dict[str, Any]:
         """Build response listing all exposed entities with optional filter."""
         filtered = exposed_entities
         if assistant:
@@ -591,9 +629,7 @@ class VoiceAssistantTools:
             "count": len(filtered),
             "total_entities_with_settings": len(exposed_entities),
             "summary": (
-                summary
-                if not assistant
-                else {assistant: summary.get(assistant, 0)}
+                summary if not assistant else {assistant: summary.get(assistant, 0)}
             ),
             "filters_applied": filters_applied,
         }
@@ -601,7 +637,11 @@ class VoiceAssistantTools:
     @tool(
         name="ha_get_entity_exposure",
         tags={"Entity Registry"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Entity Exposure"},
+        annotations={
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Get Entity Exposure",
+        },
     )
     @log_tool_usage
     async def ha_get_entity_exposure(
@@ -649,15 +689,20 @@ class VoiceAssistantTools:
         """
         try:
             if assistant and assistant not in KNOWN_ASSISTANTS:
-                raise_tool_error(create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"Invalid assistant: {assistant}",
-                    context={"assistant": assistant, "valid_assistants": KNOWN_ASSISTANTS},
-                    suggestions=[
-                        f"Valid assistants are: {', '.join(KNOWN_ASSISTANTS)}",
-                        "Check the assistant parameter spelling",
-                    ],
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Invalid assistant: {assistant}",
+                        context={
+                            "assistant": assistant,
+                            "valid_assistants": KNOWN_ASSISTANTS,
+                        },
+                        suggestions=[
+                            f"Valid assistants are: {', '.join(KNOWN_ASSISTANTS)}",
+                            "Check the assistant parameter spelling",
+                        ],
+                    )
+                )
 
             message: dict[str, Any] = {"type": "homeassistant/expose_entity/list"}
 
@@ -670,11 +715,13 @@ class VoiceAssistantTools:
                     if isinstance(error, dict)
                     else str(error)
                 )
-                raise_tool_error(create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Failed to get exposure settings: {error_msg}",
-                    context={"entity_id": entity_id},
-                ))
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Failed to get exposure settings: {error_msg}",
+                        context={"entity_id": entity_id},
+                    )
+                )
 
             exposed_entities = result.get("result", {}).get("exposed_entities", {})
 
@@ -688,6 +735,7 @@ class VoiceAssistantTools:
         except Exception as e:
             logger.error(f"Error getting entity exposure: {e}")
             exception_to_structured_error(e, context={"entity_id": entity_id})
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_voice_assistant_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -384,6 +384,7 @@ class YamlConfigTools:
             augment_error_dict_with_skill_content(error, bp_warnings=None)
             raise_tool_error(error)
             return None  # raise_tool_error always raises; explicit for CodeQL
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_yaml_config_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -383,6 +383,7 @@ class YamlConfigTools:
             )
             augment_error_dict_with_skill_content(error, bp_warnings=None)
             raise_tool_error(error)
+            return None  # raise_tool_error always raises; explicit for CodeQL
 
 
 def register_yaml_config_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -129,6 +129,7 @@ class ZoneTools:
                     "Use ha_get_zone() without zone_id to see all available zones",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @staticmethod
     def _validate_coordinates(
@@ -354,6 +355,7 @@ class ZoneTools:
                     else "Verify zone_id exists using ha_get_zone()",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
     @tool(
         name="ha_remove_zone",
@@ -439,6 +441,7 @@ class ZoneTools:
                     "Ensure zone is not the 'home' zone (YAML-defined)",
                 ],
             )
+            return None  # unreachable: exception_to_structured_error always raises
 
 
 def register_zone_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -356,6 +356,7 @@ class ZoneTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
     @tool(
         name="ha_remove_zone",
@@ -442,6 +443,7 @@ class ZoneTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+        return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 def register_zone_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -1940,21 +1940,6 @@ _WRITE_TOOL_BP_HINT_SUGGESTION = (
     "the relevant reference file before retrying."
 )
 
-# Hint shipped at the top of ha_get_skill_guide responses that deliver
-# best-practice skill content directly (Tier 3 on the
-# `home-assistant-best-practices` skill). Smart clients that fetch the
-# reference files proactively via this tool would otherwise still
-# receive duplicate canonical content from the per-call write-tool
-# attach — this hint tells them to opt out so the same body doesn't
-# ride along again on every subsequent write.
-_SKILL_GUIDE_MANDATORYBPS_HINT = (
-    "You now have this best-practice reference in your context. "
-    "Pass `MandatoryBPS=false` on subsequent write-tool calls in this "
-    "session (ha_config_set_automation / _script / _scene / _helper / "
-    "_dashboard / _yaml) to avoid re-receiving the canonical reference "
-    "files inline."
-)
-
 
 def attach_skill_content(
     response: dict[str, Any],

--- a/src/ha_mcp/transforms/categorized_search.py
+++ b/src/ha_mcp/transforms/categorized_search.py
@@ -387,8 +387,10 @@ class CategorizedSearchTransform(BM25SearchTransform):
                 arguments = arguments.get("arguments") or {}
 
             if name not in allowed:
-                # Provide a helpful error with the correct proxy name
-                actual_category = "unknown"
+                # Provide a helpful error with the correct proxy name.
+                # actual_category/correct_proxy are assigned in every branch
+                # below that reaches the raise (the else branch raises early),
+                # so no initial sentinel value is needed.
                 correct_proxy = ""
                 if name in transform._read_tools:
                     actual_category = "read"

--- a/src/ha_mcp/utils/kill_signal_diagnostics.py
+++ b/src/ha_mcp/utils/kill_signal_diagnostics.py
@@ -126,7 +126,9 @@ assert _Siginfo.si_uid.offset == 20, (
 )
 
 
-_SignalHandler = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.POINTER(_Siginfo), ctypes.c_void_p)
+_SignalHandler = ctypes.CFUNCTYPE(
+    None, ctypes.c_int, ctypes.POINTER(_Siginfo), ctypes.c_void_p
+)
 
 
 class _Sigaction(ctypes.Structure):
@@ -152,7 +154,15 @@ def read_proc_status_summary() -> dict[str, str]:
     Empty dict on non-Linux or unreadable status — callers don't need
     to special-case missing data.
     """
-    fields = {"VmRSS", "VmHWM", "VmPeak", "Threads", "State", "oom_score", "oom_score_adj"}
+    fields = {
+        "VmRSS",
+        "VmHWM",
+        "VmPeak",
+        "Threads",
+        "State",
+        "oom_score",
+        "oom_score_adj",
+    }
     out: dict[str, str] = {}
     try:
         with open("/proc/self/status", "rb") as f:
@@ -210,7 +220,11 @@ def format_diagnostic_block(
     proc_status: dict[str, str],
 ) -> str:
     """Compose the multi-line log block written when a signal is caught."""
-    sig_name = signal.Signals(signum).name if signum in signal.Signals.__members__.values() else str(signum)
+    sig_name = (
+        signal.Signals(signum).name
+        if signum in signal.Signals.__members__.values()
+        else str(signum)
+    )
     code_name = _SI_CODE_NAMES.get(si_code, f"SI_UNKNOWN({si_code})")
 
     # si_pid == 0 from the kernel means the sender was outside our PID
@@ -243,7 +257,15 @@ def format_diagnostic_block(
     if proc_status:
         lines.extend(
             f"  {key}: {proc_status[key]}"
-            for key in ("State", "VmRSS", "VmHWM", "VmPeak", "Threads", "oom_score", "oom_score_adj")
+            for key in (
+                "State",
+                "VmRSS",
+                "VmHWM",
+                "VmPeak",
+                "Threads",
+                "oom_score",
+                "oom_score_adj",
+            )
             if key in proc_status
         )
     else:
@@ -268,6 +290,8 @@ def _emit_block_safely(block: str) -> None:
     try:
         os.write(2, payload)
     except OSError:
+        # Best-effort diagnostics write from a signal context: if stderr is
+        # closed/full there is no async-signal-safe fallback, so swallow it.
         pass
 
 
@@ -282,6 +306,8 @@ def _restore_default_and_reraise(signum: int) -> None:
         try:
             _libc.signal(int(signum), _SIG_DFL_PTR)
         except OSError:
+            # Best-effort disposition reset: even if it fails we still fall
+            # through to os.kill below to terminate the process.
             pass
     os.kill(os.getpid(), signum)
 
@@ -335,6 +361,8 @@ def _make_handler() -> Any:
                     ),
                 )
             except OSError:
+                # Last-resort error reporting already failed; nothing safe
+                # left to do in a signal handler, so swallow and proceed.
                 pass
 
         _chain_or_reraise(signum)
@@ -372,12 +400,18 @@ def install_kill_signal_diagnostics() -> bool:
     try:
         libc_path = ctypes.util.find_library("c")
         if libc_path is None:
-            logger.warning("advanced_debug_logging: libc not found; skipping signal handler install")
+            logger.warning(
+                "advanced_debug_logging: libc not found; skipping signal handler install"
+            )
             return False
 
         libc = ctypes.CDLL(libc_path, use_errno=True)
         libc.sigaction.restype = ctypes.c_int
-        libc.sigaction.argtypes = [ctypes.c_int, ctypes.POINTER(_Sigaction), ctypes.POINTER(_Sigaction)]
+        libc.sigaction.argtypes = [
+            ctypes.c_int,
+            ctypes.POINTER(_Sigaction),
+            ctypes.POINTER(_Sigaction),
+        ]
         # signal(int, sighandler_t) — used by the handler itself to
         # restore SIG_DFL via the AS-safe libc entry point.
         libc.signal.restype = ctypes.c_void_p

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -25,6 +25,7 @@ PROXY_ADDON_DIR = "homeassistant-addon-webhook-proxy"
 # Helper: import start.py from the addon directory
 # ---------------------------------------------------------------------------
 
+
 def _import_start():
     """Import the webhook proxy start.py as a module."""
     start_path = os.path.join(PROXY_ADDON_DIR, "start.py")
@@ -37,6 +38,7 @@ def _import_start():
 # ---------------------------------------------------------------------------
 # Helper: import mcp_proxy/__init__.py with homeassistant imports stubbed
 # ---------------------------------------------------------------------------
+
 
 class _FakeConfigEntryError(Exception):
     pass
@@ -80,6 +82,7 @@ def _install_runtime_stubs():
     # construction. Use the real package if available, otherwise minimal stub.
     try:
         import yarl as _real_yarl
+
         yarl_mod = _real_yarl
     except ImportError:
         yarl_mod = types.ModuleType("yarl")
@@ -98,6 +101,7 @@ def _install_runtime_stubs():
                 if not self._extra:
                     return self._url
                 from urllib.parse import urlencode
+
                 sep = "&" if "?" in self._url else "?"
                 return f"{self._url}{sep}{urlencode(self._extra)}"
 
@@ -114,43 +118,40 @@ def _install_runtime_stubs():
     ha_components_repairs.RepairsFlow = type("RepairsFlow", (), {})
     ha_data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
     ha_data_entry_flow.FlowResult = dict
-    ha_helpers_issue_registry = types.ModuleType(
-        "homeassistant.helpers.issue_registry"
-    )
-    ha_helpers_issue_registry.async_create_issue = MagicMock(
-        name="async_create_issue"
-    )
-    ha_helpers_issue_registry.async_delete_issue = MagicMock(
-        name="async_delete_issue"
-    )
+    ha_helpers_issue_registry = types.ModuleType("homeassistant.helpers.issue_registry")
+    ha_helpers_issue_registry.async_create_issue = MagicMock(name="async_create_issue")
+    ha_helpers_issue_registry.async_delete_issue = MagicMock(name="async_delete_issue")
 
     class _IssueSeverity:
         ERROR = "error"
         WARNING = "warning"
         CRITICAL = "critical"
+
     ha_helpers_issue_registry.IssueSeverity = _IssueSeverity
 
     voluptuous_mod = types.ModuleType("voluptuous")
     voluptuous_mod.Schema = MagicMock(name="Schema")
 
-    sys.modules.update({
-        "homeassistant": ha,
-        "homeassistant.components": ha_components,
-        "homeassistant.components.webhook": ha_webhook,
-        "homeassistant.components.http": ha_components_http,
-        "homeassistant.components.repairs": ha_components_repairs,
-        "homeassistant.config_entries": ha_config_entries,
-        "homeassistant.core": ha_core,
-        "homeassistant.helpers": ha_helpers,
-        "homeassistant.helpers.typing": ha_helpers_typing,
-        "homeassistant.helpers.issue_registry": ha_helpers_issue_registry,
-        "homeassistant.exceptions": ha_exceptions,
-        "homeassistant.data_entry_flow": ha_data_entry_flow,
-        "aiohttp": aiohttp_mod,
-        "aiohttp.web": aiohttp_web,
-        "yarl": yarl_mod,
-        "voluptuous": voluptuous_mod,
-    })
+    sys.modules.update(
+        {
+            "homeassistant": ha,
+            "homeassistant.components": ha_components,
+            "homeassistant.components.webhook": ha_webhook,
+            "homeassistant.components.http": ha_components_http,
+            "homeassistant.components.repairs": ha_components_repairs,
+            "homeassistant.config_entries": ha_config_entries,
+            "homeassistant.core": ha_core,
+            "homeassistant.helpers": ha_helpers,
+            "homeassistant.helpers.typing": ha_helpers_typing,
+            "homeassistant.helpers.issue_registry": ha_helpers_issue_registry,
+            "homeassistant.exceptions": ha_exceptions,
+            "homeassistant.data_entry_flow": ha_data_entry_flow,
+            "aiohttp": aiohttp_mod,
+            "aiohttp.web": aiohttp_web,
+            "yarl": yarl_mod,
+            "voluptuous": voluptuous_mod,
+        }
+    )
 
 
 def _import_mcp_proxy(preload_oauth=None):
@@ -168,9 +169,8 @@ def _import_mcp_proxy(preload_oauth=None):
     spec = importlib.util.spec_from_file_location(
         "mcp_proxy_init",
         init_path,
-        submodule_search_locations=[
-            os.path.join(PROXY_ADDON_DIR, "mcp_proxy")
-        ])
+        submodule_search_locations=[os.path.join(PROXY_ADDON_DIR, "mcp_proxy")],
+    )
     mod = importlib.util.module_from_spec(spec)
     sys.modules["mcp_proxy_init"] = mod
     if preload_oauth is not None:
@@ -307,6 +307,7 @@ class TestWebhookProxyStructure:
     def test_start_script_syntax(self):
         """Verify start.py is valid Python."""
         import ast
+
         with open(f"{PROXY_ADDON_DIR}/start.py") as f:
             ast.parse(f.read())
 
@@ -324,10 +325,12 @@ class TestAddonDiscovery:
 
         def mock_supervisor_get(path):
             if path == "/addons":
-                return {"addons": [
-                    {"slug": "ha_mcp"},
-                    {"slug": "ha_mcp_dev"},
-                ]}
+                return {
+                    "addons": [
+                        {"slug": "ha_mcp"},
+                        {"slug": "ha_mcp_dev"},
+                    ]
+                }
             if path == "/addons/ha_mcp/info":
                 return {
                     "state": "started",
@@ -394,10 +397,12 @@ class TestAddonDiscovery:
 
         def mock_supervisor_get(path):
             if path == "/addons":
-                return {"addons": [
-                    {"slug": "xyz999_ha_mcp"},
-                    {"slug": "xyz999_ha_mcp_dev"},
-                ]}
+                return {
+                    "addons": [
+                        {"slug": "xyz999_ha_mcp"},
+                        {"slug": "xyz999_ha_mcp_dev"},
+                    ]
+                }
             if path == "/addons/xyz999_ha_mcp/info":
                 return {
                     "state": "started",
@@ -423,10 +428,12 @@ class TestAddonDiscovery:
 
         def mock_supervisor_get(path):
             if path == "/addons":
-                return {"addons": [
-                    {"slug": "ha_mcp"},
-                    {"slug": "ha_mcp_dev"},
-                ]}
+                return {
+                    "addons": [
+                        {"slug": "ha_mcp"},
+                        {"slug": "ha_mcp_dev"},
+                    ]
+                }
             if path == "/addons/ha_mcp/info":
                 return {"state": "stopped", "ip_address": "172.30.33.1", "options": {}}
             if path == "/addons/ha_mcp_dev/info":
@@ -870,7 +877,6 @@ class TestTargetUrlValidation:
 
 
 class TestSetupEntrySurfaceFailures:
-
     @pytest.fixture
     def mod(self):
         return _import_mcp_proxy()
@@ -895,7 +901,8 @@ class TestSetupEntrySurfaceFailures:
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register") as mock_register,
             patch.object(mod.aiohttp, "ClientSession") as mock_session,
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "Invalid target_url" in str(exc_info.value)
@@ -914,7 +921,8 @@ class TestSetupEntrySurfaceFailures:
             caplog.at_level("ERROR"),
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
-            pytest.raises(_FakeConfigEntryError)):
+            pytest.raises(_FakeConfigEntryError),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "validation failed" in caplog.text
@@ -927,7 +935,8 @@ class TestSetupEntrySurfaceFailures:
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register") as mock_register,
             patch.object(mod.aiohttp, "ClientSession") as mock_session,
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "Missing target_url" in str(exc_info.value)
@@ -943,7 +952,8 @@ class TestSetupEntrySurfaceFailures:
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register") as mock_register,
             patch.object(mod.aiohttp, "ClientSession") as mock_session,
-            pytest.raises(_FakeConfigEntryError)):
+            pytest.raises(_FakeConfigEntryError),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         mock_register.assert_not_called()
@@ -951,7 +961,8 @@ class TestSetupEntrySurfaceFailures:
 
     @pytest.mark.parametrize(
         "register_error",
-        [RuntimeError("boom"), ValueError("duplicate webhook"), KeyError("not loaded")])
+        [RuntimeError("boom"), ValueError("duplicate webhook"), KeyError("not loaded")],
+    )
     async def test_register_failure_closes_session_and_raises(
         self, mod, hass, register_error
     ):
@@ -971,7 +982,8 @@ class TestSetupEntrySurfaceFailures:
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register", side_effect=register_error),
             patch.object(mod.aiohttp, "ClientSession", side_effect=make_session),
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "Failed to register webhook endpoint" in str(exc_info.value)
@@ -986,7 +998,8 @@ class TestSetupEntrySurfaceFailures:
         hass.async_add_executor_job = AsyncMock(side_effect=fake_executor)
         with (
             patch.object(mod, "async_register") as mock_register,
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "Failed to read" in str(exc_info.value)
@@ -1000,7 +1013,8 @@ class TestSetupEntrySurfaceFailures:
         hass.async_add_executor_job = AsyncMock(side_effect=fake_executor)
         with (
             patch.object(mod, "async_register") as mock_register,
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "Failed to read" in str(exc_info.value)
@@ -1015,7 +1029,8 @@ class TestSetupEntrySurfaceFailures:
         with (
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register") as mock_register,
-            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock())):
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
             result = await mod.async_setup_entry(hass, MagicMock())
 
         assert result is True
@@ -1108,7 +1123,8 @@ class TestOAuthOffPreservesBehavior:
         with (
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
-            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock())):
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "oauth" not in hass.data[mod.DOMAIN]
@@ -1132,7 +1148,8 @@ class TestOAuthOffPreservesBehavior:
         with (
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
-            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock())):
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         # The submodule name follows from the parent's package name
@@ -1154,7 +1171,8 @@ class TestOAuthOffPreservesBehavior:
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
             patch.object(mod.aiohttp, "ClientSession", return_value=session),
-            pytest.raises(_FakeConfigEntryError) as exc_info):
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "client_id and/or client_secret is blank" in str(exc_info.value)
@@ -1198,7 +1216,9 @@ class TestOAuthProvider:
             hass=hass,
             client_id="client-id-1234567890",
             client_secret="client-secret-very-secret",
-            webhook_id="mcp_webhook_id_xxx", signing_key=b"\x00" * 32)
+            webhook_id="mcp_webhook_id_xxx",
+            signing_key=b"\x00" * 32,
+        )
 
     def test_issues_and_validates_access_token(self, provider):
         token = provider.issue_access_token()
@@ -1244,7 +1264,8 @@ class TestOAuthProvider:
             client_id="cid-1234567890ABCDEF",
             client_secret="sec",
             webhook_id="wh",
-            signing_key=b"\x00" * 32)
+            signing_key=b"\x00" * 32,
+        )
         token = provider.issue_access_token()
         future = int(time.time()) + oauth.ACCESS_TOKEN_TTL + 60
         with patch.object(oauth.time, "time", return_value=future):
@@ -1272,14 +1293,10 @@ class TestOAuthProvider:
         )
 
     def test_authenticate_client_rejects_wrong_id(self, provider):
-        assert not provider.authenticate_client(
-            "wrong", "client-secret-very-secret"
-        )
+        assert not provider.authenticate_client("wrong", "client-secret-very-secret")
 
     def test_authenticate_client_rejects_wrong_secret(self, provider):
-        assert not provider.authenticate_client(
-            "client-id-1234567890", "wrong"
-        )
+        assert not provider.authenticate_client("client-id-1234567890", "wrong")
 
     def test_authenticate_client_rejects_blanks(self, provider):
         assert not provider.authenticate_client("", "")
@@ -1315,25 +1332,43 @@ class TestOAuthProvider:
         oauth = _import_oauth(tmp_secret_dir=tmp_path)
         hass = MagicMock()
         provider1 = oauth.OAuthProvider(
-            hass=hass, client_id="id-aaaaaaaaaaaaaaaaa", client_secret="secret",
-            webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=hass,
+            client_id="id-aaaaaaaaaaaaaaaaa",
+            client_secret="secret",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         token = provider1.issue_access_token()
         # New provider with a different client_id (admin rotated) — token
         # signed for the old client_id must be rejected.
         provider2 = oauth.OAuthProvider(
-            hass=hass, client_id="id-bbbbbbbbbbbbbbbbb", client_secret="secret",
-            webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=hass,
+            client_id="id-bbbbbbbbbbbbbbbbb",
+            client_secret="secret",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         assert provider2.validate_access_token(token) is False
 
     def test_signing_key_persists_across_provider_instances(self, tmp_path):
         oauth = _import_oauth(tmp_secret_dir=tmp_path)
         hass = MagicMock()
         provider1 = oauth.OAuthProvider(
-            hass=hass, client_id="cid-1234567890ABCDEF", client_secret="sec", webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         token = provider1.issue_access_token()
         # New provider on the same disk → same signing key → token still valid
         provider2 = oauth.OAuthProvider(
-            hass=hass, client_id="cid-1234567890ABCDEF", client_secret="sec", webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         assert provider2.validate_access_token(token) is True
 
 
@@ -1376,7 +1411,8 @@ class TestOAuthSetupEntry:
         with (
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
-            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock())):
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         provider = hass.data[mod.DOMAIN]["oauth"]
@@ -1422,8 +1458,12 @@ class TestOAuthWebhookHandler:
     async def test_returns_401_on_missing_bearer(self, setup):
         mod, oauth = setup
         provider = oauth.OAuthProvider(
-            hass=MagicMock(), client_id="cid-1234567890ABCDEF",
-            client_secret="sec", webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         hass = self._make_hass(mod, provider)
         request = self._make_request(None)
         request.headers["Host"] = "example.nabu.casa"
@@ -1442,8 +1482,12 @@ class TestOAuthWebhookHandler:
     async def test_returns_401_on_invalid_bearer(self, setup):
         mod, oauth = setup
         provider = oauth.OAuthProvider(
-            hass=MagicMock(), client_id="cid-1234567890ABCDEF",
-            client_secret="sec", webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         hass = self._make_hass(mod, provider)
         request = self._make_request("Bearer not.a.valid.token")
         request.headers["Host"] = "example.nabu.casa"
@@ -1458,8 +1502,12 @@ class TestOAuthWebhookHandler:
     async def test_passes_through_with_valid_bearer(self, setup):
         mod, oauth = setup
         provider = oauth.OAuthProvider(
-            hass=MagicMock(), client_id="cid-1234567890ABCDEF",
-            client_secret="sec", webhook_id="wh", signing_key=b"\x00" * 32)
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
         token = provider.issue_access_token()
         hass = self._make_hass(mod, provider)
         request = self._make_request(f"Bearer {token}")
@@ -1529,9 +1577,7 @@ class TestResolveOAuthCreds:
         assert stored["client_id"] == "user-id-1234567890123"
         assert stored["client_secret"] == "user-secret"
 
-    def test_partial_override_picks_persisted_for_blank_field(
-        self, start, tmp_path
-    ):
+    def test_partial_override_picks_persisted_for_blank_field(self, start, tmp_path):
         # Generate and persist baseline
         gen_cid, gen_sec = start._resolve_oauth_creds(tmp_path, "", "")
         # User rotates only the secret, leaves client_id blank
@@ -1566,6 +1612,7 @@ class TestStartOAuthValidation:
             if arg == "/data":
                 return options_dir
             return Path(arg)
+
         return path_factory
 
     def _run_main_with_options(self, tmp_path, **opts):
@@ -1579,7 +1626,8 @@ class TestStartOAuthValidation:
             tmp_path,
             enable_oauth=True,
             oauth_client_id="too-short",
-            oauth_client_secret="some-secret-here-with-length")
+            oauth_client_secret="some-secret-here-with-length",
+        )
         assert rc == 1
         assert "OAuth Client ID is too short" in capsys.readouterr().err
 
@@ -1601,16 +1649,12 @@ class TestRegenerateOAuthCreds:
         start._regenerate_oauth_creds(tmp_path)
         assert not creds_file.exists()
 
-    def test_regenerate_is_idempotent_when_file_missing(
-        self, start, tmp_path
-    ):
+    def test_regenerate_is_idempotent_when_file_missing(self, start, tmp_path):
         # Should not raise even though the file isn't there
         start._regenerate_oauth_creds(tmp_path)
         assert not (tmp_path / "oauth_creds.json").exists()
 
-    def test_regenerate_followed_by_resolve_yields_new_values(
-        self, start, tmp_path
-    ):
+    def test_regenerate_followed_by_resolve_yields_new_values(self, start, tmp_path):
         creds_file = tmp_path / "oauth_creds.json"
         creds_file.write_text(
             '{"client_id": "old-id-1234567890", "client_secret": "old-sec"}'
@@ -1622,9 +1666,7 @@ class TestRegenerateOAuthCreds:
         assert cid.startswith("hamcp-")
         assert len(sec) >= 32
 
-    def test_clear_regenerate_toggle_posts_options_with_false(
-        self, start
-    ):
+    def test_clear_regenerate_toggle_posts_options_with_false(self, start):
         captured = {}
 
         def fake_post(path, data):
@@ -1650,9 +1692,7 @@ class TestRegenerateOAuthCreds:
             }
         }
 
-    def test_clear_regenerate_toggle_returns_false_on_supervisor_error(
-        self, start
-    ):
+    def test_clear_regenerate_toggle_returns_false_on_supervisor_error(self, start):
         with patch.object(start, "_supervisor_post", return_value=False):
             ok = start._clear_regenerate_toggle({"regenerate_oauth_creds": True})
         assert ok is False
@@ -1693,9 +1733,7 @@ class TestStartInstallIntegration:
         dst_parent = tmp_path / "dst-parent"
         dst_parent.mkdir()
         (dst_parent / "mcp_proxy").mkdir()
-        (dst_parent / "mcp_proxy" / "manifest.json").write_text(
-            '{"version": "1.0.2"}'
-        )
+        (dst_parent / "mcp_proxy" / "manifest.json").write_text('{"version": "1.0.2"}')
 
         def path_factory(arg):
             if arg == "/opt/mcp_proxy":
@@ -1739,9 +1777,7 @@ class TestStartInstallIntegration:
         assert first_install is False
         assert version_changed is False
 
-    def test_corrupt_dst_manifest_does_not_trigger_version_changed(
-        self, tmp_path
-    ):
+    def test_corrupt_dst_manifest_does_not_trigger_version_changed(self, tmp_path):
         """A corrupt destination manifest should NOT report version_changed
         — that's reserved for genuine version differences. The integration
         files are still copied (to repair the install) but the user isn't
@@ -1795,17 +1831,14 @@ def _provider_for_view_tests(tmp_path, public_base_url=None):
         client_secret="client-secret-very-secret",
         webhook_id="mcp_webhook_id_aaaa",
         signing_key=b"\x00" * 32,
-        public_base_url=public_base_url)
+        public_base_url=public_base_url,
+    )
     return oauth, provider
 
 
 def _make_view_request(
-    *,
-    headers=None,
-    query=None,
-    method="GET",
-    post_data=None,
-    scheme="https"):
+    *, headers=None, query=None, method="GET", post_data=None, scheme="https"
+):
     """Mock a starlette/aiohttp-style web.Request with the bits the views read."""
     req = MagicMock()
     req.headers = headers or {}
@@ -1850,9 +1883,7 @@ class TestBuildBaseUrl:
         assert result == "https://real.example"
 
     def test_falls_back_to_host_header(self, oauth):
-        request = _make_view_request(
-            headers={"Host": "host.example"}, scheme="https"
-        )
+        request = _make_view_request(headers={"Host": "host.example"}, scheme="https")
         result = oauth._build_base_url(request, None)
         assert result == "https://host.example"
 
@@ -1948,9 +1979,7 @@ class TestAuthorizeViewGet:
 
     async def test_rejects_short_code_challenge(self, setup):
         oauth, provider, view = setup
-        request = _make_view_request(
-            query=self._good_query(code_challenge="too-short")
-        )
+        request = _make_view_request(query=self._good_query(code_challenge="too-short"))
         resp = await view.get(request)
         assert resp.status == 400
         assert "code_challenge" in resp.text
@@ -2015,9 +2044,7 @@ class TestAuthorizeViewGet:
         try to XSS the consent page. The page must HTML-escape it."""
         oauth, provider, view = setup
         evil = "https://evil.example/?<script>alert(1)</script>"
-        request = _make_view_request(
-            query=self._good_query(redirect_uri=evil)
-        )
+        request = _make_view_request(query=self._good_query(redirect_uri=evil))
         with patch.object(oauth.web, "Response") as resp_ctor:
             await view.get(request)
         html = resp_ctor.call_args.kwargs.get("text", "")
@@ -2059,9 +2086,7 @@ class TestAuthorizeViewPost:
 
     async def test_approve_issues_code_and_redirects(self, setup):
         oauth, provider, view = setup
-        request = _make_view_request(
-            method="POST", post_data=self._good_form()
-        )
+        request = _make_view_request(method="POST", post_data=self._good_form())
         resp = await view.post(request)
         assert resp.status == 302
         loc = resp.headers["Location"]
@@ -2074,7 +2099,8 @@ class TestAuthorizeViewPost:
         oauth, provider, view = setup
         request = _make_view_request(
             method="POST",
-            post_data=self._good_form(client_id="attacker-substituted-id"))
+            post_data=self._good_form(client_id="attacker-substituted-id"),
+        )
         resp = await view.post(request)
         assert resp.status == 400
         assert "client_id" in resp.text
@@ -2083,7 +2109,8 @@ class TestAuthorizeViewPost:
         oauth, provider, view = setup
         request = _make_view_request(
             method="POST",
-            post_data=self._good_form(redirect_uri="http://evil.example/"))
+            post_data=self._good_form(redirect_uri="http://evil.example/"),
+        )
         resp = await view.post(request)
         assert resp.status == 400
 
@@ -2106,9 +2133,8 @@ class TestTokenView:
     @staticmethod
     def _basic_header(client_id, client_secret):
         import base64 as _b64
-        token = _b64.b64encode(
-            f"{client_id}:{client_secret}".encode()
-        ).decode("ascii")
+
+        token = _b64.b64encode(f"{client_id}:{client_secret}".encode()).decode("ascii")
         return f"Basic {token}"
 
     async def test_invalid_client_via_basic_returns_401(self, setup):
@@ -2116,7 +2142,8 @@ class TestTokenView:
         request = _make_view_request(
             method="POST",
             headers={"Authorization": self._basic_header("wrong", "pw")},
-            post_data={"grant_type": "authorization_code"})
+            post_data={"grant_type": "authorization_code"},
+        )
 
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
@@ -2125,9 +2152,10 @@ class TestTokenView:
         body = resp_ctor.call_args.args[0]
         assert body == {"error": "invalid_client"}
         assert kwargs.get("status") == 401
-        assert kwargs.get("headers", {}).get(
-            "WWW-Authenticate"
-        ) == 'Basic realm="MCP Proxy OAuth"'
+        assert (
+            kwargs.get("headers", {}).get("WWW-Authenticate")
+            == 'Basic realm="MCP Proxy OAuth"'
+        )
 
     async def test_invalid_client_via_form_returns_401(self, setup):
         oauth, provider, view = setup
@@ -2137,7 +2165,8 @@ class TestTokenView:
                 "grant_type": "authorization_code",
                 "client_id": "wrong",
                 "client_secret": "pw",
-            })
+            },
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
         body = resp_ctor.call_args.args[0]
@@ -2152,7 +2181,8 @@ class TestTokenView:
                     "client-id-1234567890ABCDEF", "client-secret-very-secret"
                 )
             },
-            post_data={"grant_type": "client_credentials"})
+            post_data={"grant_type": "client_credentials"},
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
         body = resp_ctor.call_args.args[0]
@@ -2169,7 +2199,8 @@ class TestTokenView:
                     "client-id-1234567890ABCDEF", "client-secret-very-secret"
                 )
             },
-            post_data={"grant_type": "authorization_code"})
+            post_data={"grant_type": "authorization_code"},
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
         body = resp_ctor.call_args.args[0]
@@ -2179,9 +2210,8 @@ class TestTokenView:
         oauth, provider, view = setup
         verifier = "abcdefghij" * 5  # 50 chars, passes RFC 7636 length check
         import hashlib
-        challenge = oauth._b64url_encode(
-            hashlib.sha256(verifier.encode()).digest()
-        )
+
+        challenge = oauth._b64url_encode(hashlib.sha256(verifier.encode()).digest())
         code = provider.issue_code("https://claude.ai/cb", challenge)
 
         request = _make_view_request(
@@ -2196,7 +2226,8 @@ class TestTokenView:
                 "code": code,
                 "redirect_uri": "https://claude.ai/cb",
                 "code_verifier": verifier,
-            })
+            },
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
 
@@ -2223,7 +2254,8 @@ class TestTokenView:
             post_data={
                 "grant_type": "refresh_token",
                 "refresh_token": refresh,
-            })
+            },
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
 
@@ -2244,7 +2276,8 @@ class TestTokenView:
             post_data={
                 "grant_type": "refresh_token",
                 "refresh_token": "garbage.token",
-            })
+            },
+        )
         with patch.object(oauth.web, "json_response") as resp_ctor:
             await view.post(request)
         body = resp_ctor.call_args.args[0]
@@ -2270,20 +2303,14 @@ class TestPkceLengthEnforcement:
     def test_rejects_long_verifier(self, provider):
         challenge = "X" * 43
         code = provider.issue_code("https://claude.ai/cb", challenge)
-        assert (
-            provider.consume_code(
-                code, "https://claude.ai/cb", "X" * 129
-            )
-            is False
-        )
+        assert provider.consume_code(code, "https://claude.ai/cb", "X" * 129) is False
 
     def test_rejects_verifier_with_disallowed_chars(self, provider):
         challenge = "X" * 43
         code = provider.issue_code("https://claude.ai/cb", challenge)
         bad_verifier = "a" * 42 + " "  # 43 chars but space is not in unreserved set
         assert (
-            provider.consume_code(code, "https://claude.ai/cb", bad_verifier)
-            is False
+            provider.consume_code(code, "https://claude.ai/cb", bad_verifier) is False
         )
 
 
@@ -2371,7 +2398,8 @@ class TestRedirectUriValidation:
             ("", False),
             ("https://claude.ai/cb#fragment", False),
             ("not-a-url", False),
-        ])
+        ],
+    )
     def test_validates_redirect_uri(self, oauth, uri, expected):
         assert oauth._is_valid_redirect_uri(uri) is expected
 
@@ -2392,7 +2420,8 @@ class TestOAuthProviderConstructorValidation:
                 client_id="",
                 client_secret="secret",
                 webhook_id="wh",
-                signing_key=b"\x00" * 32)
+                signing_key=b"\x00" * 32,
+            )
 
     def test_rejects_short_client_id(self, oauth):
         with pytest.raises(ValueError, match="client_id"):
@@ -2401,7 +2430,8 @@ class TestOAuthProviderConstructorValidation:
                 client_id="too-short",
                 client_secret="secret",
                 webhook_id="wh",
-                signing_key=b"\x00" * 32)
+                signing_key=b"\x00" * 32,
+            )
 
     def test_rejects_blank_client_secret(self, oauth):
         with pytest.raises(ValueError, match="client_secret"):
@@ -2410,7 +2440,8 @@ class TestOAuthProviderConstructorValidation:
                 client_id="client-id-1234567890ABCDEF",
                 client_secret="",
                 webhook_id="wh",
-                signing_key=b"\x00" * 32)
+                signing_key=b"\x00" * 32,
+            )
 
     def test_rejects_short_signing_key(self, oauth):
         with pytest.raises(ValueError, match="signing_key"):
@@ -2419,7 +2450,8 @@ class TestOAuthProviderConstructorValidation:
                 client_id="client-id-1234567890ABCDEF",
                 client_secret="secret",
                 webhook_id="wh",
-                signing_key=b"too-short")
+                signing_key=b"too-short",
+            )
 
 
 class TestRepairsModule:
@@ -2429,13 +2461,9 @@ class TestRepairsModule:
     @pytest.fixture
     def repairs(self, tmp_path):
         _install_runtime_stubs()
-        repairs_path = os.path.join(
-            PROXY_ADDON_DIR, "mcp_proxy", "repairs.py"
-        )
+        repairs_path = os.path.join(PROXY_ADDON_DIR, "mcp_proxy", "repairs.py")
         sys.modules.pop("mcp_proxy_repairs", None)
-        spec = importlib.util.spec_from_file_location(
-            "mcp_proxy_repairs", repairs_path
-        )
+        spec = importlib.util.spec_from_file_location("mcp_proxy_repairs", repairs_path)
         mod = importlib.util.module_from_spec(spec)
         sys.modules["mcp_proxy_repairs"] = mod
         spec.loader.exec_module(mod)
@@ -2462,12 +2490,14 @@ class TestRepairsModule:
 
     def test_maybe_create_issue_no_op_when_marker_missing(self, repairs):
         from homeassistant.helpers import issue_registry
+
         hass = MagicMock()
         repairs.maybe_create_issue(hass, "mcp_proxy")
         issue_registry.async_create_issue.assert_not_called()
 
     def test_maybe_create_issue_fires_when_marker_present(self, repairs):
         from homeassistant.helpers import issue_registry
+
         issue_registry.async_create_issue.reset_mock()
         repairs.RESTART_MARKER_FILE.write_text("test")
         hass = MagicMock()
@@ -2481,6 +2511,7 @@ class TestRepairsModule:
 
     def test_clear_issue_deletes_marker_and_calls_delete_issue(self, repairs):
         from homeassistant.helpers import issue_registry
+
         issue_registry.async_delete_issue.reset_mock()
         repairs.RESTART_MARKER_FILE.write_text("test")
         hass = MagicMock()
@@ -2501,22 +2532,16 @@ class TestRepairsFlowSubmit:
     @pytest.fixture
     def repairs(self, tmp_path):
         _install_runtime_stubs()
-        repairs_path = os.path.join(
-            PROXY_ADDON_DIR, "mcp_proxy", "repairs.py"
-        )
+        repairs_path = os.path.join(PROXY_ADDON_DIR, "mcp_proxy", "repairs.py")
         sys.modules.pop("mcp_proxy_repairs", None)
-        spec = importlib.util.spec_from_file_location(
-            "mcp_proxy_repairs", repairs_path
-        )
+        spec = importlib.util.spec_from_file_location("mcp_proxy_repairs", repairs_path)
         mod = importlib.util.module_from_spec(spec)
         sys.modules["mcp_proxy_repairs"] = mod
         spec.loader.exec_module(mod)
         mod.RESTART_MARKER_FILE = tmp_path / ".mcp_proxy_oauth_restart_required"
         return mod
 
-    async def test_confirm_with_input_calls_restart_and_clears_marker(
-        self, repairs
-    ):
+    async def test_confirm_with_input_calls_restart_and_clears_marker(self, repairs):
         repairs.RESTART_MARKER_FILE.write_text("test")
         flow = repairs.OAuthRestartRepairFlow()
         hass = MagicMock()
@@ -2527,9 +2552,7 @@ class TestRepairsFlowSubmit:
 
         hass.async_add_executor_job = AsyncMock(side_effect=fake_executor)
         flow.hass = hass
-        flow.async_create_entry = MagicMock(
-            return_value={"type": "create_entry"}
-        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
         await flow.async_step_confirm({})
 
@@ -2541,7 +2564,7 @@ class TestRepairsFlowSubmit:
     async def test_confirm_without_input_shows_form(self, repairs):
         flow = repairs.OAuthRestartRepairFlow()
         flow.async_show_form = MagicMock(return_value={"type": "form"})
-        result = await flow.async_step_confirm(None)
+        await flow.async_step_confirm(None)
         flow.async_show_form.assert_called_once()
         assert flow.async_show_form.call_args.kwargs["step_id"] == "confirm"
 
@@ -2553,20 +2576,14 @@ class TestStringsJSONIssueKeys:
     localized text."""
 
     def test_issue_translation_keys_match_repair_flow(self):
-        with open(
-            f"{PROXY_ADDON_DIR}/mcp_proxy/strings.json"
-        ) as f:
+        with open(f"{PROXY_ADDON_DIR}/mcp_proxy/strings.json") as f:
             strings = json.load(f)
 
         assert "oauth_restart_required" in strings.get("issues", {})
         issue = strings["issues"]["oauth_restart_required"]
         assert issue.get("title")
 
-        confirm = (
-            issue.get("fix_flow", {})
-            .get("step", {})
-            .get("confirm", {})
-        )
+        confirm = issue.get("fix_flow", {}).get("step", {}).get("confirm", {})
         assert confirm.get("title")
         assert confirm.get("description")
 
@@ -2582,9 +2599,7 @@ class TestProbeOAuthActive:
     def start(self):
         return _import_start()
 
-    def test_probe_returns_true_when_metadata_endpoint_returns_json(
-        self, start
-    ):
+    def test_probe_returns_true_when_metadata_endpoint_returns_json(self, start):
         with (
             patch.object(start, "_read_integration_domain", return_value="mcp_proxy"),
             patch.object(
@@ -2613,9 +2628,7 @@ class TestProbeOAuthActive:
         ):
             assert start._probe_oauth_active() is False
 
-    def test_probe_returns_false_when_authorization_servers_missing(
-        self, start
-    ):
+    def test_probe_returns_false_when_authorization_servers_missing(self, start):
         # A different endpoint accidentally exists at the same URL
         with (
             patch.object(start, "_read_integration_domain", return_value="mcp_proxy"),
@@ -2681,7 +2694,8 @@ class TestOAuthSetupEntryRegistersExpectedViews:
         with (
             patch.object(mod, "_read_config", return_value=proxy_config),
             patch.object(mod, "async_register"),
-            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock())):
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
             await mod.async_setup_entry(hass, MagicMock())
 
         registered_urls = {
@@ -2719,7 +2733,4 @@ class TestUnauthorizedResponseShape:
         ww = kwargs["headers"]["WWW-Authenticate"]
         # Pinned base means evil.example is NOT in the metadata URL
         assert "evil.example" not in ww
-        assert (
-            "https://legit.example/api/mcp_proxy/oauth/protected-resource"
-            in ww
-        )
+        assert "https://legit.example/api/mcp_proxy/oauth/protected-resource" in ww

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -1564,8 +1564,9 @@ class TestResolveOAuthCreds:
         assert sec1 == sec2
 
     def test_user_value_overrides_persisted(self, start, tmp_path):
-        # First call generates and persists
-        gen_cid, gen_sec = start._resolve_oauth_creds(tmp_path, "", "")
+        # First call generates and persists (return value intentionally unused;
+        # this call's side effect is writing oauth_creds.json to disk).
+        start._resolve_oauth_creds(tmp_path, "", "")
         # Second call with user-supplied values uses those
         cid, sec = start._resolve_oauth_creds(
             tmp_path, "user-id-1234567890123", "user-secret"

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -674,6 +674,7 @@ def _wait_for_ha_api_ready(
                 logger.info(f"🏠 Home Assistant API ready after {elapsed}s")
                 return True
         except _requests.exceptions.RequestException:
+            # Boot-phase polling: HA API not up yet — retry until timeout (#1266).
             pass
         time.sleep(1)
     return False
@@ -985,10 +986,10 @@ def _reset_ha_in_process_caches() -> None:
     attribute on the singleton without clearing the connection pool, since
     ``_client`` is not declared on the class.
     """
-    import ha_mcp.config
+    from ha_mcp import config
     from ha_mcp.client.websocket_client import websocket_manager
 
-    ha_mcp.config._settings = None
+    config._settings = None
     websocket_manager._clients.clear()
     websocket_manager._last_used.clear()
     websocket_manager._current_loop = None
@@ -1276,6 +1277,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     requests.exceptions.RequestException,
                     json.JSONDecodeError,
                 ):
+                    # Boot-phase polling: state machine not ready — retry (#1266).
                     pass
                 time.sleep(1)
             else:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -133,7 +133,6 @@ def pytest_collection_modifyitems(config, items):
     del config
     haos = is_haos_backend_selected()
     inaddon = haos and is_haos_inaddon_mode()
-    external_haos = haos and not inaddon
     skip_haos = pytest.mark.skip(
         reason="HAOS backend not selected (set HAOS_TEST_IMAGE_PATH)"
     )

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1236,7 +1236,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 # "connection refused for 60s" from "endpoint returned
                 # 200 but state was 'unknown'".
                 logger.warning(
-                    "⚠️ HAOS sun.sun still not ready after %ds "
+                    "HAOS sun.sun still not ready after %ds "
                     "(last_status=%s, last_exc=%r) — template / connection "
                     "tests may race",
                     SUN_WAIT,
@@ -1268,7 +1268,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                     if light_resp.status_code == 200:
                         elapsed = time.monotonic() - light_start
                         logger.info(
-                            "✅ HAOS light.bed_light is in state machine after %.1fs",
+                            "HAOS light.bed_light is in state machine after %.1fs",
                             elapsed,
                         )
                         break
@@ -1280,7 +1280,7 @@ def ha_container_with_fresh_config(_blueprint_http_server):
                 time.sleep(1)
             else:
                 logger.warning(
-                    "⚠️ HAOS light.bed_light still not in state machine after "
+                    "HAOS light.bed_light still not in state machine after "
                     "%ds (last_status=%s) — search / state tests may race",
                     LIGHT_WAIT,
                     last_light_status,

--- a/tests/src/e2e/haos_only/test_addon_lifecycle.py
+++ b/tests/src/e2e/haos_only/test_addon_lifecycle.py
@@ -107,6 +107,9 @@ async def _resolve_slug(mcp_client: Any, display_name: str) -> str:
         f"Addon {display_name!r} not found in installed listing. "
         f"Installed: {installed}. Check build_image.py ADDONS tuple."
     )
+    raise AssertionError(
+        "unreachable: pytest.fail always raises"
+    )  # explicit for CodeQL
 
 
 async def _get_addon_detail(mcp_client: Any, slug: str) -> dict[str, Any]:

--- a/tests/src/e2e/haos_only/test_integration_setup.py
+++ b/tests/src/e2e/haos_only/test_integration_setup.py
@@ -43,12 +43,6 @@ LOG = logging.getLogger(__name__)
 pytestmark = [pytest.mark.haos_only]
 
 
-# Node-RED's HA integration historically registered under the ``nodered``
-# domain (no underscore); some addon versions use ``node_red``. Accept either
-# so the test is robust across addon-version drift.
-_NODE_RED_DOMAIN_CANDIDATES: tuple[str, ...] = ("nodered", "node_red")
-
-
 def _find_entry_for_domain(
     entries: list[dict[str, Any]], domain: str
 ) -> dict[str, Any] | None:

--- a/tests/src/e2e/haos_only/test_manage_addon_modes.py
+++ b/tests/src/e2e/haos_only/test_manage_addon_modes.py
@@ -106,6 +106,9 @@ async def _resolve_slug(mcp_client: Any, display_name: str) -> str:
         f"Addon {display_name!r} not found in installed listing. "
         f"Installed: {installed}. Check build_image.py ADDONS tuple."
     )
+    raise AssertionError(
+        "unreachable: pytest.fail always raises"
+    )  # explicit for CodeQL
 
 
 async def _wait_addon_running(

--- a/tests/src/e2e/workflows/automation/test_lifecycle.py
+++ b/tests/src/e2e/workflows/automation/test_lifecycle.py
@@ -180,7 +180,9 @@ class TestAutomationLifecycle:
         # automation engine — much faster than the 10s logbook poll the
         # previous flow used, which was the largest single chunk of
         # this test's runtime (~10s of the ~16s total on regular e2e).
-        logger.info("🚀 Triggering automation + waiting for automation_triggered event...")
+        logger.info(
+            "🚀 Triggering automation + waiting for automation_triggered event..."
+        )
 
         async def _fire_trigger():
             trigger_result = await mcp_client.call_tool(
@@ -196,13 +198,16 @@ class TestAutomationLifecycle:
         triggered_event = await wait_for_ha_event(
             "automation_triggered",
             _fire_trigger,
-            predicate=lambda ev: (ev.get("data") or {}).get("entity_id")
-            == automation_entity,
+            predicate=lambda ev: (
+                (ev.get("data") or {}).get("entity_id") == automation_entity
+            ),
             timeout=5.0,
         )
 
         if triggered_event:
-            logger.info(f"✅ automation_triggered event observed for {automation_entity}")
+            logger.info(
+                f"✅ automation_triggered event observed for {automation_entity}"
+            )
         else:
             # Belt-and-suspenders fallback: even though the WS event
             # missed, the trigger service call succeeded. Try the
@@ -242,12 +247,10 @@ class TestAutomationLifecycle:
 
         update_result = await mcp_client.call_tool(
             "ha_config_set_automation",
-            {
-                "identifier": automation_entity,
-                "config": update_config},
+            {"identifier": automation_entity, "config": update_config},
         )
 
-        update_data = assert_mcp_success(update_result, "automation update")
+        assert_mcp_success(update_result, "automation update")
         logger.info("✅ Automation updated successfully")
 
         # 7. VERIFY: Update was applied
@@ -283,10 +286,10 @@ class TestAutomationLifecycle:
         logger.info("🗑️ Deleting automation...")
         delete_result = await mcp_client.call_tool(
             "ha_config_remove_automation",
-            { "identifier": automation_entity},
+            {"identifier": automation_entity},
         )
 
-        delete_data = assert_mcp_success(delete_result, "automation deletion")
+        assert_mcp_success(delete_result, "automation deletion")
         logger.info("✅ Automation deleted successfully")
 
         # 9. VERIFY: Automation is gone
@@ -345,8 +348,7 @@ class TestAutomationLifecycle:
 
         logger.info(f"📝 Creating disabled automation: {automation_name}")
         create_result = await mcp_client.call_tool(
-            "ha_config_set_automation",
-            { "config": config}
+            "ha_config_set_automation", {"config": config}
         )
 
         create_data = assert_mcp_success(create_result, "disabled automation creation")
@@ -376,7 +378,7 @@ class TestAutomationLifecycle:
             },
         )
 
-        enable_data = assert_mcp_success(enable_result, "automation enable")
+        assert_mcp_success(enable_result, "automation enable")
 
         # Verify automation is now enabled
         state_reached = await wait_for_entity_state(
@@ -398,7 +400,7 @@ class TestAutomationLifecycle:
             },
         )
 
-        disable_data = assert_mcp_success(disable_result, "automation disable")
+        assert_mcp_success(disable_result, "automation disable")
 
         # Verify automation is now disabled
         state_reached = await wait_for_entity_state(
@@ -412,7 +414,7 @@ class TestAutomationLifecycle:
         # Clean up
         delete_result = await mcp_client.call_tool(
             "ha_config_remove_automation",
-            { "identifier": automation_entity},
+            {"identifier": automation_entity},
         )
         assert_mcp_success(delete_result, "automation cleanup")
         logger.info("🗑️ Automation cleaned up")
@@ -451,8 +453,7 @@ class TestAutomationLifecycle:
         )
 
         create_result = await mcp_client.call_tool(
-            "ha_config_set_automation",
-            { "config": valid_config}
+            "ha_config_set_automation", {"config": valid_config}
         )
 
         create_data = assert_mcp_success(create_result, "valid configuration creation")
@@ -465,8 +466,7 @@ class TestAutomationLifecycle:
 
         # Verify configuration structure
         get_result = await mcp_client.call_tool(
-            "ha_config_get_automation",
-            { "identifier": automation_entity}
+            "ha_config_get_automation", {"identifier": automation_entity}
         )
 
         get_data = assert_mcp_success(get_result, "configuration retrieval")
@@ -506,8 +506,7 @@ class TestAutomationLifecycle:
 
         try:
             invalid_result = await mcp_client.call_tool(
-                "ha_config_set_automation",
-                { "config": invalid_config}
+                "ha_config_set_automation", {"config": invalid_config}
             )
 
             invalid_data = parse_mcp_result(invalid_result)
@@ -529,7 +528,7 @@ class TestAutomationLifecycle:
         # Clean up valid automation
         delete_result = await mcp_client.call_tool(
             "ha_config_remove_automation",
-            { "identifier": automation_entity},
+            {"identifier": automation_entity},
         )
         assert_mcp_success(delete_result, "valid automation cleanup")
         logger.info("🗑️ Test automations cleaned up")
@@ -592,8 +591,7 @@ class TestAutomationLifecycle:
 
         logger.info(f"📝 Creating complex automation: {automation_name}")
         create_result = await mcp_client.call_tool(
-            "ha_config_set_automation",
-            { "config": complex_config}
+            "ha_config_set_automation", {"config": complex_config}
         )
 
         create_data = assert_mcp_success(create_result, "complex automation creation")
@@ -629,8 +627,7 @@ class TestAutomationLifecycle:
         # Verify complex configuration
         logger.info("🔍 Verifying complex automation configuration...")
         get_result = await mcp_client.call_tool(
-            "ha_config_get_automation",
-            { "identifier": automation_entity}
+            "ha_config_get_automation", {"identifier": automation_entity}
         )
 
         get_data = assert_mcp_success(get_result, "complex automation retrieval")
@@ -664,10 +661,10 @@ class TestAutomationLifecycle:
         logger.info("🗑️ Cleaning up complex automation...")
         delete_result = await mcp_client.call_tool(
             "ha_config_remove_automation",
-            { "identifier": automation_entity},
+            {"identifier": automation_entity},
         )
 
-        delete_data = assert_mcp_success(delete_result, "complex automation deletion")
+        assert_mcp_success(delete_result, "complex automation deletion")
         logger.info("✅ Complex automation cleaned up")
 
     async def test_automation_mode_behaviors(
@@ -706,8 +703,7 @@ class TestAutomationLifecycle:
                 mode_config.pop("max", None)
 
             create_result = await mcp_client.call_tool(
-                "ha_config_set_automation",
-                { "config": mode_config}
+                "ha_config_set_automation", {"config": mode_config}
             )
 
             create_data = assert_mcp_success(
@@ -728,7 +724,7 @@ class TestAutomationLifecycle:
             # Verify mode is set correctly
             get_result = await mcp_client.call_tool(
                 "ha_config_get_automation",
-                { "identifier": automation_entity},
+                {"identifier": automation_entity},
             )
 
             get_data = assert_mcp_success(
@@ -756,12 +752,10 @@ class TestAutomationLifecycle:
             # Cleanup immediately to avoid entity ID conflicts
             delete_result = await mcp_client.call_tool(
                 "ha_config_remove_automation",
-                { "identifier": automation_entity},
+                {"identifier": automation_entity},
             )
 
-            delete_data = assert_mcp_success(
-                delete_result, f"{mode} mode automation deletion"
-            )
+            assert_mcp_success(delete_result, f"{mode} mode automation deletion")
             logger.info(f"🗑️ Mode {mode} automation cleaned up")
 
 
@@ -827,7 +821,6 @@ async def test_automation_search_and_discovery(mcp_client):
         logger.info(f"🔍 Pattern '{pattern}' search: {len(results)} results")
 
     logger.info("✅ Automation search and discovery tests completed")
-
 
 
 @pytest.mark.automation
@@ -976,16 +969,16 @@ async def test_automation_with_choose_block(mcp_client):
         # The key could be 'conditions' or 'condition' depending on HA version
         # But our normalization should have sent 'conditions' to the API
         has_conditions = "conditions" in option or "condition" in option
-        assert has_conditions, (
-            f"Choose option {i} should have conditions defined"
-        )
+        assert has_conditions, f"Choose option {i} should have conditions defined"
         logger.info(f"✅ Choose option {i} has condition key: {list(option.keys())}")
 
     # The fact that we successfully created and retrieved the automation
     # with choose blocks proves the normalization fix works.
     # Execution testing would require more complex setup (triggering actual
     # entity state changes) which is beyond the scope of this normalization test.
-    logger.info("✅ Choose block normalization verified - automation API accepted the config")
+    logger.info(
+        "✅ Choose block normalization verified - automation API accepted the config"
+    )
 
     # Clean up
     logger.info("🧹 Cleaning up test automation...")
@@ -1039,11 +1032,15 @@ async def test_duplicate_automation_prevention(mcp_client, cleanup_tracker):
     # Now retrieve the automation config — it will contain the 'id' field
     config = await wait_for_automation(mcp_client, automation_entity, timeout=10)
     assert config is not None, "Could not retrieve created automation"
-    assert "id" in config, f"Retrieved config should contain 'id' field: {config.keys()}"
+    assert "id" in config, (
+        f"Retrieved config should contain 'id' field: {config.keys()}"
+    )
 
     # Attempt to create a new automation using this config WITHOUT passing identifier.
     # This should be rejected because the config contains an existing 'id'.
-    logger.info("Attempting to create automation with existing 'id' in config (no identifier)...")
+    logger.info(
+        "Attempting to create automation with existing 'id' in config (no identifier)..."
+    )
     duplicate_result = await safe_call_tool(
         mcp_client,
         "ha_config_set_automation",
@@ -1057,9 +1054,7 @@ async def test_duplicate_automation_prevention(mcp_client, cleanup_tracker):
     # Verify the error mentions the 'id' field and provides guidance
     error = duplicate_result.get("error", {})
     error_msg = error.get("message", "") if isinstance(error, dict) else str(error)
-    assert "id" in error_msg.lower(), (
-        f"Error should mention 'id' field: {error_msg}"
-    )
+    assert "id" in error_msg.lower(), f"Error should mention 'id' field: {error_msg}"
     logger.info(f"Correctly rejected with error: {error_msg}")
 
     # Clean up
@@ -1128,7 +1123,6 @@ async def test_automation_creation_returns_verified_entity(
     )
     assert_mcp_success(delete_result, "verified entity test cleanup")
     logger.info("Automation creation verified entity test passed")
-
 
 
 async def _find_test_light_entity(mcp_client) -> str:
@@ -1210,7 +1204,9 @@ class TestConfigHashMismatch:
         logger.info(f"Real config_hash: {real_hash[:12]}...")
 
         # 3. Construct a stale hash — guarantee it differs from the real one
-        stale_hash = real_hash[:-4] + ("0000" if not real_hash.endswith("0000") else "ffff")
+        stale_hash = real_hash[:-4] + (
+            "0000" if not real_hash.endswith("0000") else "ffff"
+        )
         assert stale_hash != real_hash, "stale_hash must differ from real_hash"
 
         # 4. Attempt update with the stale hash — guard must reject it
@@ -1284,7 +1280,9 @@ class TestConfigHashMismatch:
                 "config_hash": real_hash,
             },
         )
-        assert result.get("success") is True, f"expected success with correct hash: {result}"
+        assert result.get("success") is True, (
+            f"expected success with correct hash: {result}"
+        )
         logger.info("Correct hash accepted — update succeeded")
 
     async def test_update_without_hash_succeeds(
@@ -1357,9 +1355,7 @@ class TestSetAutomationNegativeInputs:
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "both config and python_transform" in result["error"]["message"].lower()
 
-    async def test_python_transform_requires_identifier(
-        self, mcp_client
-    ) -> None:
+    async def test_python_transform_requires_identifier(self, mcp_client) -> None:
         """Rejects python_transform when identifier is absent.
 
         Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
@@ -1377,9 +1373,7 @@ class TestSetAutomationNegativeInputs:
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "identifier is required" in result["error"]["message"].lower()
 
-    async def test_python_transform_requires_config_hash(
-        self, mcp_client
-    ) -> None:
+    async def test_python_transform_requires_config_hash(self, mcp_client) -> None:
         """Rejects python_transform when config_hash is absent.
 
         Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
@@ -1397,9 +1391,7 @@ class TestSetAutomationNegativeInputs:
         assert result["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "config_hash is required" in result["error"]["message"].lower()
 
-    async def test_requires_at_least_one_input(
-        self, mcp_client
-    ) -> None:
+    async def test_requires_at_least_one_input(self, mcp_client) -> None:
         """Rejects a call that supplies neither config nor python_transform.
 
         Guard: tools_config_automations.py — raises VALIDATION_INVALID_PARAMETER
@@ -1440,7 +1432,9 @@ class TestAutomationDestructiveNegativeInputs:
         Source path: Exception with "404"/"not found" in str →
         RESOURCE_NOT_FOUND branch → raise_tool_error.
         """
-        logger.info("Testing ha_config_remove_automation with nonexistent identifier...")
+        logger.info(
+            "Testing ha_config_remove_automation with nonexistent identifier..."
+        )
 
         data = await safe_call_tool(
             mcp_client,
@@ -1458,7 +1452,9 @@ class TestAutomationDestructiveNegativeInputs:
         assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (
             f"Expected 'not found'/'does not exist'/'404' in error, got: {data.get('error')}"
         )
-        logger.info("\u2705 Nonexistent automation removal correctly returned structured error")
+        logger.info(
+            "\u2705 Nonexistent automation removal correctly returned structured error"
+        )
 
     async def test_remove_automation_double_delete(
         self, mcp_client, test_data_factory, cleanup_tracker
@@ -1476,7 +1472,9 @@ class TestAutomationDestructiveNegativeInputs:
         config = test_data_factory.automation_config(
             automation_name,
             trigger=[{"platform": "time", "at": "06:00:00"}],
-            action=[{"service": "light.turn_on", "target": {"entity_id": "light.bed_light"}}],
+            action=[
+                {"service": "light.turn_on", "target": {"entity_id": "light.bed_light"}}
+            ],
         )
 
         logger.info("Creating automation for double-delete test...")
@@ -1484,7 +1482,9 @@ class TestAutomationDestructiveNegativeInputs:
             "ha_config_set_automation",
             {"config": config},
         )
-        create_data = assert_mcp_success(create_result, "automation creation for double-delete")
+        create_data = assert_mcp_success(
+            create_result, "automation creation for double-delete"
+        )
         entity_id = create_data.get("entity_id")
         assert entity_id, f"No entity_id returned: {create_data}"
         cleanup_tracker.track("automation", entity_id)
@@ -1515,4 +1515,6 @@ class TestAutomationDestructiveNegativeInputs:
         assert any(kw in error_msg for kw in ("not found", "does not exist", "404")), (
             f"Expected not-found error on second delete, got: {second_delete.get('error')}"
         )
-        logger.info("\u2705 Double-delete correctly returned structured error on second call")
+        logger.info(
+            "\u2705 Double-delete correctly returned structured error on second call"
+        )

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -57,7 +57,9 @@ class TestBlueprintManagement:
                 assert "path" in first_blueprint, "Blueprint should have 'path'"
                 assert "domain" in first_blueprint, "Blueprint should have 'domain'"
                 assert "name" in first_blueprint, "Blueprint should have 'name'"
-                logger.info(f"First blueprint: {first_blueprint.get('name')} ({first_blueprint.get('path')})")
+                logger.info(
+                    f"First blueprint: {first_blueprint.get('name')} ({first_blueprint.get('path')})"
+                )
 
             logger.info("ha_get_blueprint (list mode) for automation domain succeeded")
 
@@ -103,7 +105,9 @@ class TestBlueprintManagement:
             )
 
             # Verify error response includes valid domains
-            assert "valid_domains" in result, "Error response should include valid domains"
+            assert "valid_domains" in result, (
+                "Error response should include valid domains"
+            )
             logger.info("ha_get_blueprint properly rejects invalid domain")
 
     async def test_get_blueprint_details(self, mcp_client):
@@ -141,14 +145,18 @@ class TestBlueprintManagement:
             assert "path" in detail_result, "Response should contain 'path'"
             assert "domain" in detail_result, "Response should contain 'domain'"
             assert "name" in detail_result, "Response should contain 'name'"
-            assert detail_result["path"] == first_blueprint_path, "Path should match requested path"
+            assert detail_result["path"] == first_blueprint_path, (
+                "Path should match requested path"
+            )
 
             logger.info(f"Blueprint details retrieved: {detail_result.get('name')}")
 
             # Check for metadata if available
             if "metadata" in detail_result:
                 meta = detail_result["metadata"]
-                logger.info(f"  Description: {(meta.get('description') or 'N/A')[:100]}...")
+                logger.info(
+                    f"  Description: {(meta.get('description') or 'N/A')[:100]}..."
+                )
                 logger.info(f"  Author: {meta.get('author') or 'N/A'}")
 
             # Check for inputs if available
@@ -176,7 +184,10 @@ class TestBlueprintManagement:
             # Try to get a non-existent blueprint
             result = await mcp.call_tool_failure(
                 "ha_get_blueprint",
-                {"path": "nonexistent/blueprint_a2_e2e_xyz_404.yaml", "domain": "automation"},
+                {
+                    "path": "nonexistent/blueprint_a2_e2e_xyz_404.yaml",
+                    "domain": "automation",
+                },
                 expected_error="not found",
             )
 
@@ -204,7 +215,9 @@ class TestBlueprintManagement:
                 expected_error="Invalid domain",
             )
 
-            assert "valid_domains" in result, "Error response should include valid domains"
+            assert "valid_domains" in result, (
+                "Error response should include valid domains"
+            )
             logger.info("ha_get_blueprint properly rejects invalid domain")
 
     async def test_import_blueprint_invalid_url(self, mcp_client):
@@ -243,11 +256,15 @@ class TestBlueprintManagement:
             )
 
             # Should fail with appropriate error (suggestions nested under "error")
-            assert "suggestions" in result.get("error", {}), "Error response should include suggestions"
+            assert "suggestions" in result.get("error", {}), (
+                "Error response should include suggestions"
+            )
             logger.info("ha_import_blueprint properly handles non-existent URL")
 
     @pytest.mark.slow
-    async def test_import_blueprint_saves_to_disk(self, mcp_client, local_blueprint_server):
+    async def test_import_blueprint_saves_to_disk(
+        self, mcp_client, local_blueprint_server
+    ):
         """
         Test: Import blueprint actually saves to disk (issue #685)
 
@@ -280,14 +297,19 @@ class TestBlueprintManagement:
             if result.get("success"):
                 # Import succeeded - verify metadata is populated
                 imported = result.get("imported_blueprint", {})
-                assert imported.get("path", "").endswith(".yaml"), \
+                assert imported.get("path", "").endswith(".yaml"), (
                     f"Blueprint path should end with .yaml, got: {imported.get('path')}"
-                assert imported.get("domain") in ("automation", "script"), \
+                )
+                assert imported.get("domain") in ("automation", "script"), (
                     f"Blueprint domain should be automation or script, got: {imported.get('domain')}"
+                )
                 assert imported.get("name"), "Blueprint name should not be empty"
-                assert imported["path"] not in before_paths, \
+                assert imported["path"] not in before_paths, (
                     f"Blueprint {imported['path']} should not have existed before import"
-                logger.info(f"Blueprint imported: {imported.get('name')} at {imported.get('path')}")
+                )
+                logger.info(
+                    f"Blueprint imported: {imported.get('name')} at {imported.get('path')}"
+                )
 
                 # Verify it appears in the blueprint list
                 after = await mcp.call_tool_success(
@@ -295,14 +317,16 @@ class TestBlueprintManagement:
                     {"domain": imported.get("domain", "automation")},
                 )
                 after_paths = [bp["path"] for bp in after.get("blueprints", [])]
-                assert imported["path"] in after_paths, \
+                assert imported["path"] in after_paths, (
                     f"Imported blueprint {imported['path']} should appear in blueprint list"
+                )
                 logger.info("Blueprint appears in list after import")
             else:
                 # Only acceptable failure is "already exists"
                 error_msg = extract_error_message(result)
-                assert "already exists" in error_msg.lower(), \
+                assert "already exists" in error_msg.lower(), (
                     f"Expected 'already exists' error, got: {result}"
+                )
                 logger.info("Blueprint already existed (prior test run), still valid")
 
             logger.info("ha_import_blueprint save-to-disk test completed")
@@ -359,7 +383,9 @@ async def test_blueprint_discovery_workflow(mcp_client):
                 inputs = detail_result["inputs"]
                 logger.info(f"Blueprint requires {len(inputs)} inputs:")
                 for input_name, input_config in list(inputs.items())[:3]:
-                    logger.info(f"  - {input_name}: {(input_config.get('description') or 'No description')[:50]}")
+                    logger.info(
+                        f"  - {input_name}: {(input_config.get('description') or 'No description')[:50]}"
+                    )
         else:
             logger.info("Step 3: Skipped (no blueprints available)")
 
@@ -456,12 +482,18 @@ async def test_blueprint_automation_lifecycle(mcp_client):
             error_msg = str(create_result.get("error", {}).get("message", ""))
             # If error is about missing blueprint inputs, our validation passed! HA rejected it.
             if "Missing input" in error_msg or "input" in error_msg.lower():
-                logger.info("✅ Our validation passed (config reached HA), HA rejected due to missing blueprint inputs as expected")
-                logger.info("✅ Blueprint automation lifecycle test completed (validation works)")
+                logger.info(
+                    "✅ Our validation passed (config reached HA), HA rejected due to missing blueprint inputs as expected"
+                )
+                logger.info(
+                    "✅ Blueprint automation lifecycle test completed (validation works)"
+                )
                 return
             # If error is about missing trigger/action, our fix didn't work
             if "trigger" in error_msg.lower() or "action" in error_msg.lower():
-                raise AssertionError(f"Our validation failed - still requiring trigger/action: {error_msg}")
+                raise AssertionError(
+                    f"Our validation failed - still requiring trigger/action: {error_msg}"
+                )
             # Some other error
             raise AssertionError(f"Unexpected error: {create_result}")
 
@@ -473,12 +505,14 @@ async def test_blueprint_automation_lifecycle(mcp_client):
         # If we got here, the automation was created successfully
         # Step 4: Wait for automation to be registered, then verify no trigger/action fields
         config = await wait_for_automation(mcp_client, automation_id)
-        assert config is not None, f"Automation {automation_id} not found after creation"
+        assert config is not None, (
+            f"Automation {automation_id} not found after creation"
+        )
         assert "use_blueprint" in config, "Config should have use_blueprint"
         logger.info("✅ Blueprint automation config verified")
 
         # Step 5: Clean up
-        delete_result = await mcp.call_tool_success(
+        await mcp.call_tool_success(
             "ha_config_remove_automation",
             {"identifier": automation_id},
         )
@@ -535,18 +569,24 @@ async def test_blueprint_automation_with_empty_arrays(mcp_client):
             error_msg = str(create_result.get("error", {}).get("message", ""))
             # If error is about missing blueprint inputs, our validation passed!
             if "Missing input" in error_msg or "input" in error_msg.lower():
-                logger.info("✅ Empty arrays were stripped (passed our validation, failed HA blueprint validation as expected)")
+                logger.info(
+                    "✅ Empty arrays were stripped (passed our validation, failed HA blueprint validation as expected)"
+                )
                 logger.info("✅ Empty arrays test completed")
                 return
             # If error is about missing trigger/action, our fix didn't work
             if "trigger" in error_msg.lower() or "action" in error_msg.lower():
-                raise AssertionError(f"Empty arrays not stripped - validation failed: {error_msg}")
+                raise AssertionError(
+                    f"Empty arrays not stripped - validation failed: {error_msg}"
+                )
             # Some other error
             raise AssertionError(f"Unexpected error: {create_result}")
 
         # If somehow it succeeded (unlikely with empty inputs)
         automation_id = create_result.get("entity_id") or create_result.get("id")
-        logger.info(f"✅ Created blueprint automation with empty arrays: {automation_id}")
+        logger.info(
+            f"✅ Created blueprint automation with empty arrays: {automation_id}"
+        )
 
         # Clean up
         await mcp.call_tool_success(

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1531,7 +1531,7 @@ class TestTagCRUD:
         )
 
         create_data = assert_mcp_success(create_result, "Create tag")
-        entity_id = get_entity_id_from_response(create_data, "tag")
+        get_entity_id_from_response(create_data, "tag")
         # Tag may not return entity_id in same format
         tag_id = create_data.get("data", {}).get("id") or test_tag_id
         cleanup_tracker.track("tag", tag_id)

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -1531,7 +1531,6 @@ class TestTagCRUD:
         )
 
         create_data = assert_mcp_success(create_result, "Create tag")
-        get_entity_id_from_response(create_data, "tag")
         # Tag may not return entity_id in same format
         tag_id = create_data.get("data", {}).get("id") or test_tag_id
         cleanup_tracker.track("tag", tag_id)

--- a/tests/src/e2e/workflows/core/test_bulk.py
+++ b/tests/src/e2e/workflows/core/test_bulk.py
@@ -193,7 +193,7 @@ class TestBulkControl:
             {"operations": operations},
         )
 
-        data = assert_mcp_success(result, "Bulk turn_off multiple lights")
+        assert_mcp_success(result, "Bulk turn_off multiple lights")
         logger.info("Multiple lights bulk turn_off executed")
 
     async def test_bulk_control_with_parameters(self, mcp_client, test_light_entity):

--- a/tests/src/e2e/workflows/labels/test_label_operations.py
+++ b/tests/src/e2e/workflows/labels/test_label_operations.py
@@ -63,7 +63,9 @@ class TestLabelSetOperation:
         data = assert_mcp_success(result, "set labels")
         assert label_id in data.get("entity_entry", {}).get("labels", [])
 
-        logger.info(f"Set labels on {entity_id}: {data.get('entity_entry', {}).get('labels')}")
+        logger.info(
+            f"Set labels on {entity_id}: {data.get('entity_entry', {}).get('labels')}"
+        )
 
         # Clean up: clear labels
         await mcp_client.call_tool(
@@ -71,7 +73,9 @@ class TestLabelSetOperation:
             {"entity_id": entity_id, "labels": []},
         )
 
-    async def test_set_multiple_labels(self, mcp_client, cleanup_tracker, test_entity_id):
+    async def test_set_multiple_labels(
+        self, mcp_client, cleanup_tracker, test_entity_id
+    ):
         """Test: Set multiple labels on an entity at once."""
         entity_id = test_entity_id
 
@@ -196,7 +200,7 @@ class TestLabelEntityRegistryIntegrity:
             "ha_get_state",
             {"entity_id": entity_id},
         )
-        initial_data = parse_mcp_result(initial_result)
+        parse_mcp_result(initial_result)
 
         # Create and set a label
         create_result = await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/scripts/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scripts/test_lifecycle.py
@@ -134,8 +134,7 @@ async def verify_script_exists_and_registered(
         try:
             # Method 1: Try to get script config via management API
             get_result = await mcp_client.call_tool(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
             get_data = enhanced_parse_mcp_result(get_result)
             if get_data.get("success") and get_data.get("config"):
@@ -260,7 +259,7 @@ class TestScriptOrchestration:
 
         async with MCPAssertions(mcp_client) as mcp:
             # 1. CREATE: Basic delay script
-            create_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_config_set_script",
                 {
                     "script_id": script_id,
@@ -289,8 +288,7 @@ class TestScriptOrchestration:
 
             # 3. GET: Verify script configuration
             get_data = await mcp.call_tool_success(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
 
             # Issue #1334: returned ``script_id`` is the canonical storage
@@ -314,7 +312,7 @@ class TestScriptOrchestration:
             logger.info("✅ Script configuration verified")
 
             # 4. EXECUTE: Run the script
-            execute_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_call_service",
                 {"domain": "script", "service": "turn_on", "entity_id": script_entity},
             )
@@ -334,16 +332,15 @@ class TestScriptOrchestration:
                 )
 
             # 6. DELETE: Clean up script
-            delete_data = await mcp.call_tool_success(
-                "ha_config_remove_script",
-                { "script_id": script_id}
+            await mcp.call_tool_success(
+                "ha_config_remove_script", {"script_id": script_id}
             )
             logger.info("✅ Script deleted successfully")
 
             # 7. VERIFY: Script no longer exists
-            final_get_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_get_script",
-                { "script_id": script_id},
+                {"script_id": script_id},
                 expected_error="not found",
             )
             logger.info("✅ Script deletion verified")
@@ -363,7 +360,7 @@ class TestScriptOrchestration:
 
         async with MCPAssertions(mcp_client) as mcp:
             # 1. CREATE: Script that controls a light
-            create_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_config_set_script",
                 {
                     "script_id": script_id,
@@ -403,8 +400,7 @@ class TestScriptOrchestration:
 
             # 3. VERIFY: Configuration contains correct service calls
             get_data = await mcp.call_tool_success(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
 
             config = extract_script_config(get_data)
@@ -449,7 +445,7 @@ class TestScriptOrchestration:
             logger.info(f"💡 Initial light state: {initial_state}")
 
             # Execute the script
-            execute_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_call_service",
                 {"domain": "script", "service": "turn_on", "entity_id": script_entity},
             )
@@ -466,9 +462,8 @@ class TestScriptOrchestration:
             logger.info(f"💡 Final light state: {final_state}")
 
             # 4. CLEANUP: Delete script
-            delete_data = await mcp.call_tool_success(
-                "ha_config_remove_script",
-                { "script_id": script_id}
+            await mcp.call_tool_success(
+                "ha_config_remove_script", {"script_id": script_id}
             )
             logger.info("✅ Service call script cleaned up")
 
@@ -485,7 +480,7 @@ class TestScriptOrchestration:
 
         async with MCPAssertions(mcp_client) as mcp:
             # 1. CREATE: Script with input fields and templating
-            create_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_config_set_script",
                 {
                     "script_id": script_id,
@@ -528,8 +523,7 @@ class TestScriptOrchestration:
             # 2. VERIFY: Configuration includes fields and templating
 
             get_data = await mcp.call_tool_success(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
 
             config = extract_script_config(get_data)
@@ -571,7 +565,7 @@ class TestScriptOrchestration:
             test_message = "E2E Test Message"
             test_delay = 2
 
-            execute_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_call_service",
                 {
                     "domain": "script",
@@ -600,9 +594,8 @@ class TestScriptOrchestration:
                 logger.info(f"🔄 Script execution state: {script_state}")
 
             # 4. CLEANUP: Delete script
-            delete_data = await mcp.call_tool_success(
-                "ha_config_remove_script",
-                { "script_id": script_id}
+            await mcp.call_tool_success(
+                "ha_config_remove_script", {"script_id": script_id}
             )
             logger.info("✅ Parameterized script cleaned up")
 
@@ -626,9 +619,9 @@ class TestScriptOrchestration:
                 "mode": "single",
             }
 
-            create_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_config_set_script",
-                { "script_id": script_id, "config": initial_config},
+                {"script_id": script_id, "config": initial_config},
             )
 
             script_entity = f"script.{script_id}"
@@ -638,8 +631,7 @@ class TestScriptOrchestration:
             # 2. VERIFY: Initial configuration
 
             get_data = await mcp.call_tool_success(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
 
             initial_retrieved = extract_script_config(get_data)
@@ -671,17 +663,16 @@ class TestScriptOrchestration:
                 "mode": "restart",
             }
 
-            update_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_config_set_script",
-                { "script_id": script_id, "config": updated_config},
+                {"script_id": script_id, "config": updated_config},
             )
             logger.info("✅ Script updated successfully")
 
             # 4. VERIFY: Updated configuration
 
             updated_get_data = await mcp.call_tool_success(
-                "ha_config_get_script",
-                { "script_id": script_id}
+                "ha_config_get_script", {"script_id": script_id}
             )
 
             updated_retrieved = extract_script_config(updated_get_data)
@@ -710,17 +701,15 @@ class TestScriptOrchestration:
             logger.info("✅ Updated configuration verified")
 
             # 5. EXECUTE: Test updated script
-            execute_data = await mcp.call_tool_success(
+            await mcp.call_tool_success(
                 "ha_call_service",
                 {"domain": "script", "service": "turn_on", "entity_id": script_entity},
             )
             logger.info("✅ Updated script executed successfully")
 
-
             # 6. CLEANUP: Delete script
-            delete_data = await mcp.call_tool_success(
-                "ha_config_remove_script",
-                { "script_id": script_id}
+            await mcp.call_tool_success(
+                "ha_config_remove_script", {"script_id": script_id}
             )
             logger.info("✅ Updated script cleaned up")
 
@@ -768,11 +757,9 @@ class TestScriptOrchestration:
                 if mode in ["queued", "parallel"]:
                     create_config["max"] = 3
 
-                create_data = await mcp.call_tool_success(
+                await mcp.call_tool_success(
                     "ha_config_set_script",
-                    {
-                        "script_id": script_id,
-                        "config": create_config},
+                    {"script_id": script_id, "config": create_config},
                 )
 
                 script_entity = f"script.{script_id}"
@@ -780,13 +767,11 @@ class TestScriptOrchestration:
                 created_scripts.append((script_id, script_entity, mode))
                 logger.info(f"✅ Created {mode} mode script: {script_entity}")
 
-
             # VERIFY: All scripts created with correct modes
 
             for script_id, _script_entity, expected_mode in created_scripts:
                 get_data = await mcp.call_tool_success(
-                    "ha_config_get_script",
-                    { "script_id": script_id}
+                    "ha_config_get_script", {"script_id": script_id}
                 )
 
                 config = extract_script_config(get_data)
@@ -809,12 +794,11 @@ class TestScriptOrchestration:
             logger.info("✅ All execution modes verified")
 
             # EXECUTE: Test each mode with timeout protection
-            execution_tasks = []
             for _script_id, script_entity, mode in created_scripts:
                 logger.info(f"🚀 Testing execution of {mode} mode script...")
 
                 # Execute the script
-                execute_data = await mcp.call_tool_success(
+                await mcp.call_tool_success(
                     "ha_call_service",
                     {
                         "domain": "script",
@@ -828,7 +812,7 @@ class TestScriptOrchestration:
                 if mode in ["queued", "parallel"]:
                     logger.info(f"🔄 Testing concurrent execution for {mode} mode...")
                     # Execute again immediately to test mode behavior
-                    execute_data2 = await mcp.call_tool_success(
+                    await mcp.call_tool_success(
                         "ha_call_service",
                         {
                             "domain": "script",
@@ -838,15 +822,13 @@ class TestScriptOrchestration:
                     )
                     logger.info(f"✅ Second execution initiated for {mode} mode")
 
-
             # Allow all executions to complete with generous timeout
             logger.info("⏳ Allowing all script executions to complete...")
 
             # CLEANUP: Delete all test scripts
             for script_id, script_entity, mode in created_scripts:
-                delete_data = await mcp.call_tool_success(
-                    "ha_config_remove_script",
-                    { "script_id": script_id}
+                await mcp.call_tool_success(
+                    "ha_config_remove_script", {"script_id": script_id}
                 )
                 logger.debug(f"🗑️ Deleted {mode} script: {script_entity}")
 
@@ -909,9 +891,9 @@ class TestScriptOrchestration:
             logger.info(f"🚀 Creating {len(scripts_to_create)} scripts...")
             for script_id, config in scripts_to_create:
                 try:
-                    create_data = await mcp.call_tool_success(
+                    await mcp.call_tool_success(
                         "ha_config_set_script",
-                        { "script_id": script_id, "config": config},
+                        {"script_id": script_id, "config": config},
                     )
 
                     script_entity = f"script.{script_id}"
@@ -923,7 +905,6 @@ class TestScriptOrchestration:
                 except Exception as e:
                     logger.error(f"❌ Failed to create {script_id}: {e}")
                     failed_scripts.append((script_id, str(e)))
-
 
             if failed_scripts:
                 logger.warning(
@@ -941,8 +922,7 @@ class TestScriptOrchestration:
             for script_id, script_entity in created_scripts:
                 try:
                     get_data = await mcp.call_tool_success(
-                        "ha_config_get_script",
-                        { "script_id": script_id}
+                        "ha_config_get_script", {"script_id": script_id}
                     )
 
                     config = extract_script_config(get_data)
@@ -970,7 +950,7 @@ class TestScriptOrchestration:
             executed_scripts = []
             for script_id, script_entity in verified_scripts:
                 try:
-                    execute_data = await mcp.call_tool_success(
+                    await mcp.call_tool_success(
                         "ha_call_service",
                         {
                             "domain": "script",
@@ -995,16 +975,14 @@ class TestScriptOrchestration:
 
             for script_id, script_entity in created_scripts:
                 try:
-                    delete_data = await mcp.call_tool_success(
-                        "ha_config_remove_script",
-                        { "script_id": script_id}
+                    await mcp.call_tool_success(
+                        "ha_config_remove_script", {"script_id": script_id}
                     )
                     deleted_scripts.append((script_id, script_entity))
                     logger.debug(f"🗑️ Deleted: {script_entity}")
                 except Exception as e:
                     logger.error(f"❌ Failed to delete {script_entity}: {e}")
                     failed_deletions.append((script_id, script_entity, str(e)))
-
 
             logger.info(
                 f"✅ Bulk deletion completed: {len(deleted_scripts)} deleted, {len(failed_deletions)} failed"
@@ -1027,16 +1005,16 @@ class TestScriptOrchestration:
 
         async with MCPAssertions(mcp_client) as mcp:
             # 1. TEST: Get non-existent script
-            nonexistent_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_get_script",
-                { "script_id": "nonexistent_script_xyz"},
+                {"script_id": "nonexistent_script_xyz"},
                 expected_error="not found",
             )
             logger.info("✅ Non-existent script properly handled")
 
             # 2. TEST: Invalid config (missing sequence)
             script_id = "test_invalid_config"
-            invalid_config_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_set_script",
                 {
                     "script_id": script_id,
@@ -1051,22 +1029,22 @@ class TestScriptOrchestration:
             logger.info("✅ Invalid config (missing sequence) properly rejected")
 
             # 3. TEST: Delete non-existent script
-            delete_nonexistent_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_remove_script",
-                { "script_id": "nonexistent_delete_xyz"},
+                {"script_id": "nonexistent_delete_xyz"},
                 expected_error="not found",
             )
             logger.info("✅ Delete non-existent script properly handled")
 
             # 4. TEST: Invalid script ID format
-            invalid_id_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_get_script",
-                { "script_id": "invalid.script.id.with.dots"},
+                {"script_id": "invalid.script.id.with.dots"},
             )
             logger.info("✅ Invalid script ID format properly handled")
 
             # 5. TEST: Invalid sequence structure (non-list)
-            invalid_sequence_data = await mcp.call_tool_failure(
+            await mcp.call_tool_failure(
                 "ha_config_set_script",
                 {
                     "script_id": "test_invalid_sequence",
@@ -1074,7 +1052,8 @@ class TestScriptOrchestration:
                         "alias": "Invalid Sequence Script",
                         "description": "Script with invalid sequence type",
                         "sequence": "not_a_list",  # Invalid sequence type
-                        "mode": "single"},
+                        "mode": "single",
+                    },
                 },
             )
             logger.info("✅ Invalid sequence type properly rejected")
@@ -1123,7 +1102,7 @@ async def test_script_search_and_discovery(mcp_client):
                     try:
                         get_data = await mcp.call_tool_success(
                             "ha_config_get_script",
-                            { "script_id": script_id},
+                            {"script_id": script_id},
                         )
 
                         config = extract_script_config(get_data)
@@ -1241,7 +1220,9 @@ async def test_blueprint_script_lifecycle(
                 logger.info(
                     "✅ Our validation passed (config reached HA), HA rejected due to missing blueprint inputs as expected"
                 )
-                logger.info("✅ Blueprint script lifecycle test completed (validation works)")
+                logger.info(
+                    "✅ Blueprint script lifecycle test completed (validation works)"
+                )
                 return
             # If error is about missing sequence, our fix didn't work
             if "sequence" in error_msg.lower():
@@ -1284,7 +1265,7 @@ async def test_blueprint_script_with_empty_sequence(
     """
     logger.info("Testing blueprint script with empty sequence array...")
 
-    async with MCPAssertions(mcp_client) as mcp:
+    async with MCPAssertions(mcp_client):
         # Use the blueprint path from fixture
         blueprint_path = script_blueprint_path
 

--- a/tests/src/unit/conftest.py
+++ b/tests/src/unit/conftest.py
@@ -43,6 +43,7 @@ def _unit_test_default_auto_backup_off():
 
         _reset_global_settings()
     except ImportError:
+        # ha_mcp not importable in this test run; nothing to reset.
         pass
     yield
     if previous is None:

--- a/tests/src/unit/policy/test_approval_queue.py
+++ b/tests/src/unit/policy/test_approval_queue.py
@@ -317,8 +317,6 @@ async def test_find_or_create_lock_blocks_concurrent_create_under_real_race():
     a missing lock would let multiple tasks pass the find()==None
     check before any of them runs create().
     """
-    import ha_mcp.policy.approval_queue as mod
-
     q = ApprovalQueue()
     orig_find = q.find
 
@@ -369,4 +367,3 @@ async def test_find_or_create_lock_blocks_concurrent_create_under_real_race():
     # Silence the slow_find reference so ruff doesn't complain about
     # the unused helper — kept in the source for future strengthening.
     _ = slow_find
-    _ = mod

--- a/tests/src/unit/policy/test_middleware.py
+++ b/tests/src/unit/policy/test_middleware.py
@@ -34,7 +34,7 @@ def queue():
 
 @pytest.mark.anyio
 async def test_empty_policy_passes_through(queue):
-    mw = PolicyMiddleware(policy_provider=lambda: Policy(), queue=queue)
+    mw = PolicyMiddleware(policy_provider=Policy, queue=queue)
     call_next = AsyncMock(return_value="real_result")
     result = await mw.on_call_tool(
         make_context("ha_call_service", {"domain": "lock"}), call_next

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 import yaml
 
+from ha_mcp import backup_manager as bm
 from ha_mcp.backup_manager import (
     SCHEMA_VERSION,
     BackupManager,
@@ -513,8 +514,6 @@ class TestTrackerPrune:
     ) -> None:
         # Patch the cap to a small number so we can exercise the prune
         # path without needing 10_000 entries.
-        import ha_mcp.backup_manager as bm
-
         monkeypatch.setattr(bm, "_TRACKER_SOFT_CAP", 5)
         monkeypatch.setattr(bm, "_TRACKER_PRUNE_BATCH", 2)
         mgr = BackupManager(_StubSettings(auto_backup_dir=str(tmp_path)), _StubClient())

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -1,0 +1,108 @@
+"""Unit tests for scripts/codeql_quality_gate.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "codeql_quality_gate.py"
+_spec = importlib.util.spec_from_file_location("codeql_quality_gate", _SCRIPT)
+assert _spec and _spec.loader
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def _write_sarif(tmp_path: Path, results: list[dict]) -> Path:
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "CodeQL", "rules": [{"id": "py/rule-0"}]}},
+                "results": results,
+            }
+        ]
+    }
+    path = tmp_path / "quality.sarif"
+    path.write_text(json.dumps(sarif), encoding="utf-8")
+    return path
+
+
+def _result(rule_id: str | None, uri: str, line: int, text: str) -> dict:
+    result: dict = {
+        "message": {"text": text},
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": uri},
+                    "region": {"startLine": line},
+                }
+            }
+        ],
+    }
+    if rule_id is None:
+        result["rule"] = {"index": 0}
+    else:
+        result["ruleId"] = rule_id
+    return result
+
+
+def test_load_findings_sorted_and_parsed(tmp_path: Path) -> None:
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result("py/empty-except", "src/z.py", 5, "Empty except"),
+            _result("py/unused", "src/a.py", 10, "Unused a"),
+            _result("py/unused", "src/a.py", 2, "Unused a earlier"),
+        ],
+    )
+    findings = gate.load_findings(path)
+    # Sorted by (rule, file, line): empty-except first, then unused by line.
+    assert findings == [
+        ("src/z.py", 5, "py/empty-except", "Empty except"),
+        ("src/a.py", 2, "py/unused", "Unused a earlier"),
+        ("src/a.py", 10, "py/unused", "Unused a"),
+    ]
+
+
+def test_rule_id_resolved_from_rules_table(tmp_path: Path) -> None:
+    """A result without ruleId falls back to the driver rules table by index."""
+    path = _write_sarif(tmp_path, [_result(None, "src/a.py", 1, "x")])
+    findings = gate.load_findings(path)
+    assert findings[0][2] == "py/rule-0"
+
+
+def test_main_exit_codes(tmp_path: Path) -> None:
+    with_findings = _write_sarif(tmp_path, [_result("py/x", "src/a.py", 1, "x")])
+    assert gate.main(["prog", str(with_findings)]) == 1
+
+    empty = _write_sarif(tmp_path, [])
+    assert gate.main(["prog", str(empty)]) == 0
+
+
+def test_main_missing_file_returns_2(tmp_path: Path) -> None:
+    assert gate.main(["prog", str(tmp_path / "nope.sarif")]) == 2
+
+
+def test_render_groups_and_counts(tmp_path: Path) -> None:
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result("py/x", "src/a.py", 1, "first"),
+            _result("py/x", "src/b.py", 2, "second"),
+            _result("py/y", "src/c.py", 3, "third"),
+        ],
+    )
+    report = gate.render(gate.load_findings(path))
+    assert "CodeQL code-quality findings: 3" in report
+    assert "2  py/x" in report
+    assert "## py/y (1)" in report
+
+
+def test_render_empty() -> None:
+    assert "No CodeQL code-quality findings" in gate.render([])
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -169,5 +169,113 @@ def test_allowlist_requires_all_three_of_rule_path_message(tmp_path: Path) -> No
     assert not suppressed
 
 
+def test_allowlist_wrong_rule_is_not_suppressed(tmp_path: Path) -> None:
+    """Right path + right symbol but a different rule must still gate."""
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/empty-except",  # not the allowlisted rule for this symbol
+                "src/ha_mcp/__main__.py",
+                580,
+                "The global variable '_shutdown_in_progress' is not used.",
+            ),
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
+
+
+def test_allowlist_wrong_path_is_not_suppressed(tmp_path: Path) -> None:
+    """Right rule + right symbol but a different file must still gate."""
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/unused-global-variable",
+                "src/ha_mcp/tools/somewhere_else.py",
+                10,
+                "The global variable '_shutdown_in_progress' is not used.",
+            ),
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
+
+
+def test_result_without_location_still_gates(tmp_path: Path) -> None:
+    """A result with no physical location is kept with a placeholder file/line."""
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "CodeQL"}},
+                "results": [{"ruleId": "py/no-loc", "message": {"text": "x"}}],
+            }
+        ]
+    }
+    path = tmp_path / "q.sarif"
+    path.write_text(json.dumps(sarif), encoding="utf-8")
+    findings = gate.load_findings(path)
+    assert findings == [("<no-location>", 0, "py/no-loc", "x")]
+
+
+def test_missing_region_and_message_default_cleanly(tmp_path: Path) -> None:
+    """Absent region.startLine and message text fall back to 0 / empty string."""
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"name": "CodeQL"}},
+                "results": [
+                    {
+                        "ruleId": "py/x",
+                        "locations": [
+                            {"physicalLocation": {"artifactLocation": {"uri": "a.py"}}}
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    path = tmp_path / "q.sarif"
+    path.write_text(json.dumps(sarif), encoding="utf-8")
+    findings = gate.load_findings(path)
+    assert findings == [("a.py", 0, "py/x", "")]
+
+
+def test_malformed_sarif_returns_exit_2(tmp_path: Path) -> None:
+    path = tmp_path / "bad.sarif"
+    path.write_text("{not valid json", encoding="utf-8")
+    assert gate.main(["prog", str(path)]) == 2
+
+
+def test_suppressed_findings_are_reported_to_stdout(tmp_path: Path, capsys) -> None:
+    """Allowlisted findings must be printed, never silently dropped."""
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/unused-import",
+                "packaging/binary/pyinstaller_hooks/runtime_hook.py",
+                7,
+                "Import of 'idna' is not used.",
+            ),
+        ],
+    )
+    assert gate.main(["prog", str(path)]) == 0  # only a suppressed finding
+    out = capsys.readouterr().out
+    assert "Suppressed (allowlisted false positives): 1" in out
+    assert "py/unused-import" in out
+
+
+def test_github_step_summary_is_written(tmp_path: Path, monkeypatch) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    path = _write_sarif(tmp_path, [_result("py/x", "src/a.py", 1, "boom")])
+    gate.main(["prog", str(path)])
+    assert "CodeQL Code Quality" in summary.read_text(encoding="utf-8")
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -128,5 +128,46 @@ def test_parser_diagnostic_rule_is_ignored(tmp_path: Path) -> None:
     assert [f[2] for f in findings] == ["py/empty-except"]
 
 
+def test_allowlisted_finding_is_suppressed_not_gated(tmp_path: Path) -> None:
+    """An allowlisted false positive is reported as suppressed, not gated."""
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/unused-global-variable",
+                "src/ha_mcp/__main__.py",
+                580,
+                "The global variable '_shutdown_in_progress' is not used.",
+            ),
+            _result("py/empty-except", "src/a.py", 1, "real finding"),
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert [f[2] for f in findings] == ["py/empty-except"]
+    assert len(suppressed) == 1
+    assert suppressed[0][2] == "py/unused-global-variable"
+    assert suppressed[0][4]  # a non-empty reason string
+    # The gate still fails because a real finding remains.
+    assert gate.main(["prog", str(path)]) == 1
+
+
+def test_allowlist_requires_all_three_of_rule_path_message(tmp_path: Path) -> None:
+    """Same rule+path but a different symbol must NOT be suppressed."""
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/unused-global-variable",
+                "src/ha_mcp/__main__.py",
+                99,
+                "The global variable 'something_else' is not used.",
+            ),
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -104,5 +104,29 @@ def test_render_empty() -> None:
     assert "No CodeQL code-quality findings" in gate.render([])
 
 
+def test_vendored_paths_are_ignored(tmp_path: Path) -> None:
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result("py/empty-except", "tests/initial_test_state/x.py", 1, "vendored"),
+            _result("py/empty-except", "src/a.py", 1, "first-party"),
+        ],
+    )
+    findings = gate.load_findings(path)
+    assert [f[0] for f in findings] == ["src/a.py"]
+
+
+def test_parser_diagnostic_rule_is_ignored(tmp_path: Path) -> None:
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result("py/syntax-error", "tests/src/e2e/conftest.py", 1, "tsg-python"),
+            _result("py/empty-except", "src/a.py", 1, "real"),
+        ],
+    )
+    findings = gate.load_findings(path)
+    assert [f[2] for f in findings] == ["py/empty-except"]
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -116,16 +116,15 @@ def test_vendored_paths_are_ignored(tmp_path: Path) -> None:
     assert [f[0] for f in findings] == ["src/a.py"]
 
 
-def test_parser_diagnostic_rule_is_ignored(tmp_path: Path) -> None:
+def test_syntax_errors_are_not_suppressed(tmp_path: Path) -> None:
+    """py/syntax-error is no longer blanket-ignored; any parse failure gates."""
     path = _write_sarif(
         tmp_path,
-        [
-            _result("py/syntax-error", "tests/src/e2e/conftest.py", 1, "tsg-python"),
-            _result("py/empty-except", "src/a.py", 1, "real"),
-        ],
+        [_result("py/syntax-error", "tests/src/e2e/conftest.py", 1, "invalid syntax")],
     )
-    findings = gate.load_findings(path)
-    assert [f[2] for f in findings] == ["py/empty-except"]
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
 
 
 def test_allowlisted_finding_is_suppressed_not_gated(tmp_path: Path) -> None:

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -21,7 +21,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
 
-from ha_mcp.config import BETA_FEATURE_FIELDS, FEATURE_FLAG_FIELDS, Settings
+import ha_mcp.config as config
 
 
 @pytest.fixture(autouse=True)
@@ -41,24 +41,26 @@ def _clear_env(monkeypatch: Any) -> None:
 
 class TestSettings:
     def test_flag_default_disabled(self) -> None:
-        assert Settings().enable_dashboard_screenshot is False
+        assert config.Settings().enable_dashboard_screenshot is False
 
     def test_flag_enabled_via_env(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("HAMCP_ENABLE_DASHBOARD_SCREENSHOT", "true")
-        assert Settings().enable_dashboard_screenshot is True
+        assert config.Settings().enable_dashboard_screenshot is True
 
     def test_flag_empty_string_means_false(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("HAMCP_ENABLE_DASHBOARD_SCREENSHOT", "")
-        assert Settings().enable_dashboard_screenshot is False
+        assert config.Settings().enable_dashboard_screenshot is False
 
     def test_engine_url_default_empty(self) -> None:
-        assert Settings().dashboard_screenshot_engine_url == ""
+        assert config.Settings().dashboard_screenshot_engine_url == ""
 
     def test_engine_url_from_env(self, monkeypatch: Any) -> None:
         monkeypatch.setenv(
             "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL", "http://engine:10000"
         )
-        assert Settings().dashboard_screenshot_engine_url == "http://engine:10000"
+        assert (
+            config.Settings().dashboard_screenshot_engine_url == "http://engine:10000"
+        )
 
     @pytest.mark.parametrize("bad", ["ftp://engine:10000", "engine:10000", "//engine"])
     def test_engine_url_rejects_non_http(self, monkeypatch: Any, bad: str) -> None:
@@ -66,26 +68,30 @@ class TestSettings:
         # scheme URL instead of letting it 0-byte-fail at render time.
         monkeypatch.setenv("HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL", bad)
         with pytest.raises(ValidationError):
-            Settings()
+            config.Settings()
 
     def test_engine_url_validator_strips_trailing_slash(self, monkeypatch: Any) -> None:
         # The field validator (not just resolve_engine_url) normalizes the URL.
         monkeypatch.setenv(
             "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL", "http://engine:10000/"
         )
-        assert Settings().dashboard_screenshot_engine_url == "http://engine:10000"
+        assert (
+            config.Settings().dashboard_screenshot_engine_url == "http://engine:10000"
+        )
 
     def test_flag_in_feature_flag_fields(self) -> None:
-        assert "enable_dashboard_screenshot" in {f.field for f in FEATURE_FLAG_FIELDS}
+        assert "enable_dashboard_screenshot" in {
+            f.field for f in config.FEATURE_FLAG_FIELDS
+        }
 
     def test_flag_is_beta_gated(self) -> None:
-        assert "enable_dashboard_screenshot" in BETA_FEATURE_FIELDS
+        assert "enable_dashboard_screenshot" in config.BETA_FEATURE_FIELDS
 
     def test_engine_url_not_a_feature_flag(self) -> None:
         # Connection string, deliberately not a web-editable beta toggle.
-        names = {f.field for f in FEATURE_FLAG_FIELDS}
+        names = {f.field for f in config.FEATURE_FLAG_FIELDS}
         assert "dashboard_screenshot_engine_url" not in names
-        assert "dashboard_screenshot_engine_url" not in BETA_FEATURE_FIELDS
+        assert "dashboard_screenshot_engine_url" not in config.BETA_FEATURE_FIELDS
 
 
 # ---------------------------------------------------------------------------
@@ -103,7 +109,6 @@ class _RecordingMcp:
 
 class TestRegistrationGate:
     def test_gate_off_registers_nothing(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.tools import tools_dashboard_screenshot as mod
 
         monkeypatch.setattr(
@@ -116,7 +121,6 @@ class TestRegistrationGate:
         assert mcp.added == []
 
     def test_gate_on_registers_tool(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.tools import tools_dashboard_screenshot as mod
 
         monkeypatch.setattr(
@@ -136,7 +140,6 @@ class TestRegistrationGate:
 
 class TestResolveEngineUrl:
     async def test_explicit_url_strips_trailing_slash(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import provision
 
         monkeypatch.setattr(
@@ -149,7 +152,6 @@ class TestResolveEngineUrl:
         assert await provision.resolve_engine_url() == "http://engine:10000"
 
     async def test_stdio_no_token_raises(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import provision
 
         monkeypatch.setattr(
@@ -445,7 +447,6 @@ class TestMaybeAttachScreenshot:
         assert out is result
 
     async def test_feature_off_warns(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.tools.tools_config_dashboards import _maybe_attach_screenshot
 
         monkeypatch.setattr(
@@ -459,7 +460,6 @@ class TestMaybeAttachScreenshot:
         assert any("disabled" in w.lower() for w in result.get("warnings", []))
 
     async def test_capture_failure_warns(self, monkeypatch: Any) -> None:
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import capture
         from ha_mcp.tools.tools_config_dashboards import _maybe_attach_screenshot
 
@@ -481,7 +481,6 @@ class TestMaybeAttachScreenshot:
 
     async def test_full_page_passed_through(self, monkeypatch: Any) -> None:
         """_maybe_attach_screenshot forwards full_page to the capture call."""
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import capture
         from ha_mcp.tools.tools_config_dashboards import _maybe_attach_screenshot
 
@@ -512,7 +511,6 @@ class TestMaybeAttachScreenshot:
     ) -> None:
         from fastmcp.tools.tool import ToolResult
 
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import capture
         from ha_mcp.tools.tools_config_dashboards import _maybe_attach_screenshot
 
@@ -540,7 +538,6 @@ class TestMaybeAttachScreenshot:
     async def test_get_path_raises_on_capture_failure(self, monkeypatch: Any) -> None:
         """raise_on_failure (the get path) propagates the engine error instead
         of demoting it to a warning the caller may never read."""
-        import ha_mcp.config as config
         from ha_mcp.dashboard_screenshot import capture
         from ha_mcp.tools.tools_config_dashboards import _maybe_attach_screenshot
 

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -18,10 +18,10 @@ class TestSignalHandlerSetup:
 
     def test_setup_signal_handlers_registers_sigterm(self):
         """Signal handlers should register SIGTERM handler."""
-        from ha_mcp.__main__ import _setup_signal_handlers, _signal_handler
+        import ha_mcp.__main__ as main_module
 
         with patch("signal.signal") as mock_signal:
-            _setup_signal_handlers()
+            main_module._setup_signal_handlers()
             # Check that SIGTERM handler was registered
             calls = [
                 call
@@ -29,14 +29,14 @@ class TestSignalHandlerSetup:
                 if call[0][0] == signal.SIGTERM
             ]
             assert len(calls) == 1
-            assert calls[0][0][1] == _signal_handler
+            assert calls[0][0][1] == main_module._signal_handler
 
     def test_setup_signal_handlers_registers_sigint(self):
         """Signal handlers should register SIGINT handler."""
-        from ha_mcp.__main__ import _setup_signal_handlers, _signal_handler
+        import ha_mcp.__main__ as main_module
 
         with patch("signal.signal") as mock_signal:
-            _setup_signal_handlers()
+            main_module._setup_signal_handlers()
             # Check that SIGINT handler was registered
             calls = [
                 call
@@ -44,7 +44,7 @@ class TestSignalHandlerSetup:
                 if call[0][0] == signal.SIGINT
             ]
             assert len(calls) == 1
-            assert calls[0][0][1] == _signal_handler
+            assert calls[0][0][1] == main_module._signal_handler
 
 
 class TestSignalHandler:
@@ -209,9 +209,9 @@ class TestShutdownTimeout:
 
     def test_shutdown_timeout_is_two_seconds(self):
         """Shutdown timeout should be 2 seconds as per requirements."""
-        from ha_mcp.__main__ import SHUTDOWN_TIMEOUT_SECONDS
+        import ha_mcp.__main__ as main_module
 
-        assert SHUTDOWN_TIMEOUT_SECONDS == 2.0
+        assert main_module.SHUTDOWN_TIMEOUT_SECONDS == 2.0
 
 
 class TestGracefulShutdownIntegration:
@@ -291,6 +291,8 @@ class TestGracefulShutdownIntegration:
             try:
                 await asyncio.wait_for(server_task, timeout=3.0)
             except (TimeoutError, asyncio.CancelledError):
+                # Either outcome is acceptable here: the test only asserts that
+                # cleanup ran (checked below), not how the task ultimately ended.
                 pass
 
             # Verify cleanup was called
@@ -304,7 +306,7 @@ class TestStdinDetection:
         """Stdin should be available when connected to a tty."""
         import stat as stat_module
 
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with (
             patch("sys.stdin") as mock_stdin,
@@ -315,13 +317,13 @@ class TestStdinDetection:
             mock_stdin.fileno.return_value = 0
             mock_fstat.return_value = MagicMock(st_mode=stat_module.S_IFCHR)
 
-            assert _check_stdin_available() is True
+            assert main_module._check_stdin_available() is True
 
     def test_stdin_available_when_pipe(self):
         """Stdin should be available when connected to a pipe (FIFO)."""
         import stat as stat_module
 
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with (
             patch("sys.stdin") as mock_stdin,
@@ -332,13 +334,13 @@ class TestStdinDetection:
             mock_stdin.fileno.return_value = 0
             mock_fstat.return_value = MagicMock(st_mode=stat_module.S_IFIFO)
 
-            assert _check_stdin_available() is True
+            assert main_module._check_stdin_available() is True
 
     def test_stdin_available_when_regular_file(self):
         """Stdin should be available when connected to a regular file."""
         import stat as stat_module
 
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with (
             patch("sys.stdin") as mock_stdin,
@@ -349,28 +351,28 @@ class TestStdinDetection:
             mock_stdin.fileno.return_value = 0
             mock_fstat.return_value = MagicMock(st_mode=stat_module.S_IFREG)
 
-            assert _check_stdin_available() is True
+            assert main_module._check_stdin_available() is True
 
     def test_stdin_not_available_when_closed(self):
         """Stdin should not be available when closed."""
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with patch("sys.stdin") as mock_stdin:
             mock_stdin.closed = True
-            assert _check_stdin_available() is False
+            assert main_module._check_stdin_available() is False
 
     def test_stdin_not_available_when_none(self):
         """Stdin should not be available when None."""
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with patch("sys.stdin", None):
-            assert _check_stdin_available() is False
+            assert main_module._check_stdin_available() is False
 
     def test_stdin_not_available_when_char_device_not_tty(self):
         """Stdin should not be available when char device but not tty (like /dev/null)."""
         import stat as stat_module
 
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with (
             patch("sys.stdin") as mock_stdin,
@@ -381,20 +383,20 @@ class TestStdinDetection:
             mock_stdin.fileno.return_value = 0
             mock_fstat.return_value = MagicMock(st_mode=stat_module.S_IFCHR)
 
-            assert _check_stdin_available() is False
+            assert main_module._check_stdin_available() is False
 
     def test_stdin_not_available_when_fileno_raises(self):
         """Stdin should not be available when fileno() raises."""
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with patch("sys.stdin") as mock_stdin:
             mock_stdin.closed = False
             mock_stdin.fileno.side_effect = ValueError("no fileno")
-            assert _check_stdin_available() is False
+            assert main_module._check_stdin_available() is False
 
     def test_stdin_not_available_when_fstat_raises(self):
         """Stdin should not be available when fstat() raises."""
-        from ha_mcp.__main__ import _check_stdin_available
+        import ha_mcp.__main__ as main_module
 
         with (
             patch("sys.stdin") as mock_stdin,
@@ -403,7 +405,7 @@ class TestStdinDetection:
             mock_stdin.closed = False
             mock_stdin.fileno.return_value = 0
 
-            assert _check_stdin_available() is False
+            assert main_module._check_stdin_available() is False
 
     def test_main_exits_when_stdin_not_available(self):
         """Main should exit with error when stdin is not available."""
@@ -424,7 +426,7 @@ class TestMainEntryPoint:
 
     def test_smoke_test_flag_runs_smoke_test(self):
         """--smoke-test flag should run smoke test instead of server."""
-        from ha_mcp.__main__ import main
+        import ha_mcp.__main__ as main_module
 
         mock_smoke_test = MagicMock(return_value=0)
 
@@ -433,7 +435,7 @@ class TestMainEntryPoint:
             patch("ha_mcp.smoke_test.main", mock_smoke_test),
             pytest.raises(SystemExit) as exc_info,
         ):
-            main()
+            main_module.main()
 
         assert exc_info.value.code == 0
         mock_smoke_test.assert_called_once()
@@ -539,13 +541,13 @@ class TestHTTPEntryPoints:
 
     def test_http_runtime_uses_env_vars(self):
         """HTTP runtime should read host, port, and path from environment."""
-        from ha_mcp.__main__ import _get_http_runtime
+        import ha_mcp.__main__ as main_module
 
         with patch.dict(
             os.environ,
             {"MCP_HOST": "127.0.0.1", "MCP_PORT": "9000", "MCP_SECRET_PATH": "/custom"},
         ):
-            host, port, path = _get_http_runtime()
+            host, port, path = main_module._get_http_runtime()
 
         assert host == "127.0.0.1"
         assert port == 9000
@@ -557,7 +559,7 @@ class TestHTTPEntryPoints:
         Default host is 0.0.0.0 (preserves prior behavior — FastMCP's own
         default is 127.0.0.1, so the explicit fallback is load-bearing).
         """
-        from ha_mcp.__main__ import _get_http_runtime
+        import ha_mcp.__main__ as main_module
 
         # Clear any existing env vars
         env = os.environ.copy()
@@ -566,7 +568,7 @@ class TestHTTPEntryPoints:
         env.pop("MCP_SECRET_PATH", None)
 
         with patch.dict(os.environ, env, clear=True):
-            host, port, path = _get_http_runtime()
+            host, port, path = main_module._get_http_runtime()
 
         assert host == "0.0.0.0"
         assert port == 8086
@@ -574,12 +576,12 @@ class TestHTTPEntryPoints:
 
     def test_http_runtime_invalid_port_exits(self):
         """Non-integer MCP_PORT should cause sys.exit(1)."""
-        from ha_mcp.__main__ import _get_http_runtime
+        import ha_mcp.__main__ as main_module
 
         with (
             patch.dict(os.environ, {"MCP_PORT": "not-a-number"}),
             pytest.raises(SystemExit) as exc_info,
         ):
-            _get_http_runtime()
+            main_module._get_http_runtime()
 
         assert exc_info.value.code == 1

--- a/tests/src/unit/test_helper_update_persistence.py
+++ b/tests/src/unit/test_helper_update_persistence.py
@@ -762,14 +762,6 @@ class TestFlowHelperRouting:
         """Top-level name param is injected into config dict when not already present."""
         captured_config: dict = {}
 
-        async def capture_start(helper_type):
-            # called by create_flow_helper; return minimal success
-            return {
-                "type": "create_entry",
-                "flow_id": "flow-c",
-                "result": {"entry_id": "entry-c", "title": "t", "domain": helper_type},
-            }
-
         async def capture_submit(flow_id, data):
             captured_config.update(data)
             return {

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -703,6 +703,9 @@ class TestDashboardsIdentifierValidation:
         try:
             await ha_config_get_dashboard(list_only=True)
         except (AttributeError, KeyError, TypeError):
+            # Expected: the bare MagicMock response makes the list-mode body
+            # trip on missing keys/attrs. Swallowed deliberately so the
+            # call-count assertion below is the real check.
             pass
         # Positive proof: at least one WS message was attempted (the
         # list-dashboards fetch). Guard would have raised before that.

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -1396,13 +1396,15 @@ class TestWebSocketManagerPool:
 
         # Both connections created
         assert call_count == 2
+        count_before_reuse = call_count
 
         # User A again — should reuse existing connection
         client_a2 = await manager.get_client(
             url="http://ha.local:8123", token="token_user_a"
         )
         assert client_a2 is mock_client_a
-        assert call_count == 2  # No new connection
+        # No new connection: the factory was not invoked again.
+        assert call_count == count_before_reuse
 
     @pytest.mark.asyncio
     async def test_pool_evicts_lru_when_over_max_size(self):

--- a/tests/src/unit/test_python_sandbox.py
+++ b/tests/src/unit/test_python_sandbox.py
@@ -659,7 +659,7 @@ class TestSandboxErrorSubclasses:
         except PythonSandboxExecutionError:
             pytest.fail("validation error matched PythonSandboxExecutionError")
         except PythonSandboxValidationError:
-            pass
+            pass  # Expected: the validation error is caught here, not above.
 
     def test_execution_error_is_distinct_from_validation_error(self):
         """A runtime failure should not match a validation-error catcher."""
@@ -670,7 +670,7 @@ class TestSandboxErrorSubclasses:
         except PythonSandboxValidationError:
             pytest.fail("execution error matched PythonSandboxValidationError")
         except PythonSandboxExecutionError:
-            pass
+            pass  # Expected: the execution error is caught here, not above.
 
     def test_execution_error_truncates_long_exception_text(self):
         """Runtime exception text is capped so embedded config/data isn't pasted whole.

--- a/tests/src/unit/test_saved_tools_persistence.py
+++ b/tests/src/unit/test_saved_tools_persistence.py
@@ -17,34 +17,28 @@ import json
 from pathlib import Path
 
 import ha_mcp.tools.tools_code as tools_code
-from ha_mcp.tools.tools_code import (
-    _MAX_SAVED_TOOLS,
-    _SAVED_TOOLS_SCHEMA_VERSION,
-    _load_saved_tools,
-    _save_saved_tools,
-)
 
 
 class TestLoadSavedTools:
     def test_empty_path_returns_empty(self):
         """An empty path string disables persistence — return {}."""
-        assert _load_saved_tools("") == {}
+        assert tools_code._load_saved_tools("") == {}
 
     def test_missing_file_returns_empty(self, tmp_path: Path):
         """First-run case: the file doesn't exist yet."""
         path = tmp_path / "saved.json"
-        assert _load_saved_tools(str(path)) == {}
+        assert tools_code._load_saved_tools(str(path)) == {}
 
     def test_malformed_json_returns_empty(self, tmp_path: Path):
         """Corrupt JSON must not crash; just log and start empty."""
         path = tmp_path / "saved.json"
         path.write_text("{this is not json", encoding="utf-8")
-        assert _load_saved_tools(str(path)) == {}
+        assert tools_code._load_saved_tools(str(path)) == {}
 
     def test_top_level_not_dict_returns_empty(self, tmp_path: Path):
         path = tmp_path / "saved.json"
         path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
-        assert _load_saved_tools(str(path)) == {}
+        assert tools_code._load_saved_tools(str(path)) == {}
 
     def test_filters_invalid_name(self, tmp_path: Path):
         """Names that don't match _SAVE_NAME_PATTERN are dropped."""
@@ -63,7 +57,7 @@ class TestLoadSavedTools:
             ),
             encoding="utf-8",
         )
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         assert set(loaded.keys()) == {"valid_name"}
 
     def test_filters_invalid_entry_shape(self, tmp_path: Path):
@@ -84,7 +78,7 @@ class TestLoadSavedTools:
             ),
             encoding="utf-8",
         )
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         assert set(loaded.keys()) == {"valid"}
 
     def test_normalizes_missing_justification(self, tmp_path: Path):
@@ -102,7 +96,7 @@ class TestLoadSavedTools:
             ),
             encoding="utf-8",
         )
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         assert loaded["tool_a"]["justification"] == ""
         assert loaded["tool_b"]["justification"] == ""
 
@@ -111,13 +105,13 @@ class TestLoadSavedTools:
         path = tmp_path / "saved.json"
         big = {
             f"tool_{i:04d}": {"code": "1", "justification": ""}
-            for i in range(_MAX_SAVED_TOOLS + 50)
+            for i in range(tools_code._MAX_SAVED_TOOLS + 50)
         }
         path.write_text(
             json.dumps({"version": 1, "saved_tools": big}), encoding="utf-8"
         )
-        loaded = _load_saved_tools(str(path))
-        assert len(loaded) == _MAX_SAVED_TOOLS
+        loaded = tools_code._load_saved_tools(str(path))
+        assert len(loaded) == tools_code._MAX_SAVED_TOOLS
 
 
 class TestSaveSavedTools:
@@ -125,7 +119,7 @@ class TestSaveSavedTools:
         """Empty path string disables persistence — should not write anything."""
         # Confirm by listing the dir before/after.
         before = sorted(p.name for p in tmp_path.iterdir())
-        _save_saved_tools("", {"foo": {"code": "1", "justification": ""}})
+        tools_code._save_saved_tools("", {"foo": {"code": "1", "justification": ""}})
         after = sorted(p.name for p in tmp_path.iterdir())
         assert before == after
 
@@ -133,38 +127,47 @@ class TestSaveSavedTools:
         """Payload includes schema version, timestamp, and tools dict."""
         path = tmp_path / "saved.json"
         tools = {"foo": {"code": "1+1", "justification": "test"}}
-        _save_saved_tools(str(path), tools)
+        tools_code._save_saved_tools(str(path), tools)
 
         assert path.exists()
         payload = json.loads(path.read_text(encoding="utf-8"))
-        assert payload["version"] == _SAVED_TOOLS_SCHEMA_VERSION
+        assert payload["version"] == tools_code._SAVED_TOOLS_SCHEMA_VERSION
         assert "saved_at" in payload
         assert payload["saved_tools"] == tools
 
     def test_creates_parent_directory(self, tmp_path: Path):
         """Path with non-existent parent dir gets created."""
         path = tmp_path / "subdir" / "nested" / "saved.json"
-        _save_saved_tools(str(path), {"foo": {"code": "1", "justification": ""}})
+        tools_code._save_saved_tools(
+            str(path), {"foo": {"code": "1", "justification": ""}}
+        )
         assert path.exists()
 
     def test_roundtrip(self, tmp_path: Path):
         """save → load returns the same tools."""
         path = tmp_path / "saved.json"
         tools = {
-            "tool_a": {"code": "await api_get('/states')", "justification": "list states"},
+            "tool_a": {
+                "code": "await api_get('/states')",
+                "justification": "list states",
+            },
             "tool_b": {"code": "1 + 1", "justification": "math"},
         }
-        _save_saved_tools(str(path), tools)
-        loaded = _load_saved_tools(str(path))
+        tools_code._save_saved_tools(str(path), tools)
+        loaded = tools_code._load_saved_tools(str(path))
         assert loaded == tools
 
     def test_overwrites_existing_file_atomically(self, tmp_path: Path):
         """Second save replaces the first atomically (no .tmp leftover)."""
         path = tmp_path / "saved.json"
-        _save_saved_tools(str(path), {"v1": {"code": "1", "justification": ""}})
-        _save_saved_tools(str(path), {"v2": {"code": "2", "justification": ""}})
+        tools_code._save_saved_tools(
+            str(path), {"v1": {"code": "1", "justification": ""}}
+        )
+        tools_code._save_saved_tools(
+            str(path), {"v2": {"code": "2", "justification": ""}}
+        )
 
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         assert set(loaded.keys()) == {"v2"}
 
         # No leftover .tmp files in the parent.
@@ -174,13 +177,21 @@ class TestSaveSavedTools:
     def test_returns_true_on_success(self, tmp_path: Path):
         """_save_saved_tools returns True when the write succeeded."""
         path = tmp_path / "saved.json"
-        assert _save_saved_tools(
-            str(path), {"foo": {"code": "1", "justification": ""}}
-        ) is True
+        assert (
+            tools_code._save_saved_tools(
+                str(path), {"foo": {"code": "1", "justification": ""}}
+            )
+            is True
+        )
 
     def test_returns_true_when_path_unset(self):
         """Empty path means persistence is disabled — that's not a failure."""
-        assert _save_saved_tools("", {"foo": {"code": "1", "justification": ""}}) is True
+        assert (
+            tools_code._save_saved_tools(
+                "", {"foo": {"code": "1", "justification": ""}}
+            )
+            is True
+        )
 
 
 class TestSchemaVersionGuard:
@@ -194,15 +205,13 @@ class TestSchemaVersionGuard:
         path.write_text(
             json.dumps(
                 {
-                    "version": _SAVED_TOOLS_SCHEMA_VERSION + 1,
-                    "saved_tools": {
-                        "future_tool": {"code": "1", "justification": ""}
-                    },
+                    "version": tools_code._SAVED_TOOLS_SCHEMA_VERSION + 1,
+                    "saved_tools": {"future_tool": {"code": "1", "justification": ""}},
                 }
             ),
             encoding="utf-8",
         )
-        assert _load_saved_tools(str(path)) == {}
+        assert tools_code._load_saved_tools(str(path)) == {}
 
     def test_unknown_version_sets_load_failed_flag(self, tmp_path: Path):
         """And persistence must be suppressed so we don't overwrite the
@@ -211,11 +220,11 @@ class TestSchemaVersionGuard:
         path.write_text(
             json.dumps({"version": 99, "saved_tools": {}}), encoding="utf-8"
         )
-        _load_saved_tools(str(path))
+        tools_code._load_saved_tools(str(path))
         try:
             assert tools_code._saved_tools_load_failed is True
             # _save_saved_tools refuses to write while the flag is set.
-            ok = _save_saved_tools(
+            ok = tools_code._save_saved_tools(
                 str(path), {"foo": {"code": "1", "justification": ""}}
             )
             assert ok is False
@@ -235,7 +244,7 @@ class TestSchemaVersionGuard:
             json.dumps({"saved_tools": {"x": {"code": "1"}}}), encoding="utf-8"
         )
         try:
-            assert _load_saved_tools(str(path)) == {}
+            assert tools_code._load_saved_tools(str(path)) == {}
             assert tools_code._saved_tools_load_failed is True
         finally:
             tools_code._saved_tools_load_failed = False
@@ -255,10 +264,15 @@ class TestLoadFailedFlag:
         try:
             path = tmp_path / "saved.json"
             path.write_text(
-                json.dumps({"version": _SAVED_TOOLS_SCHEMA_VERSION, "saved_tools": {}}),
+                json.dumps(
+                    {
+                        "version": tools_code._SAVED_TOOLS_SCHEMA_VERSION,
+                        "saved_tools": {},
+                    }
+                ),
                 encoding="utf-8",
             )
-            _load_saved_tools(str(path))
+            tools_code._load_saved_tools(str(path))
             assert tools_code._saved_tools_load_failed is False
         finally:
             tools_code._saved_tools_load_failed = False
@@ -270,7 +284,7 @@ class TestLoadFailedFlag:
         path = tmp_path / "saved.json"
         # Pre-populate so we can confirm it's NOT overwritten.
         original = {
-            "version": _SAVED_TOOLS_SCHEMA_VERSION,
+            "version": tools_code._SAVED_TOOLS_SCHEMA_VERSION,
             "saved_tools": {"keep_me": {"code": "1", "justification": ""}},
         }
         path.write_text(json.dumps(original), encoding="utf-8")
@@ -278,7 +292,7 @@ class TestLoadFailedFlag:
 
         tools_code._saved_tools_load_failed = True
         try:
-            ok = _save_saved_tools(
+            ok = tools_code._save_saved_tools(
                 str(path), {"different": {"code": "2", "justification": ""}}
             )
             assert ok is False
@@ -308,25 +322,25 @@ class TestHydrationRoundTrip:
                 "justification": "Bedtime",
             },
         }
-        assert _save_saved_tools(str(path), first) is True
+        assert tools_code._save_saved_tools(str(path), first) is True
 
         # Simulate a fresh process by clearing/reloading.
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         assert loaded == first
 
     def test_load_then_save_then_reload_with_modification(self, tmp_path: Path):
         """Realistic LLM lifecycle: load existing tools, add a new one,
         persist the merged set, and verify it survives the next load."""
         path = tmp_path / "saved.json"
-        _save_saved_tools(
+        tools_code._save_saved_tools(
             str(path),
             {"a": {"code": "1", "justification": "first"}},
         )
-        loaded = _load_saved_tools(str(path))
+        loaded = tools_code._load_saved_tools(str(path))
         loaded["b"] = {"code": "2", "justification": "added later"}
-        _save_saved_tools(str(path), loaded)
+        tools_code._save_saved_tools(str(path), loaded)
 
-        roundtrip = _load_saved_tools(str(path))
+        roundtrip = tools_code._load_saved_tools(str(path))
         assert set(roundtrip.keys()) == {"a", "b"}
         assert roundtrip["b"]["justification"] == "added later"
 
@@ -350,17 +364,17 @@ class TestSaveCapEnforcement:
         path = tmp_path / "saved.json"
         big = {
             f"tool_{i:04d}": {"code": "1", "justification": ""}
-            for i in range(_MAX_SAVED_TOOLS + 200)
+            for i in range(tools_code._MAX_SAVED_TOOLS + 200)
         }
         path.write_text(
             json.dumps(
-                {"version": _SAVED_TOOLS_SCHEMA_VERSION, "saved_tools": big}
+                {"version": tools_code._SAVED_TOOLS_SCHEMA_VERSION, "saved_tools": big}
             ),
             encoding="utf-8",
         )
-        loaded = _load_saved_tools(str(path))
-        assert len(loaded) == _MAX_SAVED_TOOLS, (
-            f"Load must cap at {_MAX_SAVED_TOOLS}, got {len(loaded)}"
+        loaded = tools_code._load_saved_tools(str(path))
+        assert len(loaded) == tools_code._MAX_SAVED_TOOLS, (
+            f"Load must cap at {tools_code._MAX_SAVED_TOOLS}, got {len(loaded)}"
         )
 
     def test_save_does_not_self_cap(self, tmp_path: Path):
@@ -375,10 +389,10 @@ class TestSaveCapEnforcement:
         path = tmp_path / "saved.json"
         oversized = {
             f"tool_{i:04d}": {"code": "1", "justification": ""}
-            for i in range(_MAX_SAVED_TOOLS + 5)
+            for i in range(tools_code._MAX_SAVED_TOOLS + 5)
         }
-        assert _save_saved_tools(str(path), oversized) is True
+        assert tools_code._save_saved_tools(str(path), oversized) is True
         # The on-disk file has all of them; the load-side cap then
         # truncates back to _MAX_SAVED_TOOLS as covered above.
         roundtrip = json.loads(path.read_text(encoding="utf-8"))
-        assert len(roundtrip["saved_tools"]) == _MAX_SAVED_TOOLS + 5
+        assert len(roundtrip["saved_tools"]) == tools_code._MAX_SAVED_TOOLS + 5

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -387,7 +387,7 @@ class TestRouteRegistration:
     def _reset_http_settings_prefix(self):
         # _http_settings_prefix is process-global; isolate each test so the
         # recording assertions below are not order-dependent (issue #1458).
-        import ha_mcp.settings_ui as _su
+        from ha_mcp import settings_ui as _su
 
         saved = _su._http_settings_prefix
         _su._http_settings_prefix = None
@@ -1075,7 +1075,7 @@ class TestGetBackupSettingOrigin:
         assert get_backup_setting_origin("AUTO_BACKUP_THROTTLE_MINUTES") == "env"
 
     def test_file_present_returns_file(self, monkeypatch, tmp_path):
-        import ha_mcp.config as cfg_mod
+        from ha_mcp import config as cfg_mod
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.delenv("ENABLE_AUTO_BACKUP", raising=False)
@@ -1105,7 +1105,7 @@ class TestApplyBackupOverrides:
     """``get_global_settings`` applies the override file unless env wins."""
 
     def test_file_value_applied_when_no_env(self, monkeypatch, tmp_path):
-        import ha_mcp.config as cfg_mod
+        from ha_mcp import config as cfg_mod
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         for env in (
@@ -1129,7 +1129,7 @@ class TestApplyBackupOverrides:
         cfg_mod._reset_global_settings()
 
     def test_env_var_wins_over_file(self, monkeypatch, tmp_path):
-        import ha_mcp.config as cfg_mod
+        from ha_mcp import config as cfg_mod
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         monkeypatch.setenv("ENABLE_AUTO_BACKUP", "false")
@@ -1147,7 +1147,7 @@ class TestApplyBackupOverrides:
         cfg_mod._reset_global_settings()
 
     def test_addon_mode_ignores_override_file(self, monkeypatch, tmp_path):
-        import ha_mcp.config as cfg_mod
+        from ha_mcp import config as cfg_mod
 
         monkeypatch.setenv("SUPERVISOR_TOKEN", "abc")
         # start.py would set this in real addon; simulate.
@@ -1163,7 +1163,7 @@ class TestApplyBackupOverrides:
         cfg_mod._reset_global_settings()
 
     def test_out_of_range_skipped(self, monkeypatch, tmp_path):
-        import ha_mcp.config as cfg_mod
+        from ha_mcp import config as cfg_mod
 
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         for env in (
@@ -1289,8 +1289,8 @@ class TestSaveBackupConfigEndpoint:
     async def test_standalone_writes_file_and_invalidates_cache(
         self, monkeypatch, tmp_path
     ):
-        import ha_mcp.config as cfg_mod
-        import ha_mcp.settings_ui as sui_mod
+        from ha_mcp import config as cfg_mod
+        from ha_mcp import settings_ui as sui_mod
 
         override_path = tmp_path / "backup_settings.json"
         monkeypatch.setattr(
@@ -3061,7 +3061,7 @@ class TestBetaMasterGateInSave:
             monkeypatch.delenv(ename, raising=False)
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         # Wrap _get_override_file_lock so we can count entries.
-        import ha_mcp.settings_ui as ui_mod
+        from ha_mcp import settings_ui as ui_mod
 
         real_get_lock = ui_mod._get_override_file_lock
         entries = {"count": 0}
@@ -3113,7 +3113,7 @@ class TestBetaMasterGateInSave:
         monkeypatch.delenv("HA_TIMEOUT", raising=False)
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
         get_data_dir.cache_clear()
-        import ha_mcp.settings_ui as ui_mod
+        from ha_mcp import settings_ui as ui_mod
 
         real_get_lock = ui_mod._get_override_file_lock
         entries = {"count": 0}

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -512,8 +512,11 @@ class TestRunMainWiring:
             touched = False
 
             def __getattr__(self, name: str) -> object:
+                # __getattr__ must raise AttributeError per the protocol;
+                # the ``touched`` flag (asserted False below) is the real
+                # detection mechanism if uvicorn is accessed at all.
                 _TrackingProxy.touched = True
-                raise AssertionError(
+                raise AttributeError(
                     f"uvicorn.{name} accessed despite disable sentinel"
                 )
 

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -232,7 +232,6 @@ class TestToolAnnotations:
         read_only_tools = [t for t in tools if t["has_read_only_hint"]]
 
         # These prefixes/patterns indicate read-only operations
-        read_only_patterns = ["get", "list", "search", "check", "eval", "render"]
 
         suspicious = []
         for tool in read_only_tools:

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -231,8 +231,6 @@ class TestToolAnnotations:
 
         read_only_tools = [t for t in tools if t["has_read_only_hint"]]
 
-        # These prefixes/patterns indicate read-only operations
-
         suspicious = []
         for tool in read_only_tools:
             func = tool["function"].lower()

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -3237,6 +3237,7 @@ class TestManageAddon:
                     "in SSH (core_ssh)",
                 )
             )
+            return None  # raise_tool_error always raises; explicit for CodeQL
 
         with (
             patch(

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -1211,7 +1211,12 @@ class TestExtractClientInfo:
         # If the context shape is unexpected (future MCP / FastMCP API churn),
         # we'd rather degrade silently than fail the bug report.
         class Boom:
-            def __getattr__(self, _name):
+            # Use a property (not __getattr__) so the raise is a normal
+            # attribute access, not a special-method protocol violation.
+            # _extract_client_info reads ``ctx.session`` first, so raising
+            # here drives it into the broad ``except Exception`` swallow path.
+            @property
+            def session(self):
                 raise RuntimeError("unexpected ctx shape")
 
         assert _extract_client_info(Boom()) == {}

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -184,10 +184,7 @@ class TestShapeCheckValidateOnly:
                 {"name": "no-stat-bad-2"},
             ],
         }
-        assert (
-            _shape_check(bad, validate_only={"device_consumption": set()})
-            == []
-        )
+        assert _shape_check(bad, validate_only={"device_consumption": set()}) == []
 
     def test_unlisted_key_is_skipped(self):
         # Bad entry under device_consumption — but validate_only only asks
@@ -196,12 +193,7 @@ class TestShapeCheckValidateOnly:
             "device_consumption": [{"name": "no-stat"}],
             "energy_sources": [{"type": "grid"}],
         }
-        assert (
-            _shape_check(
-                config, validate_only={"energy_sources": {0}}
-            )
-            == []
-        )
+        assert _shape_check(config, validate_only={"energy_sources": {0}}) == []
 
     def test_unlisted_indices_within_a_key_are_skipped(self):
         # device_consumption[0] is bad, [1] is good. validate_only={1} only
@@ -222,9 +214,7 @@ class TestShapeCheckValidateOnly:
                 {"name": "no-stat-bad"},
             ],
         }
-        errors = _shape_check(
-            config, validate_only={"device_consumption": {1}}
-        )
+        errors = _shape_check(config, validate_only={"device_consumption": {1}})
         assert any("stat_consumption" in e["message"] for e in errors)
 
     def test_structural_must_be_a_list_check_still_fires_for_listed_keys(self):
@@ -340,9 +330,7 @@ class TestGetPrefs:
         assert "config_hash_per_key" in result
         assert set(result["config_hash_per_key"]) == set(_PREFS_TOP_LEVEL_KEYS)
         for key in _PREFS_TOP_LEVEL_KEYS:
-            assert result["config_hash_per_key"][key] == compute_config_hash(
-                {key: []}
-            )
+            assert result["config_hash_per_key"][key] == compute_config_hash({key: []})
 
 
 # -----------------------------------------------------------------------------
@@ -829,9 +817,7 @@ class TestSetPrefsPerKeyHash:
         assert result["success"] is True
         assert result["mode"] == "set"
         # Save payload only carries the submitted top-level key.
-        save_payload = tools._client.send_websocket_message.call_args_list[
-            1
-        ].args[0]
+        save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
         assert save_payload["type"] == "energy/save_prefs"
         assert save_payload["device_consumption"] == new_dc
         assert "energy_sources" not in save_payload
@@ -876,7 +862,7 @@ class TestSetPrefsPerKeyHash:
         on the comprehension at the dict-branch's mismatch loop.
         """
         current_prefs = _sample_prefs()
-        per_key = _compute_per_key_hashes(current_prefs)
+        _compute_per_key_hashes(current_prefs)
         # Both device_consumption and energy_sources are stale; only
         # device_consumption_water hash is fresh (and not submitted).
         config = {
@@ -1034,9 +1020,7 @@ class TestSetPrefsPerKeyHash:
         assert "at least one top-level key" in json.dumps(err)
         assert tools._client.send_websocket_message.call_count == 1
 
-    async def test_response_includes_fresh_per_key_hashes_after_write(
-        self, tools
-    ):
+    async def test_response_includes_fresh_per_key_hashes_after_write(self, tools):
         """After a per-key write, the response carries an updated
         config_hash_per_key reflecting the new merged state. An agent can
         chain another per-key write without an intermediate mode='get'.
@@ -1063,13 +1047,9 @@ class TestSetPrefsPerKeyHash:
         expected_after = {
             "energy_sources": current_prefs["energy_sources"],
             "device_consumption": new_dc,
-            "device_consumption_water": current_prefs[
-                "device_consumption_water"
-            ],
+            "device_consumption_water": current_prefs["device_consumption_water"],
         }
-        assert result["config_hash_per_key"] == _compute_per_key_hashes(
-            expected_after
-        )
+        assert result["config_hash_per_key"] == _compute_per_key_hashes(expected_after)
         # Backward-compat: full-blob config_hash is also still emitted.
         assert result["config_hash"] == compute_config_hash(expected_after)
 
@@ -1181,9 +1161,7 @@ class TestConvenienceModesPassStrHash:
         )
         assert captured["config_hash_type"] == "str"
 
-    async def test_add_source_forwards_str_hash_to_set_prefs(
-        self, tools, monkeypatch
-    ):
+    async def test_add_source_forwards_str_hash_to_set_prefs(self, tools, monkeypatch):
         from ha_mcp.tools.tools_energy import EnergyTools
 
         original_set_prefs = EnergyTools._set_prefs
@@ -1244,9 +1222,7 @@ class TestConvenienceModesPreExistingInvalid:
         assert result["success"] is True
         # The pre-existing broken entry survives unchanged in the saved
         # payload — full-replace semantics on the top-level key.
-        save_payload = tools._client.send_websocket_message.call_args_list[
-            1
-        ].args[0]
+        save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
         assert save_payload["device_consumption"] == [
             {"name": "broken_no_stat"},
             {"stat_consumption": "sensor.fridge_energy"},
@@ -1276,9 +1252,7 @@ class TestConvenienceModesPreExistingInvalid:
             mode="add_source", source=new_source
         )
         assert result["success"] is True
-        save_payload = tools._client.send_websocket_message.call_args_list[
-            1
-        ].args[0]
+        save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
         assert save_payload["energy_sources"][1] == new_source
 
     async def test_remove_device_succeeds_with_invalid_pre_existing(self, tools):
@@ -1302,9 +1276,7 @@ class TestConvenienceModesPreExistingInvalid:
         )
         assert result["success"] is True
         # The unaffected (still-broken) entry remains in the saved payload.
-        save_payload = tools._client.send_websocket_message.call_args_list[
-            1
-        ].args[0]
+        save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
         assert save_payload["device_consumption"] == [
             {"name": "broken_no_stat"},
         ]
@@ -1365,9 +1337,7 @@ class TestConvenienceModesPreExistingInvalid:
             "result": invalid_prefs,
         }
 
-        result = await tools.ha_manage_energy_prefs(
-            mode=mode, dry_run=True, **kwargs
-        )
+        result = await tools.ha_manage_energy_prefs(mode=mode, dry_run=True, **kwargs)
         assert result["success"] is True
         assert result["dry_run"] is True
 

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -862,7 +862,10 @@ class TestSetPrefsPerKeyHash:
         on the comprehension at the dict-branch's mismatch loop.
         """
         current_prefs = _sample_prefs()
-        _compute_per_key_hashes(current_prefs)
+        hashes = _compute_per_key_hashes(current_prefs)
+        assert hashes and all(
+            isinstance(h, str) and len(h) > 0 for h in hashes.values()
+        )
         # Both device_consumption and energy_sources are stale; only
         # device_consumption_water hash is fresh (and not submitted).
         config = {

--- a/tests/src/unit/test_wait_helpers.py
+++ b/tests/src/unit/test_wait_helpers.py
@@ -476,7 +476,7 @@ class TestWsPathRegistered:
         result = await wait_for_entity_registered(
             mock_client, "light.test", timeout=5.0
         )
-        await fire_task
+        _ = await fire_task
 
         assert result is True
         assert mock_client.get_entity_state.call_count == 2
@@ -498,7 +498,7 @@ class TestWsPathRegistered:
         result = await wait_for_entity_registered(
             mock_client, "light.target", timeout=0.2
         )
-        await noise_task
+        _ = await noise_task
 
         assert result is False  # Timed out — noise event was correctly filtered.
 
@@ -535,7 +535,7 @@ class TestWsPathRemoved:
 
         fire_task = asyncio.create_task(fire_after())
         result = await wait_for_entity_removed(mock_client, "light.test", timeout=5.0)
-        await fire_task
+        _ = await fire_task
 
         assert result is True
         # Cleanup still ran.
@@ -563,7 +563,7 @@ class TestWsPathStateChange:
         result = await wait_for_state_change(
             mock_client, "light.test", expected_state="on", timeout=5.0
         )
-        await fire_task
+        _ = await fire_task
 
         assert result is not None
         assert result["state"] == "on"
@@ -612,7 +612,7 @@ class TestWsPathStateChange:
 
         fire_task = asyncio.create_task(fire_two())
         result = await wait_for_state_change(mock_client, "light.test", timeout=5.0)
-        await fire_task
+        _ = await fire_task
 
         assert result is not None
         assert result["state"] == "on"
@@ -656,7 +656,7 @@ class TestWsPathConnectionDrop:
         result = await wait_for_entity_registered(
             mock_client, "light.test", timeout=5.0, poll_interval=0.01
         )
-        await fire_task
+        _ = await fire_task
 
         assert result is True
         # We sampled at least three times: post-subscribe, post-noise-nudge,
@@ -926,7 +926,7 @@ class TestWsPathAutomationDiscovery:
         result = await wait_for_automation_entity_by_unique_id(
             mock_client, "uid_99", timeout=2.0
         )
-        await fire_task
+        _ = await fire_task
 
         assert result == "automation.discovered"
 
@@ -949,7 +949,7 @@ class TestWsPathAutomationDiscovery:
         result = await wait_for_automation_entity_by_unique_id(
             mock_client, "uid_42", timeout=0.2, poll_interval=0.05
         )
-        await noise_task
+        _ = await noise_task
 
         assert result is None
 
@@ -972,7 +972,7 @@ class TestWsPathAutomationDiscovery:
         result = await wait_for_automation_entity_by_unique_id(
             mock_client, "uid_target", timeout=0.2, poll_interval=0.05
         )
-        await noise_task
+        _ = await noise_task
 
         assert result is None
 
@@ -1032,7 +1032,7 @@ class TestWsPathAutomationDiscovery:
         result = await wait_for_automation_entity_by_unique_id(
             mock_client, "uid_dup", timeout=2.0
         )
-        await fire_task
+        _ = await fire_task
 
         # Working short-circuit: event payload's entity_id wins.
         # Regression (no short-circuit): REST entity would override.
@@ -1118,7 +1118,7 @@ class TestWsPathAutomationDiscovery:
             result = await wait_for_automation_entity_by_unique_id(
                 mock_client, "uid_dup", timeout=2.0
             )
-            await fire_task
+            _ = await fire_task
 
         assert result == "automation.first"
         # Collision warning emitted naming both entity_ids.

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -333,6 +333,7 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
         try:
             raw_json = json.loads(stdout_text)
         except json.JSONDecodeError:
+            # stdout wasn't JSON; fields are extracted from raw text below.
             pass
 
         # Extract fields from JSON if available

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -358,6 +358,7 @@ def _run_test_prompt(
         try:
             summary = json.loads(result.stdout)
         except json.JSONDecodeError:
+            # Non-JSON stdout (e.g. partial/garbled output); leave summary as None.
             pass
 
     return result.returncode, summary
@@ -533,6 +534,7 @@ def get_git_info() -> tuple[str, str]:
         )
         sha = result.stdout.strip()
     except Exception:
+        # Best-effort git lookup; keep the "unknown" default if git is unavailable.
         pass
     try:
         result = subprocess.run(
@@ -543,6 +545,7 @@ def get_git_info() -> tuple[str, str]:
         )
         describe = result.stdout.strip()
     except Exception:
+        # Best-effort git lookup; keep the "unknown" default if git is unavailable.
         pass
     return sha, describe
 

--- a/tests/uat/stories/scripts/ha_query.py
+++ b/tests/uat/stories/scripts/ha_query.py
@@ -78,9 +78,12 @@ def run_gemini_query(
         result = subprocess.run(
             [
                 "gemini",
-                "-p", query,
-                "--approval-mode", "yolo",
-                "--allowed-mcp-server-names", "homeassistant",
+                "-p",
+                query,
+                "--approval-mode",
+                "yolo",
+                "--allowed-mcp-server-names",
+                "homeassistant",
             ],
             capture_output=True,
             text=True,
@@ -96,6 +99,7 @@ def run_gemini_query(
             if isinstance(data, dict) and "response" in data:
                 output = data["response"]
         except json.JSONDecodeError:
+            # Output wasn't JSON; keep the raw stdout text as-is.
             pass
 
         if result.returncode != 0 and result.stderr:
@@ -139,14 +143,20 @@ def run_claude_query(
         result = subprocess.run(
             [
                 "claude",
-                "-p", query,
-                "--mcp-config", str(config_file),
+                "-p",
+                query,
+                "--mcp-config",
+                str(config_file),
                 "--strict-mcp-config",
-                "--allowedTools", "mcp__home-assistant",
-                "--output-format", "text",
+                "--allowedTools",
+                "mcp__home-assistant",
+                "--output-format",
+                "text",
                 "--no-session-persistence",
-                "--permission-mode", "bypassPermissions",
-                "--model", "sonnet",
+                "--permission-mode",
+                "bypassPermissions",
+                "--model",
+                "sonnet",
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## What does this PR do?
Implements #1513: adds a CodeQL code-quality gate to CI and clears every finding.

**1. New CI gate** (`.github/workflows/codeql-quality.yml` + `scripts/codeql_quality_gate.py`)
Runs the CodeQL `python-code-quality.qls` suite on every Python-touching PR and fails on
any finding. It does NOT upload SARIF (the repo's existing CodeQL default setup makes code
scanning reject advanced-setup uploads); it gates on job status, prints findings to the log +
job summary, and keeps the SARIF as an artifact. Unit-tested.

**2. Why not the "Settings -> Code quality" route in the issue**
GitHub Code Quality (Preview) is gated to Team/Enterprise Cloud org plans; this org is free,
so that page is unavailable. The CodeQL CLI also has no linux-arm64 build, so it can't run in
a pre-commit hook or on ARM dev machines -- `ruff` covers the locally reproducible subset
(F841 unused-locals now enforced in lefthook + CI); the CodeQL suite runs in CI only.

**3. Cleared all findings**, behavior-preserving:
- py/mixed-returns (98): explicit terminal `return None` / re-raise after the always-raising
  error helpers (verified NoReturn)
- py/implicit-string-concatenation-in-list (47): explicit `+`, byte-identical strings
- py/import-and-import-from (37): consolidated import style per module
- py/empty-except (36): explanatory comments on intentional suppression
- a tsg-python parser failure that left tests/src/e2e/conftest.py entirely unanalyzed --
  fixed at source (dropped emoji prefixes that desynced the parser on %-format log strings),
  restoring full coverage of that file
- py/ineffectual-statement (15) plus unused vars/imports/globals, a duplicate import, an
  unnecessary lambda, a redundant comparison, a module-level print, base-exception narrowing,
  and special-method raise corrections

**Suppressed (4)** -- documented in a tight allowlist (rule + path + symbol must all match;
suppressions are reported, never silent): `_shutdown_in_progress` (read across signal
invocations -- a CodeQL dead-store false positive), the two PyInstaller runtime-hook
side-effect imports (`idna`, `encodings.idna`), and the intentional top-level `BaseException`
supervisor handler. Two earlier suppressions were instead fixed at source after review (the
conftest parser issue above, and a cross-module-only constant moved to its consumer).

Gate result: "No CodeQL code-quality findings." + 4 allowlisted.

## Type of change
- [x] Maintenance/refactor (CI + code-quality cleanup)

## Testing
- [x] All automated tests pass (added unit tests for the gate)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

Closes #1513
