### PR TITLE
feat: add dead_entities section to ha_get_system_health

### DIFF
--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -1002,7 +1002,7 @@ class SystemTools:
                 self._client.send_websocket_message(
                     {"type": "config/entity_registry/list"}
                 ),
-                self._client.send_websocket_message({"type": "config/entries/get"}),
+                self._client.send_websocket_message({"type": "config_entries/get"}),
                 return_exceptions=True,
             )
             states = results[0]

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -33,6 +33,21 @@ from .util_helpers import (
 
 logger = logging.getLogger(__name__)
 
+
+def _reraise_if_fatal(exc: BaseException) -> None:
+    """Re-raise exceptions that must unwind rather than be demoted to an
+    embedded section error: task cancellation and interpreter exit
+    (``CancelledError``/``KeyboardInterrupt``/``SystemExit`` are all
+    ``BaseException`` but not ``Exception``) plus ``ToolError`` (which carries
+    the MCP ``isError`` contract). Mirrors the re-raise pre-pass on the ws
+    ``sections`` gather in ``ha_get_system_health``. Recoverable
+    ``Exception``-level failures fall through to the caller's embed-as-error
+    handling, matching every sibling section helper.
+    """
+    if isinstance(exc, ToolError) or not isinstance(exc, Exception):
+        raise exc
+
+
 # Mapping of reload targets to their service domains and services
 RELOAD_TARGETS = {
     "all": None,  # Special case - reload all
@@ -939,7 +954,12 @@ class SystemTools:
         the ``result`` list on success, else ``None`` so the caller can treat a
         backend failure as "source unavailable".
         """
-        if isinstance(resp, BaseException) or not isinstance(resp, dict):
+        if isinstance(resp, BaseException):
+            # gather(return_exceptions=True) hands back the raw exception; let
+            # truly-fatal ones unwind instead of masking them as "unavailable".
+            _reraise_if_fatal(resp)
+            return None
+        if not isinstance(resp, dict):
             return None
         # Require success truthy before trusting ``result`` — matches the
         # ``if result.get("success")`` convention used by the other WS handlers
@@ -1010,8 +1030,17 @@ class SystemTools:
             )
             states = results[0]
 
-            if isinstance(states, BaseException) or not isinstance(states, list):
+            if isinstance(states, BaseException):
+                # Truly-fatal errors must propagate, not demote to a section
+                # error string (mirrors the ws sections gather pre-pass).
+                _reraise_if_fatal(states)
                 dead["error"] = f"Could not fetch entity states: {states}"
+                return dead
+            if not isinstance(states, list):
+                dead["error"] = (
+                    "Could not fetch entity states: expected list, got "
+                    f"{type(states).__name__}"
+                )
                 return dead
             registry = self._ws_result_list(results[1])
             if registry is None:

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -938,7 +938,11 @@ class SystemTools:
         """
         if isinstance(resp, BaseException) or not isinstance(resp, dict):
             return None
-        if resp.get("success") is False:
+        # Require success truthy before trusting ``result`` — matches the
+        # ``if result.get("success")`` convention used by the other WS handlers
+        # in this file (and treats a malformed envelope missing the key as a
+        # failure rather than reading a half-built result).
+        if not resp.get("success"):
             return None
         result = resp.get("result")
         return result if isinstance(result, list) else None

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -36,16 +36,37 @@ logger = logging.getLogger(__name__)
 
 def _reraise_if_fatal(exc: BaseException) -> None:
     """Re-raise exceptions that must unwind rather than be demoted to an
-    embedded section error: task cancellation and interpreter exit
-    (``CancelledError``/``KeyboardInterrupt``/``SystemExit`` are all
-    ``BaseException`` but not ``Exception``) plus ``ToolError`` (which carries
-    the MCP ``isError`` contract). Encapsulates the same policy as the
-    re-raise pre-pass on the ws ``sections`` gather in ``ha_get_system_health``
-    — keep both in sync when adding exception classes. Recoverable
-    ``Exception``-level failures fall through to the caller's embed-as-error
-    handling, matching every sibling section helper.
+    embedded section error:
+
+    - ``CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit`` (all
+      ``BaseException`` but not ``Exception``) — task cancellation and
+      interpreter exit.
+    - ``ToolError`` — carries the MCP ``isError`` contract.
+    - ``HomeAssistantConnectionError`` — once the HA transport is dead the
+      remaining section fetches will fail anyway, so propagate the root
+      cause as ``isError=true`` rather than embed N per-section connection
+      errors. The codebase's ``rest_client._request`` already wraps
+      ``OSError`` / timeout / transport failures into this class, so it is
+      the single fatal class to gate on.
+
+    This implements the cross-section policy proposed in #1624: a dead
+    connection fails loud rather than degrade per-section. Every section
+    helper in ``ha_get_system_health`` routes its ``except Exception`` block
+    through this gate as its first line, so the policy is consistent across
+    the ws ``sections`` gather pre-pass and every inline section. Recoverable
+    ``Exception``-level failures still fall through to the caller's
+    embed-as-error handling.
     """
-    if isinstance(exc, ToolError) or not isinstance(exc, Exception):
+    # Local import: ``rest_client`` imports from tool helpers transitively,
+    # so a module-level import here would risk a circular import in the
+    # tools package.
+    from ..client.rest_client import HomeAssistantConnectionError
+
+    if (
+        isinstance(exc, ToolError)
+        or not isinstance(exc, Exception)
+        or isinstance(exc, HomeAssistantConnectionError)
+    ):
         raise exc
 
 
@@ -557,17 +578,13 @@ class SystemTools:
                 # inside a helper would otherwise be silently demoted to
                 # ``{"error": "ToolError: …"}`` and break the MCP
                 # ``isError=true`` contract for the whole tool.
+                # ``_reraise_if_fatal`` encapsulates the policy (cancellation,
+                # interpreter-exit, ``ToolError``, and the codebase's transport
+                # ``HomeAssistantConnectionError``) — the single source of
+                # truth shared with each section helper's ``except`` chain.
                 for section_result in gathered:
-                    if isinstance(section_result, asyncio.CancelledError):
-                        raise section_result
-                    if isinstance(section_result, ToolError):
-                        raise section_result
-                    if isinstance(section_result, BaseException) and not isinstance(
-                        section_result, Exception
-                    ):
-                        # ``KeyboardInterrupt`` / ``SystemExit`` — never demote
-                        # these to a section-level error string.
-                        raise section_result
+                    if isinstance(section_result, BaseException):
+                        _reraise_if_fatal(section_result)
                 for (section_name, _), section_result in zip(
                     sections, gathered, strict=True
                 ):
@@ -669,7 +686,16 @@ class SystemTools:
                 # (states via /api/states, registry + config-entries via the
                 # bridge), not the health ws_client — so it runs inline like
                 # config_check and survives a baseline-WS-down install.
-                result["dead_entities"] = await self._fetch_dead_entities()
+                dead_section = await self._fetch_dead_entities()
+                # Pop the ``_warnings`` sentinel and bubble it to the top-level
+                # ``result["warnings"]`` (the documented contract location).
+                # The section helper uses this sentinel so its return signature
+                # stays uniform with every other section (a plain dict) while
+                # avoiding a collision with the reserved ``warnings`` term.
+                section_warnings = dead_section.pop("_warnings", None)
+                if section_warnings:
+                    result.setdefault("warnings", []).extend(section_warnings)
+                result["dead_entities"] = dead_section
 
             return result
 
@@ -798,6 +824,7 @@ class SystemTools:
                 )
                 repairs["error"] = f"Repairs data not available: {err_msg}"
         except Exception as e:
+            _reraise_if_fatal(e)
             logger.warning("Failed to fetch repairs: %s", e)
             repairs["error"] = f"Repairs data not available: {e}"
         return repairs
@@ -843,6 +870,7 @@ class SystemTools:
                         "Use ha_get_device(integration='zha') for full device list."
                     )
         except Exception as e:
+            _reraise_if_fatal(e)
             logger.warning("Failed to fetch ZHA network data: %s", e)
             zha_network["error"] = f"ZHA integration not available or error: {e}"
         return zha_network
@@ -906,6 +934,7 @@ class SystemTools:
                         "Use ha_get_device(integration='zwave_js') for full device list."
                     )
         except Exception as e:
+            _reraise_if_fatal(e)
             logger.warning("Failed to fetch Z-Wave network data: %s", e)
             zwave_network["error"] = (
                 f"Z-Wave JS integration not available or error: {e}"
@@ -940,36 +969,53 @@ class SystemTools:
                 )
                 themes_data["error"] = f"Themes data not available: {err_msg}"
         except Exception as e:
+            _reraise_if_fatal(e)
             logger.warning("Failed to fetch themes: %s", e)
             themes_data["error"] = f"Themes data not available: {e}"
         return themes_data
 
     @staticmethod
-    def _ws_result_list(resp: Any) -> list[dict[str, Any]] | None:
-        """Unwrap a ``send_websocket_message`` response into a list, or None.
+    def _ws_result_list(
+        resp: Any,
+    ) -> tuple[list[dict[str, Any]] | None, str | None]:
+        """Unwrap a ``send_websocket_message`` response into ``(list, None)``
+        on success or ``(None, error_str)`` on failure.
 
         ``send_websocket_message`` returns the HA WebSocket envelope
         (``{"success": bool, "result": [...]}``) on success and
         ``{"success": False, "error": ...}`` on failure; ``return_exceptions``
