### PR TITLE
docs(security): note that security-advisory disposition is API-blind (UI-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ define what ha-mcp does and doesn't defend against (trusted MCP clients, local
 network boundary, OAuth Bearer token design, single-tenant standard mode, HA
 permission scope).
 
+**Security advisories:** The API exposes an advisory's body but not its
+discussion thread, where the maintainer disposition (dismiss-vs-fix and the
+agreed fix scope) lives. Confirm the scope from that thread (GitHub UI or ask a
+maintainer) before writing the fix.
+
 ## External Documentation
 
 When implementing features or debugging, consult these resources:


### PR DESCRIPTION
## What does this PR do?

Adds a short note to the AGENTS.md **Security** section: a repository security advisory's discussion thread — the maintainer dismiss-vs-fix verdict and the agreed fix scope — is **not reachable via REST or GraphQL** (only the advisory body is). Contributors should confirm the scope decision from that thread (GitHub UI, or ask a maintainer) before writing the fix, rather than inferring it from the reporter's submission alone.

Context: working from the advisory body alone led to an over-broad fix scope on a past advisory. This was raised in maintainer coordination (requested by julienld, who hit the same problem). `CLAUDE.md` is a symlink to `AGENTS.md`, so this single edit covers both files the request named.

Note on the size check: this note takes AGENTS.md from 39917 to 40182 chars (`wc -m`), crossing the soft 40k threshold, so the **Docs Size Check** emits its `::warning` annotation (it stays green — warning-only, not a gate). The Security section had only ~83 chars of headroom under 40k, so any meaningful note crosses it; the size is left as-is rather than trimming unrelated sections here.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Docs-only change to `AGENTS.md` — no code paths touched, no tests applicable; ruff does not apply to markdown.

## Checklist
- [x] I have updated documentation if needed