### PR TITLE
feat: user-configurable custom filesystem directories for the file tools (closes #1567)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -194,19 +194,49 @@ async def _load_or_create_caller_token(hass: HomeAssistant) -> str:
 async def _load_allowed_paths(hass: HomeAssistant) -> list[str]:
     """Return the persisted user-configurable extra directories.
 
-    Empty list on first run, a missing/corrupt store, or any non-string
-    entries — fail safe to "no extra access" rather than raising, mirroring
-    the defensive shape of :func:`_load_or_create_caller_token`.
+    Each stored entry is re-validated through :func:`_normalize_extra_dir`, so a
+    hand-edited or corrupted store can never load a traversal / deny-floor /
+    out-of-config entry into ``hass.data`` (defense in depth — the deny floor is
+    also re-checked at enforcement time). Anything dropped is logged so a
+    "my custom directories disappeared" case is one grep away. Empty list on
+    first run or a malformed store — fail safe to "no extra access" rather than
+    raising, mirroring :func:`_load_or_create_caller_token`.
     """
     store: Store = Store(
         hass, _ALLOWED_PATHS_STORAGE_VERSION, _ALLOWED_PATHS_STORAGE_KEY
     )
     data = await store.async_load()
-    if isinstance(data, dict):
-        paths = data.get("paths")
-        if isinstance(paths, list):
-            return [p for p in paths if isinstance(p, str)]
-    return []
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("paths")
+    if not isinstance(raw, list):
+        if raw is not None:
+            _LOGGER.warning(
+                "ha_mcp_tools allowed-paths store is malformed (paths is %s, "
+                "expected list); ignoring it.",
+                type(raw).__name__,
+            )
+        return []
+    config_dir = Path(hass.config.config_dir)
+    normalized: list[str] = []
+    dropped: list[Any] = []
+    for entry in raw:
+        norm = (
+            _normalize_extra_dir(entry, config_dir) if isinstance(entry, str) else None
+        )
+        if norm is None:
+            dropped.append(entry)
+        elif norm not in normalized:
+            normalized.append(norm)
+    if dropped:
+        _LOGGER.warning(
+            "ha_mcp_tools: dropped %d invalid entr%s from the persisted "
+            "allowed-paths store: %r",
+            len(dropped),
+            "y" if len(dropped) == 1 else "ies",
+            dropped,
+        )
+    return normalized
 
 
 async def _save_allowed_paths(hass: HomeAssistant, paths: list[str]) -> None:

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -37,6 +37,8 @@ from .const import (
     ALLOWED_YAML_CONFIG_FILES,
     ALLOWED_YAML_KEYS,
     DASHBOARD_URL_PATH_PATTERN,
+    DENY_PATH_SEGMENTS,
+    DENY_READ_BASENAMES,
     DOMAIN,
     PACKAGES_ONLY_YAML_KEYS,
     RESERVED_DASHBOARD_URL_PATHS,
@@ -54,6 +56,8 @@ SERVICE_WRITE_FILE = "write_file"
 SERVICE_DELETE_FILE = "delete_file"
 SERVICE_EDIT_YAML_CONFIG = "edit_yaml_config"
 SERVICE_GET_CALLER_TOKEN = "get_caller_token"
+SERVICE_GET_ALLOWED_PATHS = "get_allowed_paths"
+SERVICE_SET_ALLOWED_PATHS = "set_allowed_paths"
 
 # Caller-token auth (PR: restrict ha_mcp_tools.* to ha-mcp callers).
 # ha-mcp injects this field in every service-call payload; non-ha-mcp callers
@@ -63,6 +67,15 @@ CALLER_TOKEN_FIELD = "_ha_mcp_token"
 _TOKEN_STORAGE_KEY = f"{DOMAIN}_auth"
 _TOKEN_STORAGE_VERSION = 1
 _HASS_DATA_TOKEN_KEY = "caller_token"
+
+# User-configurable extra read/write directories (issue #1567). Persisted in a
+# SEPARATE Store from the caller token so a corrupt/edited allowlist can never
+# affect token bootstrap, and the security credential is never mixed with user
+# config. Loaded into hass.data at setup and updated in place by
+# set_allowed_paths so enforcement picks up changes with no HA restart.
+_ALLOWED_PATHS_STORAGE_KEY = f"{DOMAIN}_allowed_paths"
+_ALLOWED_PATHS_STORAGE_VERSION = 1
+_HASS_DATA_ALLOWED_PATHS_KEY = "allowed_paths"
 
 # Service schemas
 SERVICE_EDIT_YAML_CONFIG_SCHEMA = vol.Schema(
@@ -128,6 +141,24 @@ SERVICE_GET_CALLER_TOKEN_SCHEMA = vol.Schema(
     }
 )
 
+# get_allowed_paths / set_allowed_paths back the ha-mcp settings UI's custom
+# filesystem-directory editor (issue #1567). Both are caller-token + admin
+# gated. set_allowed_paths receives the FULL replacement list (mirrors how
+# disabled_packages_keys sends the whole set each call); the handler validates
+# and drops any entry that hits the deny floor or escapes the config dir.
+SERVICE_GET_ALLOWED_PATHS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
+    }
+)
+
+SERVICE_SET_ALLOWED_PATHS_SCHEMA = vol.Schema(
+    {
+        vol.Optional("paths", default=list): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CALLER_TOKEN_FIELD): cv.string,
+    }
+)
+
 # Files that are allowed to be read (even if not in ALLOWED_READ_DIRS)
 ALLOWED_READ_FILES = [
     "configuration.yaml",
@@ -158,6 +189,32 @@ async def _load_or_create_caller_token(hass: HomeAssistant) -> str:
     token = secrets.token_urlsafe(32)
     await store.async_save({"token": token})
     return token
+
+
+async def _load_allowed_paths(hass: HomeAssistant) -> list[str]:
+    """Return the persisted user-configurable extra directories.
+
+    Empty list on first run, a missing/corrupt store, or any non-string
+    entries — fail safe to "no extra access" rather than raising, mirroring
+    the defensive shape of :func:`_load_or_create_caller_token`.
+    """
+    store: Store = Store(
+        hass, _ALLOWED_PATHS_STORAGE_VERSION, _ALLOWED_PATHS_STORAGE_KEY
+    )
+    data = await store.async_load()
+    if isinstance(data, dict):
+        paths = data.get("paths")
+        if isinstance(paths, list):
+            return [p for p in paths if isinstance(p, str)]
+    return []
+
+
+async def _save_allowed_paths(hass: HomeAssistant, paths: list[str]) -> None:
+    """Persist the user-configurable extra directories to .storage."""
+    store: Store = Store(
+        hass, _ALLOWED_PATHS_STORAGE_VERSION, _ALLOWED_PATHS_STORAGE_KEY
+    )
+    await store.async_save({"paths": paths})
 
 
 def _unauthorized_response(service_name: str, **extra: Any) -> dict[str, Any]:
@@ -212,10 +269,121 @@ async def _caller_is_admin(hass: HomeAssistant, call: ServiceCall) -> bool:
     return user is not None and bool(user.is_admin)
 
 
+def _is_within_config_dir(config_dir: Path, normalized: str) -> bool:
+    """Resolve ``config_dir / normalized`` and confirm it stays within
+    ``config_dir`` (symlink-aware).
+
+    Uses ``Path.is_relative_to`` rather than a string prefix so a sibling like
+    ``<config>-evil`` can't masquerade as being inside the config dir. Fails
+    closed on any resolution error.
+    """
+    try:
+        resolved = (config_dir / normalized).resolve()
+        config_resolved = config_dir.resolve()
+    except (OSError, ValueError):
+        return False
+    return resolved == config_resolved or resolved.is_relative_to(config_resolved)
+
+
+def _violates_deny_floor(config_dir: Path, normalized: str) -> bool:
+    """True if ``normalized`` (a ``normpath``'d, config-relative path) hits the
+    non-overridable deny floor (issue #1567).
+
+    Checked BEFORE any allow decision on every read/write/list/delete, so a
+    user-configured extra directory — whether stored or supplied in-flight —
+    can never reach these locations. See ``const.DENY_PATH_SEGMENTS`` /
+    ``const.DENY_READ_BASENAMES`` for the rationale.
+    """
+    # All comparisons are case-insensitive: on a case-insensitive filesystem
+    # (macOS APFS, some Docker bind mounts / SMB) ".STORAGE" opens the real
+    # ".storage", so an exact-case match would let a mixed-case entry slip
+    # through. The deny sets are already lowercase, so lowering the input is
+    # enough. This only ever denies MORE — no legitimate path is a case-variant
+    # of ".storage"/"secrets.yaml".
+    parts = [p for p in normalized.split(os.sep) if p]
+    # A .storage segment anywhere in the relative path (".storage",
+    # ".storage/auth", "x/.storage/y").
+    if any(p.lower() in DENY_PATH_SEGMENTS for p in parts):
+        return True
+    # Symlink defence: resolve and reject if the real target passes THROUGH a
+    # denied segment (e.g. an in-config symlink pointing at .storage). A segment
+    # scan of the resolved path is robust to platform symlink-canonicalization
+    # quirks that make a prefix/``is_relative_to`` comparison unreliable. Fail
+    # closed on any resolution error.
+    try:
+        resolved = (config_dir / normalized).resolve()
+    except (OSError, ValueError):
+        return True
+    if any(seg.lower() in DENY_PATH_SEGMENTS for seg in resolved.parts):
+        return True
+    # secrets.yaml — by basename of BOTH the requested path AND the resolved
+    # target, so a renamed symlink (``www/notes.txt`` → ``secrets.yaml``) can't
+    # dodge it and then escape masking (the read handler masks only the literal
+    # ``secrets.yaml``). The canonical config-root file is the one exception,
+    # matched EXACTLY (not lowercased) because that is the only path the handler
+    # masks — a mixed-case ``SECRETS.YAML`` at the root is NOT masked, so it
+    # must be denied.
+    return (
+        os.path.basename(normalized).lower() in DENY_READ_BASENAMES
+        or resolved.name.lower() in DENY_READ_BASENAMES
+    ) and normalized != "secrets.yaml"
+
+
+def _normalize_extra_dir(entry: str, config_dir: Path) -> str | None:
+    """Validate and normalize one user-supplied extra directory (issue #1567).
+
+    Returns the cleaned, config-relative directory, or ``None`` if the entry
+    must be rejected: not a string, empty, the config root, absolute, uses
+    ``..`` traversal, resolves outside the config dir, or hits the deny floor.
+    Rejected entries are dropped (mirrors the filter-to-known-good discipline
+    used for ``disabled_packages_keys``).
+    """
+    if not isinstance(entry, str) or os.path.isabs(entry):
+        return None
+    cleaned = entry.strip().strip("/")
+    if not cleaned:
+        return None
+    normalized = os.path.normpath(cleaned)
+    if (
+        normalized in (".", "")
+        or normalized.startswith("..")
+        or normalized.startswith("/")
+    ):
+        return None
+    if not _is_within_config_dir(config_dir, normalized):
+        return None
+    if _violates_deny_floor(config_dir, normalized):
+        return None
+    return normalized
+
+
+def _matches_extra_dir(normalized: str, extra_dirs: list[str] | None) -> bool:
+    """True if ``normalized`` IS one of the user-configured extra directories
+    or a path under one (issue #1567).
+
+    Prefix match on a path-separator boundary so a multi-segment entry like
+    ``foo/bar`` grants ``foo/bar`` and ``foo/bar/...`` exactly as configured
+    (the built-in allowlists are single-segment and matched on ``parts[0]``,
+    but extra dirs may be nested), while ``foo`` never matches ``foobar``.
+    """
+    if not extra_dirs:
+        return False
+    return any(normalized == d or normalized.startswith(d + os.sep) for d in extra_dirs)
+
+
 def _is_path_allowed_for_dir(
-    config_dir: Path, rel_path: str, allowed_dirs: list[str]
+    config_dir: Path,
+    rel_path: str,
+    allowed_dirs: list[str],
+    extra_dirs: list[str] | None = None,
 ) -> bool:
-    """Check if a path is within allowed directories."""
+    """Check if a path is within allowed directories.
+
+    ``extra_dirs`` are the user-configured custom directories (issue #1567),
+    granted in addition to ``allowed_dirs``. The non-overridable deny floor is
+    checked first, so a custom directory can never grant access to ``.storage``
+    or other floored paths.
+    """
     # Normalize the path
     normalized = os.path.normpath(rel_path)
 
@@ -223,28 +391,35 @@ def _is_path_allowed_for_dir(
     if normalized.startswith("..") or normalized.startswith("/"):
         return False
 
-    # Check if path starts with an allowed directory
+    # NON-OVERRIDABLE deny floor — before any allow decision (issue #1567).
+    if _violates_deny_floor(config_dir, normalized):
+        return False
+
+    # Built-in allowlist matches on the first segment; user-configured extra
+    # dirs match on a path-boundary prefix (so nested entries work).
     parts = normalized.split(os.sep)
-    if not parts or parts[0] not in allowed_dirs:
+    builtin_ok = bool(parts) and parts[0] in allowed_dirs
+    if not builtin_ok and not _matches_extra_dir(normalized, extra_dirs):
         return False
 
     # Resolve full path and verify it's still under config_dir
-    full_path = config_dir / normalized
-    try:
-        resolved = full_path.resolve()
-        config_resolved = config_dir.resolve()
-        return str(resolved).startswith(str(config_resolved))
-    except (OSError, ValueError):
-        return False
+    return _is_within_config_dir(config_dir, normalized)
 
 
-def _is_path_allowed_for_read(config_dir: Path, rel_path: str) -> bool:
+def _is_path_allowed_for_read(
+    config_dir: Path, rel_path: str, extra_dirs: list[str] | None = None
+) -> bool:
     """Check if a path is allowed for reading.
 
     Allowed:
     - Files directly in config dir: configuration.yaml, automations.yaml, etc.
     - Files in allowed directories: www/, themes/, custom_templates/
     - Files matching patterns: packages/*.yaml, custom_components/**/*.py
+    - User-configured extra directories (``extra_dirs``), granted read+write
+      (issue #1567)
+
+    The non-overridable deny floor is checked first, so a custom directory can
+    never reach ``.storage`` or an unmasked ``secrets.yaml``.
     """
     normalized = os.path.normpath(rel_path)
 
@@ -253,13 +428,11 @@ def _is_path_allowed_for_read(config_dir: Path, rel_path: str) -> bool:
         return False
 
     # Resolve full path and verify it's still under config_dir
-    full_path = config_dir / normalized
-    try:
-        resolved = full_path.resolve()
-        config_resolved = config_dir.resolve()
-        if not str(resolved).startswith(str(config_resolved)):
-            return False
-    except (OSError, ValueError):
+    if not _is_within_config_dir(config_dir, normalized):
+        return False
+
+    # NON-OVERRIDABLE deny floor — before any allow decision (issue #1567).
+    if _violates_deny_floor(config_dir, normalized):
         return False
 
     # Check if it's one of the explicitly allowed files in config root
@@ -279,7 +452,12 @@ def _is_path_allowed_for_read(config_dir: Path, rel_path: str) -> bool:
         return True
 
     # Check for custom_components/**/*.py pattern
-    return fnmatch.fnmatch(normalized, "custom_components/**/*.py")
+    if fnmatch.fnmatch(normalized, "custom_components/**/*.py"):
+        return True
+
+    # User-configured extra directories (read+write) — issue #1567. Prefix
+    # match so nested entries (e.g. "foo/bar") grant paths under them.
+    return _matches_extra_dir(normalized, extra_dirs)
 
 
 def _mask_secrets_content(content: str) -> str:
@@ -945,6 +1123,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     caller_token = await _load_or_create_caller_token(hass)
     hass.data.setdefault(DOMAIN, {})[_HASS_DATA_TOKEN_KEY] = caller_token
 
+    # Load the user-configurable extra read/write directories (issue #1567)
+    # into hass.data so the file handlers read them with no I/O. set_allowed_paths
+    # updates this in place, so changes apply live (no HA restart).
+    hass.data.setdefault(DOMAIN, {})[
+        _HASS_DATA_ALLOWED_PATHS_KEY
+    ] = await _load_allowed_paths(hass)
+
+    def _current_extra_dirs() -> list[str]:
+        """Return the live user-configured extra directories from hass.data."""
+        domain_data = hass.data.get(DOMAIN)
+        if isinstance(domain_data, dict):
+            paths = domain_data.get(_HASS_DATA_ALLOWED_PATHS_KEY)
+            if isinstance(paths, list):
+                return paths
+        return []
+
     # One-time migration of pre-fix YAML backups out of the publicly-served
     # www/ directory (GHSA-g39v-cvjh-8fpf). Wrapped so a migration failure
     # cannot prevent the integration from loading — the integration's
@@ -1014,11 +1208,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         pattern = call.data.get("pattern")
 
         # Security check
-        if not _is_path_allowed_for_dir(config_dir, rel_path, ALLOWED_READ_DIRS):
+        extra_dirs = _current_extra_dirs()
+        if not _is_path_allowed_for_dir(
+            config_dir, rel_path, ALLOWED_READ_DIRS, extra_dirs
+        ):
             _LOGGER.warning("Attempted to list files in disallowed path: %s", rel_path)
             return {
                 "success": False,
-                "error": f"Path not allowed. Must be in: {', '.join(ALLOWED_READ_DIRS)}",
+                "error": f"Path not allowed. Must be in: {', '.join(ALLOWED_READ_DIRS + extra_dirs)}",
                 "files": [],
             }
 
@@ -1074,12 +1271,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         tail_lines = call.data.get("tail_lines")
 
         # Security check
-        if not _is_path_allowed_for_read(config_dir, rel_path):
+        extra_dirs = _current_extra_dirs()
+        if not _is_path_allowed_for_read(config_dir, rel_path, extra_dirs):
             _LOGGER.warning("Attempted to read disallowed path: %s", rel_path)
             allowed_patterns = (
                 ALLOWED_READ_FILES
                 + [f"{d}/**" for d in ALLOWED_READ_DIRS]
                 + ["packages/*.yaml", "custom_components/**/*.py"]
+                + [f"{d}/**" for d in extra_dirs]
             )
             return {
                 "success": False,
@@ -1177,11 +1376,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         create_dirs = call.data.get("create_dirs", True)
 
         # Security check - only allow writes to specific directories
-        if not _is_path_allowed_for_dir(config_dir, rel_path, ALLOWED_WRITE_DIRS):
+        extra_dirs = _current_extra_dirs()
+        if not _is_path_allowed_for_dir(
+            config_dir, rel_path, ALLOWED_WRITE_DIRS, extra_dirs
+        ):
             _LOGGER.warning("Attempted to write to disallowed path: %s", rel_path)
             return {
                 "success": False,
-                "error": f"Write not allowed. Must be in: {', '.join(ALLOWED_WRITE_DIRS)}",
+                "error": f"Write not allowed. Must be in: {', '.join(ALLOWED_WRITE_DIRS + extra_dirs)}",
             }
 
         target_file = config_dir / rel_path
@@ -1242,11 +1444,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         rel_path = call.data["path"]
 
         # Security check - only allow deletes from specific directories
-        if not _is_path_allowed_for_dir(config_dir, rel_path, ALLOWED_WRITE_DIRS):
+        extra_dirs = _current_extra_dirs()
+        if not _is_path_allowed_for_dir(
+            config_dir, rel_path, ALLOWED_WRITE_DIRS, extra_dirs
+        ):
             _LOGGER.warning("Attempted to delete from disallowed path: %s", rel_path)
             return {
                 "success": False,
-                "error": f"Delete not allowed. Must be in: {', '.join(ALLOWED_WRITE_DIRS)}",
+                "error": f"Delete not allowed. Must be in: {', '.join(ALLOWED_WRITE_DIRS + extra_dirs)}",
             }
 
         target_file = config_dir / rel_path
@@ -1351,6 +1556,72 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "version": version,
         }
 
+    async def handle_get_allowed_paths(call: ServiceCall) -> ServiceResponse:
+        """Return the user-configurable extra directories plus the built-in
+        allowlists and the non-overridable deny floor (issue #1567).
+
+        Backs the ha-mcp settings UI's custom filesystem-directory editor.
+        Caller-token + admin gated (matching get_caller_token): it reveals the
+        filesystem layout, so it is not a public read.
+        """
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_GET_ALLOWED_PATHS, paths=[])
+        if not await _caller_is_admin(hass, call):
+            return {
+                "success": False,
+                "error_code": "unauthorized",
+                "error": "ha_mcp_tools.get_allowed_paths requires admin auth.",
+                "paths": [],
+            }
+        return {
+            "success": True,
+            "paths": _current_extra_dirs(),
+            "builtin_read_dirs": list(ALLOWED_READ_DIRS),
+            "builtin_write_dirs": list(ALLOWED_WRITE_DIRS),
+            "deny_floor": sorted(DENY_PATH_SEGMENTS | DENY_READ_BASENAMES),
+        }
+
+    async def handle_set_allowed_paths(call: ServiceCall) -> ServiceResponse:
+        """Replace the user-configurable extra directories (issue #1567).
+
+        Receives the FULL replacement list. Each entry is validated and
+        normalized; entries that use traversal, are absolute, escape the config
+        directory, or hit the non-overridable deny floor are dropped and
+        reported in ``rejected``. Persists to .storage AND updates hass.data so
+        enforcement applies live with no HA restart. Caller-token + admin gated.
+        """
+        if not _caller_token_ok(hass, call):
+            return _unauthorized_response(SERVICE_SET_ALLOWED_PATHS, paths=[])
+        if not await _caller_is_admin(hass, call):
+            return {
+                "success": False,
+                "error_code": "unauthorized",
+                "error": "ha_mcp_tools.set_allowed_paths requires admin auth.",
+                "paths": [],
+            }
+        raw_paths = call.data.get("paths", [])
+        normalized: list[str] = []
+        rejected: list[str] = []
+        for entry in raw_paths:
+            norm = _normalize_extra_dir(entry, config_dir)
+            if norm is None:
+                rejected.append(entry)
+            elif norm not in normalized:
+                normalized.append(norm)
+
+        await _save_allowed_paths(hass, normalized)
+        hass.data.setdefault(DOMAIN, {})[_HASS_DATA_ALLOWED_PATHS_KEY] = normalized
+        _LOGGER.info(
+            "Updated ha_mcp_tools custom filesystem directories: %s (%d rejected)",
+            normalized,
+            len(rejected),
+        )
+        return {
+            "success": True,
+            "paths": normalized,
+            "rejected": rejected,
+        }
+
     # Register all services with response support
     hass.services.async_register(
         DOMAIN,
@@ -1400,6 +1671,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         supports_response=SupportsResponse.ONLY,
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_ALLOWED_PATHS,
+        handle_get_allowed_paths,
+        schema=SERVICE_GET_ALLOWED_PATHS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_ALLOWED_PATHS,
+        handle_set_allowed_paths,
+        schema=SERVICE_SET_ALLOWED_PATHS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
     _LOGGER.info("HA MCP Tools initialized with file management services")
     return True
 
@@ -1413,10 +1700,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_remove(DOMAIN, SERVICE_WRITE_FILE)
     hass.services.async_remove(DOMAIN, SERVICE_DELETE_FILE)
     hass.services.async_remove(DOMAIN, SERVICE_GET_CALLER_TOKEN)
+    hass.services.async_remove(DOMAIN, SERVICE_GET_ALLOWED_PATHS)
+    hass.services.async_remove(DOMAIN, SERVICE_SET_ALLOWED_PATHS)
 
-    # Drop the cached token from hass.data so a subsequent setup_entry
-    # re-reads from storage (covers the reload-after-rotate path).
+    # Drop the cached token + allowlist from hass.data so a subsequent
+    # setup_entry re-reads from storage (covers the reload-after-rotate path).
     domain_data = hass.data.get(DOMAIN)
     if isinstance(domain_data, dict):
         domain_data.pop(_HASS_DATA_TOKEN_KEY, None)
+        domain_data.pop(_HASS_DATA_ALLOWED_PATHS_KEY, None)
     return True

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -205,7 +205,19 @@ async def _load_allowed_paths(hass: HomeAssistant) -> list[str]:
     store: Store = Store(
         hass, _ALLOWED_PATHS_STORAGE_VERSION, _ALLOWED_PATHS_STORAGE_KEY
     )
-    data = await store.async_load()
+    try:
+        data = await store.async_load()
+    except Exception:
+        # Honour the documented fail-safe contract: a corrupt/unreadable
+        # allowed-paths blob must NOT propagate out of async_setup_entry and
+        # take down the integration. Log loudly and fall back to no extra
+        # access.
+        _LOGGER.warning(
+            "ha_mcp_tools: could not load the allowed-paths store; ignoring it "
+            "and granting no extra directories.",
+            exc_info=True,
+        )
+        return []
     if not isinstance(data, dict):
         return []
     raw = data.get("paths")
@@ -336,15 +348,20 @@ def _violates_deny_floor(config_dir: Path, normalized: str) -> bool:
     if any(p.lower() in DENY_PATH_SEGMENTS for p in parts):
         return True
     # Symlink defence: resolve and reject if the real target passes THROUGH a
-    # denied segment (e.g. an in-config symlink pointing at .storage). A segment
-    # scan of the resolved path is robust to platform symlink-canonicalization
-    # quirks that make a prefix/``is_relative_to`` comparison unreliable. Fail
-    # closed on any resolution error.
+    # denied segment (e.g. an in-config symlink pointing at .storage). Scan ONLY
+    # the portion of the resolved path that is *under the config dir* — not the
+    # full absolute path — so the floor doesn't blanket-ban every access when the
+    # config dir itself happens to live below a ".storage" component (e.g.
+    # ``/var/.storage/config``). This mirrors the pre-PR allowlist model, which
+    # likewise only ever reasons about the config-relative path. ``relative_to``
+    # raising ValueError means the resolved target escaped the config dir (e.g. a
+    # symlink out) — fail closed. Fail closed on any resolution error too.
     try:
         resolved = (config_dir / normalized).resolve()
+        rel_parts = resolved.relative_to(config_dir.resolve()).parts
     except (OSError, ValueError):
         return True
-    if any(seg.lower() in DENY_PATH_SEGMENTS for seg in resolved.parts):
+    if any(seg.lower() in DENY_PATH_SEGMENTS for seg in rel_parts):
         return True
     # secrets.yaml — by basename of BOTH the requested path AND the resolved
     # target, so a renamed symlink (``www/notes.txt`` → ``secrets.yaml``) can't

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -179,9 +179,23 @@ async def _load_or_create_caller_token(hass: HomeAssistant) -> str:
     The token authorizes a caller as ha-mcp. It's stored under
     ``.storage/ha_mcp_tools_auth`` and remains stable across restarts so the
     ha-mcp server can re-bootstrap without user intervention.
+
+    A corrupt/unreadable store must NOT propagate out of async_setup_entry and
+    take down the integration: on a load failure we log and fall through to
+    generating a fresh token (same path as first run), overwriting the bad
+    blob. ha-mcp transparently re-bootstraps the new token via its
+    unauthorized-retry, so the only cost is a one-time token rotation.
     """
     store: Store = Store(hass, _TOKEN_STORAGE_VERSION, _TOKEN_STORAGE_KEY)
-    data = await store.async_load()
+    try:
+        data = await store.async_load()
+    except Exception:
+        _LOGGER.warning(
+            "ha_mcp_tools: could not load the caller-token store; generating a "
+            "fresh token and overwriting it.",
+            exc_info=True,
+        )
+        data = None
     if isinstance(data, dict):
         existing = data.get("token")
         if isinstance(existing, str) and existing:

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -8,6 +8,26 @@ DOMAIN = "ha_mcp_tools"
 ALLOWED_READ_DIRS = ["www", "themes", "custom_templates", "dashboards"]
 ALLOWED_WRITE_DIRS = ["www", "themes", "custom_templates", "dashboards"]
 
+# NON-OVERRIDABLE deny floor for the user-configurable extra read/write
+# directories (issue #1567). The custom allowlist is applied ON TOP of the
+# built-in ALLOWED_*_DIRS, but a custom directory can NEVER grant access to
+# these. The floor is re-checked before any allow decision on every read,
+# write, list, and delete, so neither a stored entry nor an in-flight one can
+# punch through it.
+#
+# .storage holds HA's auth database (refresh/access tokens), hashed passwords,
+# and every integration's cleartext credentials (core.config_entries,
+# application_credentials, cloud) — including this component's OWN caller
+# token (.storage/ha_mcp_tools_auth). Letting a custom dir reach it would both
+# leak secrets and hand out the key to this component's own auth gate.
+DENY_PATH_SEGMENTS = frozenset({".storage"})
+
+# secrets.yaml is reachable ONLY as the canonical config-root file, where the
+# read handler masks its values. Any OTHER secrets.yaml surfaced via a custom
+# dir would be returned UNMASKED (masking keys off the literal root path), so
+# the floor blocks the basename everywhere except that one canonical location.
+DENY_READ_BASENAMES = frozenset({"secrets.yaml"})
+
 # Files allowed for managed YAML editing
 ALLOWED_YAML_CONFIG_FILES = ["configuration.yaml"]
 # Also allows packages/*.yaml via pattern matching

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/homeassistant-ai/ha-mcp/issues",
     "requirements": ["ruamel.yaml>=0.18.0"],
-    "version": "0.6.0"
+    "version": "0.7.0"
 }

--- a/custom_components/ha_mcp_tools/services.yaml
+++ b/custom_components/ha_mcp_tools/services.yaml
@@ -156,3 +156,33 @@ get_caller_token:
     and persisted to .storage. Not intended for direct invocation from
     automations or scripts.
   fields: {}
+
+get_allowed_paths:
+  name: Get Allowed Filesystem Paths (Internal)
+  description: >-
+    Internal service used by the ha-mcp server settings UI. Returns the
+    user-configurable extra read/write directories, the built-in allowlists,
+    and the non-overridable deny floor. Restricted to the ha-mcp server
+    (requires the `_ha_mcp_token`) and admin auth. Not intended for direct
+    invocation from automations or scripts.
+  fields: {}
+
+set_allowed_paths:
+  name: Set Allowed Filesystem Paths (Internal)
+  description: >-
+    Internal service used by the ha-mcp server settings UI. Replaces the
+    user-configurable extra read/write directories (each granted both read and
+    write). Entries that use path traversal, are absolute, escape the config
+    directory, or hit the non-overridable deny floor (e.g. .storage) are
+    dropped. Restricted to the ha-mcp server (requires the `_ha_mcp_token`) and
+    admin auth.
+  fields:
+    paths:
+      name: Paths
+      description: >-
+        Directories relative to the config directory, each granted read and
+        write (e.g. "pyscript", "python_scripts"). Replaces the current list.
+      required: false
+      example: '["pyscript", "python_scripts"]'
+      selector:
+        object:

--- a/src/ha_mcp/settings.js
+++ b/src/ha_mcp/settings.js
@@ -893,7 +893,9 @@ async function saveBackupConfig() {
 // proxy to it via authenticated HA service calls. Cached so the sub-form
 // re-renders synchronously when the beta master / filesystem-tools toggle
 // flips, without re-fetching.
-let _fsCustomPathsData = null; // {available, paths, deny_floor, reason} | null
+// Consumed fields of the GET response: {available, paths, deny_floor, reason}
+// (the endpoint also returns builtin_read_dirs/builtin_write_dirs, unused here).
+let _fsCustomPathsData = null;
 
 async function loadFsCustomPaths() {
   try {

--- a/src/ha_mcp/settings.js
+++ b/src/ha_mcp/settings.js
@@ -888,6 +888,147 @@ async function saveBackupConfig() {
   }
 }
 
+// ---- Custom filesystem directories (issue #1567) ---------------------------
+// The list lives in the ha_mcp_tools custom component; the GET/POST endpoints
+// proxy to it via authenticated HA service calls. Cached so the sub-form
+// re-renders synchronously when the beta master / filesystem-tools toggle
+// flips, without re-fetching.
+let _fsCustomPathsData = null; // {available, paths, deny_floor, reason} | null
+
+async function loadFsCustomPaths() {
+  try {
+    const resp = await fetch('./api/settings/fs-custom-paths');
+    if (!resp.ok) {
+      _fsCustomPathsData = {
+        available: false,
+        reason: `HTTP ${resp.status}`,
+        paths: [],
+        deny_floor: [],
+      };
+    } else {
+      _fsCustomPathsData = await resp.json();
+    }
+  } catch (err) {
+    _fsCustomPathsData = {
+      available: false,
+      reason: 'Network error: ' + String(err),
+      paths: [],
+      deny_floor: [],
+    };
+  }
+  // Re-render the feature panel so the sub-form reflects the loaded data.
+  if (Object.keys(_lastFeatureFlags).length) renderFeatureFlags(_lastFeatureFlags);
+}
+
+// Injected beneath the enable_filesystem_tools row in renderFeatureFlags.
+// Second-level nested (under filesystem tools, itself beta-sub-nested under
+// the master), dimmed when either the master beta or filesystem tools is off.
+function renderFsCustomPathsSubForm(parentEl, masterOn, fsOn) {
+  const lockedByGate = !masterOn || !fsOn;
+  const d = _fsCustomPathsData;
+  const row = document.createElement('div');
+  row.className =
+    'feature-row fs-custom-paths-sub' + (lockedByGate ? ' dimmed' : '');
+
+  const info = document.createElement('div');
+  info.className = 'feature-info';
+  const denyList =
+    d && Array.isArray(d.deny_floor) && d.deny_floor.length
+      ? d.deny_floor.join(', ')
+      : '.storage, secrets.yaml';
+  info.innerHTML =
+    `<div class="feature-name">Custom filesystem directories (advanced)</div>` +
+    `<div class="feature-help">Extra directories (one per line, relative to your config dir) that the file tools may READ and WRITE — e.g. <code>pyscript</code>, <code>python_scripts</code>. Each entry grants both read and write. Applies immediately; no restart needed.</div>` +
+    `<div class="feature-help">Always blocked (cannot be added): <code>${escapeHtml(denyList)}</code>, path traversal (<code>..</code>), and absolute paths.</div>`;
+
+  const control = document.createElement('div');
+  control.className = 'feature-control';
+
+  if (lockedByGate) {
+    const note = document.createElement('div');
+    note.className = 'feature-locked-note';
+    note.textContent =
+      'Enable beta features and filesystem tools above to edit.';
+    control.appendChild(note);
+  } else if (!d) {
+    const note = document.createElement('div');
+    note.className = 'feature-help';
+    note.textContent = 'Loading…';
+    control.appendChild(note);
+  } else if (!d.available) {
+    const note = document.createElement('div');
+    note.className = 'feature-locked-note';
+    note.textContent =
+      d.reason || 'Custom directories are currently unavailable.';
+    control.appendChild(note);
+  } else {
+    const ta = document.createElement('textarea');
+    ta.id = 'fsCustomPathsInput';
+    ta.rows = 4;
+    ta.value = (d.paths || []).join('\n');
+    const btn = document.createElement('button');
+    btn.id = 'fsCustomPathsSave';
+    btn.className = 'adv-save-btn';
+    btn.textContent = 'Save directories';
+    btn.addEventListener('click', saveFsCustomPaths);
+    const status = document.createElement('div');
+    status.id = 'fsCustomPathsStatus';
+    status.className = 'feature-help';
+    control.appendChild(ta);
+    control.appendChild(btn);
+    control.appendChild(status);
+  }
+
+  row.appendChild(info);
+  row.appendChild(control);
+  parentEl.appendChild(row);
+}
+
+async function saveFsCustomPaths() {
+  const ta = document.getElementById('fsCustomPathsInput');
+  const btn = document.getElementById('fsCustomPathsSave');
+  const statusEl = document.getElementById('fsCustomPathsStatus');
+  if (!ta || !btn || !statusEl) return;
+  const paths = ta.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(s => s.length);
+  btn.disabled = true;
+  statusEl.textContent = 'Saving…';
+  try {
+    const resp = await fetch('./api/settings/fs-custom-paths', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ paths }),
+    });
+    const data = await resp.json();
+    btn.disabled = false;
+    if (!resp.ok || !data.success) {
+      let msg = 'Save failed';
+      if (data && data.error) {
+        if (typeof data.error === 'string') msg = data.error;
+        else if (data.error.message) msg = data.error.message;
+      }
+      statusEl.textContent = msg;
+      return;
+    }
+    // Reflect the component's canonical normalized list; drop any rejected.
+    _fsCustomPathsData = {
+      ...(_fsCustomPathsData || {}),
+      available: true,
+      paths: data.paths || [],
+    };
+    ta.value = (data.paths || []).join('\n');
+    const rejected = data.rejected || [];
+    statusEl.textContent = rejected.length
+      ? `Saved. Rejected (blocked or invalid): ${rejected.join(', ')}`
+      : 'Saved.';
+  } catch (err) {
+    btn.disabled = false;
+    statusEl.textContent = 'Network error: ' + String(err);
+  }
+}
+
 async function loadBackups() {
   const params = new URLSearchParams();
   const d = document.getElementById('backupDomain').value.trim();
@@ -1350,6 +1491,14 @@ function renderFeatureFlags(flags) {
     if (fieldName === 'enable_yaml_config_editing') {
       const parentOn = !!f.value;
       renderYamlPackagesSubRows(flags, targetBody, masterOn, parentOn);
+    }
+    // After the enable_filesystem_tools row, inject the custom-directories
+    // editor (issue #1567). Dimmed when either the master beta is off or
+    // filesystem tools itself is off. The list is component-owned and fetched
+    // separately via loadFsCustomPaths(); this renders from that cache.
+    if (fieldName === 'enable_filesystem_tools') {
+      const fsOn = !!f.value;
+      renderFsCustomPathsSubForm(targetBody, masterOn, fsOn);
     }
   });
 }
@@ -2718,6 +2867,7 @@ document.getElementById('advSaveBtn').addEventListener('click', saveAdvancedSett
 loadFeatureFlags();
 loadAdvancedSettings();
 loadTools();
+loadFsCustomPaths();
 
 // Auto-activate tab from ?tab=<name> query string (used by approval URLs
 // generated by the policy middleware: /settings?tab=tool-security-policies&token=...).

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -2912,6 +2912,159 @@ def build_settings_handlers(
             }
         )
 
+    async def _fs_custom_paths_call(service: str, data: dict[str, Any]) -> Any:
+        """Invoke a ha_mcp_tools component service for the custom-paths editor,
+        in any deployment mode (issue #1567).
+
+        Uses the live server's HA client in HTTP/add-on modes; in the stdio
+        sidecar (``server is None``) builds a transient ``HomeAssistantClient``
+        from the HA URL/token the sidecar inherits, and closes it afterward.
+        The caller wraps this in try/except so an unreachable HA / missing
+        token (e.g. OAuth mode, where ``server.client`` has no request-scoped
+        token) degrades to an "unavailable" envelope rather than a 500.
+        """
+        from .tools.tools_filesystem import call_mcp_tools_service
+
+        own_client = None
+        try:
+            if server is not None:
+                client = server.client
+            else:
+                from .client.rest_client import HomeAssistantClient
+
+                client = own_client = HomeAssistantClient()
+            return await call_mcp_tools_service(client, service, data)
+        finally:
+            if own_client is not None and hasattr(own_client, "close"):
+                with contextlib.suppress(Exception):
+                    await own_client.close()
+
+    async def _get_fs_custom_paths(_: Request) -> JSONResponse:
+        """Return the user-configured extra filesystem directories from the
+        ha_mcp_tools component, plus the non-overridable deny floor for the UI
+        blurb (issue #1567).
+
+        Always 200s with an ``available`` flag: when filesystem tools are off,
+        the component is missing/too old, or HA is unreachable, ``available``
+        is False with a human-readable ``reason`` so the UI can show a disabled
+        section instead of an error.
+        """
+        from .tools.tools_filesystem import is_filesystem_tools_enabled
+        from .tools.util_helpers import unwrap_service_response
+
+        def _unavailable(reason: str) -> JSONResponse:
+            return JSONResponse(
+                {
+                    "success": True,
+                    "available": False,
+                    "reason": reason,
+                    "paths": [],
+                    "deny_floor": [],
+                }
+            )
+
+        if not is_filesystem_tools_enabled():
+            return _unavailable(
+                "Filesystem tools are disabled. Enable them (beta) to "
+                "configure custom directories."
+            )
+        try:
+            result = await _fs_custom_paths_call("get_allowed_paths", {})
+        except Exception as exc:
+            logger.warning("fs-custom-paths GET could not reach ha_mcp_tools: %s", exc)
+            return _unavailable(f"Could not reach the ha_mcp_tools component: {exc}")
+
+        data = unwrap_service_response(result) if isinstance(result, dict) else {}
+        if not isinstance(data, dict) or not data.get("success", False):
+            reason = (
+                data.get("error") if isinstance(data, dict) else None
+            ) or "ha_mcp_tools returned an unexpected response."
+            return _unavailable(str(reason))
+        return JSONResponse(
+            {
+                "success": True,
+                "available": True,
+                "paths": data.get("paths", []),
+                "deny_floor": data.get("deny_floor", []),
+                "builtin_read_dirs": data.get("builtin_read_dirs", []),
+                "builtin_write_dirs": data.get("builtin_write_dirs", []),
+            }
+        )
+
+    async def _save_fs_custom_paths(request: Request) -> JSONResponse:
+        """Replace the user-configured extra filesystem directories via the
+        ha_mcp_tools component (issue #1567).
+
+        The component validates each entry and drops anything that hits the
+        deny floor or escapes the config dir; the dropped entries come back in
+        ``rejected``. ``restart_required`` is False — the component applies the
+        new allowlist live.
+        """
+        from .tools.tools_filesystem import is_filesystem_tools_enabled
+        from .tools.util_helpers import unwrap_service_response
+
+        if not is_filesystem_tools_enabled():
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Filesystem tools are disabled; enable them (beta) before "
+                    "configuring custom directories.",
+                ),
+                status_code=409,
+            )
+        try:
+            body = await request.json()
+        except (ValueError, TypeError):
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_JSON,
+                    "Request body must be valid JSON.",
+                ),
+                status_code=400,
+            )
+        paths = body.get("paths") if isinstance(body, dict) else None
+        if paths is None:
+            paths = []
+        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "'paths' must be a list of directory strings.",
+                ),
+                status_code=400,
+            )
+        try:
+            result = await _fs_custom_paths_call("set_allowed_paths", {"paths": paths})
+        except Exception as exc:
+            logger.warning("fs-custom-paths POST could not reach ha_mcp_tools: %s", exc)
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Could not reach the ha_mcp_tools component: {exc}",
+                ),
+                status_code=502,
+            )
+
+        data = unwrap_service_response(result) if isinstance(result, dict) else {}
+        if not isinstance(data, dict) or not data.get("success", False):
+            reason = (
+                data.get("error") if isinstance(data, dict) else None
+            ) or "ha_mcp_tools rejected the update."
+            return JSONResponse(
+                create_error_response(ErrorCode.SERVICE_CALL_FAILED, str(reason)),
+                status_code=502,
+            )
+        return JSONResponse(
+            {
+                "success": True,
+                "applied": data.get("paths", []),
+                "paths": data.get("paths", []),
+                "rejected": data.get("rejected", []),
+                "mode": "component",
+                "restart_required": False,
+            }
+        )
+
     handlers: dict[str, Any] = {
         "root_page": _root_page,
         "settings_page": _settings_page,
@@ -2931,6 +3084,8 @@ def build_settings_handlers(
         "delete_backups_bulk": _delete_backups_bulk,
         "get_backup_config": _get_backup_config,
         "save_backup_config": _save_backup_config,
+        "get_fs_custom_paths": _get_fs_custom_paths,
+        "save_fs_custom_paths": _save_fs_custom_paths,
     }
 
     # Tool security policies. The main server attaches an
@@ -3100,6 +3255,9 @@ def register_settings_routes(
         ("/api/settings/backups/{name}", ["DELETE"], "delete_backup"),
         ("/api/settings/backup-config", ["GET"], "get_backup_config"),
         ("/api/settings/backup-config", ["POST"], "save_backup_config"),
+        # Custom filesystem directories (issue #1567) — component-owned list
+        ("/api/settings/fs-custom-paths", ["GET"], "get_fs_custom_paths"),
+        ("/api/settings/fs-custom-paths", ["POST"], "save_fs_custom_paths"),
         # Tool security policies endpoints
         ("/api/policy/config", ["GET"], "policy_get_config"),
         ("/api/policy/config", ["PUT"], "policy_put_config"),

--- a/src/ha_mcp/stdio_settings_sidecar.py
+++ b/src/ha_mcp/stdio_settings_sidecar.py
@@ -602,6 +602,21 @@ def _build_app(
             handlers["save_feature_flags"],
             methods=["POST"],
         ),
+        # Custom filesystem directories (issue #1567). The sub-form is rendered
+        # in the features panel, so the stdio sidecar must serve these too — its
+        # route list is hand-maintained and does NOT derive from
+        # register_settings_routes. The handler builds a transient HA client
+        # from the inherited env when server is None (sidecar mode).
+        Route(
+            f"{secret_prefix}/api/settings/fs-custom-paths",
+            handlers["get_fs_custom_paths"],
+            methods=["GET"],
+        ),
+        Route(
+            f"{secret_prefix}/api/settings/fs-custom-paths",
+            handlers["save_fs_custom_paths"],
+            methods=["POST"],
+        ),
         # Tool security policies endpoints (#966). Pending/approve/deny
         # are wired as stubs that return 503 in sidecar mode — the
         # in-memory ApprovalQueue lives in the main server process, so

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -53,7 +53,7 @@ CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
 # server-side behavior change requires it. Older components (no
 # ``version`` in the get_caller_token response, or a version below this)
 # get an actionable "update via HACS" error.
-MIN_COMPONENT_VERSION = "0.5.2"
+MIN_COMPONENT_VERSION = "0.7.0"
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
@@ -265,25 +265,6 @@ def _reset_caller_token_cache() -> None:
     _CALLER_TOKEN_LOCKS.clear()
 
 
-# Security constants - mirrors the custom component config
-READABLE_PATTERNS = [
-    "configuration.yaml",
-    "automations.yaml",
-    "scripts.yaml",
-    "scenes.yaml",
-    "secrets.yaml",  # Content will be masked by the custom component
-    "packages/*.yaml",
-    "home-assistant.log",
-    "www/**",
-    "themes/**",
-    "custom_templates/**",
-    "dashboards/**",
-    "custom_components/**/*.py",
-]
-
-WRITABLE_DIRS = ["www", "themes", "custom_templates", "dashboards"]
-
-
 def is_filesystem_tools_enabled() -> bool:
     """Check if the filesystem tools feature is enabled.
 
@@ -375,6 +356,7 @@ class FilesystemTools:
         - `themes/` - Theme files
         - `custom_templates/` - Jinja2 template files
         - `dashboards/` - YAML-mode dashboard files
+        - Plus any custom directories configured in the ha-mcp settings UI
 
         **Security:** Only directories in the allowed list can be accessed.
         Path traversal attempts (../) are blocked.
@@ -482,6 +464,7 @@ class FilesystemTools:
         - `home-assistant.log` (tail only)
         - `www/**`, `themes/**`, `custom_templates/**`, `dashboards/**`
         - `custom_components/**/*.py` (read-only)
+        - Plus any custom directories configured in the ha-mcp settings UI
 
         **Security:**
         - Path traversal (../) is blocked
@@ -604,6 +587,7 @@ class FilesystemTools:
         - `themes/` - Theme YAML files
         - `custom_templates/` - Jinja2 template files
         - `dashboards/` - YAML-mode dashboard files
+        - Plus any custom directories configured in the ha-mcp settings UI
 
         **Security:**
         - Only the directories above allow writes
@@ -718,6 +702,7 @@ class FilesystemTools:
         - `themes/` - Theme files
         - `custom_templates/` - Template files
         - `dashboards/` - YAML-mode dashboard files
+        - Plus any custom directories configured in the ha-mcp settings UI
 
         **Security:**
         - Only the directories above allow deletions

--- a/tests/src/e2e/workflows/filesystem/test_custom_paths.py
+++ b/tests/src/e2e/workflows/filesystem/test_custom_paths.py
@@ -133,11 +133,16 @@ class TestCustomFilesystemPaths:
         base_url = ha_container_with_fresh_config["base_url"]
         token = await _bootstrap_token(base_url)
         try:
-            sr = await _set_allowed_paths(base_url, token, [".storage", "pyscript"])
-            # The deny floor drops .storage; the valid entry is kept.
+            # Mixed batch: a deny-floor entry (dropped), a valid entry, and a
+            # duplicate-after-normalization of it ("pyscript/" -> "pyscript").
+            sr = await _set_allowed_paths(
+                base_url, token, [".storage", "pyscript", "pyscript/"]
+            )
+            # The deny floor drops .storage; the valid entry is kept once (the
+            # normalized duplicate is deduped, not stored twice).
             assert ".storage" in sr.get("rejected", []), sr
             assert ".storage" not in sr.get("paths", []), sr
-            assert "pyscript" in sr.get("paths", []), sr
+            assert sr.get("paths") == ["pyscript"], sr
 
             # Even with a valid custom dir configured, .storage stays blocked.
             data = await safe_call_tool(

--- a/tests/src/e2e/workflows/filesystem/test_custom_paths.py
+++ b/tests/src/e2e/workflows/filesystem/test_custom_paths.py
@@ -1,0 +1,151 @@
+"""E2E coverage for user-configurable custom filesystem directories (#1567).
+
+Proves the full chain end-to-end: the ``ha_mcp_tools.set_allowed_paths``
+service persists a custom directory, the file tools grant read+write into it
+LIVE (no HA restart), and the non-overridable deny floor still blocks
+``.storage`` even when a malicious entry tries to add it.
+
+Cross-lane (no backend marker). The component services are driven directly
+over HA REST with the admin token (mirrors ``test_ha_mcp_tools_refusal.py``);
+the file tools are driven via the MCP client. The custom allowlist lives in
+the component (HA process), so a set over REST is visible to the file handlers
+the MCP client invokes — the same HA instance backs both.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import pytest
+
+from ...utilities.assertions import MCPAssertions, safe_call_tool
+
+logger = logging.getLogger(__name__)
+
+FEATURE_FLAG = "HAMCP_ENABLE_FILESYSTEM_TOOLS"
+
+
+@pytest.fixture(scope="module")
+def _filesystem_feature_flag(ha_container_with_fresh_config):
+    """Enable the filesystem feature flag for this module (see the sibling
+    suites' identical fixtures)."""
+    os.environ[FEATURE_FLAG] = "true"
+    yield
+    os.environ.pop(FEATURE_FLAG, None)
+
+
+@pytest.fixture
+async def mcp_client_fs(
+    _filesystem_feature_flag,
+    mcp_server,
+    mcp_client,
+    ha_container_with_fresh_config,
+):
+    """Yield an MCP client with filesystem tools available, in every lane."""
+    if mcp_server is None:
+        yield mcp_client
+        return
+
+    from fastmcp import Client
+
+    client = Client(mcp_server.mcp)
+    async with client:
+        yield client
+
+
+async def _bootstrap_token(base_url: str) -> str:
+    """Fetch the caller token via the admin-gated bootstrap service."""
+    import httpx
+
+    from tests.test_constants import TEST_TOKEN
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{base_url}/api/services/ha_mcp_tools/get_caller_token",
+            headers={
+                "Authorization": f"Bearer {TEST_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            params={"return_response": ""},
+            json={},
+        )
+    assert resp.status_code == 200, f"get_caller_token failed: {resp.text!r}"
+    service_response = resp.json().get("service_response", {})
+    assert service_response.get("success") is True, f"bootstrap failed: {resp.text!r}"
+    return service_response["token"]
+
+
+async def _set_allowed_paths(base_url: str, token: str, paths: list[str]) -> dict:
+    """Call set_allowed_paths with the admin token + caller token; return the
+    structured service response."""
+    import httpx
+
+    from tests.test_constants import TEST_TOKEN
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{base_url}/api/services/ha_mcp_tools/set_allowed_paths",
+            headers={
+                "Authorization": f"Bearer {TEST_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            params={"return_response": ""},
+            json={"_ha_mcp_token": token, "paths": paths},
+        )
+    assert resp.status_code == 200, f"set_allowed_paths failed: {resp.text!r}"
+    return resp.json().get("service_response", {})
+
+
+@pytest.mark.filesystem
+class TestCustomFilesystemPaths:
+    """The custom-directory allowlist applies live and respects the floor."""
+
+    async def test_custom_dir_grants_read_write_live(
+        self, mcp_client_fs, ha_container_with_fresh_config
+    ):
+        base_url = ha_container_with_fresh_config["base_url"]
+        token = await _bootstrap_token(base_url)
+        fname = f"pyscript/e2e_{uuid.uuid4().hex}.py"
+        try:
+            sr = await _set_allowed_paths(base_url, token, ["pyscript"])
+            assert sr.get("success") is True, sr
+            assert "pyscript" in sr.get("paths", []), sr
+
+            async with MCPAssertions(mcp_client_fs) as mcp:
+                written = await mcp.call_tool_success(
+                    "ha_write_file",
+                    {"path": fname, "content": "# 1567 test", "overwrite": True},
+                )
+                assert written.get("success") is True, written
+                read = await mcp.call_tool_success("ha_read_file", {"path": fname})
+                assert "# 1567 test" in read.get("content", ""), read
+        finally:
+            await safe_call_tool(
+                mcp_client_fs, "ha_delete_file", {"path": fname, "confirm": True}
+            )
+            await _set_allowed_paths(base_url, token, [])
+
+    async def test_deny_floor_blocks_storage_even_with_custom_dir(
+        self, mcp_client_fs, ha_container_with_fresh_config
+    ):
+        base_url = ha_container_with_fresh_config["base_url"]
+        token = await _bootstrap_token(base_url)
+        try:
+            sr = await _set_allowed_paths(base_url, token, [".storage", "pyscript"])
+            # The deny floor drops .storage; the valid entry is kept.
+            assert ".storage" in sr.get("rejected", []), sr
+            assert ".storage" not in sr.get("paths", []), sr
+            assert "pyscript" in sr.get("paths", []), sr
+
+            # Even with a valid custom dir configured, .storage stays blocked.
+            data = await safe_call_tool(
+                mcp_client_fs, "ha_read_file", {"path": ".storage/auth"}
+            )
+            assert data.get("success") is not True, (
+                f".storage must remain unreadable regardless of the custom "
+                f"allowlist; got: {data!r}"
+            )
+        finally:
+            await _set_allowed_paths(base_url, token, [])

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -838,6 +838,36 @@ class TestLoadAllowedPaths:
         assert result == []
 
 
+class TestLoadCallerToken:
+    """_load_or_create_caller_token must fail safe on a corrupt store rather
+    than propagating out of async_setup_entry and bricking the integration."""
+
+    async def test_corrupt_load_regenerates_token(self, monkeypatch):
+        import custom_components.ha_mcp_tools as comp
+
+        hass = MagicMock()
+        store = MagicMock()
+        store.async_load = AsyncMock(side_effect=ValueError("corrupt blob"))
+        store.async_save = AsyncMock()
+        monkeypatch.setattr(comp, "Store", lambda *a, **k: store)
+        token = await comp._load_or_create_caller_token(hass)
+        # A fresh token is generated and persisted (overwriting the bad blob).
+        assert isinstance(token, str) and token
+        store.async_save.assert_awaited_once()
+
+    async def test_existing_token_returned(self, monkeypatch):
+        import custom_components.ha_mcp_tools as comp
+
+        hass = MagicMock()
+        store = MagicMock()
+        store.async_load = AsyncMock(return_value={"token": "existing-tok"})
+        store.async_save = AsyncMock()
+        monkeypatch.setattr(comp, "Store", lambda *a, **k: store)
+        token = await comp._load_or_create_caller_token(hass)
+        assert token == "existing-tok"
+        store.async_save.assert_not_awaited()
+
+
 class TestExtraDirsReadWrite:
     """A user-configured extra directory grants BOTH read and write."""
 

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -4,6 +4,7 @@ These tests focus on the pure Python utility functions that don't require
 Home Assistant dependencies.
 """
 
+import os
 import shutil
 import sys
 import tempfile
@@ -30,10 +31,13 @@ from custom_components.ha_mcp_tools import (  # noqa: E402
     _delete_file_sync,
     _is_path_allowed_for_dir,
     _is_path_allowed_for_read,
+    _is_within_config_dir,
     _list_files_sync,
     _mask_secrets_content,
     _migrate_legacy_backup_dir,
+    _normalize_extra_dir,
     _read_file_sync,
+    _violates_deny_floor,
     _write_file_sync,
 )
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
@@ -688,3 +692,203 @@ class TestMigrateLegacyBackupDir:
         assert "GHSA-g39v-cvjh-8fpf" in src, (
             "persistent notification must reference the security advisory"
         )
+
+
+class TestDenyFloor:
+    """The non-overridable deny floor (issue #1567): a user-configured extra
+    directory can NEVER reach .storage or an unmasked secrets file, even when
+    the directory is explicitly present in the extra-dirs list."""
+
+    def test_storage_blocked_for_read_even_as_extra_dir(self, tmp_path):
+        assert (
+            _is_path_allowed_for_read(tmp_path, ".storage/auth", [".storage"]) is False
+        )
+        assert _is_path_allowed_for_read(tmp_path, ".storage", [".storage"]) is False
+
+    def test_storage_blocked_for_dir_even_as_extra_dir(self, tmp_path):
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, ".storage/auth", ALLOWED_WRITE_DIRS, [".storage"]
+            )
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, ".storage", ALLOWED_READ_DIRS, [".storage"]
+            )
+            is False
+        )
+
+    def test_violates_deny_floor_storage(self, tmp_path):
+        assert _violates_deny_floor(tmp_path, ".storage") is True
+        assert _violates_deny_floor(tmp_path, ".storage/auth") is True
+
+    def test_root_secrets_yaml_not_a_violation(self, tmp_path):
+        # The canonical config-root secrets.yaml passes the floor; the read
+        # handler masks it. Only OTHER secrets.yaml files are blocked.
+        assert _violates_deny_floor(tmp_path, "secrets.yaml") is False
+        assert _is_path_allowed_for_read(tmp_path, "secrets.yaml") is True
+
+    def test_nested_secrets_yaml_blocked(self, tmp_path):
+        # A secrets.yaml surfaced via a custom dir would be returned UNMASKED.
+        assert _violates_deny_floor(tmp_path, "pyscript/secrets.yaml") is True
+        assert (
+            _is_path_allowed_for_read(tmp_path, "pyscript/secrets.yaml", ["pyscript"])
+            is False
+        )
+
+    def test_symlink_into_storage_blocked(self, tmp_path):
+        (tmp_path / ".storage").mkdir()
+        (tmp_path / "evil").symlink_to(tmp_path / ".storage")
+        assert _violates_deny_floor(tmp_path, "evil/auth") is True
+        assert _is_path_allowed_for_read(tmp_path, "evil/auth", ["evil"]) is False
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "evil/auth", ALLOWED_WRITE_DIRS, ["evil"]
+            )
+            is False
+        )
+
+    def test_renamed_symlink_to_secrets_blocked(self, tmp_path):
+        # A symlink with an innocuous name pointing at secrets.yaml must not
+        # leak it UNMASKED — masking keys off the literal 'secrets.yaml' path,
+        # so the floor must catch the resolved target's basename.
+        (tmp_path / "secrets.yaml").write_text("api_key: SECRET\n")
+        (tmp_path / "www").mkdir()
+        (tmp_path / "www" / "notes.txt").symlink_to(tmp_path / "secrets.yaml")
+        assert _violates_deny_floor(tmp_path, "www/notes.txt") is True
+        assert _is_path_allowed_for_read(tmp_path, "www/notes.txt") is False
+
+    def test_case_insensitive_storage_blocked(self, tmp_path):
+        # On a case-insensitive FS '.STORAGE' opens the real '.storage'; the
+        # floor must match case-insensitively so it can't be bypassed.
+        assert _violates_deny_floor(tmp_path, ".STORAGE") is True
+        assert _violates_deny_floor(tmp_path, ".Storage/auth") is True
+
+    def test_case_insensitive_secrets_blocked(self, tmp_path):
+        assert _violates_deny_floor(tmp_path, "pyscript/SECRETS.YAML") is True
+        # The canonical lowercase root file still passes (it is masked).
+        assert _violates_deny_floor(tmp_path, "secrets.yaml") is False
+
+
+class TestExtraDirsReadWrite:
+    """A user-configured extra directory grants BOTH read and write."""
+
+    def test_extra_dir_allows_read(self, tmp_path):
+        assert (
+            _is_path_allowed_for_read(tmp_path, "pyscript/foo.py", ["pyscript"]) is True
+        )
+        assert (
+            _is_path_allowed_for_read(tmp_path, "pyscript/sub/bar.py", ["pyscript"])
+            is True
+        )
+
+    def test_extra_dir_allows_write_and_list(self, tmp_path):
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "pyscript/foo.py", ALLOWED_WRITE_DIRS, ["pyscript"]
+            )
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "pyscript", ALLOWED_READ_DIRS, ["pyscript"]
+            )
+            is True
+        )
+
+    def test_dir_not_in_extra_still_blocked(self, tmp_path):
+        assert (
+            _is_path_allowed_for_read(tmp_path, "esphome/x.yaml", ["pyscript"]) is False
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "esphome/x.yaml", ALLOWED_WRITE_DIRS, ["pyscript"]
+            )
+            is False
+        )
+
+    def test_no_extra_dirs_preserves_builtin_behavior(self, tmp_path):
+        # Default (no extra dirs) — built-in allowlist behavior unchanged.
+        assert _is_path_allowed_for_read(tmp_path, "www/x.css") is True
+        assert _is_path_allowed_for_read(tmp_path, "pyscript/foo.py") is False
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "www/x.css", ALLOWED_WRITE_DIRS) is True
+        )
+
+    def test_nested_extra_dir_grants_read_write(self, tmp_path):
+        # A multi-segment entry grants the dir itself and paths under it
+        # (the normalizer accepts nested entries, so enforcement must honor
+        # them — not silently store a dead entry).
+        extra = ["foo/bar"]
+        assert _is_path_allowed_for_read(tmp_path, "foo/bar", extra) is True
+        assert _is_path_allowed_for_read(tmp_path, "foo/bar/x.py", extra) is True
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "foo/bar/x.py", ALLOWED_WRITE_DIRS, extra
+            )
+            is True
+        )
+
+    def test_nested_extra_dir_respects_path_boundary(self, tmp_path):
+        extra = ["foo/bar"]
+        # A sibling and the parent itself are NOT granted by 'foo/bar'.
+        assert _is_path_allowed_for_read(tmp_path, "foo/other/x.py", extra) is False
+        assert _is_path_allowed_for_read(tmp_path, "foo/x.py", extra) is False
+        # Prefix must respect the separator boundary: 'foo/barbaz' is not under
+        # 'foo/bar'.
+        assert _is_path_allowed_for_read(tmp_path, "foo/barbaz/x.py", extra) is False
+
+
+class TestNormalizeExtraDir:
+    """Validation/normalization applied by set_allowed_paths before persisting."""
+
+    def test_accepts_simple_dir(self, tmp_path):
+        assert _normalize_extra_dir("pyscript", tmp_path) == "pyscript"
+        assert _normalize_extra_dir("python_scripts", tmp_path) == "python_scripts"
+
+    def test_strips_whitespace_and_trailing_slash(self, tmp_path):
+        assert _normalize_extra_dir("  pyscript/  ", tmp_path) == "pyscript"
+
+    def test_accepts_nested_dir(self, tmp_path):
+        assert _normalize_extra_dir("foo/bar", tmp_path) == "foo/bar"
+
+    def test_rejects_empty_and_root(self, tmp_path):
+        assert _normalize_extra_dir("", tmp_path) is None
+        assert _normalize_extra_dir("   ", tmp_path) is None
+        assert _normalize_extra_dir(".", tmp_path) is None
+
+    def test_rejects_traversal(self, tmp_path):
+        assert _normalize_extra_dir("..", tmp_path) is None
+        assert _normalize_extra_dir("../etc", tmp_path) is None
+        assert _normalize_extra_dir("www/../../etc", tmp_path) is None
+
+    def test_rejects_absolute(self, tmp_path):
+        assert _normalize_extra_dir("/etc/passwd", tmp_path) is None
+        assert _normalize_extra_dir("/pyscript", tmp_path) is None
+
+    def test_rejects_deny_floor(self, tmp_path):
+        assert _normalize_extra_dir(".storage", tmp_path) is None
+        assert _normalize_extra_dir(".storage/auth", tmp_path) is None
+        # Collapses to .storage after normpath — still rejected.
+        assert _normalize_extra_dir("www/../.storage", tmp_path) is None
+
+    def test_rejects_non_string(self, tmp_path):
+        assert _normalize_extra_dir(123, tmp_path) is None  # type: ignore[arg-type]
+
+
+class TestIsWithinConfigDir:
+    """The symlink-aware containment check (fixes the prior str-prefix bug)."""
+
+    def test_sibling_prefix_not_treated_as_inside(self, tmp_path):
+        # A sibling dir sharing a name prefix must NOT count as inside config.
+        config = tmp_path / "config"
+        config.mkdir()
+        (tmp_path / "config-evil").mkdir()
+        # '../config-evil' normalizes outside config and must be rejected.
+        assert (
+            _is_within_config_dir(config, os.path.normpath("../config-evil")) is False
+        )
+
+    def test_plain_subpath_is_inside(self, tmp_path):
+        assert _is_within_config_dir(tmp_path, "www/x.css") is True

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -769,6 +769,73 @@ class TestDenyFloor:
         assert _violates_deny_floor(tmp_path, "pyscript/SECRETS.YAML") is True
         # The canonical lowercase root file still passes (it is masked).
         assert _violates_deny_floor(tmp_path, "secrets.yaml") is False
+
+    def test_config_dir_under_storage_is_not_blanket_banned(self, tmp_path):
+        # Regression (patch76 nit): if the HA config dir itself lives below a
+        # ".storage" component (e.g. /var/.storage/config), normal access must
+        # NOT be denied — the floor only scans the config-RELATIVE portion of
+        # the resolved path, mirroring the pre-PR allowlist model.
+        config_dir = tmp_path / ".storage" / "config"
+        config_dir.mkdir(parents=True)
+        assert _violates_deny_floor(config_dir, "www/x.css") is False
+        assert _is_path_allowed_for_read(config_dir, "www/x.css") is True
+        assert (
+            _is_path_allowed_for_dir(config_dir, "www/x.css", ALLOWED_WRITE_DIRS)
+            is True
+        )
+        # A real .storage UNDER this config is still denied (relative-input scan).
+        assert _violates_deny_floor(config_dir, ".storage/auth") is True
+        assert _is_path_allowed_for_read(config_dir, ".storage/auth") is False
+
+
+class TestLoadAllowedPaths:
+    """_load_allowed_paths re-validates the persisted store and fails safe.
+
+    Store is mocked (HA is stubbed at import), so async_load is an AsyncMock.
+    Runs under asyncio_mode=auto (no explicit marker needed).
+    """
+
+    async def _load(self, monkeypatch, tmp_path, *, load_return=None, load_exc=None):
+        import custom_components.ha_mcp_tools as comp
+
+        hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
+        store = MagicMock()
+        if load_exc is not None:
+            store.async_load = AsyncMock(side_effect=load_exc)
+        else:
+            store.async_load = AsyncMock(return_value=load_return)
+        monkeypatch.setattr(comp, "Store", lambda *a, **k: store)
+        return await comp._load_allowed_paths(hass)
+
+    async def test_revalidates_and_drops_invalid_stored_entries(
+        self, monkeypatch, tmp_path
+    ):
+        # Traversal, deny-floor, non-string, and a duplicate are all dropped;
+        # the one valid entry survives (deduped).
+        result = await self._load(
+            monkeypatch,
+            tmp_path,
+            load_return={"paths": ["pyscript", "../etc", ".storage", "pyscript", 123]},
+        )
+        assert result == ["pyscript"]
+
+    async def test_corrupt_store_load_fails_safe(self, monkeypatch, tmp_path):
+        # A raising async_load (corrupt blob) must not propagate — fall back to [].
+        result = await self._load(
+            monkeypatch, tmp_path, load_exc=ValueError("corrupt json")
+        )
+        assert result == []
+
+    async def test_non_list_paths_ignored(self, monkeypatch, tmp_path):
+        result = await self._load(
+            monkeypatch, tmp_path, load_return={"paths": "not-a-list"}
+        )
+        assert result == []
+
+    async def test_first_run_returns_empty(self, monkeypatch, tmp_path):
+        result = await self._load(monkeypatch, tmp_path, load_return=None)
+        assert result == []
 
 
 class TestExtraDirsReadWrite:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3412,3 +3412,127 @@ class TestIngressGateApplied:
         # Secret-path handlers are raw (no ingress IP gate).
         secret = captured[("/private_x/api/policy/config", ("PUT",))]
         assert not hasattr(secret, "__wrapped__")
+
+
+class TestFsCustomPathsEndpoints:
+    """/api/settings/fs-custom-paths GET+POST handlers (issue #1567).
+
+    These proxy to the ha_mcp_tools component's get/set_allowed_paths
+    services; the component (not these handlers) owns enforcement. The
+    handlers are tested with ``call_mcp_tools_service`` /
+    ``is_filesystem_tools_enabled`` patched on the tools_filesystem module
+    (they are imported lazily inside the handler).
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_unavailable_when_filesystem_tools_disabled(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: False)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["available"] is False
+        assert "disabled" in body["reason"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_happy_path(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def fake_call(client, service, data):
+            assert service == "get_allowed_paths"
+            return {
+                "service_response": {
+                    "success": True,
+                    "paths": ["pyscript"],
+                    "deny_floor": [".storage", "secrets.yaml"],
+                    "builtin_read_dirs": ["www"],
+                    "builtin_write_dirs": ["www"],
+                }
+            }
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", fake_call)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        body = json.loads(resp.body)
+        assert body["available"] is True
+        assert body["paths"] == ["pyscript"]
+        assert ".storage" in body["deny_floor"]
+
+    @pytest.mark.asyncio
+    async def test_get_degrades_on_component_error(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def boom(client, service, data):
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", boom)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        # Degrades to an "unavailable" envelope, never a 500.
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["available"] is False
+        assert "connection refused" in body["reason"]
+
+    @pytest.mark.asyncio
+    async def test_save_disabled_returns_409(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: False)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": ["pyscript"]})
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_save_rejects_non_list_paths(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": "not-a-list"})
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_save_happy_path_surfaces_rejected(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def fake_call(client, service, data):
+            assert service == "set_allowed_paths"
+            assert data == {"paths": ["pyscript", ".storage"]}
+            # The component validates and drops the deny-floor entry.
+            return {
+                "service_response": {
+                    "success": True,
+                    "paths": ["pyscript"],
+                    "rejected": [".storage"],
+                }
+            }
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", fake_call)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": ["pyscript", ".storage"]})
+        resp = await handlers["save_fs_custom_paths"](req)
+        body = json.loads(resp.body)
+        assert body["success"] is True
+        assert body["paths"] == ["pyscript"]
+        assert body["rejected"] == [".storage"]
+        assert body["restart_required"] is False

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3536,3 +3536,113 @@ class TestFsCustomPathsEndpoints:
         assert body["paths"] == ["pyscript"]
         assert body["rejected"] == [".storage"]
         assert body["restart_required"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_unavailable_on_component_non_success(self, monkeypatch):
+        # The component answered but with success=false (e.g. admin gate
+        # rejected) — degrade to available:false with the component's reason,
+        # not a false available:true.
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def fake_call(client, service, data):
+            return {
+                "service_response": {
+                    "success": False,
+                    "error_code": "unauthorized",
+                    "error": "ha_mcp_tools.get_allowed_paths requires admin auth.",
+                }
+            }
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", fake_call)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["available"] is False
+        assert "admin" in body["reason"].lower()
+
+    @pytest.mark.asyncio
+    async def test_save_502_on_component_non_success(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def fake_call(client, service, data):
+            return {
+                "service_response": {
+                    "success": False,
+                    "error": "ha_mcp_tools.set_allowed_paths requires admin auth.",
+                }
+            }
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", fake_call)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": ["pyscript"]})
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_save_502_on_component_unreachable(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def boom(client, service, data):
+            raise RuntimeError("connection refused")
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", boom)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": ["pyscript"]})
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_save_400_on_invalid_json_body(self, monkeypatch):
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(side_effect=ValueError("not json"))
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_sidecar_builds_and_closes_transient_client(self, monkeypatch):
+        # In the stdio sidecar (server=None) the handler must build a transient
+        # HomeAssistantClient, use it, and close it.
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        fake_client = MagicMock()
+        fake_client.close = AsyncMock()
+        seen = {}
+
+        def _make_client():
+            return fake_client
+
+        async def fake_call(client, service, data):
+            seen["client"] = client
+            return {
+                "service_response": {"success": True, "paths": [], "deny_floor": []}
+            }
+
+        monkeypatch.setattr(
+            "ha_mcp.client.rest_client.HomeAssistantClient", _make_client
+        )
+        monkeypatch.setattr(tf, "call_mcp_tools_service", fake_call)
+        handlers = build_settings_handlers(server=None, is_sidecar=True)
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        assert json.loads(resp.body)["available"] is True
+        assert seen["client"] is fake_client
+        fake_client.close.assert_awaited_once()

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -101,6 +101,9 @@ class TestBuildSettingsHandlers:
             # Advanced settings handlers.
             "get_advanced_settings",
             "save_advanced_settings",
+            # Custom filesystem directories (issue #1567).
+            "get_fs_custom_paths",
+            "save_fs_custom_paths",
         }
 
     def test_get_tools_reads_cache_when_server_is_none(

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -32,18 +32,6 @@ def _reset_settings_singleton():
     _reset_global_settings()
 
 
-def test_filesystem_constants_include_dashboards():
-    """READABLE_PATTERNS and WRITABLE_DIRS must mirror the custom component allowlist."""
-    from ha_mcp.tools.tools_filesystem import READABLE_PATTERNS, WRITABLE_DIRS
-
-    assert "dashboards/**" in READABLE_PATTERNS, (
-        "dashboards/** must be readable to support YAML-mode dashboards"
-    )
-    assert "dashboards" in WRITABLE_DIRS, (
-        "dashboards must be writable to support YAML-mode dashboards"
-    )
-
-
 class TestFeatureFlag:
     """Test feature flag functionality.
 


### PR DESCRIPTION
## What does this PR do?

Lets power users grant the filesystem tools (`ha_read_file` / `ha_write_file` /
`ha_delete_file` / `ha_list_files`) read AND write access to extra directories
under the HA config dir (e.g. `pyscript/`, `python_scripts/`), editable from the
ha-mcp settings web UI — in all three deployment modes (add-on, container,
stdio sidecar). Closes #1567.

Design:

- **The component stays the security boundary.** The custom allowlist lives in
  and is enforced by the `ha_mcp_tools` custom component, not the ha-mcp wrapper.
  It's persisted in its own `.storage` blob and applied **live** (no HA restart).
- **Non-overridable deny floor.** A custom directory can never punch through to
  `.storage` (segment scan + symlink-resolution defence) or to `secrets.yaml`
  (blocked by both the requested and the *resolved* basename, so a renamed
  symlink can't dodge masking). All deny matching is case-insensitive so a
  mixed-case `.STORAGE` can't slip through on a case-insensitive filesystem.
  The canonical config-root `secrets.yaml` stays readable-but-masked.
- **Two new admin + caller-token gated component services** — `get_allowed_paths`
  / `set_allowed_paths` — back the editor. The settings UI proxies to them over
  the existing caller-token chain (`server.client` in HTTP/add-on modes, a
  transient `HomeAssistantClient` in the stdio sidecar), degrading to a clear
  "unavailable" state when filesystem tools are off or HA is unreachable.
- Rides the existing `enable_filesystem_tools` beta gate — **no new flag**. The
  editor is an advanced sub-form under that beta row, with a short blurb listing
  what is hard-locked-out.
- Component manifest `0.6.0 → 0.7.0` and `MIN_COMPONENT_VERSION 0.5.2 → 0.7.0`
  bumped in lockstep. Removes the now-misleading dead `READABLE_PATTERNS` /
  `WRITABLE_DIRS` mirror in `tools_filesystem.py`.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