-        in the caller's ``gather`` can also hand back a raw exception. Returns
-        the ``result`` list on success, else ``None`` so the caller can treat a
-        backend failure as "source unavailable".
+        in the caller's ``gather`` can also hand back a raw exception.
+        Preserves the underlying cause string (envelope error message,
+        exception type, or wrong-shape description) so the caller can
+        attribute the failure rather than substitute a fixed "unavailable"
+        message that hides the root cause (auth vs command error vs
+        malformed envelope). Fatal exceptions (per ``_reraise_if_fatal``)
+        unwind instead of being returned as an error string.
         """
         if isinstance(resp, BaseException):
             # gather(return_exceptions=True) hands back the raw exception; let
             # truly-fatal ones unwind instead of masking them as "unavailable".
             _reraise_if_fatal(resp)
-            return None
+            return None, f"{type(resp).__name__}: {resp}"
         if not isinstance(resp, dict):
-            return None
+            return None, f"unexpected response type: {type(resp).__name__}"
         # Require success truthy before trusting ``result`` — matches the
         # ``if result.get("success")`` convention used by the other WS handlers
         # in this file (and treats a malformed envelope missing the key as a
         # failure rather than reading a half-built result).
         if not resp.get("success"):
-            return None
+            err = resp.get("error")
+            if isinstance(err, dict):
+                err_msg = err.get("message") or err.get("code") or str(err)
+            elif err:
+                err_msg = str(err)
+            else:
+                err_msg = "unknown error"
+            return None, str(err_msg)
         result = resp.get("result")
-        return result if isinstance(result, list) else None
+        if isinstance(result, list):
+            return result, None
+        return None, f"unexpected result shape: {type(result).__name__}"
 
     async def _fetch_dead_entities(self) -> dict[str, Any]:
         """Surface orphaned/stale entity-registry entries.
@@ -1012,6 +1058,14 @@ class SystemTools:
             "stale_restored": {"items": [], "count": 0, "total_count": 0},
             "summary": {"candidate_total": 0, "registry_total": 0},
         }
+        # Warnings collected here are bubbled to the top-level
+        # ``result["warnings"]`` by the aggregator. The section returns a
+        # plain dict (like every other section helper, keeping the return
+        # signature uniform) with a ``_warnings`` sentinel that
+        # ``ha_get_system_health`` pops and extends onto ``result["warnings"]``
+        # — the documented contract location, which a section-local
+        # ``warnings`` key would collide with.
+        bubble_warnings: list[str] = []
         try:
             # Index the gather result (rather than tuple-unpack) so mypy can
             # type each element through the return_exceptions=True overload;
@@ -1038,32 +1092,43 @@ class SystemTools:
                     f"{type(states).__name__}"
                 )
                 return dead
-            registry = self._ws_result_list(results[1])
+            registry, registry_err = self._ws_result_list(results[1])
             if registry is None:
+                # Preserve the underlying cause (envelope error message,
+                # exception type, or wrong-shape description) so the client
+                # can distinguish auth vs command vs malformed envelope
+                # rather than see a fixed "unavailable" substitute.
                 dead["error"] = (
-                    "Could not fetch entity registry "
-                    "(config/entity_registry/list unavailable)"
+                    f"Could not fetch entity registry "
+                    f"(config/entity_registry/list: {registry_err})"
                 )
                 return dead
 
             # config-entries is the only optional source: without it the
             # definitive orphan tier can't be computed, but stale_restored still
             # can — so degrade rather than fail the whole section.
-            entries = self._ws_result_list(results[2])
+            entries, entries_err = self._ws_result_list(results[2])
             live_entry_ids: set[str] | None = None
-            # Treat an empty list like a failed fetch. A config-entry-linked
-            # registry entry implies its config entry exists, so an empty
-            # config_entries/get is either a genuinely integration-less install
-            # (no cfg-linked entries to orphan anyway) or a backend hiccup that
-            # masquerades as success. Either way we cannot tell a removed
-            # integration from the empty result — so skip the orphan tier rather
-            # than flag every cfg-linked entry as dead.
-            if not entries:
+            if entries is None:
+                # Genuine fetch failure — preserve the cause so a backend
+                # failure isn't reported as "no entries".
                 dead["config_entries_checked"] = False
