### PR TITLE
fix: coerce JSON-encoded strings on dict/list tool params

### DIFF
--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -46,6 +46,7 @@ from .helpers import (
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
+    JSON_STRING_COERCION,
     apply_entity_category,
     attach_skill_content,
     augment_error_dict_with_skill_content,
@@ -435,6 +436,7 @@ class AutomationConfigTools:
         self,
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Complete automation configuration with required fields: 'alias', 'triggers', 'actions'. "
                 "Optional: 'description', 'conditions', 'mode', 'max', 'initial_state', 'variables'. "

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -32,6 +32,7 @@ from .helpers import (
     validate_identifier_not_empty,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     attach_skill_content,
     augment_error_dict_with_skill_content,
     augment_tool_error_with_skill_content,
@@ -1021,6 +1022,7 @@ def register_config_dashboard_tools(mcp: Any, client: Any, **kwargs: Any) -> Non
         ],
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Dashboard configuration with views and cards. "
                 "Omit or set to None to create dashboard without initial config. "

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -35,6 +35,7 @@ from .tools_config_entry_flow import (
     update_flow_helper,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     apply_entity_category,
     attach_skill_content,
     augment_error_dict_with_skill_content,
@@ -3686,6 +3687,7 @@ class HelperConfigTools:
         ] = None,
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Config dict for flow-based helper types and "

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -38,6 +38,7 @@ from .helpers import (
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
+    JSON_STRING_COERCION,
     apply_entity_category,
     attach_skill_content,
     augment_error_dict_with_skill_content,
@@ -438,6 +439,7 @@ class ConfigSceneTools:
         ],
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Scene configuration dictionary. Must include 'entities' "

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -41,6 +41,7 @@ from .helpers import (
 )
 from .reference_validator import validate_config_references
 from .util_helpers import (
+    JSON_STRING_COERCION,
     apply_entity_category,
     attach_skill_content,
     augment_error_dict_with_skill_content,
@@ -399,6 +400,7 @@ class ConfigScriptTools:
         ],
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Script configuration dictionary. Must include EITHER 'sequence' (for regular scripts) OR 'use_blueprint' (for blueprint-based scripts). "
                 "Optional fields: 'alias', 'description', 'icon', 'mode', 'max', 'fields'. "

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -22,7 +22,11 @@ from .helpers import (
     validate_identifier_not_empty,
 )
 from .tools_voice_assistant import KNOWN_ASSISTANTS
-from .util_helpers import parse_json_param, parse_string_list_param
+from .util_helpers import (
+    JSON_STRING_COERCION,
+    parse_json_param,
+    parse_string_list_param,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -596,6 +600,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         options: Annotated[
             dict[str, dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Per-domain entity registry options (e.g. sensor 'display_precision', "
@@ -641,6 +646,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         categories: Annotated[
             dict[str, str | None] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Category assignment as a dict mapping scope to category_id. "
@@ -667,6 +673,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = "set",
         expose_to: Annotated[
             dict[str, bool] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Control voice assistant exposure. Pass a dict mapping assistant IDs to booleans. "

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -24,6 +24,7 @@ from .helpers import (
     register_tool_methods,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     compact_service_result,
     parse_json_param,
     parse_string_list_param,
@@ -297,7 +298,7 @@ class ServiceTools:
         domain: str,
         service: str,
         entity_id: str | None = None,
-        data: dict[str, Any] | None = None,
+        data: Annotated[dict[str, Any] | None, JSON_STRING_COERCION] = None,
         return_response: bool = False,
         wait: bool = True,
         verbose: Annotated[
@@ -584,7 +585,7 @@ class ServiceTools:
     @log_tool_usage
     async def ha_bulk_control(
         self,
-        operations: list[dict[str, Any]],
+        operations: Annotated[list[dict[str, Any]], JSON_STRING_COERCION],
         parallel: bool = True,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
@@ -632,7 +633,7 @@ class ServiceTools:
     async def ha_call_event(
         self,
         event_type: str,
-        data: dict[str, Any] | None = None,
+        data: Annotated[dict[str, Any] | None, JSON_STRING_COERCION] = None,
     ) -> dict[str, Any]:
         """Execute a custom event on the Home Assistant event bus.
 

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastmcp.exceptions import ToolError
-from pydantic import ValidationError
+from pydantic import BeforeValidator, ValidationError
 
 from ..client.rest_client import (
     HomeAssistantAPIError,
@@ -117,6 +117,33 @@ def parse_json_param(
     raise ValueError(
         f"{param_name} must be string, dict, list, or None, got {type(param).__name__}"
     )
+
+
+def _loads_if_json_container_str(value: Any) -> Any:
+    """Parse a JSON-encoded object/array string into its container value.
+
+    Anything that isn't a string encoding a JSON object or array passes
+    through unchanged, so Pydantic still raises dict_type/list_type for
+    genuinely-malformed input (which ValidationErrorMiddleware rewrites
+    into an actionable message).
+    """
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            return value
+        if isinstance(parsed, (dict, list)):
+            return parsed
+    return value
+
+
+# Annotated metadata for MCP-exposed dict/list params (issue #1581): coerces a
+# JSON-encoded string to its parsed container before validation, without
+# re-advertising string in the tool schema (the #1485/#1487/#1492 fix). Some
+# MCP client stacks (Claude Desktop stdio among them) pass model-emitted
+# stringified objects through unrepaired, so the strict schema boundary alone
+# rejects previously-valid traffic.
+JSON_STRING_COERCION = BeforeValidator(_loads_if_json_container_str)
 
 
 def _parse_json_to_str_list(s: str, param_name: str) -> list[str]:

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -130,7 +130,9 @@ def _loads_if_json_container_str(value: Any) -> Any:
     if isinstance(value, str):
         try:
             parsed = json.loads(value)
-        except ValueError:
+        except (ValueError, RecursionError):
+            # RecursionError (deeply-nested input) must not escape: Pydantic
+            # only converts ValueError/AssertionError into ValidationError.
             return value
         if isinstance(parsed, (dict, list)):
             return parsed

--- a/tests/src/e2e/tools/test_ha_call_event.py
+++ b/tests/src/e2e/tools/test_ha_call_event.py
@@ -45,6 +45,19 @@ async def test_call_event_with_dict_data(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_call_event_with_json_string_data(mcp_client):
+    """Regression #1581: a JSON-encoded object string for data is coerced."""
+    result = await mcp_client.call_tool(
+        "ha_call_event",
+        {"event_type": "test_mcp_event_json_str", "data": '{"source": "e2e_test"}'},
+    )
+    data = assert_mcp_success(result, "call event with JSON string data")
+    assert data["success"] is True
+    assert data["event_type"] == "test_mcp_event_json_str"
+    logger.info("Called event with JSON string data: %s", data)
+
+
+@pytest.mark.asyncio
 async def test_call_event_list_data_rejected(mcp_client):
     """Event data must be a dict — a native list is rejected with ToolError."""
     with pytest.raises(ToolError):

--- a/tests/src/e2e/workflows/core/test_service.py
+++ b/tests/src/e2e/workflows/core/test_service.py
@@ -313,6 +313,28 @@ class TestCallService:
         data = assert_mcp_success(result, "Scene turn_on service call")
         logger.info(f"Scene activation executed: {data.get('message')}")
 
+    async def test_call_service_data_as_json_string(self, mcp_client):
+        """Regression #1581: data passed as a JSON-encoded string is coerced.
+
+        Some MCP client stacks (Claude Desktop stdio among them) pass
+        model-emitted stringified objects through unrepaired; 7.7.0 rejected
+        them at the schema boundary with VALIDATION_FAILED/dict_type.
+        """
+        logger.info("Testing ha_call_service with JSON string data")
+
+        result = await mcp_client.call_tool(
+            "ha_call_service",
+            {
+                "domain": "persistent_notification",
+                "service": "create",
+                "data": '{"notification_id": "issue_1581", "title": "t", "message": "m"}',
+            },
+        )
+
+        data = assert_mcp_success(result, "Service call with JSON string data")
+        assert data["success"] is True
+        logger.info("Service call with JSON string data succeeded")
+
     async def test_call_service_without_entity_id(self, mcp_client):
         """Test calling domain-wide service without entity_id."""
         logger.info("Testing ha_call_service without entity_id")

--- a/tests/src/unit/test_json_string_param_coercion.py
+++ b/tests/src/unit/test_json_string_param_coercion.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #1581: JSON-encoded strings on dict/list params.
+
+The #1485/#1487/#1492 schema cleanup narrowed MCP-exposed dict/list params from
+`str | dict` to `dict` so the advertised schema stops teaching models to send
+JSON-encoded strings. But some MCP client stacks (Claude Desktop stdio among
+them) pass model-emitted stringified objects through unrepaired, so the strict
+boundary rejected previously-valid traffic with VALIDATION_FAILED/dict_type.
+
+These tests pin the lenient-runtime half of the contract: a JSON-parseable
+string for a dict/list-typed param is coerced to its parsed value before
+validation, while genuinely-malformed input still fails dict_type (and gets
+the actionable message from #1491's ValidationErrorMiddleware). The strict
+schema half — no string arm advertised — is pinned by
+test_config_param_no_string_schema.py.
+
+Validation is checked at the annotation level: FastMCP builds its argument
+TypeAdapter from the tool function's signature, so the annotation on the
+registered tool fn is exactly what the transport enforces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from .test_config_param_no_string_schema import (
+    _BULK_TOOLS,
+    _CONFIG_TOOLS,
+    _SERVICE_AND_ENTITY_TOOLS,
+)
+
+
+def _get_param_annotation(
+    register_fn: Callable[..., Any], tool_name: str, param_name: str
+) -> Any:
+    from fastmcp import FastMCP
+
+    async def _inner() -> Any:
+        mcp = FastMCP("test")
+        register_fn(mcp, MagicMock(), device_tools=MagicMock())
+        tool = await mcp.get_tool(tool_name)
+        return inspect.signature(tool.fn).parameters[param_name].annotation
+
+    return asyncio.run(_inner())
+
+
+def _resolve(module: str, register_fn: str) -> Callable[..., Any]:
+    import importlib
+
+    return getattr(importlib.import_module(module), register_fn)
+
+
+# Param-appropriate sample values: each must satisfy the param's value type
+# (e.g. ha_set_entity.expose_to is dict[str, bool]).
+_DICT_SAMPLES: dict[tuple[str, str], dict[str, Any]] = {
+    ("ha_set_entity", "options"): {"sensor": {"display_precision": 2}},
+    ("ha_set_entity", "categories"): {"automation": "category_id"},
+    ("ha_set_entity", "expose_to"): {"conversation": True},
+    ("ha_call_service", "data"): {
+        "notification_id": "x",
+        "title": "t",
+        "message": "m",
+    },
+    ("ha_call_event", "data"): {"source": "unit_test"},
+}
+_DEFAULT_DICT_SAMPLE: dict[str, Any] = {"alias": "Test", "key": "value"}
+
+_LIST_SAMPLE: list[dict[str, Any]] = [
+    {"entity_id": "light.kitchen", "action": "turn_on"}
+]
+
+_DICT_PARAMS = _CONFIG_TOOLS + _SERVICE_AND_ENTITY_TOOLS
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _DICT_PARAMS,
+)
+def test_dict_param_coerces_json_string(module, register_fn, tool_name, param_name):
+    """A JSON-encoded object string is coerced to a dict before validation."""
+    sample = _DICT_SAMPLES.get((tool_name, param_name), _DEFAULT_DICT_SAMPLE)
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(json.dumps(sample)) == sample
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _DICT_PARAMS,
+)
+def test_dict_param_passes_native_dict_through(
+    module, register_fn, tool_name, param_name
+):
+    """A native dict continues to validate unchanged."""
+    sample = _DICT_SAMPLES.get((tool_name, param_name), _DEFAULT_DICT_SAMPLE)
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(sample) == sample
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _BULK_TOOLS,
+)
+def test_list_param_coerces_json_string(module, register_fn, tool_name, param_name):
+    """A JSON-encoded array string is coerced to a list before validation."""
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(json.dumps(_LIST_SAMPLE)) == _LIST_SAMPLE
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _DICT_PARAMS,
+)
+def test_dict_param_rejects_unparseable_string(
+    module, register_fn, tool_name, param_name
+):
+    """A non-JSON string still fails validation (keeps #1491's actionable error)."""
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    with pytest.raises(ValidationError):
+        TypeAdapter(ann).validate_python("definitely not json {")
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _DICT_PARAMS,
+)
+def test_dict_param_rejects_json_string_of_array(
+    module, register_fn, tool_name, param_name
+):
+    """A JSON-encoded array for a dict param still fails dict validation."""
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    with pytest.raises(ValidationError):
+        TypeAdapter(ann).validate_python("[1, 2, 3]")

--- a/tests/src/unit/test_json_string_param_coercion.py
+++ b/tests/src/unit/test_json_string_param_coercion.py
@@ -137,3 +137,52 @@ def test_dict_param_rejects_json_string_of_array(
     ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
     with pytest.raises(ValidationError):
         TypeAdapter(ann).validate_python("[1, 2, 3]")
+
+
+@pytest.mark.parametrize("scalar_string", ['"hello"', "123", "null"])
+def test_dict_param_passes_json_scalar_string_through_unchanged(scalar_string):
+    """A well-formed JSON scalar string is not coerced: it fails dict_type
+    with the original string as the offending input."""
+    module, register_fn, tool_name, param_name = _DICT_PARAMS[0]
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    with pytest.raises(ValidationError) as exc_info:
+        TypeAdapter(ann).validate_python(scalar_string)
+    assert exc_info.value.errors()[0]["input"] == scalar_string
+
+
+def test_deeply_nested_string_fails_validation_not_recursion():
+    """Regression: json.loads raises RecursionError on deeply-nested input.
+
+    Pydantic only converts ValueError/AssertionError raised in a validator
+    into a ValidationError, so an uncaught RecursionError would surface as an
+    opaque internal error instead of the actionable dict_type message.
+    """
+    module, register_fn, tool_name, param_name = _DICT_PARAMS[0]
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    with pytest.raises(ValidationError):
+        TypeAdapter(ann).validate_python("[" * 100_000)
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _BULK_TOOLS,
+)
+def test_list_param_passes_native_list_through(
+    module, register_fn, tool_name, param_name
+):
+    """A native list continues to validate unchanged."""
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(_LIST_SAMPLE) == _LIST_SAMPLE
+
+
+@pytest.mark.parametrize(
+    ("module", "register_fn", "tool_name", "param_name"),
+    _BULK_TOOLS,
+)
+def test_list_param_rejects_json_string_of_object(
+    module, register_fn, tool_name, param_name
+):
+    """A JSON-encoded object for a list param still fails list validation."""
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+    with pytest.raises(ValidationError):
+        TypeAdapter(ann).validate_python('{"entity_id": "light.kitchen"}')


### PR DESCRIPTION
Closes #1581.

Implements option **(a) — strict schema, lenient runtime** from the maintainer analysis on the issue.

## Problem

The #1485/#1487/#1492 schema cleanup narrowed MCP-exposed dict/list params from `str | dict` to `dict` so the advertised schema stops teaching models to pass JSON-encoded strings. But some MCP client stacks (Claude Desktop stdio among them) pass model-emitted stringified objects through unrepaired, so previously-valid calls started failing with `VALIDATION_FAILED … dict_type` at the schema boundary, before the tool body ran — triggering the retry loops #1491 set out to prevent.

## Fix

`JSON_STRING_COERCION` — a shared pydantic `BeforeValidator` in `util_helpers.py` that parses a JSON-encoded object/array string into its container before validation and passes everything else through unchanged. Applied to every param narrowed by the series:

- `ha_call_service.data`, `ha_call_event.data` (#1487)
- `ha_set_entity.options` / `.categories` / `.expose_to` (#1487)
- `ha_bulk_control.operations` (#1492)
- `config` on `ha_config_set_automation` / `_script` / `_scene` / `_helper` / `_dashboard` (#1485)

Both goals of the original series are preserved:
- **Advertised schema unchanged** — no string arm; the existing schema regression tests from #1485/#1487/#1492 pass untouched.
- **Genuinely-malformed strings still fail** `dict_type` and get #1491's actionable message.

## Red→green evidence

New regression suite `tests/src/unit/test_json_string_param_coercion.py` pins the contract at the annotation level (FastMCP builds its argument TypeAdapter from the tool fn signature, so the annotation is exactly what the transport enforces). Before the fix, the 11 coercion tests fail with the reported error, one per affected param:

```
FAILED test_dict_param_coerces_json_string[...ha_config_set_automation-config]
  - pydantic_core...ValidationError: ... Input should be a valid dictionary
    [type=dict_type, input_value='{"alias": "Test", "key": "value"}', input_type=str]
(11 failed, 30 passed)
```

After the fix: 41/41 pass. Guard tests pin that native dicts pass through, non-JSON strings are still rejected, and a JSON-encoded *array* for a dict param is still rejected.

E2E: restores the two stringified-`data` tests removed in #1487 (`ha_call_service` with the exact payload from the issue report, `ha_call_event`), now exercising the coercion through the real MCP transport.

## Test results

- Unit: 4,626 passed
- Full E2E suite (`-n2 --dist loadscope`): 953 passed, 60 skipped (environment-gated HAOS/add-on)
- ruff check / ruff format / mypy / ast-grep: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)