### PR TITLE
test(uat): harden BAT story runner against agent crashes

### DIFF
--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -47,6 +47,58 @@ def _strip_pydantic_url(text: str) -> str:
     return _PYDANTIC_URL_LINE.sub("", text)
 
 
+# llama-server reports a context overflow as HTTP 400 with type
+# ``exceed_context_size_error`` and a message like:
+#   request (27220 tokens) exceeds the available context size (24576 tokens)
+_CTX_OVERFLOW_RE = re.compile(
+    r"request \((\d+) tokens?\) exceeds the available context size \((\d+) tokens?\)"
+)
+
+
+class ContextWindowExceededError(RuntimeError):
+    """Raised when the accumulated conversation overflows the backend's context.
+
+    Carries the requested prompt size and the backend context limit (either may
+    be ``None`` if the marker matched but the numbers couldn't be parsed). The
+    inline path surfaces this as a hard failure so a verification-based PASS
+    can't mask an agent that crashed mid-run.
+    """
+
+    def __init__(self, requested_tokens: int | None, context_size: int | None) -> None:
+        self.requested_tokens = requested_tokens
+        self.context_size = context_size
+        detail = (
+            f"request ({requested_tokens} tokens) exceeds context size "
+            f"({context_size} tokens)"
+            if requested_tokens is not None and context_size is not None
+            else "context window exceeded"
+        )
+        super().__init__(detail)
+
+
+def _parse_context_overflow(
+    exc: openai.BadRequestError,
+) -> tuple[int | None, int | None] | None:
+    """Return (requested_tokens, context_size) if ``exc`` is a context overflow.
+
+    Matches llama-server's ``exceed_context_size_error`` type or its
+    "exceeds the available context size" message on the stringified exception
+    (version-robust vs. structured fields). Returns ``None`` when the error is
+    some other 400, or ``(None, None)`` when the marker is present but the token
+    counts can't be parsed.
+    """
+    text = str(getattr(exc, "message", "") or "") + " " + str(exc)
+    if (
+        "exceed_context_size_error" not in text
+        and "exceeds the available context size" not in text
+    ):
+        return None
+    match = _CTX_OVERFLOW_RE.search(text)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    return None, None
+
+
 logger = logging.getLogger("uat.openai_agent")
 
 
