### PR TITLE
test(uat): rework c01 routing probe to ha_search registry-listing mode after #1529

### DIFF
--- a/tests/uat/stories/README.md
+++ b/tests/uat/stories/README.md
@@ -54,8 +54,9 @@ The filename prefix determines whether a story runs in automated discovery:
   path: `run_story.py --all`, `conftest.discover_stories()` (the
   `test_stories.py` pytest parametrization), and the `bat-story-eval` skill — all
   glob `s*.yaml`.
-- **`t*` / `c*` — on-demand probes.** A/B routing probes (`t*`) and confusion-pair
-  probes (`c*`) for one-off architectural comparisons. **Excluded** from `--all`
+- **`t*` / `c*` — on-demand probes.** A/B routing probes (`t*`) and confusion /
+  mode-discrimination probes (`c*`) for one-off architectural comparisons.
+  **Excluded** from `--all`
   and pytest discovery (the `s*.yaml` glob does not match them); run them by
   explicit path, e.g. `run_story.py catalog/t01_eval_template_average_calc.yaml`.
 

--- a/tests/uat/stories/catalog/c01_search_entities_in_area.yaml
+++ b/tests/uat/stories/catalog/c01_search_entities_in_area.yaml
@@ -1,31 +1,36 @@
 id: c01
-title: "Enumerate entities of a domain in a specific area (search_entities-only territory)"
+title: "Enumerate entities of a domain in a specific area (ha_search registry-listing mode)"
 category: entity
 weight: 3
 description: >
-  Confusion-pair story for #1175 BAT. The user asks for entities of a given
-  domain in a given area — a pure entity-registry query. Right pick is
-  ha_search_entities (variant: ha_search) with domain_filter + area_filter.
-  ha_deep_search would search config bodies and return nothing useful here
-  (sensors that exist are not necessarily referenced in any automation),
-  so picking deep_search is the wrong tool. Pairs with s14 (deep_search-
-  only territory) to form a flip-flop-detecting pair: on the baseline, the
-  agent must choose correctly between the two; on the variant (merged
-  ha_search), one tool spans both surfaces and the choice disappears.
+  Routing probe for #1175 BAT. The user asks for entities of a given domain in
+  a given area — a pure entity-registry question ("what entities exist"). After
+  #1529 folded the former ha_search_entities and ha_deep_search into a single
+  ha_search, the discrimination is no longer which TOOL to pick but which MODE
+  of ha_search the agent drives it in:
 
-  Right-pick rationale from docstrings: ha_search_entities is documented
-  as the entity-registry path ("Search for entities (lights, sensors,
-  switches, etc.) by name, domain, or area"); ha_deep_search is documented
-  as the config-body path ("not for finding entity IDs ... use
-  ha_search_entities instead"). The story's prompt is "list sensor
-  entities in the bathroom" — purely "what entities exist", not "what
-  configurations contain something".
+  Right pick — structured registry-listing mode: pass domain_filter +
+  area_filter with NO free-text query. ha_search then enumerates the entity
+  registry and skips the config-body backend entirely (the tool documents this
+  as "registry-listing mode" and gates config-body search off whenever an
+  entity-only filter is present).
+
+  Wrong pick — drop the structured filters and pass a free-text query instead
+  (e.g. query="sensors in the Bathroom"). With no entity-intent filter the
+  config-body branch runs, scanning automation/script/scene/helper bodies — the
+  wrong surface for "what entities exist", since a sensor that exists is not
+  necessarily referenced in any configuration — and it trades precise
+  domain+area scoping for fuzzy free-text matching.
+
+  Pre-#1529 this was a confusion-pair against ha_deep_search (the config-body
+  path); that surface now lives inside ha_search's query mode, so the wrong-pick
+  illustration is preserved as a mode rather than a separate tool.
 
 tags:
   - search
   - entities
   - area_filter
-  - confusion_pair_1175
+  - routing_1175
 
 setup: []
   # Read-only — no writes against the target HA instance.
@@ -51,14 +56,15 @@ verify:
 
 expected:
   tools_should_use:
