### PR TITLE
test(uat): treat request timeout as per-story failure, not suite abort

### DIFF
--- a/tests/uat/README.md
+++ b/tests/uat/README.md
@@ -97,7 +97,7 @@ echo '{"test_prompt":"..."}' | uv run python tests/uat/run_uat.py --agents opena
 | `--ha-url` | (start container) | Use existing HA instance |
 | `--ha-token` | test token | HA long-lived access token |
 | `--branch` | (local code) | Git branch/tag for ha-mcp |
-| `--timeout` | 120 | Timeout per phase in seconds |
+| `--timeout` | 300 | Timeout per phase in seconds |
 | `--base-url` | — | OpenAI-compatible API base URL (required for `openai` agent) |
 | `--api-key` | `no-key` | API key for OpenAI-compatible endpoint |
 | `--model` | (auto-detect) | Model name (auto-detected from `/v1/models` for openai) |

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -32,7 +32,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from uat._logging import configure_cli_logging
 
 DEFAULT_API_KEY = "no-key"
-DEFAULT_TIMEOUT = 120
+# Per-request timeout. Sized for slow local backends: a full DEFAULT_MAX_TOKENS
+# generation on a small quantized model plus prefill on a large tool context can
+# run several minutes, so a tight timeout would fail legitimate long turns. A
+# single timed-out turn is no longer suite-fatal (see _run_test_prompt_inline's
+# APITimeoutError handling), so erring high is cheap.
+DEFAULT_TIMEOUT = 600
+# Retries are for transient blips; retrying a slow local generation just re-runs
+# the same slow work, so one retry is plenty and keeps a timed-out turn's worst
+# case at 2x timeout rather than 3x.
+DEFAULT_MAX_RETRIES = 1
 DEFAULT_MAX_TOKENS = 8192
 MAX_TOOL_LOOP_ITERATIONS = 20
 