-                dead.setdefault("warnings", []).append(
-                    "config_entries/get returned no entries; config_entry_orphans "
-                    "tier skipped (cannot distinguish a removed integration from "
-                    "an empty or failed fetch). stale_restored still computed."
+                bubble_warnings.append(
+                    f"config_entries/get failed ({entries_err}); "
+                    "config_entry_orphans tier skipped (cannot distinguish a "
+                    "removed integration from a failed fetch). stale_restored "
+                    "still computed."
+                )
+            elif not entries:
+                # Real empty list — HA reports no config entries configured.
+                # Distinct from a fetch failure: the message names the actual
+                # state. The orphan tier still skips since there is no live
+                # set to diff against; stale_restored still computed.
+                dead["config_entries_checked"] = False
+                bubble_warnings.append(
+                    "config_entries/get returned an empty list (no "
+                    "integrations configured); config_entry_orphans tier "
+                    "skipped. stale_restored still computed."
                 )
             else:
                 live_entry_ids = {
@@ -1167,8 +1232,18 @@ class SystemTools:
             # error string here (AGENTS.md error-handling guard pattern).
             raise
         except Exception as e:
-            logger.warning("Failed to compute dead entities: %s", e)
+            _reraise_if_fatal(e)
+            # ``logger.exception`` so an unexpected diff bug gets a full
+            # traceback rather than a one-line warning that hides the
+            # site of the regression.
+            logger.exception("Failed to compute dead entities")
             dead["error"] = f"Dead-entities diff not available: {e}"
+        # ``_warnings`` is a sentinel that ``ha_get_system_health`` pops to
+        # ``result["warnings"]``; it never reaches the client. Attaching it
+        # outside the try/except keeps it correct on both happy and
+        # embed-as-error paths.
+        if bubble_warnings:
+            dead["_warnings"] = bubble_warnings
         return dead
 
     async def _fetch_config_check(self) -> dict[str, Any]:
@@ -1199,6 +1274,7 @@ class SystemTools:
                 "errors": errors,
             }
         except Exception as e:
+            _reraise_if_fatal(e)
             logger.warning("Failed to check config: %s", e)
             config_check["error"] = f"Config check not available: {e}"
         return config_check

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -1080,8 +1080,12 @@ class SystemTools:
                 state_obj = state_by_id.get(eid)
                 if state_obj is None:
                     continue
-                attrs = state_obj.get("attributes") or {}
-                if state_obj.get("state") == "unavailable" and attrs.get("restored"):
+                attrs = state_obj.get("attributes")
+                if (
+                    state_obj.get("state") == "unavailable"
+                    and isinstance(attrs, dict)
+                    and attrs.get("restored")
+                ):
                     stale.append(
                         {
                             "entity_id": eid,

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -954,7 +954,7 @@ class SystemTools:
         config-entries set, classifying findings into confidence tiers:
 
         - ``config_entry_orphans`` (definitive): registry entries whose
-          ``config_entry_id`` is no longer present in ``config/entries/get`` —
+          ``config_entry_id`` is no longer present in ``config_entries/get`` —
           the owning integration instance was removed, leaving the registry
           entry behind.
         - ``stale_restored`` (likely): entries HA recreated from the registry on
@@ -1026,7 +1026,7 @@ class SystemTools:
             if entries is None:
                 dead["config_entries_checked"] = False
                 dead.setdefault("warnings", []).append(
-                    "config/entries/get unavailable; config_entry_orphans tier "
+                    "config_entries/get unavailable; config_entry_orphans tier "
                     "skipped (stale_restored still computed)."
                 )
             else:

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -39,8 +39,9 @@ def _reraise_if_fatal(exc: BaseException) -> None:
     embedded section error: task cancellation and interpreter exit
     (``CancelledError``/``KeyboardInterrupt``/``SystemExit`` are all
     ``BaseException`` but not ``Exception``) plus ``ToolError`` (which carries
-    the MCP ``isError`` contract). Mirrors the re-raise pre-pass on the ws
-    ``sections`` gather in ``ha_get_system_health``. Recoverable
+    the MCP ``isError`` contract). Encapsulates the same policy as the
+    re-raise pre-pass on the ws ``sections`` gather in ``ha_get_system_health``
+    — keep both in sync when adding exception classes. Recoverable
     ``Exception``-level failures fall through to the caller's embed-as-error
     handling, matching every sibling section helper.
     """
@@ -993,7 +994,9 @@ class SystemTools:
         also gone — those still surface as orphans). The ``restored`` flag is
         what HA sets when it rebuilds a state object from the registry's cached
         last state because no live platform currently provides the entity; it is
-        the discriminator between "dead" and "temporarily offline".
+        the discriminator between "dead" and "temporarily offline". (This tracks
+        HA Core's state-restoration behaviour; re-verify if classification drifts
+        after an HA upgrade.)
 
         Entities can appear under ``stale_restored`` transiently right after a
         restart, before integrations finish loading; ``note`` flags this.
@@ -1145,6 +1148,12 @@ class SystemTools:
                 "candidate_total": len(orphans) + len(stale),
                 "registry_total": len(registry),
             }
+        except ToolError:
+            # A ToolError (incl. one re-raised by _reraise_if_fatal) carries the
+            # MCP isError contract — let it reach ha_get_system_health's own
+            # ``except ToolError: raise`` instead of being demoted to a section
+            # error string here (AGENTS.md error-handling guard pattern).
+            raise
         except Exception as e:
             logger.warning("Failed to compute dead entities: %s", e)
             dead["error"] = f"Dead-entities diff not available: {e}"

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -1011,13 +1011,6 @@ class SystemTools:
             "config_entry_orphans": {"items": [], "count": 0, "total_count": 0},
             "stale_restored": {"items": [], "count": 0, "total_count": 0},
             "summary": {"candidate_total": 0, "registry_total": 0},
-            "note": (
-                "Excludes 'unknown'-state entities and merely-offline devices "
-                "(bare 'unavailable' without 'restored'). Entries can appear "
-                "under stale_restored transiently right after a restart; re-run "
-                "if HA restarted recently. Remove a confirmed-dead entity with "
-                "ha_remove_entity(entity_id)."
-            ),
         }
         try:
             # Index the gather result (rather than tuple-unpack) so mypy can
@@ -1058,11 +1051,19 @@ class SystemTools:
             # can — so degrade rather than fail the whole section.
             entries = self._ws_result_list(results[2])
             live_entry_ids: set[str] | None = None
-            if entries is None:
+            # Treat an empty list like a failed fetch. A config-entry-linked
+            # registry entry implies its config entry exists, so an empty
+            # config_entries/get is either a genuinely integration-less install
+            # (no cfg-linked entries to orphan anyway) or a backend hiccup that
+            # masquerades as success. Either way we cannot tell a removed
+            # integration from the empty result — so skip the orphan tier rather
+            # than flag every cfg-linked entry as dead.
+            if not entries:
                 dead["config_entries_checked"] = False
                 dead.setdefault("warnings", []).append(
-                    "config_entries/get unavailable; config_entry_orphans tier "
-                    "skipped (stale_restored still computed)."
+                    "config_entries/get returned no entries; config_entry_orphans "
+                    "tier skipped (cannot distinguish a removed integration from "
+                    "an empty or failed fetch). stale_restored still computed."
                 )
             else:
                 live_entry_ids = {
@@ -1142,12 +1143,23 @@ class SystemTools:
                     )
                 return bucket
 
+            candidate_total = len(orphans) + len(stale)
             dead["config_entry_orphans"] = _bucket(orphans)
             dead["stale_restored"] = _bucket(stale)
             dead["summary"] = {
-                "candidate_total": len(orphans) + len(stale),
+                "candidate_total": candidate_total,
                 "registry_total": len(registry),
             }
+            # Only attach the guidance note when there is something to act on —
+            # no point spending tokens on cleanup advice for an empty result.
+            if candidate_total:
+                dead["note"] = (
+                    "Excludes 'unknown'-state entities and merely-offline "
+                    "devices (bare 'unavailable' without 'restored'). Entries "
+                    "can appear under stale_restored transiently right after a "
+                    "restart; re-run if HA restarted recently. Remove a "
+                    "confirmed-dead entity with ha_remove_entity(entity_id)."
+                )
         except ToolError:
             # A ToolError (incl. one re-raised by _reraise_if_fatal) carries the
             # MCP isError contract — let it reach ha_get_system_health's own

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -842,8 +842,11 @@ class SystemTools:
             "total_count": 0,
         }
         try:
-            # Get all zwave_js config entries to find entry_id
-            entries_result = await ws_client.send_command("config/entries/get")
+            # Get all zwave_js config entries to find entry_id. The HA command
+            # is ``config_entries/get`` (underscore); the slash form is rejected
+            # as "Unknown command", which the outer except would mask as
+            # "Z-Wave JS integration not available".
+            entries_result = await ws_client.send_command("config_entries/get")
             zwave_entry_id = None
             if entries_result.get("success"):
                 for entry in entries_result.get("result", []):

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -354,6 +354,15 @@ class SystemTools:
           - "config_check": Validate HA configuration via POST /config/core/check_config
             (the pre-restart safety check; ha_restart runs it automatically). Returns
             {result: valid|invalid, is_valid, errors}; read-only/idempotent, takes no args.
+          - "dead_entities": Surface orphaned/stale entity-registry entries by diffing
+            the registry against the state machine and the live config-entries set.
+            Returns confidence-tiered buckets — ``config_entry_orphans`` (owning
+            integration instance gone; definitively dead) and ``stale_restored`` (HA
+            restored the entity from the registry on startup but the loaded integration
+            no longer provides it). Each item carries entity_id + platform so a client
+            can propose cleanup with ha_remove_entity. Deliberately excludes
+            ``unknown``-state entities and merely-offline devices to keep false positives
+            low. Read-only; takes no args.
           - Example: include="repairs,zha_network,zwave_network,config_check"
           - Example: include="diagnostics", config_entry_id="abc123..."
         - include_dismissed_repairs: Include user-dismissed/ignored repairs (default: False). Only meaningful when "repairs" is in `include`.
@@ -416,16 +425,19 @@ class SystemTools:
                 # catch cannot swallow an unrelated ToolError.
                 #
                 # Degrade gracefully ONLY when the caller asked for a REST-based
-                # section (config_check / diagnostics) that can still be served
-                # without the WebSocket. config_check is the pure-REST
-                # replacement for the removed ha_check_config tool, so it must
-                # not depend on the health WebSocket (the system_health/info
-                # command carries its own 10s timeout and can hang/be absent on
-                # some installs). If the caller asked for nothing (the health
-                # baseline itself) or only WS-backed sections, the baseline WAS
-                # the deliverable: re-raise so the failure surfaces as
-                # isError=true, exactly as before this change.
-                if not (includes & {"config_check", "diagnostics"}):
+                # section (config_check / diagnostics / dead_entities) that can
+                # still be served without the WebSocket. config_check is the
+                # pure-REST replacement for the removed ha_check_config tool, so
+                # it must not depend on the health WebSocket (the
+                # system_health/info command carries its own 10s timeout and can
+                # hang/be absent on some installs). dead_entities uses the REST
+                # client's own per-client WebSocket bridge for the registry +
+                # config-entries (not this health ws_client), so it is likewise
+                # independent of the baseline. If the caller asked for nothing
+                # (the health baseline itself) or only WS-backed sections, the
+                # baseline WAS the deliverable: re-raise so the failure surfaces
+                # as isError=true, exactly as before this change.
+                if not (includes & {"config_check", "diagnostics", "dead_entities"}):
                     raise
                 logger.warning("system_health baseline unavailable: %s", health_err)
                 ws_client = None
@@ -450,6 +462,7 @@ class SystemTools:
                 "diagnostics",
                 "config_check",
                 "themes",
+                "dead_entities",
             }
             unknown = includes - VALID_INCLUDES
             if unknown:
@@ -634,6 +647,13 @@ class SystemTools:
                 # ``if`` (not chained to diagnostics) so both can be requested
                 # in one call.
                 result["config_check"] = await self._fetch_config_check()
+
+            if "dead_entities" in includes:
+                # REST + the REST client's own per-client WebSocket bridge
+                # (states via /api/states, registry + config-entries via the
+                # bridge), not the health ws_client — so it runs inline like
+                # config_check and survives a baseline-WS-down install.
+                result["dead_entities"] = await self._fetch_dead_entities()
 
             return result
 
@@ -904,6 +924,191 @@ class SystemTools:
             logger.warning("Failed to fetch themes: %s", e)
             themes_data["error"] = f"Themes data not available: {e}"
         return themes_data
+
+    @staticmethod
+    def _ws_result_list(resp: Any) -> list[dict[str, Any]] | None:
+        """Unwrap a ``send_websocket_message`` response into a list, or None.
+
+        ``send_websocket_message`` returns the HA WebSocket envelope
+        (``{"success": bool, "result": [...]}``) on success and
+        ``{"success": False, "error": ...}`` on failure; ``return_exceptions``
+        in the caller's ``gather`` can also hand back a raw exception. Returns
+        the ``result`` list on success, else ``None`` so the caller can treat a
+        backend failure as "source unavailable".
+        """
+        if isinstance(resp, BaseException) or not isinstance(resp, dict):
+            return None
+        if resp.get("success") is False:
+            return None
+        result = resp.get("result")
+        return result if isinstance(result, list) else None
+
+    async def _fetch_dead_entities(self) -> dict[str, Any]:
+        """Surface orphaned/stale entity-registry entries.
+
+        Diffs the entity registry against the state machine and the live
+        config-entries set, classifying findings into confidence tiers:
+
+        - ``config_entry_orphans`` (definitive): registry entries whose
+          ``config_entry_id`` is no longer present in ``config/entries/get`` —
+          the owning integration instance was removed, leaving the registry
+          entry behind.
+        - ``stale_restored`` (likely): entries HA recreated from the registry on
+          startup — state ``unavailable`` with ``restored: true`` — whose owning
+          config entry still exists. The integration is loaded but no longer
+          provides the entity (renamed/removed device, re-paired Zigbee).
+
+        Deliberately NEVER flagged, to keep false positives low: ``unknown``
+        state (alive, just no current value — e.g. weather/disaster-alert
+        sensors), bare ``unavailable`` without ``restored`` (a loaded
+        integration reporting a device merely offline right now), and entries
+        disabled via ``disabled_by`` (intentional, unless their config entry is
+        also gone — those still surface as orphans). The ``restored`` flag is
+        what HA sets when it rebuilds a state object from the registry's cached
+        last state because no live platform currently provides the entity; it is
+        the discriminator between "dead" and "temporarily offline".
+
+        Entities can appear under ``stale_restored`` transiently right after a
+        restart, before integrations finish loading; ``note`` flags this.
+
+        Instance method (not @staticmethod): uses the REST client
+        (``self._client``) for states plus its per-client WebSocket bridge for
+        the registry + config entries, so it needs no system_health ws_client
+        and runs even when the health baseline is unavailable.
+        """
+        DEAD_ENTITIES_LIMIT = 50
+        dead: dict[str, Any] = {
+            "config_entry_orphans": {"items": [], "count": 0, "total_count": 0},
+            "stale_restored": {"items": [], "count": 0, "total_count": 0},
+            "summary": {"candidate_total": 0, "registry_total": 0},
+            "note": (
+                "Excludes 'unknown'-state entities and merely-offline devices "
+                "(bare 'unavailable' without 'restored'). Entries can appear "
+                "under stale_restored transiently right after a restart; re-run "
+                "if HA restarted recently. Remove a confirmed-dead entity with "
+                "ha_remove_entity(entity_id)."
+            ),
+        }
+        try:
+            # Index the gather result (rather than tuple-unpack) so mypy can
+            # type each element through the return_exceptions=True overload;
+            # mirrors smart_search/_entities.py::_fetch_search_entities.
+            results = await asyncio.gather(
+                self._client.get_states(),
+                self._client.send_websocket_message(
+                    {"type": "config/entity_registry/list"}
+                ),
+                self._client.send_websocket_message({"type": "config/entries/get"}),
+                return_exceptions=True,
+            )
+            states = results[0]
+
+            if isinstance(states, BaseException) or not isinstance(states, list):
+                dead["error"] = f"Could not fetch entity states: {states}"
+                return dead
+            registry = self._ws_result_list(results[1])
+            if registry is None:
+                dead["error"] = (
+                    "Could not fetch entity registry "
+                    "(config/entity_registry/list unavailable)"
+                )
+                return dead
+
+            # config-entries is the only optional source: without it the
+            # definitive orphan tier can't be computed, but stale_restored still
+            # can — so degrade rather than fail the whole section.
+            entries = self._ws_result_list(results[2])
+            live_entry_ids: set[str] | None = None
+            if entries is None:
+                dead["config_entries_checked"] = False
+                dead.setdefault("warnings", []).append(
+                    "config/entries/get unavailable; config_entry_orphans tier "
+                    "skipped (stale_restored still computed)."
+                )
+            else:
+                live_entry_ids = {
+                    e["entry_id"]
+                    for e in entries
+                    if isinstance(e, dict) and e.get("entry_id")
+                }
+                dead["config_entries_checked"] = True
+
+            state_by_id = {
+                s["entity_id"]: s
+                for s in states
+                if isinstance(s, dict) and s.get("entity_id")
+            }
+
+            orphans: list[dict[str, Any]] = []
+            stale: list[dict[str, Any]] = []
+            for entry in registry:
+                if not isinstance(entry, dict):
+                    continue
+                eid = entry.get("entity_id")
+                if not eid:
+                    continue
+                cfg = entry.get("config_entry_id")
+                disabled_by = entry.get("disabled_by")
+
+                # Tier 1 — config-entry orphan (only when the live set loaded).
+                # Covers disabled leftovers too: a disabled entity whose config
+                # entry is gone is still dead cruft (disabled_by is surfaced on
+                # the item so the client sees why it lingered).
+                if live_entry_ids is not None and cfg and cfg not in live_entry_ids:
+                    orphans.append(
+                        {
+                            "entity_id": eid,
+                            "platform": entry.get("platform"),
+                            "config_entry_id": cfg,
+                            "disabled_by": disabled_by,
+                            "has_state": eid in state_by_id,
+                        }
+                    )
+                    continue
+
+                # Tier 2 — stale restored. Skip intentionally-disabled entries
+                # (they normally have no state object anyway).
+                if disabled_by is not None:
+                    continue
+                state_obj = state_by_id.get(eid)
+                if state_obj is None:
+                    continue
+                attrs = state_obj.get("attributes") or {}
+                if state_obj.get("state") == "unavailable" and attrs.get("restored"):
+                    stale.append(
+                        {
+                            "entity_id": eid,
+                            "platform": entry.get("platform"),
+                            "config_entry_id": cfg,
+                        }
+                    )
+
+            def _bucket(items: list[dict[str, Any]]) -> dict[str, Any]:
+                total = len(items)
+                capped = items[:DEAD_ENTITIES_LIMIT]
+                bucket: dict[str, Any] = {
+                    "items": capped,
+                    "count": len(capped),
+                    "total_count": total,
+                }
+                if total > DEAD_ENTITIES_LIMIT:
+                    bucket["truncated"] = True
+                    bucket["hint"] = (
+                        f"Showing {DEAD_ENTITIES_LIMIT} of {total}; "
+                        "remove cleanup candidates in batches and re-run."
+                    )
+                return bucket
+
+            dead["config_entry_orphans"] = _bucket(orphans)
+            dead["stale_restored"] = _bucket(stale)
+            dead["summary"] = {
+                "candidate_total": len(orphans) + len(stale),
+                "registry_total": len(registry),
+            }
+        except Exception as e:
+            logger.warning("Failed to compute dead entities: %s", e)
+            dead["error"] = f"Dead-entities diff not available: {e}"
+        return dead
 
     async def _fetch_config_check(self) -> dict[str, Any]:
         """Validate HA configuration via POST /config/core/check_config.

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -71,6 +71,50 @@ class TestSystemTools:
         logger.info("Config check test completed successfully")
 
     @pytest.mark.asyncio
+    async def test_dead_entities_via_system_health(self, mcp_client):
+        """
+        Test: Surface orphaned/stale registry entries via
+        ha_get_system_health(include="dead_entities").
+
+        Validates the section shape (tiered buckets + summary) against a real HA
+        instance. The clean test environment is not expected to carry dead
+        entries, so the assertion is on structure, not on specific findings.
+        """
+        logger.info("Fetching dead entities via system health...")
+
+        result = await mcp_client.call_tool(
+            "ha_get_system_health", {"include": "dead_entities"}
+        )
+        data = parse_mcp_result(result)
+
+        logger.info(f"System health (dead_entities) result: {data}")
+
+        assert data.get("success") is True, f"Health check failed: {data.get('error')}"
+
+        assert "dead_entities" in data, "Missing 'dead_entities' section"
+        dead = data["dead_entities"]
+        # Foundational sources (states + registry) must be reachable on a live
+        # instance — a section-level error here is a real failure.
+        assert "error" not in dead, f"dead_entities errored: {dead.get('error')}"
+
+        for tier in ("config_entry_orphans", "stale_restored"):
+            assert tier in dead, f"Missing '{tier}' tier"
+            bucket = dead[tier]
+            assert "items" in bucket and isinstance(bucket["items"], list)
+            assert "count" in bucket and "total_count" in bucket
+
+        assert "summary" in dead, "Missing 'summary'"
+        assert "registry_total" in dead["summary"]
+        assert dead["summary"]["registry_total"] > 0, (
+            "A live HA instance should have a non-empty entity registry"
+        )
+        # config/entries/get is available in the test env, so the definitive
+        # orphan tier should be active.
+        assert dead.get("config_entries_checked") is True
+
+        logger.info("Dead entities test completed successfully")
+
+    @pytest.mark.asyncio
     async def test_restart_without_confirmation(self, mcp_client):
         """
         Test: Restart without confirmation fails safely.

--- a/tests/src/e2e/workflows/system/test_system_tools.py
+++ b/tests/src/e2e/workflows/system/test_system_tools.py
@@ -49,7 +49,9 @@ class TestSystemTools:
         logger.info(f"System health (config_check) result: {data}")
 
         # Verify the tool executed successfully
-        assert data.get("success") is True, f"Health check failed: {data.get('error')}"
+        assert data.get("success") is True, (
+            f"Health check failed: {extract_error_message(data)}"
+        )
 
         # Verify the folded config_check section is present with expected fields
         assert "config_check" in data, "Missing 'config_check' section"
@@ -89,7 +91,9 @@ class TestSystemTools:
 
         logger.info(f"System health (dead_entities) result: {data}")
 
-        assert data.get("success") is True, f"Health check failed: {data.get('error')}"
+        assert data.get("success") is True, (
+            f"Health check failed: {extract_error_message(data)}"
+        )
 
         assert "dead_entities" in data, "Missing 'dead_entities' section"
         dead = data["dead_entities"]

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -218,6 +218,51 @@ class TestFetchRepairs:
         assert "ws disconnect" in result["error"]
 
 
+class TestFetchZwaveNetwork:
+    """``_fetch_zwave_network`` resolves the zwave_js config entry then fetches
+    network status. Regression guard for the config_entries/get command name —
+    the helper was previously only mocked whole, so a slash-vs-underscore typo
+    in the command went undetected (it errored as 'integration not available'
+    for every install)."""
+
+    def _zwave_ws_client(self):
+        """ws_client whose send_command dispatches on the canonical commands."""
+        ws = MagicMock()
+
+        async def _send(command, **kwargs):
+            if command == "config_entries/get":
+                return {
+                    "success": True,
+                    "result": [{"domain": "zwave_js", "entry_id": "zw_entry"}],
+                }
+            if command == "zwave_js/network_status":
+                return {
+                    "success": True,
+                    "result": {"controller": {"nodes": [{"node_id": 1}]}},
+                }
+            return {"success": False, "error": {"message": "Unknown command."}}
+
+        ws.send_command = AsyncMock(side_effect=_send)
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_uses_canonical_config_entries_command(self):
+        """The entry lookup must use 'config_entries/get' (underscore). With the
+        wrong slash name the mock returns Unknown-command and the section would
+        report 'integration not found' despite zwave_js being present."""
+        ws = self._zwave_ws_client()
+        result = await SystemTools._fetch_zwave_network(ws)
+
+        sent_commands = [call.args[0] for call in ws.send_command.call_args_list]
+        assert "config_entries/get" in sent_commands
+        assert "config/entries/get" not in sent_commands
+        # Proves the entry was actually resolved (only possible with the right
+        # command name) — not the "integration not found" error path.
+        assert "error" not in result
+        assert result["count"] == 1
+        assert result["nodes"][0]["node_id"] == 1
+
+
 class TestGetSystemHealthGather:
     """``ha_get_system_health`` runs optional sections concurrently via ``asyncio.gather``.
 

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -1275,6 +1275,17 @@ class TestFetchDeadEntities:
         assert "states" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_fatal_cancellation_propagates_not_embedded(self):
+        """A CancelledError from a source fetch must unwind, not be demoted to a
+        section error string — guards the _reraise_if_fatal pre-pass."""
+        client = _make_dead_entities_client(
+            states=None,
+            states_exc=asyncio.CancelledError(),
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await SystemTools(client)._fetch_dead_entities()
+
+    @pytest.mark.asyncio
     async def test_stale_bucket_truncates_at_limit(self):
         """The stale bucket caps its item list and reports truncation + totals so
         large installs stay token-friendly."""

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -1153,6 +1153,33 @@ class TestFetchDeadEntities:
         assert result["config_entry_orphans"]["items"] == []
 
     @pytest.mark.asyncio
+    async def test_non_dict_attributes_does_not_crash(self):
+        """A malformed state whose `attributes` is not a dict must be skipped,
+        not raise AttributeError on `.get()` — guards the isinstance check."""
+        client = _make_dead_entities_client(
+            states=[
+                {
+                    "entity_id": "sensor.weird",
+                    "state": "unavailable",
+                    "attributes": "not-a-dict",
+                }
+            ],
+            registry=[
+                {
+                    "entity_id": "sensor.weird",
+                    "platform": "hue",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert "error" not in result
+        assert result["stale_restored"]["items"] == []
+
+    @pytest.mark.asyncio
     async def test_disabled_entity_with_live_entry_not_flagged(self):
         """An intentionally-disabled entry whose config entry still exists is a
         user choice, not dead — excluded from both tiers."""

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -990,7 +990,7 @@ def _make_dead_entities_client(
             if registry_resp is not None:
                 return registry_resp
             return {"success": True, "result": registry or []}
-        if msg_type == "config/entries/get":
+        if msg_type == "config_entries/get":
             if entries_resp is not None:
                 return entries_resp
             return {"success": True, "result": entries or []}
@@ -1230,6 +1230,27 @@ class TestFetchDeadEntities:
         assert bucket["total_count"] == 60
         assert bucket["truncated"] is True
         assert result["summary"]["candidate_total"] == 60
+
+    @pytest.mark.asyncio
+    async def test_uses_canonical_ws_command_names(self):
+        """Pin the exact HA WebSocket command strings. A wrong name (e.g.
+        'config/entries/get' with a slash instead of 'config_entries/get')
+        returns 'Unknown command' against a real HA and silently degrades the
+        orphan tier — but a mock keyed to the wrong name would still pass. This
+        asserts the real names are sent so a typo is caught without live HA."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[],
+            entries=[],
+        )
+        await SystemTools(client)._fetch_dead_entities()
+
+        sent_types = {
+            call.args[0].get("type")
+            for call in client.send_websocket_message.call_args_list
+        }
+        assert "config/entity_registry/list" in sent_types
+        assert "config_entries/get" in sent_types
 
     @pytest.mark.asyncio
     async def test_dead_entities_via_tool_routes_to_helper(self):

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -959,3 +959,316 @@ class TestGetSystemHealthConfigCheck:
         assert "repairs" in result
         assert "config_check" in result
         assert result["config_check"]["is_valid"] is True
+
+
+def _make_dead_entities_client(
+    states,
+    *,
+    registry=None,
+    entries=None,
+    registry_resp=None,
+    entries_resp=None,
+    states_exc=None,
+):
+    """Build a mock client for ``_fetch_dead_entities``.
+
+    ``get_states`` returns ``states`` (or raises ``states_exc``).
+    ``send_websocket_message`` dispatches on the message ``type`` and returns the
+    HA envelope for the registry / config-entries lists. Pass ``registry_resp`` /
+    ``entries_resp`` to inject a raw (e.g. failure) envelope instead of wrapping a
+    list.
+    """
+    client = MagicMock()
+    if states_exc is not None:
+        client.get_states = AsyncMock(side_effect=states_exc)
+    else:
+        client.get_states = AsyncMock(return_value=states)
+
+    async def _ws(message):
+        msg_type = message.get("type")
+        if msg_type == "config/entity_registry/list":
+            if registry_resp is not None:
+                return registry_resp
+            return {"success": True, "result": registry or []}
+        if msg_type == "config/entries/get":
+            if entries_resp is not None:
+                return entries_resp
+            return {"success": True, "result": entries or []}
+        return {"success": False, "error": f"unexpected ws message: {msg_type}"}
+
+    client.send_websocket_message = AsyncMock(side_effect=_ws)
+    return client
+
+
+def _state(entity_id, state, *, restored=None):
+    """Build a minimal state-machine object."""
+    attrs = {}
+    if restored is not None:
+        attrs["restored"] = restored
+    return {"entity_id": entity_id, "state": state, "attributes": attrs}
+
+
+class TestFetchDeadEntities:
+    """``_fetch_dead_entities`` diffs the registry against states + config
+    entries and classifies orphaned/stale registry entries (issue #1578)."""
+
+    @pytest.mark.asyncio
+    async def test_config_entry_orphan_surfaces(self):
+        """A registry entry whose config_entry_id is not in the live entries set
+        is a definitive orphan, regardless of whether it still has a state."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.ghost", "unavailable", restored=True)],
+            registry=[
+                {
+                    "entity_id": "sensor.ghost",
+                    "platform": "pi_hole",
+                    "config_entry_id": "gone_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        orphans = result["config_entry_orphans"]["items"]
+        assert len(orphans) == 1
+        assert orphans[0]["entity_id"] == "sensor.ghost"
+        assert orphans[0]["config_entry_id"] == "gone_entry"
+        assert orphans[0]["has_state"] is True
+        # An orphan must NOT be double-counted under stale_restored.
+        assert result["stale_restored"]["items"] == []
+        assert result["config_entries_checked"] is True
+        assert result["summary"]["candidate_total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_restored_surfaces(self):
+        """unavailable + restored, with the owning config entry still alive,
+        classifies as stale_restored (not orphan)."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.stale", "unavailable", restored=True)],
+            registry=[
+                {
+                    "entity_id": "sensor.stale",
+                    "platform": "mobile_app",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "mobile_app"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entry_orphans"]["items"] == []
+        stale = result["stale_restored"]["items"]
+        assert len(stale) == 1
+        assert stale[0]["entity_id"] == "sensor.stale"
+
+    @pytest.mark.asyncio
+    async def test_unknown_state_never_flagged(self):
+        """An 'unknown'-state entity (alive, just no current value — e.g. a
+        disaster-alert sensor) must never be flagged. This is the core
+        false-positive guard from issue #1578."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.disaster_alert", "unknown")],
+            registry=[
+                {
+                    "entity_id": "sensor.disaster_alert",
+                    "platform": "weather",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "weather"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entry_orphans"]["items"] == []
+        assert result["stale_restored"]["items"] == []
+        assert result["summary"]["candidate_total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_bare_unavailable_without_restored_not_flagged(self):
+        """A loaded integration reporting a device merely offline right now
+        (unavailable WITHOUT restored) is alive — must not be flagged."""
+        client = _make_dead_entities_client(
+            states=[_state("light.offline_now", "unavailable")],
+            registry=[
+                {
+                    "entity_id": "light.offline_now",
+                    "platform": "hue",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["stale_restored"]["items"] == []
+        assert result["config_entry_orphans"]["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_entity_with_live_entry_not_flagged(self):
+        """An intentionally-disabled entry whose config entry still exists is a
+        user choice, not dead — excluded from both tiers."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[
+                {
+                    "entity_id": "sensor.disabled",
+                    "platform": "hue",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": "user",
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entry_orphans"]["items"] == []
+        assert result["stale_restored"]["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_orphan_still_surfaces_with_disabled_by(self):
+        """A disabled entry whose config entry is ALSO gone is still dead cruft —
+        surfaces as an orphan with disabled_by preserved for client context."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[
+                {
+                    "entity_id": "sensor.disabled_orphan",
+                    "platform": "removed_integration",
+                    "config_entry_id": "gone_entry",
+                    "disabled_by": "integration",
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        orphans = result["config_entry_orphans"]["items"]
+        assert len(orphans) == 1
+        assert orphans[0]["disabled_by"] == "integration"
+        assert orphans[0]["has_state"] is False
+
+    @pytest.mark.asyncio
+    async def test_config_entries_unavailable_degrades_to_stale_only(self):
+        """If config/entries/get fails, the definitive orphan tier is skipped but
+        stale_restored is still computed — graceful degradation, not a hard
+        failure."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.stale", "unavailable", restored=True)],
+            registry=[
+                {
+                    "entity_id": "sensor.stale",
+                    "platform": "mobile_app",
+                    "config_entry_id": "some_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries_resp={"success": False, "error": "ws down"},
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entries_checked"] is False
+        assert result["config_entry_orphans"]["items"] == []
+        assert len(result["stale_restored"]["items"]) == 1
+        assert any("config_entry_orphans" in w for w in result["warnings"])
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_registry_unavailable_is_section_error(self):
+        """The registry is the foundational source — if it can't be fetched, the
+        section returns an embedded error (never raises)."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry_resp={"success": False, "error": "ws down"},
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert "error" in result
+        assert "registry" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_states_unavailable_is_section_error(self):
+        """A states-fetch failure surfaces as an embedded section error, not an
+        unhandled raise."""
+        client = _make_dead_entities_client(
+            states=None,
+            states_exc=RuntimeError("states boom"),
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert "error" in result
+        assert "states" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_stale_bucket_truncates_at_limit(self):
+        """The stale bucket caps its item list and reports truncation + totals so
+        large installs stay token-friendly."""
+        registry = [
+            {
+                "entity_id": f"sensor.stale_{i}",
+                "platform": "mobile_app",
+                "config_entry_id": "live_entry",
+                "disabled_by": None,
+            }
+            for i in range(60)
+        ]
+        states = [
+            _state(f"sensor.stale_{i}", "unavailable", restored=True) for i in range(60)
+        ]
+        client = _make_dead_entities_client(
+            states=states,
+            registry=registry,
+            entries=[{"entry_id": "live_entry", "domain": "mobile_app"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        bucket = result["stale_restored"]
+        assert bucket["count"] == 50
+        assert bucket["total_count"] == 60
+        assert bucket["truncated"] is True
+        assert result["summary"]["candidate_total"] == 60
+
+    @pytest.mark.asyncio
+    async def test_dead_entities_via_tool_routes_to_helper(self):
+        """include='dead_entities' routes to the helper and embeds its result."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        payload = {"summary": {"candidate_total": 0, "registry_total": 0}}
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_dead_entities",
+                new=AsyncMock(return_value=payload),
+            ) as mock_dead,
+        ):
+            result = await tools.ha_get_system_health(include="dead_entities")
+        assert result["dead_entities"] == payload
+        mock_dead.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dead_entities_returns_when_health_ws_unavailable(self):
+        """dead_entities is REST-based, so it survives a WS-baseline failure —
+        mirrors the config_check / diagnostics degradation guarantee."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        payload = {"summary": {"candidate_total": 0, "registry_total": 0}}
+        with (
+            patch.object(
+                SystemTools,
+                "_fetch_health_info",
+                new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+            ),
+            patch.object(
+                SystemTools,
+                "_fetch_dead_entities",
+                new=AsyncMock(return_value=payload),
+            ),
+        ):
+            result = await tools.ha_get_system_health(include="dead_entities")
+        assert result["success"] is True
+        assert result["baseline_available"] is False
+        assert result["dead_entities"] == payload

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -7,12 +7,16 @@ ha_restart reports failure when a reverse proxy returns 504 during restart.
 import asyncio
 import json
 from contextlib import contextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import HomeAssistantAPIError
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantConnectionError,
+)
 from ha_mcp.tools.tools_system import SystemTools
 
 
@@ -1014,14 +1018,17 @@ def _make_dead_entities_client(
     registry_resp=None,
     entries_resp=None,
     states_exc=None,
+    registry_exc=None,
+    entries_exc=None,
 ):
     """Build a mock client for ``_fetch_dead_entities``.
 
     ``get_states`` returns ``states`` (or raises ``states_exc``).
-    ``send_websocket_message`` dispatches on the message ``type`` and returns the
-    HA envelope for the registry / config-entries lists. Pass ``registry_resp`` /
-    ``entries_resp`` to inject a raw (e.g. failure) envelope instead of wrapping a
-    list.
+    ``send_websocket_message`` dispatches on the message ``type`` and returns
+    the HA envelope for the registry / config-entries lists. Pass
+    ``registry_resp`` / ``entries_resp`` to inject a raw (e.g. failure)
+    envelope, or ``registry_exc`` / ``entries_exc`` to make the WS call
+    raise (covering the fatal-propagation paths).
     """
     client = MagicMock()
     if states_exc is not None:
@@ -1032,10 +1039,14 @@ def _make_dead_entities_client(
     async def _ws(message):
         msg_type = message.get("type")
         if msg_type == "config/entity_registry/list":
+            if registry_exc is not None:
+                raise registry_exc
             if registry_resp is not None:
                 return registry_resp
             return {"success": True, "result": registry or []}
         if msg_type == "config_entries/get":
+            if entries_exc is not None:
+                raise entries_exc
             if entries_resp is not None:
                 return entries_resp
             return {"success": True, "result": entries or []}
@@ -1245,7 +1256,14 @@ class TestFetchDeadEntities:
         assert result["config_entries_checked"] is False
         assert result["config_entry_orphans"]["items"] == []
         assert len(result["stale_restored"]["items"]) == 1
-        assert any("config_entry_orphans" in w for w in result["warnings"])
+        # The section returns warnings under the ``_warnings`` sentinel; the
+        # aggregator (``ha_get_system_health``) bubbles them to top-level
+        # ``result["warnings"]``. Direct-call tests assert the sentinel; the
+        # bubbling contract is covered by an integration test below.
+        assert any("config_entry_orphans" in w for w in result["_warnings"])
+        # A genuine fetch failure (success=false) preserves the envelope
+        # error string rather than substituting a fixed "no entries" message.
+        assert any("ws down" in w for w in result["_warnings"])
         assert "error" not in result
 
     @pytest.mark.asyncio
@@ -1321,6 +1339,15 @@ class TestFetchDeadEntities:
         assert bucket["count"] == 50
         assert bucket["total_count"] == 60
         assert bucket["truncated"] is True
+        # The actionable cleanup guidance must (a) be present, (b) name
+        # both cap and total in the documented ``"Showing X of Y"`` form
+        # so a client can render the truncation context, and (c) carry
+        # the "remove ... batches" instruction so the user knows the
+        # cleanup is iterative — a wrong-template copy-paste from the
+        # ZHA truncation hint would fail this.
+        assert "hint" in bucket
+        assert "50 of 60" in bucket["hint"]
+        assert "remove" in bucket["hint"].lower()
 
     @pytest.mark.asyncio
     async def test_entity_without_config_entry_id_classifies_as_stale(self):
@@ -1386,7 +1413,13 @@ class TestFetchDeadEntities:
 
         assert result["config_entry_orphans"]["items"] == []
         assert result["config_entries_checked"] is False
-        assert any("config_entry_orphans" in w for w in result["warnings"])
+        # Direct-call asserts the ``_warnings`` sentinel; integration test
+        # below covers the bubble to top-level ``result["warnings"]``.
+        assert any("config_entry_orphans" in w for w in result["_warnings"])
+        # Real empty list — distinct from a fetch failure, which would
+        # carry the underlying error string. Asserts the two paths produce
+        # distinct messages (the "empty list" vs "failed" branching).
+        assert any("empty list" in w for w in result["_warnings"])
 
     @pytest.mark.asyncio
     async def test_note_present_when_candidates_found(self):
@@ -1469,6 +1502,11 @@ class TestFetchDeadEntities:
         assert bucket["count"] == 50
         assert bucket["total_count"] == 60
         assert bucket["truncated"] is True
+        # Same template assertions as the orphan bucket so a copy-paste
+        # error swapping the two buckets' hints is caught.
+        assert "hint" in bucket
+        assert "50 of 60" in bucket["hint"]
+        assert "remove" in bucket["hint"].lower()
         assert result["summary"]["candidate_total"] == 60
 
     @pytest.mark.asyncio
@@ -1533,3 +1571,349 @@ class TestFetchDeadEntities:
         assert result["success"] is True
         assert result["baseline_available"] is False
         assert result["dead_entities"] == payload
+
+
+class TestWsResultList:
+    """Edge cases for ``SystemTools._ws_result_list``: the unwrap shape is a
+    tuple ``(list | None, error_str | None)``, preserving the underlying cause
+    so the caller can attribute a failure rather than substitute a fixed
+    "unavailable" message that hides whether it was auth, command, or
+    malformed envelope. The recoverable-Exception branch, the non-dict
+    response, and the success-but-result-not-a-list branches were previously
+    only exercised through ``_fetch_dead_entities``; pinning them directly
+    documents the contract and guards against a refactor regressing it."""
+
+    def test_recoverable_exception_returns_cause_string(self):
+        """A bare ``Exception`` from ``gather`` is recoverable (per
+        ``_reraise_if_fatal`` policy): returns ``(None, cause)`` with the
+        exception class name + message preserved."""
+        data, err = SystemTools._ws_result_list(RuntimeError("ws boom"))
+        assert data is None
+        assert err is not None
+        assert "RuntimeError" in err
+        assert "ws boom" in err
+
+    def test_non_dict_response_reports_unexpected_type(self):
+        """A non-dict envelope (e.g. a list slipped through) is a protocol
+        violation worth surfacing in the cause string, not a silent
+        ``None`` substitution."""
+        data, err = SystemTools._ws_result_list(["unexpected", "shape"])
+        assert data is None
+        assert err is not None
+        assert "list" in err
+
+    def test_success_false_envelope_preserves_error_message(self):
+        """An HA error envelope (``{"success": False, "error": {...}}``)
+        carries the actual cause (auth, command name, validation) — the
+        caller surfaces it instead of a fixed "unavailable" substitute."""
+        resp = {
+            "success": False,
+            "error": {"code": "unknown_command", "message": "Unknown command."},
+        }
+        data, err = SystemTools._ws_result_list(resp)
+        assert data is None
+        assert err == "Unknown command."
+
+    def test_success_false_envelope_code_only_falls_back_to_code(self):
+        """When the envelope error dict has only ``code`` (no ``message``),
+        the code is still preserved as the cause — better than substituting
+        a generic "unknown error" and losing the discriminator."""
+        data, err = SystemTools._ws_result_list(
+            {"success": False, "error": {"code": "auth_failed"}}
+        )
+        assert data is None
+        assert err == "auth_failed"
+
+    def test_success_false_envelope_unknown_shape_uses_str_repr(self):
+        """A dict-error envelope with neither ``message`` nor ``code`` still
+        surfaces something attributable to the client — degrades to
+        ``str(err)`` so the discriminating field reaches the cause string."""
+        data, err = SystemTools._ws_result_list(
+            {"success": False, "error": {"detail": "weird"}}
+        )
+        assert data is None
+        assert err is not None
+        assert "weird" in err
+
+    def test_success_false_string_error_preserved(self):
+        """Some envelopes report ``error`` as a plain string; that path must
+        also survive (the envelope-dict branch can't claim it)."""
+        data, err = SystemTools._ws_result_list({"success": False, "error": "ws down"})
+        assert data is None
+        assert err == "ws down"
+
+    def test_success_false_no_error_field_defaults_to_unknown(self):
+        """A malformed envelope without ``error`` shouldn't crash; degrade
+        to a sentinel string so the caller can still attribute the failure."""
+        data, err = SystemTools._ws_result_list({"success": False})
+        assert data is None
+        assert err == "unknown error"
+
+    def test_success_but_result_not_a_list_reports_wrong_shape(self):
+        """``success=True`` with a non-list ``result`` (e.g. a dict from a
+        sibling command shape) is reportable as a wrong-shape failure."""
+        data, err = SystemTools._ws_result_list(
+            {"success": True, "result": {"unexpected": "dict"}}
+        )
+        assert data is None
+        assert err is not None
+        assert "dict" in err
+
+    def test_success_with_list_result_returns_data_and_no_error(self):
+        """Happy path: list returned as data, error slot is ``None``."""
+        data, err = SystemTools._ws_result_list(
+            {"success": True, "result": [{"id": 1}, {"id": 2}]}
+        )
+        assert data == [{"id": 1}, {"id": 2}]
+        assert err is None
+
+    def test_cancelled_error_unwinds_not_returned(self):
+        """Per ``_reraise_if_fatal``: cancellation must propagate; the
+        function never returns ``(None, ...)`` for it."""
+        with pytest.raises(asyncio.CancelledError):
+            SystemTools._ws_result_list(asyncio.CancelledError())
+
+    def test_home_assistant_connection_error_unwinds_not_returned(self):
+        """Transport-dead errors propagate via ``_reraise_if_fatal`` (the
+        #1624 policy folded into this PR) — once the HA connection is dead
+        the remaining section fetches will fail anyway, so a propagated
+        root cause beats N per-section embedded errors."""
+        with pytest.raises(HomeAssistantConnectionError):
+            SystemTools._ws_result_list(HomeAssistantConnectionError("transport dead"))
+
+
+class TestRegistryFailurePreservesCause:
+    """The ``registry`` branch in ``_fetch_dead_entities`` previously
+    substituted a fixed ``"config/entity_registry/list unavailable"`` string
+    and discarded ``resp.get("error")``. The new contract preserves the
+    envelope cause so a client can distinguish auth vs command-error vs
+    malformed envelope."""
+
+    @pytest.mark.asyncio
+    async def test_registry_envelope_error_preserved_in_section_error(self):
+        client = _make_dead_entities_client(
+            states=[],
+            registry_resp={
+                "success": False,
+                "error": {"code": "auth_failed", "message": "Auth required."},
+            },
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+        assert "error" in result
+        # The original envelope message is preserved (rather than masked as
+        # "unavailable"), so the cause class is attributable from the dict.
+        assert "Auth required." in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_registry_exception_class_preserved_in_section_error(self):
+        client = _make_dead_entities_client(
+            states=[],
+            registry_resp=None,
+            registry_exc=RuntimeError("transport hiccup"),
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+        assert "error" in result
+        assert "RuntimeError" in result["error"]
+        assert "transport hiccup" in result["error"]
+
+
+class TestConfigEntriesFailureVsEmpty:
+    """The config-entries branch previously folded the genuine-fetch-failure
+    case and the truly-empty-list case under the same "returned no entries"
+    message. The new contract distinguishes them so a backend failure isn't
+    reported as "no entries"."""
+
+    @pytest.mark.asyncio
+    async def test_failure_message_carries_underlying_cause(self):
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[],
+            entries_resp={
+                "success": False,
+                "error": {"code": "unknown_command", "message": "Bad."},
+            },
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+        # The bubbled warning surfaces the cause string rather than the
+        # generic "no entries" message — i.e. distinguishable from the
+        # empty-list path below.
+        assert "_warnings" in result
+        msg = next(iter(result["_warnings"]))
+        assert "failed" in msg
+        assert "Bad." in msg
+
+    @pytest.mark.asyncio
+    async def test_empty_list_message_names_the_empty_state_not_a_failure(self):
+        client = _make_dead_entities_client(states=[], registry=[], entries=[])
+        result = await SystemTools(client)._fetch_dead_entities()
+        assert "_warnings" in result
+        msg = next(iter(result["_warnings"]))
+        # Distinguishable from the failure path: this branch names the
+        # actual state ("empty list"/"no integrations configured") rather
+        # than reporting a fetch failure with a cause string.
+        assert "empty list" in msg
+        assert "failed" not in msg
+
+
+class TestWarningsBubbleToTopLevel:
+    """Section-emitted warnings must surface under the top-level
+    ``result["warnings"]`` (the documented contract location), not on the
+    section dict's reserved-term-colliding ``warnings`` key. The section
+    helper uses a ``_warnings`` sentinel that the aggregator pops + appends
+    to ``result["warnings"]``."""
+
+    @pytest.mark.asyncio
+    async def test_dead_entities_warnings_bubble_to_result_warnings(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(return_value={"success": True})
+        tools = SystemTools(client)
+        section_payload = {
+            "summary": {"candidate_total": 0, "registry_total": 0},
+            "_warnings": ["config_entries/get failed (boom); tier skipped."],
+        }
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_dead_entities",
+                new=AsyncMock(return_value=section_payload),
+            ),
+        ):
+            result = await tools.ha_get_system_health(include="dead_entities")
+        # The sentinel is stripped from the section dict so a client never
+        # sees the internal key.
+        assert "_warnings" not in result["dead_entities"]
+        # And the message lands under the documented contract location.
+        assert any("config_entries/get failed" in w for w in result.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_dead_entities_without_warnings_does_not_create_warnings_key(self):
+        """No warnings ⇒ no spurious top-level ``warnings`` key (avoids
+        adding noise to the aggregator output)."""
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(return_value={"success": True})
+        tools = SystemTools(client)
+        section_payload = {"summary": {"candidate_total": 0, "registry_total": 0}}
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_dead_entities",
+                new=AsyncMock(return_value=section_payload),
+            ),
+        ):
+            result = await tools.ha_get_system_health(include="dead_entities")
+        # No-warnings happy path: no spurious top-level key. (The
+        # aggregator may still add unrelated warnings for orphan args etc.
+        # — we assert specifically that no dead-entities-bubbled message
+        # surfaced rather than checking the key's absence outright.)
+        assert all("config_entries/get" not in w for w in result.get("warnings", []))
+
+
+class TestHomeAssistantConnectionErrorPropagation:
+    """#1624 policy folded into this PR: a dead HA transport propagates as
+    ``isError=true`` (via ``_reraise_if_fatal``) rather than being demoted to
+    N per-section embedded errors. Applies to ``_fetch_dead_entities``, every
+    sibling section helper, and the ws ``sections`` gather pre-pass — the
+    cross-section consistency was the whole point of the #1624 decision."""
+
+    @pytest.mark.asyncio
+    async def test_connection_error_from_states_propagates(self):
+        """A ``HomeAssistantConnectionError`` from the REST states fetch
+        unwinds out of ``_fetch_dead_entities`` rather than being demoted
+        to a section error string."""
+        client = _make_dead_entities_client(
+            states=None,
+            states_exc=HomeAssistantConnectionError("transport dead"),
+        )
+        with pytest.raises(HomeAssistantConnectionError):
+            await SystemTools(client)._fetch_dead_entities()
+
+    @pytest.mark.asyncio
+    async def test_connection_error_from_registry_propagates(self):
+        """Connection failure on the WS registry fetch unwinds (via
+        ``_ws_result_list``'s fatal pre-pass) rather than landing as a
+        section error string."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry_resp=None,
+            registry_exc=HomeAssistantConnectionError("ws gone"),
+        )
+        with pytest.raises(HomeAssistantConnectionError):
+            await SystemTools(client)._fetch_dead_entities()
+
+    @pytest.mark.parametrize(
+        "helper_name",
+        [
+            "_fetch_repairs",
+            "_fetch_zha_network",
+            "_fetch_zwave_network",
+            "_fetch_themes",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_connection_error_from_ws_section_helper_propagates(
+        self, helper_name
+    ):
+        """Each ws-backed sibling section helper's ``except Exception`` chain
+        routes through ``_reraise_if_fatal`` as its first line, so a
+        connection error from one section unwinds the request rather than
+        embedding N per-section errors. Parametrized across every helper
+        so a regression that removes the call from one (and only one) is
+        caught — the cross-section consistency #1624 demanded."""
+        ws_client = MagicMock()
+        ws_client.send_command = AsyncMock(
+            side_effect=HomeAssistantConnectionError("ws gone")
+        )
+        helper = getattr(SystemTools, helper_name)
+        kwargs: dict[str, Any] = {}
+        if helper_name == "_fetch_zha_network":
+            kwargs["full"] = False
+        with pytest.raises(HomeAssistantConnectionError):
+            await helper(ws_client, **kwargs)
+
+    @pytest.mark.asyncio
+    async def test_connection_error_from_config_check_propagates(self):
+        """``_fetch_config_check`` is REST-based (calls
+        ``self._client.check_config()``) and runs inline rather than through
+        the gather pre-pass, so its propagation can't piggyback on the
+        ws-section parametrize above. Pin it independently."""
+        client = MagicMock()
+        client.check_config = AsyncMock(
+            side_effect=HomeAssistantConnectionError("rest dead")
+        )
+        with pytest.raises(HomeAssistantConnectionError):
+            await SystemTools(client)._fetch_config_check()
+
+    @pytest.mark.asyncio
+    async def test_aggregator_pre_pass_propagates_connection_error_as_tool_error(
+        self,
+    ):
+        """The ws ``sections`` gather pre-pass uses the same
+        ``_reraise_if_fatal`` policy: a HomeAssistantConnectionError from
+        any section result element unwinds the gather and is then wrapped
+        by ``ha_get_system_health``'s outer ``except Exception``
+        (``exception_to_structured_error``) into a ``ToolError`` with the
+        ``CONNECTION_FAILED`` code — the MCP ``isError=true`` contract for
+        a dead transport. Without ``_reraise_if_fatal``, the connection
+        error would have been demoted to one section's ``error`` string,
+        and the tool would have returned ``success=True`` with the dead
+        transport silently embedded — the exact #1624 anti-pattern."""
+        client = MagicMock()
+        tools = SystemTools(client)
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_repairs",
+                new=AsyncMock(side_effect=HomeAssistantConnectionError("ws gone")),
+            ),
+            pytest.raises(ToolError) as excinfo,
+        ):
+            await tools.ha_get_system_health(include="repairs")
+        # The structured error preserves the cause string + the
+        # CONNECTION_FAILED code, so a client sees the real root cause
+        # rather than a per-section embedded ``{"error": "..."}``.
+        msg = str(excinfo.value)
+        assert "CONNECTION_FAILED" in msg
+        assert "ws gone" in msg

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -1286,6 +1286,116 @@ class TestFetchDeadEntities:
             await SystemTools(client)._fetch_dead_entities()
 
     @pytest.mark.asyncio
+    async def test_tool_error_propagates_not_embedded(self):
+        """A ToolError from a source fetch must propagate (MCP isError
+        contract), not be demoted to a section error string by the outer
+        except — guards the `except ToolError: raise` chain order."""
+        client = _make_dead_entities_client(
+            states=None,
+            states_exc=ToolError("boom"),
+        )
+        with pytest.raises(ToolError):
+            await SystemTools(client)._fetch_dead_entities()
+
+    @pytest.mark.asyncio
+    async def test_orphan_bucket_truncates_at_limit(self):
+        """The orphan bucket caps + flags truncation independently of the stale
+        bucket (the two tiers populate via different code paths)."""
+        registry = [
+            {
+                "entity_id": f"sensor.orphan_{i}",
+                "platform": "removed",
+                "config_entry_id": "gone_entry",
+                "disabled_by": None,
+            }
+            for i in range(60)
+        ]
+        client = _make_dead_entities_client(
+            states=[],
+            registry=registry,
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        bucket = result["config_entry_orphans"]
+        assert bucket["count"] == 50
+        assert bucket["total_count"] == 60
+        assert bucket["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_entity_without_config_entry_id_classifies_as_stale(self):
+        """A restored-unavailable entry with config_entry_id=None (e.g. a
+        YAML/helper entity its provider no longer supplies) is not an orphan
+        (no config entry to be missing) but still surfaces as stale_restored,
+        carrying config_entry_id: None."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.no_cfg", "unavailable", restored=True)],
+            registry=[
+                {
+                    "entity_id": "sensor.no_cfg",
+                    "platform": "template",
+                    "config_entry_id": None,
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entry_orphans"]["items"] == []
+        stale = result["stale_restored"]["items"]
+        assert len(stale) == 1
+        assert stale[0]["entity_id"] == "sensor.no_cfg"
+        assert stale[0]["config_entry_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_sources_return_zero_counts(self):
+        """All sources empty-but-successful → baseline structure with zeros, no
+        error, no crash on len()."""
+        client = _make_dead_entities_client(states=[], registry=[], entries=[])
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert "error" not in result
+        assert result["config_entry_orphans"]["count"] == 0
+        assert result["stale_restored"]["count"] == 0
+        assert result["summary"] == {"candidate_total": 0, "registry_total": 0}
+        assert result["config_entries_checked"] is True
+
+    @pytest.mark.asyncio
+    async def test_entities_sharing_config_entry_classified_independently(self):
+        """Set-membership is per-entity: two entries on a live entry are not
+        orphans, a third on a gone entry is — no first-match-wins bug."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[
+                {
+                    "entity_id": "light.a",
+                    "platform": "hue",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                },
+                {
+                    "entity_id": "light.b",
+                    "platform": "hue",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                },
+                {
+                    "entity_id": "light.c",
+                    "platform": "removed",
+                    "config_entry_id": "gone_entry",
+                    "disabled_by": None,
+                },
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "hue"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        orphans = result["config_entry_orphans"]["items"]
+        assert len(orphans) == 1
+        assert orphans[0]["entity_id"] == "light.c"
+
+    @pytest.mark.asyncio
     async def test_stale_bucket_truncates_at_limit(self):
         """The stale bucket caps its item list and reports truncation + totals so
         large installs stay token-friendly."""

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -1351,7 +1351,9 @@ class TestFetchDeadEntities:
     @pytest.mark.asyncio
     async def test_empty_sources_return_zero_counts(self):
         """All sources empty-but-successful → baseline structure with zeros, no
-        error, no crash on len()."""
+        error, no crash on len(). Empty config-entries degrades the orphan tier
+        (cannot distinguish a removed integration from an empty fetch), and the
+        guidance note is omitted when there is nothing to act on."""
         client = _make_dead_entities_client(states=[], registry=[], entries=[])
         result = await SystemTools(client)._fetch_dead_entities()
 
@@ -1359,7 +1361,52 @@ class TestFetchDeadEntities:
         assert result["config_entry_orphans"]["count"] == 0
         assert result["stale_restored"]["count"] == 0
         assert result["summary"] == {"candidate_total": 0, "registry_total": 0}
-        assert result["config_entries_checked"] is True
+        assert result["config_entries_checked"] is False
+        assert "note" not in result
+
+    @pytest.mark.asyncio
+    async def test_empty_config_entries_skips_orphan_tier(self):
+        """An empty-but-successful config_entries/get must NOT flag every
+        cfg-linked registry entry as an orphan — empty is treated like a failed
+        fetch (it is indistinguishable from a backend hiccup), so the orphan
+        tier is skipped rather than producing a mass false positive."""
+        client = _make_dead_entities_client(
+            states=[],
+            registry=[
+                {
+                    "entity_id": "sensor.has_cfg",
+                    "platform": "hue",
+                    "config_entry_id": "some_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["config_entry_orphans"]["items"] == []
+        assert result["config_entries_checked"] is False
+        assert any("config_entry_orphans" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_note_present_when_candidates_found(self):
+        """The guidance note is attached when there is at least one candidate."""
+        client = _make_dead_entities_client(
+            states=[_state("sensor.stale", "unavailable", restored=True)],
+            registry=[
+                {
+                    "entity_id": "sensor.stale",
+                    "platform": "mobile_app",
+                    "config_entry_id": "live_entry",
+                    "disabled_by": None,
+                }
+            ],
+            entries=[{"entry_id": "live_entry", "domain": "mobile_app"}],
+        )
+        result = await SystemTools(client)._fetch_dead_entities()
+
+        assert result["summary"]["candidate_total"] == 1
+        assert "ha_remove_entity" in result["note"]
 
     @pytest.mark.asyncio
     async def test_entities_sharing_config_entry_classified_independently(self):


### PR DESCRIPTION
Closes #1578
Closes #1624

## What does this PR do?

Adds an optional `dead_entities` section to `ha_get_system_health` (requested via the existing `include` mechanism) that surfaces orphaned/stale entity-registry entries so a client can propose targeted cleanup with `ha_remove_entity`. No new tool.

It diffs the entity registry against the state machine and the live config-entries set, classifying findings into confidence tiers:

- **`config_entry_orphans`** (definitive) — registry entries whose `config_entry_id` is no longer present in `config_entries/get`; the owning integration instance was removed.
- **`stale_restored`** (likely) — entries HA restored from the registry on startup (`unavailable` + `restored: true`) whose config entry still exists; the integration is loaded but no longer provides the entity (renamed/removed device, re-paired Zigbee).

To keep false positives low it never flags `unknown`-state entities (alive, just no current value — e.g. disaster-alert sensors), bare `unavailable` without `restored` (merely-offline devices), or intentionally-disabled entries (unless their config entry is also gone). Buckets are capped at 50 items with truncation metadata to stay token-friendly.

The section is REST-based (uses the client's own WebSocket bridge for the registry + config entries, not the health `ws_client`), so it runs even when the `system_health` baseline is unavailable — the same degradation guarantee as `config_check`/`diagnostics`.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed