### PR TITLE
ci: free disk space before the HAOS publish bake

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -118,6 +118,28 @@ jobs:
       - name: Install build-script Python deps
         run: pip install -r tests/haos_image_build/requirements.txt
 
+      - name: Free disk space for the bake
+        # The publish always local-builds the qcow2 (no cache / GHCR
+        # fallback), so it hits the same disk peak the e2e local-build path
+        # guards against: GitHub runners ship ~30 GB of unused tooling and
+        # only ~14 GB of usable SSD, while the qcow2 grows to ~12 GB apparent
+        # during boot + add-on install. The Puppet (Chromium) add-on is the
+        # largest Docker build and the last to run, so it is the first to
+        # trip "No space left on device", which Supervisor surfaces only as a
+        # generic "unknown error" (publish failures since ~2026-06-11).
+        # Mirrors the haos-e2e-tests.yml prune, minus its cache-miss gate
+        # since the publish has no cache path to skip. The df -h bookends
+        # make the disk headroom visible in the run log. Keep
+        # /opt/hostedtoolcache: Python from there is on PATH for
+        # build_image.py.
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
+            /usr/local/lib/android /usr/local/.ghcup
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h /
+
       - name: Build image
         run: python3 tests/haos_image_build/build_image.py --verbose --output haos-test-image.qcow2
 


### PR DESCRIPTION
## What does this PR do?

Adds a disk-cleanup step before the HAOS publish bake to address the `Build HAOS Test Image (Publish to GHCR)` workflow's failures at the Puppet (Chromium) add-on build.

The publish always local-builds the qcow2 (no cache / GHCR fallback to skip), so it hits the same disk peak `haos-e2e-tests.yml`'s local-build path already guards against, but without that prune. The qcow2 grows to ~12 GB apparent during boot + add-on install on a runner with ~14 GB of usable SSD; the Puppet (Chromium) add-on is the largest Docker build and the last to run, so it is the first to exhaust the disk. Supervisor surfaces this only as a generic `unknown_error ... while trying to build the image for app local_puppet`, with the real error in its own (uncaptured) logs. The fast-fail (~12 s, before any build work) and the flaky pattern (publishes failing since ~2026-06-11; the last fresh image is from 2026-06-09) both point to disk exhaustion rather than a Puppet-source regression.

Why it matters beyond the publish: with no fresh image, GHCR serves the stale 2026-06-09 build and every cache-miss HAOS run inherits it, which is what currently breaks HAOS CI repo-wide (e.g. the `MIN_COMPONENT_VERSION=0.8.0` mismatch from the stale 0.7.0 component).

This mirrors the e2e prune (minus its cache-miss gate, which the publish has no cache path to use) and bookends it with `df -h` so the next publish both gains headroom and confirms the diagnosis.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

YAML is valid and the change is a verbatim mirror of the proven `haos-e2e-tests.yml` prune. The publish workflow only runs on master push, so this PR's checks do not exercise it; the fix is validated by the next publish run, where the `df -h` bookends make the reclaimed headroom visible.

## Checklist
- [x] I have updated documentation if needed
