### PR TITLE
fix(tools): bring HA API field names to 2026.6 — stale docstrings, automation plural canonicalization, fan speed (closes #1540)

### DIFF
--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -197,10 +197,10 @@ def check_automation_config(
 
     warnings = BestPracticeCheckResult()
 
-    # Read the canonical 2024.10+ plural root keys, tolerating the singular
-    # aliases too (HA accepts both, and this checker may see raw user input that
-    # has not been through _normalize_automation_config). Mirrors _check_triggers'
-    # existing platform/trigger tolerance below.
+    # Read the canonical 2024.10+ plural root keys, falling back to the singular
+    # aliases. The internal pipeline always pre-normalizes to plural, so the
+    # fallback is defensive for direct/public callers of check_automation_config
+    # (HA accepts both forms). Mirrors _check_triggers' platform/trigger tolerance.
     # Condition templates
     _check_condition_templates(
         config.get("conditions", config.get("condition", [])), warnings, skill_prefix

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -197,14 +197,24 @@ def check_automation_config(
 
     warnings = BestPracticeCheckResult()
 
+    # Read the canonical 2024.10+ plural root keys, tolerating the singular
+    # aliases too (HA accepts both, and this checker may see raw user input that
+    # has not been through _normalize_automation_config). Mirrors _check_triggers'
+    # existing platform/trigger tolerance below.
     # Condition templates
-    _check_condition_templates(config.get("condition", []), warnings, skill_prefix)
+    _check_condition_templates(
+        config.get("conditions", config.get("condition", [])), warnings, skill_prefix
+    )
 
     # Action tree (wait_template + nested conditions + target templates)
-    _check_action_tree(config.get("action", []), warnings, skill_prefix)
+    _check_action_tree(
+        config.get("actions", config.get("action", [])), warnings, skill_prefix
+    )
 
     # Trigger templates + device_id
-    _check_triggers(config.get("trigger", []), warnings, skill_prefix)
+    _check_triggers(
+        config.get("triggers", config.get("trigger", [])), warnings, skill_prefix
+    )
 
     # Mode vs motion pattern
     _check_mode_motion(config, warnings, skill_prefix)
@@ -738,7 +748,7 @@ def _check_mode_motion(
     if mode != "single":
         return
 
-    triggers = _as_list(config.get("trigger", []))
+    triggers = _as_list(config.get("triggers", config.get("trigger", [])))
     has_motion = any(
         isinstance(t, dict)
         and any(
@@ -750,7 +760,7 @@ def _check_mode_motion(
     if not has_motion:
         return
 
-    if _has_delay_or_wait(config.get("action", [])):
+    if _has_delay_or_wait(config.get("actions", config.get("action", []))):
         _emit(
             warnings,
             "Automation uses motion trigger with delay/wait but "

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -91,9 +91,12 @@ def _normalize_automation_config(
     """
     Recursively normalize automation config field names to HA API format.
 
-    Home Assistant accepts both singular ('trigger', 'action', 'condition')
-    and plural ('triggers', 'actions', 'conditions') field names in YAML,
-    but the API expects singular forms at the root level.
+    Home Assistant's 2024.10+ canonical form uses the plural root keys
+    ('triggers', 'actions', 'conditions'); the singular forms ('trigger',
+    'action', 'condition') remain fully accepted as silent aliases. This tool
+    normalizes to the singular root forms internally so the config-API
+    round-trip and the downstream validators / best-practice checker all see
+    one stable shape (HA accepts whichever we send).
 
     IMPORTANT: 'triggers' -> 'trigger' and 'actions' -> 'action' normalization
     is ONLY applied at the root level. Deeper in the tree these keys are either
@@ -181,8 +184,10 @@ def _normalize_trigger_keys(triggers: list[dict[str, Any]]) -> list[dict[str, An
     """
     Normalize trigger objects for round-trip compatibility.
 
-    Home Assistant GET API returns triggers with 'trigger' key for the platform type,
-    but the SET API expects 'platform' key. This function converts between formats.
+    Home Assistant's GET API returns triggers with the modern 'trigger' key for
+    the platform type. This tool canonicalizes each trigger to the legacy
+    'platform' key so its internal pipeline sees one stable shape; HA accepts
+    either form on the SET side.
 
     Args:
         triggers: List of trigger configuration dicts
@@ -420,8 +425,8 @@ class AutomationConfigTools:
         config: Annotated[
             dict[str, Any] | None,
             Field(
-                description="Complete automation configuration with required fields: 'alias', 'trigger', 'action'. "
-                "Optional: 'description', 'condition', 'mode', 'max', 'initial_state', 'variables'. "
+                description="Complete automation configuration with required fields: 'alias', 'triggers', 'actions'. "
+                "Optional: 'description', 'conditions', 'mode', 'max', 'initial_state', 'variables'. "
                 "Mutually exclusive with python_transform.",
                 default=None,
             ),
@@ -527,7 +532,8 @@ class AutomationConfigTools:
 
         IMPORTANT: python_transform requires 'identifier' and 'config_hash' from ha_config_get_automation().
 
-        PYTHON TRANSFORM EXAMPLES:
+        PYTHON TRANSFORM EXAMPLES (operate on the fetched config, which uses the
+        singular root keys 'trigger'/'action'/'condition' with per-trigger 'platform'):
         - Update action: python_transform="config['action'][0]['data']['brightness'] = 255"
         - Add trigger: python_transform="config['trigger'].append({'platform': 'state', 'entity_id': 'binary_sensor.motion', 'to': 'on'})"
         - Remove last action: python_transform="config['action'].pop()"
@@ -541,8 +547,8 @@ class AutomationConfigTools:
 
         REQUIRED FIELDS (Regular Automations):
         - alias: Human-readable automation name
-        - trigger: List of trigger conditions (time, state, event, etc.)
-        - action: List of actions to execute
+        - triggers: List of triggers (time, state, event, etc.)
+        - actions: List of actions to execute
 
         REQUIRED FIELDS (Blueprint Automations):
         - alias: Human-readable automation name
@@ -553,7 +559,7 @@ class AutomationConfigTools:
         OPTIONAL CONFIG FIELDS (Regular Automations):
         - description: Detailed description of the user's intent (RECOMMENDED: helps safely modify implementation later)
         - category: Category ID for organization (use ha_config_get_category to list, ha_config_set_category to create)
-        - condition: Additional conditions that must be met
+        - conditions: Additional conditions that must be met
         - mode: 'single' (default), 'restart', 'queued', 'parallel'
         - max: Maximum concurrent executions (for queued/parallel modes)
         - initial_state: Whether automation starts enabled (true/false)
@@ -565,19 +571,19 @@ class AutomationConfigTools:
         ha_config_set_automation(config={
             "alias": "Morning Lights",
             "description": "Turn on bedroom lights at 7 AM to help wake up",
-            "trigger": [{"platform": "time", "at": "07:00:00"}],
-            "action": [{"action": "light.turn_on", "target": {"area_id": "bedroom"}}]
+            "triggers": [{"trigger": "time", "at": "07:00:00"}],
+            "actions": [{"action": "light.turn_on", "target": {"area_id": "bedroom"}}]
         })
 
         Motion-activated lighting — `for:` on the off-transition replaces action-delay:
         ha_config_set_automation(config={
             "alias": "Motion Light",
-            "trigger": [
-                {"platform": "state", "entity_id": "binary_sensor.motion", "to": "on", "id": "motion_on"},
-                {"platform": "state", "entity_id": "binary_sensor.motion", "to": "off",
+            "triggers": [
+                {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on", "id": "motion_on"},
+                {"trigger": "state", "entity_id": "binary_sensor.motion", "to": "off",
                  "for": {"minutes": 5}, "id": "motion_off"}
             ],
-            "action": [
+            "actions": [
                 {"choose": [
                     {"conditions": [
                         {"condition": "trigger", "id": "motion_on"},
@@ -595,8 +601,8 @@ class AutomationConfigTools:
             identifier="automation.morning_routine",
             config={
                 "alias": "Updated Morning Routine",
-                "trigger": [{"platform": "time", "at": "06:30:00"}],
-                "action": [
+                "triggers": [{"trigger": "time", "at": "06:30:00"}],
+                "actions": [
                     {"action": "light.turn_on", "target": {"area_id": "bedroom"}},
                     {"action": "climate.set_temperature", "target": {"entity_id": "climate.bedroom"}, "data": {"temperature": 22}}
                 ]

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -251,6 +251,36 @@ def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
     return cast(dict[str, Any], normalized)
 
 
+def _detect_conflicting_root_keys(config: Any) -> list[str]:
+    """Warn when a config carries BOTH a singular alias and its canonical plural
+    root key with *different* values.
+
+    ``_normalize_automation_config`` keeps the canonical plural and silently drops
+    the singular alias, so a caller that set, say, ``config['trigger']`` on a
+    config that already has ``triggers`` would have that change discarded. The
+    config is malformed (a caller should send one form), but surfacing the
+    conflict beats dropping data silently.
+    """
+    if not isinstance(config, dict):
+        return []
+    warnings: list[str] = []
+    for singular, plural in (
+        ("trigger", "triggers"),
+        ("action", "actions"),
+        ("condition", "conditions"),
+    ):
+        if (
+            singular in config
+            and plural in config
+            and config[singular] != config[plural]
+        ):
+            warnings.append(
+                f"Config contains both '{singular}' and '{plural}' with different "
+                f"values; using the canonical '{plural}' and ignoring '{singular}'."
+            )
+    return warnings
+
+
 def _strip_redundant_identifier_echo(
     result: dict[str, Any],
     *,
@@ -701,6 +731,10 @@ class AutomationConfigTools:
             config_category = config_dict.pop("category", None)
             effective_category = category if category is not None else config_category
 
+            # Detect conflicting singular+plural root keys BEFORE normalization
+            # drops the singular alias (surface rather than silently discard).
+            conflict_warnings = _detect_conflicting_root_keys(config_dict)
+
             # Normalize field names to HA's canonical plural root keys
             # (trigger -> triggers, action -> actions, condition -> conditions).
             config_dict = _normalize_automation_config(config_dict)
@@ -723,6 +757,7 @@ class AutomationConfigTools:
                 bp_warnings,
                 validation_meta,
                 MandatoryBPS,
+                conflict_warnings,
             )
 
         except ToolError as te:
@@ -832,6 +867,11 @@ class AutomationConfigTools:
         transform_category = transformed_config.pop("category", None)
         effective_category = category if category is not None else transform_category
 
+        # Detect conflicting singular+plural root keys (e.g. a transform that set
+        # the singular 'trigger' on a fetched plural config) before normalization
+        # drops the singular alias.
+        conflict_warnings = _detect_conflicting_root_keys(transformed_config)
+
         transformed_config = _normalize_automation_config(transformed_config)
         self._validate_required_fields(transformed_config, identifier)
         bp_warnings = _check_best_practices(transformed_config)
@@ -839,6 +879,8 @@ class AutomationConfigTools:
         result = await self._client.upsert_automation_config(
             transformed_config, identifier
         )
+        for warning in conflict_warnings:
+            result.setdefault("warnings", []).append(warning)
         refetched = await self._get_automation_config_internal(identifier)
         new_config_hash = refetched[1]
 
@@ -883,9 +925,13 @@ class AutomationConfigTools:
         bp_warnings: BestPracticeCheckResult,
         validation_meta: dict[str, Any],
         MandatoryBPS: bool,
+        conflict_warnings: list[str] | None = None,
     ) -> dict[str, Any]:
         """Execute config-replacement mode and return the tool response."""
         result = await self._client.upsert_automation_config(config_dict, identifier)
+
+        for warning in conflict_warnings or []:
+            result.setdefault("warnings", []).append(warning)
 
         if result.get("entity_not_verified"):
             result.setdefault("warnings", []).append(

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -168,11 +168,19 @@ def _normalize_trigger_keys(triggers: list[dict[str, Any]]) -> list[dict[str, An
     """
     normalized_triggers = []
     for trigger in triggers:
+        # Defensive: a malformed (e.g. LLM-generated) item may not be a dict.
+        if not isinstance(trigger, dict):
+            normalized_triggers.append(trigger)
+            continue
         normalized_trigger = trigger.copy()
-        # Convert legacy 'platform' key to modern 'trigger' if present and
-        # 'trigger' is not already set.
-        if "platform" in normalized_trigger and "trigger" not in normalized_trigger:
-            normalized_trigger["trigger"] = normalized_trigger.pop("platform")
+        # Convert legacy 'platform' to modern 'trigger'. If both are present,
+        # drop the legacy alias so HA's strict schema doesn't reject the config
+        # with "extra keys not allowed" (mirrors _normalize_automation_config).
+        if "platform" in normalized_trigger:
+            if "trigger" not in normalized_trigger:
+                normalized_trigger["trigger"] = normalized_trigger.pop("platform")
+            else:
+                del normalized_trigger["platform"]
         normalized_triggers.append(normalized_trigger)
     return normalized_triggers
 
@@ -223,7 +231,8 @@ def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
     directly passed to ha_config_set_automation without modification.
 
     Transformations:
-    1. Field names: canonicalized to plural root keys (triggers/actions/conditions)
+    1. Field names: canonicalized to plural root keys (triggers/actions/conditions);
+       a stray `sequences` key is normalized to `sequence`.
     2. Trigger keys: platform -> trigger (inside each trigger object)
 
     Args:
@@ -692,7 +701,8 @@ class AutomationConfigTools:
             config_category = config_dict.pop("category", None)
             effective_category = category if category is not None else config_category
 
-            # Normalize field names (triggers -> trigger, actions -> action, etc.)
+            # Normalize field names to HA's canonical plural root keys
+            # (trigger -> triggers, action -> actions, condition -> conditions).
             config_dict = _normalize_automation_config(config_dict)
 
             # Optional hash check for full config updates
@@ -728,7 +738,7 @@ class AutomationConfigTools:
             error_text = str(e)
             suggestions = [
                 "Check automation configuration format",
-                "Ensure required fields: alias, trigger, action",
+                "Ensure required fields: alias, triggers, actions",
                 "Use entity_id format: automation.morning_routine or unique_id",
                 "Use ha_search(domain_filter='automation') to find automations",
                 "Use ha_get_skill_guide for automation examples",

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -82,59 +82,37 @@ NOT_VERIFIED_WARNING_PREFIX = (
 )
 
 
-def _normalize_automation_config(
-    config: Any,
-    parent_key: str | None = None,
-    in_choose_or_if: bool = False,
-    is_root: bool = True,
-) -> Any:
+def _normalize_automation_config(config: Any, is_root: bool = True) -> Any:
     """
-    Recursively normalize automation config field names to HA API format.
+    Recursively normalize automation config field names to HA's canonical form.
 
-    Home Assistant's 2024.10+ canonical form uses the plural root keys
+    Home Assistant's 2024.10+ canonical form uses the plural root list keys
     ('triggers', 'actions', 'conditions'); the singular forms ('trigger',
     'action', 'condition') remain fully accepted as silent aliases. This tool
-    normalizes to the singular root forms internally so the config-API
-    round-trip and the downstream validators / best-practice checker all see
-    one stable shape (HA accepts whichever we send).
+    canonicalizes to the plural root forms so the config-API round-trip and the
+    downstream validators / best-practice checker all see one stable, modern
+    shape (HA accepts whichever we send).
 
-    IMPORTANT: 'triggers' -> 'trigger' and 'actions' -> 'action' normalization
-    is ONLY applied at the root level. Deeper in the tree these keys are either
-    invalid or semantically different, and normalizing them can produce keys
-    that Home Assistant rejects (e.g., 'action' inside a delay object).
-
-    IMPORTANT: Inside 'choose' and 'if' action blocks, the 'conditions' key
-    (plural) is required by the HA schema and should NOT be normalized to
-    'condition' (singular).
-
-    IMPORTANT: Inside compound condition blocks ('or', 'and', 'not'), the
-    'conditions' key (plural) is required and should NOT be normalized to
-    'condition' (singular).
+    Only the ROOT list keys are pluralized. The singular keys that act as type
+    discriminators or service calls inside trigger/condition/action items
+    ('trigger:' = trigger type, 'condition:' = condition type, 'action:' =
+    service call) are semantically different and are left untouched, as is the
+    singular 'sequence' key inside choose/if options and scripts. The nested
+    'conditions' lists required inside choose/if and compound (or/and/not)
+    blocks are already plural and pass through unchanged (issue #498: never
+    rewrite these deeper keys).
 
     Args:
         config: Automation configuration (dict, list, or primitive)
-        parent_key: The parent dictionary key (for context tracking)
-        in_choose_or_if: Whether we're inside a choose/if option that requires
-                         'conditions' (plural) to remain unchanged
-        is_root: Whether this is the root-level automation config dict.
-                 Only root level gets 'triggers'->'trigger' and
-                 'actions'->'action' normalization.
+        is_root: Whether this is the root-level automation config dict. Only the
+                 root level gets the singular -> plural list-key normalization.
 
     Returns:
-        Normalized configuration with singular field names at root level,
-        but preserving 'conditions' (plural) inside choose/if blocks and
-        compound condition blocks (or/and/not)
+        Normalized configuration with plural list field names at the root level.
     """
     # Handle lists - recursively process each item
     if isinstance(config, list):
-        # If parent is 'choose' or 'if', items are options that need 'conditions' preserved
-        is_option_list = parent_key in ("choose", "if")
-        return [
-            _normalize_automation_config(
-                item, parent_key, is_option_list, is_root=False
-            )
-            for item in config
-        ]
+        return [_normalize_automation_config(item, is_root=False) for item in config]
 
     # Handle primitives (strings, numbers, etc.)
     if not isinstance(config, dict):
@@ -143,39 +121,32 @@ def _normalize_automation_config(
     # Process dictionary
     normalized = config.copy()
 
-    # Check if this dict is a compound condition block (or/and/not)
-    # that needs its nested 'conditions' key preserved
-    is_compound_condition_block = normalized.get("condition") in ("or", "and", "not")
-
-    # Build field mappings based on context
+    # Build field mappings (source alias -> canonical key).
     field_mappings: dict[str, str] = {}
 
-    # 'triggers' -> 'trigger' and 'actions' -> 'action' ONLY at root level.
-    # Deeper in the tree these keys are invalid and normalizing them produces
-    # keys HA rejects (e.g., 'action' inside a delay object -- see issue #498).
+    # Pluralize the root list keys to HA's 2024.10+ canonical form. ONLY at the
+    # root level: deeper in the tree 'trigger'/'action'/'condition' are type
+    # discriminators / service calls, not list keys, and must not be touched
+    # (e.g., 'action' inside a delay object -- see issue #498).
     if is_root:
-        field_mappings["triggers"] = "trigger"
-        field_mappings["actions"] = "action"
+        field_mappings["trigger"] = "triggers"
+        field_mappings["action"] = "actions"
+        field_mappings["condition"] = "conditions"
 
-    # 'sequences' -> 'sequence' is safe at any level (only meaningful in choose options)
+    # 'sequences' -> 'sequence': the canonical key is singular at any level.
     field_mappings["sequences"] = "sequence"
 
-    # Only add 'conditions' mapping if NOT inside a choose/if option
-    # AND NOT a compound condition block (or/and/not)
-    if not in_choose_or_if and not is_compound_condition_block:
-        field_mappings["conditions"] = "condition"
-
-    # Apply field mapping to current level
-    for plural, singular in field_mappings.items():
-        if plural in normalized and singular not in normalized:
-            normalized[singular] = normalized.pop(plural)
-        elif plural in normalized and singular in normalized:
-            # Both exist - prefer singular, remove plural
-            del normalized[plural]
+    # Apply field mapping to current level, preferring the canonical key.
+    for src, dst in field_mappings.items():
+        if src in normalized and dst not in normalized:
+            normalized[dst] = normalized.pop(src)
+        elif src in normalized and dst in normalized:
+            # Both present -- prefer the canonical key, drop the alias.
+            del normalized[src]
 
     # Recursively process all values in the dictionary
     for key, value in normalized.items():
-        normalized[key] = _normalize_automation_config(value, key, is_root=False)
+        normalized[key] = _normalize_automation_config(value, is_root=False)
 
     return normalized
 
@@ -184,23 +155,24 @@ def _normalize_trigger_keys(triggers: list[dict[str, Any]]) -> list[dict[str, An
     """
     Normalize trigger objects for round-trip compatibility.
 
-    Home Assistant's GET API returns triggers with the modern 'trigger' key for
-    the platform type. This tool canonicalizes each trigger to the legacy
-    'platform' key so its internal pipeline sees one stable shape; HA accepts
-    either form on the SET side.
+    Older Home Assistant configs (and some integrations) still emit triggers
+    keyed by the legacy 'platform'. This tool canonicalizes each trigger to the
+    modern 'trigger' key (HA 2024.10+) so its pipeline and round-trip output use
+    one stable, current shape; HA accepts either form on the SET side.
 
     Args:
         triggers: List of trigger configuration dicts
 
     Returns:
-        List of triggers with 'platform' key instead of 'trigger' key
+        List of triggers with 'trigger' key instead of 'platform' key
     """
     normalized_triggers = []
     for trigger in triggers:
         normalized_trigger = trigger.copy()
-        # Convert 'trigger' key to 'platform' if present and 'platform' is not
-        if "trigger" in normalized_trigger and "platform" not in normalized_trigger:
-            normalized_trigger["platform"] = normalized_trigger.pop("trigger")
+        # Convert legacy 'platform' key to modern 'trigger' if present and
+        # 'trigger' is not already set.
+        if "platform" in normalized_trigger and "trigger" not in normalized_trigger:
+            normalized_trigger["trigger"] = normalized_trigger.pop("platform")
         normalized_triggers.append(normalized_trigger)
     return normalized_triggers
 
@@ -251,8 +223,8 @@ def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
     directly passed to ha_config_set_automation without modification.
 
     Transformations:
-    1. Field names: triggers -> trigger, actions -> action, conditions -> condition
-    2. Trigger keys: trigger -> platform (inside each trigger object)
+    1. Field names: canonicalized to plural root keys (triggers/actions/conditions)
+    2. Trigger keys: platform -> trigger (inside each trigger object)
 
     Args:
         config: Raw automation configuration from HA API
@@ -260,12 +232,12 @@ def _normalize_config_for_roundtrip(config: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Normalized configuration compatible with SET API
     """
-    # First normalize field names (plural -> singular)
+    # First normalize field names (singular -> plural at the root level)
     normalized = _normalize_automation_config(config)
 
-    # Then normalize trigger keys (trigger -> platform)
-    if "trigger" in normalized and isinstance(normalized["trigger"], list):
-        normalized["trigger"] = _normalize_trigger_keys(normalized["trigger"])
+    # Then normalize trigger keys (legacy 'platform' -> modern 'trigger')
+    if "triggers" in normalized and isinstance(normalized["triggers"], list):
+        normalized["triggers"] = _normalize_trigger_keys(normalized["triggers"])
 
     return cast(dict[str, Any], normalized)
 
@@ -447,8 +419,8 @@ class AutomationConfigTools:
                 "Requires identifier and config_hash for validation. "
                 "WARNING: Expressions with infinite loops will hang the server. "
                 "Examples: "
-                "Simple: python_transform=\"config['action'][0]['data']['brightness'] = 255\" "
-                "Pattern: python_transform=\"for a in config['action']: "
+                "Simple: python_transform=\"config['actions'][0]['data']['brightness'] = 255\" "
+                "Pattern: python_transform=\"for a in config['actions']: "
                 "if a.get('alias') == 'My Step': a['data']['value'] = 100\" "
                 "\n\n" + get_security_documentation(),
             ),
@@ -532,11 +504,11 @@ class AutomationConfigTools:
 
         IMPORTANT: python_transform requires 'identifier' and 'config_hash' from ha_config_get_automation().
 
-        PYTHON TRANSFORM EXAMPLES (operate on the fetched config, which uses the
-        singular root keys 'trigger'/'action'/'condition' with per-trigger 'platform'):
-        - Update action: python_transform="config['action'][0]['data']['brightness'] = 255"
-        - Add trigger: python_transform="config['trigger'].append({'platform': 'state', 'entity_id': 'binary_sensor.motion', 'to': 'on'})"
-        - Remove last action: python_transform="config['action'].pop()"
+        PYTHON TRANSFORM EXAMPLES (operate on the fetched config, which uses HA's
+        canonical plural root keys 'triggers'/'actions'/'conditions'):
+        - Update action: python_transform="config['actions'][0]['data']['brightness'] = 255"
+        - Add trigger: python_transform="config['triggers'].append({'trigger': 'state', 'entity_id': 'binary_sensor.motion', 'to': 'on'})"
+        - Remove last action: python_transform="config['actions'].pop()"
 
         Creates a new automation (if identifier omitted) or updates existing automation with provided configuration.
 
@@ -1104,13 +1076,13 @@ class AutomationConfigTools:
         config_dict: dict[str, Any], identifier: str | None
     ) -> None:
         """Raise if an empty-trigger config wraps scene.create (common model misroute)."""
-        trigger_value = config_dict.get("trigger")
+        trigger_value = config_dict.get("triggers")
         trigger_empty = trigger_value is None or (
             isinstance(trigger_value, list) and not trigger_value
         )
         if not trigger_empty:
             return
-        actions_list = coerce_to_list(config_dict.get("action"))
+        actions_list = coerce_to_list(config_dict.get("actions"))
         scene_create_indices = [
             i for i, a in enumerate(actions_list) if _action_contains_scene_create(a)
         ]
@@ -1140,7 +1112,7 @@ class AutomationConfigTools:
     @staticmethod
     def _validate_condition_platform(config_dict: dict[str, Any]) -> None:
         """Raise if any condition uses 'platform' (trigger syntax) instead of 'condition'."""
-        for idx, cond in enumerate(coerce_to_list(config_dict.get("condition"))):
+        for idx, cond in enumerate(coerce_to_list(config_dict.get("conditions"))):
             if not isinstance(cond, dict):
                 continue
             if "platform" in cond and "condition" not in cond:
@@ -1154,7 +1126,7 @@ class AutomationConfigTools:
                         suggestions=[
                             f"Replace 'platform' with 'condition': "
                             f"{{'condition': '{cond['platform']}', ...}}",
-                            "Triggers use 'platform'; conditions use 'condition'.",
+                            "Triggers use 'trigger'; conditions use 'condition'.",
                         ],
                         context={"condition_index": idx, "found_key": "platform"},
                     )
@@ -1167,12 +1139,12 @@ class AutomationConfigTools:
         """Validate required fields and prevent duplicate creation."""
         if "use_blueprint" in config_dict:
             required_fields = ["alias"]
-            # Strip empty trigger/action/condition arrays that would override blueprint
-            for field in ["trigger", "action", "condition"]:
+            # Strip empty triggers/actions/conditions arrays that would override blueprint
+            for field in ["triggers", "actions", "conditions"]:
                 if field in config_dict and config_dict[field] == []:
                     del config_dict[field]
         else:
-            required_fields = ["alias", "trigger", "action"]
+            required_fields = ["alias", "triggers", "actions"]
 
         missing_fields = [f for f in required_fields if f not in config_dict]
         if missing_fields:
@@ -1180,7 +1152,7 @@ class AutomationConfigTools:
             # script — point them at ha_config_set_script instead of the generic
             # missing-fields error.
             if "sequence" in config_dict and (
-                "trigger" in missing_fields or "action" in missing_fields
+                "triggers" in missing_fields or "actions" in missing_fields
             ):
                 context: dict[str, Any] = {"missing_fields": missing_fields}
                 if identifier:
@@ -1191,11 +1163,11 @@ class AutomationConfigTools:
                         message=f"Missing required fields: {', '.join(missing_fields)}",
                         details=(
                             "Config contains 'sequence', which belongs to scripts. "
-                            "Automations use 'trigger' and 'action'; scripts use 'sequence'."
+                            "Automations use 'triggers' and 'actions'; scripts use 'sequence'."
                         ),
                         suggestions=[
                             "Did you mean ha_config_set_script? Scripts use 'sequence' directly.",
-                            "For an automation, replace 'sequence' with 'action' and add a 'trigger'.",
+                            "For an automation, replace 'sequence' with 'actions' and add 'triggers'.",
                         ],
                         context=context,
                     )

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -2331,7 +2331,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 default=None,
                 description=(
                     "Return only the specified keys from each entity's attributes dict "
-                    '(e.g. ["brightness", "color_temp"] for lights). '
+                    '(e.g. ["brightness", "color_temp_kelvin"] for lights). '
                     "None = full attributes (default). "
                     "Unknown keys are silently dropped. "
                     'Requires "attributes" to be present in fields= (or fields=None).'

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -81,7 +81,10 @@ _STATE_CHANGING_SERVICES = {
     "set_temperature",
     "set_hvac_mode",
     "set_fan_mode",
-    "set_speed",
+    # fan.set_speed was removed in the HA percentage migration (gone in 2026.6);
+    # its state-changing successors are set_percentage / set_preset_mode.
+    "set_percentage",
+    "set_preset_mode",
     "select_option",
     "set_value",
     "set_datetime",

--- a/src/ha_mcp/utils/domain_handlers.py
+++ b/src/ha_mcp/utils/domain_handlers.py
@@ -74,7 +74,10 @@ DOMAIN_HANDLERS = {
     },
     "fan": {
         "valid_actions": ["on", "off", "toggle", "set"],
-        "parameters": ["speed", "percentage", "preset_mode", "direction"],
+        # HA removed the legacy `speed` param / `fan.set_speed` service in the
+        # 2021-2022 percentage migration (absent in 2026.6). Use percentage
+        # (fan.set_percentage) and preset_mode (fan.set_preset_mode).
+        "parameters": ["percentage", "preset_mode", "direction"],
         "quick_actions": ["toggle", "speed_up", "speed_down"],
         "state_attributes": ["percentage", "preset_mode"],
         "supports_speed": True,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -25,7 +25,7 @@ await mcp.call_tool("ha_config_get_script", {})
 await mcp.call_tool("ha_config_get_script", {"script_id": "nonexistent"})
 ```
 
-**HA API uses singular field names:** `trigger` not `triggers`, `action` not `actions`.
+**HA automation config uses plural root keys (HA 2024.10+):** `triggers`/`actions`/`conditions` (singular `trigger`/`action`/`condition` are still accepted as aliases). The tool canonicalizes to plural, so `ha_config_get_automation` returns the plural shape and `python_transform` operates on it.
 
 **Poll after creating entities.** After creating an entity (automation, script, helper, etc.), HA needs time to register it. Never search/query immediately — use polling helpers from `tests/src/e2e/utilities/wait_helpers.py`:
 ```python

--- a/tests/src/e2e/workflows/automation/test_python_transform.py
+++ b/tests/src/e2e/workflows/automation/test_python_transform.py
@@ -40,7 +40,7 @@ async def test_python_transform_simple_update(mcp_client, ha_client):
         {
             "identifier": entity_id,
             "config_hash": config_hash,
-            "python_transform": "config['action'][0]['data']['brightness'] = 255",
+            "python_transform": "config['actions'][0]['data']['brightness'] = 255",
         },
     )
 
@@ -51,7 +51,7 @@ async def test_python_transform_simple_update(mcp_client, ha_client):
     verify = await mcp.call_tool_success(
         "ha_config_get_automation", {"identifier": entity_id}
     )
-    assert verify["config"]["action"][0]["data"]["brightness"] == 255
+    assert verify["config"]["actions"][0]["data"]["brightness"] == 255
 
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_python_transform_pattern_update(mcp_client, ha_client):
             "identifier": entity_id,
             "config_hash": config_hash,
             "python_transform": """
-for a in config['action']:
+for a in config['actions']:
     if a.get('action') == 'light.turn_on':
         a['data']['brightness'] = 200
 """,
@@ -113,7 +113,7 @@ for a in config['action']:
     verify = await mcp.call_tool_success(
         "ha_config_get_automation", {"identifier": entity_id}
     )
-    actions = verify["config"]["action"]
+    actions = verify["config"]["actions"]
     assert actions[0]["data"]["brightness"] == 200
     assert actions[1]["data"]["brightness"] == 200
     assert actions[2]["data"]["temperature"] == 22
@@ -142,7 +142,7 @@ async def test_python_transform_requires_config_hash(mcp_client, ha_client):
         "ha_config_set_automation",
         {
             "identifier": entity_id,
-            "python_transform": "config['action'] = []",
+            "python_transform": "config['actions'] = []",
         },
     )
     error_msg = extract_error_message(result)
@@ -158,7 +158,7 @@ async def test_python_transform_requires_identifier(mcp_client, ha_client):
         "ha_config_set_automation",
         {
             "config_hash": "fakehash",
-            "python_transform": "config['action'] = []",
+            "python_transform": "config['actions'] = []",
         },
     )
     error_msg = extract_error_message(result)
@@ -175,7 +175,7 @@ async def test_python_transform_mutual_exclusivity(mcp_client, ha_client):
         {
             "identifier": "automation.test",
             "config": {"alias": "test", "trigger": [], "action": []},
-            "python_transform": "config['action'] = []",
+            "python_transform": "config['actions'] = []",
         },
     )
     error_msg = extract_error_message(result)
@@ -225,7 +225,7 @@ async def test_python_transform_hash_conflict(mcp_client, ha_client):
         {
             "identifier": entity_id,
             "config_hash": config_hash,
-            "python_transform": "config['action'][0]['data'] = {'brightness': 100}",
+            "python_transform": "config['actions'][0]['data'] = {'brightness': 100}",
         },
     )
     error_msg = extract_error_message(result)
@@ -301,7 +301,7 @@ async def test_chained_transforms(mcp_client, ha_client):
         {
             "identifier": entity_id,
             "config_hash": get_result["config_hash"],
-            "python_transform": "config['action'][0]['data']['brightness'] = 100",
+            "python_transform": "config['actions'][0]['data']['brightness'] = 100",
         },
     )
     assert result1["success"] is True
@@ -312,7 +312,7 @@ async def test_chained_transforms(mcp_client, ha_client):
         {
             "identifier": entity_id,
             "config_hash": result1["config_hash"],
-            "python_transform": "config['action'][0]['data']['brightness'] = 200",
+            "python_transform": "config['actions'][0]['data']['brightness'] = 200",
         },
     )
     assert result2["success"] is True
@@ -386,7 +386,7 @@ async def test_transform_invalid_config_rejected(mcp_client, ha_client):
         {
             "identifier": entity_id,
             "config_hash": get_result["config_hash"],
-            "python_transform": "del config['action']",
+            "python_transform": "del config['actions']",
         },
     )
     error_msg = extract_error_message(result)
@@ -427,10 +427,11 @@ async def test_config_hash_stable_across_reads(mcp_client, ha_client):
 
 @pytest.mark.asyncio
 async def test_plural_key_hash_stability(mcp_client, ha_client):
-    """Test that plural keys (triggers/actions) don't cause hash instability.
+    """Test that plural-key input doesn't cause hash instability.
 
-    HA REST API returns plural keys which get normalized to singular.
-    Hash must be stable across this normalization.
+    The tool canonicalizes automation configs to HA's 2024.10+ plural root
+    keys. The normalized (plural) shape — and therefore the hash — must be
+    stable across reads.
     """
     mcp = MCPAssertions(mcp_client)
 
@@ -614,7 +615,7 @@ async def test_categorized_automation_transform_preserves_category(
         {
             "identifier": entity_id,
             "config_hash": config_hash,
-            "python_transform": "config['action'][0]['data']['brightness'] = 200",
+            "python_transform": "config['actions'][0]['data']['brightness'] = 200",
         },
     )
 
@@ -622,5 +623,5 @@ async def test_categorized_automation_transform_preserves_category(
     verify = await mcp.call_tool_success(
         "ha_config_get_automation", {"identifier": entity_id}
     )
-    assert verify["config"]["action"][0]["data"]["brightness"] == 200
+    assert verify["config"]["actions"][0]["data"]["brightness"] == 200
     assert verify["config"].get("category") == category_id

--- a/tests/src/unit/test_automation_normalization.py
+++ b/tests/src/unit/test_automation_normalization.py
@@ -655,14 +655,23 @@ class TestRoundtripNormalization:
         assert "platform" not in result[0]
         assert result[1]["trigger"] == "time"
 
-    def test_normalize_trigger_keys_prefers_existing_trigger(self):
-        """When both 'platform' and 'trigger' exist, 'trigger' wins and 'platform' is left."""
+    def test_normalize_trigger_keys_drops_platform_when_trigger_present(self):
+        """When both 'platform' and 'trigger' exist, 'trigger' wins and the legacy
+        'platform' alias is dropped (HA strict schema rejects extra keys)."""
         triggers = [{"platform": "state", "trigger": "time"}]
 
         result = _normalize_trigger_keys(triggers)
 
-        # Existing 'trigger' is not overwritten by 'platform'.
         assert result[0]["trigger"] == "time"
+        assert "platform" not in result[0]
+
+    def test_normalize_trigger_keys_passes_non_dict_through(self):
+        """Malformed non-dict trigger items pass through untouched (no AttributeError)."""
+        # Deliberately malformed input to exercise the defensive guard.
+        result = _normalize_trigger_keys([{"platform": "state"}, "oops", None])  # type: ignore[list-item]
+        assert result[0] == {"trigger": "state"}
+        assert result[1] == "oops"
+        assert result[2] is None
 
     def test_roundtrip_produces_plural_roots_and_modern_trigger_keys(self):
         """A GET-shaped config is canonicalized to plural roots + 'trigger:' keys."""

--- a/tests/src/unit/test_automation_normalization.py
+++ b/tests/src/unit/test_automation_normalization.py
@@ -7,6 +7,7 @@ level only; the singular forms remain accepted as silent aliases on input.
 """
 
 from ha_mcp.tools.tools_config_automations import (
+    _detect_conflicting_root_keys,
     _normalize_automation_config,
     _normalize_config_for_roundtrip,
     _normalize_trigger_keys,
@@ -690,3 +691,38 @@ class TestRoundtripNormalization:
         # Per-trigger key canonicalized to modern 'trigger:'.
         assert result["triggers"][0]["trigger"] == "time"
         assert "platform" not in result["triggers"][0]
+
+
+class TestConflictingRootKeys:
+    """_detect_conflicting_root_keys surfaces a warning when a config carries both
+    a singular alias and its canonical plural with different values (normalization
+    keeps the plural and would otherwise silently drop the singular)."""
+
+    def test_detects_conflict_with_differing_values(self):
+        warnings = _detect_conflicting_root_keys(
+            {"trigger": [{"trigger": "state"}], "triggers": []}
+        )
+        assert len(warnings) == 1
+        assert "trigger" in warnings[0] and "triggers" in warnings[0]
+
+    def test_no_conflict_when_values_equal(self):
+        assert _detect_conflicting_root_keys({"trigger": [], "triggers": []}) == []
+
+    def test_no_conflict_for_single_form(self):
+        assert _detect_conflicting_root_keys({"triggers": [{"trigger": "state"}]}) == []
+
+    def test_detects_all_three_pairs(self):
+        warnings = _detect_conflicting_root_keys(
+            {
+                "trigger": [1],
+                "triggers": [2],
+                "action": [1],
+                "actions": [2],
+                "condition": [1],
+                "conditions": [2],
+            }
+        )
+        assert len(warnings) == 3
+
+    def test_non_dict_returns_empty(self):
+        assert _detect_conflicting_root_keys(["not", "a", "dict"]) == []

--- a/tests/src/unit/test_automation_normalization.py
+++ b/tests/src/unit/test_automation_normalization.py
@@ -1,42 +1,65 @@
-"""Unit tests for automation configuration normalization."""
+"""Unit tests for automation configuration normalization.
 
-from ha_mcp.tools.tools_config_automations import _normalize_automation_config
+HA's 2024.10+ canonical automation shape uses the plural root list keys
+('triggers', 'actions', 'conditions') with per-trigger 'trigger:' type keys.
+``_normalize_automation_config`` canonicalizes to that plural form at the root
+level only; the singular forms remain accepted as silent aliases on input.
+"""
+
+from ha_mcp.tools.tools_config_automations import (
+    _normalize_automation_config,
+    _normalize_config_for_roundtrip,
+    _normalize_trigger_keys,
+)
 
 
 class TestAutomationNormalization:
     """Tests for _normalize_automation_config function."""
 
-    def test_normalize_root_level_plural_to_singular(self):
-        """Test that root-level plural keys are normalized to singular."""
+    def test_normalize_root_level_singular_to_plural(self):
+        """Root-level singular keys are normalized to the canonical plural."""
         config = {
-            "triggers": [{"platform": "state"}],
-            "conditions": [{"condition": "state"}],
-            "actions": [{"service": "light.turn_on"}],
+            "trigger": [{"trigger": "state"}],
+            "condition": [{"condition": "state"}],
+            "action": [{"action": "light.turn_on"}],
         }
 
         result = _normalize_automation_config(config)
 
-        assert "trigger" in result
-        assert "condition" in result
-        assert "action" in result
-        assert "triggers" not in result
-        assert "conditions" not in result
-        assert "actions" not in result
+        assert "triggers" in result
+        assert "conditions" in result
+        assert "actions" in result
+        assert "trigger" not in result
+        assert "condition" not in result
+        assert "action" not in result
+
+    def test_idempotent_on_canonical_plural(self):
+        """Already-canonical plural root keys pass through unchanged."""
+        config = {
+            "triggers": [{"trigger": "state"}],
+            "conditions": [{"condition": "state"}],
+            "actions": [{"action": "light.turn_on"}],
+        }
+
+        result = _normalize_automation_config(config)
+
+        assert set(result) == {"triggers", "conditions", "actions"}
+        assert result == config
 
     def test_preserve_conditions_in_choose_blocks(self):
-        """Test that 'conditions' (plural) is preserved inside choose blocks."""
+        """'conditions' (plural) is preserved inside choose blocks."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
                     "choose": [
                         {
                             "conditions": [{"condition": "trigger", "id": "trigger_1"}],
-                            "sequence": [{"service": "light.turn_on"}],
+                            "sequence": [{"action": "light.turn_on"}],
                         },
                         {
                             "conditions": [{"condition": "trigger", "id": "trigger_2"}],
-                            "sequence": [{"service": "light.turn_off"}],
+                            "sequence": [{"action": "light.turn_off"}],
                         },
                     ]
                 }
@@ -45,21 +68,19 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Root level should have singular forms
-        assert "trigger" in result
-        assert "action" in result
+        # Root level should use the canonical plural forms.
+        assert "triggers" in result
+        assert "actions" in result
 
-        # Inside choose blocks, 'conditions' should remain plural
-        choose_block = result["action"][0]["choose"]
+        # Inside choose blocks, 'conditions' should remain plural.
+        choose_block = result["actions"][0]["choose"]
         assert "conditions" in choose_block[0]
-        assert "condition" not in choose_block[0]
         assert "conditions" in choose_block[1]
-        assert "condition" not in choose_block[1]
 
     def test_preserve_conditions_in_if_blocks(self):
-        """Test that 'conditions' (plural) is preserved inside if action blocks."""
+        """'conditions' (plural) is preserved inside if action blocks."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
                     "if": [
@@ -69,25 +90,24 @@ class TestAutomationNormalization:
                             ]
                         }
                     ],
-                    "then": [{"service": "light.turn_on"}],
-                    "else": [{"service": "light.turn_off"}],
+                    "then": [{"action": "light.turn_on"}],
+                    "else": [{"action": "light.turn_off"}],
                 }
             ],
         }
 
         result = _normalize_automation_config(config)
 
-        # Inside if blocks, 'conditions' should remain plural
-        if_block = result["action"][0]["if"]
+        # Inside if blocks, 'conditions' should remain plural.
+        if_block = result["actions"][0]["if"]
         assert "conditions" in if_block[0]
-        assert "condition" not in if_block[0]
 
     def test_nested_choose_with_multiple_conditions(self):
-        """Test complex nested choose blocks with multiple conditions."""
+        """Complex nested choose blocks with multiple conditions."""
         config = {
             "triggers": [
-                {"platform": "template", "id": "trigger_1"},
-                {"platform": "template", "id": "trigger_2"},
+                {"trigger": "template", "id": "trigger_1"},
+                {"trigger": "template", "id": "trigger_2"},
             ],
             "actions": [
                 {
@@ -97,7 +117,7 @@ class TestAutomationNormalization:
                                 {"condition": "trigger", "id": "trigger_1"},
                                 {"condition": "state", "entity_id": "light.test"},
                             ],
-                            "sequences": [{"service": "light.turn_on"}],
+                            "sequences": [{"action": "light.turn_on"}],
                         },
                     ]
                 }
@@ -106,94 +126,95 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Root level normalization
-        assert "trigger" in result
-        assert "action" in result
+        # Root level stays canonical plural.
+        assert "triggers" in result
+        assert "actions" in result
 
-        # Inside choose, 'conditions' (plural) should be preserved
-        choose_option = result["action"][0]["choose"][0]
+        # Inside choose, 'conditions' (plural) should be preserved.
+        choose_option = result["actions"][0]["choose"][0]
         assert "conditions" in choose_option
         assert len(choose_option["conditions"]) == 2
 
-        # 'sequences' should be normalized to 'sequence'
+        # 'sequences' should be normalized to the canonical singular 'sequence'.
         assert "sequence" in choose_option
         assert "sequences" not in choose_option
 
     def test_default_action_in_choose(self):
-        """Test that choose blocks with default actions work correctly."""
+        """choose blocks with default actions work correctly."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
                     "choose": [
                         {
                             "conditions": [{"condition": "trigger", "id": "trigger_1"}],
-                            "sequence": [{"service": "light.turn_on"}],
+                            "sequence": [{"action": "light.turn_on"}],
                         }
                     ],
-                    "default": [{"service": "light.turn_off"}],
+                    "default": [{"action": "light.turn_off"}],
                 }
             ],
         }
 
         result = _normalize_automation_config(config)
 
-        # Verify choose structure
-        choose_action = result["action"][0]
+        # Verify choose structure.
+        choose_action = result["actions"][0]
         assert "choose" in choose_action
         assert "default" in choose_action
         assert "conditions" in choose_action["choose"][0]
 
-    def test_mixed_singular_and_plural_prefers_singular(self):
-        """Test that when both singular and plural exist, singular is preferred."""
+    def test_mixed_singular_and_plural_prefers_plural(self):
+        """When both singular and plural exist, the canonical plural is preferred."""
         config = {
-            "trigger": [{"platform": "state", "entity_id": "test.entity"}],
-            "triggers": [{"platform": "time"}],  # Should be removed
+            "trigger": [
+                {"trigger": "state", "entity_id": "test.entity"}
+            ],  # alias, dropped
+            "triggers": [{"trigger": "time"}],
         }
 
         result = _normalize_automation_config(config)
 
-        assert "trigger" in result
-        assert "triggers" not in result
-        # Original singular value should be preserved
-        assert result["trigger"][0]["platform"] == "state"
+        assert "triggers" in result
+        assert "trigger" not in result
+        # The canonical plural value is preserved; the singular alias is dropped.
+        assert result["triggers"][0]["trigger"] == "time"
 
     def test_primitives_and_lists_unchanged(self):
-        """Test that primitive values and non-config lists are unchanged."""
+        """Primitive values and non-config lists are unchanged."""
         config = {
             "alias": "Test Automation",
             "description": "A test",
-            "trigger": [{"platform": "state"}],
-            "action": [{"service": "test.service", "data": {"param": [1, 2, 3]}}],
+            "trigger": [{"trigger": "state"}],
+            "action": [{"action": "test.service", "data": {"param": [1, 2, 3]}}],
         }
 
         result = _normalize_automation_config(config)
 
         assert result["alias"] == "Test Automation"
         assert result["description"] == "A test"
-        assert result["action"][0]["data"]["param"] == [1, 2, 3]
+        assert result["actions"][0]["data"]["param"] == [1, 2, 3]
 
     def test_empty_config(self):
-        """Test that empty configurations are handled gracefully."""
+        """Empty configurations are handled gracefully."""
         assert _normalize_automation_config({}) == {}
         assert _normalize_automation_config([]) == []
         assert _normalize_automation_config(None) is None
         assert _normalize_automation_config("string") == "string"
         assert _normalize_automation_config(123) == 123
 
-    def test_normalize_conditions_in_sequence_of_choose_block(self):
-        """Test that 'conditions' is normalized inside a sequence of a choose block."""
+    def test_nested_conditions_not_touched_below_root(self):
+        """A 'conditions' list below the root is never rewritten (only root is normalized)."""
         config = {
-            "action": [
+            "actions": [
                 {
                     "choose": [
                         {
-                            "conditions": [
-                                {"condition": "state"}
-                            ],  # Should be preserved
+                            "conditions": [{"condition": "state"}],  # preserved
                             "sequence": [
                                 {
-                                    # This 'conditions' block is a condition action, and should be normalized
+                                    # A nested 'conditions' block deeper in the tree
+                                    # must also be left untouched.
                                     "conditions": [
                                         {
                                             "condition": "state",
@@ -211,21 +232,19 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        choose_option = result["action"][0]["choose"][0]
+        choose_option = result["actions"][0]["choose"][0]
         action_in_sequence = choose_option["sequence"][0]
 
-        # Verify 'conditions' is preserved at the choose option level
+        # 'conditions' is preserved at the choose option level.
         assert "conditions" in choose_option
-        assert "condition" not in choose_option
-
-        # Verify 'conditions' is normalized to 'condition' inside the sequence
-        assert "condition" in action_in_sequence
-        assert "conditions" not in action_in_sequence
+        # 'conditions' deeper in the sequence is also preserved (never singularized).
+        assert "conditions" in action_in_sequence
+        assert "condition" not in action_in_sequence
 
     def test_preserve_conditions_in_or_blocks(self):
-        """Test that 'conditions' (plural) is preserved inside 'or' condition blocks."""
+        """'conditions' (plural) is preserved inside 'or' condition blocks."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "condition": [
                 {
                     "condition": "or",
@@ -247,20 +266,21 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Root level should have singular form
-        assert "condition" in result
-        assert "conditions" not in result
+        # Root level uses the canonical plural form.
+        assert "conditions" in result
+        assert "condition" not in result
 
-        # Inside 'or' block, 'conditions' should remain plural
-        or_condition = result["condition"][0]
+        # Inside 'or' block, 'conditions' should remain plural and 'condition'
+        # is the type discriminator (string).
+        or_condition = result["conditions"][0]
         assert or_condition["condition"] == "or"
         assert "conditions" in or_condition
         assert len(or_condition["conditions"]) == 2
 
     def test_preserve_conditions_in_and_blocks(self):
-        """Test that 'conditions' (plural) is preserved inside 'and' condition blocks."""
+        """'conditions' (plural) is preserved inside 'and' condition blocks."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "condition": [
                 {
                     "condition": "and",
@@ -282,16 +302,15 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Inside 'and' block, 'conditions' should remain plural
-        and_condition = result["condition"][0]
+        and_condition = result["conditions"][0]
         assert and_condition["condition"] == "and"
         assert "conditions" in and_condition
         assert len(and_condition["conditions"]) == 2
 
     def test_preserve_conditions_in_not_blocks(self):
-        """Test that 'conditions' (plural) is preserved inside 'not' condition blocks."""
+        """'conditions' (plural) is preserved inside 'not' condition blocks."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "condition": [
                 {
                     "condition": "not",
@@ -304,16 +323,15 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Inside 'not' block, 'conditions' should remain plural
-        not_condition = result["condition"][0]
+        not_condition = result["conditions"][0]
         assert not_condition["condition"] == "not"
         assert "conditions" in not_condition
         assert len(not_condition["conditions"]) == 1
 
     def test_nested_compound_conditions(self):
-        """Test deeply nested compound conditions (or inside and, etc.)."""
+        """Deeply nested compound conditions (or inside and, etc.)."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "conditions": [
                 {
                     "condition": "and",
@@ -345,26 +363,26 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Root level: conditions -> condition
-        assert "condition" in result
-        assert "conditions" not in result
+        # Root level uses canonical plural 'conditions'.
+        assert "conditions" in result
+        assert "condition" not in result
 
-        # First level: 'and' block should preserve 'conditions'
-        and_condition = result["condition"][0]
+        # First level: 'and' block preserves 'conditions'.
+        and_condition = result["conditions"][0]
         assert and_condition["condition"] == "and"
         assert "conditions" in and_condition
         assert len(and_condition["conditions"]) == 2
 
-        # Second level: nested 'or' block should preserve 'conditions'
+        # Second level: nested 'or' block preserves 'conditions'.
         or_condition = and_condition["conditions"][1]
         assert or_condition["condition"] == "or"
         assert "conditions" in or_condition
         assert len(or_condition["conditions"]) == 2
 
     def test_compound_conditions_in_choose_block(self):
-        """Test compound conditions inside choose block conditions."""
+        """Compound conditions inside choose block conditions."""
         config = {
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
                     "choose": [
@@ -387,7 +405,7 @@ class TestAutomationNormalization:
                                     ],
                                 },
                             ],
-                            "sequence": [{"service": "light.turn_on"}],
+                            "sequence": [{"action": "light.turn_on"}],
                         }
                     ]
                 }
@@ -396,22 +414,22 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Verify choose block preserves 'conditions' at top level
-        choose_option = result["action"][0]["choose"][0]
+        # Verify choose block preserves 'conditions' at top level.
+        choose_option = result["actions"][0]["choose"][0]
         assert "conditions" in choose_option
         assert len(choose_option["conditions"]) == 2
 
-        # Verify nested 'or' block preserves 'conditions'
+        # Verify nested 'or' block preserves 'conditions'.
         or_condition = choose_option["conditions"][1]
         assert or_condition["condition"] == "or"
         assert "conditions" in or_condition
         assert len(or_condition["conditions"]) == 2
 
-    def test_root_level_plural_normalization_with_compound_conditions(self):
-        """Test that root level 'conditions' is normalized even with compound conditions."""
+    def test_root_level_normalization_with_compound_conditions(self):
+        """Root-level singular keys are pluralized even with compound conditions."""
         config = {
-            "triggers": [{"platform": "state"}],
-            "conditions": [
+            "trigger": [{"trigger": "state"}],
+            "condition": [
                 {
                     "condition": "or",
                     "conditions": [
@@ -423,34 +441,34 @@ class TestAutomationNormalization:
                     ],
                 }
             ],
-            "actions": [{"service": "light.turn_on"}],
+            "action": [{"action": "light.turn_on"}],
         }
 
         result = _normalize_automation_config(config)
 
-        # Root level should be normalized to singular
-        assert "trigger" in result
-        assert "condition" in result
-        assert "action" in result
-        assert "triggers" not in result
-        assert "conditions" not in result
-        assert "actions" not in result
+        # Root level normalized to canonical plural.
+        assert "triggers" in result
+        assert "conditions" in result
+        assert "actions" in result
+        assert "trigger" not in result
+        assert "condition" not in result
+        assert "action" not in result
 
-        # Inside compound condition, 'conditions' should be preserved
-        or_condition = result["condition"][0]
+        # Inside compound condition, 'conditions' should be preserved.
+        or_condition = result["conditions"][0]
         assert "conditions" in or_condition
 
-    def test_no_normalize_actions_inside_delay_object(self):
-        """Test that 'actions' is NOT normalized to 'action' inside nested structures.
+    def test_no_normalize_singular_action_inside_delay_object(self):
+        """A singular 'action' key below the root is NOT pluralized.
 
-        Regression test for issue #498: AI models sometimes include an 'actions'
-        key inside a delay object or other nested structure. The normalizer should
-        NOT convert it to 'action' because that produces a key HA rejects as
-        'extra keys not allowed'.
+        Regression for issue #498 (inverted direction): the root list key is
+        pluralized, but a singular 'action:' deeper in the tree (e.g. a service
+        call inside a sequence step) is a discriminator, not a list key, and
+        must be left untouched.
         """
         config = {
             "alias": "Test",
-            "trigger": [{"platform": "state", "entity_id": "sensor.test"}],
+            "trigger": [{"trigger": "state", "entity_id": "sensor.test"}],
             "action": [
                 {
                     "choose": [
@@ -459,7 +477,7 @@ class TestAutomationNormalization:
                             "sequence": [
                                 {
                                     "delay": {"seconds": 5},
-                                    "actions": [{"service": "light.turn_on"}],
+                                    "action": "light.turn_on",
                                 },
                             ],
                         }
@@ -470,25 +488,27 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # The erroneous 'actions' key inside the delay step should NOT be
-        # normalized to 'action' — it should be left as-is so that HA can
-        # return a clear validation error about the malformed structure.
-        delay_step = result["action"][0]["choose"][0]["sequence"][0]
-        assert "actions" in delay_step
-        assert "action" not in delay_step
+        # The singular 'action:' service call inside the sequence step must stay
+        # singular (it is not a root list key).
+        delay_step = result["actions"][0]["choose"][0]["sequence"][0]
+        assert delay_step["action"] == "light.turn_on"
+        assert "actions" not in delay_step
 
-    def test_no_normalize_triggers_inside_nested_structure(self):
-        """Test that 'triggers' is NOT normalized to 'trigger' inside nested structures."""
+    def test_no_normalize_plural_actions_inside_nested_structure(self):
+        """A stray 'actions' key below the root is left untouched (issue #498)."""
         config = {
             "alias": "Test",
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
                     "choose": [
                         {
                             "conditions": [{"condition": "trigger", "id": "t1"}],
                             "sequence": [
-                                {"service": "light.turn_on", "triggers": ["fake"]},
+                                {
+                                    "delay": {"seconds": 5},
+                                    "actions": [{"action": "light.turn_on"}],
+                                },
                             ],
                         }
                     ]
@@ -498,57 +518,56 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # 'triggers' inside a service call should NOT be normalized
-        service_step = result["action"][0]["choose"][0]["sequence"][0]
-        assert "triggers" in service_step
-        assert "trigger" not in service_step
+        # A malformed nested 'actions' key is left as-is so HA can surface a
+        # clear validation error rather than the normalizer silently rewriting it.
+        delay_step = result["actions"][0]["choose"][0]["sequence"][0]
+        assert "actions" in delay_step
 
-    def test_no_normalize_actions_inside_then_block(self):
-        """Test that 'actions' inside if/then blocks is NOT normalized (issue #498)."""
+    def test_no_normalize_triggers_inside_nested_structure(self):
+        """A stray 'triggers' key below the root is left untouched."""
         config = {
             "alias": "Test",
-            "trigger": [{"platform": "state"}],
+            "trigger": [{"trigger": "state"}],
             "action": [
                 {
-                    "if": [
-                        {"condition": "state", "entity_id": "light.test", "state": "on"}
-                    ],
-                    "then": [
-                        {"delay": {"seconds": 10}},
-                        {"actions": [{"service": "light.turn_off"}]},
-                    ],
+                    "choose": [
+                        {
+                            "conditions": [{"condition": "trigger", "id": "t1"}],
+                            "sequence": [
+                                {"action": "light.turn_on", "triggers": ["fake"]},
+                            ],
+                        }
+                    ]
                 }
             ],
         }
 
         result = _normalize_automation_config(config)
 
-        # 'actions' inside then block should NOT be normalized to 'action'
-        then_steps = result["action"][0]["then"]
-        step_with_actions = then_steps[1]
-        assert "actions" in step_with_actions
-        assert "action" not in step_with_actions
+        # 'triggers' inside a service call should NOT be touched.
+        service_step = result["actions"][0]["choose"][0]["sequence"][0]
+        assert "triggers" in service_step
 
-    def test_root_level_actions_still_normalized(self):
-        """Test that root-level 'actions' is still normalized to 'action'."""
+    def test_root_level_singular_still_pluralized(self):
+        """Root-level singular 'trigger'/'action' are pluralized to the canonical form."""
         config = {
             "alias": "Test",
-            "triggers": [{"platform": "state"}],
-            "actions": [{"service": "light.turn_on"}],
+            "trigger": [{"trigger": "state"}],
+            "action": [{"action": "light.turn_on"}],
         }
 
         result = _normalize_automation_config(config)
 
-        assert "trigger" in result
-        assert "triggers" not in result
-        assert "action" in result
-        assert "actions" not in result
+        assert "triggers" in result
+        assert "trigger" not in result
+        assert "actions" in result
+        assert "action" not in result
 
     def test_complex_nested_choose_if_then_with_delays(self):
-        """Test the exact scenario from issue #498 — complex nested choose/if/then with delays."""
+        """The exact scenario from issue #498 — complex nested choose/if/then with delays."""
         config = {
             "alias": "Complex Automation",
-            "triggers": [{"platform": "state", "entity_id": "sensor.test"}],
+            "triggers": [{"trigger": "state", "entity_id": "sensor.test"}],
             "actions": [
                 {
                     "choose": [
@@ -556,7 +575,7 @@ class TestAutomationNormalization:
                             "conditions": [{"condition": "trigger", "id": "t1"}],
                             "sequence": [
                                 {
-                                    "service": "notify.mobile",
+                                    "action": "notify.mobile",
                                     "data": {"message": "Step 1"},
                                 },
                                 {"delay": {"minutes": 2}},
@@ -571,7 +590,7 @@ class TestAutomationNormalization:
                                     "then": [
                                         {"delay": {"seconds": 30}},
                                         {
-                                            "service": "light.turn_off",
+                                            "action": "light.turn_off",
                                             "target": {"entity_id": "light.test"},
                                         },
                                     ],
@@ -583,14 +602,14 @@ class TestAutomationNormalization:
                             "sequence": [
                                 {"delay": {"seconds": 5}},
                                 {
-                                    "service": "light.turn_on",
+                                    "action": "light.turn_on",
                                     "target": {"entity_id": "light.test"},
                                 },
                             ],
                         },
                     ],
                     "default": [
-                        {"service": "notify.mobile", "data": {"message": "Default"}}
+                        {"action": "notify.mobile", "data": {"message": "Default"}}
                     ],
                 }
             ],
@@ -598,19 +617,67 @@ class TestAutomationNormalization:
 
         result = _normalize_automation_config(config)
 
-        # Root level should be normalized
-        assert "trigger" in result
-        assert "action" in result
-        assert "triggers" not in result
-        assert "actions" not in result
+        # Root level stays canonical plural.
+        assert "triggers" in result
+        assert "actions" in result
+        assert "trigger" not in result
+        assert "action" not in result
 
-        # Choose conditions should be preserved as plural
-        choose_block = result["action"][0]["choose"]
+        # Choose conditions should be preserved as plural.
+        choose_block = result["actions"][0]["choose"]
         assert "conditions" in choose_block[0]
         assert "conditions" in choose_block[1]
 
-        # Nested if/then structure should be intact
+        # Nested if/then structure should be intact.
         if_block = choose_block[0]["sequence"][2]
         assert "if" in if_block
         assert "then" in if_block
         assert len(if_block["then"]) == 2
+
+
+class TestRoundtripNormalization:
+    """Tests for the GET->SET round-trip helpers (_normalize_config_for_roundtrip).
+
+    These canonicalize a config fetched from HA into the modern 2024.10+ shape:
+    plural root list keys and per-trigger 'trigger:' type keys.
+    """
+
+    def test_normalize_trigger_keys_platform_to_trigger(self):
+        """Legacy per-trigger 'platform' is canonicalized to modern 'trigger'."""
+        triggers = [
+            {"platform": "state", "entity_id": "binary_sensor.motion"},
+            {"trigger": "time", "at": "07:00:00"},  # already modern, untouched
+        ]
+
+        result = _normalize_trigger_keys(triggers)
+
+        assert result[0]["trigger"] == "state"
+        assert "platform" not in result[0]
+        assert result[1]["trigger"] == "time"
+
+    def test_normalize_trigger_keys_prefers_existing_trigger(self):
+        """When both 'platform' and 'trigger' exist, 'trigger' wins and 'platform' is left."""
+        triggers = [{"platform": "state", "trigger": "time"}]
+
+        result = _normalize_trigger_keys(triggers)
+
+        # Existing 'trigger' is not overwritten by 'platform'.
+        assert result[0]["trigger"] == "time"
+
+    def test_roundtrip_produces_plural_roots_and_modern_trigger_keys(self):
+        """A GET-shaped config is canonicalized to plural roots + 'trigger:' keys."""
+        config = {
+            "alias": "Morning",
+            "trigger": [{"platform": "time", "at": "07:00:00"}],
+            "condition": [{"condition": "state", "entity_id": "x", "state": "on"}],
+            "action": [{"action": "light.turn_on"}],
+        }
+
+        result = _normalize_config_for_roundtrip(config)
+
+        assert "triggers" in result and "trigger" not in result
+        assert "conditions" in result and "condition" not in result
+        assert "actions" in result and "action" not in result
+        # Per-trigger key canonicalized to modern 'trigger:'.
+        assert result["triggers"][0]["trigger"] == "time"
+        assert "platform" not in result["triggers"][0]

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -2256,3 +2256,51 @@ class TestDurationMathDetector:
         }
         warnings = check_automation_config(config)
         assert _has_warning_containing(warnings, "last_changed/last_updated", "for:")
+
+
+class TestPluralKeyTolerance:
+    """check_automation_config reads HA 2024.10+ canonical plural root keys.
+
+    In production the config is pre-normalized to plural before this checker runs,
+    so the plural-first read (config.get("triggers", config.get("trigger", [])) etc.)
+    is the live path. These pin that contract — the rest of the suite only feeds the
+    singular fallback.
+    """
+
+    def test_condition_template_warning_on_plural_conditions(self):
+        """The condition-template anti-pattern fires when conditions are under the
+        canonical plural 'conditions' key (covers the plural-first condition read)."""
+        config = {
+            "triggers": [],
+            "conditions": [
+                {
+                    "condition": "template",
+                    "value_template": "{{ states('sensor.temp') | float > 25 }}",
+                }
+            ],
+            "actions": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(
+            warnings, "float/int comparison", "numeric_state"
+        )
+
+    def test_mode_motion_warning_on_plural_keys(self):
+        """The mode:single motion+delay warning fires on plural 'triggers'/'actions'
+        (covers the plural-first trigger and action reads in _check_mode_motion)."""
+        config = {
+            "triggers": [
+                {
+                    "trigger": "state",
+                    "entity_id": "binary_sensor.hallway_motion",
+                    "to": "on",
+                }
+            ],
+            "actions": [
+                {"action": "light.turn_on", "target": {"entity_id": "light.hallway"}},
+                {"delay": {"minutes": 5}},
+                {"action": "light.turn_off", "target": {"entity_id": "light.hallway"}},
+            ],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "motion", "mode: restart")

--- a/tests/src/unit/test_config_automation_validation.py
+++ b/tests/src/unit/test_config_automation_validation.py
@@ -4,6 +4,10 @@ Covers:
 - _validate_required_fields: missing-field errors and the ha_config_set_script hint
 - _parse_and_validate_config: VALIDATION_INVALID_JSON error message and suggestions
 - _validate_required_fields: sun trigger event pre-validation
+
+The validators run on *normalized* configs (post ``_normalize_automation_config``),
+so the inputs here use HA's canonical plural root list keys
+('triggers'/'actions'/'conditions').
 """
 
 from __future__ import annotations
@@ -33,7 +37,7 @@ class TestParseAndValidateConfig:
         # (e.g. unquoted key, which is a common model mistake)
         with pytest.raises(ToolError) as exc_info:
             AutomationConfigTools._parse_and_validate_config(
-                '{alias: "x", "trigger": []}'  # unquoted key — invalid JSON
+                '{alias: "x", "triggers": []}'  # unquoted key — invalid JSON
             )
         error = _error_from_tool_error(exc_info.value)
         assert error["code"] == "VALIDATION_INVALID_JSON"
@@ -46,7 +50,7 @@ class TestValidateRequiredFields:
     def test_valid_automation_passes(self) -> None:
         """Complete automation config raises nothing."""
         AutomationConfigTools._validate_required_fields(
-            {"alias": "x", "trigger": [], "action": []},
+            {"alias": "x", "triggers": [], "actions": []},
             identifier=None,
         )
 
@@ -54,21 +58,21 @@ class TestValidateRequiredFields:
         """Missing fields without a 'sequence' key emit the default suggestions."""
         with pytest.raises(ToolError) as exc_info:
             AutomationConfigTools._validate_required_fields(
-                {"alias": "x", "action": []},
+                {"alias": "x", "actions": []},
                 identifier=None,
             )
         error = _error_from_tool_error(exc_info.value)
         assert error["code"] == "CONFIG_MISSING_REQUIRED_FIELDS"
-        assert "trigger" in error["message"]
+        assert "triggers" in error["message"]
         # The generic suggestion should NOT mention ha_config_set_script.
         all_text = json.dumps(error)
         assert "ha_config_set_script" not in all_text
 
     def test_sequence_in_config_hints_at_set_script(self) -> None:
-        """A config with 'sequence' and missing trigger/action hints at ha_config_set_script."""
+        """A config with 'sequence' and missing triggers/actions hints at ha_config_set_script."""
         with pytest.raises(ToolError) as exc_info:
             AutomationConfigTools._validate_required_fields(
-                {"alias": "Goodnight", "sequence": [{"service": "light.turn_off"}]},
+                {"alias": "Goodnight", "sequence": [{"action": "light.turn_off"}]},
                 identifier=None,
             )
         error = _error_from_tool_error(exc_info.value)
@@ -80,13 +84,13 @@ class TestValidateRequiredFields:
         assert "sequence" in all_text
 
     def test_sequence_in_config_with_trigger_but_no_action_still_hints(self) -> None:
-        """Sequence + trigger but no action still triggers the script hint."""
+        """Sequence + triggers but no actions still triggers the script hint."""
         with pytest.raises(ToolError) as exc_info:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "x",
-                    "trigger": [],
-                    "sequence": [{"service": "light.turn_off"}],
+                    "triggers": [],
+                    "sequence": [{"action": "light.turn_off"}],
                 },
                 identifier=None,
             )
@@ -97,13 +101,14 @@ class TestValidateRequiredFields:
 class TestValidateConditionBlocks:
     """Pre-validation of condition blocks for platform vs condition confusion.
 
-    Triggers use 'platform'; conditions use 'condition'. Models familiar with
-    trigger syntax often write {'platform': 'state', ...} in condition lists,
-    which HA accepts without a 400 but then crashes with an unhelpful 500.
+    Triggers use 'trigger' (legacy 'platform'); conditions use 'condition'.
+    Models familiar with trigger syntax often write {'platform': 'state', ...}
+    in condition lists, which HA accepts without a 400 but then crashes with an
+    unhelpful 500.
     """
 
     def _base_config(self, conditions: object) -> dict:
-        return {"alias": "x", "trigger": [], "action": [], "condition": conditions}
+        return {"alias": "x", "triggers": [], "actions": [], "conditions": conditions}
 
     def test_valid_state_condition_passes(self) -> None:
         AutomationConfigTools._validate_required_fields(
@@ -171,8 +176,8 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "Movie Snapshot",
-                    "trigger": [],
-                    "action": [
+                    "triggers": [],
+                    "actions": [
                         {
                             "service": "scene.create",
                             "data": {
@@ -201,8 +206,8 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "Movie Snapshot",
-                    "trigger": [],
-                    "action": [
+                    "triggers": [],
+                    "actions": [
                         {
                             "action": "scene.create",
                             "data": {"scene_id": "movie_night"},
@@ -217,7 +222,7 @@ class TestEmptyTriggerSceneCreateDefense:
         assert "ha_config_set_scene" in suggestions_blob
 
     def test_trigger_none_with_scene_create_rejected(self) -> None:
-        """R1 blocker 1: ``trigger: null`` reaches the gate. The
+        """R1 blocker 1: ``triggers: null`` reaches the gate. The
         missing-fields check uses ``not in config_dict`` so present-but-null
         slips through to here, where the gate normalises both ``[]`` and
         ``None`` as empty-trigger."""
@@ -225,8 +230,8 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "Movie",
-                    "trigger": None,
-                    "action": [{"service": "scene.create", "data": {"scene_id": "x"}}],
+                    "triggers": None,
+                    "actions": [{"service": "scene.create", "data": {"scene_id": "x"}}],
                 },
                 identifier=None,
             )
@@ -299,8 +304,8 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": f"Nested-{case_name}",
-                    "trigger": [],
-                    "action": [wrapper_action],
+                    "triggers": [],
+                    "actions": [wrapper_action],
                 },
                 identifier=None,
             )
@@ -310,7 +315,7 @@ class TestEmptyTriggerSceneCreateDefense:
         assert "ha_config_set_scene" in suggestions_blob
 
     def test_action_as_single_dict_caught(self) -> None:
-        """R1 while-you're-in: ``action`` accepted as a single dict (not a
+        """R1 while-you're-in: ``actions`` accepted as a single dict (not a
         list) — ``coerce_to_list`` lifts it; the gate must still catch
         this shape so a regression that drops the coerce wouldn't silently
         re-open the gate."""
@@ -318,9 +323,9 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "Single dict action",
-                    "trigger": [],
+                    "triggers": [],
                     # NB: dict, not list-of-dict
-                    "action": {"service": "scene.create", "data": {"scene_id": "x"}},
+                    "actions": {"service": "scene.create", "data": {"scene_id": "x"}},
                 },
                 identifier=None,
             )
@@ -334,9 +339,9 @@ class TestEmptyTriggerSceneCreateDefense:
         AutomationConfigTools._validate_required_fields(
             {
                 "alias": "Draft",
-                "trigger": [],
-                "action": [
-                    {"service": "light.turn_on", "target": {"entity_id": "light.x"}}
+                "triggers": [],
+                "actions": [
+                    {"action": "light.turn_on", "target": {"entity_id": "light.x"}}
                 ],
             },
             identifier=None,
@@ -348,14 +353,14 @@ class TestEmptyTriggerSceneCreateDefense:
         AutomationConfigTools._validate_required_fields(
             {
                 "alias": "Snapshot on guest mode",
-                "trigger": [
+                "triggers": [
                     {
-                        "platform": "state",
+                        "trigger": "state",
                         "entity_id": "input_boolean.guest_mode",
                         "to": "on",
                     }
                 ],
-                "action": [
+                "actions": [
                     {
                         "service": "scene.create",
                         "data": {"scene_id": "before_guests"},
@@ -367,7 +372,7 @@ class TestEmptyTriggerSceneCreateDefense:
 
     def test_use_blueprint_empty_trigger_strip_preserved(self) -> None:
         """Backwards-compat: ``use_blueprint`` configs that pass empty
-        ``trigger: []`` have those stripped before validation (the
+        ``triggers: []`` have those stripped before validation (the
         blueprint provides the trigger). The misroute gate must not
         break that path."""
         AutomationConfigTools._validate_required_fields(
@@ -382,8 +387,8 @@ class TestEmptyTriggerSceneCreateDefense:
                 },
                 # These should be stripped by the use_blueprint pre-pass and
                 # never reach the misroute gate.
-                "trigger": [],
-                "action": [],
+                "triggers": [],
+                "actions": [],
             },
             identifier=None,
         )
@@ -395,8 +400,8 @@ class TestEmptyTriggerSceneCreateDefense:
             AutomationConfigTools._validate_required_fields(
                 {
                     "alias": "Multi",
-                    "trigger": [],
-                    "action": [
+                    "triggers": [],
+                    "actions": [
                         {"service": "light.turn_on"},
                         {"service": "scene.create", "data": {"scene_id": "a"}},
                         {"action": "scene.create", "data": {"scene_id": "b"}},


### PR DESCRIPTION
## What does this PR do?

Audits the ha-mcp tool surface for stale Home Assistant API field/service names and
brings it to HA 2026.6 (follow-on to #1539's `service:`→`action:` fix, issue #1540).
Two verified multi-agent passes — (1) all 83 tool docstrings for inline JSON/dict
examples, (2) all HA-payload-emitting / state-consuming source modules — with every
flagged item re-verified against HA core source for the current release before changing.

### Stale docstring example (issue #1540 core)
- **`ha_get_state`** — `attribute_keys` example `["brightness", "color_temp"]` →
  `color_temp_kelvin`. HA removed the `color_temp` light *state attribute* in **2026.3**;
  `attribute_keys` silently drops unknown keys, so the example taught a no-op.

### Automation config canonicalized to HA 2024.10+ (plural)
HA 2024.10 made the plural root keys (`triggers`/`actions`/`conditions`) and per-trigger
`trigger:` canonical (singular + `platform:` remain accepted aliases). The tool's internal
wire convention is migrated to the modern shape:
- `_normalize_automation_config` canonicalizes root list keys **singular → plural** (root
  only; nested discriminators/service calls untouched — issue #498).
- `_normalize_trigger_keys` / `_normalize_config_for_roundtrip` emit per-trigger `trigger:`.
- Internal validators read plural; `best_practice_checker` reads plural but tolerates the
  singular aliases (mirroring its existing per-trigger `platform`/`trigger` tolerance).
- **Behavior change:** `ha_config_get_automation` now returns the canonical plural +
  `trigger:` shape and `python_transform` operates on it. HA accepts both forms, legacy
  singular **input** is still accepted (covered by tests), so this is a representation
  change, not breaking (per AGENTS.md).
- Docstring examples updated to the canonical form.

### 2026.6 codebase sweep
- **fan `speed` / `fan.set_speed`** removed in the 2021–2022 percentage migration (verified
  absent in HA core 2026.6.0): dropped `"speed"` from the fan domain's suggested parameters;
  replaced the dead `set_speed` in `_STATE_CHANGING_SERVICES` with its successors
  `set_percentage` / `set_preset_mode` so fan speed changes are still awaited.
- Verified clean (no change): lights already emit `color_temp_kelvin`; calendar uses
  `calendar.get_events`; climate/cover/media_player/todo/energy/scripts/scenes current;
  template helpers are config-flow based. False positives correctly skipped (`friendly_name`
  state-attr reads, `value_template` condition reads, detector legacy references).

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Maintenance/refactor

## Testing
- [x] Unit suites for all changed areas pass locally (automation normalization rewritten for
      the plural contract + round-trip tests added; validators; best-practice; device/service).
      `ruff check` / `ruff format` clean on all changed files. Full e2e runs in CI.
- [ ] I have tested these changes with a LLM agent

## Checklist
- [x] I have updated documentation if needed (docstrings)