-    - ha_search_entities
     - ha_search
   description: >
-    Agent should call ha_search_entities (or, on the variant arm, ha_search)
-    with domain_filter='sensor' and area_filter='Bathroom' (or equivalent
-    case/locale variant). ha_deep_search is the WRONG pick here — it
-    searches configuration bodies (automations/scripts/scenes/helpers),
-    which does not answer "which sensor entities exist in this area";
-    that's a registry-list question. Picking ha_deep_search counts as a
-    wrong-tool mis-pick for this story. A flip-flop (one then the other)
-    is also a mis-pick on the baseline arm.
+    Agent should call ha_search in registry-listing mode — domain_filter='sensor'
+    and area_filter='Bathroom' (or an equivalent case/locale variant), with NO
+    free-text query. Passing a free-text query instead of the structured filters
+    makes ha_search run config-body search (automations/scripts/scenes/helpers),
+    which is the wrong surface for a registry-list question and counts as an
+    over-reach mis-pick for this story. Because both modes invoke the single
+    ha_search tool, the mis-pick is observable only by inspecting the call's
+    arguments (structured domain/area filter vs free-text query) in the agent
+    trace — the tool-name sequence and the response checks pass either way, so
+    this is a manual A/B benchmark signal, not an automated pass/fail.


### PR DESCRIPTION
## What does this PR do?

Reworks the `c01_search_entities_in_area` BAT story after #1529 consolidated `ha_search_entities` and `ha_deep_search` into a single `ha_search` (both former tools are now internal/unregistered). Per maintainer direction the story is **kept and reworked, not retired**.

c01 was a #1175 confusion-pair: right pick `ha_search_entities` (entity registry) vs wrong pick `ha_deep_search` (config bodies), paired with s14 to detect a flip-flop. With one tool spanning both surfaces that tool-choice no longer exists, so the rework re-points the same intent onto the surviving discrimination — which **mode** of `ha_search` the agent drives it in:

- **Right** — structured registry-listing mode: `domain_filter` + `area_filter`, no free-text `query`. `ha_search` enumerates the registry and skips the config-body backend (the tool's own "registry-listing mode"; config-body search is gated off whenever an entity-only filter is present).
- **Wrong** — drop the structured filters and pass a free-text `query` instead. With no entity-intent signal the config-body branch runs, scanning automation/script/scene/helper bodies — the wrong surface for "what entities exist".

Changes: retitled; tag `confusion_pair_1175` → `routing_1175`; dropped the s14-pairing / flip-flop prose; narrowed `tools_should_use` to `[ha_search]`. The former-`ha_deep_search` wrong-pick is preserved as a *mode* within `ha_search` rather than a separate tool. The prompt and `verify` checks are unchanged.

**Measurability caveat (also stated in the story):** because both modes invoke the single `ha_search` tool, the right/wrong distinction lives in the call **arguments**, not the tool name. The BAT's tool-name sequence (`_extract_tool_sequence`, names only) and the `response_contains` checks pass for either mode, so this is a **manual A/B benchmark** signal — a reviewer reads the `ha_search` call args in the trace — not an automated pass/fail. This matches the "these are meant more as benchmarks" framing; the story description spells it out so the limitation isn't mistaken for a working discriminator.

Also broadens the `c*` prefix definition in `tests/uat/stories/README.md` (added by the now-merged #1550) from "confusion-pair probes" to "confusion / mode-discrimination probes", since reworked c01 is an intra-tool mode probe rather than a tool pair.

The s14 half of the post-#1529 sweep landed in #1550 (merged).

Closes #1551

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Two doc/test-fixture files (story YAML + the stories README); the YAML is validated via `yaml.safe_load`. Story-eval tests skip without an agent CLI, and as noted above the right/wrong mode is a manual A/B trace read, not an automated assertion. Local full pytest is unavailable in my Alpine/py3.13 env — relying on CI; ruff does not apply to story YAML / markdown.

## Checklist
- [x] I have updated documentation if needed
