### PR TITLE
feat: expose all user-tunable env vars in the settings UI (add-on parity)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ HA_MAX_RETRIES=3
 FUZZY_THRESHOLD=60
 ENTITY_SEARCH_LIMIT=20
 
+# Smart-search config-fetch time budgets (seconds). Cap how long ha_search /
+# ha_deep_search spends fetching automation/script/scene definitions before
+# returning a partial result. Raise on instances with many automations.
+# Also editable from the web Settings UI (Advanced section) for add-on users.
+# HAMCP_AUTOMATION_CONFIG_TIME_BUDGET=30
+# HAMCP_SCRIPT_CONFIG_TIME_BUDGET=20
+# HAMCP_SCENE_CONFIG_TIME_BUDGET=20
+
 # WebSocket Configuration (essential for async operations)
 ENABLE_WEBSOCKET=true
 

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -687,6 +687,18 @@ ADVANCED_SETTINGS_FIELDS: tuple[AdvancedField, ...] = (
     # Operations.
     AdvancedField("backup_hint", "BACKUP_HINT", str, "operations", True),
     AdvancedField("enable_websocket", "ENABLE_WEBSOCKET", bool, "operations", True),
+    # Dashboard-screenshot engine URL (#1538): docker/.env users could set
+    # HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL, but add-on users had no path to
+    # it. It is resolved live per capture (resolve_engine_url), so unlike the
+    # time budgets it takes effect without a restart. Blank = auto-discover
+    # the Puppet add-on via the Supervisor.
+    AdvancedField(
+        "dashboard_screenshot_engine_url",
+        "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL",
+        str,
+        "operations",
+        True,
+    ),
     AdvancedField(
         "enabled_tool_modules", "ENABLED_TOOL_MODULES", str, "tools_surface", True
     ),

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -71,8 +71,8 @@ class Settings(BaseSettings):
     # result. Surfaced in the Advanced settings panel (issue #1538) so
     # add-on users — who cannot set raw env vars — can tune them. Consumed
     # as import-time module constants in tools/smart_search/_config.py, so
-    # a change requires an MCP-host restart to take effect (the same
-    # restart-required behavior the Advanced panel already advertises).
+    # a change requires an MCP-host restart to take effect (advanced
+    # settings already carry a restart-required notice in the UI).
     automation_config_time_budget: float = Field(
         30.0, alias="HAMCP_AUTOMATION_CONFIG_TIME_BUDGET"
     )
@@ -319,25 +319,42 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _lenient_time_budget(cls, v: object, info: ValidationInfo) -> object:
-        """Preserve the legacy ``_env_float`` contract for the three smart-
-        search time budgets: an empty or unparseable value falls back to
-        the field default (with a warning) instead of crashing startup with
-        a ``ValidationError``. Mirrors the tolerance the override-file path
-        already applies via ``_ADVANCED_SETTINGS_BOUNDS``."""
-        assert info.field_name is not None
-        default = cls.model_fields[info.field_name].default
+        """Coerce the three smart-search time budgets, falling back to the
+        field default (with a warning) instead of crashing startup.
+
+        Preserves the parse-tolerance of the removed ``_env_float`` helper
+        (empty / unparseable -> default) and additionally enforces the same
+        ``_ADVANCED_SETTINGS_BOUNDS`` range as the override-file / UI-POST
+        path, so the env-var path can't smuggle in an out-of-range or
+        non-finite budget. A ``<= 0`` budget would silently disable the
+        per-id config-fetch scan, and ``inf`` / ``nan`` would uncap it; the
+        ``lo <= val <= hi`` test rejects all three (NaN comparisons are
+        False), keeping the env and override-file paths consistent."""
+        field_name = info.field_name
+        if field_name is None:  # always set for field_validator; defensive
+            return v
+        default = cls.model_fields[field_name].default
         if v is None or (isinstance(v, str) and not v.strip()):
             return default
         try:
-            return float(v)  # type: ignore[arg-type]
+            val = float(v)  # type: ignore[arg-type]
         except (ValueError, TypeError):
             logger.warning(
-                "Invalid value for %s=%r; using default %s",
-                info.field_name,
+                "Invalid value for %s=%r; using default %s", field_name, v, default
+            )
+            return default
+        lo, hi = _ADVANCED_SETTINGS_BOUNDS[field_name]
+        if not (lo <= val <= hi):
+            logger.warning(
+                "%s=%r is outside %s-%s; using default %s",
+                field_name,
                 v,
+                lo,
+                hi,
                 default,
             )
             return default
+        return val
 
     @property
     def env_file_name(self) -> str:

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple
 
 from dotenv import load_dotenv
-from pydantic import Field, field_validator
+from pydantic import Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ha_mcp._version import get_version
@@ -64,6 +64,24 @@ class Settings(BaseSettings):
     # Tool configuration
     fuzzy_threshold: int = Field(60, alias="FUZZY_THRESHOLD")
     entity_search_limit: int = Field(20, alias="ENTITY_SEARCH_LIMIT")
+
+    # Smart-search config-fetch time budgets (seconds). Bound how long
+    # ha_search / ha_deep_search spends fetching automation/script/scene
+    # definitions during the per-id fallback before reporting a partial
+    # result. Surfaced in the Advanced settings panel (issue #1538) so
+    # add-on users — who cannot set raw env vars — can tune them. Consumed
+    # as import-time module constants in tools/smart_search/_config.py, so
+    # a change requires an MCP-host restart to take effect (the same
+    # restart-required behavior the Advanced panel already advertises).
+    automation_config_time_budget: float = Field(
+        30.0, alias="HAMCP_AUTOMATION_CONFIG_TIME_BUDGET"
+    )
+    script_config_time_budget: float = Field(
+        20.0, alias="HAMCP_SCRIPT_CONFIG_TIME_BUDGET"
+    )
+    scene_config_time_budget: float = Field(
+        20.0, alias="HAMCP_SCENE_CONFIG_TIME_BUDGET"
+    )
 
     # Backup tool configuration
     backup_hint: str = Field("normal", alias="BACKUP_HINT")
@@ -292,6 +310,34 @@ class Settings(BaseSettings):
         if isinstance(v, str) and not v.strip():
             return False
         return v
+
+    @field_validator(
+        "automation_config_time_budget",
+        "script_config_time_budget",
+        "scene_config_time_budget",
+        mode="before",
+    )
+    @classmethod
+    def _lenient_time_budget(cls, v: object, info: ValidationInfo) -> object:
+        """Preserve the legacy ``_env_float`` contract for the three smart-
+        search time budgets: an empty or unparseable value falls back to
+        the field default (with a warning) instead of crashing startup with
+        a ``ValidationError``. Mirrors the tolerance the override-file path
+        already applies via ``_ADVANCED_SETTINGS_BOUNDS``."""
+        assert info.field_name is not None
+        default = cls.model_fields[info.field_name].default
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return default
+        try:
+            return float(v)  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid value for %s=%r; using default %s",
+                info.field_name,
+                v,
+                default,
+            )
+            return default
 
     @property
     def env_file_name(self) -> str:
