### PR TITLE
ci: fix HAOS bake with a mock screenshot engine; make e2e lanes safe to require

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -59,12 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Required for the bake's submodules: the skills bundle at
-          # src/ha_mcp/resources/skills-vendor (test_skills_resources.py) AND
-          # the vendored Puppet add-on at
-          # tests/haos_image_build/vendor/home-assistant-addons, which
-          # stage_puppet_addon_source bakes into the qcow2 (it hard-fails
-          # without the submodule checked out).
+          # Required for the skills bundle submodule at
+          # src/ha_mcp/resources/skills-vendor (test_skills_resources.py).
           submodules: true
 
       - name: Install build dependencies
@@ -102,13 +98,11 @@ jobs:
 
       - name: Free disk space for the bake
         # The cache-prime always local-builds the qcow2, so it hits the same
-        # disk peak the e2e local-build path guards against. The Puppet
-        # (Chromium) add-on is the largest and last build, so it is the first
-        # to trip the runner's ~14 GB SSD: the e2e lanes build Puppet fine
-        # with this exact prune, while the cache-prime (which lacked it)
-        # failed at the Puppet build. The df -h bookends make the reclaimed
-        # headroom visible. Keep /opt/hostedtoolcache: Python from there is
-        # on PATH for build_image.py.
+        # disk peak the e2e local-build path guards against: the ~7 GB qcow2
+        # plus the in-qcow2 add-on image builds (dev addon, webhook proxy,
+        # screenshot-engine mock) grow it toward the runner's ~14 GB SSD. The
+        # df -h bookends make the reclaimed headroom visible. Keep
+        # /opt/hostedtoolcache: Python from there is on PATH for build_image.py.
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -20,18 +20,15 @@ name: HAOS E2E Tests (inaddon)
 # external_only / inaddon_only markers).
 
 on:
+  # No workflow-level `paths:` filter on purpose. This check is a REQUIRED
+  # status check, and a path-filtered workflow that doesn't trigger leaves the
+  # required check Pending forever, wedging the merge of any PR that doesn't
+  # touch the listed paths. Instead we trigger on every PR and let the
+  # `changes` job below decide whether the heavy suite runs: a job skipped via
+  # `if:` reports Success to a required check (unlike a workflow-level
+  # path-skip, which reports nothing). See the `changes` job for the run/skip
+  # rule (skip only pure docs/website; addon + bake inputs always run).
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'homeassistant-addon/**'
-      - 'homeassistant-addon-dev/**'
-      - '.github/workflows/haos-e2e-inaddon-tests.yml'
-      # Trigger on external workflow changes too — both lanes share the
-      # qcow2 cache key, so a change to either workflow's cache logic
-      # needs the other lane to re-run for parity verification.
-      - '.github/workflows/haos-e2e-tests.yml'
   workflow_dispatch:
     inputs:
       pytest_args:
@@ -59,8 +56,65 @@ env:
   LIBGUESTFS_BACKEND: direct
 
 jobs:
