### PR TITLE
feat(addon): one-click MCP Server add-on install from the ha_mcp_tools integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ These tools also require feature flags: `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` (fi
 
 To add manually: open **HACS** > **Integrations** > three-dot menu > **Custom repositories** > add `https://github.com/homeassistant-ai/ha-mcp` (category: Integration) > **Download**.
 
-After installing, restart Home Assistant. Then open **Settings** > **Devices & Services** > **Add Integration** and search for **HA MCP Tools**.
+After installing, restart Home Assistant. Then open **Settings** > **Devices & Services** > **Add Integration** and search for **Home Assistant MCP Server Custom Component**.
+
+On **Home Assistant OS / Supervised**, the integration offers to add the add-on repository and install and start the **Home Assistant MCP Server** add-on for you — no need to add the add-on repository by hand. On **Container / Core** installs (no Supervisor) there is no add-on; run the server via Docker or pip and the integration just sets up the file/YAML services.
 
 ### Install manually
 

--- a/custom_components/ha_mcp_tools/addon.py
+++ b/custom_components/ha_mcp_tools/addon.py
@@ -1,0 +1,188 @@
+"""Bootstrap the Home Assistant MCP Server add-on from the integration.
+
+On Supervisor-based installs (Home Assistant OS / Supervised) this module adds
+the ha-mcp add-on repository to the Supervisor store, installs the stable
+"Home Assistant MCP Server" add-on, and starts it. A user can therefore install
+everything from HACS without visiting the Add-on Store or pasting a repository
+URL by hand.
+
+It is intentionally inert on Container / Core installs (no Supervisor, no
+add-ons); callers gate on ``homeassistant.helpers.hassio.is_hassio`` before
+invoking it.
+
+This flow is independent of the integration's privileged file/YAML services:
+installing the add-on never enables those, and they remain gated by the ha-mcp
+server's own beta feature flags.
+
+The Home Assistant / aiohasupervisor imports are deferred into the async
+function so the pure resolution helpers below stay importable (and unit
+testable) without a Home Assistant environment.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Same repository users add manually today (the README "Add Repository" badge
+# points here). Adding it surfaces every add-on in the repo — stable, dev, and
+# the webhook proxy — exactly like the manual flow; we only ever install the
+# stable one.
+ADDON_REPOSITORY_URL = "https://github.com/homeassistant-ai/ha-mcp"
+
+# The stable add-on's config slug is ``ha_mcp``. Supervisor namespaces
+# third-party add-ons as ``<repo_hash>_<config_slug>``, so the installed slug is
+# ``<hash>_ha_mcp``. The dev add-on (config slug ``ha_mcp_dev``) becomes
+# ``<hash>_ha_mcp_dev``, which does NOT end with ``_ha_mcp`` — so the suffix
+# test below selects the stable add-on only. We always pull stable.
+STABLE_ADDON_SLUG_SUFFIX = "_ha_mcp"
+ADDON_NAME = "Home Assistant MCP Server"
+
+# aiohasupervisor's AddonState reports a running add-on as "started" (the
+# enum has no "running" member: startup/started/stopped/unknown/error).
+_RUNNING_STATES = ("started",)
+
+
+class AddonBootstrapError(Exception):
+    """Raised when the add-on could not be installed or started automatically."""
+
+
+def _normalize_repo_url(url: str) -> str:
+    """Normalize a repository URL for comparison (case, trailing slash, .git)."""
+    normalized = url.strip().lower().rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[: -len(".git")]
+    return normalized
+
+
+def _find_repository(repositories: list[Any], url: str) -> Any | None:
+    """Return the store repository whose ``source`` matches ``url``, if present."""
+    target = _normalize_repo_url(url)
+    for repo in repositories:
+        source = getattr(repo, "source", None)
+        if isinstance(source, str) and _normalize_repo_url(source) == target:
+            return repo
+    return None
+
+
+def _select_stable_addon(addons: list[Any], repo_slug: str | None) -> Any | None:
+    """Pick the stable ha-mcp add-on from a list of store add-ons.
+
+    When the repository slug is known, only an add-on that belongs to that
+    repository (``repository == repo_slug``) and whose slug ends in ``_ha_mcp``
+    (stable only — the dev add-on ends in ``_ha_mcp_dev``) is selected; a match
+    in a different repository is never used, and None is returned if our
+    repository has no matching stable add-on. Only when the repository slug is
+    unknown does it fall back to the slug suffix across all add-ons.
+    """
+    if repo_slug is not None:
+        for addon in addons:
+            if getattr(addon, "repository", None) == repo_slug and getattr(
+                addon, "slug", ""
+            ).endswith(STABLE_ADDON_SLUG_SUFFIX):
+                return addon
+        return None
+    for addon in addons:
+        if getattr(addon, "slug", "").endswith(STABLE_ADDON_SLUG_SUFFIX):
+            return addon
+    return None
+
+
+def _is_running(addon_info: Any) -> bool:
+    """Return True if an installed add-on's info reports a running state."""
+    state = getattr(addon_info, "state", None)
+    state_value = getattr(state, "value", state)
+    return state_value in _RUNNING_STATES
+
+
+async def async_install_and_start_addon(hass: Any) -> None:
+    """Add the repository (if needed), install the stable add-on, and start it.
+
+    Idempotent: skips the repository-add when already present, skips install
+    when already installed, and skips start when already running. Raises
+    :class:`AddonBootstrapError` on any failure, or when the Supervisor client
+    is unavailable.
+    """
+    # get_supervisor_client landed in HA 2024.x; guard for very old cores.
+    try:
+        from homeassistant.components.hassio import get_supervisor_client
+        from homeassistant.helpers.hassio import is_hassio
+    except ImportError as err:  # pragma: no cover
+        raise AddonBootstrapError(
+            "This Home Assistant version does not expose the Supervisor client "
+            "needed to install the add-on automatically."
+        ) from err
+
+    # Defence in depth: the config flow only offers the add-on on Supervisor
+    # installs, but never attempt the bootstrap without a Supervisor — Container
+    # and Core installs have no add-on system at all.
+    if not is_hassio(hass):
+        raise AddonBootstrapError(
+            "Home Assistant Supervisor is not available; the add-on can only be "
+            "installed on Home Assistant OS or Supervised. Run the ha-mcp server "
+            "via Docker or pip instead."
+        )
+
+    # aiohasupervisor ships with every Supervisor install; guarded for safety.
+    try:
+        from aiohasupervisor import SupervisorError
+        from aiohasupervisor.models import StoreAddonInstall, StoreAddRepository
+    except ImportError as err:  # pragma: no cover
+        raise AddonBootstrapError(
+            "The Supervisor client library is unavailable; install the "
+            "Home Assistant MCP Server add-on manually from the Add-on Store."
+        ) from err
+
+    client = get_supervisor_client(hass)
+
+    try:
+        repositories = await client.store.repositories_list()
+        repo = _find_repository(repositories, ADDON_REPOSITORY_URL)
+        if repo is None:
+            _LOGGER.info("Adding ha-mcp add-on repository to the Supervisor store")
+            await client.store.add_repository(
+                StoreAddRepository(repository=ADDON_REPOSITORY_URL)
+            )
+            # Refresh the store index so the newly added add-ons appear.
+            await client.store.reload()
+            repositories = await client.store.repositories_list()
+            repo = _find_repository(repositories, ADDON_REPOSITORY_URL)
+
+        addons = await client.store.addons_list()
+        addon = _select_stable_addon(addons, getattr(repo, "slug", None))
+        if addon is None:
+            raise AddonBootstrapError(
+                f"The '{ADDON_NAME}' add-on was not found in the store after "
+                "adding the repository."
+            )
+
+        slug = addon.slug
+        if not getattr(addon, "installed", False):
+            _LOGGER.info("Installing the %s add-on (%s)", ADDON_NAME, slug)
+            # Pass background=False explicitly (the library default also blocks)
+            # so the blocking behaviour stays pinned if that default changes —
+            # the subsequent start must not race an in-progress install.
+            await client.store.install_addon(
+                slug, options=StoreAddonInstall(background=False)
+            )
+
+        info = await client.addons.addon_info(slug)
+        if not _is_running(info):
+            _LOGGER.info("Starting the %s add-on (%s)", ADDON_NAME, slug)
+            await client.addons.start_addon(slug)
+    except AddonBootstrapError:
+        raise
+    except SupervisorError as err:
+        raise AddonBootstrapError(
+            f"Supervisor could not install or start the add-on: {err}"
+        ) from err
+    except Exception as err:
+        # Orchestration boundary: surface any unexpected failure (a malformed
+        # store entry, a non-SupervisorError client/transport error, etc.) as
+        # AddonBootstrapError so the config flow's install_failed path runs and
+        # still creates the integration entry, instead of crashing the flow.
+        raise AddonBootstrapError(
+            f"Unexpected error while installing the add-on: {err}"
+        ) from err

--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigFlow
+import asyncio
+import logging
+from typing import Any
 
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.core import callback
+from homeassistant.helpers.hassio import is_hassio
+
+from .addon import AddonBootstrapError, async_install_and_start_addon
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENTRY_TITLE = "Home Assistant MCP Server Custom Component"
+_CONF_INSTALL_ADDON = "install_addon"
 
 
 class HaMcpToolsConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -12,13 +25,101 @@ class HaMcpToolsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._install_task: asyncio.Task[None] | None = None
+        self._install_error: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
-        # Check if already configured
         await self.async_set_unique_id(DOMAIN)
         self._abort_if_unique_id_configured()
 
-        if user_input is not None:
-            return self.async_create_entry(title="HA MCP Tools", data={})
+        # On Supervisor installs (HA OS / Supervised), offer to install the
+        # Home Assistant MCP Server add-on too. On Container / Core installs
+        # there is no add-on, so fall back to the plain confirm-and-create
+        # behaviour (the server runs via Docker or pip there).
+        if is_hassio(self.hass):
+            return await self.async_step_addon()
 
+        if user_input is not None:
+            return self._create_entry()
         return self.async_show_form(step_id="user")
+
+    async def async_step_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Offer to install the Home Assistant MCP Server add-on."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="addon",
+                data_schema=vol.Schema(
+                    {vol.Required(_CONF_INSTALL_ADDON, default=True): bool}
+                ),
+            )
+        if not user_input[_CONF_INSTALL_ADDON]:
+            return self._create_entry()
+        return await self.async_step_install_addon()
+
+    async def async_step_install_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Install and start the add-on, showing a progress spinner."""
+        if self._install_task is None:
+            self._install_task = self.hass.async_create_task(
+                async_install_and_start_addon(self.hass)
+            )
+        install_task = self._install_task
+
+        if not install_task.done():
+            return self.async_show_progress(
+                step_id="install_addon",
+                progress_action="install_addon",
+                progress_task=install_task,
+            )
+
+        try:
+            await install_task
+        except AddonBootstrapError as err:
+            _LOGGER.error("ha-mcp add-on bootstrap failed: %s", err)
+            self._install_error = str(err)
+            return self.async_show_progress_done(next_step_id="install_failed")
+        finally:
+            self._install_task = None
+
+        return self.async_show_progress_done(next_step_id="addon_success")
+
+    async def async_step_addon_success(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Finish setup after the add-on was installed and started."""
+        return self._create_entry()
+
+    async def async_step_install_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Add-on bootstrap failed; still set up the integration's services."""
+        if user_input is not None:
+            return self._create_entry()
+        return self.async_show_form(
+            step_id="install_failed",
+            data_schema=vol.Schema({}),
+            description_placeholders={"error": self._install_error or "unknown error"},
+        )
+
+    def _create_entry(self) -> ConfigFlowResult:
+        """Create the integration config entry."""
+        return self.async_create_entry(title=_ENTRY_TITLE, data={})
+
+    @callback
+    def async_remove(self) -> None:
+        """Cancel an in-flight add-on install if the flow is abandoned."""
+        if self._install_task is not None and not self._install_task.done():
+            _LOGGER.info(
+                "Config flow abandoned during add-on install; cancelling. The "
+                "add-on repository may already be added and the add-on may be "
+                "partially installed — check the Add-on Store."
+            )
+            self._install_task.cancel()