@@ -598,6 +644,29 @@ ADVANCED_SETTINGS_FIELDS: tuple[AdvancedField, ...] = (
     # Search & matching.
     AdvancedField("fuzzy_threshold", "FUZZY_THRESHOLD", int, "search", True),
     AdvancedField("entity_search_limit", "ENTITY_SEARCH_LIMIT", int, "search", True),
+    # Smart-search config-fetch time budgets (#1538). Restart-required
+    # (consumed as import-time constants in smart_search/_config.py).
+    AdvancedField(
+        "automation_config_time_budget",
+        "HAMCP_AUTOMATION_CONFIG_TIME_BUDGET",
+        float,
+        "search",
+        True,
+    ),
+    AdvancedField(
+        "script_config_time_budget",
+        "HAMCP_SCRIPT_CONFIG_TIME_BUDGET",
+        float,
+        "search",
+        True,
+    ),
+    AdvancedField(
+        "scene_config_time_budget",
+        "HAMCP_SCENE_CONFIG_TIME_BUDGET",
+        float,
+        "search",
+        True,
+    ),
     # Operations.
     AdvancedField("backup_hint", "BACKUP_HINT", str, "operations", True),
     AdvancedField("enable_websocket", "ENABLE_WEBSOCKET", bool, "operations", True),
@@ -660,6 +729,9 @@ _ADVANCED_SETTINGS_BOUNDS: dict[str, tuple[float, float]] = {
     "max_retries": (0, 20),
     "fuzzy_threshold": (0, 100),
     "entity_search_limit": (1, 1000),
+    "automation_config_time_budget": (1.0, 600.0),
+    "script_config_time_budget": (1.0, 600.0),
+    "scene_config_time_budget": (1.0, 600.0),
     "code_mode_max_duration": (1.0, 300.0),
     "code_mode_max_memory": (1_048_576, 268_435_456),
     "code_mode_max_recursion": (1, 10_000),

--- a/src/ha_mcp/settings.js
+++ b/src/ha_mcp/settings.js
@@ -2400,7 +2400,11 @@ const ADVANCED_FIELD_META = {
   verify_ssl:          { label: "Verify SSL certificates",     help: "Skip TLS verification only on trusted networks (self-signed certs, hostname mismatch). Restart required." },
   fuzzy_threshold:     { label: "Fuzzy-search threshold",      help: "Lower = looser entity match. Range 0–100." },
   entity_search_limit: { label: "Entity search result limit",  help: "Max entities returned by ha_search_entities. Range 1–1000." },
+  automation_config_time_budget: { label: "Automation config time budget (s)", help: "Max seconds ha_search/ha_deep_search spends fetching automation configs before returning a partial result. Raise on instances with many automations. Range 1–600. Restart required." },
+  script_config_time_budget:     { label: "Script config time budget (s)",     help: "Max seconds ha_search/ha_deep_search spends fetching script configs before returning a partial result. Range 1–600. Restart required." },
+  scene_config_time_budget:      { label: "Scene config time budget (s)",      help: "Max seconds ha_search/ha_deep_search spends fetching scene configs before returning a partial result. Range 1–600. Restart required." },
   backup_hint:         { label: "Backup-hint level",           help: "Tunes how strongly the LLM is prompted to take a full-HA snapshot before risky writes." },
+  dashboard_screenshot_engine_url: { label: "Dashboard screenshot engine URL", help: "Base URL of the screenshot engine (e.g. http://puppet:10000). Leave blank to auto-discover the Puppet add-on via the Supervisor (HA OS / Supervised). Only used when the Dashboard Screenshot beta feature is enabled. Takes effect without a restart." },
   enable_websocket:    { label: "Enable WebSocket",            help: "WebSocket-based state monitoring. Disabling falls back to polling — many tools degrade. Restart required." },
   enabled_tool_modules: { label: "Enabled tool modules",       help: "Comma-separated module names, or 'all'. Restricts which tool registry modules load at startup. Restart required." },
   enable_dashboard_partial_tools: { label: "Dashboard partial-update tools", help: "Token-efficient partial dashboard tools. Disable for clients with programmatic tool use." },
@@ -2430,6 +2434,12 @@ const ADVANCED_RESTART_REQUIRED = new Set([
   // lazy-init singleton (tools/smart_search.py) — changes
   // need restart to rebuild the searcher.
   "fuzzy_threshold",
+  // The three smart-search time budgets are read once at import by
+  // SmartSearchTools' _config module (singleton), so a change needs a
+  // restart. dashboard_screenshot_engine_url is intentionally absent —
+  // it is resolved live per capture, so it takes effect immediately.
+  "automation_config_time_budget", "script_config_time_budget",
+  "scene_config_time_budget",
   "code_mode_max_duration", "code_mode_max_memory",
   "code_mode_max_recursion", "code_mode_max_invocations",
   "code_mode_saved_tools_path",

--- a/src/ha_mcp/tools/smart_search/_config.py
+++ b/src/ha_mcp/tools/smart_search/_config.py
@@ -5,11 +5,7 @@ smart-search mixins and the public ``smart_search`` shell can both depend
 on it without creating an import cycle.
 """
 
-import logging
-import os
-
-logger = logging.getLogger(__name__)
-
+from ha_mcp.config import get_global_settings
 
 # Default concurrency limit for parallel operations
 DEFAULT_CONCURRENCY_LIMIT = 20
@@ -20,22 +16,17 @@ BULK_WEBSOCKET_TIMEOUT = 3.0  # Timeout for bulk WebSocket calls
 INDIVIDUAL_CONFIG_TIMEOUT = 5.0  # Timeout for individual config fetches
 
 
-# Time budgets for fallback individual fetching (in seconds).
-# Configurable via env vars for instances with many automations/scripts.
-def _env_float(key: str, default: float) -> float:
-    raw = os.environ.get(key)
-    if raw is None:
-        return default
-    try:
-        return float(raw)
-    except (ValueError, TypeError):
-        logger.warning(f"Invalid value for {key}={raw!r}, using default {default}")
-        return default
-
-
-AUTOMATION_CONFIG_TIME_BUDGET = _env_float("HAMCP_AUTOMATION_CONFIG_TIME_BUDGET", 30.0)
-SCRIPT_CONFIG_TIME_BUDGET = _env_float("HAMCP_SCRIPT_CONFIG_TIME_BUDGET", 20.0)
-SCENE_CONFIG_TIME_BUDGET = _env_float("HAMCP_SCENE_CONFIG_TIME_BUDGET", 20.0)
+# Time budgets for fallback individual fetching (in seconds). Sourced from
+# the resolved Settings (issue #1538) so the env var, the web Settings UI
+# override file, and the field defaults all flow through one precedence path
+# — and so add-on users (who cannot set raw env vars) can tune them from the
+# Advanced panel. Read once at import as module-level constants; a change
+# takes effect on the next MCP-host restart (the Advanced panel advertises
+# this restart-required behavior).
+_settings = get_global_settings()
+AUTOMATION_CONFIG_TIME_BUDGET = _settings.automation_config_time_budget
+SCRIPT_CONFIG_TIME_BUDGET = _settings.script_config_time_budget
+SCENE_CONFIG_TIME_BUDGET = _settings.scene_config_time_budget
 
 # Batch size for parallel individual config fetches (Attempt C fallback)
 INDIVIDUAL_FETCH_BATCH_SIZE = 10

--- a/src/ha_mcp/tools/smart_search/_config.py
+++ b/src/ha_mcp/tools/smart_search/_config.py
@@ -21,8 +21,8 @@ INDIVIDUAL_CONFIG_TIMEOUT = 5.0  # Timeout for individual config fetches
 # override file, and the field defaults all flow through one precedence path
 # — and so add-on users (who cannot set raw env vars) can tune them from the
 # Advanced panel. Read once at import as module-level constants; a change
-# takes effect on the next MCP-host restart (the Advanced panel advertises
-# this restart-required behavior).
+# takes effect on the next MCP-host restart (advanced settings already
+# carry a restart-required notice in the UI).
 _settings = get_global_settings()
 AUTOMATION_CONFIG_TIME_BUDGET = _settings.automation_config_time_budget
 SCRIPT_CONFIG_TIME_BUDGET = _settings.script_config_time_budget

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -903,8 +903,9 @@ class DeepSearchMixin(SceneSearchMixin):
                 f"{automation_skipped} automation(s) not scanned (time budget "
                 "exhausted) — their match status is unknown; this result is "
                 "not exhaustive. Pass `config_time_budget=` on `ha_search` to "
-                "raise the per-call limit (or set "
-                "HAMCP_AUTOMATION_CONFIG_TIME_BUDGET for the default)."
+                "raise the per-call limit (or, for the default, set "
+                "HAMCP_AUTOMATION_CONFIG_TIME_BUDGET or the matching field in "
+                "the web Settings UI's Advanced section)."
             )
         if automation_failed:
             reasons.append(
@@ -925,8 +926,9 @@ class DeepSearchMixin(SceneSearchMixin):
                 f"{script_skipped} script(s) not scanned (time budget "
                 "exhausted) — their match status is unknown; this result is "
                 "not exhaustive. Pass `config_time_budget=` on `ha_search` to "
-                "raise the per-call limit (or set "
-                "HAMCP_SCRIPT_CONFIG_TIME_BUDGET for the default)."
+                "raise the per-call limit (or, for the default, set "
+                "HAMCP_SCRIPT_CONFIG_TIME_BUDGET or the matching field in "
+                "the web Settings UI's Advanced section)."
             )
         if script_failed:
             reasons.append(

--- a/src/ha_mcp/tools/smart_search/_scenes.py
+++ b/src/ha_mcp/tools/smart_search/_scenes.py
@@ -347,8 +347,9 @@ class SceneSearchMixin(ConfigFetchMixin):
                 f"{skipped} scene(s) not scanned (time budget exhausted) — "
                 "their match status is unknown; this result is not exhaustive. "
                 "Pass `config_time_budget=` on `ha_search` to raise the "
-                "per-call limit (or set HAMCP_SCENE_CONFIG_TIME_BUDGET for "
-                "the default)."
+                "per-call limit (or, for the default, set "
+                "HAMCP_SCENE_CONFIG_TIME_BUDGET or the matching field in the "
+                "web Settings UI's Advanced section)."
             )
         if scene_stats["integration_skipped"]:
             # Informational, not an unknown-match-status condition: these

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -31,11 +31,6 @@ ALLOWLIST: set[str] = {
     # Advanced Settings or Feature Flags panels.
     "DISABLED_TOOLS",
     "PINNED_TOOLS",
-    # Screenshot-engine URL is a deployment-environment connection string
-    # (the Docker/Container sidecar path), not a user-facing UI toggle — it
-    # is deliberately env/.env-only and absent from every override registry.
-    # See the comment on dashboard_screenshot_engine_url in config.py.
-    "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL",
 }
 
 
@@ -367,6 +362,45 @@ def test_scanner_detects_all_direct_read_forms() -> None:
         "J_SETDEFAULT",
         "M_POP",
     }
+
+
+def test_every_advanced_field_has_a_settings_js_label() -> None:
+    """The Advanced GET handler is data-driven over ADVANCED_SETTINGS_FIELDS,
+    but settings.js looks up each row's label/help in ``ADVANCED_FIELD_META``
+    (falling back to the raw snake_case field name). A row added to config.py
+    without a matching JS entry silently degrades the UI — guard against that
+    drift (issue #1538 added three rows that initially lacked entries)."""
+    import re
+
+    js = (_package_dir() / "settings.js").read_text(encoding="utf-8")
+    m = re.search(r"const ADVANCED_FIELD_META = \{(.*?)\n\};", js, re.S)
+    assert m, "ADVANCED_FIELD_META object not found in settings.js"
+    meta_keys = set(
+        re.findall(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\{", m.group(1), re.M)
+    )
+    missing = sorted({f.field for f in ADVANCED_SETTINGS_FIELDS} - meta_keys)
+    assert not missing, (
+        "ADVANCED_SETTINGS_FIELDS rows missing an ADVANCED_FIELD_META entry in "
+        f"settings.js (they would render with a raw field-name label): {missing}."
+    )
+
+
+def test_screenshot_engine_url_is_surfaced_as_editable_advanced_field() -> None:
+    """#1538: the screenshot engine URL is env-settable (docker/.env) but was
+    invisible to add-on users. It must now be an editable Advanced row, no
+    longer on the env-only ALLOWLIST."""
+    row = next(
+        (
+            r
+            for r in ADVANCED_SETTINGS_FIELDS
+            if r.field == "dashboard_screenshot_engine_url"
+        ),
+        None,
+    )
+    assert row is not None, "dashboard_screenshot_engine_url must be an advanced field"
+    assert row.ftype is str
+    assert row.editable is True
+    assert "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL" not in ALLOWLIST
 
 
 def test_advanced_registries_are_name_disjoint() -> None:

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -276,7 +276,7 @@ def _env_reads_in_tree(tree: ast.Module) -> set[str]:
             fn = node.func
             if _is_getenv(fn) or (
                 isinstance(fn, ast.Attribute)
-                and fn.attr in {"get", "setdefault"}
+                and fn.attr in {"get", "setdefault", "pop"}
                 and _is_environ(fn.value)
             ):
                 name = _first_literal(node.args)
@@ -351,6 +351,7 @@ def test_scanner_detects_all_direct_read_forms() -> None:
         "h = _env.get('H_FROM_ALIAS')\n"
         "i = _ge('I_GETENV_ALIAS')\n"
         "os.environ.setdefault('J_SETDEFAULT', 'x')\n"
+        "m = os.environ.pop('M_POP', None)\n"
         "k = os.environ.get(some_var)\n"  # non-literal -> skipped
     )
     assert _env_reads_in_tree(ast.parse(src)) == {
@@ -364,6 +365,7 @@ def test_scanner_detects_all_direct_read_forms() -> None:
         "H_FROM_ALIAS",
         "I_GETENV_ALIAS",
         "J_SETDEFAULT",
+        "M_POP",
     }
 
 

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -12,6 +12,10 @@ allow-list is for things that genuinely have no place in the panel,
 e.g. fields populated from package metadata).
 """
 
+import ast
+from pathlib import Path
+
+import ha_mcp
 from ha_mcp.config import (
     ADVANCED_SETTINGS_FIELDS,
     BACKUP_OVERRIDE_FIELDS,
@@ -168,6 +172,125 @@ def test_validate_registries_rejects_beta_field_not_in_feature_flags(
     monkeypatch.setattr(cfg, "BETA_FEATURE_FIELDS", patched_beta)
     with pytest.raises(RuntimeError, match="BETA_FEATURE_FIELDS contains names not in"):
         cfg._validate_registries()
+
+
+# ---------------------------------------------------------------------------
+# Guard against env-var drift bypassing config.py (issue #1538)
+# ---------------------------------------------------------------------------
+#
+# The coverage gate above only sees env vars that are ``Settings`` fields.
+# A tunable knob read directly via ``os.environ`` / ``os.getenv`` never
+# becomes a Settings field, so it stays invisible to the web Settings UI
+# and unreachable for add-on users. That is exactly how the three
+# ``HAMCP_*_TIME_BUDGET`` knobs drifted out of the panel before #1538.
+#
+# This guard scans the shipped source for *direct, string-literal* env
+# reads and requires each to be either a registered ``Settings`` alias
+# (and therefore covered by the gate above) or on the explicit
+# ``ENV_ONLY`` list below. Registry-driven reads (``os.environ.get(var)``
+# with a non-literal argument, as in ``config.py`` / ``settings_ui.py``)
+# carry no literal to inspect and are correctly skipped — those iterate
+# the registries themselves.
+
+# Env vars deliberately read straight from the environment with no panel
+# home. Each is a bind / secret / bootstrap / path value that must be set
+# before (or independently of) the UI that would otherwise edit it.
+ENV_ONLY: dict[str, str] = {
+    "SUPERVISOR_TOKEN": "Injected by Supervisor; identifies add-on mode (secret/bootstrap)",
+    "SUPERVISOR_BASE_URL": "Supervisor API base; bootstrap before any settings exist",
+    "HAMCP_ENV_FILE": "Selects which .env file to load — read before Settings is built",
+    "HA_MCP_CONFIG_DIR": "Resolves the data dir that *holds* the override files (path)",
+    "XDG_DATA_HOME": "Data-dir fallback root (path)",
+    "HA_MCP_BUILD_VERSION": "Build metadata stamped at image build (bootstrap)",
+    "HA_MCP_DISABLE_SETTINGS_UI": "Kill-switch for the settings sidecar itself (chicken-and-egg)",
+    "MCP_HOST": "HTTP listener bind address — configured before the server is up",
+    "MCP_PORT": "HTTP listener port — configured before the server is up",
+    "MCP_HTTP_PORT": "HTTP listener port (alt name) — bind config",
+    "MCP_BASE_URL": "Externally advertised base URL — bind/deployment config",
+    "MCP_SECRET_PATH": "Secret URL path component for the MCP endpoint (secret)",
+    "FASTMCP_PORT": "FastMCP transport bind port",
+    "FASTMCP_TRANSPORT": "FastMCP transport selection — bootstrap",
+}
+
+
+def _literal_env_reads() -> dict[str, set[str]]:
+    """Map ``ENV_VAR -> {relative source paths}`` for every direct
+    string-literal ``os.environ`` / ``os.getenv`` read in the package."""
+    pkg_dir = Path(ha_mcp.__file__).resolve().parent
+
+    def _is_os_attr(node: ast.expr, attr: str) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == attr
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        )
+
+    def _is_os_environ(node: ast.expr) -> bool:
+        return _is_os_attr(node, "environ")
+
+    def _first_literal(args: list[ast.expr]) -> str | None:
+        if (
+            args
+            and isinstance(args[0], ast.Constant)
+            and isinstance(args[0].value, str)
+        ):
+            return args[0].value
+        return None
+
+    found: dict[str, set[str]] = {}
+    for py in pkg_dir.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        rel = py.relative_to(pkg_dir).as_posix()
+        for node in ast.walk(tree):
+            name: str | None = None
+            if isinstance(node, ast.Call):
+                fn = node.func
+                if _is_os_attr(fn, "getenv"):
+                    name = _first_literal(node.args)
+                elif isinstance(fn, ast.Attribute) and fn.attr in {
+                    "get",
+                    "setdefault",
+                }:
+                    if _is_os_environ(fn.value):
+                        name = _first_literal(node.args)
+            elif isinstance(node, ast.Subscript) and _is_os_environ(node.value):
+                sl = node.slice
+                if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+                    name = sl.value
+            if name is not None:
+                found.setdefault(name, set()).add(rel)
+    return found
+
+
+def test_no_unregistered_direct_env_reads() -> None:
+    """Every direct ``os.environ`` read of a literal var name must be a
+    registered ``Settings`` alias or an explicitly documented ENV_ONLY var."""
+    reads = _literal_env_reads()
+    aliases = _all_env_aliases()
+    offenders = {
+        name: sorted(paths)
+        for name, paths in reads.items()
+        if name not in aliases and name not in ENV_ONLY
+    }
+    assert not offenders, (
+        "Direct os.environ reads of unregistered env vars (invisible to the "
+        f"Settings UI): {offenders}. Promote each to a Settings field (and a "
+        "registry: ADVANCED_SETTINGS_FIELDS / FEATURE_FLAG_FIELDS / "
+        "BACKUP_OVERRIDE_FIELDS), or add it to ENV_ONLY with a one-line reason."
+    )
+
+
+def test_env_only_list_has_no_dead_entries() -> None:
+    """Keep ENV_ONLY honest — an entry no longer read anywhere (and not a
+    Settings alias) is dead and should be removed so the list documents
+    reality."""
+    reads = _literal_env_reads()
+    aliases = _all_env_aliases()
+    dead = sorted(
+        name for name in ENV_ONLY if name not in reads and name not in aliases
+    )
+    assert not dead, f"ENV_ONLY lists vars no longer read in src: {dead}"
 
 
 def test_advanced_registries_are_name_disjoint() -> None:

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -13,9 +13,9 @@ e.g. fields populated from package metadata).
 """
 
 import ast
+import sys
 from pathlib import Path
 
-import ha_mcp
 from ha_mcp.config import (
     ADVANCED_SETTINGS_FIELDS,
     BACKUP_OVERRIDE_FIELDS,
@@ -187,7 +187,10 @@ def test_validate_registries_rejects_beta_field_not_in_feature_flags(
 # This guard scans the shipped source for *direct, string-literal* env
 # reads and requires each to be either a registered ``Settings`` alias
 # (and therefore covered by the gate above) or on the explicit
-# ``ENV_ONLY`` list below. Registry-driven reads (``os.environ.get(var)``
+# ``ENV_ONLY`` list below. It resolves the relevant import aliases per
+# file, so both the attribute forms (``os.environ[...]`` / ``os.getenv``)
+# and the ``from os import environ, getenv`` forms — including ``as``
+# aliases — are caught. Registry-driven reads (``os.environ.get(var)``
 # with a non-literal argument, as in ``config.py`` / ``settings_ui.py``)
 # carry no literal to inspect and are correctly skipped — those iterate
 # the registries themselves.
@@ -213,53 +216,89 @@ ENV_ONLY: dict[str, str] = {
 }
 
 
+def _package_dir() -> Path:
+    cfg = sys.modules["ha_mcp.config"]
+    assert cfg.__file__ is not None  # regular module always has __file__
+    return Path(cfg.__file__).resolve().parent
+
+
+def _first_literal(args: list[ast.expr]) -> str | None:
+    if args and isinstance(args[0], ast.Constant) and isinstance(args[0].value, str):
+        return args[0].value
+    return None
+
+
+def _env_reads_in_tree(tree: ast.Module) -> set[str]:
+    """Resolve per-file aliases for the ``os`` module and the ``environ`` /
+    ``getenv`` names, then collect every literal env var read through them."""
+    os_aliases: set[str] = set()  # names bound to the ``os`` module
+    environ_aliases: set[str] = set()  # names bound to ``os.environ``
+    getenv_aliases: set[str] = set()  # names bound to ``os.getenv``
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "os":
+                    os_aliases.add(alias.asname or "os")
+        elif isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                if alias.name == "environ":
+                    environ_aliases.add(alias.asname or "environ")
+                elif alias.name == "getenv":
+                    getenv_aliases.add(alias.asname or "getenv")
+
+    def _is_environ(node: ast.expr) -> bool:
+        # ``os.environ`` (attribute on the os module) or a bare ``environ``
+        # imported via ``from os import environ``.
+        if isinstance(node, ast.Name):
+            return node.id in environ_aliases
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in os_aliases
+        )
+
+    def _is_getenv(node: ast.expr) -> bool:
+        # ``os.getenv`` or a bare ``getenv`` imported via ``from os import``.
+        if isinstance(node, ast.Name):
+            return node.id in getenv_aliases
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "getenv"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in os_aliases
+        )
+
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        name: str | None = None
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if _is_getenv(fn) or (
+                isinstance(fn, ast.Attribute)
+                and fn.attr in {"get", "setdefault"}
+                and _is_environ(fn.value)
+            ):
+                name = _first_literal(node.args)
+        elif isinstance(node, ast.Subscript) and _is_environ(node.value):
+            sl = node.slice
+            if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+                name = sl.value
+        if name is not None:
+            names.add(name)
+    return names
+
+
 def _literal_env_reads() -> dict[str, set[str]]:
     """Map ``ENV_VAR -> {relative source paths}`` for every direct
     string-literal ``os.environ`` / ``os.getenv`` read in the package."""
-    pkg_dir = Path(ha_mcp.__file__).resolve().parent
-
-    def _is_os_attr(node: ast.expr, attr: str) -> bool:
-        return (
-            isinstance(node, ast.Attribute)
-            and node.attr == attr
-            and isinstance(node.value, ast.Name)
-            and node.value.id == "os"
-        )
-
-    def _is_os_environ(node: ast.expr) -> bool:
-        return _is_os_attr(node, "environ")
-
-    def _first_literal(args: list[ast.expr]) -> str | None:
-        if (
-            args
-            and isinstance(args[0], ast.Constant)
-            and isinstance(args[0].value, str)
-        ):
-            return args[0].value
-        return None
-
+    pkg_dir = _package_dir()
     found: dict[str, set[str]] = {}
     for py in pkg_dir.rglob("*.py"):
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
         rel = py.relative_to(pkg_dir).as_posix()
-        for node in ast.walk(tree):
-            name: str | None = None
-            if isinstance(node, ast.Call):
-                fn = node.func
-                if _is_os_attr(fn, "getenv"):
-                    name = _first_literal(node.args)
-                elif isinstance(fn, ast.Attribute) and fn.attr in {
-                    "get",
-                    "setdefault",
-                }:
-                    if _is_os_environ(fn.value):
-                        name = _first_literal(node.args)
-            elif isinstance(node, ast.Subscript) and _is_os_environ(node.value):
-                sl = node.slice
-                if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
-                    name = sl.value
-            if name is not None:
-                found.setdefault(name, set()).add(rel)
+        for name in _env_reads_in_tree(tree):
+            found.setdefault(name, set()).add(rel)
     return found
 
 
@@ -291,6 +330,41 @@ def test_env_only_list_has_no_dead_entries() -> None:
         name for name in ENV_ONLY if name not in reads and name not in aliases
     )
     assert not dead, f"ENV_ONLY lists vars no longer read in src: {dead}"
+
+
+def test_scanner_detects_all_direct_read_forms() -> None:
+    """Guard the guard: the scanner must catch every direct-read form,
+    including the ``from os import ...`` and ``as``-aliased variants, and
+    must skip non-literal (registry-driven) reads."""
+    src = (
+        "import os\n"
+        "import os as _os\n"
+        "from os import environ, getenv\n"
+        "from os import environ as _env, getenv as _ge\n"
+        "a = os.environ['A_ATTR_SUBSCRIPT']\n"
+        "b = os.environ.get('B_ATTR_GET')\n"
+        "c = os.getenv('C_ATTR_GETENV')\n"
+        "d = _os.environ['D_OS_ALIAS']\n"
+        "e = environ['E_FROM_SUBSCRIPT']\n"
+        "f = environ.get('F_FROM_GET')\n"
+        "g = getenv('G_FROM_GETENV')\n"
+        "h = _env.get('H_FROM_ALIAS')\n"
+        "i = _ge('I_GETENV_ALIAS')\n"
+        "os.environ.setdefault('J_SETDEFAULT', 'x')\n"
+        "k = os.environ.get(some_var)\n"  # non-literal -> skipped
+    )
+    assert _env_reads_in_tree(ast.parse(src)) == {
+        "A_ATTR_SUBSCRIPT",
+        "B_ATTR_GET",
+        "C_ATTR_GETENV",
+        "D_OS_ALIAS",
+        "E_FROM_SUBSCRIPT",
+        "F_FROM_GET",
+        "G_FROM_GETENV",
+        "H_FROM_ALIAS",
+        "I_GETENV_ALIAS",
+        "J_SETDEFAULT",
+    }
 
 
 def test_advanced_registries_are_name_disjoint() -> None:

--- a/tests/src/unit/test_search_time_budget_settings.py
+++ b/tests/src/unit/test_search_time_budget_settings.py
@@ -106,18 +106,24 @@ def test_invalid_env_value_falls_back_to_default(field, env, default, monkeypatc
     assert getattr(Settings(), field) == default
 
 
-def test_smart_search_constants_track_settings_defaults():
+def test_smart_search_constants_track_settings_field_defaults():
     """The module-level constants the smart-search mixins import must be
-    sourced from the resolved Settings, not a private env read."""
+    sourced from ``Settings`` (issue #1538), not re-hardcoded.
+
+    The constants are read once at import (restart-required by design — the
+    consuming ``SmartSearchTools`` is a startup singleton), so this asserts
+    against the static ``Settings`` field defaults rather than a live
+    ``get_global_settings()`` value. That keeps the check deterministic
+    regardless of any settings rebuild / caching elsewhere in the session,
+    while still catching a constant that drifts away from the Settings
+    default (e.g. someone re-hardcoding it)."""
     from ha_mcp.tools.smart_search import _config
 
-    _reset_global_settings()
-    try:
-        settings = get_global_settings()
-        assert (
-            settings.automation_config_time_budget
-        ) == _config.AUTOMATION_CONFIG_TIME_BUDGET
-        assert settings.script_config_time_budget == _config.SCRIPT_CONFIG_TIME_BUDGET
-        assert settings.scene_config_time_budget == _config.SCENE_CONFIG_TIME_BUDGET
-    finally:
-        _reset_global_settings()
+    constants = {
+        "automation_config_time_budget": _config.AUTOMATION_CONFIG_TIME_BUDGET,
+        "script_config_time_budget": _config.SCRIPT_CONFIG_TIME_BUDGET,
+        "scene_config_time_budget": _config.SCENE_CONFIG_TIME_BUDGET,
+    }
+    for field, _env, default in BUDGET_FIELDS:
+        assert constants[field] == default
+        assert constants[field] == Settings.model_fields[field].default

--- a/tests/src/unit/test_search_time_budget_settings.py
+++ b/tests/src/unit/test_search_time_budget_settings.py
@@ -98,12 +98,49 @@ def test_override_file_value_is_applied(
 
 
 @pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
-def test_invalid_env_value_falls_back_to_default(field, env, default, monkeypatch):
-    """Preserve the lenient ``_env_float`` contract: an unparseable env
-    value must fall back to the default, not raise at startup."""
+@pytest.mark.parametrize("bad_value", [9999.0, 0.0, -5.0])
+def test_out_of_range_override_file_value_is_rejected(
+    field, env, default, bad_value, isolated_data_dir, monkeypatch
+):
+    """An override-file value outside 1.0-600.0 is ignored; the field stays
+    at its default (``_apply_advanced_overrides`` bounds check)."""
+    import json
+
     _clear_budget_envs(monkeypatch)
-    monkeypatch.setenv(env, "not-a-number")
+    (isolated_data_dir / "feature_flags.json").write_text(
+        json.dumps({field: bad_value})
+    )
+    _reset_global_settings()
+    try:
+        assert getattr(get_global_settings(), field) == default
+    finally:
+        _reset_global_settings()
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+@pytest.mark.parametrize(
+    "bad_value", ["not-a-number", "", "   ", "0", "-5", "9999", "nan", "inf"]
+)
+def test_invalid_or_out_of_range_env_value_falls_back_to_default(
+    field, env, default, bad_value, monkeypatch
+):
+    """Lenient contract: an empty, unparseable, or out-of-range (incl.
+    non-finite) env value falls back to the default rather than crashing
+    startup or smuggling a budget past _ADVANCED_SETTINGS_BOUNDS. A ``<= 0``
+    budget would silently disable the per-id config-fetch scan."""
+    _clear_budget_envs(monkeypatch)
+    monkeypatch.setenv(env, bad_value)
     assert getattr(Settings(), field) == default
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+@pytest.mark.parametrize("good_value", ["1", "45", "600"])
+def test_in_range_env_value_is_honored(field, env, default, good_value, monkeypatch):
+    """In-range env values (including the inclusive 1.0 / 600.0 bounds) are
+    parsed and kept."""
+    _clear_budget_envs(monkeypatch)
+    monkeypatch.setenv(env, good_value)
+    assert getattr(Settings(), field) == float(good_value)
 
 
 def test_smart_search_constants_track_settings_field_defaults():

--- a/tests/src/unit/test_search_time_budget_settings.py
+++ b/tests/src/unit/test_search_time_budget_settings.py
@@ -1,0 +1,123 @@
+"""Regression tests for issue #1538 — the three smart-search config
+time-budget knobs must be first-class, UI-tunable ``Settings`` fields
+rather than direct ``os.environ`` reads that bypass ``config.py``.
+
+Before #1538 these lived only as ``os.environ.get(...)`` reads inside
+``tools/smart_search/_config.py``, so add-on users (who cannot set raw
+env vars) had no way to tune them — the web Settings UI only surfaces
+fields registered in ``config.py``. These tests lock in that they are
+now registered ``Settings`` fields, rendered in the Advanced panel, and
+resolved through the same env / override-file precedence as every other
+advanced setting.
+"""
+
+import pytest
+
+from ha_mcp.config import (
+    _ADVANCED_SETTINGS_BOUNDS,
+    ADVANCED_SETTINGS_FIELDS,
+    Settings,
+    _reset_global_settings,
+    get_global_settings,
+)
+
+# (settings field name, env alias, default)
+BUDGET_FIELDS = (
+    ("automation_config_time_budget", "HAMCP_AUTOMATION_CONFIG_TIME_BUDGET", 30.0),
+    ("script_config_time_budget", "HAMCP_SCRIPT_CONFIG_TIME_BUDGET", 20.0),
+    ("scene_config_time_budget", "HAMCP_SCENE_CONFIG_TIME_BUDGET", 20.0),
+)
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Point ``get_data_dir`` at a tmp dir so override-file tests don't
+    read the developer's real ``feature_flags.json``."""
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    get_data_dir.cache_clear()
+    monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+    yield tmp_path
+    get_data_dir.cache_clear()
+
+
+def _clear_budget_envs(monkeypatch):
+    for _name, env, _default in BUDGET_FIELDS:
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+def test_budget_field_exists_with_alias_and_default(field, env, default):
+    model_field = Settings.model_fields.get(field)
+    assert model_field is not None, f"{field} must be a Settings field"
+    assert model_field.alias == env
+    settings = Settings()
+    assert getattr(settings, field) == default
+    assert isinstance(getattr(settings, field), float)
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+def test_budget_field_is_editable_float_in_advanced_search_section(field, env, default):
+    row = next((r for r in ADVANCED_SETTINGS_FIELDS if r.field == field), None)
+    assert row is not None, f"{field} must be in ADVANCED_SETTINGS_FIELDS"
+    assert row.env == env
+    assert row.ftype is float
+    assert row.editable is True
+    assert row.section == "search"
+    # Numeric advanced fields must carry UI/POST bounds.
+    assert field in _ADVANCED_SETTINGS_BOUNDS
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+def test_env_var_flows_to_resolved_settings(field, env, default, monkeypatch):
+    _clear_budget_envs(monkeypatch)
+    monkeypatch.setenv(env, "45")
+    _reset_global_settings()
+    try:
+        assert getattr(get_global_settings(), field) == 45.0
+    finally:
+        _reset_global_settings()
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+def test_override_file_value_is_applied(
+    field, env, default, isolated_data_dir, monkeypatch
+):
+    """Standalone (file) mode: the web UI persists advanced settings to
+    ``feature_flags.json``; ``get_global_settings`` must apply them."""
+    import json
+
+    _clear_budget_envs(monkeypatch)
+    (isolated_data_dir / "feature_flags.json").write_text(json.dumps({field: 55.0}))
+    _reset_global_settings()
+    try:
+        assert getattr(get_global_settings(), field) == 55.0
+    finally:
+        _reset_global_settings()
+
+
+@pytest.mark.parametrize("field,env,default", BUDGET_FIELDS)
+def test_invalid_env_value_falls_back_to_default(field, env, default, monkeypatch):
+    """Preserve the lenient ``_env_float`` contract: an unparseable env
+    value must fall back to the default, not raise at startup."""
+    _clear_budget_envs(monkeypatch)
+    monkeypatch.setenv(env, "not-a-number")
+    assert getattr(Settings(), field) == default
+
+
+def test_smart_search_constants_track_settings_defaults():
+    """The module-level constants the smart-search mixins import must be
+    sourced from the resolved Settings, not a private env read."""
+    from ha_mcp.tools.smart_search import _config
+
+    _reset_global_settings()
+    try:
+        settings = get_global_settings()
+        assert (
+            settings.automation_config_time_budget
+        ) == _config.AUTOMATION_CONFIG_TIME_BUDGET
+        assert settings.script_config_time_budget == _config.SCRIPT_CONFIG_TIME_BUDGET
+        assert settings.scene_config_time_budget == _config.SCENE_CONFIG_TIME_BUDGET
+    finally:
+        _reset_global_settings()


### PR DESCRIPTION
## What does this PR do?

Closes #1538. The web Settings UI only surfaces env vars registered in
`config.py`, so add-on users (who can't set raw environment variables) couldn't
reach any tunable that lived outside that registry. This audits the full
env-var surface, exposes every remaining **user-tunable** one, and adds CI
guards so the gap can't reopen.

**Newly exposed in the Advanced panel:**

- `HAMCP_AUTOMATION_CONFIG_TIME_BUDGET`, `HAMCP_SCRIPT_CONFIG_TIME_BUDGET`,
  `HAMCP_SCENE_CONFIG_TIME_BUDGET` — read directly via `os.environ` in
  `tools/smart_search/_config.py`, bypassing `config.py` entirely. Now
  first-class `Settings` fields + `ADVANCED_SETTINGS_FIELDS` rows; the
  smart-search constants are sourced from resolved `Settings` (env **and**
  override-file both apply). Restart-required (import-time constants — the
  consuming `SmartSearchTools` is a startup singleton).
- `HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL` — a `Settings` field that was
  docker/.env-settable but had no panel home (env-only allowlist). Now an
  editable Advanced row; resolved live per capture, so it takes effect
  **without** a restart.

**Audit result (issue ask #2):** those four were the only user-tunable env vars
not already reachable from a UI surface. Everything else read from the
environment is bind / secret / bootstrap / path (`MCP_*`, `FASTMCP_*`,
`SUPERVISOR_*`, `HAMCP_ENV_FILE`, `HA_MCP_CONFIG_DIR`, `XDG_DATA_HOME`,
`HA_MCP_BUILD_VERSION`, `HA_MCP_DISABLE_SETTINGS_UI`) — none are add-on-tunable
— and `DISABLED_TOOLS`/`PINNED_TOOLS` are managed in the Tool Visibility tab.

**Guards against drift (issue ask #3):**

- `test_no_unregistered_direct_env_reads` AST-scans `src/` for direct
  `os.environ`/`os.getenv`/`from os import …` literal reads and fails unless
  each is a registered `Settings` alias or an explicitly documented `ENV_ONLY`
  var (the codified audit of env-only-by-design vars).
- `test_every_advanced_field_has_a_settings_js_label` fails if a new
  `ADVANCED_SETTINGS_FIELDS` row lacks a `settings.js` label (the data-driven
  UI would otherwise render a raw field name with no restart hint).

Also: bounds (`1.0–600.0`, plus `nan`/`inf` rejection) are now enforced on the
env-var path for the budgets — matching the override-file/UI path — so a `≤ 0`
budget can't silently disable the per-id config scan. `partial_reason` hints
and `.env.example` now point at the UI.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit tests in `tests/src/unit/test_search_time_budget_settings.py` (field
registration/defaults, editable-float in `search` + bounds, env → resolved
value, override-file application, empty/invalid/out-of-range/non-finite
fallback, in-range boundary values, constants track field defaults) and
additions to `test_advanced_settings_coverage.py` (the two guards above + the
scanner self-test + screenshot-URL exposure). Relevant unit suites pass
locally; full e2e runs on CI.

## Checklist
- [x] I have updated documentation if needed