+  # Gate the heavy suite: run on any code/test/config/addon change, skip ONLY
+  # when every changed file is pure docs/website. Skipping happens at the JOB
+  # level (via `if:` below) so a skipped run reports Success to the required
+  # check; a workflow-level `paths:` skip would instead report nothing and
+  # wedge the merge. Add-on + bake-input dirs are baked into the qcow2, so
+  # their docs DO affect the suite and always count as code.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Classify changed files
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Fail-closed gate: default to RUNNING the suite; skip ONLY when we can
+          # prove the PR changed nothing but docs/website. Any classifier failure
+          # (non-PR event, base fetch / rev-parse / diff error, empty diff) leaves
+          # run=true — branch protection treats a skipped REQUIRED job as passing,
+          # so a fail-open classifier could let code merge untested.
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && git fetch --depth=1 origin "$BASE_REF" \
+            && base_sha=$(git rev-parse "origin/$BASE_REF") \
+            && changed=$(git diff --name-only --diff-filter=ACMRD "$base_sha" HEAD) \
+            && [ -n "$changed" ]; then
+            echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
+            run=false
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                # Bake inputs / addon dirs are baked into the qcow2 / shipped —
+                # their docs change what the suite tests, so they count as code.
+                homeassistant-addon/*|homeassistant-addon-dev/*|homeassistant-addon-webhook-proxy/*|custom_components/ha_mcp_tools/*|tests/haos_image_build/*|tests/initial_test_state/*)
+                  run=true; break ;;
+                # Pure docs / website do not, on their own, warrant the suite.
+                *.md|*.mdx|docs/*|site/*)
+                  continue ;;
+                # Anything else (code, tests, config, workflows, lockfile, ...) runs.
+                *)
+                  run=true; break ;;
+              esac
+            done <<< "$changed"
+          else
+            echo "Non-PR event or unresolved diff — running suite (fail-closed)."
+          fi
+          echo "run=$run"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   haos-e2e-inaddon:
     name: HAOS E2E Tests (inaddon)
+    needs: changes
+    # A skipped job reports Success to the required status check (unlike a
+    # workflow-level path-skip, which never reports). See the `changes` job.
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
 

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -12,23 +12,15 @@ name: HAOS E2E Tests
 # (previously cost ~5 min per PR).
 
 on:
+  # No workflow-level `paths:` filter on purpose. This check is a REQUIRED
+  # status check, and a path-filtered workflow that doesn't trigger leaves the
+  # required check Pending forever, wedging the merge of any PR that doesn't
+  # touch the listed paths. Instead we trigger on every PR and let the
+  # `changes` job below decide whether the heavy suite runs: a job skipped via
+  # `if:` reports Success to a required check (unlike a workflow-level
+  # path-skip, which reports nothing). See the `changes` job for the run/skip
+  # rule (skip only pure docs/website; addon + bake inputs always run).
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'homeassistant-addon/**'
-      # Bake inputs — see INVARIANT in build-haos-test-image.yml and
-      # the "Compute image cache key" step below. A PR touching only
-      # these would otherwise skip HAOS E2E despite changing what gets
-      # baked into the qcow2 the suite tests against.
-      - 'custom_components/ha_mcp_tools/**'
-      - 'homeassistant-addon-webhook-proxy/**'
-      - '.github/workflows/haos-e2e-tests.yml'
-      # Trigger on inaddon workflow changes too — both lanes share the
-      # qcow2 cache key, so a change to either workflow's cache logic
-      # needs the other lane to re-run for parity verification.
-      - '.github/workflows/haos-e2e-inaddon-tests.yml'
   workflow_dispatch:
     inputs:
       pytest_args:
@@ -54,8 +46,65 @@ env:
   LIBGUESTFS_BACKEND: direct
 
 jobs:
+  # Gate the heavy suite: run on any code/test/config/addon change, skip ONLY
+  # when every changed file is pure docs/website. Skipping happens at the JOB
+  # level (via `if:` below) so a skipped run reports Success to the required
+  # check; a workflow-level `paths:` skip would instead report nothing and
+  # wedge the merge. Add-on + bake-input dirs are baked into the qcow2, so
+  # their docs DO affect the suite and always count as code.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Classify changed files
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Fail-closed gate: default to RUNNING the suite; skip ONLY when we can
+          # prove the PR changed nothing but docs/website. Any classifier failure
+          # (non-PR event, base fetch / rev-parse / diff error, empty diff) leaves
+          # run=true — branch protection treats a skipped REQUIRED job as passing,
+          # so a fail-open classifier could let code merge untested.
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && git fetch --depth=1 origin "$BASE_REF" \
+            && base_sha=$(git rev-parse "origin/$BASE_REF") \
+            && changed=$(git diff --name-only --diff-filter=ACMRD "$base_sha" HEAD) \
+            && [ -n "$changed" ]; then
+            echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
+            run=false
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                # Bake inputs / addon dirs are baked into the qcow2 / shipped —
+                # their docs change what the suite tests, so they count as code.
+                homeassistant-addon/*|homeassistant-addon-dev/*|homeassistant-addon-webhook-proxy/*|custom_components/ha_mcp_tools/*|tests/haos_image_build/*|tests/initial_test_state/*)
+                  run=true; break ;;
+                # Pure docs / website do not, on their own, warrant the suite.
+                *.md|*.mdx|docs/*|site/*)
+                  continue ;;
+                # Anything else (code, tests, config, workflows, lockfile, ...) runs.
+                *)
+                  run=true; break ;;
+              esac
+            done <<< "$changed"
+          else
+            echo "Non-PR event or unresolved diff — running suite (fail-closed)."
+          fi
+          echo "run=$run"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
   haos-e2e:
     name: HAOS E2E Tests
+    needs: changes
+    # A skipped job reports Success to the required status check (unlike a
+    # workflow-level path-skip, which never reports). See the `changes` job.
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,86 @@ env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
+  # Decide whether the heavy E2E Validation lanes need to run. Default is RUN;
+  # we skip ONLY when every changed file is pure docs/website (top-level *.md,
+  # docs/**, site/**). Add-on + bake-input dirs are baked/shipped, so their docs
+  # DO matter and always count as code. On non-PR events (manual dispatch)
+  # always run. Consumed by e2e-validation's `if:` below — a job-level skip
+  # reports Success to a required check (a workflow path-skip would not).
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Classify changed files
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Fail-closed gate: default to RUNNING the suite; skip ONLY when we can
+          # prove the PR changed nothing but docs/website. Any classifier failure
+          # (non-PR event, base fetch / rev-parse / diff error, empty diff) leaves
+          # run=true — branch protection treats a skipped REQUIRED job as passing,
+          # so a fail-open classifier could let code merge untested.
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ] \
+            && git fetch --depth=1 origin "$BASE_REF" \
+            && base_sha=$(git rev-parse "origin/$BASE_REF") \
+            && changed=$(git diff --name-only --diff-filter=ACMRD "$base_sha" HEAD) \
+            && [ -n "$changed" ]; then
+            echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
+            run=false
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                # Bake inputs / addon dirs are baked into the qcow2 / shipped —
+                # their docs change what the suite tests, so they count as code.
+                homeassistant-addon/*|homeassistant-addon-dev/*|homeassistant-addon-webhook-proxy/*|custom_components/ha_mcp_tools/*|tests/haos_image_build/*|tests/initial_test_state/*)
+                  run=true; break ;;
+                # Pure docs / website do not, on their own, warrant the suite.
+                *.md|*.mdx|docs/*|site/*)
+                  continue ;;
+                # Anything else (code, tests, config, workflows, lockfile, ...) runs.
+                *)
+                  run=true; break ;;
+              esac
+            done <<< "$changed"
+          else
+            echo "Non-PR event or unresolved diff — running suite (fail-closed)."
+          fi
+          echo "run=$run"
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+  e2e-validation-gate:
+    # Single, ALWAYS-reported required context for branch protection. The
+    # e2e-validation job above is a MATRIX job, and a job-level `if:`-skip on a
+    # matrix does NOT emit the per-variant contexts ("E2E Validation (os)") —
+    # they report nothing and would wedge a required check on a docs-only PR
+    # (actions/runner#952). So the REQUIRED check is THIS gate, not the matrix
+    # variants: it always runs, passes when the suite was skipped (docs/website)
+    # or every variant succeeded, and fails if any variant failed.
+    name: E2E Validation Gate
+    needs: [changes, e2e-validation]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require E2E success unless skipped
+        run: |
+          if [ "${{ needs.changes.outputs.run }}" != "true" ]; then
+            echo "Docs/website-only PR — E2E Validation skipped; gate passes."
+            exit 0
+          fi
+          result="${{ needs.e2e-validation.result }}"
+          echo "e2e-validation result: $result"
+          if [ "$result" != "success" ]; then
+            echo "::error::E2E Validation did not succeed (result=$result)."
+            exit 1
+          fi
+
   lockfile:
     name: Check uv.lock
     runs-on: ubuntu-latest
@@ -196,6 +276,10 @@ jobs:
   # Comprehensive E2E validation for all PRs
   e2e-validation:
     name: E2E Validation (${{ matrix.os }})
+    needs: changes
+    # A skipped job reports Success to the required status check, so a
+    # docs/website-only PR doesn't wedge the merge waiting on these lanes.
+    if: needs.changes.outputs.run == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = src/ha_mcp/resources/skills-vendor
 	url = https://github.com/homeassistant-ai/skills.git
 	branch = main
-[submodule "tests/haos_image_build/vendor/home-assistant-addons"]
-	path = tests/haos_image_build/vendor/home-assistant-addons
-	url = https://github.com/balloob/home-assistant-addons.git
-	branch = main

--- a/src/ha_mcp/dashboard_screenshot/provision.py
+++ b/src/ha_mcp/dashboard_screenshot/provision.py
@@ -33,10 +33,9 @@ from ..tools.helpers import raise_tool_error
 logger = logging.getLogger(__name__)
 
 ENGINE_PORT = 10000
-# The Supervisor slug is ``<repo-hash>_puppet`` for balloob's Puppet add-on;
-# ``_ha_mcp_screenshot`` is the legacy vendored engine, still accepted so a
-# mid-migration install keeps working. ``str.endswith`` takes this tuple.
-ENGINE_SLUG_SUFFIXES = ("_puppet", "_ha_mcp_screenshot")
+# The Supervisor slug is ``<repo-hash>_puppet`` for balloob's Puppet add-on.
+# ``str.endswith`` accepts a tuple, kept as one for easy future extension.
+ENGINE_SLUG_SUFFIXES = ("_puppet",)
 
 _REPO_URL = "https://github.com/balloob/home-assistant-addons"
 

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -202,18 +202,17 @@ HA_MCP_TEST_SECRET_PATH = "/mcp_e2e_test_path"
 # ``_ha_mcp`` / ``_ha_mcp_dev``, so the dev addon installed just before this
 # one (slug=``local_ha_mcp_dev``) is the discovery target.
 HA_MCP_WEBHOOK_PROXY_ADDON_SLUG = "local_ha_mcp_webhook_proxy"
-# Screenshot engine = balloob's Puppet add-on, VENDORED as a pinned git
-# submodule (tests/haos_image_build/vendor/home-assistant-addons) rather than
-# registering balloob's live add-on repo in Supervisor. Pinning decouples the
-# bake from balloob's repo HEAD / availability and makes a transient repo-side
-# issue a Renovate-PR failure instead of a random master-build failure;
-# Renovate's git-submodules manager bumps the pin via reviewed, CI-gated PRs.
-# Staged into the qcow2 as a LOCAL add-on (stage_puppet_addon_source), so
-# Supervisor assigns slug ``local_<config-slug>`` -> ``local_puppet``.
-PUPPET_VENDOR_DIR = (
-    Path(__file__).resolve().parent / "vendor" / "home-assistant-addons" / "puppet"
-)
-PUPPET_ADDON_SLUG = "local_puppet"
+# Screenshot engine for the bake: a tiny in-repo MOCK (screenshot_engine_mock/)
+# that serves balloob Puppet's HTTP contract WITHOUT Chromium. The real Puppet
+# add-on's heavy ``debian:bullseye-slim`` + Chromium + ``npm ci`` build is what
+# repeatedly broke the bake under floating Supervisor versions, and real
+# Chromium rendering exercises balloob's add-on, not ha-mcp -- so the bake
+# stages the mock and the screenshot tool's discovery + request + auth-token
+# plumbing is exercised against it. Real users still install balloob's add-on;
+# the mock never ships. Slug ``puppet`` -> ``local_puppet`` (matches the
+# ``_puppet`` discovery suffix), staged as a LOCAL add-on.
+SCREENSHOT_ENGINE_MOCK_DIR = Path(__file__).resolve().parent / "screenshot_engine_mock"
+SCREENSHOT_ENGINE_SLUG = "local_puppet"
 # Advanced SSH addon user/password set at install time so the runtime
 # helper (``haos_runtime.ssh_exec``) can authenticate non-interactively.
 # CI-test-only credential — overridable via env so the value never has
@@ -664,11 +663,10 @@ def _install_addon_with_retry(
 ) -> None:
     """POST an add-on install, retrying once on a transient build/connection failure.
 
-    Heavy add-on images build inside Supervisor and occasionally fail when a
-    base-image pull, an apt mirror, or the npm registry hiccups mid-build.
-    balloob's Puppet add-on (apt-installs Chromium + ``npm ci`` from
-    ``debian:bullseye-slim``) is the usual victim — it has failed ~13 s into the
-    build, while the very same version builds cleanly on a re-run. The failure
+    The bake's local add-ons (the ha-mcp dev addon, the webhook proxy, and the
+    mock screenshot engine) build their images inside Supervisor, which can fail
+    transiently when a base-image pull or apt mirror hiccups mid-build — the same
+    version then builds cleanly on a re-run. The failure
     surfaces two ways and we retry both: Supervisor returns a ``WSCommandError``,
     OR — because the build can outlast a flaky link (the motivating failure also
     logged a Bad-file-descriptor WS drop mid-bake) — the WS connection drops and
@@ -1161,34 +1159,33 @@ def stage_webhook_proxy_addon_source(qcow2: Path) -> None:
         shutil.rmtree(workdir, ignore_errors=True)
 
 
-def stage_puppet_addon_source(qcow2: Path) -> None:
-    """Bake the vendored Puppet screenshot add-on into the qcow2 as a local add-on.
+def stage_screenshot_engine_source(qcow2: Path) -> None:
+    """Bake the mock screenshot engine into the qcow2 as a local add-on.
 
     Runs BEFORE first start_qemu so HAOS boots with the local add-on visible to
-    Supervisor's local store (slug ``local_puppet``). The source is the pinned
-    ``home-assistant-addons`` submodule's ``puppet/`` directory, copied verbatim:
-    its config.yaml has no ``image:`` field (so Supervisor builds from the local
-    Dockerfile) and the Dockerfile's ``COPY ha-puppet/ ...`` paths are already
-    addon-dir-relative, so unlike the ha-mcp dev add-on no Dockerfile patch or
-    ``image:`` strip is needed. ``install_puppet_addon`` builds it during the
-    running phase, so the heavy Chromium build is cached into the qcow2 once.
+    Supervisor's local store (slug ``local_puppet``). The source is the in-repo
+    ``screenshot_engine_mock/`` directory, copied verbatim: its config.yaml has
+    no ``image:`` field (so Supervisor builds from the local Dockerfile) and the
+    Dockerfile (``python:3.13-slim`` + a stdlib server) needs no patch or
+    ``image:`` strip. ``install_screenshot_engine`` builds it during the running
+    phase — a fast, reliable build (unlike balloob's Chromium image, which broke
+    the bake under floating Supervisor versions).
     """
-    src = PUPPET_VENDOR_DIR
+    src = SCREENSHOT_ENGINE_MOCK_DIR
     if not (src / "config.yaml").exists() or not (src / "Dockerfile").exists():
         raise RuntimeError(
-            f"Vendored Puppet add-on source not found at {src} — the "
-            f"home-assistant-addons submodule is not checked out. Run "
-            f"`git submodule update --init`."
+            f"Mock screenshot engine source not found at {src}; the checkout "
+            f"is incomplete."
         )
 
     LOG.info(
-        "Staging vendored Puppet add-on source into qcow2 "
+        "Staging mock screenshot engine source into qcow2 "
         "/supervisor/addons/local/puppet/"
     )
-    workdir = Path(tempfile.mkdtemp(prefix="haos-puppet-addon-"))
+    workdir = Path(tempfile.mkdtemp(prefix="haos-screenshot-engine-"))
     try:
         staging = workdir / "puppet"
-        shutil.copytree(src, staging)
+        shutil.copytree(src, staging, ignore=shutil.ignore_patterns("__pycache__"))
 
         seed_tar = workdir / "puppet.tar"
         _run(
@@ -1224,7 +1221,7 @@ def stage_puppet_addon_source(qcow2: Path) -> None:
                 "/supervisor/addons/local",
             ]
         )
-        LOG.info("Puppet add-on source staged at /supervisor/addons/local/puppet/")
+        LOG.info("Mock screenshot engine staged at /supervisor/addons/local/puppet/")
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -1454,15 +1451,15 @@ def install_webhook_proxy_addon(ws: HAWebSocket) -> str:
     return slug
 
 
-def install_puppet_addon(ws: HAWebSocket) -> str:
-    """Install the vendored Puppet screenshot engine as a LOCAL add-on.
+def install_screenshot_engine(ws: HAWebSocket) -> str:
+    """Install the mock screenshot engine as a LOCAL add-on.
 
     The add-on source is staged into /supervisor/addons/local/puppet/ before
-    first boot (``stage_puppet_addon_source``), so Supervisor's local-store
+    first boot (``stage_screenshot_engine_source``), so Supervisor's local-store
     scanner picks it up as ``local_puppet``. We reload the store to be explicit,
-    then install — which builds the Chromium image into the cached qcow2 (the
-    heavy build is paid once per cache-key change). No balloob repo is
-    registered; the pinned submodule is the only source.
+    then install — which builds the mock's small python:3.13-slim image into the
+    cached qcow2. No balloob repo or submodule is involved; the in-repo
+    ``screenshot_engine_mock/`` dir is the only source.
 
     Install-only — ``boot`` is set to ``manual`` so the cached qcow2 doesn't
     auto-start it on resume (the haos_only test starts it via a module
@@ -1475,23 +1472,21 @@ def install_puppet_addon(ws: HAWebSocket) -> str:
     Returns the installed slug (``local_puppet``).
     """
     _reload_store(ws)
-    slug = PUPPET_ADDON_SLUG
+    slug = SCREENSHOT_ENGINE_SLUG
     LOG.info(
-        "Installing vendored Puppet screenshot engine (slug=%s) — building the "
-        "Chromium Docker image; this is the slowest addon build, cached in the qcow2...",
+        "Installing mock screenshot engine (slug=%s) — building its small "
+        "python:3.13-slim image into the qcow2...",
         slug,
     )
-    # Generous timeout: Debian + Chromium + Node + npm-ci is the heaviest
-    # addon build in the bake.
-    _install_addon_with_retry(ws, slug, timeout=1800.0)
+    _install_addon_with_retry(ws, slug, timeout=300.0)
 
-    LOG.info("Setting Puppet addon options (boot=manual, empty token)")
+    LOG.info("Setting screenshot engine options (boot=manual, empty token)")
     ws.supervisor_api(
         f"/addons/{slug}/options",
         method="post",
         data={
-            # Seed all of Puppet's required options; the runtime fixture only
-            # overwrites access_token with a real token before starting.
+            # Seed all required options; the runtime fixture only overwrites
+            # access_token with a real token before starting.
             "options": {
                 "access_token": "",
                 "keep_browser_open": False,
@@ -1501,7 +1496,7 @@ def install_puppet_addon(ws: HAWebSocket) -> str:
         },
         timeout=60.0,
     )
-    LOG.info("Puppet screenshot engine installed (not started); slug=%s", slug)
+    LOG.info("Mock screenshot engine installed (not started); slug=%s", slug)
     return slug
 
 
@@ -1860,11 +1855,12 @@ def build(work_dir: Path, output: Path) -> None:
     # independent), but the install order below DOES — the webhook-proxy's
     # auto-discovery needs the dev addon present at first start.
     stage_webhook_proxy_addon_source(qcow2)
-    # The screenshot engine (balloob's Puppet) is staged from the pinned
-    # home-assistant-addons submodule as a local add-on; install_puppet_addon
-    # builds its Chromium image into the cached qcow2 during the running phase
-    # below.
-    stage_puppet_addon_source(qcow2)
+    # The screenshot engine is a tiny in-repo MOCK (screenshot_engine_mock/)
+    # staged as a local add-on; install_screenshot_engine builds it (a fast
+    # python:3.13-slim image) into the cached qcow2 during the running phase
+    # below. See SCREENSHOT_ENGINE_MOCK_DIR for why the mock replaced balloob's
+    # heavy Chromium Puppet add-on.
+    stage_screenshot_engine_source(qcow2)
     qemu = start_qemu(qcow2, work_dir)
     base_url = f"http://127.0.0.1:{HA_HOST_PORT}"
     try:
@@ -1880,10 +1876,10 @@ def build(work_dir: Path, output: Path) -> None:
             # Supervisor auto-discovery (slug-suffix match on _ha_mcp_dev)
             # finds a target on first start.
             install_webhook_proxy_addon(ws)
-            # Screenshot engine = balloob's Puppet, staged as a local add-on
-            # from the pinned submodule (boot=manual, empty token; the runtime
-            # fixture injects a real HA access token and starts it).
-            install_puppet_addon(ws)
+            # Screenshot engine = the in-repo mock, staged as a local add-on
+            # (boot=manual, empty token; the runtime fixture injects a real HA
+            # access token and starts it).
+            install_screenshot_engine(ws)
             install_advanced_ssh(ws)
             # TODO(#1281 follow-up): integrations (ESPHome companion, Node-RED
             # companion, Local Calendar, Sun verification) and mock RTSP/MQTT

--- a/tests/haos_image_build/screenshot_engine_mock/Dockerfile
+++ b/tests/haos_image_build/screenshot_engine_mock/Dockerfile
@@ -1,0 +1,13 @@
+# Test-only mock screenshot engine for the HAOS e2e bake. Mirrors balloob's
+# Puppet HTTP contract (GET /<path>?viewport=WxH&format=png -> image/png)
+# WITHOUT Chromium: it returns a synthetic, viewport-sized PNG and gates
+# rendering on validating the configured access_token against Home Assistant
+# (a bad token fails, exactly like the real engine reaching only the login
+# screen). python:3.13-slim is the same fast, reliable base the dev +
+# webhook-proxy add-ons build from in this bake. No apt, no npm, no Chromium.
+# Digest-pinned (matches the webhook-proxy addon) so the in-Supervisor build is
+# reproducible and Renovate-bumpable — an unpinned tag would reintroduce the
+# floating-base bake failure this change exists to eliminate.
+FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
+COPY server.py /server.py
+CMD ["python", "/server.py"]

--- a/tests/haos_image_build/screenshot_engine_mock/config.yaml
+++ b/tests/haos_image_build/screenshot_engine_mock/config.yaml
@@ -1,0 +1,31 @@
+name: HA-MCP Screenshot Engine (test mock)
+version: "1.0.0"
+# Config slug ``puppet`` -> Supervisor local slug ``local_puppet`` -> matches
+# the ``_puppet`` discovery suffix in src/ha_mcp/dashboard_screenshot/provision.py,
+# exactly as balloob's real Puppet add-on would. This is a drop-in mock for the
+# HAOS e2e bake (the test's SCREENSHOT_ADDON_SLUG stays ``local_puppet``); it is
+# NEVER shipped to users, who install balloob's actual add-on.
+slug: puppet
+description: >-
+  Test-only mock of the dashboard screenshot engine for the HAOS e2e bake.
+  Serves the same HTTP contract as balloob's Puppet add-on
+  (GET /<path>?viewport=WxH&format=png -> image/png) but returns a synthetic
+  PNG instead of launching Chromium, and gates rendering on validating the
+  configured access_token against Home Assistant. Never shipped to users.
+arch:
+  - aarch64
+  - amd64
+# python:3.13-slim is not an HA base image (no s6 init), so run our own CMD.
+init: false
+ports:
+  "10000/tcp": 10000
+options:
+  access_token: ""
+  keep_browser_open: false
+  home_assistant_url: "http://homeassistant:8123"
+schema:
+  access_token: str
+  keep_browser_open: bool
+  home_assistant_url: str
+# Mirrors balloob's puppet add-on so the discovery + options surface match.
+homeassistant_api: true

--- a/tests/haos_image_build/screenshot_engine_mock/server.py
+++ b/tests/haos_image_build/screenshot_engine_mock/server.py
@@ -1,0 +1,153 @@
+"""Test-only mock of the dashboard screenshot engine for the HAOS e2e bake.
+
+Serves the same HTTP contract ha-mcp's ``ha_get_dashboard_screenshot`` calls
+against balloob's Puppet add-on, but WITHOUT Chromium:
+
+* ``GET /<dashboard-path>?viewport=WxH&...`` -> a synthetic, viewport-sized
+  ``image/png`` (the only params ha-mcp sends are honoured: ``viewport`` for
+  the dimensions, ``format=png``; the rest of balloob's surface -- device /
+  eink / colors / dithering / bmp / rotate / ... -- is deliberately NOT
+  reimplemented, since the tool never sends it and a copy would only add a
+  maintenance fork that recovers no coverage: real rendering is Chromium,
+  which a mock can't reproduce regardless).
+* a bad ``viewport`` -> ``400`` (the engine's contract).
+* rendering is gated on the configured ``access_token``: the mock validates it
+  against Home Assistant (``GET /api/`` with the bearer). A valid token renders;
+  an invalid/unreachable one returns ``502`` so the caller raises -- exactly the
+  valid-vs-invalid contrast ``test_token_is_what_authenticates`` asserts (the
+  real engine, given a bad token, reaches only the HA login screen and cannot
+  reproduce the working render).
+
+Stdlib only; runs on python:3.13-slim. Never shipped to users.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import urllib.error
+import urllib.request
+import zlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = 10000
+# Supervisor writes the resolved add-on options here; read per-request so a
+# token change (test_token_is_what_authenticates rewrites it) is picked up
+# without depending on restart timing.
+_OPTIONS_PATH = "/data/options.json"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_DEFAULT_HA_URL = "http://homeassistant:8123"
+
+
+def _options() -> dict:
+    try:
+        with open(_OPTIONS_PATH, encoding="utf-8") as fh:
+            data = json.load(fh)
+            return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _make_png(width: int, height: int) -> bytes:
+    """A real, viewport-sized 8-bit RGB PNG with per-row varying colour.
+
+    Non-uniform on purpose: a solid-colour image zlib-compresses to well under
+    the auth test's >3000-byte "not a blank/error frame" floor, so each row
+    gets a distinct colour, which keeps the encoded image comfortably above it
+    while staying cheap to build.
+    """
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return (
+            struct.pack(">I", len(data))
+            + body
+            + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    raw = b"".join(
+        b"\x00" + bytes((y & 0xFF, (y * 2) & 0xFF, (y * 3) & 0xFF)) * width
+        for y in range(height)
+    )
+    return (
+        _PNG_MAGIC
+        + _chunk(b"IHDR", ihdr)
+        + _chunk(b"IDAT", zlib.compress(raw))
+        + _chunk(b"IEND", b"")
+    )
+
+
+def _token_authenticates(base_url: str, token: str) -> bool:
+    """True iff ``token`` is a credential HA Core accepts (``GET /api/`` -> 200).
+
+    Mirrors the real engine's behaviour: the configured token is what gets the
+    headless browser past the HA frontend login. An empty/invalid token, or an
+    unreachable HA, means "cannot authenticate" -> the mock refuses to render.
+    """
+    if not token:
+        return False
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/api/",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except urllib.error.HTTPError:
+        return False  # 401 on a bad token, etc.
+    except (urllib.error.URLError, OSError):
+        return False  # HA not reachable -> never render under a broken auth state
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # BaseHTTPRequestHandler API (uppercase method)
+        parsed = urlparse(self.path)
+        if parsed.path == "/favicon.ico":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if parsed.path == "/":
+            body = b"<html><body>HA-MCP screenshot engine (test mock)</body></html>"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+        try:
+            width, height = (int(x) for x in params.get("viewport", "").split("x"))
+        except ValueError:
+            self.send_error(400, "bad or missing viewport")
+            return
+
+        opts = _options()
+        ha_url = opts.get("home_assistant_url") or _DEFAULT_HA_URL
+        if not _token_authenticates(ha_url, opts.get("access_token", "")):
+            self.send_error(
+                502, "screenshot engine could not authenticate to Home Assistant"
+            )
+            return
+
+        png = _make_png(width, height)
+        self.send_response(200)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(len(png)))
+        self.end_headers()
+        self.wfile.write(png)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return  # silence per-request stderr logging
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), _Handler)
+    print(f"HA-MCP screenshot engine (test mock) listening on :{PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/src/e2e/haos_only/test_dashboard_screenshot_addon.py
+++ b/tests/src/e2e/haos_only/test_dashboard_screenshot_addon.py
@@ -1,21 +1,24 @@
 """Dashboard screenshot-engine addon runtime E2E for the HAOS test tier.
 
-The screenshot engine is balloob's **Puppet** add-on, vendored as a pinned
-submodule and staged as a local add-on (``local_puppet``) into the qcow2 with
+The screenshot engine here is a tiny in-repo MOCK (slug ``local_puppet``)
+staged as a local add-on into the qcow2 with
 ``boot: manual`` and an empty ``access_token`` (see
-``tests/haos_image_build/build_image.py::stage_puppet_addon_source`` /
-``install_puppet_addon``). The bake validates that the addon installs cleanly
-and pre-builds its Chromium Docker image.
+``tests/haos_image_build/build_image.py::stage_screenshot_engine_source`` /
+``install_screenshot_engine``). It serves balloob Puppet's HTTP contract
+without Chromium: a viewport-sized PNG, gated on validating the configured
+``access_token`` against Home Assistant. This keeps the HAOS-specific coverage
+— Supervisor add-on discovery (``provision.py`` mode 2), the addon lifecycle,
+and the tool's request/parse path — while dropping the heavy, fragile Chromium
+build (real Chromium rendering exercises balloob's add-on, not ha-mcp, and is
+covered against a fake engine in ``test_dashboard_screenshot_sidecar.py``).
 
-The engine authenticates the headless browser with a Home Assistant
-long-lived/user access token — the add-on's Supervisor token is NOT a valid
-frontend credential (HA Core rejects it with 401), so without a real token the
-engine can only reach the login screen. Rather than bake a token into the
-cached qcow2, the module fixture mints one at runtime via the same login flow
-the rest of the suite uses (``conftest`` exposes it as
-``ha_container_with_fresh_config['token']``), writes it to the engine's
-``access_token`` option, and starts the addon. A ~30-min access token is ample
-for one module's renders.
+The mock authenticates as the real engine does in spirit: a valid HA access
+token renders, an invalid one is rejected. The add-on's Supervisor token is NOT
+a valid frontend credential, so the module fixture mints a real token at
+runtime via the same login flow the rest of the suite uses (``conftest``
+exposes it as ``ha_container_with_fresh_config['token']``), writes it to the
+engine's ``access_token`` option, and starts the addon — rather than baking a
+credential into the cached qcow2.
 
 Tests:
 
@@ -26,10 +29,10 @@ Tests:
 4. ``ha_config_set_dashboard(return_screenshot=True)`` returns the write
    result + a PNG (the dashboard create-and-see loop).
 5. AUTH PROOF: replacing the valid token with a deliberately-invalid one means
-   the HA frontend rejects it and the engine can only reach the login screen,
-   so it FAILS to reproduce the working render. The contrast proves the
-   configured access token is what authenticates (fails closed: if the token
-   were ignored, both renders would match).
+   HA Core rejects it, so the engine cannot render and the tool fails — it does
+   NOT reproduce the working render. The contrast proves the configured access
+   token is what authenticates (fails closed: if the token were ignored, both
+   renders would match).
 """
 
 from __future__ import annotations
@@ -57,10 +60,11 @@ LOG = logging.getLogger(__name__)
 # constraint the port= proxy test documents in test_manage_addon_modes.py.
 pytestmark = [pytest.mark.haos_only, pytest.mark.inaddon_only]
 
-# balloob's Puppet add-on, vendored as a pinned submodule and staged as a LOCAL
-# add-on by the bake (see build_image.py stage_puppet_addon_source /
-# install_puppet_addon). Supervisor assigns local add-ons the slug
-# ``local_<config-slug>``; Puppet's config slug is ``puppet`` → ``local_puppet``.
+# The mock screenshot engine, staged as a LOCAL add-on by the bake (see
+# build_image.py stage_screenshot_engine_source / install_screenshot_engine).
+# Supervisor assigns local add-ons the slug ``local_<config-slug>``; the mock's
+# config slug is ``puppet`` → ``local_puppet`` (matches the ``_puppet``
+# discovery suffix, exactly as balloob's real add-on would).
 SCREENSHOT_ADDON_SLUG = "local_puppet"
 DEFAULT_DASHBOARD_PATH = "lovelace/0"
 
@@ -68,15 +72,17 @@ STOPPED_STATES: frozenset[str] = frozenset({"stopped", "boot_fail", "unknown", "
 
 _STATE_POLL_TIMEOUT = 90.0
 _STATE_POLL_INTERVAL = 1.0
-# Chromium cold-start + first render inside the addon is slow; give the
-# engine generous time to begin serving valid screenshots after start.
+# Generous budget for the addon to build (first cache miss), start, and bind
+# its HTTP server before it serves valid screenshots.
 _ENGINE_READY_TIMEOUT = 180.0
-# Transient + during-boot signals that should be retried (not treated as a
+# Transient + during-startup signals that should be retried (not treated as a
 # hard failure) while polling the engine. ValueError is included because
-# _png_dimensions raises it on a not-yet-PNG body during cold start — a
-# retryable domain condition, not a bug. Genuine bugs (AssertionError,
-# TypeError, KeyError) and ToolError still surface immediately rather than burn
-# the timeout (#1266), per the repo style guide on test polling loops.
+# _png_dimensions raises it on a not-yet-PNG body — a retryable domain
+# condition, not a bug. A ToolError (engine transport error, incl.
+# CONNECTION_FAILED before the server binds) is also retried via
+# _POLLING_TRANSIENT_ERRORS so the poll spans engine startup; genuine logic bugs
+# (AssertionError, TypeError, KeyError) still surface immediately rather than
+# burn the timeout (#1266), per the repo style guide on test polling loops.
 _ENGINE_POLL_RETRY_ERRORS = (*_POLLING_TRANSIENT_ERRORS, ValueError)
 
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
@@ -111,8 +117,8 @@ def _png_dimensions(data: bytes) -> tuple[int, int]:
     """Return (width, height) from a PNG's IHDR chunk.
 
     Raises :class:`ValueError` (a retryable domain condition, not a bug) on a
-    non-PNG body, so the engine-polling loop can retry during Chromium cold
-    start without swallowing genuine bugs.
+    non-PNG body, so the engine-polling loop can retry during engine startup
+    without swallowing genuine bugs.
     """
     if data[:8] != _PNG_MAGIC:
         raise ValueError(
@@ -230,12 +236,12 @@ async def _wait_engine_serving(
 ) -> None:
     """Poll the standalone tool until the engine returns a valid PNG.
 
-    Retries only on transient transport blips and on ValueError (the engine
-    returns a not-yet-PNG body during Chromium cold start; _png_dimensions /
-    _screenshot raise ValueError on it). Any other exception — AssertionError,
-    TypeError, KeyError — is a genuine wiring/config failure and surfaces
-    immediately instead of burning the timeout — see wait_helpers.py /
-    issue #1266.
+    Retries transient transport blips and ValueError (a not-yet-PNG body) so the
+    poll can span engine startup — before the addon's HTTP server binds, a
+    screenshot call surfaces as a ToolError(CONNECTION_FAILED), which is in the
+    retry tuple (_POLLING_TRANSIENT_ERRORS). A genuine logic bug — AssertionError,
+    TypeError, KeyError — surfaces immediately instead of burning the timeout
+    (see wait_helpers.py / issue #1266).
     """
     deadline = time.monotonic() + _ENGINE_READY_TIMEOUT
     last_err: Exception | None = None
@@ -316,9 +322,10 @@ async def test_get_dashboard_screenshot_returns_png(
 ) -> None:
     """ha_get_dashboard_screenshot returns a valid PNG of the requested size.
 
-    A valid, correctly-dimensioned, non-trivial PNG proves the engine launched
-    Chromium, authenticated to HA Core with the configured access token,
-    navigated the dashboard, and rendered.
+    A valid, correctly-dimensioned, non-trivial PNG proves the engine
+    authenticated to HA Core with the configured access token and served the
+    image, and that the tool discovered the engine, built the request, and
+    returned the bytes as an Image.
     """
     png = await _screenshot(mcp_client, DEFAULT_DASHBOARD_PATH, width=1024, height=768)
     width, height = _png_dimensions(png)
@@ -427,20 +434,18 @@ async def test_token_is_what_authenticates(
     ha_container_with_fresh_config: Any,
     screenshot_engine_started: Any,
 ) -> None:
-    """A valid token renders a real dashboard; an invalid token cannot.
+    """A valid token renders; an invalid token cannot.
 
     The fixture configured a valid HA access token, so the engine renders a
     valid PNG (asserted as the baseline). Replacing it with a
-    deliberately-invalid ``access_token`` gives the engine a credential the HA
-    frontend rejects, so it can only reach the login screen — it does NOT
-    reproduce the working dashboard render.
+    deliberately-invalid ``access_token`` gives the engine a credential HA Core
+    rejects, so it cannot render — it does NOT reproduce the working render.
 
     This is deterministic without depending on the engine's exact bad-auth
-    behavior: whether it fails to render (engine raises) or renders a
-    different (login) page, the outcome must differ from the working baseline.
-    If the token were ignored, both would render the same page and match — so
-    this fails closed on a regression. Runs last; restores the valid token in
-    ``finally`` and verifies the restore committed.
+    behavior: whether it fails to render (engine raises) or returns a different
+    image, the outcome must differ from the working baseline. If the token were
+    ignored, both would match — so this fails closed on a regression. Runs last;
+    restores the valid token in ``finally`` and verifies the restore committed.
     """
     slug = SCREENSHOT_ADDON_SLUG
     good_token = ha_container_with_fresh_config["token"]

--- a/tests/src/e2e/tools/test_dashboard_screenshot_sidecar.py
+++ b/tests/src/e2e/tools/test_dashboard_screenshot_sidecar.py
@@ -1,11 +1,12 @@
 """Container/Docker-lane E2E for the dashboard screenshot sidecar path.
 
-The real Chromium engine is exercised only on the inaddon lane
-(``haos_only/test_dashboard_screenshot_addon.py``). This module covers the
-**Docker / Container deployment** instead — the explicit
+The inaddon lane (``haos_only/test_dashboard_screenshot_addon.py``) exercises
+the Supervisor auto-discovery branch (``resolve_engine_url`` mode 2) + addon
+lifecycle against a lightweight mock engine. This module covers the **Docker /
+Container deployment** instead — the explicit
 ``HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL`` sidecar path (``resolve_engine_url``
-mode 1), which is a different resolution branch from the inaddon lane's
-Supervisor auto-discovery and is otherwise untested.
+mode 1), a different resolution branch that is otherwise untested. Neither lane
+runs real Chromium: that exercises balloob's add-on, not ha-mcp.
 
 A faithful FAKE engine stands in for ha-puppet, mirroring the real engine's
 HTTP contract so the capture client is exercised against the same wire shape it

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -8,7 +8,8 @@ Covers everything that runs inside ha-mcp itself — no container, no engine:
 - the capture HTTP client (URL/param building, PNG return, error -> ToolError)
 - the graceful get/set screenshot helper (feature-off / failure -> warning)
 
-The headless-Chromium engine is exercised end to end in the HAOS lane
+The Supervisor auto-discovery branch + addon lifecycle are exercised end to end
+against a mock engine in the HAOS inaddon lane
 (tests/src/e2e/haos_only/test_dashboard_screenshot_addon.py).
 """
 
@@ -231,12 +232,12 @@ class TestDiscoverEngineViaSupervisor:
                 "/addons": {
                     "data": {
                         "addons": [
-                            {"slug": "abc_ha_mcp_screenshot"},  # legacy, stopped
-                            {"slug": "def_puppet"},  # stock, started
+                            {"slug": "abc_puppet"},  # stopped
+                            {"slug": "def_puppet"},  # started
                         ]
                     }
                 },
-                "/addons/abc_ha_mcp_screenshot/info": {"data": {"state": "stopped"}},
+                "/addons/abc_puppet/info": {"data": {"state": "stopped"}},
                 "/addons/def_puppet/info": {
                     "data": {"state": "started", "hostname": "def-puppet"}
                 },


### PR DESCRIPTION
## What does this PR do?

Fixes the red HAOS publish bake (and every PR's HAOS e2e lanes), and makes all four
e2e lanes safe to require as status checks.

**Bake fix.** Supervisor (floated to 2026.06.x) can no longer build balloob's vendored
Puppet add-on (`debian:bullseye-slim` + Chromium) in its add-on builder, which failed the
bake at the puppet install and left the shared HAOS cache un-primed — so every PR
cache-missed into a full bake and hit the same failure. Puppet was only baked in to
validate the beta dashboard-screenshot tool, and real Chromium rendering exercises
balloob's add-on rather than ha-mcp. Replace it with a tiny in-repo mock screenshot engine
(`tests/haos_image_build/screenshot_engine_mock/`, `python:3.13-slim`, digest-pinned) that
serves Puppet's HTTP contract without Chromium and gates rendering on validating the
configured `access_token` against Home Assistant. This keeps the HAOS-specific coverage the
container lane can't give (Supervisor add-on discovery + lifecycle + the tool's
request/parse and token-auth path) and all 5 `haos_only` screenshot tests, while dropping
the heavy, version-fragile build. The balloob submodule is removed.

**Requireable e2e lanes.** All four e2e lanes (2 HAOS + the 2 `E2E Validation` matrix lanes)
now skip pure docs/website-only PRs but run on any code/test/config/add-on change. Each lane
gets a fail-closed `changes` gate job — a job-level skip reports Success to a required check
(a workflow-level `paths:` skip reports nothing and wedges the merge), and the classifier
defaults to "run" on any error so it can never silently skip a lane. The matrix
`E2E Validation` lanes are fronted by a single always-run **E2E Validation Gate** context,
because a skipped matrix job does not emit its per-variant contexts.

**Cleanup.** Removes the unused `_ha_mcp_screenshot` engine discovery suffix from `provision.py`.

**After merge (settings, not code):** mark the lanes required by updating the branch ruleset
to require `HAOS E2E Tests`, `HAOS E2E Tests (inaddon)`, and `E2E Validation Gate`, and remove
the two per-variant `E2E Validation (os)` contexts. This waits until the bake is green on master.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — the bake + e2e validation run in CI (the point of this change)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (docstrings/comments in touched files)