--- a/custom_components/ha_mcp_tools/hacs.json
+++ b/custom_components/ha_mcp_tools/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "HA MCP Tools",
+    "name": "Home Assistant MCP Server Custom Component",
     "render_readme": true
 }

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "ha_mcp_tools",
-    "name": "HA MCP Tools",
+    "name": "Home Assistant MCP Server Custom Component",
+    "after_dependencies": ["hassio"],
     "codeowners": ["@homeassistant-ai"],
     "config_flow": true,
     "dependencies": [],
@@ -8,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/homeassistant-ai/ha-mcp/issues",
     "requirements": ["ruamel.yaml>=0.18.0"],
-    "version": "0.5.2"
+    "version": "0.6.0"
 }

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -2,12 +2,26 @@
     "config": {
         "step": {
             "user": {
-                "title": "HA MCP Tools",
-                "description": "This integration provides advanced file management services for AI assistants via ha-mcp."
+                "title": "Home Assistant MCP Server Custom Component",
+                "description": "This integration provides the advanced file and YAML configuration services used by ha-mcp. No Home Assistant Supervisor was detected, so the MCP Server add-on can't be installed automatically here — run ha-mcp via Docker or pip instead. Select **Submit** to enable the services."
+            },
+            "addon": {
+                "title": "Install the Home Assistant MCP Server add-on",
+                "description": "Home Assistant Supervisor was detected. This integration can add the add-on repository and install and start the **Home Assistant MCP Server** add-on for you — no need to add a repository URL by hand. Leave the box checked to install it now, or uncheck to set up only the integration services.",
+                "data": {
+                    "install_addon": "Install the Home Assistant MCP Server add-on"
+                }
+            },
+            "install_failed": {
+                "title": "Add-on installation failed",
+                "description": "The add-on could not be installed automatically:\n\n{error}\n\nThe add-on repository may already have been added for you, so you only need to install the **Home Assistant MCP Server** add-on from the Add-on Store. The integration's services will still be set up — select **Submit** to finish."
             }
         },
+        "progress": {
+            "install_addon": "Adding the add-on repository, installing the Home Assistant MCP Server add-on, and starting it. This can take a few minutes."
+        },
         "abort": {
-            "already_configured": "HA MCP Tools is already configured."
+            "already_configured": "The Home Assistant MCP Server Custom Component is already set up."
         }
     }
 }

