### PR TITLE
docs: throwaway gate demo (DO NOT MERGE)

### DIFF
--- a/docs/gate-demo-throwaway.md
+++ b/docs/gate-demo-throwaway.md
@@ -1,0 +1,4 @@
+# Gate demo (throwaway)
+
+Throwaway docs-only change to demonstrate the e2e-lane gating: this PR touches
+only a `docs/**` file, so the four e2e lanes should skip. Safe to close/delete.

--- a/docs/gate-demo-throwaway.md
+++ b/docs/gate-demo-throwaway.md
@@ -2,3 +2,5 @@
 
 Throwaway docs-only change to demonstrate the e2e-lane gating: this PR touches
 only a `docs/**` file, so the four e2e lanes should skip. Safe to close/delete.
+
+<!-- retrigger CI to evaluate the new required-check ruleset -->

--- a/tests/_gate_demo.txt
+++ b/tests/_gate_demo.txt
@@ -1,0 +1,4 @@
+Throwaway non-docs file to flip the e2e gate to run=true on this PR.
+Not under a bake-input path (tests/haos_image_build, tests/initial_test_state,
+custom_components/ha_mcp_tools, homeassistant-addon-webhook-proxy), so the HAOS
+cache key is unchanged and the lanes cache-hit instead of full-baking.


### PR DESCRIPTION
Throwaway docs-only PR to show the e2e-lane gating. It touches only a `docs/**` file, so the four e2e lanes should skip while the `E2E Validation Gate` still reports. Will close after the demo.