### PR TITLE
ci: fix stale token-cap comment and harden triage budget tests (#1514)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -790,7 +790,8 @@ jobs:
               return { status: resp.status, data };
             };
 
-            // gpt-4o-mini: 16K input token free-tier limit (vs 8K for gpt-4.1).
+            // gpt-4o-mini on GitHub Models enforces an 8000-token input cap (issue #1514);
+            // build_prompt budgets the prompt under it. gpt-4o shares the same cap.
             // Retry on 5xx with exponential backoff; fall back to gpt-4o on 429;
             // on 413 (prompt over the model's input cap) retry once with the
             // minimal prompt. The prompt is already budgeted in build_prompt.

--- a/scripts/verify_triage_prompt_budget.mjs
+++ b/scripts/verify_triage_prompt_budget.mjs
@@ -62,7 +62,7 @@ const check = (name, cond, detail = "") => {
 
 const x = (n) => "x".repeat(n);
 
-console.log("Triage prompt budget checks (cap 8000 tokens, target", TOKEN_BUDGET, "):");
+console.log("Triage prompt budget checks (self-imposed target", TOKEN_BUDGET, "tokens, under the 8000 model cap):");
 
 // 1. Real worst case: full framing + 4 BM25 candidates @ ~1200 chars + a
 //    16000-char body + a large release-context block + long author comments.
@@ -84,6 +84,14 @@ console.log("Triage prompt budget checks (cap 8000 tokens, target", TOKEN_BUDGET
   const r = fitToBudget({ staticText: x(7000), issueBody: x(4000), authorSection: x(80000) });
   check("long author comments trimmed to fit", r.tokens <= TOKEN_BUDGET, `got ${r.tokens} tokens`);
   check("author trimmed before body, body untouched", r.author.length < 80000 && r.body.length === 4000, `author ${r.author.length}, body ${r.body.length}`);
+}
+
+// 1c. Author-floor clamp exercised: framing alone dominates the budget, so
+//     authorSection is trimmed down to exactly AUTHOR_FLOOR (the Math.max
+//     clamp). Pins the constant the same way 2b pins the body floor.
+{
+  const r = fitToBudget({ staticText: x(40000), issueBody: x(2000), authorSection: x(50000) });
+  check("author clamped exactly to floor when framing dominates", r.author.length === AUTHOR_FLOOR, `got ${r.author.length} chars`);
 }
 
 // 2. Huge body alone fits (body truncated, floor not yet binding).

--- a/scripts/verify_triage_prompt_budget.mjs
+++ b/scripts/verify_triage_prompt_budget.mjs
@@ -117,6 +117,14 @@ console.log("Triage prompt budget checks (self-imposed target", TOKEN_BUDGET, "t
   check("changelog trimmed before body, body untouched", r.log.length < 60000 && r.body.length === 4000, `log ${r.log.length}, body ${r.body.length}`);
 }
 
+// 3b. Changelog-floor clamp exercised: framing alone dominates the budget, so
+//     changelog is trimmed down to exactly CHANGELOG_FLOOR. Pins the constant
+//     the same way 1c/2b pin the author and body floors.
+{
+  const r = fitToBudget({ staticText: x(40000), issueBody: x(2000), changelog: x(50000) });
+  check("changelog clamped exactly to floor when framing dominates", r.log.length === CHANGELOG_FLOOR, `got ${r.log.length} chars`);
+}
+
 // 4. Ordering: duplicates are dropped before the body or changelog is touched,
 //    and the body survives intact when dropping duplicates alone suffices.
 {

--- a/tests/src/unit/test_triage_prompt_budget.py
+++ b/tests/src/unit/test_triage_prompt_budget.py
@@ -100,7 +100,13 @@ def test_trim_order_in_sync() -> None:
     assert harness_order == _CANONICAL_TRIM_ORDER, harness_order
 
 
-_LITERAL = re.compile(r"'((?:[^'\\]|\\.)*)'")
+# Match a JS string literal in any quote style (', ", or `). The backreference
+# requires the same quote to close, so a quote of a different style inside the
+# literal (e.g. the double quotes inside the single-quoted jsonSchema) is body,
+# not a new literal — finditer's non-overlapping scan then counts each string
+# once. Single-quote-only would silently under-count if framing ever switched
+# quote style.
+_LITERAL = re.compile(r"""(['"`])((?:(?!\1)[^\\]|\\.)*)\1""")
 
 
 def _assemble_framing_chars(text: str) -> int:
@@ -113,10 +119,10 @@ def _assemble_framing_chars(text: str) -> int:
     """
     block = re.search(r"const assemble = \(o = \{\}\) => \[(.*?)\]\.join", text, re.S)
     assert block, "could not locate assemble() array in workflow"
-    framing = sum(len(s) for s in _LITERAL.findall(block.group(1)))
+    framing = sum(len(m.group(2)) for m in _LITERAL.finditer(block.group(1)))
     schema = re.search(r"const jsonSchema =(.*?);", text, re.S)
     assert schema, "could not locate jsonSchema in workflow"
-    framing += sum(len(s) for s in _LITERAL.findall(schema.group(1)))
+    framing += sum(len(m.group(2)) for m in _LITERAL.finditer(schema.group(1)))
     # join('\n') inserts a newline between array elements; counting source lines
     # in the block is a conservative (over-)estimate of those newlines.
     framing += block.group(1).count("\n")

--- a/tests/src/unit/test_triage_prompt_budget.py
+++ b/tests/src/unit/test_triage_prompt_budget.py
@@ -114,8 +114,8 @@ def _assemble_framing_chars(text: str) -> int:
     the static string literals in its array plus the ``jsonSchema`` it
     references, joined by newlines. The per-issue and trimmable variable
     sections (issueBody/authorSection/duplicateSection/changelog, number,
-    title, type, keywords) are excluded — they are inputs the budgeter trims,
-    not fixed framing.
+    title, type, keywords) are excluded — they are per-issue variable values
+    (some trimmed by the budgeter, some bounded upstream), not fixed framing.
     """
     block = re.search(r"const assemble = \(o = \{\}\) => \[(.*?)\]\.join", text, re.S)
     assert block, "could not locate assemble() array in workflow"
@@ -135,11 +135,19 @@ def test_static_framing_within_harness_assumption() -> None:
     harness's "worst case fits budget" guarantee — the workflow only warns
     about it at runtime, after the prompt has already shipped over budget.
     """
-    assumed = re.search(r"staticText:\s*x\((\d+)\)", _HARNESS.read_text())
-    assert assumed, "could not find staticText worst-case stand-in in harness"
+    # The worst-case "fits budget" check uses the SMALLEST staticText stand-in;
+    # the larger ones (checks 1c/2b/3b) are inflated on purpose to force the
+    # floor clamps and must not be mistaken for the framing assumption. Bind to
+    # min() rather than the first match so a future reorder of the harness
+    # checks can't silently relax this guard.
+    stand_ins = [
+        int(n) for n in re.findall(r"staticText:\s*x\((\d+)\)", _HARNESS.read_text())
+    ]
+    assert stand_ins, "could not find any staticText stand-in in harness"
+    assumed = min(stand_ins)
     framing = _assemble_framing_chars(_WORKFLOW.read_text())
-    assert framing <= int(assumed.group(1)), (
+    assert framing <= assumed, (
         f"assemble() fixed framing is ~{framing} chars but the harness worst-case "
-        f"assumes staticText <= {assumed.group(1)}; trim the framing or raise the "
-        f"harness staticText (and re-check the budget headroom)."
+        f"assumes staticText <= {assumed}; trim the framing or raise the harness "
+        f"staticText (and re-check the budget headroom)."
     )

--- a/tests/src/unit/test_triage_prompt_budget.py
+++ b/tests/src/unit/test_triage_prompt_budget.py
@@ -98,3 +98,42 @@ def test_trim_order_in_sync() -> None:
     harness_order = _trim_order(_HARNESS.read_text(), _HARNESS_TRIM_MARKERS)
     assert workflow_order == _CANONICAL_TRIM_ORDER, workflow_order
     assert harness_order == _CANONICAL_TRIM_ORDER, harness_order
+
+
+_LITERAL = re.compile(r"'((?:[^'\\]|\\.)*)'")
+
+
+def _assemble_framing_chars(text: str) -> int:
+    """Approximate the fixed framing build_prompt's ``assemble()`` always emits:
+    the static string literals in its array plus the ``jsonSchema`` it
+    references, joined by newlines. The per-issue and trimmable variable
+    sections (issueBody/authorSection/duplicateSection/changelog, number,
+    title, type, keywords) are excluded — they are inputs the budgeter trims,
+    not fixed framing.
+    """
+    block = re.search(r"const assemble = \(o = \{\}\) => \[(.*?)\]\.join", text, re.S)
+    assert block, "could not locate assemble() array in workflow"
+    framing = sum(len(s) for s in _LITERAL.findall(block.group(1)))
+    schema = re.search(r"const jsonSchema =(.*?);", text, re.S)
+    assert schema, "could not locate jsonSchema in workflow"
+    framing += sum(len(s) for s in _LITERAL.findall(schema.group(1)))
+    # join('\n') inserts a newline between array elements; counting source lines
+    # in the block is a conservative (over-)estimate of those newlines.
+    framing += block.group(1).count("\n")
+    return framing
+
+
+def test_static_framing_within_harness_assumption() -> None:
+    """Fail if the real assemble() framing outgrows the harness's worst-case
+    ``staticText`` stand-in. Otherwise framing growth silently invalidates the
+    harness's "worst case fits budget" guarantee — the workflow only warns
+    about it at runtime, after the prompt has already shipped over budget.
+    """
+    assumed = re.search(r"staticText:\s*x\((\d+)\)", _HARNESS.read_text())
+    assert assumed, "could not find staticText worst-case stand-in in harness"
+    framing = _assemble_framing_chars(_WORKFLOW.read_text())
+    assert framing <= int(assumed.group(1)), (
+        f"assemble() fixed framing is ~{framing} chars but the harness worst-case "
+        f"assumes staticText <= {assumed.group(1)}; trim the framing or raise the "
+        f"harness staticText (and re-check the budget headroom)."
+    )


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1522 (dynamic triage-prompt budgeting) — three small hardening items surfaced while reviewing that PR but deliberately not gated on it:

- **Fix a stale, contradictory comment.** The Evaluate step in `issue-triage.yml` still carried `// gpt-4o-mini: 16K input token free-tier limit (vs 8K for gpt-4.1).` — the exact wrong assumption #1514 names as root cause #1. It now contradicts the 8000-token-cap budgeting #1522 added a few lines below it. Corrected to state the real 8000-token cap.
- **Pin `AUTHOR_FLOOR` behaviourally.** `verify_triage_prompt_budget.mjs` gains an author-floor boundary check (mirrors the existing body-floor check 2b) that drives `authorSection` to exactly `AUTHOR_FLOOR`, so the constant can't change silently without a test failing. Also clarifies the harness header that 7000 is the self-imposed target under the 8000-token model cap.
- **Catch silent framing growth.** `test_triage_prompt_budget.py` gains a guard asserting the real `assemble()` fixed framing (~4.6k chars today) stays within the harness's worst-case `staticText` stand-in (7000). The harness only *assumes* this; if the framing prose grows past it, the "worst case fits budget" guarantee silently weakens and the workflow would only warn at runtime. Now it fails pre-merge.

No runtime behaviour change beyond the corrected comment — all three are guards/docs around the budgeting #1522 introduced.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`node scripts/verify_triage_prompt_budget.mjs` → 11/11. `pytest tests/src/unit/test_triage_prompt_budget.py` → 4/4. `ruff format --check` + `ruff check` clean.

## Checklist
- [x] I have updated documentation if needed