--- a/tests/src/e2e/haos_only/test_integration_setup.py
+++ b/tests/src/e2e/haos_only/test_integration_setup.py
@@ -263,3 +263,36 @@ async def test_local_calendar_lifecycle(mcp_client: Any, ha_client: Any) -> None
                 f"subsequent ha_search_entities calls will slow over time. "
                 f"Result: {cleanup}"
             )
+
+
+async def test_ha_mcp_tools_config_flow_loads_on_supervisor(ha_client: Any) -> None:
+    """The ha_mcp_tools bootstrap config flow imports and runs on real HA OS.
+
+    Starting the flow forces ``custom_components/ha_mcp_tools/config_flow.py``
+    (and its imports) to load and execute inside a real Supervised Home
+    Assistant process — coverage that neither the testcontainer tier nor the
+    seeded-entry setup path provides (the qcow2 seeds the config entry directly
+    in ``.storage`` and never drives the flow).
+
+    The integration is single-instance, so where it is already configured the
+    flow aborts with ``already_configured``; if it is not yet configured it
+    reaches the Supervisor-aware add-on step (proving ``is_hassio`` routing
+    works on a real Supervisor). Either outcome proves the flow loaded. The flow
+    is left un-submitted, so no add-on is installed and no duplicate entry is
+    created.
+    """
+    flow_init = await ha_client.start_config_flow("ha_mcp_tools")
+    flow_type = flow_init.get("type")
+    assert flow_type in ("abort", "form", "menu"), (
+        f"ha_mcp_tools config flow did not load cleanly on HA OS: {flow_init}"
+    )
+    if flow_type == "abort":
+        assert flow_init.get("reason") == "already_configured", (
+            f"Unexpected abort reason from ha_mcp_tools config flow: {flow_init}"
+        )
+    else:
+        LOG.info(
+            "ha_mcp_tools config flow reached step %r on Supervisor (left "
+            "un-submitted)",
+            flow_init.get("step_id"),
+        )

