### PR TITLE
refactor: add display title to ha_get_skill_guide tool

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -1212,7 +1212,11 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         self.mcp.tool(
             name=SKILL_TOOL_NAME,
             description=tool_description,
-            annotations={"readOnlyHint": True, "idempotentHint": True},
+            annotations={
+                "readOnlyHint": True,
+                "idempotentHint": True,
+                "title": "Get Home Assistant Best Practices Skill Guide",
+            },
             tags={"System"},
         )(ha_get_skill_guide)
         logger.info(

--- a/tests/src/unit/test_skills_instructions.py
+++ b/tests/src/unit/test_skills_instructions.py
@@ -630,7 +630,13 @@ class TestSkillToolRegistration:
 
     def test_tool_annotations_are_correct(self, server, populated_dir, captor):
         """readOnlyHint + idempotentHint must stay set — a flip to
-        destructiveHint would weaken client-side permission gating."""
+        destructiveHint would weaken client-side permission gating.
+
+        The ``title`` annotation must also be present so the tool shows a
+        human-readable display name in client tool lists, matching every
+        other tool (all of which carry an ``annotations.title``). Without
+        it, clients fall back to rendering the raw ``ha_get_skill_guide``
+        name."""
         from ha_mcp.server import SKILL_TOOL_NAME
 
         captured, fake_tool = captor
@@ -643,6 +649,9 @@ class TestSkillToolRegistration:
         assert annotations.get("readOnlyHint") is True
         assert annotations.get("idempotentHint") is True
         assert annotations.get("destructiveHint") is not True
+        assert (
+            annotations.get("title") == "Get Home Assistant Best Practices Skill Guide"
+        )
 
     def test_tool_tags_are_correct(self, server, populated_dir, captor):
         """``System`` tag drives settings-UI placement; a missing tag


### PR DESCRIPTION
## What does this PR do?

`ha_get_skill_guide` was the only tool that did not show a human-readable
display name in MCP client tool lists, so clients fell back to rendering the
raw `ha_get_skill_guide` name.

Every other tool sets a `title` inside its `annotations` dict (e.g.
`"title": "Get Blueprint"`), which MCP clients render as the display name.
`ha_get_skill_guide` is registered inline in `server.py` via
`self.mcp.tool(...)` rather than the `@tool` decorator path, and the title
annotation was never carried over when the per-skill tools were consolidated
into this one polymorphic tool (#1289).

This adds `"title": "Get Home Assistant Best Practices Skill Guide"` to its
annotations, restoring parity with all other tools.

The change is display-only. The tool `name` -- used for invocation,
mandatory-pinning, and BM25 retrieval -- is unchanged, so capability is
unaffected. A title assertion was added to `test_tool_annotations_are_correct`.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
