### PR TITLE
fix: coerce JSON-string dict/list args on all MCP container params

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -41,7 +41,7 @@ from .helpers import (
     raise_tool_error,
     validate_identifier_not_empty,
 )
-from .util_helpers import ANSI_ESCAPE_RE
+from .util_helpers import ANSI_ESCAPE_RE, JSON_STRING_COERCION
 
 logger = logging.getLogger(__name__)
 
@@ -2712,6 +2712,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         ] = None,
         options: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Config mode: Add-on configuration values (the 'Configuration' tab in the UI).",
                 default=None,
@@ -2719,6 +2720,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         ] = None,
         network: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Config mode: Host port mappings (e.g., {'5800/tcp': 8081}).",
                 default=None,
@@ -2747,6 +2749,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         ] = None,
         array_patch: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Array-patch mode: atomically GET a JSON array endpoint, "
@@ -2760,6 +2763,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         ] = None,
         request_headers: Annotated[
             dict[str, str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Proxy/array-patch mode: extra HTTP headers to send to the addon API. "

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -23,6 +23,7 @@ from .helpers import (
     validate_identifier_not_empty,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     parse_string_list_param,
     project_fields,
     project_records,
@@ -148,6 +149,7 @@ class AreaTools:
         self,
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -162,6 +164,7 @@ class AreaTools:
         ] = None,
         area_fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -446,6 +449,7 @@ class AreaTools:
         ] = None,
         aliases: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Alternative names for voice assistant recognition (e.g., ['lounge'], empty list to clear)",
                 default=None,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3500,6 +3500,7 @@ class HelperConfigTools:
         ] = None,
         labels: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(description="Labels to categorize the helper", default=None),
         ] = None,
         min_value: Annotated[
@@ -3535,6 +3536,7 @@ class HelperConfigTools:
         ] = None,
         options: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="List of options for input_select (required for input_select)",
                 default=None,
@@ -3582,6 +3584,7 @@ class HelperConfigTools:
         ] = None,
         monday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Monday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes (e.g. {'from': '07:00', 'to': '22:00', 'data': {'mode': 'comfort'}})",
                 default=None,
@@ -3589,6 +3592,7 @@ class HelperConfigTools:
         ] = None,
         tuesday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Tuesday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3596,6 +3600,7 @@ class HelperConfigTools:
         ] = None,
         wednesday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Wednesday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3603,6 +3608,7 @@ class HelperConfigTools:
         ] = None,
         thursday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Thursday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3610,6 +3616,7 @@ class HelperConfigTools:
         ] = None,
         friday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Friday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3617,6 +3624,7 @@ class HelperConfigTools:
         ] = None,
         saturday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Saturday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3624,6 +3632,7 @@ class HelperConfigTools:
         ] = None,
         sunday: Annotated[
             list[dict[str, Any]] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Schedule time ranges for Sunday. List of {'from': 'HH:MM', 'to': 'HH:MM'} dicts. Optional 'data' dict for additional attributes.",
                 default=None,
@@ -3654,6 +3663,7 @@ class HelperConfigTools:
         ] = None,
         device_trackers: Annotated[
             list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="List of device_tracker entity IDs for person", default=None
             ),

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -43,6 +43,7 @@ from .helpers import (
     register_tool_methods,
     validate_identifier_not_empty,
 )
+from .util_helpers import JSON_STRING_COERCION
 
 logger = logging.getLogger(__name__)
 
@@ -341,6 +342,7 @@ class EnergyTools:
         ],
         config: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Full prefs payload for mode='set'. Must contain the "
@@ -362,9 +364,12 @@ class EnergyTools:
                     "Hash from a previous mode='get' call. REQUIRED for "
                     "mode='set' unless dry_run=True. Two forms: str (full-"
                     "blob lock) or dict (per-key lock, taken from the "
-                    "config_hash_per_key field of mode='get'). See the tool "
-                    "docstring for fail-closed semantics. Ignored by "
-                    "convenience modes."
+                    "config_hash_per_key field of mode='get'). Pass the dict "
+                    "form as a native object, NOT a JSON-encoded string — a "
+                    "stringified dict is treated as a full-blob token and will "
+                    "report RESOURCE_LOCKED; clients that can only send strings "
+                    "should use the str full-blob form. See the tool docstring "
+                    "for fail-closed semantics. Ignored by convenience modes."
                 ),
                 default=None,
             ),
