### PR TITLE
docs(tools): sharpen ha_eval_template usage routing for compute-from-state queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,7 +503,7 @@ src/ha_mcp/
 `ha_<verb>_<noun>`:
 - `get` — single item (`ha_get_state`)
 - `list` — collections (`ha_list_services`)
-- `search` — filtered queries (`ha_search_entities`)
+- `search` — filtered queries (`ha_search`)
 - `set` — create/update (`ha_config_set_helper`)
 - `delete` — delete dashboards, config entries, or files (`ha_config_delete_dashboard`, `ha_delete_file`)
 - `remove` — remove registry items (`ha_remove_entity`, `ha_remove_area_or_floor`)
@@ -516,7 +516,7 @@ src/ha_mcp/
 **Accepted exceptions**: A small set of tools name a single, distinct operation where forcing a `<verb>_<noun>` shape would read worse than the natural name. These are accepted as-is and should not be flagged:
 - `ha_restart`, `ha_reload_core`, `ha_eval_template`
 - `ha_report_issue`, `ha_import_blueprint`
-- `ha_read_file`, `ha_write_file`, `ha_deep_search`, `ha_bulk_control`
+- `ha_read_file`, `ha_write_file`, `ha_bulk_control`
 - `ha_install_mcp_tools`
 
 **Adding new verbs**: When no existing verb fits a new tool's purpose, add the verb to the approved-verbs list above rather than forcing a poor fit. `.gemini/styleguide.md` points back to this section as the single source of truth, so updates here propagate automatically.
@@ -561,7 +561,7 @@ The single-line template is the default -- extend it only where it genuinely hel
 - One sentence describing what the tool does (not how)
 
 **Add `RELATED TOOLS` when** the tool is a workflow entry point and the natural next step is not obvious.
-Example: `ha_search_entities` hints at `ha_get_state`.
+Example: `ha_search` hints at `ha_get_state`.
 
 **Add `EXAMPLES` when** the tool has multiple modes or non-obvious parameters.
 Omit when a single required parameter makes the call self-evident.

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1109,7 +1109,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         into automation logic; for `condition:` / `trigger:` positions native
         constructs win (see "When NOT to use" below).
         - "average temperature across the bedroom sensors"
-          -> `{{ ([states('sensor.a'), states('sensor.b')] | map('float') | sum) / 2 }}`
+          -> `{{ ([states('sensor.a'), states('sensor.b')] | map('float', 0) | sum) / 2 }}`
         - "how many lights are on"
           -> `{{ states.light | selectattr('state', 'eq', 'on') | list | count }}`
         NOT for a plain single-entity value ("what's the state of X") — that is

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1147,8 +1147,8 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         **Numeric Operations:**
         ```jinja2
         {{ states('sensor.temperature') | float(0) }}   # Convert to float with default
-        {{ states('sensor.humidity') | int }}           # Convert to integer
-        {{ (states('sensor.temp') | float + 5) | round(1) }} # Math operations
+        {{ states('sensor.humidity') | int(0) }}        # Convert to integer with default
+        {{ (states('sensor.temp') | float(0) + 5) | round(1) }} # Math operations
         ```
 
         **Time and Date:**
@@ -1218,7 +1218,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         **Test mathematical operations:**
         ```python
-        ha_eval_template("{{ (states('sensor.temperature') | float + 5) | round(1) }}")
+        ha_eval_template("{{ (states('sensor.temperature') | float(0) + 5) | round(1) }}")
         ```
 
         **Test entity counting:**

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1102,8 +1102,11 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         **When NOT to use this for automation/script logic:**
         Templates have legitimate uses (notification bodies, dynamic `data.*` values,
         debugging existing templates), but `condition:` / `trigger:` positions and
-        action service names are better expressed as native HA constructs — they
-        validate at config load, fail loudly, and avoid silent runtime failures.
+        action service names are better expressed as native HA constructs:
+        native constructs are schema-validated at config load and surface
+        structural errors loudly, whereas equivalent template logic only errors
+        at runtime — and a template that renders a non-truthy value is silently
+        treated as false.
         Prefer:
         - `condition: numeric_state` over `{{ states('x') | float > N }}`
         - `condition: state` over `{{ is_state(...) }}`
