### PR TITLE
fix(energy): accept "water" energy source in ha_manage_energy_prefs

### DIFF
--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -60,19 +60,28 @@ _PREFS_TOP_LEVEL_KEYS: tuple[_PrefsKey, ...] = (
 )
 
 # Energy source ``type`` values accepted by HA Core's ``SourceType`` union
-# (homeassistant/components/energy/data.py). This is the single source of truth
-# for the local shape check — a type missing here is spuriously rejected even
-# though ``energy/save_prefs`` would accept it. When HA Core adds a source type,
-# add it here. Ordered (not a ``set``) to match the upstream union and to keep
-# error messages deterministic. See issue #1530.
-_ENERGY_SOURCE_TYPES: tuple[str, ...] = ("grid", "solar", "battery", "gas", "water")
+# (homeassistant/components/energy/data.py). ``_EnergySourceType`` names the
+# domain (mirroring the ``_PrefsKey`` pattern above) and ``_ENERGY_SOURCE_TYPES``
+# is its ordered realization — the single source of truth for the local shape
+# check. A type missing here is spuriously rejected even though
+# ``energy/save_prefs`` would accept it; when HA Core adds a source type, add it
+# in both places. Ordered (not a ``set``) to match the upstream union and to
+# keep error messages deterministic. See issue #1530.
+_EnergySourceType = Literal["grid", "solar", "battery", "gas", "water"]
+_ENERGY_SOURCE_TYPES: tuple[_EnergySourceType, ...] = (
+    "grid",
+    "solar",
+    "battery",
+    "gas",
+    "water",
+)
 
 # Non-grid source types. Each requires a ``stat_energy_from`` consumption
-# statistic and is uniquely identified by ``(type, stat_energy_from)`` (used for
-# both the shape check's required-field rule and ``_append_unique_source``
-# de-duplication). ``grid`` is excluded: its ``stat_energy_from`` is optional and
-# a hub can legitimately carry multiple grid variants, so it has no single
-# uniqueness key.
+# statistic and is de-duplicated by this tool on ``(type, stat_energy_from)``
+# (used for both the shape check's required-field rule and
+# ``_append_unique_source`` de-duplication). ``grid`` is excluded: its
+# ``stat_energy_from`` is optional and a hub can legitimately carry multiple grid
+# variants, so it has no single uniqueness key.
 _STAT_FROM_SOURCE_TYPES: frozenset[str] = frozenset(
     t for t in _ENERGY_SOURCE_TYPES if t != "grid"
 )

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -59,6 +59,24 @@ _PREFS_TOP_LEVEL_KEYS: tuple[_PrefsKey, ...] = (
     "device_consumption_water",
 )
 
