### PR TITLE
perf: fast-fail HACS not-found lookups + batch-verify deep-search E2E fixtures (#1515)

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -267,3 +267,48 @@ jobs:
           oras tag "$versioned" "${HAOS_VERSION}-${TAG_SUFFIX}"
           echo "Pushed $versioned"
           echo "Pushed $moving"
+
+      # --- Warm the shared Actions cache (master only) -----------------------
+      # The E2E lanes (haos-e2e-tests.yml / haos-e2e-inaddon-tests.yml) restore
+      # the qcow2 from the Actions cache and fall back to this GHCR image on a
+      # miss. Today nothing primes that cache except a PR run's lazy save, which
+      # is branch-scoped — so every new PR branch starts cold and pays the GHCR
+      # pull (and the ~6.8 GB blob is ~68% of the 10 GB repo cache cap, so it
+      # LRU-evicts fast). Saving the same blob under the same key here, on the
+      # default branch, lets PR runs restore it via GitHub's default-branch
+      # cache scope and skip the GHCR pull. Purely additive: on a miss/eviction
+      # the lanes fall back to GHCR exactly as before (#1515).
+      - name: Compute E2E image cache key (master only)
+        id: e2e_cache_key
+        if: github.ref == 'refs/heads/master'
+        # Best-effort: the GHCR push above already published the image, so a
+        # prime hiccup must not fail the publish job — PRs just fall back to
+        # GHCR as before.
+        continue-on-error: true
+        # INVARIANT: this git ls-tree MUST stay byte-identical to the
+        # "Compute image cache key" step in BOTH haos-e2e-tests.yml and
+        # haos-e2e-inaddon-tests.yml — otherwise this warms a key the lanes
+        # never restore (a wasted prime, not a stale test: the lanes still
+        # recompute their own correct key). Keep all three (plus this file's
+        # push-trigger paths) in sync.
+        run: |
+          hash=$(git ls-tree -r HEAD \
+            tests/haos_image_build \
+            tests/initial_test_state \
+            custom_components/ha_mcp_tools \
+            homeassistant-addon-webhook-proxy \
+            | sha256sum | cut -d' ' -f1 | head -c16)
+          echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
+          # Move to the exact path the lanes restore to. /tmp and the workspace
+          # share the runner's root filesystem, so this is a rename (no extra
+          # disk). The artifact upload + GHCR push above already consumed the
+          # workspace copy, so nothing later needs it.
+          mv haos-test-image.qcow2 /tmp/haos-test-image.qcow2
+
+      - name: Warm shared Actions cache for E2E lanes (master only)
+        if: github.ref == 'refs/heads/master' && steps.e2e_cache_key.outputs.cache-key != ''
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/haos-test-image.qcow2
+          key: ${{ steps.e2e_cache_key.outputs.cache-key }}

--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -273,11 +273,11 @@ jobs:
       # the qcow2 from the Actions cache and fall back to this GHCR image on a
       # miss. Today nothing primes that cache except a PR run's lazy save, which
       # is branch-scoped — so every new PR branch starts cold and pays the GHCR
-      # pull (and the ~6.8 GB blob is ~68% of the 10 GB repo cache cap, so it
-      # LRU-evicts fast). Saving the same blob under the same key here, on the
-      # default branch, lets PR runs restore it via GitHub's default-branch
-      # cache scope and skip the GHCR pull. Purely additive: on a miss/eviction
-      # the lanes fall back to GHCR exactly as before (#1515).
+      # pull (and the multi-GB image is a large fraction of the 10 GB repo cache
+      # cap, so it LRU-evicts fast). Saving the same blob under the same key
+      # here, on the default branch, lets PR runs restore it via GitHub's
+      # default-branch cache scope and skip the GHCR pull. Purely additive: on a
+      # miss/eviction the lanes fall back to GHCR exactly as before (#1515).
       - name: Compute E2E image cache key (master only)
         id: e2e_cache_key
         if: github.ref == 'refs/heads/master'
@@ -285,13 +285,23 @@ jobs:
         # prime hiccup must not fail the publish job — PRs just fall back to
         # GHCR as before.
         continue-on-error: true
-        # INVARIANT: this git ls-tree MUST stay byte-identical to the
+        # INVARIANT: this git ls-tree must stay byte-IDENTICAL to the
         # "Compute image cache key" step in BOTH haos-e2e-tests.yml and
         # haos-e2e-inaddon-tests.yml — otherwise this warms a key the lanes
         # never restore (a wasted prime, not a stale test: the lanes still
-        # recompute their own correct key). Keep all three (plus this file's
-        # push-trigger paths) in sync.
+        # recompute their own correct key). NOTE the push-trigger paths above
+        # are a deliberate SUPERSET (they also list homeassistant-addon-dev/**
+        # + this file), NOT an identical mirror — keep that distinction in mind
+        # when editing.
         run: |
+          # Position the qcow2 at the exact path the lanes restore to FIRST, so
+          # the cache-key output below is set only once the file is in place
+          # (the save step guards on a non-empty cache-key, so a failed move
+          # leaves the key empty and skips the save). On GitHub-hosted runners
+          # /tmp and the workspace share the root filesystem, so this is a
+          # rename, not a copy. The artifact upload + GHCR push above already
+          # consumed the workspace copy, so nothing later needs it.
+          mv haos-test-image.qcow2 /tmp/haos-test-image.qcow2
           hash=$(git ls-tree -r HEAD \
             tests/haos_image_build \
             tests/initial_test_state \
@@ -299,11 +309,6 @@ jobs:
             homeassistant-addon-webhook-proxy \
             | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
-          # Move to the exact path the lanes restore to. /tmp and the workspace
-          # share the runner's root filesystem, so this is a rename (no extra
-          # disk). The artifact upload + GHCR push above already consumed the
-          # workspace copy, so nothing later needs it.
-          mv haos-test-image.qcow2 /tmp/haos-test-image.qcow2
 
       - name: Warm shared Actions cache for E2E lanes (master only)
         if: github.ref == 'refs/heads/master' && steps.e2e_cache_key.outputs.cache-key != ''

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -145,9 +145,50 @@ jobs:
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \
             | tar -xz -C /tmp oras
-          mkdir -p /tmp/haos-pull
-          (cd /tmp/haos-pull && /tmp/oras pull "$tag")
-          mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
+          dest=/tmp/haos-pull
+          # Retry ONLY on a genuine hang — zero download progress for 7 full
+          # minutes. A slow-but-moving pull (legit pulls have taken ~10 min) is
+          # never interrupted; only a dead-connection stall (the ~17 min
+          # zero-progress hang in #1515) is killed and re-pulled. 2 tries keeps
+          # even the both-stall -> local-build worst case well under the 45-min
+          # job cap, which stays the hard backstop.
+          stall_secs=420
+          attempts=2
+
+          pull_once() {
+            rm -rf "$dest"; mkdir -p "$dest"
+            # exec => $! is the oras PID, so the kill below reaches oras itself.
+            ( cd "$dest" && exec /tmp/oras pull "$tag" ) &
+            local pid=$! last=0 last_progress=$SECONDS size
+            while kill -0 "$pid" 2>/dev/null; do
+              sleep 30
+              size=$(du -sb "$dest" 2>/dev/null | cut -f1) || size=0
+              size=${size:-0}
+              if [ "$size" -gt "$last" ]; then
+                last=$size; last_progress=$SECONDS          # any growth resets the clock
+              elif [ $(( SECONDS - last_progress )) -ge "$stall_secs" ]; then
+                echo "::warning::oras pull made zero progress for ${stall_secs}s (stuck at ${size} bytes) — killing to retry"
+                kill "$pid" 2>/dev/null || true
+                wait "$pid" 2>/dev/null || true
+                return 1
+              fi
+            done
+            wait "$pid"                                       # propagate oras's own exit code
+          }
+
+          ok=
+          for a in $(seq 1 "$attempts"); do
+            echo "GHCR pull attempt ${a}/${attempts}"
+            if pull_once; then ok=1; break; fi
+            echo "::warning::GHCR pull attempt ${a} did not complete; retrying"
+          done
+          if [ -z "$ok" ]; then
+            echo "::warning::all ${attempts} GHCR pull attempts stalled/failed — using local build"
+            exit 1
+          fi
+          # Explicit source path so a future oras layout change that drops
+          # files into a subdirectory of pwd doesn't silently no-op the mv.
+          mv "$dest"/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
 
       - name: Free disk space for local build (cache miss + GHCR miss only)
         # See ``haos-e2e-tests.yml`` for the full rationale — same prune

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -94,6 +94,13 @@ jobs:
           path: /tmp/haos-test-image.qcow2
           key: ${{ steps.key.outputs.cache-key }}
 
+      - name: Report image-acquisition path
+        # Surfaces whether this run hit the (master-primed) Actions cache or
+        # falls through to the GHCR pull — so the cache-prime's effect is
+        # observable in the run summary. See build-haos-test-image.yml.
+        run: |
+          echo "::notice title=HAOS image cache::cache-hit=${{ steps.restore-cache.outputs.cache-hit }} key=${{ steps.key.outputs.cache-key }}"
+
       - name: Install QEMU + OVMF + libguestfs
         run: |
           sudo apt-get update

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -158,11 +158,51 @@ jobs:
             -u ${{ github.actor }} --password-stdin
           curl -fsSL https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz \
             | tar -xz -C /tmp oras
-          mkdir -p /tmp/haos-pull
-          (cd /tmp/haos-pull && /tmp/oras pull "$tag")
+
+          dest=/tmp/haos-pull
+          # Retry ONLY on a genuine hang — zero download progress for 7 full
+          # minutes. A slow-but-moving pull (legit pulls have taken ~10 min) is
+          # never interrupted; only a dead-connection stall (the ~17 min
+          # zero-progress hang in #1515) is killed and re-pulled. 2 tries keeps
+          # even the both-stall -> local-build worst case well under the 45-min
+          # job cap, which stays the hard backstop.
+          stall_secs=420
+          attempts=2
+
+          pull_once() {
+            rm -rf "$dest"; mkdir -p "$dest"
+            # exec => $! is the oras PID, so the kill below reaches oras itself.
+            ( cd "$dest" && exec /tmp/oras pull "$tag" ) &
+            local pid=$! last=0 last_progress=$SECONDS size
+            while kill -0 "$pid" 2>/dev/null; do
+              sleep 30
+              size=$(du -sb "$dest" 2>/dev/null | cut -f1) || size=0
+              size=${size:-0}
+              if [ "$size" -gt "$last" ]; then
+                last=$size; last_progress=$SECONDS          # any growth resets the clock
+              elif [ $(( SECONDS - last_progress )) -ge "$stall_secs" ]; then
+                echo "::warning::oras pull made zero progress for ${stall_secs}s (stuck at ${size} bytes) — killing to retry"
+                kill "$pid" 2>/dev/null || true
+                wait "$pid" 2>/dev/null || true
+                return 1
+              fi
+            done
+            wait "$pid"                                       # propagate oras's own exit code
+          }
+
+          ok=
+          for a in $(seq 1 "$attempts"); do
+            echo "GHCR pull attempt ${a}/${attempts}"
+            if pull_once; then ok=1; break; fi
+            echo "::warning::GHCR pull attempt ${a} did not complete; retrying"
+          done
+          if [ -z "$ok" ]; then
+            echo "::warning::all ${attempts} GHCR pull attempts stalled/failed — using local build"
+            exit 1
+          fi
           # Explicit source path so a future oras layout change that drops
           # files into a subdirectory of pwd doesn't silently no-op the mv.
-          mv /tmp/haos-pull/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
+          mv "$dest"/haos-test-image.qcow2 /tmp/haos-test-image.qcow2
 
       - name: Free disk space for local build (cache miss + GHCR miss only)
         # GitHub-hosted Linux runners ship with ~30 GB of pre-installed

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -99,6 +99,13 @@ jobs:
           path: /tmp/haos-test-image.qcow2
           key: ${{ steps.key.outputs.cache-key }}
 
+      - name: Report image-acquisition path
+        # Surfaces whether this run hit the (master-primed) Actions cache or
+        # falls through to the GHCR pull — so the cache-prime's effect is
+        # observable in the run summary. See build-haos-test-image.yml.
+        run: |
+          echo "::notice title=HAOS image cache::cache-hit=${{ steps.restore-cache.outputs.cache-hit }} key=${{ steps.key.outputs.cache-key }}"
+
       - name: Install QEMU + OVMF + libguestfs
         run: |
           sudo apt-get update

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -704,6 +704,21 @@ HACS_REPO_BACKSTOP_POLL_INTERVAL = 5.0
 # 30 s resolve budget does not apply here.
 HACS_ADD_REGISTRATION_TIMEOUT = 10.0
 
+# Wall-clock budget for ``_resolve_hacs_repo_id`` (the ``owner/repo`` lookup
+# behind read-only ``ha_get_hacs_info(action="info")`` and
+# ``ha_manage_hacs(action="download")``). Unlike ``ha_install_mcp_tools`` —
+# which adds a repo and then waits the full ``HACS_REPO_REGISTRATION_TIMEOUT``
+# for that fresh registration to land — a plain info/download lookup targets a
+# repo that should ALREADY be in HACS's index: default repos always are, and
+# ``add_repository`` blocks until registration is confirmed before returning.
+# So the post-subscribe sample resolves an existing repo instantly, and the
+# dispatch-signal wait only ever burns wall-clock when the repo is genuinely
+# absent. The old 30 s budget made every not-found lookup a 30 s stall (the
+# dominant cost in the HAOS E2E suite per #1515); 10 s still leaves event-driven
+# headroom for the rare mid-registration race while failing a genuinely-missing
+# lookup ~3x faster.
+HACS_RESOLVE_REGISTRATION_TIMEOUT = 10.0
+
 
 async def _find_repo_in_list_by_full_name(
     ws_client: Any, full_name_lower: str
@@ -919,7 +934,9 @@ async def _resolve_hacs_repo_id(ws_client: Any, repository_id: str) -> tuple[str
     if "/" not in repository_id:
         return repository_id, repository_id
 
-    repo = await wait_for_repo_registration(ws_client, repository_id)
+    repo = await wait_for_repo_registration(
+        ws_client, repository_id, timeout=HACS_RESOLVE_REGISTRATION_TIMEOUT
+    )
 
     if repo is not None:
         return str(repo.get("id")), repo.get("name") or repository_id

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -93,10 +93,16 @@ _STATE_CHANGING_SERVICES = {
     "media_stop",
 }
 
-# Domains where service calls don't produce entity state changes
+# Domains where a service call does not move the TARGET entity's own primary
+# state to a value the verifier can wait for. ``scene`` belongs here with
+# ``automation``/``script``: activating a scene changes the member entities,
+# but the scene entity's own state is a last-activated timestamp that never
+# becomes "on"/"off" — so waiting for ``turn_on`` -> "on" always times out and
+# only appends a spurious "could not be verified" warning (~10s wasted).
 _NON_STATE_CHANGING_DOMAINS = {
     "automation",
     "script",
+    "scene",
     "homeassistant",
     "notify",
     "tts",

--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -89,9 +89,12 @@ async def bulk_automations(mcp_client):
     created_ids = []
 
     for i in range(_AUTOMATION_COUNT):
+        # wait=False: skip the per-call registration poll and batch-verify all
+        # registrations in one WS wait below. The documented bulk pattern, and
+        # it avoids N sequential per-create registration waits (#1515).
         result = await mcp_client.call_tool(
             "ha_config_set_automation",
-            {"config": _automation_config(i)},
+            {"config": _automation_config(i), "wait": False},
         )
         data = assert_mcp_success(result, f"Create bulk automation {i}")
         # Use the actual entity_id returned by HA (handles conflicts with _2 suffix)
@@ -156,9 +159,11 @@ async def bulk_scripts(mcp_client):
 
     for i in range(_SCRIPT_COUNT):
         script_id = f"{_MARKER}_script_{i}"
+        # wait=False: batch-verify registrations in one WS wait below rather
+        # than paying a per-create registration poll each iteration (#1515).
         result = await mcp_client.call_tool(
             "ha_config_set_script",
-            {"script_id": script_id, "config": _script_config(i)},
+            {"script_id": script_id, "config": _script_config(i), "wait": False},
         )
         assert_mcp_success(result, f"Create bulk script {i}")
         created_ids.append(script_id)

--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -133,11 +133,19 @@ async def bulk_automations(mcp_client):
                     return False
             return True
 
-        await wait_for_condition(
+        registered = await wait_for_condition(
             all_entities_registered,
             condition_name=f"All {len(created_ids)} bulk automations registered (fallback)",
             timeout=10,
         )
+        if not registered:
+            # Fail loudly at setup rather than yielding unregistered entities,
+            # which would surface as a confusing search-assertion failure
+            # downstream instead of a clear "setup couldn't register" error.
+            pytest.fail(
+                f"bulk automations never registered after WS + REST waits "
+                f"(WS saw {len(seen)}/{len(created_ids)})"
+            )
 
     yield created_ids
 
@@ -195,11 +203,16 @@ async def bulk_scripts(mcp_client):
                     return False
             return True
 
-        await wait_for_condition(
+        registered = await wait_for_condition(
             all_scripts_registered,
             condition_name=f"All {len(created_ids)} bulk scripts registered (fallback)",
             timeout=10,
         )
+        if not registered:
+            pytest.fail(
+                f"bulk scripts never registered after WS + REST waits "
+                f"(WS saw {len(seen)}/{len(expected_entity_ids)})"
+            )
 
     yield created_ids
 

--- a/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
+++ b/tests/src/e2e/tools/test_deep_search_bulk_fetch.py
@@ -108,30 +108,35 @@ async def bulk_automations(mcp_client):
         created_ids.append(entity_id)
         logger.info(f"Created automation {i}/{_AUTOMATION_COUNT}: {entity_id}")
 
-    # Wait via HA WebSocket for ``state_changed`` on each created
-    # automation. This avoids the ~10s ``ha_list_states`` polling burn
-    # observed on HAOS (the bulk fixture's old wait_for_condition fired
-    # the warning path on every run). After WS confirms, one
-    # ``ha_list_states`` call below acts as the final correctness check.
+    # Confirm registration via HA WebSocket: the helper subscribes to
+    # ``state_changed`` and takes a post-subscribe ``get_states`` sample, so
+    # the entities created above (with wait=False) are confirmed in one batch
+    # wait rather than N per-create polls.
     from ..utilities.wait_helpers import wait_for_entities_registered_via_ws
 
     seen = await wait_for_entities_registered_via_ws(created_ids, timeout=30.0)
     if seen != set(created_ids):
-        # Fall back to the old poll-via-mcp pattern for the stragglers
-        # rather than failing setup — keeps the fixture robust if WS
-        # misses an event (e.g. coalesced state during heavy CI load).
+        # Fall back to a per-entity REST poll for the stragglers rather than
+        # failing setup — keeps the fixture robust if the WS path drops
+        # (e.g. a transient socket error under heavy CI load).
+        from ..utilities.assertions import safe_call_tool
         from ..utilities.wait_helpers import wait_for_condition
 
         async def all_entities_registered():
-            states = await mcp_client.call_tool("ha_list_states", {})
-            state_data = assert_mcp_success(states, "Get states (fallback polling)")
-            registered_ids = {s.get("entity_id") for s in state_data.get("states", [])}
-            return all(eid in registered_ids for eid in created_ids)
+            # Per-entity ha_get_state (there is no bulk "list states" tool);
+            # an unregistered entity returns no data, so the poll retries.
+            for eid in created_ids:
+                data = await safe_call_tool(
+                    mcp_client, "ha_get_state", {"entity_id": eid}
+                )
+                if not (isinstance(data, dict) and data.get("data") is not None):
+                    return False
+            return True
 
         await wait_for_condition(
             all_entities_registered,
             condition_name=f"All {len(created_ids)} bulk automations registered (fallback)",
-            timeout=10.0,
+            timeout=10,
         )
 
     yield created_ids
@@ -169,31 +174,31 @@ async def bulk_scripts(mcp_client):
         created_ids.append(script_id)
         logger.info(f"Created script {i}/{_SCRIPT_COUNT}: {script_id}")
 
-    # WS-based wait — mirrors the bulk_automations fixture above to
-    # avoid the chronic ~10s ``ha_list_states`` poll on HAOS. Script
-    # entity_ids carry the ``script.`` domain prefix in the state
-    # machine; created_ids hold the script_id without the prefix.
+    # WS-based wait — mirrors the bulk_automations fixture above (subscribe +
+    # post-subscribe get_states sample). Script entity_ids carry the
+    # ``script.`` domain prefix in the state machine; created_ids hold the
+    # script_id without the prefix.
     from ..utilities.wait_helpers import wait_for_entities_registered_via_ws
 
     expected_entity_ids = {f"script.{sid}" for sid in created_ids}
     seen = await wait_for_entities_registered_via_ws(expected_entity_ids, timeout=30.0)
     if seen != expected_entity_ids:
+        from ..utilities.assertions import safe_call_tool
         from ..utilities.wait_helpers import wait_for_condition
 
         async def all_scripts_registered():
-            states = await mcp_client.call_tool("ha_list_states", {})
-            state_data = assert_mcp_success(states, "Get states (fallback polling)")
-            registered_ids = {
-                s.get("entity_id")
-                for s in state_data.get("states", [])
-                if s.get("entity_id", "").startswith("script.")
-            }
-            return expected_entity_ids.issubset(registered_ids)
+            for eid in expected_entity_ids:
+                data = await safe_call_tool(
+                    mcp_client, "ha_get_state", {"entity_id": eid}
+                )
+                if not (isinstance(data, dict) and data.get("data") is not None):
+                    return False
+            return True
 
         await wait_for_condition(
             all_scripts_registered,
             condition_name=f"All {len(created_ids)} bulk scripts registered (fallback)",
-            timeout=10.0,
+            timeout=10,
         )
 
     yield created_ids

--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -826,13 +826,21 @@ async def wait_for_entities_registered_via_ws(
     ha_url: str | None = None,
     token: str | None = None,
 ) -> set[str]:
-    """Block until ``state_changed`` arrives for every expected entity_id, via HA WS.
+    """Block until every expected entity_id is registered in HA, via HA WS.
 
     Opens a fresh WebSocket connection to HA, authenticates with the
-    test token, subscribes to ``state_changed``, and resolves as soon as
-    each entity_id in ``expected_entity_ids`` has produced at least one
-    state_changed event. Avoids the chronic 10s ``ha_list_states`` polling
-    burn observed in the HAOS bulk-fixture wait (#1349 audit).
+    test token, subscribes to ``state_changed``, takes a single
+    ``get_states`` sample over the same connection (so entities that
+    registered BEFORE the subscribe landed are caught immediately rather
+    than waiting out the full timeout — they never re-fire a
+    ``state_changed`` we could observe), then resolves as soon as every
+    entity_id in ``expected_entity_ids`` is either in that sample or has
+    produced a ``state_changed`` event. The sample-after-subscribe order
+    mirrors the other event-driven waiters in this module
+    (``_ws_wait_for_predicate``). Avoids the chronic 10s
+    ``ha_list_states`` polling burn observed in the HAOS bulk-fixture
+    wait (#1349 audit) and the full-timeout stall when callers create
+    entities before waiting (#1515).
 
     Pairs with a subsequent ``ha_list_states`` call (or per-entity
     ``ha_get_state``) for a final correctness check — this helper only
@@ -922,6 +930,20 @@ async def wait_for_entities_registered_via_ws(
             ):
                 raise RuntimeError(f"subscribe_events failed: {sub_result!r}")
 
+            # Post-subscribe sample: an entity that registered BEFORE our
+            # subscribe landed never fires a ``state_changed`` event we can
+            # observe, so the event loop alone would wait out the FULL timeout
+            # for it. That was the dominant cost in the deep-search bulk
+            # fixtures — the entities were already registered (created with the
+            # per-call registration wait) by the time this helper subscribed,
+            # so every run burned the entire 30s budget then fell back to REST
+            # (#1515). Query the current state set once over the SAME
+            # connection and mark any already-present entity as seen. Mirrors
+            # the sample-after-subscribe pattern the other event-driven waiters
+            # in this module use (``_ws_wait_for_predicate``).
+            states_msg_id = 2
+            await ws.send(json.dumps({"id": states_msg_id, "type": "get_states"}))
+
             while seen != expected:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
@@ -931,7 +953,19 @@ async def wait_for_entities_registered_via_ws(
                 except TimeoutError:
                     break
                 payload = json.loads(raw)
-                if payload.get("type") != "event":
+                ptype = payload.get("type")
+                if ptype == "result" and payload.get("id") == states_msg_id:
+                    # Response to our post-subscribe ``get_states``. Mark every
+                    # expected entity already in the state machine as seen so a
+                    # before-subscribe registration doesn't stall the wait.
+                    for state in payload.get("result") or []:
+                        eid = (
+                            state.get("entity_id") if isinstance(state, dict) else None
+                        )
+                        if eid in expected:
+                            seen.add(eid)
+                    continue
+                if ptype != "event":
                     continue
                 event = payload.get("event") or {}
                 data = event.get("data") or {}

--- a/tests/src/e2e/utilities/wait_helpers.py
+++ b/tests/src/e2e/utilities/wait_helpers.py
@@ -837,15 +837,14 @@ async def wait_for_entities_registered_via_ws(
     entity_id in ``expected_entity_ids`` is either in that sample or has
     produced a ``state_changed`` event. The sample-after-subscribe order
     mirrors the other event-driven waiters in this module
-    (``_ws_wait_for_predicate``). Avoids the chronic 10s
-    ``ha_list_states`` polling burn observed in the HAOS bulk-fixture
-    wait (#1349 audit) and the full-timeout stall when callers create
-    entities before waiting (#1515).
+    (``_ws_wait_for_predicate``). Avoids the chronic 10s REST polling
+    burn observed in the HAOS bulk-fixture wait (#1349 audit) and the
+    full-timeout stall when callers create entities before waiting
+    (#1515).
 
-    Pairs with a subsequent ``ha_list_states`` call (or per-entity
-    ``ha_get_state``) for a final correctness check — this helper only
-    confirms HA has published the entity to the state machine; the
-    caller does the authoritative read.
+    Pairs with a subsequent per-entity ``ha_get_state`` call for a final
+    correctness check — this helper only confirms HA has published the
+    entity to the state machine; the caller does the authoritative read.
 
     Args:
         expected_entity_ids: The set of entity_ids whose registration we

--- a/tests/src/e2e/workflows/device_control/test_lights.py
+++ b/tests/src/e2e/workflows/device_control/test_lights.py
@@ -419,8 +419,11 @@ class TestDeviceControl:
         assert_mcp_success(temp_result, "set temperature")
         logger.info("✅ Temperature setting command executed")
 
-        # Test HVAC mode setting (wait=False for the same reason — see above;
-        # this test asserts only on final attributes, not verified state).
+        # Test HVAC mode setting. wait=False here because this test asserts
+        # only on the final attributes read below, never the verified state, so
+        # the post-call state-change wait is pure overhead. (Unlike
+        # set_temperature, set_hvac_mode does move the primary state, so its
+        # wait would usually resolve quickly — but it's still unneeded here.)
         mode_result = await mcp_client.call_tool(
             "ha_call_service",
             {

--- a/tests/src/e2e/workflows/device_control/test_lights.py
+++ b/tests/src/e2e/workflows/device_control/test_lights.py
@@ -312,9 +312,15 @@ class TestDeviceControl:
 
             for i, operation_id in enumerate(operation_ids):
                 try:
+                    # Status here is purely informational (asserted nowhere
+                    # below). WS-resolvable ops complete sub-second; an op
+                    # whose target equals the light's current state never emits
+                    # a state_changed event and would otherwise sit PENDING for
+                    # the full timeout. 3s caps that waste without losing the
+                    # informational snapshot (#1515).
                     status_result = await mcp_client.call_tool(
                         "ha_get_operation_status",
-                        {"operation_id": operation_id, "timeout_seconds": 10},
+                        {"operation_id": operation_id, "timeout_seconds": 3},
                     )
 
                     status_data = parse_mcp_result(status_result)
@@ -394,7 +400,11 @@ class TestDeviceControl:
         entity_data = validate_entity_state(initial_data, climate_entity)
         logger.info(f"🌡️ Initial climate state: {entity_data['state']}")
 
-        # Test temperature setting
+        # Test temperature setting. wait=False: set_temperature only moves the
+        # `temperature` ATTRIBUTE, not the entity's primary state, so the
+        # tool's state-change verifier would wait out its full 10s timeout for
+        # a change that never comes (the test only inspects attributes below,
+        # never the verified state) — #1515.
         temp_result = await mcp_client.call_tool(
             "ha_call_service",
             {
@@ -402,13 +412,15 @@ class TestDeviceControl:
                 "service": "set_temperature",
                 "entity_id": climate_entity,
                 "data": {"temperature": 22},
+                "wait": False,
             },
         )
 
         assert_mcp_success(temp_result, "set temperature")
         logger.info("✅ Temperature setting command executed")
 
-        # Test HVAC mode setting
+        # Test HVAC mode setting (wait=False for the same reason — see above;
+        # this test asserts only on final attributes, not verified state).
         mode_result = await mcp_client.call_tool(
             "ha_call_service",
             {
@@ -416,6 +428,7 @@ class TestDeviceControl:
                 "service": "set_hvac_mode",
                 "entity_id": climate_entity,
                 "data": {"hvac_mode": "heat"},
+                "wait": False,
             },
         )
 

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -15,9 +15,18 @@ from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_hacs import (
     HACS_ADD_REGISTRATION_TIMEOUT,
+    HACS_REPO_REGISTRATION_TIMEOUT,
     HACS_RESOLVE_REGISTRATION_TIMEOUT,
     HacsTools,
 )
+
+
+def test_resolve_budget_is_shorter_than_post_add_budget() -> None:
+    """The resolve budget must stay materially shorter than the 30s post-add
+    registration budget; a regression back to the slow value would re-open the
+    #1515 not-found stall, which the equality assertion below would not catch."""
+    assert HACS_RESOLVE_REGISTRATION_TIMEOUT < HACS_REPO_REGISTRATION_TIMEOUT
+    assert HACS_RESOLVE_REGISTRATION_TIMEOUT <= 10
 
 
 async def _identity_timezone(_client, data):

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.tools_hacs import HACS_ADD_REGISTRATION_TIMEOUT, HacsTools
+from ha_mcp.tools.tools_hacs import (
+    HACS_ADD_REGISTRATION_TIMEOUT,
+    HACS_RESOLVE_REGISTRATION_TIMEOUT,
+    HacsTools,
+)
 
 
 async def _identity_timezone(_client, data):
@@ -93,6 +97,33 @@ class TestManageHacsDownload:
         assert result["repository"] == "441028036"  # numeric id resolves to itself
         assert "Successfully installed" in result["message"]
         assert ws.send_command.await_args.args[0] == "hacs/repository/download"
+
+    async def test_owner_repo_resolve_uses_fast_fail_budget(self, tools):
+        # A GitHub-path download resolves owner/repo -> numeric id via
+        # wait_for_repo_registration. That lookup targets an already-registered
+        # repo, so it must use the short HACS_RESOLVE_REGISTRATION_TIMEOUT, not
+        # the 30 s post-add registration budget — otherwise a not-found path
+        # stalls the caller (and the E2E suite, #1515) for 30 s.
+        ws = _ws({"status": "ok"})
+        registered = {"id": "555", "full_name": "owner/repo", "name": "Repo"}
+        with (
+            _patched_hacs(ws),
+            patch(
+                "ha_mcp.tools.tools_hacs.wait_for_repo_registration",
+                new_callable=AsyncMock,
+            ) as wait_mock,
+        ):
+            wait_mock.return_value = registered
+            result = await tools.ha_manage_hacs(
+                action="download", repository_id="owner/repo"
+            )
+
+        assert result["success"] is True
+        assert result["repository"] == "Repo"  # resolved display name
+        assert (
+            wait_mock.await_args.kwargs.get("timeout")
+            == HACS_RESOLVE_REGISTRATION_TIMEOUT
+        )
 
 
 class TestManageHacsAddRepository:

--- a/tests/src/unit/test_wait_parameter.py
+++ b/tests/src/unit/test_wait_parameter.py
@@ -503,6 +503,21 @@ class TestServiceCallWaitParameter:
             assert result["success"] is True
             mock_wait.assert_not_called()
 
+    async def test_call_service_no_wait_for_scene(self, tools, mock_client):
+        """scene.turn_on doesn't wait: a scene's own state is a last-activated
+        timestamp, never "on", so the wait would always time out (#1515)."""
+        with patch(
+            "ha_mcp.tools.tools_service.wait_for_state_change", new_callable=AsyncMock
+        ) as mock_wait:
+            result = await tools.ha_call_service(
+                domain="scene",
+                service="turn_on",
+                entity_id="scene.movie_night",
+            )
+            assert result["success"] is True
+            assert "verified_state" not in result
+            mock_wait.assert_not_called()
+
     async def test_call_service_no_wait_without_entity(self, tools, mock_client):
         """Services without entity_id don't wait."""
         with patch(


### PR DESCRIPTION
## What does this PR do?

Removes the largest fixed waits from the HAOS E2E suite — the floor that
dominates cache-hit runs (#1515) — without dropping any coverage. Measured on
the external HAOS lane: **~414s → ~350s (≈60s, ~15% faster)**, consistent
across runs (the run-to-run spread is QEMU-boot jitter). The HACS and deep-search
waits below were in the suite's slowest-10 and are gone from it after the change;
the scene/climate/bulk-light waits were ~10s tail entries, also trimmed — no
coverage dropped.

**1. `perf(hacs)`: fast-fail not-found repo lookups (~60s of suite time).**
`_resolve_hacs_repo_id` — the `owner/repo` lookup behind read-only
`ha_get_hacs_info(action="info")` and `ha_manage_hacs(action="download")` —
waited the full 30s `HACS_REPO_REGISTRATION_TIMEOUT` whenever the repo was
absent. That budget exists for `ha_install_mcp_tools`, which adds a repo and
genuinely waits for the fresh registration. A plain info/download lookup
targets a repo that should already be in HACS's index (default repos always
are; `add_repository` blocks until registered), so the post-subscribe sample
resolves an existing repo instantly and the dispatch-signal wait only burns
wall-clock on a genuinely-missing repo. New dedicated
`HACS_RESOLVE_REGISTRATION_TIMEOUT = 10.0`: still event-driven (instant on the
rare mid-registration race), fails a not-found lookup ~3x faster. User-facing:
HACS errors on a missing repo return in ~10s instead of stalling 30s.

**2. `test(e2e)`: batch-verify bulk registrations with a post-subscribe sample (~66s).**
`wait_for_entities_registered_via_ws` only waited for `state_changed` events
with no post-subscribe sample — the one event-driven waiter in
`wait_helpers.py` missing it. An entity that registered before the subscribe
landed never re-fires an observable event, so the wait burned the entire 30s
budget then fell back to REST. The deep-search bulk fixtures hit this every
run (the fixed ~30s was identical for 10 automations and 5 scripts — the tell
that it's a timeout, not per-entity cost). Adds a single `get_states` sample
over the same WS right after subscribe (mirrors the pattern the other waiters
use), and switches the fixtures to `wait=False` creates so registration is
batch-verified in one WS wait instead of N sequential per-create polls.

**3. `fix(service)`: don't run a doomed state-change wait on scene.turn_on (~10s).**
`ha_call_service` waited for the scene entity to reach state "on", but a
scene's own state is a last-activated timestamp that never becomes "on"/"off",
so the wait always ran out its 10s timeout and appended a spurious "could not
be verified" warning. Adds `scene` to `_NON_STATE_CHANGING_DOMAINS` alongside
`automation`/`script` (activating a scene changes member entities, not the
scene entity's state). Real callers get a snappy scene.turn_on too.

**4. `test(e2e)`: trim two more doomed device-control waits + repair a broken fallback.**
- `test_climate_control`: `wait=False` on `set_temperature`/`set_hvac_mode`
  (the test asserts only on attributes; `set_temperature` moves an attribute,
  not the primary state the verifier waits for). ~10s.
- `test_bulk_light_control`: informational operation-status poll 10s → 3s
  (status is asserted nowhere; WS-resolvable ops finish sub-second). ~7s.
- The deep-search bulk fixtures' REST fallback polled a **non-existent
  `ha_list_states` tool** — harmless dead code while creates used the per-call
  registration wait, but load-bearing once they use `wait=False`. Replaced with
  a per-entity `ha_get_state` poll that now fails loudly if registration never
  lands (instead of silently yielding unregistered entities).

**5. `ci`: prime the shared HAOS image cache from master (image-acquisition, a separate axis).**
Investigation (the addon is injected at runtime — inaddon via offline overlay + Supervisor update, external via in-process import — so the cache key correctly *excludes* `src/ha_mcp`/`homeassistant-addon-dev`) showed the cache key is already optimally scoped; there's no key-trimming win to take. The real issue: the multi-GB qcow2 is a large fraction of GitHub's 10 GB Actions-cache cap and nothing primes it except a PR's branch-scoped lazy save, so new PR branches start cold and pay the GHCR pull (usually ~50s, occasionally 600s+). The master/cron image-publish job now also `actions/cache/save`s the qcow2 under the lanes' exact key, so PRs restore one durable default-branch entry instead of pulling GHCR (and a cache hit skips the per-PR save, stopping the cap thrash). Purely additive (GHCR fallback unchanged on miss/eviction), best-effort (never fails the publish job). Both lanes emit a `::notice::` with the cache-hit status. This lands on PRs cut *after* merge (master populates it), so it doesn't speed up this PR's own runs.

Unit tests pin the new behavior: HACS resolve-budget wiring + a numeric bound
(`< HACS_REPO_REGISTRATION_TIMEOUT`), and scene.turn_on not waiting.

The slowest-10 after this PR is entirely irreducible QEMU boot or genuinely-slow
work (real backups, the deliberate code-mode timeout test, addon WS-proxy
validation) — each was investigated and left alone rather than masked.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified across CI runs: both HAOS E2E lanes (external + inaddon), testcontainer
E2E (`E2E Validation`), Unit Tests, Mypy, and Ruff. The CI cache-prime (item 5)
touches only the master-triggered image-publish job — not exercised by PR CI —
plus a trivial cache-status notice step in each lane. Local Docker is unavailable
in this environment, so the HAOS suite is the verification venue; the LLM-agent
box is N/A for E2E-infra changes.

## Checklist
- [x] I have updated documentation if needed