--- a/tests/src/unit/test_addon_bootstrap.py
+++ b/tests/src/unit/test_addon_bootstrap.py
@@ -1,0 +1,258 @@
+"""Unit tests for the ha_mcp_tools add-on bootstrap logic.
+
+Covers the pure slug/repository resolution helpers and the
+``async_install_and_start_addon`` orchestration (repository-add, install, and
+start sequencing) with a faked Supervisor client. The live Supervisor path
+needs a real Home Assistant OS / Supervised host; it is not exercised by CI
+(the HAOS tier seeds the config entry via storage rather than driving this
+config flow), so the aiohasupervisor method and model names were verified
+against the library source instead.
+
+Home Assistant, voluptuous, and aiohasupervisor are mocked in ``sys.modules``
+so importing the component package (and the deferred imports inside
+``async_install_and_start_addon``) succeeds without a Home Assistant install.
+Mirrors the mocking approach in ``test_custom_component_filesystem.py``.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("voluptuous", MagicMock())
+sys.modules.setdefault("homeassistant", MagicMock())
+sys.modules.setdefault("homeassistant.components", MagicMock())
+sys.modules.setdefault("homeassistant.components.hassio", MagicMock())
+sys.modules.setdefault("homeassistant.components.persistent_notification", MagicMock())
+sys.modules.setdefault("homeassistant.config_entries", MagicMock())
+sys.modules.setdefault("homeassistant.core", MagicMock())
+sys.modules.setdefault("homeassistant.helpers", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.config_validation", MagicMock())
+sys.modules.setdefault("homeassistant.helpers.storage", MagicMock())
+sys.modules.setdefault("homeassistant.loader", MagicMock())
+
+_HELPERS_HASSIO = MagicMock()
+_HELPERS_HASSIO.is_hassio = MagicMock(return_value=True)
+sys.modules["homeassistant.helpers.hassio"] = _HELPERS_HASSIO
+
+
+class _FakeSupervisorError(Exception):
+    """Stand-in for aiohasupervisor.SupervisorError (must be a real Exception)."""
+
+
+_FAKE_AIOHASUPERVISOR = MagicMock()
+_FAKE_AIOHASUPERVISOR.SupervisorError = _FakeSupervisorError
+sys.modules.setdefault("aiohasupervisor", _FAKE_AIOHASUPERVISOR)
+sys.modules.setdefault("aiohasupervisor.models", MagicMock())
+
+from custom_components.ha_mcp_tools.addon import (  # noqa: E402
+    ADDON_REPOSITORY_URL,
+    AddonBootstrapError,
+    _find_repository,
+    _is_running,
+    _normalize_repo_url,
+    _select_stable_addon,
+    async_install_and_start_addon,
+)
+
+
+def _store_addon(slug: str, repository: str = "abcd1234", installed: bool = False):
+    return SimpleNamespace(slug=slug, repository=repository, installed=installed)
+
+
+class TestNormalizeRepoUrl:
+    def test_strips_trailing_slash_and_lowercases(self):
+        assert (
+            _normalize_repo_url("https://github.com/Org/Ha-Mcp/")
+            == "https://github.com/org/ha-mcp"
+        )
+
+    def test_strips_dot_git(self):
+        assert (
+            _normalize_repo_url("https://github.com/org/ha-mcp.git")
+            == "https://github.com/org/ha-mcp"
+        )
+
+
+class TestFindRepository:
+    def test_matches_by_source_ignoring_trailing_slash(self):
+        repos = [SimpleNamespace(slug="abcd1234", source=ADDON_REPOSITORY_URL)]
+        assert _find_repository(repos, ADDON_REPOSITORY_URL + "/") is repos[0]
+
+    def test_returns_none_when_absent(self):
+        repos = [SimpleNamespace(slug="x", source="https://github.com/other/repo")]
+        assert _find_repository(repos, ADDON_REPOSITORY_URL) is None
+
+    def test_ignores_repo_without_source(self):
+        repos = [SimpleNamespace(slug="x")]
+        assert _find_repository(repos, ADDON_REPOSITORY_URL) is None
+
+
+class TestSelectStableAddon:
+    def test_prefers_repo_match_and_stable_suffix(self):
+        addons = [
+            _store_addon("abcd1234_ha_mcp_dev"),
+            _store_addon("abcd1234_ha_mcp"),
+            _store_addon("ffff0000_other", repository="ffff0000"),
+        ]
+        assert _select_stable_addon(addons, "abcd1234").slug == "abcd1234_ha_mcp"
+
+    def test_excludes_dev_addon(self):
+        addons = [_store_addon("abcd1234_ha_mcp_dev")]
+        assert _select_stable_addon(addons, "abcd1234") is None
+
+    def test_falls_back_to_suffix_when_repo_slug_unknown(self):
+        addons = [_store_addon("abcd1234_ha_mcp")]
+        assert _select_stable_addon(addons, None).slug == "abcd1234_ha_mcp"
+
+    def test_returns_none_when_repo_known_but_addon_from_other_repo(self):
+        # repo_slug is known but the only stable add-on belongs to a different
+        # repository, so it must not be selected (no cross-repo fallback).
+        addons = [_store_addon("abcd1234_ha_mcp", repository="abcd1234")]
+        assert _select_stable_addon(addons, "zzzzzzzz") is None
+
+    def test_returns_none_when_no_stable_addon(self):
+        addons = [_store_addon("abcd1234_ha_mcp_dev"), _store_addon("ffff0000_other")]
+        assert _select_stable_addon(addons, "abcd1234") is None
+
+
+class TestIsRunning:
+    def test_started_string(self):
+        assert _is_running(SimpleNamespace(state="started")) is True
+
+    def test_startup_state_not_running(self):
+        # "startup" is a real AddonState that is not yet running.
+        assert _is_running(SimpleNamespace(state="startup")) is False
+
+    def test_enum_like_state(self):
+        assert (
+            _is_running(SimpleNamespace(state=SimpleNamespace(value="started"))) is True
+        )
+
+    def test_stopped(self):
+        assert _is_running(SimpleNamespace(state="stopped")) is False
+
+    def test_missing_state(self):
+        assert _is_running(SimpleNamespace()) is False
+
+
+def _make_client(*, repo_present, addon, addon_state):
+    """Build a fake aiohasupervisor SupervisorClient."""
+    repo = SimpleNamespace(slug="abcd1234", source=ADDON_REPOSITORY_URL)
+    store = MagicMock()
+    if repo_present:
+        store.repositories_list = AsyncMock(return_value=[repo])
+    else:
+        # Empty before the add, populated after add_repository + reload.
+        store.repositories_list = AsyncMock(side_effect=[[], [repo]])
+    store.add_repository = AsyncMock()
+    store.reload = AsyncMock()
+    store.addons_list = AsyncMock(return_value=[addon])
+    store.install_addon = AsyncMock()
+
+    addons = MagicMock()
+    addons.addon_info = AsyncMock(return_value=SimpleNamespace(state=addon_state))
+    addons.start_addon = AsyncMock()
+    return SimpleNamespace(store=store, addons=addons)
+
+
+def _patch_supervisor_client(client):
+    sys.modules["homeassistant.components.hassio"].get_supervisor_client = MagicMock(
+        return_value=client
+    )
+
+
+class TestAsyncInstallAndStartAddon:
+    def test_adds_repo_installs_and_starts_when_absent(self):
+        addon = _store_addon("abcd1234_ha_mcp", installed=False)
+        client = _make_client(repo_present=False, addon=addon, addon_state="stopped")
+        _patch_supervisor_client(client)
+
+        asyncio.run(async_install_and_start_addon(object()))
+
+        assert client.store.add_repository.await_count == 1
+        assert client.store.reload.await_count == 1
+        assert client.store.install_addon.await_count == 1
+        assert client.addons.start_addon.await_count == 1
+
+    def test_idempotent_when_already_installed_and_running(self):
+        addon = _store_addon("abcd1234_ha_mcp", installed=True)
+        client = _make_client(repo_present=True, addon=addon, addon_state="started")
+        _patch_supervisor_client(client)
+
+        asyncio.run(async_install_and_start_addon(object()))
+
+        assert client.store.add_repository.await_count == 0
+        assert client.store.install_addon.await_count == 0
+        # State was checked before skipping the start (not a blind skip).
+        assert client.addons.addon_info.await_count == 1
+        assert client.addons.start_addon.await_count == 0
+
+    def test_starts_when_installed_but_stopped(self):
+        addon = _store_addon("abcd1234_ha_mcp", installed=True)
+        client = _make_client(repo_present=True, addon=addon, addon_state="stopped")
+        _patch_supervisor_client(client)
+
+        asyncio.run(async_install_and_start_addon(object()))
+
+        assert client.store.install_addon.await_count == 0
+        assert client.addons.start_addon.await_count == 1
+
+    def test_raises_when_stable_addon_missing(self):
+        addon = _store_addon("abcd1234_ha_mcp_dev", installed=False)
+        client = _make_client(repo_present=True, addon=addon, addon_state="stopped")
+        _patch_supervisor_client(client)
+
+        with pytest.raises(AddonBootstrapError):
+            asyncio.run(async_install_and_start_addon(object()))
+
+    def test_wraps_supervisor_error(self):
+        addon = _store_addon("abcd1234_ha_mcp", installed=False)
+        client = _make_client(repo_present=True, addon=addon, addon_state="stopped")
+        client.store.install_addon = AsyncMock(side_effect=_FakeSupervisorError("boom"))
+        _patch_supervisor_client(client)
+
+        with pytest.raises(AddonBootstrapError):
+            asyncio.run(async_install_and_start_addon(object()))
+
+    def test_wraps_unexpected_non_supervisor_error(self):
+        # A non-SupervisorError (transport/parse error, malformed entry, etc.)
+        # must still surface as AddonBootstrapError so the config flow degrades
+        # gracefully instead of crashing with no entry created.
+        addon = _store_addon("abcd1234_ha_mcp", installed=False)
+        client = _make_client(repo_present=True, addon=addon, addon_state="stopped")
+        client.store.install_addon = AsyncMock(side_effect=RuntimeError("boom"))
+        _patch_supervisor_client(client)
+
+        with pytest.raises(AddonBootstrapError):
+            asyncio.run(async_install_and_start_addon(object()))
+
+    def test_succeeds_via_suffix_when_repo_not_refound(self):
+        # If the repository cannot be re-found after add + reload, resolution
+        # falls back to the slug suffix and still installs + starts the add-on.
+        addon = _store_addon("abcd1234_ha_mcp", installed=False)
+        client = _make_client(repo_present=False, addon=addon, addon_state="stopped")
+        client.store.repositories_list = AsyncMock(return_value=[])
+        _patch_supervisor_client(client)
+
+        asyncio.run(async_install_and_start_addon(object()))
+
+        assert client.store.add_repository.await_count == 1
+        assert client.store.install_addon.await_count == 1
+        assert client.addons.start_addon.await_count == 1
+
+    def test_raises_when_not_supervised(self):
+        # Defence in depth: even if invoked without a Supervisor (Container /
+        # Core), the bootstrap must refuse clearly rather than misbehave.
+        # Patch the live sys.modules entry the lazy import resolves against, so
+        # this is robust to another test module restubbing helpers.hassio.
+        mod = sys.modules["homeassistant.helpers.hassio"]
+        saved = mod.is_hassio
+        mod.is_hassio = MagicMock(return_value=False)
+        try:
+            with pytest.raises(AddonBootstrapError):
+                asyncio.run(async_install_and_start_addon(object()))
+        finally:
+            mod.is_hassio = saved

--- a/tests/src/unit/test_config_flow_bootstrap.py
+++ b/tests/src/unit/test_config_flow_bootstrap.py
@@ -1,0 +1,182 @@
+"""Unit tests for the ha_mcp_tools bootstrap config flow.
+
+These drive the config-flow state machine (Supervisor-detection routing, the
+add-on install/decline steps, the progress -> success/failed transitions, and
+async_remove task cancellation) without a real Home Assistant. The framework
+methods (async_show_form / async_show_progress / async_create_entry / ...) are
+stubbed on the flow instance so each step's routing decision is asserted
+directly. The real Supervisor calls live in addon.py and are covered by
+test_addon_bootstrap.py; a live end-to-end check runs on the HAOS tier.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+
+# --- Stub Home Assistant modules so config_flow imports without HA installed.
+# config_flow subclasses ConfigFlow, so unlike the plain-MagicMock approach in
+# test_addon_bootstrap.py we need a real, subclassable base class here.
+class _FakeConfigFlowResult(dict):
+    """Stand-in for homeassistant.config_entries.ConfigFlowResult."""
+
+
+class _FakeConfigFlowBase:
+    """Minimal subclassable stand-in for ConfigFlow (absorbs domain=...)."""
+
+    def __init_subclass__(cls, **kwargs):
+        return None
+
+
+_ce = MagicMock()
+_ce.ConfigFlow = _FakeConfigFlowBase
+_ce.ConfigFlowResult = _FakeConfigFlowResult
+sys.modules["homeassistant.config_entries"] = _ce
+
+_core = MagicMock()
+_core.callback = lambda func: func
+sys.modules["homeassistant.core"] = _core
+
+sys.modules["homeassistant.helpers.hassio"] = MagicMock()
+
+for _mod in [
+    "voluptuous",
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.persistent_notification",
+    "homeassistant.helpers",
+    "homeassistant.helpers.config_validation",
+    "homeassistant.helpers.storage",
+    "homeassistant.loader",
+]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+from custom_components.ha_mcp_tools import config_flow as cf  # noqa: E402
+from custom_components.ha_mcp_tools.addon import AddonBootstrapError  # noqa: E402
+
+
+def _make_flow(*, is_hassio: bool) -> cf.HaMcpToolsConfigFlow:
+    """Build a flow with the HA framework methods stubbed to return markers."""
+    flow = cf.HaMcpToolsConfigFlow()
+    flow.async_set_unique_id = AsyncMock(return_value=None)
+    flow._abort_if_unique_id_configured = MagicMock(return_value=None)
+    flow.async_show_form = MagicMock(side_effect=lambda **kw: {"type": "form", **kw})
+    flow.async_create_entry = MagicMock(
+        side_effect=lambda **kw: {"type": "entry", **kw}
+    )
+    flow.async_show_progress = MagicMock(
+        side_effect=lambda **kw: {"type": "progress", **kw}
+    )
+    flow.async_show_progress_done = MagicMock(
+        side_effect=lambda **kw: {"type": "progress_done", **kw}
+    )
+    flow.hass = SimpleNamespace(
+        async_create_task=lambda coro: asyncio.ensure_future(coro)
+    )
+    cf.is_hassio = lambda hass: is_hassio
+    return flow
+
+
+async def _drive_install(flow, addon_input):
+    """Accept the add-on step, then pump the progress step to completion."""
+    result = await flow.async_step_addon(addon_input)
+    guard = 0
+    while result.get("type") == "progress":
+        guard += 1
+        assert guard < 5, "install step did not converge"
+        if flow._install_task is not None:
+            await asyncio.gather(flow._install_task, return_exceptions=True)
+        result = await flow.async_step_install_addon()
+    return result
+
+
+class TestUserStep:
+    def test_non_supervisor_shows_form_then_creates_entry(self):
+        flow = _make_flow(is_hassio=False)
+        form = asyncio.run(flow.async_step_user(None))
+        assert form["type"] == "form"
+        assert form["step_id"] == "user"
+
+        entry = asyncio.run(flow.async_step_user({}))
+        assert entry["type"] == "entry"
+        assert entry["title"] == cf._ENTRY_TITLE
+
+    def test_supervisor_routes_to_addon_step(self):
+        flow = _make_flow(is_hassio=True)
+        form = asyncio.run(flow.async_step_user(None))
+        assert form["type"] == "form"
+        assert form["step_id"] == "addon"
+
+
+class TestAddonStep:
+    def test_decline_creates_entry_without_installing(self):
+        flow = _make_flow(is_hassio=True)
+        cf.async_install_and_start_addon = AsyncMock()
+        result = asyncio.run(flow.async_step_addon({cf._CONF_INSTALL_ADDON: False}))
+        assert result["type"] == "entry"
+        cf.async_install_and_start_addon.assert_not_called()
+
+    def test_accept_installs_then_succeeds(self):
+        flow = _make_flow(is_hassio=True)
+        cf.async_install_and_start_addon = AsyncMock(return_value=None)
+        result = asyncio.run(_drive_install(flow, {cf._CONF_INSTALL_ADDON: True}))
+        assert result["type"] == "progress_done"
+        assert result["next_step_id"] == "addon_success"
+
+    def test_accept_failure_routes_to_install_failed(self):
+        flow = _make_flow(is_hassio=True)
+        cf.async_install_and_start_addon = AsyncMock(
+            side_effect=AddonBootstrapError("boom")
+        )
+        result = asyncio.run(_drive_install(flow, {cf._CONF_INSTALL_ADDON: True}))
+        assert result["type"] == "progress_done"
+        assert result["next_step_id"] == "install_failed"
+        assert flow._install_error == "boom"
+
+
+class TestTerminalSteps:
+    def test_addon_success_creates_entry(self):
+        flow = _make_flow(is_hassio=True)
+        result = asyncio.run(flow.async_step_addon_success())
+        assert result["type"] == "entry"
+        assert result["title"] == cf._ENTRY_TITLE
+
+    def test_install_failed_surfaces_error_then_creates_entry(self):
+        flow = _make_flow(is_hassio=True)
+        flow._install_error = "boom"
+        form = asyncio.run(flow.async_step_install_failed(None))
+        assert form["type"] == "form"
+        assert form["step_id"] == "install_failed"
+        assert form["description_placeholders"]["error"] == "boom"
+
+        entry = asyncio.run(flow.async_step_install_failed({}))
+        assert entry["type"] == "entry"
+
+    def test_install_failed_defaults_error_placeholder(self):
+        flow = _make_flow(is_hassio=True)
+        form = asyncio.run(flow.async_step_install_failed(None))
+        assert form["description_placeholders"]["error"] == "unknown error"
+
+
+class TestAsyncRemove:
+    def test_cancels_inflight_task(self):
+        flow = cf.HaMcpToolsConfigFlow()
+        task = MagicMock()
+        task.done.return_value = False
+        flow._install_task = task
+        flow.async_remove()
+        task.cancel.assert_called_once()
+
+    def test_no_cancel_when_task_done(self):
+        flow = cf.HaMcpToolsConfigFlow()
+        task = MagicMock()
+        task.done.return_value = True
+        flow._install_task = task
+        flow.async_remove()
+        task.cancel.assert_not_called()
+
+    def test_no_error_when_no_task(self):
+        flow = cf.HaMcpToolsConfigFlow()
+        flow._install_task = None
+        flow.async_remove()  # must not raise


