### PR TITLE
docs: update advanced mode notes

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1197,6 +1197,8 @@ class HomeAssistantClient:
         show_advanced_options: bool | None = None,
     ) -> dict[str, Any]:
         """Start a config subentry create or reconfigure flow."""
+        # HA 2026.6+ treats show_advanced_options as a no-op; keep passing it
+        # for older HA versions until the server-side property is removed.
         # HA requires the handler as [parent_entry_id, subentry_type].
         payload: dict[str, Any] = {"handler": [entry_id, subentry_type]}
         if subentry_id is not None:

--- a/src/ha_mcp/tools/tools_config_entry_flow.py
+++ b/src/ha_mcp/tools/tools_config_entry_flow.py
@@ -714,6 +714,8 @@ async def set_config_subentry(
 
     Presence of ``subentry_id`` is the discriminator: omitted creates a new
     subentry, provided reconfigures that existing subentry.
+    ``show_advanced_options`` is a no-op on HA 2026.6+ and kept only for older
+    HA versions pending removal before HA 2027.6.
     """
     flow_result = await client.start_config_subentry_flow(
         entry_id,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3480,8 +3480,9 @@ class HelperConfigTools:
             bool,
             Field(
                 description=(
-                    "When helper_type='config_subentry', ask Home Assistant "
-                    "to expose advanced flow options."
+                    "When helper_type='config_subentry', ask older Home "
+                    "Assistant versions to expose advanced flow options. No-op "
+                    "on HA 2026.6+; pending removal before HA 2027.6."
                 ),
                 default=False,
             ),

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -370,8 +370,9 @@ class IntegrationTools:
             bool,
             Field(
                 description=(
-                    "When include_subentry_schema=True, ask Home Assistant to "
-                    "expose advanced flow options."
+                    "When include_subentry_schema=True, ask older Home Assistant "
+                    "versions to expose advanced flow options. No-op on HA "
+                    "2026.6+; pending removal before HA 2027.6."
                 ),
                 default=False,
             ),

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -184,8 +184,8 @@ class ResourceTools:
         - List all resources: ha_config_list_dashboard_resources()
         - List with full content: ha_config_list_dashboard_resources(include_content=True)
 
-        Note: Requires advanced mode to be enabled in Home Assistant for resource
-        management through the UI, but API access works regardless.
+        Note: Home Assistant 2026.6+ exposes resource management in the UI by
+        default, and API access works regardless of UI availability.
         """
         try:
             result = await self._client.send_websocket_message(


### PR DESCRIPTION
## What does this PR do?

Updates stale Home Assistant Advanced Mode references after HA 2026.6 made formerly advanced UI/config-flow options available by default.

Fixes #1532

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Relevant validation run:
- `uv run ruff check src/ha_mcp/tools/tools_resources.py src/ha_mcp/client/rest_client.py src/ha_mcp/tools/tools_integrations.py src/ha_mcp/tools/tools_config_helpers.py src/ha_mcp/tools/tools_config_entry_flow.py`
- `uv run python -m py_compile src/ha_mcp/tools/tools_resources.py src/ha_mcp/client/rest_client.py src/ha_mcp/tools/tools_integrations.py src/ha_mcp/tools/tools_config_helpers.py src/ha_mcp/tools/tools_config_entry_flow.py`
- `git submodule update --init --depth 1`
- `uv run pytest tests/src/unit/test_tools_resources.py tests/src/unit/test_resources.py tests/src/unit/test_tools_integrations.py tests/src/unit/test_helper_schema_inline.py` (197 passed)

## Future improvements

N/A

## Checklist
- [x] I have updated documentation if needed
