### PR TITLE
fix: gate installer uv check on uvx, not uv

### DIFF
--- a/.github/workflows/test-installer-scripts.yml
+++ b/.github/workflows/test-installer-scripts.yml
@@ -201,3 +201,32 @@ jobs:
             echo "guard wrongly fired for --claude-code under WSL"; exit 1
           fi
           echo "OK: --claude-code not blocked under WSL"
+
+  test-stale-uv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stale uv without uvx falls through to the upgrade path (issue #1593)
+        run: |
+          set -e
+          # Reproduce a pre-uvx uv: a `uv` binary on PATH with no `uvx` beside
+          # it. The old `uv || uvx` gate accepted this stale uv and then
+          # hard-exited at the uvx lookup; the gate now keys on uvx, so this
+          # must instead reach the install/upgrade path and end with a uvx.
+          STALE="$(mktemp -d)"
+          printf '#!/bin/sh\necho "uv 0.1.39"\n' > "$STALE/uv"
+          chmod +x "$STALE/uv"
+          # Curated PATH: the stale uv stub plus the system dirs the installer
+          # needs (sh, curl, python3), and crucially no real uvx. A real uvx
+          # leaking onto PATH would mask the bug, so fail loudly if present.
+          export PATH="$STALE:/usr/bin:/bin"
+          command -v uv >/dev/null || { echo "precondition: uv stub not on PATH"; exit 1; }
+          if command -v uvx >/dev/null; then
+            echo "precondition failed: uvx unexpectedly on PATH"; exit 1
+          fi
+          sh scripts/install.sh
+          # The upgrade path must have produced a working uvx.
+          export PATH="$HOME/.local/bin:$PATH"
+          command -v uvx >/dev/null || { echo "uvx missing after upgrade path"; exit 1; }
+          echo "OK: stale uv triggered the upgrade path, uvx now available"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,7 +88,11 @@ printf "\n"
 
 # Step 1: Check/install uv
 printf "${YELLOW}Step 1: Checking for uv...${NC}\n"
-if command -v uv > /dev/null 2>&1 || command -v uvx > /dev/null 2>&1; then
+# Gate on uvx, not uv. uvx (the `uv tool run` shortcut) ships only with newer
+# uv releases, so an old uv can be present without it. Since the rest of this
+# script invokes uvx, a uvx-less uv must fall through to the install/upgrade
+# path rather than being treated as already installed (issue #1593).
+if command -v uvx > /dev/null 2>&1; then
     printf "${GREEN}  uv is already installed${NC}\n"
 else
     printf "  Installing uv...\n"


### PR DESCRIPTION
## What does this PR do?

Closes #1593.

`scripts/install.sh` gated Step 1 on `command -v uv || command -v uvx`, so a stale `uv` (released before the `uvx` shortcut existed) satisfied the check and skipped the install/upgrade branch — then hard-exited a few lines later when the required `uvx` was absent.

This gates on `uvx` instead, matching the existing `install-windows.ps1` behavior. A uvx-less `uv` now falls through to the install/upgrade path (astral installer, with the OS-aware manual-install hint on failure), which produces a working `uvx`.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

This change touches only `scripts/install.sh` and a CI workflow — no Python, so `pytest` / `ruff` do not apply to the diff. The installer is exercised by the dedicated `Test Installer Scripts` workflow; this PR adds a `test-stale-uv` job there that stubs a uvx-less `uv` on a curated PATH and asserts the installer reaches the upgrade path and ends with a working `uvx`, rather than dead-ending.

## Checklist
- [x] I have updated documentation if needed