### PR TITLE
test: cover rrule error paths in ha_config_set_calendar_event

### DIFF
--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -6,12 +6,24 @@ recurrence is only accepted by the WebSocket command
 present → WebSocket command carrying an RFC 5545 event payload
 (``dtstart``/``dtend`` keys); ``rrule`` absent → the pre-existing REST
 service call (``start_date_time``/``end_date_time`` keys), unchanged.
+
+They also cover the three failure paths unique to the rrule branch: a
+WebSocket connect failure (both the supplied-error and the synthesised
+``CONNECTION_FAILED`` cases), the guarded disconnect that must not mask the
+original ``send_command`` error, and the rrule-specific error suggestion.
+``raise_tool_error`` serialises the structured error as JSON into the
+``ToolError`` message, so the failure-path tests parse it back to assert on
+code/context/suggestions.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.errors import ErrorCode
 from ha_mcp.tools.tools_calendar import CalendarTools
 
 
@@ -124,3 +136,179 @@ async def test_no_rrule_keeps_rest_service_path():
     ws_factory.assert_not_called()
     assert result["success"] is True
     assert result["event"]["rrule"] is None
+
+
+def _structured_error(exc: ToolError) -> dict:
+    """Parse the JSON structured-error payload carried by a ToolError."""
+    return json.loads(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Error-path coverage for the rrule WebSocket branch. These three branches are
+# all new with the recurring-event feature and only reachable on the rrule
+# path; the happy-path tests above never exercise them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_failure_surfaces_supplied_error_verbatim():
+    """rrule path, get_connected_ws_client returns (None, error) → that exact
+    error is raised and the REST service is never touched."""
+    client = _make_mock_client()
+    conn_error = {
+        "success": False,
+        "error": {
+            "code": ErrorCode.CONNECTION_FAILED.value,
+            "message": "ws factory said no",
+        },
+    }
+
+    with patch(
+        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
+        return_value=(None, conn_error),
+    ):
+        tools = CalendarTools(client)
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_calendar_event(
+                entity_id="calendar.test",
+                summary="Weekly sync",
+                start="2026-06-15T10:00:00",
+                end="2026-06-15T10:30:00",
+                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+            )
+
+    assert _structured_error(exc_info.value) == conn_error
+    client.call_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_failure_without_error_raises_connection_failed():
+    """rrule path, get_connected_ws_client returns (None, None) → a synthesised
+    CONNECTION_FAILED error carrying the entity_id, REST service untouched."""
+    client = _make_mock_client()
+
+    with patch(
+        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
+        return_value=(None, None),
+    ):
+        tools = CalendarTools(client)
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_calendar_event(
+                entity_id="calendar.test",
+                summary="Weekly sync",
+                start="2026-06-15T10:00:00",
+                end="2026-06-15T10:30:00",
+                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+            )
+
+    err = _structured_error(exc_info.value)
+    assert err["error"]["code"] == ErrorCode.CONNECTION_FAILED.value
+    # create_error_response merges context at the top level, not under "error".
+    assert err["entity_id"] == "calendar.test"
+    client.call_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_error_does_not_mask_send_command_error():
+    """If send_command AND the guarded disconnect both raise, the caller must
+    see the send_command error, not the teardown error."""
+    client = _make_mock_client()
+    ws = AsyncMock()
+    ws.send_command = AsyncMock(
+        side_effect=HomeAssistantCommandError("Command failed: backend rejected rrule")
+    )
+    ws.disconnect = AsyncMock(side_effect=RuntimeError("socket already torn down"))
+
+    with patch(
+        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
+        return_value=(ws, None),
+    ):
+        tools = CalendarTools(client)
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_calendar_event(
+                entity_id="calendar.test",
+                summary="Weekly sync",
+                start="2026-06-15T10:00:00",
+                end="2026-06-15T10:30:00",
+                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+            )
+
+    message = _structured_error(exc_info.value)["error"]["message"]
+    assert "backend rejected rrule" in message
+    assert "socket already torn down" not in message
+    ws.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_error_swallowed_on_success():
+    """A disconnect failure after a successful send_command must not fail the tool."""
+    client = _make_mock_client()
+    ws = AsyncMock()
+    ws.send_command = AsyncMock(return_value={"success": True, "result": None})
+    ws.disconnect = AsyncMock(side_effect=RuntimeError("socket already torn down"))
+
+    with patch(
+        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
+        return_value=(ws, None),
+    ):
+        tools = CalendarTools(client)
+        result = await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Weekly sync",
+            start="2026-06-15T10:00:00",
+            end="2026-06-15T10:30:00",
+            rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+        )
+
+    assert result["success"] is True
+    ws.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rrule_failure_prepends_rrule_suggestion():
+    """A failed rrule create surfaces the RRULE-syntax hint as the first suggestion."""
+    client = _make_mock_client()
+    ws = AsyncMock()
+    ws.send_command = AsyncMock(
+        side_effect=HomeAssistantCommandError("Command failed: backend rejected rrule")
+    )
+
+    with patch(
+        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
+        return_value=(ws, None),
+    ):
+        tools = CalendarTools(client)
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_calendar_event(
+                entity_id="calendar.test",
+                summary="Weekly sync",
+                start="2026-06-15T10:00:00",
+                end="2026-06-15T10:30:00",
+                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+            )
+
+    suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
+    assert suggestions[0].startswith("Check RRULE syntax")
+
+
+@pytest.mark.asyncio
+async def test_non_rrule_failure_omits_rrule_suggestion():
+    """The RRULE-syntax hint must not appear when no rrule was supplied."""
+    client = _make_mock_client()
+    client.call_service = AsyncMock(
+        side_effect=HomeAssistantCommandError("Command failed: backend boom")
+    )
+
+    with patch("ha_mcp.tools.tools_calendar.get_connected_ws_client") as ws_factory:
+        tools = CalendarTools(client)
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_calendar_event(
+                entity_id="calendar.test",
+                summary="One-off",
+                start="2026-06-15T10:00:00",
+                end="2026-06-15T11:00:00",
+            )
+
+    suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
+    assert all(not s.startswith("Check RRULE syntax") for s in suggestions)
+    ws_factory.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1585 (recurring calendar events). That PR's unit tests covered only the happy path; this adds six tests for the three new branches unique to the `rrule` WebSocket path in `ha_config_set_calendar_event`, all driven through the already-mocked WS client:

- **WS connect failure** — `get_connected_ws_client` returning `(None, error)` surfaces that error verbatim and never falls back to the REST service; returning `(None, None)` raises a synthesised `CONNECTION_FAILED` carrying the `entity_id`.
- **Guarded disconnect** — a disconnect error does not mask the original `send_command` error, and a disconnect failure after a successful send still returns success.
- **rrule-specific suggestion** — prepended on a failed recurring create, and absent on the non-rrule REST failure path.

Tests-only; no production code changes.

## Type of change
- [x] 🧪 Tests only

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit file: 9 passed; `ruff check` and `ruff format --check` clean.

## Checklist
- [x] I have updated documentation if needed