+# Energy source ``type`` values accepted by HA Core's ``SourceType`` union
+# (homeassistant/components/energy/data.py). This is the single source of truth
+# for the local shape check — a type missing here is spuriously rejected even
+# though ``energy/save_prefs`` would accept it. When HA Core adds a source type,
+# add it here. Ordered (not a ``set``) to match the upstream union and to keep
+# error messages deterministic. See issue #1530.
+_ENERGY_SOURCE_TYPES: tuple[str, ...] = ("grid", "solar", "battery", "gas", "water")
+
+# Non-grid source types. Each requires a ``stat_energy_from`` consumption
+# statistic and is uniquely identified by ``(type, stat_energy_from)`` (used for
+# both the shape check's required-field rule and ``_append_unique_source``
+# de-duplication). ``grid`` is excluded: its ``stat_energy_from`` is optional and
+# a hub can legitimately carry multiple grid variants, so it has no single
+# uniqueness key.
+_STAT_FROM_SOURCE_TYPES: frozenset[str] = frozenset(
+    t for t in _ENERGY_SOURCE_TYPES if t != "grid"
+)
+
 
 def _default_prefs() -> dict[str, Any]:
     """Return the default empty prefs structure used by HA Core.
@@ -196,25 +214,25 @@ def _shape_check(
                 )
                 continue
             if key == "energy_sources":
-                valid_types = {"grid", "solar", "battery", "gas"}
-                requires_stat_from = {"solar", "battery", "gas"}
+                valid_types = "|".join(_ENERGY_SOURCE_TYPES)
                 entry_type = entry.get("type")
                 if entry_type is None:
                     errors.append(
                         {
                             "path": f"{key}[{idx}]",
-                            "message": "energy_sources entries require 'type' (grid|solar|battery|gas)",
+                            "message": f"energy_sources entries require 'type' ({valid_types})",
                         }
                     )
-                elif entry_type not in valid_types:
+                elif entry_type not in _ENERGY_SOURCE_TYPES:
                     errors.append(
                         {
                             "path": f"{key}[{idx}].type",
-                            "message": f"invalid type '{entry_type}' (must be one of grid|solar|battery|gas)",
+                            "message": f"invalid type '{entry_type}' (must be one of {valid_types})",
                         }
                     )
                 elif (
-                    entry_type in requires_stat_from and "stat_energy_from" not in entry
+                    entry_type in _STAT_FROM_SOURCE_TYPES
+                    and "stat_energy_from" not in entry
                 ):
                     errors.append(
                         {
@@ -354,7 +372,7 @@ class EnergyTools:
                     "the mutation against a fresh read and reports what would "
                     "change without writing — but still raises "
                     "RESOURCE_ALREADY_EXISTS (duplicate add_device, or duplicate "
-                    "add_source for solar/battery/gas), RESOURCE_NOT_FOUND "
+                    "add_source for solar/battery/gas/water), RESOURCE_NOT_FOUND "
                     "(missing remove_device), or VALIDATION_FAILED (post-mutator "
                     "shape error) when the proposed mutation is not applicable. "
                     "Default False."
@@ -414,11 +432,14 @@ class EnergyTools:
             Field(
                 description=(
                     "Single energy_sources entry for mode='add_source'. Must "
-                    "contain 'type' (one of grid|solar|battery|gas) and the "
-                    "type-specific required fields (e.g. solar/battery/gas "
-                    "require 'stat_energy_from'). Note: HA Core's voluptuous "
-                    "schema for grid sources requires the full field set "
-                    "(cost_adjustment_day, stat_energy_to, stat_cost, "
+                    "contain 'type' (one of grid|solar|battery|gas|water) and "
+                    "the type-specific required fields (e.g. "
+                    "solar/battery/gas/water require 'stat_energy_from'). Every "
+                    "source type also accepts an optional 'name' (display label "
+                    "in the energy graphs); battery additionally accepts "
+                    "'stat_soc' (state-of-charge statistic). Note: HA Core's "
+                    "voluptuous schema for grid sources requires the full field "
+                    "set (cost_adjustment_day, stat_energy_to, stat_cost, "
                     "entity_energy_price, number_energy_price, "
                     "entity_energy_price_export, number_energy_price_export, "
                     "stat_compensation) — the local shape check is narrower, "
@@ -434,11 +455,11 @@ class EnergyTools:
         """
         Manage the Home Assistant Energy Dashboard preferences.
 
-        The Energy Dashboard configuration (grid/solar/battery/gas sources,
-        individual device consumption sensors, cost tariffs, water) is stored
-        in ``.storage/energy`` and not otherwise reachable via REST, services,
-        or helper flows — this tool is the only way for agents to inspect or
-        modify it.
+        The Energy Dashboard configuration (grid/solar/battery/gas/water energy
+        sources, individual device consumption sensors for electricity and
+        water, cost tariffs) is stored in ``.storage/energy`` and not otherwise
+        reachable via REST, services, or helper flows — this tool is the only
+        way for agents to inspect or modify it.
 
         WHEN TO USE:
         - mode='get' / 'set': inspect or replace the full Energy Dashboard
@@ -449,7 +470,8 @@ class EnergyTools:
           internally; the caller does NOT manage config_hash. Use ``water=True``
           to target the water meter list instead of electricity.
         - mode='add_source': append a single entry to ``energy_sources`` (grid,
-          solar, battery, or gas). Same atomic read-modify-write semantics.
+          solar, battery, gas, or water). Same atomic read-modify-write
+          semantics.
 
         WHEN NOT TO USE:
         - To create the underlying statistics themselves — they must already