@@ -194,7 +246,14 @@ async def tool_call_loop(
             # model kept reasoning despite this request, so a no-op is visible.
             kwargs["extra_body"] = {"chat_template_kwargs": {"enable_thinking": False}}
 
-        response = await client.chat.completions.create(**kwargs)
+        try:
+            response = await client.chat.completions.create(**kwargs)
+        except openai.BadRequestError as e:
+            overflow = _parse_context_overflow(e)
+            if overflow is not None:
+                requested, ctx = overflow
+                raise ContextWindowExceededError(requested, ctx) from e
+            raise
         num_turns += 1
 
         # Accumulate running token totals; also capture first-turn prompt size as

--- a/tests/uat/stories/conftest.py
+++ b/tests/uat/stories/conftest.py
@@ -104,7 +104,7 @@ def ha_container():
         os.environ["HOMEASSISTANT_URL"] = url
         os.environ["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
 
-        wait_for_ha_ready(url, TEST_TOKEN, log=logger.info)
+        wait_for_ha_ready(url, TEST_TOKEN)
 
         yield {"url": url, "token": TEST_TOKEN, "port": port}
 

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -413,7 +413,12 @@ async def _run_test_prompt_inline(
     """
     import traceback
 
-    from uat.openai_agent import DEFAULT_MAX_TOKENS, run_scenario_inline
+    import openai
+    from uat.openai_agent import (
+        DEFAULT_MAX_TOKENS,
+        ContextWindowExceededError,
+        run_scenario_inline,
+    )
 
     tool_trace: list[str] = []
     start = time.monotonic()
@@ -428,6 +433,29 @@ async def _run_test_prompt_inline(
             tool_trace_sink=tool_trace,
             openai_tools=openai_tools,
         )
+    except ContextWindowExceededError as e:
+        # The conversation overflowed the backend context. Surface it as a
+        # distinct hard failure so a verification-based PASS can't mask a run
+        # that crashed mid-conversation (the entity may already exist from an
+        # earlier turn). See _compute_passed's completed guard.
+        logger.error(f"  [{agent_name}] context window exceeded: {e}")
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return 1, _inline_failure_summary(
+            agent_name,
+            error_msg="context_window_exceeded",
+            duration_ms=duration_ms,
+            tool_trace=tool_trace,
+            context_overflow={
+                "requested_tokens": e.requested_tokens,
+                "context_size": e.context_size,
+            },
+        )
+    except openai.APIConnectionError:
+        # The LLM backend is unreachable after the SDK exhausted its own
+        # retries (covers APITimeoutError). This is suite-fatal, not a per-story
+        # failure: propagate so the story loop aborts instead of swallowing it
+        # into a FAIL summary and then timing out on every remaining story.
+        raise
     except Exception as e:
         logger.exception(f"  [{agent_name}] inline run failed")
         tb = traceback.format_exc()
@@ -489,6 +517,7 @@ def _inline_failure_summary(
     traceback_text: str | None = None,
     duration_ms: int = 0,
     tool_trace: list[str] | None = None,
+    context_overflow: dict | None = None,
 ) -> dict:
     """Build a summary dict for a failed inline run (matches make_summary shape)."""
     test_phase: dict = {
@@ -499,6 +528,8 @@ def _inline_failure_summary(
         "error": error_msg,
         "tool_trace": tool_trace or [],
     }
+    if context_overflow is not None:
+        test_phase["context_overflow"] = context_overflow
     return {
         "agents": {
             agent_name: {
@@ -580,23 +611,54 @@ def get_git_info() -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 # Pass/fail determination
 # ---------------------------------------------------------------------------
+def _run_completed(test_phase: dict, summary: dict | None, exit_code: int) -> bool:
+    """Whether the agent run completed, as opposed to crashing mid-run.
+
+    Fail-closed: a subprocess agent that crashes produces unparseable stdout
+    (summary is None → empty test_phase), which must not count as completed
+    just because ha_checks pass on state left from an earlier turn. That is the
+    same masking class the inline ContextWindowExceededError path closes. Both
+    the inline and subprocess summary builders set ``completed`` explicitly, so
+    the fallback only fires when the summary is missing entirely.
+    """
+    return test_phase.get("completed", summary is not None and exit_code == 0)
+
+
 def _compute_passed(
     exit_code: int,
     tool_calls: int | None,
     verify_results: list[dict] | None,
+    completed: bool = True,
 ) -> bool:
     """Determine passed based on tool usage and verification results.
 
     Rules:
+    - Run did not complete (crashed mid-run, e.g. context overflow) → fail.
+      Checked first so a verification-based PASS can't mask a crashed agent
+      that happened to leave good HA state from an earlier turn.
     - Zero tool calls → fail (agent did nothing useful)
     - ha_checks present → all checks must pass
     - No checks → fall back to exit code
     """
+    if not completed:
+        return False
     if tool_calls == 0:
         return False
     if verify_results is not None:
         return all(r["passed"] for r in verify_results)
     return exit_code == 0
+
+
+def _suite_exit_code(all_results: list, backend_aborted: bool) -> int:
+    """Process exit code for a story run.
+
+    An aborted suite (the LLM backend went unreachable mid-run) is never a clean
+    pass, even if every story that did run passed, because it never ran to
+    completion. Otherwise nonzero iff any completed story run failed.
+    """
+    if backend_aborted:
+        return 1
+    return 1 if any(not passed for *_, passed in all_results) else 0
 
 
 # ---------------------------------------------------------------------------
@@ -643,6 +705,16 @@ def append_result(
     }
     if session_file:
         record["session_file"] = session_file
+
+    # Surface the failure-reason marker so reports can tell an incomplete run
+    # (e.g. context_window_exceeded, hit_iteration_limit) apart from a run that
+    # finished but failed its checks.
+    error = test_phase.get("error")
+    if error:
+        record["error"] = error
+    context_overflow = test_phase.get("context_overflow")
+    if context_overflow:
+        record["context_overflow"] = context_overflow
 
     # Cost from Claude's JSON output (direct, no session file needed)
     cost_usd = test_phase.get("cost_usd")
@@ -697,6 +769,41 @@ def append_result(
         f.write(json.dumps(record, separators=(",", ":")) + "\n")
 
 
+def append_abort_marker(
+    results_file: Path,
+    agent: str,
+    sha: str,
+    describe: str,
+    branch: str | None,
+    skipped_stories: list[str],
+    detail: str,
+) -> None:
+    """Append a run-level marker recording that the suite aborted early.
+
+    When the LLM backend goes unreachable the remaining stories are skipped
+    rather than recorded, so without this marker the results file would be
+    indistinguishable from a complete run that just happened to contain fewer
+    stories. A reader (or bat-story-eval) could fold a crashed run into a
+    baseline as a clean partial pass. The marker carries no ``story``/``passed``
+    keys, so it can't be miscounted as a per-story result; it exists so the
+    durable artifact is as self-describing as the nonzero exit code.
+    """
+    record = {
+        "sha": sha,
+        "version": describe,
+        "branch": branch,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "agent": agent,
+        "aborted": True,
+        "error": "backend_unreachable",
+        "detail": detail,
+        "skipped_stories": skipped_stories,
+    }
+    results_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(results_file, "a") as f:
+        f.write(json.dumps(record, separators=(",", ":")) + "\n")
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -733,6 +840,7 @@ async def run_stories(
 
     all_results: list[tuple[str, str, dict, int, dict | None, str | None, bool]] = []
     # Each entry: (agent, story_id, story, exit_code, summary, session_file, passed)
+    backend_aborted = False  # set if any agent aborted on an unreachable backend
 
     mcp_env_dict = parse_mcp_env(
         getattr(args, "mcp_env", None),
@@ -770,6 +878,7 @@ async def run_stories(
                 agent_stack.callback(_stop_container, ha)
 
             if use_inline:
+                import openai  # runtime ref for APIConnectionError in the story loop
                 from fastmcp import Client as _MCPClient
                 from uat.openai_agent import (
                     create_and_warm_openai_client,
@@ -843,7 +952,7 @@ async def run_stories(
                 inprocess_mcp_client(ha_url, ha_token)
             )
 
-            for _path, story in filtered:
+            for story_index, (_path, story) in enumerate(filtered):
                 sid = story["id"]
                 logger.info(f"\n{'=' * 60}")
                 logger.info(f"[{agent}] Story {sid}: {story['title']}")
@@ -870,16 +979,43 @@ async def run_stories(
                     ), (
                         "inline setup invariant: clients/model are populated when use_inline is True"
                     )
-                    rc, summary = await _run_test_prompt_inline(
-                        story["prompt"],
-                        agent_name=agent,
-                        openai_client=openai_client,
-                        mcp_client=inline_mcp_client,
-                        model=resolved_model,
-                        openai_tools=openai_tools,
-                        no_think=args.no_think,
-                        max_tokens=getattr(args, "max_tokens", None),
-                    )
+                    try:
+                        rc, summary = await _run_test_prompt_inline(
+                            story["prompt"],
+                            agent_name=agent,
+                            openai_client=openai_client,
+                            mcp_client=inline_mcp_client,
+                            model=resolved_model,
+                            openai_tools=openai_tools,
+                            no_think=args.no_think,
+                            max_tokens=getattr(args, "max_tokens", None),
+                        )
+                    except openai.APIConnectionError as e:
+                        # Backend unreachable after the SDK's retries. Abort this
+                        # agent's remaining stories rather than timing out on each.
+                        # Skipped stories are NOT recorded (they were never validly
+                        # tested), so the pass rate isn't corrupted by false fails.
+                        skipped = [s["id"] for _p, s in filtered[story_index:]]
+                        detail = f"{type(e).__name__}: {e}"
+                        logger.critical(
+                            f"[{agent}/{sid}] LLM backend unreachable "
+                            f"({detail}); aborting agent. "
+                            f"Skipped (not run): {', '.join(skipped)}"
+                        )
+                        # Record a run-level marker so the results file is as
+                        # self-describing as the nonzero exit code (the skipped
+                        # stories are otherwise absent, not recorded as fails).
+                        append_abort_marker(
+                            args.results_file,
+                            agent,
+                            sha,
+                            describe,
+                            args.branch,
+                            skipped,
+                            detail,
+                        )
+                        backend_aborted = True
+                        break
                 else:
                     rc, summary = _run_test_prompt(
                         story["prompt"],
@@ -943,6 +1079,7 @@ async def run_stories(
                     exit_code=rc,
                     tool_calls=agg.get("total_tool_calls"),
                     verify_results=verify_results,
+                    completed=_run_completed(test_phase, summary, rc),
                 )
                 all_results.append(
                     (agent, sid, story, rc, summary, session_file, passed)
@@ -983,11 +1120,16 @@ async def run_stories(
 
     failed = sum(1 for *_, passed in all_results if not passed)
     total = len(all_results)
-    if failed:
+    if backend_aborted:
+        logger.warning(
+            f"\nRun aborted: LLM backend became unreachable "
+            f"({failed}/{total} completed story runs failed before the abort)"
+        )
+    elif failed:
         logger.warning(f"\n{failed}/{total} story runs failed")
-        return 1
-    logger.info(f"\nAll {total} story runs passed")
-    return 0
+    else:
+        logger.info(f"\nAll {total} story runs passed")
+    return _suite_exit_code(all_results, backend_aborted)
 
 
 def main() -> None:

--- a/tests/uat/stories/test_run_story_record.py
+++ b/tests/uat/stories/test_run_story_record.py
@@ -5,7 +5,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from uat.stories.run_story import _extract_model, append_result
+import pytest
+from uat.openai_agent import ContextWindowExceededError
+from uat.stories.run_story import (
+    _compute_passed,
+    _extract_model,
+    _run_completed,
+    _run_test_prompt_inline,
+    _suite_exit_code,
+    append_abort_marker,
+    append_result,
+)
 
 _STORY = {"id": "s01", "category": "automation", "weight": 5}
 
@@ -123,3 +133,274 @@ def test_model_from_claude_session_fallback(tmp_path):
     sf = _write_claude_session(tmp_path, "claude-sonnet-4-6")
     record = _write_and_read(tmp_path, {}, agent="claude", session_file=sf)
     assert record["model"] == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Context-overflow hard failure (a crashed run must never be a clean PASS)
+# ---------------------------------------------------------------------------
+def test_compute_passed_incomplete_run_fails_despite_verify():
+    """A crashed run (completed=False) fails even when every ha_check passed.
+
+    This is the core un-masking: verification confirms end state, but if the
+    agent never finished, it isn't a clean pass.
+    """
+    assert (
+        _compute_passed(
+            exit_code=0,
+            tool_calls=5,
+            verify_results=[{"passed": True}],
+            completed=False,
+        )
+        is False
+    )
+
+
+def test_compute_passed_completed_run_still_uses_verify():
+    """A completed run is scored by verify as before (no behavior change)."""
+    assert (
+        _compute_passed(
+            exit_code=1,
+            tool_calls=5,
+            verify_results=[{"passed": True}],
+            completed=True,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_run_not_clean_pass(monkeypatch):
+    """End-to-end: an overflow crash flows through the inline path to a FAIL.
+
+    Exercises the real seam — the inline failure summary's completed flag and
+    its consumption by _compute_passed — so a wiring mistake that re-introduces
+    the mask is caught.
+    """
+
+    async def _raise(*_args, **_kwargs):
+        raise ContextWindowExceededError(27220, 24576)
+
+    monkeypatch.setattr("uat.openai_agent.run_scenario_inline", _raise)
+
+    rc, summary = await _run_test_prompt_inline(
+        "create an automation",
+        agent_name="openai",
+        openai_client=object(),
+        mcp_client=object(),
+        model="qwen3.6",
+        openai_tools=[],
+    )
+
+    assert rc == 1
+    test_phase = summary["agents"]["openai"]["test"]
+    assert test_phase["completed"] is False
+    assert test_phase["error"] == "context_window_exceeded"
+    assert test_phase["context_overflow"] == {
+        "requested_tokens": 27220,
+        "context_size": 24576,
+    }
+
+    # Verification passes (entity created before the overflow), but the run
+    # crashed mid-conversation, so it must NOT be scored as a clean pass.
+    passed = _compute_passed(
+        exit_code=rc,
+        tool_calls=5,
+        verify_results=[{"passed": True}],
+        completed=test_phase.get("completed", True),
+    )
+    assert passed is False
+
+
+def test_context_overflow_fields_recorded(tmp_path):
+    """error and context_overflow are surfaced in the JSONL record."""
+    record = _write_and_read(
+        tmp_path,
+        {
+            "error": "context_window_exceeded",
+            "context_overflow": {"requested_tokens": 27220, "context_size": 24576},
+        },
+    )
+    assert record["error"] == "context_window_exceeded"
+    assert record["context_overflow"] == {
+        "requested_tokens": 27220,
+        "context_size": 24576,
+    }
+
+
+def test_clean_record_omits_error_fields(tmp_path):
+    """A normal run carries no error/context_overflow clutter."""
+    record = _write_and_read(tmp_path, {"tokens_input": 10, "tokens_output": 5})
+    assert "error" not in record
+    assert "context_overflow" not in record
+
+
+# ---------------------------------------------------------------------------
+# _run_completed: the fail-closed seam that feeds _compute_passed's guard.
+# Three reviewers flagged the subprocess crash (summary=None) path as the same
+# masking class the inline fix closes, so pin it directly.
+# ---------------------------------------------------------------------------
+def test_run_completed_uses_explicit_flag():
+    """An explicit completed flag in test_phase wins over the fallback."""
+    assert _run_completed({"completed": True}, {"agents": {}}, 1) is True
+    assert _run_completed({"completed": False}, {"agents": {}}, 0) is False
+
+
+def test_run_completed_fail_closed_on_missing_summary():
+    """A subprocess crash (summary None → empty test_phase) is never completed.
+
+    Fail-closed even on exit_code 0, so a crash can't ride a passing ha_check to
+    a green PASS on state left from an earlier turn.
+    """
+    assert _run_completed({}, None, 1) is False
+    assert _run_completed({}, None, 0) is False
+
+
+def test_run_completed_present_summary_missing_flag_uses_exit_code():
+    """Defensive fallback: summary present but no completed key defers to exit code."""
+    assert _run_completed({}, {"agents": {}}, 0) is True
+    assert _run_completed({}, {"agents": {}}, 1) is False
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_degraded_counts_still_fails(monkeypatch):
+    """Overflow with unparseable counts (None, None) still hard-fails.
+
+    The safety net the design relies on: even when token counts can't be
+    parsed, the run is marked incomplete and cannot be masked by passing checks.
+    """
+
+    async def _raise(*_args, **_kwargs):
+        raise ContextWindowExceededError(None, None)
+
+    monkeypatch.setattr("uat.openai_agent.run_scenario_inline", _raise)
+
+    _rc, summary = await _run_test_prompt_inline(
+        "create an automation",
+        agent_name="openai",
+        openai_client=object(),
+        mcp_client=object(),
+        model="qwen3.6",
+        openai_tools=[],
+    )
+
+    test_phase = summary["agents"]["openai"]["test"]
+    assert test_phase["completed"] is False
+    assert test_phase["context_overflow"] == {
+        "requested_tokens": None,
+        "context_size": None,
+    }
+    passed = _compute_passed(
+        exit_code=1,
+        tool_calls=5,
+        verify_results=[{"passed": True}],
+        completed=_run_completed(test_phase, summary, 1),
+    )
+    assert passed is False
+
+
+# ---------------------------------------------------------------------------
+# Backend-unreachable fail-fast: a connection error (LLM gone, retries
+# exhausted) must PROPAGATE out of the inline path so the story loop can abort,
+# rather than being swallowed into a per-story FAIL summary that lets every
+# remaining story time out.
+# ---------------------------------------------------------------------------
+async def _run_inline_with_raise(monkeypatch, exc):
+    async def _raise(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr("uat.openai_agent.run_scenario_inline", _raise)
+    return await _run_test_prompt_inline(
+        "create an automation",
+        agent_name="openai",
+        openai_client=object(),
+        mcp_client=object(),
+        model="qwen3.6",
+        openai_tools=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_connection_error_propagates(monkeypatch):
+    """An APIConnectionError is not swallowed into a FAIL summary; it propagates."""
+    import httpx
+    import openai
+
+    req = httpx.Request("POST", "http://x/v1/chat/completions")
+    with pytest.raises(openai.APIConnectionError):
+        await _run_inline_with_raise(
+            monkeypatch, openai.APIConnectionError(request=req)
+        )
+
+
+@pytest.mark.asyncio
+async def test_backend_timeout_propagates_as_connection_error(monkeypatch):
+    """APITimeoutError (an APIConnectionError subclass) propagates the same way.
+
+    The loop catches APIConnectionError, so a timeout must be catchable as one.
+    """
+    import httpx
+    import openai
+
+    req = httpx.Request("POST", "http://x/v1/chat/completions")
+    with pytest.raises(openai.APIConnectionError):
+        await _run_inline_with_raise(monkeypatch, openai.APITimeoutError(request=req))
+
+
+def _row(passed: bool) -> tuple:
+    """A minimal all_results entry: (agent, sid, story, rc, summary, session, passed)."""
+    return ("openai", "s01", {}, 0, {}, None, passed)
+
+
+def test_suite_exit_code_abort_is_never_success():
+    """A backend abort returns nonzero even when every story that ran passed.
+
+    This is the invariant the fail-fast exists for: an incomplete suite is not a
+    clean pass.
+    """
+    assert _suite_exit_code([_row(True), _row(True)], backend_aborted=True) == 1
+
+
+def test_suite_exit_code_clean_pass():
+    """All ran stories passed and no abort → success."""
+    assert _suite_exit_code([_row(True), _row(True)], backend_aborted=False) == 0
+
+
+def test_suite_exit_code_failure_without_abort():
+    """A failed story (no abort) returns nonzero."""
+    assert _suite_exit_code([_row(True), _row(False)], backend_aborted=False) == 1
+
+
+def test_suite_exit_code_abort_with_no_completed_stories():
+    """Backend dies on the very first story: empty results + abort still nonzero.
+
+    `any(...)` over [] is False, so without the abort short-circuit this would
+    return 0 (success) and re-open the masking bug.
+    """
+    assert _suite_exit_code([], backend_aborted=True) == 1
+
+
+def test_abort_marker_is_self_describing(tmp_path):
+    """The abort marker records the skip and carries no story/passed keys.
+
+    Absence of story/passed is the contract: bat-story-eval counts per-story
+    results by grepping those keys, so the marker must not be miscountable as a
+    pass or fail for any story.
+    """
+    results_file = tmp_path / "results.jsonl"
+    append_abort_marker(
+        results_file,
+        "openai",
+        sha="abc123",
+        describe="v7.6.0",
+        branch=None,
+        skipped_stories=["s02", "s03", "s04"],
+        detail="APITimeoutError: Request timed out.",
+    )
+    record = json.loads(results_file.read_text().splitlines()[-1])
+    assert record["aborted"] is True
+    assert record["error"] == "backend_unreachable"
+    assert record["skipped_stories"] == ["s02", "s03", "s04"]
+    assert record["detail"] == "APITimeoutError: Request timed out."
+    assert record["agent"] == "openai"
+    assert "story" not in record
+    assert "passed" not in record

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -789,3 +789,96 @@ class TestDetectQuantization:
         self._patch_client(monkeypatch, raise_status=True)
         result = await openai_agent.detect_quantization("http://h/v1", "m")
         assert result is None
+
+
+def _bad_request(message: str) -> openai.BadRequestError:  # noqa: F821
+    """Build a real ``openai.BadRequestError`` carrying ``message``."""
+    import httpx
+    import openai
+
+    request = httpx.Request("POST", "http://test/v1/chat/completions")
+    response = httpx.Response(400, request=request)
+    return openai.BadRequestError(
+        message,
+        response=response,
+        body={"error": {"type": "exceed_context_size_error"}},
+    )
+
+
+class TestParseContextOverflow:
+    """Test detection/parsing of llama-server context-overflow 400s."""
+
+    def test_extracts_requested_and_context_tokens(self):
+        err = _bad_request(
+            "request (27220 tokens) exceeds the available context size (24576 tokens)"
+        )
+        assert openai_agent._parse_context_overflow(err) == (27220, 24576)
+
+    def test_none_for_unrelated_bad_request(self):
+        err = _bad_request("invalid 'temperature': must be <= 2")
+        assert openai_agent._parse_context_overflow(err) is None
+
+    def test_marker_without_numbers_returns_none_pair(self):
+        """Marker present but no parseable counts → (None, None), still an overflow."""
+        err = _bad_request("exceed_context_size_error: too long")
+        assert openai_agent._parse_context_overflow(err) == (None, None)
+
+    def test_extracts_from_sdk_wire_format(self):
+        """The SDK stringifies as ``Error code: 400 - {body-dict}``; parse survives it.
+
+        Exercises the real on-the-wire shape (regex embedded in a dict repr,
+        plus the ``exceed_context_size_error`` type marker) rather than a clean
+        pre-extracted message.
+        """
+        err = _bad_request(
+            "Error code: 400 - {'error': {'message': 'request (27220 tokens) "
+            "exceeds the available context size (24576 tokens)', "
+            "'type': 'exceed_context_size_error'}}"
+        )
+        assert openai_agent._parse_context_overflow(err) == (27220, 24576)
+
+
+class TestContextOverflowInLoop:
+    """Test that the tool-call loop surfaces context overflow distinctly."""
+
+    @pytest.mark.asyncio
+    async def test_overflow_raises_context_window_exceeded(self):
+        """A context-overflow 400 becomes ContextWindowExceededError with counts."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=_bad_request(
+                "request (27220 tokens) exceeds the available context size "
+                "(24576 tokens)"
+            )
+        )
+
+        with pytest.raises(openai_agent.ContextWindowExceededError) as exc_info:
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+            )
+
+        assert exc_info.value.requested_tokens == 27220
+        assert exc_info.value.context_size == 24576
+
+    @pytest.mark.asyncio
+    async def test_unrelated_bad_request_propagates(self):
+        """A non-overflow 400 is re-raised unchanged, not mislabeled as overflow."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=_bad_request("invalid 'temperature': must be <= 2")
+        )
+
+        import openai
+
+        with pytest.raises(openai.BadRequestError):
+            await openai_agent.tool_call_loop(
+                client=mock_client,
+                model="qwen3.6",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                mcp_client=AsyncMock(),
+            )


### PR DESCRIPTION
## What does this PR do?

Two reliability fixes to the BAT (bot-acceptance-testing) story runner so a crashed agent can no longer be recorded as a clean PASS. Both were validated live against a local llama-server.

1. **Context overflow is now a hard failure.** When the conversation exceeds the backend context window, `tool_call_loop` raises a typed `ContextWindowExceededError`, and `_compute_passed` fails the story via a new `completed` guard checked before the verification step. Previously an entity created in an earlier turn made `ha_checks` pass, masking the crash as a green PASS with null stats. The result row now records `error: context_window_exceeded` and the token counts. (Validated live: story s06 created its automation, overflowed, and is now correctly recorded FAIL.)

2. **An unreachable LLM backend aborts the suite** instead of timing out on every remaining story. A connection/timeout error (`openai.APIConnectionError`, raised only after the SDK exhausts its own retries) now propagates and aborts the current agent's remaining stories. They are skipped (not recorded as false fails), a self-describing abort marker is written to the results file, and the run exits nonzero. Previously each remaining story burned a ~120s timeout and recorded a false FAIL. (Validated live: llama-server killed mid-suite at s02; the run skipped s03-s14 and exited 1, with only s01 recorded.)

Also drops an invalid `log=` kwarg from the `wait_for_ha_ready` call in the story fixture (the function takes no such argument; it was crashing the live-container story suite at setup).

**Design notes (intentional, not bugs):**
- The abort fires on the first `APIConnectionError` with no consecutive-failure threshold. The SDK already absorbs transient retries before raising, and real backend death (killed server, VRAM OOM) is persistent.
- `backend_aborted` forces the whole invocation to exit nonzero even if a later agent on a healthy backend would pass. This is deliberately conservative: an incomplete suite is not a clean run.

All new behavior is unit-tested (overflow parsing, the raise/propagate forks, the `completed` and `_suite_exit_code` invariants, the abort-marker shape). Scope is the inline (openai) path; subprocess agents (claude/gemini) hit their own cloud APIs and already fail closed.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
