### PR TITLE
ci: reduce Docker Hub pulls in performance-tests workflow

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -29,6 +29,13 @@ env:
   UV_CACHE_DIR: /tmp/.uv-cache
   # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
   HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.5.4"
+  # Disable Testcontainers' Ryuk reaper: it has been reported to leave
+  # zombie containers on GHA runners (see #366, Ilya0527 2026-05-18).
+  # The E2E fixture in tests/src/e2e/conftest.py relies instead on the
+  # enclosing ``with container:`` context manager — Python guarantees
+  # its ``__exit__`` fires on both normal and exception flows, so the
+  # Ryuk safety net is not needed for deterministic cleanup. Refs #366.
+  TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
   performance-tests:
@@ -38,11 +45,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-      with:
-        cache-binary: true
 
     - name: Cache HA Docker image
       id: cache-ha-image

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1741,7 +1741,8 @@ def ha_container_with_fresh_config(_blueprint_http_server):
             # Container cleanup runs via the enclosing ``with container:``
             # block's ``__exit__`` (calls ``stop()`` which removes the
             # container). With ``TESTCONTAINERS_RYUK_DISABLED=true`` set in
-            # the CI workflow env (see .github/workflows/{pr,e2e-tests}.yml)
+            # the CI workflow env (see
+            # .github/workflows/{pr,e2e-tests,performance-tests}.yml)
             # the with-block exit IS the only cleanup mechanism — Python's
             # context-manager protocol guarantees ``__exit__`` fires on
             # both normal and exception flows, so the Ryuk reaper safety


### PR DESCRIPTION
## What does this PR do?

Reduces the performance-tests workflow's exposure to transient Docker Hub
(`registry-1.docker.io`) timeouts. A recent master run failed booting
BuildKit: `pulling image moby/buildkit:buildx-stable-1 ... context deadline
exceeded`. Two changes, both scoped to
`.github/workflows/performance-tests.yml`:

- Remove the unused `Set up Docker Buildx` step. The job never runs
  `docker build`/`buildx build` — it only pulls and runs a prebuilt HA image
  via testcontainers. The buildx builder it created was never consumed, and
  bootstrapping it pulled `moby/buildkit` from Docker Hub every run (the pull
  that timed out). Dead-weight cleanup.
- Set `TESTCONTAINERS_RYUK_DISABLED=true`, matching `e2e-tests.yml` and
  `pr.yml`. This was the only testcontainers workflow missing it, so it
  uniquely pulled `testcontainers/ryuk` from Docker Hub each run. Cleanup is
  handled by the fixture's `with container:` context manager (Refs #366).

Net: two of three per-run Docker Hub pulls (the large buildkit image and
ryuk) are eliminated, leaving only the small `alpine` host-probe. The HA
image already prefers GHCR with a Docker Hub fallback.

## Type of change
- [x] Maintenance/refactor

## Testing
- [ ] Tested with an LLM agent — n/a, CI workflow change
- [x] Self-validating: editing `performance-tests.yml` matches the workflow's
  own `pull_request` path filter, so the Performance Tests job runs on this PR
  with the modified workflow — confirming the suite still passes before merge.

## Checklist
- [x] Documentation updated if needed — n/a