@@ -491,7 +513,7 @@ class EnergyTools:
         - Convenience modes are NOT idempotent: 'add_device' on an existing
           ``stat_consumption`` returns RESOURCE_ALREADY_EXISTS; 'remove_device'
           on a missing entry returns RESOURCE_NOT_FOUND. 'add_source' rejects
-          duplicates by ``(type, stat_energy_from)`` for solar/battery/gas
+          duplicates by ``(type, stat_energy_from)`` for solar/battery/gas/water
           (RESOURCE_ALREADY_EXISTS); grid entries are appended without a
           duplicate check (multiple grid variants are legitimate, and grid
           has no single canonical uniqueness key) — the caller is responsible
@@ -1094,15 +1116,15 @@ class EnergyTools:
 
         The ``source`` dict is wrapped into a synthetic single-entry config
         for ``_shape_check`` reuse, which validates the type-specific
-        required fields (e.g. ``stat_energy_from`` for solar/battery/gas).
+        required fields (e.g. ``stat_energy_from`` for solar/battery/gas/water).
 
         Duplicate semantics are asymmetric to ``_add_device`` because
         ``energy_sources`` does not expose a single uniqueness key across
-        types: solar/battery/gas are keyed on ``stat_energy_from``, but
+        types: solar/battery/gas/water are keyed on ``stat_energy_from``, but
         ``grid`` entries can legitimately have multiple variants
         (different tariffs, multiple meters) where ``stat_energy_from``
         alone does not identify duplicates. We therefore reject duplicates
-        by ``(type, stat_energy_from)`` for solar/battery/gas only and
+        by ``(type, stat_energy_from)`` for solar/battery/gas/water only and
         leave grid de-duplication to the caller.
         """
         if source is None:
@@ -1112,7 +1134,7 @@ class EnergyTools:
                     "'source' is required when mode='add_source'",
                     context={"mode": "add_source"},
                     suggestions=[
-                        "Pass source={'type': 'grid'|'solar'|'battery'|'gas', ...}",
+                        "Pass source={'type': 'grid'|'solar'|'battery'|'gas'|'water', ...}",
                     ],
                 )
             )
@@ -1132,7 +1154,7 @@ class EnergyTools:
                     },
                     suggestions=[
                         "Fix the listed errors and retry",
-                        "solar/battery/gas need 'stat_energy_from'; grid needs "
+                        "solar/battery/gas/water need 'stat_energy_from'; grid needs "
                         + "only 'type' for the local check, but HA Core's voluptuous "
                         + "schema requires the full grid field set "
                         + "(cost_adjustment_day, stat_energy_to, stat_cost, "
@@ -1189,7 +1211,7 @@ class EnergyTools:
         """Append ``new_source`` to ``existing`` with type-aware duplicate
         detection.
 
-        Solar/battery/gas entries are keyed on
+        Solar/battery/gas/water entries are keyed on
         ``(type, stat_energy_from)`` — duplicates raise
         ``RESOURCE_ALREADY_EXISTS``. Grid entries are appended without a
         duplicate check (multiple grid variants are legitimate, and grid
@@ -1199,7 +1221,7 @@ class EnergyTools:
         backstop for whatever HA Core flags.
         """
         source_type = new_source.get("type")
-        if source_type in {"solar", "battery", "gas"}:
+        if source_type in _STAT_FROM_SOURCE_TYPES:
             stat = new_source.get("stat_energy_from")
             for entry in existing:
                 if (

--- a/tests/src/e2e/tools/test_tools_energy.py
+++ b/tests/src/e2e/tools/test_tools_energy.py
@@ -196,9 +196,7 @@ async def _cleanup_test_source(mcp_client, stat_energy_from: str) -> None:
     """Remove any energy_sources entry matching ``stat_energy_from`` via a
     fresh read + mode='set' rewrite. Idempotent; safe to call when the
     source is already absent."""
-    get_result = await mcp_client.call_tool(
-        "ha_manage_energy_prefs", {"mode": "get"}
-    )
+    get_result = await mcp_client.call_tool("ha_manage_energy_prefs", {"mode": "get"})
     assert_mcp_success(get_result)
     sources = get_result.data["config"]["energy_sources"]
     if not any(s.get("stat_energy_from") == stat_energy_from for s in sources):
@@ -265,7 +263,7 @@ def _non_grid_source_payload(source_type: str, stat: str) -> dict:
     """Build a server-schema-conformant source payload per type.
 
     The local ``_shape_check`` only requires ``stat_energy_from`` for
-    solar/battery/gas, but HA Core's voluptuous schema requires more for
+    solar/battery/gas/water, but HA Core's voluptuous schema requires more for
     some types (battery requires ``stat_energy_to`` and rejects None).
     These payloads track what the server actually accepts, not what the
     local check passes — the asymmetry is intentional (see B1 in the
@@ -282,9 +280,9 @@ def _non_grid_source_payload(source_type: str, stat: str) -> dict:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("source_type", ["solar", "battery", "gas"])
+@pytest.mark.parametrize("source_type", ["solar", "battery", "gas", "water"])
 async def test_energy_add_source_non_grid_roundtrip(mcp_client, source_type):
-    """mode='add_source' atomically appends solar/battery/gas entries.
+    """mode='add_source' atomically appends solar/battery/gas/water entries.
 
     Each non-grid type only requires ``stat_energy_from`` for the local
     shape check; the post-save validate may surface ``stat not found``
@@ -357,14 +355,12 @@ async def test_energy_prefs_per_key_config_hash_roundtrip(mcp_client):
             "chained writes without an intermediate get"
         )
 
-        verify = await mcp_client.call_tool(
-            "ha_manage_energy_prefs", {"mode": "get"}
-        )
+        verify = await mcp_client.call_tool("ha_manage_energy_prefs", {"mode": "get"})
         assert_mcp_success(verify)
         verify_dc = verify.data["config"]["device_consumption"]
-        assert any(
-            d.get("stat_consumption") == test_stat for d in verify_dc
-        ), f"Per-key set must persist; got device_consumption={verify_dc}"
+        assert any(d.get("stat_consumption") == test_stat for d in verify_dc), (
+            f"Per-key set must persist; got device_consumption={verify_dc}"
+        )
     finally:
         # Restore original device_consumption under a fresh per-key hash.
         cleanup_initial = await mcp_client.call_tool(
@@ -379,9 +375,7 @@ async def test_energy_prefs_per_key_config_hash_roundtrip(mcp_client):
                         "mode": "set",
                         "config": {"device_consumption": original_dc},
                         "config_hash": {
-                            "device_consumption": cleanup_per_key[
-                                "device_consumption"
-                            ],
+                            "device_consumption": cleanup_per_key["device_consumption"],
                         },
                     },
                 )

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -452,9 +452,9 @@ class TestDryRun:
         assert any("type" in e["message"] for e in result["shape_errors"])
 
     async def test_shape_errors_energy_sources_enum_and_conditional(self, tools):
-        """G1b + G1c coverage:
+        """G1b + G1c coverage (mode='set' write path):
         - invalid type reports as '.type' path with enum message
-        - solar/battery/gas without stat_energy_from reports required
+        - solar/battery/gas/water without stat_energy_from reports required
         - grid without stat_energy_from is valid (HA core schema: Optional)
         """
         tools._client.send_websocket_message.return_value = {
@@ -509,6 +509,32 @@ class TestDryRun:
             "gas entries require 'stat_energy_from'" in e["message"]
             for e in result["shape_errors"]
         )
+
+        # Water without stat_energy_from (issue #1530: water is a valid type
+        # and, like solar/battery/gas, requires stat_energy_from).
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={"energy_sources": [{"type": "water"}]},
+            dry_run=True,
+        )
+        assert result["success"] is False
+        assert any(
+            "water entries require 'stat_energy_from'" in e["message"]
+            for e in result["shape_errors"]
+        )
+
+        # Water WITH stat_energy_from is accepted on the set path (no shape
+        # errors) — the regression at the heart of issue #1530.
+        result = await tools.ha_manage_energy_prefs(
+            mode="set",
+            config={
+                "energy_sources": [
+                    {"type": "water", "stat_energy_from": "sensor.water_meter"}
+                ]
+            },
+            dry_run=True,
+        )
+        assert result["shape_errors"] == []
 
         # Grid without stat_energy_from (valid per HA core schema)
         result = await tools.ha_manage_energy_prefs(
@@ -1856,6 +1882,35 @@ class TestAddSource:
         # Two grid entries now (caller's choice).
         assert len(save_payload["energy_sources"]) == 2
 
+    async def test_cross_type_same_stat_is_not_a_duplicate(self, tools):
+        """The de-dup key is the (type, stat_energy_from) tuple, not
+        stat_energy_from alone: an existing solar source must NOT block adding a
+        water source that happens to reuse the same stat_energy_from."""
+        shared_stat = "sensor.shared_meter"
+        current_prefs = {
+            **_sample_prefs(),
+            "energy_sources": [
+                {"type": "solar", "stat_energy_from": shared_stat},
+            ],
+        }
+        tools._client.send_websocket_message.side_effect = [
+            {"success": True, "result": current_prefs},
+            {"success": True, "result": None},
+            {"success": True, "result": _empty_validate_result()},
+        ]
+        result = await tools.ha_manage_energy_prefs(
+            mode="add_source",
+            source={"type": "water", "stat_energy_from": shared_stat},
+        )
+        assert result["success"] is True
+        save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
+        # Both sources coexist — the differing type makes them distinct.
+        assert len(save_payload["energy_sources"]) == 2
+        assert save_payload["energy_sources"][-1] == {
+            "type": "water",
+            "stat_energy_from": shared_stat,
+        }
+
     async def test_dry_run_does_not_write(self, tools):
         current_prefs = _sample_prefs()
         tools._client.send_websocket_message.side_effect = [
@@ -1869,13 +1924,15 @@ class TestAddSource:
         assert result["dry_run"] is True
         assert tools._client.send_websocket_message.call_count == 1
 
-    async def test_dry_run_raises_on_duplicate_non_grid(self, tools):
-        """dry_run on a duplicate solar/battery/gas raises before the
+    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas", "water"])
+    async def test_dry_run_raises_on_duplicate_non_grid(self, tools, source_type):
+        """dry_run on a duplicate solar/battery/gas/water raises before the
         dry-run short-circuit, matching the add_device dry_run semantic."""
+        stat = f"sensor.{source_type}_panel"
         current_prefs = {
             **_sample_prefs(),
             "energy_sources": [
-                {"type": "solar", "stat_energy_from": "sensor.solar_panel"},
+                {"type": source_type, "stat_energy_from": stat},
             ],
         }
         tools._client.send_websocket_message.side_effect = [
@@ -1884,7 +1941,7 @@ class TestAddSource:
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_manage_energy_prefs(
                 mode="add_source",
-                source={"type": "solar", "stat_energy_from": "sensor.solar_panel"},
+                source={"type": source_type, "stat_energy_from": stat},
                 dry_run=True,
             )
         err = json.loads(str(exc_info.value))

--- a/tests/src/unit/test_tools_energy.py
+++ b/tests/src/unit/test_tools_energy.py
@@ -132,6 +132,51 @@ class TestShapeCheck:
         )
         assert any("type" in e["message"] for e in errors)
 
+    def test_water_source_is_valid(self):
+        # Issue #1530: 'water' is a valid HA Core energy SourceType and must
+        # not be rejected by the local shape check.
+        assert (
+            _shape_check(
+                {
+                    "energy_sources": [
+                        {"type": "water", "stat_energy_from": "sensor.water_meter"}
+                    ],
+                }
+            )
+            == []
+        )
+
+    def test_water_source_missing_stat_energy_from(self):
+        # Water requires stat_energy_from, mirroring solar/battery/gas.
+        errors = _shape_check({"energy_sources": [{"type": "water"}]})
+        assert any(
+            "water entries require 'stat_energy_from'" in e["message"] for e in errors
+        )
+
+    def test_water_source_accepts_optional_name(self):
+        # Every source type accepts an optional display 'name'.
+        assert (
+            _shape_check(
+                {
+                    "energy_sources": [
+                        {
+                            "type": "water",
+                            "stat_energy_from": "sensor.water_meter",
+                            "name": "Garden tap",
+                        }
+                    ],
+                }
+            )
+            == []
+        )
+
+    def test_invalid_type_message_lists_water(self):
+        # The enum error message advertises 'water' as an accepted type.
+        errors = _shape_check(
+            {"energy_sources": [{"type": "wind", "stat_energy_from": "sensor.x"}]}
+        )
+        assert any("water" in e["message"] for e in errors)
+
     def test_device_consumption_missing_stat_consumption(self):
         errors = _shape_check(
             {
@@ -1699,9 +1744,9 @@ class TestAddSource:
         err = json.loads(str(exc_info.value))
         assert err["error"]["code"] == "VALIDATION_FAILED"
 
-    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas"])
+    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas", "water"])
     async def test_non_grid_missing_stat_energy_from_raises(self, tools, source_type):
-        """solar/battery/gas all require stat_energy_from; grid does not."""
+        """solar/battery/gas/water all require stat_energy_from; grid does not."""
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_manage_energy_prefs(
                 mode="add_source",
@@ -1732,9 +1777,9 @@ class TestAddSource:
         assert "device_consumption" not in save_payload
         assert save_payload["energy_sources"][-1] == new_grid
 
-    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas"])
+    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas", "water"])
     async def test_non_grid_happy_path(self, tools, source_type):
-        """solar/battery/gas append to energy_sources just like grid does."""
+        """solar/battery/gas/water append to energy_sources just like grid does."""
         current_prefs = _sample_prefs()
         tools._client.send_websocket_message.side_effect = [
             {"success": True, "result": current_prefs},
@@ -1756,9 +1801,9 @@ class TestAddSource:
         save_payload = tools._client.send_websocket_message.call_args_list[1].args[0]
         assert save_payload["energy_sources"][-1] == new_source
 
-    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas"])
+    @pytest.mark.parametrize("source_type", ["solar", "battery", "gas", "water"])
     async def test_non_grid_duplicate_raises_already_exists(self, tools, source_type):
-        """solar/battery/gas reject duplicates by (type, stat_energy_from)."""
+        """solar/battery/gas/water reject duplicates by (type, stat_energy_from)."""
         stat = f"sensor.{source_type}_existing"
         current_prefs = {
             **_sample_prefs(),


### PR DESCRIPTION
## What does this PR do?

Fixes #1530: `ha_manage_energy_prefs` rejected a valid `"water"` energy source. HA Core's energy `SourceType` union includes `WaterSourceType` (`type: "water"`), but the tool's local shape check only allowed grid/solar/battery/gas, so `mode='set'` and `mode='add_source'` hard-blocked water with `invalid type 'water'`; the `add_source` duplicate check omitted it too.

- Accept `"water"`, sourced from a single module-level constant (`_ENERGY_SOURCE_TYPES`) shared by the shape check and `_append_unique_source` de-duplication — future HA source types become a one-line addition. Water requires `stat_energy_from` and de-dupes by `(type, stat_energy_from)`, mirroring solar/battery/gas.
- Document the optional `name` field (accepted on every source type) and battery `stat_soc` in the `source` parameter description. Both already round-trip but were undiscoverable to an agent.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran locally: `ruff format --check`, `ruff check`, `mypy src/`, `ast-grep scan`, and the energy unit suite (`pytest src/unit/test_tools_energy.py` — 108 passed). The e2e suite requires Docker, which wasn't available locally; the `water` round-trip is covered by extending the existing `test_energy_add_source_non_grid_roundtrip` parametrize and runs in CI.

Added/extended tests: unit + e2e `add_source` parametrizations now cover `water`, plus explicit `_shape_check` cases for a valid water source, water missing `stat_energy_from`, an optional `name`, and the enum error message advertising water.

## Checklist
- [x] I have updated documentation if needed
