### PR TITLE
ci: make sync-tool-docs push resilient to concurrent master advances

### DIFF
--- a/.github/workflows/sync-tool-docs.yml
+++ b/.github/workflows/sync-tool-docs.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'src/ha_mcp/tools/**'
       - 'scripts/extract_tools.py'
+  # Allow a manual resync against the current master tip — e.g. to recover
+  # after a push race dropped a sync commit — without having to land an
+  # unrelated tool change just to re-trigger.
+  workflow_dispatch:
 
 # Restrict permissions by default
 permissions:
@@ -51,7 +55,25 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add site/src/data/tools.json README.md homeassistant-addon/DOCS.md
-        if ! git diff --staged --quiet; then
-          git commit -m "chore(internal): sync tool docs after merge [skip ci]"
-          git push
+        if git diff --staged --quiet; then
+          echo "No tool-doc changes to sync."
+          exit 0
         fi
+        git commit -m "chore(internal): sync tool docs after merge [skip ci]"
+        # master can advance between this job's checkout and its push whenever
+        # any unrelated PR merges in the same window, which rejects a bare push
+        # as a non-fast-forward (the concurrency group only serialises sync runs
+        # against each other, not against ordinary merges). Rebase onto the
+        # latest master and retry before giving up. cancel-in-progress guarantees
+        # no competing sync run, so the only thing to rebase over is unrelated
+        # commits that do not touch the generated files — never a conflict.
+        for attempt in 1 2 3 4 5; do
+          if git push; then
+            echo "Synced tool docs (attempt ${attempt})."
+            exit 0
+          fi
+          echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
+          git pull --rebase origin master
+        done
+        echo "::error::Could not push tool-doc sync after 5 attempts."
+        exit 1


### PR DESCRIPTION
## What does this PR do?

Fixes the `Sync Tool Documentation` workflow failure on master after #1553 merged ([failed run](https://github.com/homeassistant-ai/ha-mcp/actions/runs/27140199946)).

**Root cause:** the auto-commit-back step did a bare `git push`. When an unrelated PR merges between this job's checkout and its push, master advances and the push is rejected as a non-fast-forward. After #1553 the regeneration succeeded but the push lost the race to #1563 (merged in the same window), so the run failed and the regenerated `tools.json` never landed. The existing `concurrency` group only serialises sync runs against *each other* — not against ordinary merges — so it doesn't cover this.

**Changes (workflow only):**
- Wrap the push in a rebase-and-retry loop (up to 5 attempts) so a moved master is reconciled instead of failing. `cancel-in-progress` already rules out a competing sync run, so the rebase only ever replays over commits that don't touch the generated files — no conflict path.
- Skip cleanly when there's nothing to sync.
- Add a `workflow_dispatch` trigger so a stale/lost sync can be re-driven against the current master tip **by the bot**, without landing an unrelated tool change.

**Recovering the stale `tools.json`:** after this merges, trigger `workflow_dispatch` (or let the next `src/ha_mcp/tools/**` change fire it); the workflow regenerates and commits the docs as `github-actions[bot]`. No generated files are committed in this PR.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Workflow-only change — no Python touched, so `pytest`/`ruff` are not applicable. Verified the YAML parses and that the rebase-and-retry logic is sound under `set -e`.

## Checklist
- [x] I have updated documentation if needed