### PR DESCRIPTION
## What does this PR do?

Implements **Phase 1 of #1527**. On Home Assistant OS / Supervised installs, the `ha_mcp_tools` integration's config flow now offers to add the add-on repository and install + start the stable **Home Assistant MCP Server** add-on automatically (Supervisor store API via `aiohasupervisor`), so users can set up the whole stack from HACS without opening the Add-on Store or pasting a repository URL.

> [!IMPORTANT]
> **Supervisor-only.** This bootstrap works on **Home Assistant OS / Supervised** installs — the only install types with an add-on system. On **Container / Core** (no Supervisor) the config flow detects this via `is_hassio`, never offers the add-on step (the user just gets the file/YAML services and a pointer to run the server via Docker/pip), and a defence-in-depth guard in `addon.py` refuses the bootstrap if it is ever reached without a Supervisor. Reaching Container/Core through HACS is the separate **in-process-server path (Phase 2 in #1527)**, which this PR deliberately does not attempt.

Behaviour:
- The add-on install is **opt-in** — a checkbox in the config flow (default checked, but visible and declinable). Nothing installs silently.
- Always installs the **stable** add-on (resolves the `*_ha_mcp` slug; never the dev `*_ha_mcp_dev`). Adding the repo surfaces every add-on in it, exactly like the manual flow; only stable is installed.
- **Idempotent** — skips repo-add, install, and start when already present/running.
- **Independent of the beta file/YAML services** — the bootstrap never enables them; they stay gated by the server's `HAMCP_ENABLE_FILESYSTEM_TOOLS` / `ENABLE_YAML_CONFIG_EDITING` flags.
- Graceful failure: if the add-on bootstrap fails, the flow still creates the integration entry (services keep working) and tells the user how to finish manually.

Implementation:
- New `custom_components/ha_mcp_tools/addon.py` isolates the Supervisor logic (deferred Home Assistant imports; pure, unit-tested resolution helpers; all unexpected errors wrapped as `AddonBootstrapError`).
- Config flow uses the canonical `async_show_progress` + background-task pattern (mirrors zwave_js / matter), with a graceful `install_failed` step and `async_remove` task cancellation.
- `manifest.json`: `after_dependencies: ["hassio"]` (soft — still loads off-Supervisor), version 0.5.2 to 0.6.0. Integration display + HACS name: **Home Assistant MCP Server Custom Component**.

Does **not** close #1527 — Phase 0 (HACS default listing) and Phase 2 (in-process server) remain tracked there. Appearing in HACS **search** still requires the separate `hacs/default` + `home-assistant/brands` submission (Phase 0); this PR ships only the in-repo prep.

## Type of change
- [x] New feature

## Testing
- **Unit tests — addon.py** (`tests/src/unit/test_addon_bootstrap.py`): pure slug/repository resolution, the install/start orchestration (repo-add, idempotency, suffix fallback, missing add-on), and error handling (Supervisor + non-Supervisor errors wrapped, non-Supervised guard).
- **Unit tests — config_flow.py** (`tests/src/unit/test_config_flow_bootstrap.py`): `is_hassio` routing, install/decline, progress to success/failed transitions, terminal steps, and `async_remove` cancellation (via a lightweight fake-`ConfigFlow` harness).
- **HAOS e2e smoke** (`tests/src/e2e/haos_only/test_integration_setup.py`): starts the real config flow on a Supervised host to prove `config_flow.py` loads and executes there (left un-submitted — no add-on installed, no duplicate entry).
- `ruff format` + `ruff check` clean; all CI green on the latest commit (incl. both HAOS jobs).
- The live repo-add + install + start path needs a real Supervised host and is verified against the pinned `aiohasupervisor==0.4.3` source (it is not exercised end-to-end by CI).
- [ ] Tested with an LLM agent
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (README install note)