@@ -438,6 +443,7 @@ class EnergyTools:
         ] = False,
         source: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Single energy_sources entry for mode='add_source'. Must "

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -559,6 +559,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     async def ha_set_entity(
         entity_id: Annotated[
             str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description="Entity ID or list of entity IDs to update. Bulk operations (list) only support labels, expose_to, and categories parameters."
             ),
@@ -639,6 +640,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         aliases: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="List of voice assistant aliases for the entity (replaces existing aliases). Single entity only.",
                 default=None,
@@ -659,6 +661,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         labels: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="List of label IDs for the entity. Behavior depends on label_operation parameter. Supports bulk operations.",
                 default=None,
@@ -1117,6 +1120,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     async def ha_get_entity(
         entity_id: Annotated[
             str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description="Entity ID or list of entity IDs to retrieve (e.g., 'sensor.temperature' or ['light.living_room', 'switch.porch'])"
             ),

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -26,6 +26,7 @@ from .helpers import (
     validate_identifier_not_empty,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     wait_for_entity_registered,
     wait_for_entity_removed,
 )
@@ -223,6 +224,7 @@ class GroupTools:
         ],
         entities: Annotated[
             list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="List of entity IDs for the group. Required when creating new group. When updating, replaces all entities (mutually exclusive with add_entities/remove_entities).",
                 default=None,
@@ -251,6 +253,7 @@ class GroupTools:
         ] = None,
         add_entities: Annotated[
             list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Add these entities to an existing group (mutually exclusive with entities)",
                 default=None,
@@ -258,6 +261,7 @@ class GroupTools:
         ] = None,
         remove_entities: Annotated[
             list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Remove these entities from an existing group (mutually exclusive with entities)",
                 default=None,

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -429,6 +429,9 @@ def _parse_entity_ids(entity_ids: str | list[str]) -> list[str]:
     """Parse entity_ids parameter into a list of strings."""
     if isinstance(entity_ids, str):
         if entity_ids.startswith("["):
+            # Belt-and-suspenders: JSON_STRING_COERCION on the param already
+            # parses a JSON-array string to a list upstream, so a string reaching
+            # here is normally CSV/single. This branch stays as a fallback.
             parsed_ids = parse_string_list_param(entity_ids, "entity_ids")
             if parsed_ids is None:
                 raise_tool_error(

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -30,6 +30,7 @@ from .helpers import (
     safe_progress,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     add_timezone_metadata,
     build_pagination_metadata,
     parse_string_list_param,
@@ -136,6 +137,7 @@ class HistoryTools:
         self,
         entity_ids: Annotated[
             str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description="Entity ID(s) to query. Can be a single ID, comma-separated string, or JSON array."
             ),
@@ -206,6 +208,7 @@ class HistoryTools:
         ] = "day",
         statistic_types: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description='Statistics types: "mean", "min", "max", "sum", "state", "change". Default: all. Ignored when source="history"',
                 default=None,
@@ -224,6 +227,7 @@ class HistoryTools:
         ] = "desc",
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -33,6 +33,7 @@ from .tools_config_helpers import (
     _get_entities_for_config_entry,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     build_pagination_metadata,
     fetch_integration_diagnostics,
     get_logger_levels,
@@ -459,6 +460,7 @@ class IntegrationTools:
         ] = None,
         diagnostics_fields: Annotated[
             list[str] | str | None,
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Optional list of top-level keys to keep from the diagnostics "

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -21,6 +21,7 @@ from .helpers import (
     validate_identifier_not_empty,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     build_pagination_metadata,
     parse_string_list_param,
 )
@@ -627,6 +628,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         labels: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 description="Labels to assign to the device (replaces existing labels)",
                 default=None,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -18,6 +18,7 @@ from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
 from ..utils.fuzzy_search import apply_hidden_penalty
 from .helpers import exception_to_structured_error, log_tool_usage, raise_tool_error
 from .util_helpers import (
+    JSON_STRING_COERCION,
     add_timezone_metadata,
     build_pagination_metadata,
     filter_active_repairs,
@@ -581,6 +582,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         search_types: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -672,6 +674,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         result_fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -682,6 +685,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -1810,6 +1814,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = "minimal",
         domains: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -1878,6 +1883,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = False,
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -2326,6 +2332,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     async def ha_get_state(
         entity_id: Annotated[
             str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description="Entity ID or list of entity IDs to retrieve state for "
                 "(e.g., 'light.kitchen' or ['light.kitchen', 'sensor.temperature'])"
@@ -2333,6 +2340,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ],
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -2346,6 +2354,7 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ] = None,
         attribute_keys: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -315,6 +315,7 @@ class ServiceTools:
         ] = False,
         result_fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -327,6 +328,7 @@ class ServiceTools:
         ] = None,
         result_attribute_keys: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -522,6 +524,7 @@ class ServiceTools:
         self,
         operation_id: Annotated[
             str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description=(
                     "Single operation ID or list of operation IDs to check. "
@@ -544,23 +547,15 @@ class ServiceTools:
         For current entity states, use ha_get_state instead.
         """
         try:
-            # Handle JSON string coercion (MCP clients may send '["op1","op2"]')
-            resolved_id: str | list[str] = operation_id
-            if isinstance(operation_id, str):
-                try:
-                    parsed = parse_json_param(operation_id, "operation_id")
-                    if isinstance(parsed, list):
-                        resolved_id = [str(item) for item in parsed]
-                except ValueError:
-                    pass  # Plain string — treat as single operation ID
-
-            if isinstance(resolved_id, list):
+            # JSON_STRING_COERCION turns a '["op1","op2"]' string into a list
+            # before the body runs, so operation_id is already the final shape.
+            if isinstance(operation_id, list):
                 result = await self._device_tools.get_bulk_operation_status(
-                    operation_ids=resolved_id
+                    operation_ids=operation_id
                 )
                 return cast(dict[str, Any], result)
             result = await self._device_tools.get_device_operation_status(
-                operation_id=resolved_id, timeout_seconds=timeout_seconds
+                operation_id=operation_id, timeout_seconds=timeout_seconds
             )
             return cast(dict[str, Any], result)
         except ToolError:

--- a/src/ha_mcp/tools/tools_services.py
+++ b/src/ha_mcp/tools/tools_services.py
@@ -20,6 +20,7 @@ from .helpers import (
     register_tool_methods,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     build_pagination_metadata,
     parse_string_list_param,
     project_fields,
@@ -78,6 +79,7 @@ class ServiceDiscoveryTools:
         ] = "summary",
         service_fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -91,6 +93,7 @@ class ServiceDiscoveryTools:
         ] = None,
         fields: Annotated[
             str | list[str] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -25,6 +25,7 @@ from .helpers import (
     register_tool_methods,
 )
 from .util_helpers import (
+    JSON_STRING_COERCION,
     fetch_integration_diagnostics,
     filter_active_repairs,
     parse_diagnostics_fields,
@@ -323,7 +324,9 @@ class SystemTools:
         include_dismissed_repairs: bool | None = False,
         config_entry_id: str | None = None,
         device_id: str | None = None,
-        diagnostics_fields: list[str] | str | None = None,
+        diagnostics_fields: Annotated[
+            list[str] | str | None, JSON_STRING_COERCION
+        ] = None,
         diagnostics_truncate_at_bytes: Annotated[int, Field(ge=1)] | None = None,
         diagnostics_data_path: str | None = None,
         diagnostics_data_offset: Annotated[int, Field(ge=0)] | None = 0,

--- a/src/ha_mcp/tools/validation_middleware.py
+++ b/src/ha_mcp/tools/validation_middleware.py
@@ -43,14 +43,20 @@ class ValidationErrorMiddleware(Middleware):
             return await call_next(context)
         except PydanticValidationError as exc:
             errors = exc.errors(include_url=False)
-            # Group by the real argument name (the first loc element). A union
-            # param like `str | list[str]` emits one error per arm with loc
-            # (param, "str"), (param, "list[str]"); without grouping the user
-            # saw `param.str` / `param.list[str]` instead of `param` (#1601).
+            # Group by the real argument path. A union param like
+            # `str | list[str]` emits one error per arm with loc (param, "str"),
+            # (param, "list[str]"); without grouping the user saw `param.str` /
+            # `param.list[str]` instead of `param` (#1601). We keep the param
+            # name plus any numeric list indices (so a bad element still reports
+            # `monday.1`) but drop the non-numeric union-arm tags.
             grouped: dict[str, list[Any]] = {}
             for err in errors:
                 loc = [str(p) for p in err.get("loc", ()) if p != "__root__"]
-                grouped.setdefault(loc[0] if loc else "", []).append(err)
+                if loc:
+                    key = ".".join([loc[0], *(p for p in loc[1:] if p.isdigit())])
+                else:
+                    key = ""
+                grouped.setdefault(key, []).append(err)
 
             parts: list[str] = []
             for param, errs in grouped.items():

--- a/src/ha_mcp/tools/validation_middleware.py
+++ b/src/ha_mcp/tools/validation_middleware.py
@@ -43,15 +43,27 @@ class ValidationErrorMiddleware(Middleware):
             return await call_next(context)
         except PydanticValidationError as exc:
             errors = exc.errors(include_url=False)
-            parts: list[str] = []
+            # Group by the real argument name (the first loc element). A union
+            # param like `str | list[str]` emits one error per arm with loc
+            # (param, "str"), (param, "list[str]"); without grouping the user
+            # saw `param.str` / `param.list[str]` instead of `param` (#1601).
+            grouped: dict[str, list[Any]] = {}
             for err in errors:
-                loc = err.get("loc", ())
-                param = ".".join(str(p) for p in loc if p != "__root__")
-                hint = _TYPE_HINTS.get(err["type"], err["msg"])
+                loc = [str(p) for p in err.get("loc", ()) if p != "__root__"]
+                grouped.setdefault(loc[0] if loc else "", []).append(err)
+
+            parts: list[str] = []
+            for param, errs in grouped.items():
+                # Prefer an actionable container hint when any arm produced one
+                # (dict_type/list_type); else fall back to the first raw message.
+                hint = next(
+                    (_TYPE_HINTS[e["type"]] for e in errs if e["type"] in _TYPE_HINTS),
+                    errs[0]["msg"],
+                )
                 parts.append(f"`{param}`: {hint}" if param else hint)
             raise_tool_error(
                 create_validation_error(
                     "; ".join(parts) if parts else "Invalid argument types.",
-                    details=", ".join(err["type"] for err in errors),
+                    details=", ".join(dict.fromkeys(err["type"] for err in errors)),
                 )
             )

--- a/tests/src/unit/test_container_param_coercion_complete.py
+++ b/tests/src/unit/test_container_param_coercion_complete.py
@@ -1,0 +1,246 @@
+"""Guardrail (issue #1601): EVERY MCP container param must coerce a JSON string.
+
+Issue #1581/#1601 root cause: some MCP clients (Claude Desktop, Cowork/Agent
+SDK) serialize object/array tool arguments as JSON-encoded *strings* before
+they reach the server. PR #1582 added the `JSON_STRING_COERCION` BeforeValidator
+and applied it to *some* dict/list params — but by hand, one call site at a
+time, which is exactly the pattern that let the #1485/#1487/#1492 regression
+slip through (tolerance was tied to the annotation and silently dropped).
+
+This test makes the contract structural and impossible to regress: it walks
+*every* registered MCP tool parameter, and for every parameter whose declared
+type can be a dict or a list (including `str | list[...]` unions), it asserts
+that `JSON_STRING_COERCION` is present in the annotation metadata.
+
+Adding a new container param without the coercion fails this test. Removing the
+coercion from an existing one fails this test. That is the point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+import os
+import pkgutil
+import typing
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import ha_mcp.tools as tools_pkg
+from ha_mcp.tools.util_helpers import JSON_STRING_COERCION
+
+# (tool_name, param_name) pairs deliberately exempt from coercion, each with a
+# documented reason. These are params where `str` is a semantically distinct,
+# first-class value — NOT a serialization artifact — so coercing a JSON-object
+# string into a dict could change behavior. Surfaced for maintainer decision;
+# move them out of this allowlist to opt them in.
+COERCION_EXEMPT: dict[tuple[str, str], str] = {
+    ("ha_manage_addon", "body"): (
+        "Proxy request body: 'Pass a JSON object or JSON string' — str is an "
+        "accepted raw-body form, not a serialization artifact."
+    ),
+    ("ha_manage_energy_prefs", "config_hash"): (
+        "str = full-blob optimistic-lock token, dict = per-key lock; the two "
+        "forms are semantically distinct and this is a fail-closed param."
+    ),
+}
+
+
+def _type_can_be_container(annotation: Any) -> bool:
+    """True if a dict or list appears anywhere in the type portion of an
+    annotation (unwrapping Annotated, unions, and Optional)."""
+    origin = typing.get_origin(annotation)
+
+    # Annotated[T, ...] -> inspect T only (metadata handled separately).
+    if origin is typing.Annotated:
+        return _type_can_be_container(typing.get_args(annotation)[0])
+
+    if origin in (dict, list):
+        return True
+
+    # Union / Optional: any arm being a container counts.
+    args = typing.get_args(annotation)
+    if args:
+        return any(_type_can_be_container(arg) for arg in args)
+
+    return annotation in (dict, list)
+
+
+def _has_coercion(annotation: Any) -> bool:
+    """True if JSON_STRING_COERCION is in the Annotated metadata."""
+    if typing.get_origin(annotation) is not typing.Annotated:
+        return False
+    # get_args -> (type, *metadata); skip the leading type.
+    return any(meta is JSON_STRING_COERCION for meta in typing.get_args(annotation)[1:])
+
+
+def _register_module(mcp: Any, module: Any, func_name: str | None) -> None:
+    """Call a module's register function (explicit name, or discovered
+    register_*_tools), mirroring ToolsRegistry._import_and_register_module."""
+    if func_name is not None:
+        register_fn: Any = getattr(module, func_name, None)
+    else:
+        register_fn = next(
+            (
+                getattr(module, attr)
+                for attr in dir(module)
+                if attr.startswith("register_") and attr.endswith("_tools")
+            ),
+            None,
+        )
+    if register_fn is not None:
+        register_fn(mcp, MagicMock(), smart_tools=MagicMock(), device_tools=MagicMock())
+
+
+def _all_registered_tools() -> dict[str, Any]:
+    """Register EVERY tool the real ToolsRegistry could register and return them.
+
+    Mirrors ToolsRegistry: walks the tools_*.py modules AND the EXPLICIT_MODULES
+    (e.g. backup.py, which has no tools_ prefix). Every bool feature flag is
+    forced on — except read_only_mode, which would *hide* write tools — so that
+    beta/gated modules register and their params are inspected; otherwise a
+    container param on a beta tool would silently escape the guardrail in default
+    CI, where the beta master toggle is off. Env is restored afterward.
+    """
+    from fastmcp import FastMCP
+
+    from ha_mcp.config import FEATURE_FLAG_FIELDS, _reset_global_settings
+    from ha_mcp.tools.registry import EXPLICIT_MODULES
+
+    saved_env: dict[str, str | None] = {}
+    for flag in FEATURE_FLAG_FIELDS:
+        if flag.ftype is bool and flag.field != "read_only_mode":
+            saved_env[flag.env] = os.environ.get(flag.env)
+            os.environ[flag.env] = "true"
+    _reset_global_settings()
+
+    async def _inner() -> dict[str, Any]:
+        mcp = FastMCP("guardrail")
+        for module_info in pkgutil.iter_modules(tools_pkg.__path__):
+            if module_info.name.startswith("tools_"):
+                module = importlib.import_module(f"ha_mcp.tools.{module_info.name}")
+                _register_module(mcp, module, None)
+        for module_name, func_name in EXPLICIT_MODULES.items():
+            module = importlib.import_module(f"ha_mcp.tools.{module_name}")
+            _register_module(mcp, module, func_name)
+        listed = await mcp.list_tools()
+        return {t.name: await mcp.get_tool(t.name) for t in listed}
+
+    try:
+        return asyncio.run(_inner())
+    finally:
+        for env_var, prev in saved_env.items():
+            if prev is None:
+                os.environ.pop(env_var, None)
+            else:
+                os.environ[env_var] = prev
+        _reset_global_settings()
+
+
+def test_every_container_param_has_json_string_coercion() -> None:
+    """Walk all registered MCP params; every container-typed one must coerce a
+    JSON string (or be in the documented exemption allowlist)."""
+    tools = _all_registered_tools()
+    assert tools, "no tools registered — guardrail cannot run"
+
+    gaps: list[str] = []
+    for tool_name, tool in tools.items():
+        for param_name, param in inspect.signature(tool.fn).parameters.items():
+            annotation = param.annotation
+            if annotation is inspect.Parameter.empty:
+                continue
+            if not _type_can_be_container(annotation):
+                continue
+            if (tool_name, param_name) in COERCION_EXEMPT:
+                continue
+            if not _has_coercion(annotation):
+                gaps.append(f"{tool_name}.{param_name}: {annotation!r}")
+
+    assert not gaps, (
+        "Container params missing JSON_STRING_COERCION (a stringified dict/list "
+        "from an MCP client would be rejected or silently mishandled):\n  "
+        + "\n  ".join(sorted(gaps))
+    )
+
+
+_TOOLS_CACHE: dict[str, Any] = {}
+
+
+def _param_annotation(tool_name: str, param_name: str) -> Any:
+    if not _TOOLS_CACHE:
+        _TOOLS_CACHE.update(_all_registered_tools())
+    tool = _TOOLS_CACHE[tool_name]
+    return inspect.signature(tool.fn).parameters[param_name].annotation
+
+
+# Behavioral pin for the silent-swallow union class (#1601, gioanph-sudo report):
+# a `str | list[...]` param given a JSON-array string must coerce to a list
+# instead of matching the `str` arm and being mishandled (the ha_get_state bug
+# returned ENTITY_NOT_FOUND because the whole JSON string was looked up as one id).
+@pytest.mark.parametrize(
+    ("tool_name", "param_name", "json_value", "expected"),
+    [
+        ("ha_get_state", "entity_id", '["light.a", "light.b"]', ["light.a", "light.b"]),
+        ("ha_get_entity", "entity_id", '["light.a"]', ["light.a"]),
+        (
+            "ha_set_entity",
+            "entity_id",
+            '["light.a", "light.b"]',
+            ["light.a", "light.b"],
+        ),
+        ("ha_config_set_group", "entities", '["light.a"]', ["light.a"]),
+        ("ha_get_history", "entity_ids", '["sensor.x"]', ["sensor.x"]),
+        (
+            "ha_config_set_helper",
+            "monday",
+            '[{"from": "07:00", "to": "22:00"}]',
+            [{"from": "07:00", "to": "22:00"}],
+        ),
+    ],
+)
+def test_container_param_coerces_json_array_string(
+    tool_name: str, param_name: str, json_value: str, expected: Any
+) -> None:
+    from pydantic import TypeAdapter
+
+    ann = _param_annotation(tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(json_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "param_name", "value"),
+    [
+        ("ha_get_state", "entity_id", "light.kitchen"),  # bare id stays a string
+        ("ha_get_state", "entity_id", ["light.a", "light.b"]),  # native list intact
+        (
+            "ha_get_history",
+            "entity_ids",
+            "sensor.x,sensor.y",
+        ),  # CSV stays str (split in body)
+    ],
+)
+def test_container_param_passes_non_json_through_unchanged(
+    tool_name: str, param_name: str, value: Any
+) -> None:
+    """A non-JSON-container value (bare id, CSV string, native list) is not
+    altered by the coercion — only JSON object/array strings are parsed."""
+    from pydantic import TypeAdapter
+
+    ann = _param_annotation(tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(value) == value
+
+
+def test_exempt_params_still_exist() -> None:
+    """If an exempt param is renamed/removed, force a conscious update of the
+    allowlist rather than letting it rot into a silent no-op."""
+    tools = _all_registered_tools()
+    present = {
+        (name, p)
+        for name, tool in tools.items()
+        for p in inspect.signature(tool.fn).parameters
+    }
+    stale = [f"{t}.{p}" for (t, p) in COERCION_EXEMPT if (t, p) not in present]
+    assert not stale, f"COERCION_EXEMPT references params that no longer exist: {stale}"

--- a/tests/src/unit/test_container_param_coercion_complete.py
+++ b/tests/src/unit/test_container_param_coercion_complete.py
@@ -2,10 +2,12 @@
 
 Issue #1581/#1601 root cause: some MCP clients (Claude Desktop, Cowork/Agent
 SDK) serialize object/array tool arguments as JSON-encoded *strings* before
-they reach the server. PR #1582 added the `JSON_STRING_COERCION` BeforeValidator
-and applied it to *some* dict/list params — but by hand, one call site at a
-time, which is exactly the pattern that let the #1485/#1487/#1492 regression
-slip through (tolerance was tied to the annotation and silently dropped).
+they reach the server. The #1485/#1487/#1492 series intentionally narrowed
+these params from `str | dict` to `dict` (a schema cleanup so models stop being
+told a JSON string is valid) — and that narrowing is what broke stringified-
+object clients (#1581). PR #1582 restored tolerance via the `JSON_STRING_COERCION`
+BeforeValidator, but applied it by hand, one call site at a time — the same
+per-annotation pattern that makes a missed param easy to overlook.
 
 This test makes the contract structural and impossible to regress: it walks
 *every* registered MCP tool parameter, and for every parameter whose declared
@@ -87,7 +89,9 @@ def _register_module(mcp: Any, module: Any, func_name: str | None) -> None:
             (
                 getattr(module, attr)
                 for attr in dir(module)
-                if attr.startswith("register_") and attr.endswith("_tools")
+                if attr.startswith("register_")
+                and attr.endswith("_tools")
+                and callable(getattr(module, attr))
             ),
             None,
         )
@@ -231,6 +235,101 @@ def test_container_param_passes_non_json_through_unchanged(
 
     ann = _param_annotation(tool_name, param_name)
     assert TypeAdapter(ann).validate_python(value) == value
+
+
+def _type_allows_str(annotation: Any) -> bool:
+    """True if `str` is a legitimate arm of the param's type (so it may validly
+    advertise a string in its schema)."""
+    if typing.get_origin(annotation) is typing.Annotated:
+        annotation = typing.get_args(annotation)[0]
+    args = typing.get_args(annotation)
+    if not args:
+        return annotation is str
+    return any(arg is str for arg in args)
+
+
+def _schema_advertises_string(schema: dict[str, Any]) -> bool:
+    return schema.get("type") == "string" or any(
+        variant.get("type") == "string" for variant in schema.get("anyOf", [])
+    )
+
+
+def test_dict_or_list_only_params_advertise_no_string_arm() -> None:
+    """Registry-driven companion to test_config_param_no_string_schema.py: every
+    container param that CANNOT be a `str` must not advertise a string arm in its
+    MCP schema. Walking all registered tools (not a hand-list) means a future
+    revert to `str | dict` on ANY of the coerced params re-introduces the #1485
+    regression here, not silently."""
+    if not _TOOLS_CACHE:
+        _TOOLS_CACHE.update(_all_registered_tools())
+
+    leaks: list[str] = []
+    for tool_name, tool in _TOOLS_CACHE.items():
+        props = tool.parameters.get("properties", {})
+        for param_name, param in inspect.signature(tool.fn).parameters.items():
+            annotation = param.annotation
+            if annotation is inspect.Parameter.empty:
+                continue
+            if not _type_can_be_container(annotation):
+                continue
+            if _type_allows_str(annotation):
+                continue  # union legitimately advertises a string arm
+            if (tool_name, param_name) in COERCION_EXEMPT:
+                continue
+            schema = props.get(param_name)
+            if schema and _schema_advertises_string(schema):
+                leaks.append(f"{tool_name}.{param_name}: {schema}")
+
+    assert not leaks, (
+        "dict/list-only params advertising a string arm (re-teaches models to "
+        "send JSON strings — the #1485 regression):\n  " + "\n  ".join(sorted(leaks))
+    )
+
+
+# Behavioral coercion for the dict-only params added in this PR — the guardrail
+# proves the validator is *present*; these prove it actually *works* end-to-end.
+@pytest.mark.parametrize(
+    ("tool_name", "param_name", "json_value", "expected"),
+    [
+        ("ha_manage_addon", "options", '{"ssl": true}', {"ssl": True}),
+        ("ha_manage_addon", "network", '{"5800/tcp": 8081}', {"5800/tcp": 8081}),
+        (
+            "ha_manage_energy_prefs",
+            "config",
+            '{"energy_sources": []}',
+            {"energy_sources": []},
+        ),
+    ],
+)
+def test_dict_only_param_coerces_json_object_string(
+    tool_name: str, param_name: str, json_value: str, expected: Any
+) -> None:
+    from pydantic import TypeAdapter
+
+    ann = _param_annotation(tool_name, param_name)
+    assert TypeAdapter(ann).validate_python(json_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "param_name"),
+    [
+        ("ha_manage_addon", "options"),
+        ("ha_manage_energy_prefs", "config"),
+    ],
+)
+def test_dict_only_param_rejects_malformed_and_array(
+    tool_name: str, param_name: str
+) -> None:
+    """A non-JSON string and a JSON *array* string both still fail dict
+    validation (keeps #1491's actionable error for genuinely-wrong input)."""
+    from pydantic import TypeAdapter, ValidationError
+
+    ann = _param_annotation(tool_name, param_name)
+    adapter = TypeAdapter(ann)
+    with pytest.raises(ValidationError):
+        adapter.validate_python("not valid json {")
+    with pytest.raises(ValidationError):
+        adapter.validate_python("[1, 2, 3]")
 
 
 def test_exempt_params_still_exist() -> None:

--- a/tests/src/unit/test_validation_middleware.py
+++ b/tests/src/unit/test_validation_middleware.py
@@ -143,6 +143,51 @@ async def test_union_param_malformed_container_names_param_not_union_tags():
 
 
 @pytest.mark.asyncio
+async def test_list_element_error_keeps_index_in_message():
+    """A bad ELEMENT in a list[dict] param keeps its index (`monday.1`), not
+    just the param name. Grouping must collapse union-arm tags WITHOUT dropping
+    real path elements like list indices (regression for the #1601 grouping)."""
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_schedule(monday: list[dict]) -> dict:
+        return {"ok": True}
+
+    with pytest.raises(ToolError) as exc_info:
+        # element 1 is a string, not a dict object
+        await mcp.call_tool("ha_test_schedule", {"monday": [{"from": "07:00"}, "oops"]})
+
+    msg = json.loads(str(exc_info.value))["error"]["message"]
+    assert "monday.1" in msg
+
+
+@pytest.mark.asyncio
+async def test_union_error_details_are_deduped():
+    """`details` collapses duplicate error types from union arms (#1601)."""
+    from typing import Annotated
+
+    from ha_mcp.tools.util_helpers import JSON_STRING_COERCION
+
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_union_details(
+        entity_id: Annotated[str | list[str], JSON_STRING_COERCION],
+    ) -> dict:
+        return {"ok": True}
+
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_union_details", {"entity_id": '{"a": 1}'})
+
+    details = json.loads(str(exc_info.value))["error"].get("details", "")
+    # both arms fail; each distinct type appears at most once
+    assert details.count("string_type") <= 1
+    assert details.count("list_type") <= 1
+
+
+@pytest.mark.asyncio
 async def test_tool_error_from_tool_body_passes_through_unconverted():
     """A ToolError raised inside the tool is NOT re-wrapped by the middleware."""
     mcp = FastMCP("test")

--- a/tests/src/unit/test_validation_middleware.py
+++ b/tests/src/unit/test_validation_middleware.py
@@ -107,6 +107,42 @@ async def test_error_is_structured():
 
 
 @pytest.mark.asyncio
+async def test_union_param_malformed_container_names_param_not_union_tags():
+    """A wrong-container value on a `str | list[str]` param yields ONE message
+    keyed by the real param name, not pydantic union-arm tags (`str`/`list[str]`).
+
+    Regression for #1601: extending JSON_STRING_COERCION to ~28 union params
+    widened the surface where a malformed container (e.g. a JSON-object string)
+    fails every union arm and pydantic emits one error per arm. Without grouping,
+    the user saw `entity_id.str` / `entity_id.list[str]` instead of `entity_id`.
+    """
+    from typing import Annotated
+
+    from ha_mcp.tools.util_helpers import JSON_STRING_COERCION
+
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_union_param(
+        entity_id: Annotated[str | list[str], JSON_STRING_COERCION],
+    ) -> dict:
+        return {"ok": True}
+
+    with pytest.raises(ToolError) as exc_info:
+        # A JSON-object string coerces to a dict, which fails both the str and
+        # the list[str] arm of the union.
+        await mcp.call_tool("ha_test_union_param", {"entity_id": '{"a": 1}'})
+
+    msg = json.loads(str(exc_info.value))["error"]["message"]
+    assert "entity_id" in msg
+    # No leaked pydantic union-arm tags, and a single line for the single param.
+    assert "list[str]" not in msg
+    assert "`str`" not in msg
+    assert ";" not in msg
+
+
+@pytest.mark.asyncio
 async def test_tool_error_from_tool_body_passes_through_unconverted():
     """A ToolError raised inside the tool is NOT re-wrapped by the middleware."""
     mcp = FastMCP("test")


### PR DESCRIPTION
## What does this PR do?

Extends the `JSON_STRING_COERCION` `BeforeValidator` from #1582 (issue #1581) to **every** remaining MCP container parameter, closing the rest of #1601.

#1582 fixed only the handful of params it touched. #1601 showed the same failure on others — `ha_get_state` / `ha_get_entity` / `ha_set_entity.entity_id`, `ha_config_set_group.entities`, `ha_config_set_helper`'s schedule days, `ha_get_history.entity_ids`, the `*fields` projection params, and more. When a client (Claude Desktop, Cowork/Agent SDK) serializes a container argument as a JSON-encoded string, those params either hard-rejected it (`dict_type` / `list_type`) or — for `str | list` unions — silently matched the `str` arm and mishandled it (the reported `ha_get_state` → `ENTITY_NOT_FOUND`).

**Changes**
- Apply `JSON_STRING_COERCION` to all 45 remaining container params across 13 tool modules (dict/list-only **and** `str | list` unions). Runtime-only — the advertised JSON schema is unchanged (no string arm re-introduced), so the #1485/#1487/#1492 schema fix is preserved.
- **Guardrail tests** that enumerate every registered MCP param — including `EXPLICIT_MODULES` (backup) and beta/gated tools — and fail if any container param lacks the coercion, or if any dict/list-only param advertises a string arm. Makes the contract structural so it can't silently regress again (the root cause of #1581).
- Two params deliberately exempt (documented allowlist): `ha_manage_addon.body` (str = raw request body) and `ha_manage_energy_prefs.config_hash` (str vs dict = distinct lock semantics), plus a `config_hash` doc note steering string-only clients to the full-blob form.
- `ValidationErrorMiddleware`: group errors by the real argument name so a malformed container on a union param reports `` `entity_id` `` instead of pydantic union tags (`entity_id.str` / `entity_id.list[str]`), while preserving list-element indices (e.g. `` `monday.1` ``).
- Remove the now-dead in-body JSON re-parse on `ha_get_operation_status` (the validator handles it upstream).

Closes #1601.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

- New structural + schema guardrail and behavioral tests pin both halves: a JSON-array string coerces to a list (dict and union params); native values, comma-separated strings, and bare strings pass through unchanged; and no dict/list-only param advertises a string arm.
- New middleware regression tests for union-param error rendering and list-element index preservation.
- The advertised MCP wire schema is byte-for-byte identical base vs. branch (a `BeforeValidator` is invisible to JSON-schema generation).
- `ruff`, `ruff format`, and `mypy` clean on all changed files.

## Checklist
- [x] I have updated documentation if needed (tool param descriptions)