@@ -502,7 +511,12 @@ async def create_and_warm_openai_client(
     30-120s while the model is copied in). ``quantization`` is best-effort
     (``None`` when the backend doesn't expose it). Raises on failure.
     """
-    client = openai.AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+    client = openai.AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        max_retries=DEFAULT_MAX_RETRIES,
+    )
     resolved_model = model or await detect_model(client)
     quantization = await detect_quantization(base_url, resolved_model)
     suffix = f" ({quantization})" if quantization else ""

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -63,6 +63,17 @@ DEFAULT_RESULTS_FILE = REPO_ROOT / "local" / "uat-results.jsonl"
 # stories. Claude and Gemini are external CLIs and take the subprocess path.
 INLINE_AGENTS: frozenset[str] = frozenset({"openai"})
 
+# A single request timeout is a per-story failure (the backend may be alive but
+# slow). This many *consecutive* timeouts means the backend is effectively gone
+# (unresponsive, or dropping packets so connects time out rather than refuse),
+# so the suite aborts rather than timing out on every remaining story.
+CONSECUTIVE_TIMEOUT_ABORT = 2
+
+# test_phase["error"] marker for a request timeout. Shared by the producer (the
+# inline timeout handler) and the consumer (the story loop's streak counter) so
+# the two can't drift apart and silently disable the consecutive-timeout abort.
+TIMEOUT_ERROR_MARKER = "timeout"
+
 # Add paths for imports
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(TESTS_DIR))
@@ -450,11 +461,29 @@ async def _run_test_prompt_inline(
                 "context_size": e.context_size,
             },
         )
+    except openai.APITimeoutError as e:
+        # A request timed out, but the backend may well be alive: a slow or
+        # degenerate-loop generation on a local model can outrun even a generous
+        # per-request timeout. Treat it as a per-story failure, NOT suite-fatal.
+        # completed=False (via _inline_failure_summary) so a state-based verify
+        # can't mask it. The story loop aborts only after several *consecutive*
+        # timeouts (a genuinely unresponsive or packet-dropping backend, whose
+        # connect attempts surface as timeouts rather than refusals). Must be
+        # caught before APIConnectionError; APITimeoutError subclasses it.
+        logger.warning(f"  [{agent_name}] request timed out: {e}")
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return 1, _inline_failure_summary(
+            agent_name,
+            error_msg=TIMEOUT_ERROR_MARKER,
+            duration_ms=duration_ms,
+            tool_trace=tool_trace,
+        )
     except openai.APIConnectionError:
-        # The LLM backend is unreachable after the SDK exhausted its own
-        # retries (covers APITimeoutError). This is suite-fatal, not a per-story
-        # failure: propagate so the story loop aborts instead of swallowing it
-        # into a FAIL summary and then timing out on every remaining story.
+        # The LLM backend is unreachable after the SDK exhausted its own retries:
+        # a refused or reset connection, NOT a timeout (handled above). This is
+        # suite-fatal, not a per-story failure: propagate so the story loop
+        # aborts instead of swallowing it into a FAIL summary and then failing on
+        # every remaining story.
         raise
     except Exception as e:
         logger.exception(f"  [{agent_name}] inline run failed")
@@ -804,6 +833,50 @@ def append_abort_marker(
         f.write(json.dumps(record, separators=(",", ":")) + "\n")
 
 
+def _update_timeout_streak(consecutive: int, *, was_timeout: bool) -> int:
+    """Running count of consecutive per-story request timeouts.
+
+    A timeout increments the streak; any non-timeout story resets it to 0. The
+    caller aborts the agent once the streak reaches ``CONSECUTIVE_TIMEOUT_ABORT``
+    (the backend has stopped responding, vs one slow story on a live backend).
+    """
+    return consecutive + 1 if was_timeout else 0
+
+
+def _stories_after(filtered: list[tuple[Path, dict]], story_index: int) -> list[str]:
+    """Story ids after ``story_index``: the skip list for the consecutive-timeout
+    abort. The timed-out story at ``story_index`` was already recorded as a
+    per-story failure, so only later stories are skipped. Contrast the
+    connection-error path, which skips from ``story_index`` itself because that
+    story never validly ran.
+    """
+    return [s["id"] for _p, s in filtered[story_index + 1 :]]
+
+
+def _record_backend_abort(
+    results_file: Path,
+    agent: str,
+    sid: str,
+    skipped_stories: list[str],
+    detail: str,
+    *,
+    sha: str,
+    describe: str,
+    branch: str | None,
+) -> None:
+    """Log and record an early suite abort. Shared by the connection-error path
+    (a refused/reset connection) and the consecutive-timeout path (a backend
+    that has stopped responding). ``skipped_stories`` are NOT recorded as
+    per-story rows, so the pass rate isn't corrupted by false fails."""
+    logger.critical(
+        f"[{agent}/{sid}] LLM backend unreachable ({detail}); aborting agent. "
+        f"Skipped (not run): {', '.join(skipped_stories) if skipped_stories else '(none)'}"
+    )
+    append_abort_marker(
+        results_file, agent, sha, describe, branch, skipped_stories, detail
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -952,6 +1025,10 @@ async def run_stories(
                 inprocess_mcp_client(ha_url, ha_token)
             )
 
+            # Consecutive per-story timeouts; reset by any non-timeout story.
+            # Hitting CONSECUTIVE_TIMEOUT_ABORT aborts the agent (backend gone).
+            consecutive_timeouts = 0
+
             for story_index, (_path, story) in enumerate(filtered):
                 sid = story["id"]
                 logger.info(f"\n{'=' * 60}")
@@ -991,28 +1068,20 @@ async def run_stories(
                             max_tokens=getattr(args, "max_tokens", None),
                         )
                     except openai.APIConnectionError as e:
-                        # Backend unreachable after the SDK's retries. Abort this
-                        # agent's remaining stories rather than timing out on each.
-                        # Skipped stories are NOT recorded (they were never validly
-                        # tested), so the pass rate isn't corrupted by false fails.
-                        skipped = [s["id"] for _p, s in filtered[story_index:]]
-                        detail = f"{type(e).__name__}: {e}"
-                        logger.critical(
-                            f"[{agent}/{sid}] LLM backend unreachable "
-                            f"({detail}); aborting agent. "
-                            f"Skipped (not run): {', '.join(skipped)}"
-                        )
-                        # Record a run-level marker so the results file is as
-                        # self-describing as the nonzero exit code (the skipped
-                        # stories are otherwise absent, not recorded as fails).
-                        append_abort_marker(
+                        # A refused/reset connection (NOT a timeout; those are
+                        # handled per-story inside _run_test_prompt_inline). The
+                        # backend is gone, so abort this agent's remaining stories
+                        # rather than failing each one in turn. The current story
+                        # never validly ran, so it is skipped too (not recorded).
+                        _record_backend_abort(
                             args.results_file,
                             agent,
-                            sha,
-                            describe,
-                            args.branch,
-                            skipped,
-                            detail,
+                            sid,
+                            [s["id"] for _p, s in filtered[story_index:]],
+                            f"{type(e).__name__}: {e}",
+                            sha=sha,
+                            describe=describe,
+                            branch=args.branch,
                         )
                         backend_aborted = True
                         break
@@ -1103,6 +1172,30 @@ async def run_stories(
 
                 if session_file:
                     logger.info(f"[{agent}/{sid}] Session file: {session_file}")
+
+                # A request timeout is recorded above as a per-story failure, but
+                # several in a row mean the backend has stopped responding: abort
+                # rather than time out on every remaining story. Unlike the
+                # connection-error path (which skips the current story, never
+                # validly run), the timed-out story here WAS recorded, so only
+                # the stories after it are skipped.
+                consecutive_timeouts = _update_timeout_streak(
+                    consecutive_timeouts,
+                    was_timeout=test_phase.get("error") == TIMEOUT_ERROR_MARKER,
+                )
+                if consecutive_timeouts >= CONSECUTIVE_TIMEOUT_ABORT:
+                    _record_backend_abort(
+                        args.results_file,
+                        agent,
+                        sid,
+                        _stories_after(filtered, story_index),
+                        f"{consecutive_timeouts} consecutive request timeouts",
+                        sha=sha,
+                        describe=describe,
+                        branch=args.branch,
+                    )
+                    backend_aborted = True
+                    break
 
     # Summary
     logger.info(f"\n{'=' * 60}")

--- a/tests/uat/stories/test_run_story_record.py
+++ b/tests/uat/stories/test_run_story_record.py
@@ -8,11 +8,14 @@ from pathlib import Path
 import pytest
 from uat.openai_agent import ContextWindowExceededError
 from uat.stories.run_story import (
+    CONSECUTIVE_TIMEOUT_ABORT,
     _compute_passed,
     _extract_model,
     _run_completed,
     _run_test_prompt_inline,
+    _stories_after,
     _suite_exit_code,
+    _update_timeout_streak,
     append_abort_marker,
     append_result,
 )
@@ -333,17 +336,90 @@ async def test_backend_connection_error_propagates(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_backend_timeout_propagates_as_connection_error(monkeypatch):
-    """APITimeoutError (an APIConnectionError subclass) propagates the same way.
+async def test_backend_timeout_is_per_story_failure_not_fatal(monkeypatch):
+    """APITimeoutError is a per-story FAIL, not a suite-fatal propagation.
 
-    The loop catches APIConnectionError, so a timeout must be catchable as one.
+    A timeout can happen on a slow-but-alive local backend (a long or
+    degenerate-loop generation), so unlike a refused connection it must NOT
+    abort the whole suite. It returns a failure summary marked completed=False
+    (so a state-based verify can't mask it) and error="timeout" (so the loop
+    can count consecutive timeouts toward an abort). APITimeoutError subclasses
+    APIConnectionError, so this also guards the except ordering in the inline
+    path: a regression there would re-raise and this test would error.
     """
     import httpx
     import openai
 
     req = httpx.Request("POST", "http://x/v1/chat/completions")
-    with pytest.raises(openai.APIConnectionError):
-        await _run_inline_with_raise(monkeypatch, openai.APITimeoutError(request=req))
+    rc, summary = await _run_inline_with_raise(
+        monkeypatch, openai.APITimeoutError(request=req)
+    )
+    assert rc == 1
+    test_phase = summary["agents"]["openai"]["test"]
+    assert test_phase["completed"] is False
+    assert test_phase["error"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_timeout_story_scores_as_fail(monkeypatch):
+    """A timed-out story is FAIL even if ha_checks pass on stale state.
+
+    The timeout marks completed=False, and _compute_passed's completed guard
+    fails it before the verify results are consulted, same anti-masking path
+    as a context-overflow crash.
+    """
+    import httpx
+    import openai
+
+    req = httpx.Request("POST", "http://x/v1/chat/completions")
+    _rc, summary = await _run_inline_with_raise(
+        monkeypatch, openai.APITimeoutError(request=req)
+    )
+    test_phase = summary["agents"]["openai"]["test"]
+    passed = _compute_passed(
+        exit_code=1,
+        tool_calls=None,
+        verify_results=[{"passed": True}],
+        completed=_run_completed(test_phase, summary, 1),
+    )
+    assert passed is False
+
+
+def test_consecutive_timeouts_reach_abort_threshold():
+    """Back-to-back timeouts accumulate until the abort threshold is hit."""
+    streak = 0
+    for _ in range(CONSECUTIVE_TIMEOUT_ABORT - 1):
+        streak = _update_timeout_streak(streak, was_timeout=True)
+        assert streak < CONSECUTIVE_TIMEOUT_ABORT  # still below: keep running
+    streak = _update_timeout_streak(streak, was_timeout=True)
+    assert streak >= CONSECUTIVE_TIMEOUT_ABORT  # threshold reached -> abort
+
+
+def test_non_timeout_story_resets_timeout_streak():
+    """A non-timeout story clears the streak so isolated timeouts never abort.
+
+    Without the reset, timeouts scattered across a long run would eventually sum
+    to the threshold and abort a live backend. A single timeout staying below
+    the threshold also encodes the design invariant that one timeout is not
+    suite-fatal (threshold >= 2).
+    """
+    assert _update_timeout_streak(CONSECUTIVE_TIMEOUT_ABORT - 1, was_timeout=False) == 0
+    assert _update_timeout_streak(0, was_timeout=True) < CONSECUTIVE_TIMEOUT_ABORT
+
+
+def test_timeout_abort_skips_only_stories_after_current():
+    """The consecutive-timeout abort skips stories AFTER the current one.
+
+    The timed-out story at story_index was already recorded as a per-story fail,
+    so it must NOT appear in the skip list (off-by-one here would double-count it
+    as both failed and skipped, corrupting pass-rate accounting). Contrast the
+    connection-error path, which skips from story_index itself.
+    """
+    filtered = [(Path(f"s{i}.yaml"), {"id": f"s0{i}"}) for i in range(1, 6)]
+    # Abort triggered while handling index 1 (story s02): skip s03, s04, s05.
+    assert _stories_after(filtered, 1) == ["s03", "s04", "s05"]
+    # Abort on the last story leaves nothing to skip.
+    assert _stories_after(filtered, len(filtered) - 1) == []
 
 
 def _row(passed: bool) -> tuple:


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive in the BAT story runner's backend fail-fast: a single slow LLM request was wrongly killing the whole suite.

The runner treated every `openai.APIConnectionError` as "backend unreachable" and aborted all remaining stories. But `APITimeoutError` is a *subclass* of `APIConnectionError`, and a request can time out on a slow-but-alive local backend (a long or degenerate-loop generation). In a recent gemma4 run, one slow turn on story s06 timed out and aborted the suite even though the backend was still up afterward.

Changes:

- **Classify timeout vs connection-down.** `APITimeoutError` is now a per-story FAIL (`completed=False`, so a state-based verify still can't mask it), caught *before* `APIConnectionError`. A refused/reset connection stays suite-fatal.
- **Consecutive-timeout abort.** A backend that has actually stopped responding (or drops packets, so connects time out rather than refuse) still aborts after `CONSECUTIVE_TIMEOUT_ABORT` (2) consecutive timeouts. A non-timeout story resets the streak.
- **Per-request timeout 120s to 600s, `max_retries` 2 to 1.** 120s was too tight for a small quantized model on tool-heavy turns (a full-length generation plus large-context prefill runs several minutes). One retry keeps a timed-out turn's worst case at 2x rather than 3x.

Also fixes pre-existing drift in `tests/uat/README.md` (`--timeout` default 120 to 300, the actual `run_uat.py` default).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

69 unit tests pass in `tests/uat/`. The original false-positive is the live evidence: the gemma4 run that motivated this fix. End-to-end re-validation against a deliberately-stalled backend is pending (left unchecked above).

## Checklist
- [x] I have updated documentation if needed