@@ -1121,7 +1124,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         it is the canonical way to *test* a template before embedding it. This is
         for one-shot answers and template testing only — NOT for putting templates
         into automation logic; for `condition:` / `trigger:` positions native
-        constructs win (see "When NOT to use" above).
+        constructs win.
         - "average temperature across the bedroom sensors"
           -> `{{ ([states('sensor.a'), states('sensor.b')] | map('float', 0) | sum) / 2 }}`
         - "how many lights are on"

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1099,6 +1099,22 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         Home Assistant automations, scripts, and configurations. It provides real-time evaluation with
         access to all Home Assistant states, functions, and template variables.
 
+        **When to use (reach for this tool, don't compute it yourself):**
+        Any one-shot question whose answer is DERIVED from current HA state — an
+        average/sum/min/max across sensors, a count of entities matching a
+        condition, a boolean comparison, or a rendered message with live values.
+        One render call beats fetching N states and doing the math yourself, and
+        it is the canonical way to *test* a template before embedding it. This is
+        for one-shot answers and template testing only — NOT for putting templates
+        into automation logic; for `condition:` / `trigger:` positions native
+        constructs win (see "When NOT to use" below).
+        - "average temperature across the bedroom sensors"
+          -> `{{ ([states('sensor.a'), states('sensor.b')] | map('float') | sum) / 2 }}`
+        - "how many lights are on"
+          -> `{{ states.light | selectattr('state', 'eq', 'on') | list | count }}`
+        NOT for a plain single-entity value ("what's the state of X") — that is
+        `ha_get_state` / `ha_search`; rendering `{{ states('X') }}` there is over-use.
+
         **Parameters:**
         - template: The Jinja2 template string to evaluate
         - timeout: Maximum evaluation time in seconds (default: 3)

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1099,6 +1099,20 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         Home Assistant automations, scripts, and configurations. It provides real-time evaluation with
         access to all Home Assistant states, functions, and template variables.
 
+        **When NOT to use this for automation/script logic:**
+        Templates have legitimate uses (notification bodies, dynamic `data.*` values,
+        debugging existing templates), but `condition:` / `trigger:` positions and
+        action service names are better expressed as native HA constructs — they
+        validate at config load, fail loudly, and avoid silent runtime failures.
+        Prefer:
+        - `condition: numeric_state` over `{{ states('x') | float > N }}`
+        - `condition: state` over `{{ is_state(...) }}`
+        - `condition: time` / `condition: sun` over `now().hour` / `is_state('sun.sun', ...)`
+        - Native `for:` field on state/numeric_state triggers and state conditions over
+          `{{ now() - X.last_changed > timedelta(...) }}` duration math
+        - `choose` action over templated `service:` / `action:` strings
+        See `ha_get_skill_guide` (best-practices skill) for the full anti-pattern list.
+
         **When to use (reach for this tool, don't compute it yourself):**
         Any one-shot question whose answer is DERIVED from current HA state — an
         average/sum/min/max across sensors, a count of entities matching a
@@ -1107,7 +1121,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         it is the canonical way to *test* a template before embedding it. This is
         for one-shot answers and template testing only — NOT for putting templates
         into automation logic; for `condition:` / `trigger:` positions native
-        constructs win (see "When NOT to use" below).
+        constructs win (see "When NOT to use" above).
         - "average temperature across the bedroom sensors"
           -> `{{ ([states('sensor.a'), states('sensor.b')] | map('float', 0) | sum) / 2 }}`
         - "how many lights are on"
@@ -1178,20 +1192,6 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         {{ area_entities('living_room') }}             # Get entities in area
         {{ device_id('light.bedroom') }}               # Get device ID for entity
         ```
-
-        **When NOT to use this for automation/script logic:**
-        Templates have legitimate uses (notification bodies, dynamic `data.*` values,
-        debugging existing templates), but `condition:` / `trigger:` positions and
-        action service names are better expressed as native HA constructs — they
-        validate at config load, fail loudly, and avoid silent runtime failures.
-        Prefer:
-        - `condition: numeric_state` over `{{ states('x') | float > N }}`
-        - `condition: state` over `{{ is_state(...) }}`
-        - `condition: time` / `condition: sun` over `now().hour` / `is_state('sun.sun', ...)`
-        - Native `for:` field on state/numeric_state triggers and state conditions over
-          `{{ now() - X.last_changed > timedelta(...) }}` duration math
-        - `choose` action over templated `service:` / `action:` strings
-        See `ha_get_skill_guide` (best-practices skill) for the full anti-pattern list.
 
         **Common Use Cases (legitimate template positions):**
 

--- a/tests/uat/stories/README.md
+++ b/tests/uat/stories/README.md
@@ -46,6 +46,19 @@ expected:
     - ha_config_set_automation
 ```
 
+## Story Prefixes
+
+The filename prefix determines whether a story runs in automated discovery:
+
+- **`s*` — standing regression stories.** Discovered and run by every automated
+  path: `run_story.py --all`, `conftest.discover_stories()` (the
+  `test_stories.py` pytest parametrization), and the `bat-story-eval` skill — all
+  glob `s*.yaml`.
+- **`t*` / `c*` — on-demand probes.** A/B routing probes (`t*`) and confusion-pair
+  probes (`c*`) for one-off architectural comparisons. **Excluded** from `--all`
+  and pytest discovery (the `s*.yaml` glob does not match them); run them by
+  explicit path, e.g. `run_story.py catalog/t01_eval_template_average_calc.yaml`.
+
 ## Running Stories
 
 ### Via pytest (recommended)

--- a/tests/uat/stories/catalog/s02_automation_motion_light.yaml
+++ b/tests/uat/stories/catalog/s02_automation_motion_light.yaml
@@ -43,7 +43,7 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_search_entities
+    - ha_search
     - ha_config_set_automation
   description: >
     Agent should create an automation with state trigger on the motion sensor,

--- a/tests/uat/stories/catalog/s04_dashboard_room_overview.yaml
+++ b/tests/uat/stories/catalog/s04_dashboard_room_overview.yaml
@@ -43,7 +43,7 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_search_entities
+    - ha_search
     - ha_config_set_dashboard
   description: >
     Agent should first search for light and climate entities, then create a

--- a/tests/uat/stories/catalog/s05_entity_discovery.yaml
+++ b/tests/uat/stories/catalog/s05_entity_discovery.yaml
@@ -41,7 +41,7 @@ verify:
 expected:
   tools_should_use:
     - ha_list_floors_areas
-    - ha_search_entities
+    - ha_search
   description: >
     Agent should use area listing and entity search to build a comprehensive
     overview. Should report on multiple domains (lights, sensors, climate,

--- a/tests/uat/stories/catalog/s06_script_goodnight_routine.yaml
+++ b/tests/uat/stories/catalog/s06_script_goodnight_routine.yaml
@@ -39,7 +39,7 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_search_entities
+    - ha_search
     - ha_config_set_script
   description: >
     Agent should search for lights and climate entities, then create a script

--- a/tests/uat/stories/catalog/s10_area_organization.yaml
+++ b/tests/uat/stories/catalog/s10_area_organization.yaml
@@ -39,7 +39,7 @@ verify:
 expected:
   tools_should_use:
     - ha_set_area_or_floor
-    - ha_search_entities
+    - ha_search
     - ha_list_floors_areas
   description: >
     Agent should create the three areas, then search for light entities,

--- a/tests/uat/stories/catalog/s12_label_management.yaml
+++ b/tests/uat/stories/catalog/s12_label_management.yaml
@@ -43,7 +43,7 @@ expected:
   tools_should_use:
     - ha_config_set_label
     - ha_config_get_label
-    - ha_search_entities
+    - ha_search
   description: >
     Agent should create two labels with the specified properties, then
     list labels to verify, and search for light entities to suggest

--- a/tests/uat/stories/catalog/s14_find_automations_by_entity.yaml
+++ b/tests/uat/stories/catalog/s14_find_automations_by_entity.yaml
@@ -12,7 +12,6 @@ tags:
   - search
   - automation
   - script
-  - deep_search
 
 setup:
   - tool: ha_config_set_automation
@@ -50,8 +49,8 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_deep_search
+    - ha_search
   description: >
-    Agent should use ha_deep_search to search inside automation/script
+    Agent should use ha_search to search inside automation/script
     configurations for references to light.bed_light. A good agent will
     report the automation name, its purpose, and how it uses the entity.

--- a/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
+++ b/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
@@ -52,7 +52,7 @@ expected:
     - ha_eval_template
   description: >
     Canonical fit for `ha_eval_template` with
-    `{{ ((states('input_number.bat_t01_temp1')|float) +
-    (states('input_number.bat_t01_temp2')|float)) / 2 }}`. Under-use
+    `{{ ((states('input_number.bat_t01_temp1')|float(0)) +
+    (states('input_number.bat_t01_temp2')|float(0))) / 2 }}`. Under-use
     classification: agent calls `ha_get_state` ×2 and averages in-prose
     without invoking the tool.

--- a/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
+++ b/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
@@ -44,8 +44,8 @@ verify:
     - "Did the agent compute or report the value 22?"
     - "Did the agent call a template-rendering tool, or did it average two get_state results manually?"
   ha_checks:
-    - type: response_contains
-      value: "22"
+    - type: response_matches
+      pattern: '(?i)\b22\b'
 
 expected:
   tools_should_use:

--- a/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
+++ b/tests/uat/stories/catalog/t01_eval_template_average_calc.yaml
@@ -1,0 +1,58 @@
+id: t01
+title: "Compute the average across two numeric entities (eval_template under-use probe)"
+category: template
+weight: 3
+description: >
+  User asks for an arithmetic combination of two entity states. The canonical
+  pick is `ha_eval_template` with a Jinja expression that floats both states
+  and averages them. The under-use failure mode: the agent calls
+  `ha_get_state` twice and averages "in its head" without using a tool —
+  workable for trivial cases but skips the deterministic tool path the user
+  expected. Part of issue #1175 item 2 BAT (eval_template usage measurement).
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+
+setup:
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_number
+      name: "bat t01 temp1"
+      initial: 20
+      min: -50
+      max: 50
+      step: 0.1
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_number
+      name: "bat t01 temp2"
+      initial: 24
+      min: -50
+      max: 50
+      step: 0.1
+
+prompt: >
+  What's the average value of `input_number.bat_t01_temp1` and
+  `input_number.bat_t01_temp2` right now?
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent compute or report the value 22?"
+    - "Did the agent call a template-rendering tool, or did it average two get_state results manually?"
+  ha_checks:
+    - type: response_contains
+      value: "22"
+
+expected:
+  tools_should_use:
+    - ha_eval_template
+  description: >
+    Canonical fit for `ha_eval_template` with
+    `{{ ((states('input_number.bat_t01_temp1')|float) +
+    (states('input_number.bat_t01_temp2')|float)) / 2 }}`. Under-use
+    classification: agent calls `ha_get_state` ×2 and averages in-prose
+    without invoking the tool.

--- a/tests/uat/stories/catalog/t02_eval_template_boolean_compare.yaml
+++ b/tests/uat/stories/catalog/t02_eval_template_boolean_compare.yaml
@@ -1,0 +1,56 @@
+id: t02
+title: "Boolean compare across two entities (eval_template under-use probe)"
+category: template
+weight: 3
+description: >
+  User asks a boolean question that combines two entity states. The canonical
+  pick is `ha_eval_template` with a Jinja boolean expression. The under-use
+  failure mode: the agent calls `ha_get_state` twice and resolves the boolean
+  in-prose. Part of issue #1175 item 2 BAT (eval_template usage measurement).
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+
+setup:
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_number
+      name: "bat t02 alpha"
+      initial: 10
+      min: 0
+      max: 100
+      step: 1
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_number
+      name: "bat t02 beta"
+      initial: 5
+      min: 0
+      max: 100
+      step: 1
+
+prompt: >
+  Is `input_number.bat_t02_alpha` currently greater than
+  `input_number.bat_t02_beta`?
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent answer yes/true (alpha=10 > beta=5)?"
+    - "Did the agent call a template-rendering tool to evaluate the comparison?"
+  ha_checks:
+    - type: response_matches
+      pattern: '(?i)\b(yes|true|greater)\b'
+
+expected:
+  tools_should_use:
+    - ha_eval_template
+  description: >
+    Canonical fit for `ha_eval_template` with
+    `{{ states('input_number.bat_t02_alpha')|float >
+    states('input_number.bat_t02_beta')|float }}`. Under-use classification:
+    agent calls `ha_get_state` ×2 and answers without invoking the template
+    tool.

--- a/tests/uat/stories/catalog/t02_eval_template_boolean_compare.yaml
+++ b/tests/uat/stories/catalog/t02_eval_template_boolean_compare.yaml
@@ -50,7 +50,7 @@ expected:
     - ha_eval_template
   description: >
     Canonical fit for `ha_eval_template` with
-    `{{ states('input_number.bat_t02_alpha')|float >
-    states('input_number.bat_t02_beta')|float }}`. Under-use classification:
+    `{{ states('input_number.bat_t02_alpha')|float(0) >
+    states('input_number.bat_t02_beta')|float(0) }}`. Under-use classification:
     agent calls `ha_get_state` ×2 and answers without invoking the template
     tool.

--- a/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
+++ b/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
@@ -1,0 +1,54 @@
+id: t03
+title: "Count entities matching a state filter (eval_template under-use probe)"
+category: template
+weight: 3
+description: >
+  User asks "how many of X are currently in state Y" — a canonical Jinja
+  `selectattr` filter use. The under-use failure mode: the agent calls
+  `ha_search_entities` to list, then iterates / filters in prose. Part of
+  issue #1175 item 2 BAT (eval_template usage measurement).
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+
+setup:
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_boolean
+      name: "bat t03 alpha"
+      initial: true
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_boolean
+      name: "bat t03 beta"
+      initial: true
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_boolean
+      name: "bat t03 gamma"
+      initial: false
+
+prompt: >
+  How many of my `input_boolean.bat_t03_*` toggles are currently on?
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent answer 2 (two are on, one is off)?"
+    - "Did the agent use a template selectattr filter, or list + count manually?"
+  ha_checks:
+    - type: response_contains
+      value: "2"
+
+expected:
+  tools_should_use:
+    - ha_eval_template
+  description: >
+    Canonical fit for `ha_eval_template` with
+    `{{ states.input_boolean | selectattr('entity_id','match','input_boolean.bat_t03_.*')
+    | selectattr('state','eq','on') | list | count }}`. Under-use
+    classification: agent calls `ha_search_entities` and counts the "on"
+    results manually.

--- a/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
+++ b/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
@@ -5,7 +5,7 @@ weight: 3
 description: >
   User asks "how many of X are currently in state Y" — a canonical Jinja
   `selectattr` filter use. The under-use failure mode: the agent calls
-  `ha_search_entities` to list, then iterates / filters in prose. Part of
+  `ha_search` to list, then iterates / filters in prose. Part of
   issue #1175 item 2 BAT (eval_template usage measurement).
 
 tags:
@@ -50,5 +50,5 @@ expected:
     Canonical fit for `ha_eval_template` with
     `{{ states.input_boolean | selectattr('entity_id','match','input_boolean.bat_t03_.*')
     | selectattr('state','eq','on') | list | count }}`. Under-use
-    classification: agent calls `ha_search_entities` and counts the "on"
+    classification: agent calls `ha_search` and counts the "on"
     results manually.

--- a/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
+++ b/tests/uat/stories/catalog/t03_eval_template_count_filter.yaml
@@ -40,8 +40,8 @@ verify:
     - "Did the agent answer 2 (two are on, one is off)?"
     - "Did the agent use a template selectattr filter, or list + count manually?"
   ha_checks:
-    - type: response_contains
-      value: "2"
+    - type: response_matches
+      pattern: '(?i)\b(2|two)\b'
 
 expected:
   tools_should_use:

--- a/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
+++ b/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
@@ -1,0 +1,56 @@
+id: t04
+title: "Render a notification template ahead of automation use (eval_template under-use probe)"
+category: template
+weight: 3
+description: >
+  User wants to preview what a notification body will look like before
+  embedding it in an automation. Canonical fit for `ha_eval_template` (the
+  tool exists precisely for "test this template before I commit it to a
+  config"). The under-use failure mode: the agent describes what the
+  template would do without actually rendering it, or rewrites the template
+  speculatively. Part of issue #1175 item 2 BAT.
+
+  Caveat: `trigger.*` / `this.*` / loop-vars render as undefined outside
+  automation runtime context. A good response acknowledges this and renders
+  the `now()` / `states(...)` parts that DO have context. See KP13's
+  research note on issue #1175 (comment 4597070298) for the runtime-context
+  edge case.
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+
+setup:
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_boolean
+      name: "bat t04 door"
+      initial: true
+
+prompt: >
+  Before I put this in an automation, what does this notification template
+  render to right now?
+  `Door {{ trigger.entity_id | default('input_boolean.bat_t04_door') }} is
+  {{ states('input_boolean.bat_t04_door') }} as of {{ now().strftime('%H:%M') }}`
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent render the template (showing the door is 'on' and a current time)?"
+    - "Did the agent note that `trigger.*` falls back to the default outside automation runtime?"
+  ha_checks:
+    - type: response_contains
+      value: "input_boolean.bat_t04_door"
+    - type: response_contains
+      value: "on"
+
+expected:
+  tools_should_use:
+    - ha_eval_template
+  description: >
+    The user explicitly asks "what does this render to" — canonical
+    `ha_eval_template` call. Under-use classification: agent describes the
+    template in prose, or calls `ha_get_state` and reconstructs the rendered
+    string by hand.

--- a/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
+++ b/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
@@ -10,11 +10,13 @@ description: >
   template would do without actually rendering it, or rewrites the template
   speculatively. Part of issue #1175 item 2 BAT.
 
-  Caveat: `trigger.*` / `this.*` / loop-vars render as undefined outside
-  automation runtime context. A good response acknowledges this and renders
-  the `now()` / `states(...)` parts that DO have context. See KP13's
-  research note on issue #1175 (comment 4597070298) for the runtime-context
-  edge case.
+  Caveat: `trigger.*` / `this.*` / loop-vars are undefined outside automation
+  runtime context — and accessing an attribute on undefined `trigger` *raises*
+  in `ha_eval_template` (verified live) unless guarded, so the template wraps it
+  as `(trigger | default({})).entity_id | default(...)` to render at all. A good
+  response renders successfully, with the `trigger` part falling back to the
+  default while `now()` / `states(...)` have real context. See KP13's research
+  note on issue #1175 (comment 4597070298) for the runtime-context edge case.
 
 tags:
   - template
@@ -31,7 +33,7 @@ setup:
 prompt: >
   Before I put this in an automation, what does this notification template
   render to right now?
-  `Door {{ trigger.entity_id | default('input_boolean.bat_t04_door') }} is
+  `Door {{ (trigger | default({})).entity_id | default('input_boolean.bat_t04_door') }} is
   {{ states('input_boolean.bat_t04_door') }} as of {{ now().strftime('%H:%M') }}`
 
 teardown: []

--- a/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
+++ b/tests/uat/stories/catalog/t04_eval_template_notification_render.yaml
@@ -45,8 +45,8 @@ verify:
   ha_checks:
     - type: response_contains
       value: "input_boolean.bat_t04_door"
-    - type: response_contains
-      value: "on"
+    - type: response_matches
+      pattern: '(?i)\bis\s+on\b'
 
 expected:
   tools_should_use:

--- a/tests/uat/stories/catalog/t05_eval_template_explicit_test.yaml
+++ b/tests/uat/stories/catalog/t05_eval_template_explicit_test.yaml
@@ -1,0 +1,40 @@
+id: t05
+title: "Explicit 'test this template' request (eval_template control case)"
+category: template
+weight: 3
+description: >
+  User uses the explicit verb "test" with a Jinja template. This is the
+  canonical, unambiguous use of `ha_eval_template` — the BAT's control case
+  for the under-use measurement: if the agent does not pick the tool here,
+  the under-use is severe. Part of issue #1175 item 2 BAT.
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+  - control_case
+
+setup: []
+
+prompt: >
+  Test this template before I put it in an automation condition:
+  `{{ states('sun.sun') == 'below_horizon' }}`
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent render the template (returning either 'True' or 'False' based on current sun state)?"
+    - "Did the agent answer with 'true' or 'false' rather than describing the template in prose?"
+  ha_checks:
+    - type: response_matches
+      pattern: '(?i)\b(true|false)\b'
+
+expected:
+  tools_should_use:
+    - ha_eval_template
+  description: >
+    The explicit verb "test" + a literal Jinja expression makes
+    `ha_eval_template` the only correct pick. If the agent picks anything
+    else (or nothing), under-use is severe. This story is the control case
+    for the BAT's headline metric.

--- a/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
+++ b/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
@@ -1,0 +1,52 @@
+id: t06
+title: "State lookup that should NOT use eval_template (over-use control)"
+category: template
+weight: 3
+description: >
+  User asks a plain "what's the state of X" question. The canonical pick is
+  `ha_get_state` (or, on the consolidated branch, `ha_search` with the
+  exact entity_id). Picking `ha_eval_template` via `{{ states('X') }}` is
+  over-use — the tool can do it but it's not the right shape. This story
+  is the over-use control for the eval_template usage probe; passing it
+  rules out the "agent reaches for eval_template for everything" failure
+  mode. Part of issue #1175 item 2 BAT.
+
+tags:
+  - template
+  - eval_template
+  - eval_template_bat
+  - control_case
+
+setup:
+  - tool: ha_config_set_helper
+    args:
+      helper_type: input_number
+      name: "bat t06 lookup"
+      initial: 42
+      min: 0
+      max: 100
+      step: 1
+
+prompt: >
+  What's the current value of `input_number.bat_t06_lookup`?
+
+teardown: []
+
+verify:
+  questions:
+    - "Did the agent report the value 42?"
+    - "Did the agent use a state-lookup tool (ha_get_state / ha_search) rather than rendering a template?"
+  ha_checks:
+    - type: response_contains
+      value: "42"
+
+expected:
+  tools_should_use:
+    - ha_get_state
+  description: >
+    Plain state-lookup territory — `ha_get_state` (or `ha_search` with the
+    exact entity_id) is the canonical pick. An agent that picks
+    `ha_eval_template` via `{{ states('input_number.bat_t06_lookup') }}` is
+    over-fitting the template tool to a job a simpler tool does cleaner.
+    Picking `ha_eval_template` here counts as a wrong-tool mis-pick for the
+    BAT's over-use control.

--- a/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
+++ b/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
@@ -43,6 +43,7 @@ verify:
 expected:
   tools_should_use:
     - ha_get_state
+    - ha_search
   description: >
     Plain state-lookup territory — `ha_get_state` (or `ha_search` with the
     exact entity_id) is the canonical pick. An agent that picks

--- a/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
+++ b/tests/uat/stories/catalog/t06_eval_template_overuse_control.yaml
@@ -37,8 +37,8 @@ verify:
     - "Did the agent report the value 42?"
     - "Did the agent use a state-lookup tool (ha_get_state / ha_search) rather than rendering a template?"
   ha_checks:
-    - type: response_contains
-      value: "42"
+    - type: response_matches
+      pattern: '(?i)\b42\b'
 
 expected:
   tools_should_use:


### PR DESCRIPTION
## What does this PR do?

Closes #1175 (investigate renames/merges for the naming-convention exception list). Implements the last open item — the `ha_eval_template` enhance — and finishes the exception-list bookkeeping now that the search consolidation (#1529) has merged.

- **`ha_eval_template` docstring**: adds a "When to use" routing block high in the docstring for compute-from-live-state queries (average/sum, count-with-filter, boolean compare, rendered message), the class agents were under-reaching for. Keeps the over-use boundary (plain single-entity lookups stay `ha_get_state` / `ha_search`). No behavior change — the tool itself is unchanged.
- **AGENTS.md**: drops `ha_deep_search` from the accepted naming-convention exceptions (it is now an internal function behind `ha_search` via #1529, no longer a registered tool); updates the two `ha_search_entities` references to `ha_search`.
- **BAT stories `t01`–`t06`**: an unprompted-tool-pick usage probe for `ha_eval_template` (4 canonical-fit intents, 1 explicit-test positive control, 1 over-use negative control).
- **Boy-Scout sweep**: corrects 6 pre-existing s-stories' (`s02`/`s04`/`s05`/`s06`/`s10`/`s12`) stale `ha_search_entities` expected-picks to `ha_search` — same post-#1529 staleness as the AGENTS.md refs above. (`c01` left as-is: its `ha_search_entities` is the deliberate pre-consolidation baseline arm.)

Implementation Summary (decisions + the #1175 item-by-item resolution) posted as a comment below.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed