### PR TITLE
docs: differentiate ha-mcp from Home Assistant's built-in MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Spend less time configuring, more time enjoying your smart home.
 
 Home Assistant ships its own [MCP Server integration](https://www.home-assistant.io/integrations/mcp_server/). It is built on the **Assist** pipeline, so a connected MCP client can read and control the entities you have exposed to Assist and run the intents Assist understands — handy for voice-style control of already-exposed devices.
 
-ha-mcp is a standalone server built for **configuring, building, and debugging** your smart home, not just controlling it. On top of device control it adds capabilities the built-in integration does not have:
+ha-mcp is a standalone server built for **configuring, building, and debugging** your smart home, not just controlling it. On top of device control, it adds capabilities the built-in integration does not have:
 
 | Capability | Built-in MCP Server | ha-mcp |
 |------------|:-------------------:|:------:|
@@ -231,7 +231,7 @@ ha-mcp is a standalone server built for **configuring, building, and debugging**
 | Manage helpers, areas, zones, labels, groups | No | Yes |
 | Backups, add-ons, HACS, device & entity registry | No | Yes |
 
-**Rule of thumb:** use the built-in integration for voice-style control of devices you have already exposed; use ha-mcp when you want an AI assistant that can also build and maintain your Home Assistant setup.
+**Rule of thumb:** Use the built-in integration for voice-style control of devices you have already exposed; use ha-mcp when you want an AI assistant that can also build and maintain your Home Assistant setup.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,26 @@ Spend less time configuring, more time enjoying your smart home.
 
 ---
 
+## ha-mcp vs. Home Assistant's built-in MCP Server
+
+Home Assistant ships its own [MCP Server integration](https://www.home-assistant.io/integrations/mcp_server/). It is built on the **Assist** pipeline, so a connected MCP client can read and control the entities you have exposed to Assist and run the intents Assist understands — handy for voice-style control of already-exposed devices.
+
+ha-mcp is a standalone server built for **configuring, building, and debugging** your smart home, not just controlling it. On top of device control it adds capabilities the built-in integration does not have:
+
+| Capability | Built-in MCP Server | ha-mcp |
+|------------|:-------------------:|:------:|
+| Control exposed devices, query states | Yes | Yes |
+| Entity scope | Only entities exposed to Assist | Everything in Home Assistant |
+| Create / edit automations, scripts, scenes | No | Yes |
+| Build & edit dashboards | No | Yes |
+| Debug automations from traces, read history & logs | No | Yes |
+| Manage helpers, areas, zones, labels, groups | No | Yes |
+| Backups, add-ons, HACS, device & entity registry | No | Yes |
+
+**Rule of thumb:** use the built-in integration for voice-style control of devices you have already exposed; use ha-mcp when you want an AI assistant that can also build and maintain your Home Assistant setup.
+
+---
+
 ## 🔌 Custom Component (ha_mcp_tools) *(beta)*
 
 Some tools require a companion custom component installed in Home Assistant. Standard HA APIs do not expose file system access or YAML config editing. This component provides both.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Spend less time configuring, more time enjoying your smart home.
 
 ---
 
-## ha-mcp vs. Home Assistant's built-in MCP Server
+## 🆚 ha-mcp vs. Home Assistant's built-in MCP Server
 
 Home Assistant ships its own [MCP Server integration](https://www.home-assistant.io/integrations/mcp_server/). It is built on the **Assist** pipeline, so a connected MCP client can read and control the entities you have exposed to Assist and run the intents Assist understands — handy for voice-style control of already-exposed devices.
 


### PR DESCRIPTION
## What does this PR do?

Adds a README section explaining how ha-mcp differs from Home Assistant's
built-in [MCP Server integration](https://www.home-assistant.io/integrations/mcp_server/).
The built-in integration wraps the Assist pipeline (control/query of
Assist-exposed entities), whereas ha-mcp also creates and edits automations,
scripts, scenes, dashboards, and helpers, debugs automations from traces, and
manages the rest of the configuration.

Addresses discussion #1465, where a user asked what the difference is and
suggested documenting it in the README.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent _(N/A — docs only)_
- [ ] All automated tests pass (`uv run pytest`) _(N/A — no code changed)_
- [ ] Code follows style guidelines (`uv run ruff check`) _(N/A — no Python changed)_

## Checklist
- [x] I have updated documentation if needed
