### PR TITLE
test(uat): relabel c01 as a mode-discrimination probe (taxonomy consistency)

### DIFF
--- a/tests/uat/stories/catalog/c01_search_entities_in_area.yaml
+++ b/tests/uat/stories/catalog/c01_search_entities_in_area.yaml
@@ -3,8 +3,9 @@ title: "Enumerate entities of a domain in a specific area (ha_search registry-li
 category: entity
 weight: 3
 description: >
-  Routing probe for #1175 BAT. The user asks for entities of a given domain in
-  a given area — a pure entity-registry question ("what entities exist"). After
+  Mode-discrimination probe for #1175 BAT. The user asks for entities of a
+  given domain in a given area — a pure entity-registry question ("what
+  entities exist"). After
   #1529 folded the former ha_search_entities and ha_deep_search into a single
   ha_search, the discrimination is no longer which TOOL to pick but which MODE
   of ha_search the agent drives it in:
@@ -30,7 +31,7 @@ tags:
   - search
   - entities
   - area_filter
-  - routing_1175
+  - mode_discrimination_1175
 
 setup: []
   # Read-only — no writes against the target HA instance.


### PR DESCRIPTION
## What does this PR do?

Relabels the `c01` BAT story from a "routing probe" to a "mode-discrimination probe" for consistency with the `c*`/`t*` prefix taxonomy. `tests/uat/stories/README.md` defines `t*` = "A/B routing probes" and `c*` = "confusion / mode-discrimination probes"; `c01` is a `c*` story, but #1559 left it self-labeling as "routing" (description opener) and carrying a `routing_1175` tag — inconsistent with the taxonomy that same PR defined. Updates the opener to "Mode-discrimination probe" and the tag to `mode_discrimination_1175` (free-form metadata, verified `c01`-only).

No behavior change. The merged squash-commit title from #1559 keeps its original wording (force-push to master is forbidden); this only fixes the live story file.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Single test-fixture YAML; validated via `yaml.safe_load` (description folds correctly, tags update). No code paths touched; ruff does not apply to story YAML.

## Checklist
- [x] I have updated documentation if needed
