### PR TITLE
fix(toolsearch): actionable error + refresh guidance for stale tool-search catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The proxy split lets MCP clients apply different permission policies per categor
 
 Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step. If you choose to use our toolsearch then you should disable the native Claude Opus/Sonnet toolsearch, which is called deferred tools in the settings.
 
-> 🔄 **Refresh your client's tool list after changing this (or any) setting.** Toggling `ENABLE_TOOL_SEARCH` (or changing pinned/disabled tools, Read Only Mode, etc.) changes the tools the server exposes, but your AI client keeps serving its **cached** tool list until it re-fetches. Restarting the server does **not** refresh the client — reconnect or refresh the MCP server in your client (e.g. re-add/refresh the connector in ChatGPT, or close and reopen Claude Desktop). If you skip this, tools shown as available will return `Unknown tool` when called.
+> 🔄 **Refresh your client's tool list after changing this (or any) setting.** Toggling `ENABLE_TOOL_SEARCH` (or changing pinned/disabled tools, Read Only Mode, etc.) changes the tools the server exposes, but your AI client keeps serving its **cached** tool list until it re-fetches. Restarting the add-on or Home Assistant does **not** refresh the client — reconnect or refresh the MCP server in your client (e.g. re-add/refresh the connector in ChatGPT, or close and reopen Claude Desktop). If you skip this, tools shown as available will return `Unknown tool` when called.
 
 For the HA add-on, the same option is documented in [`homeassistant-addon/DOCS.md`](homeassistant-addon/DOCS.md#enable_tool_search) along with the in-add-on settings UI for fine-grained tool enable/disable/pin.
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ The proxy split lets MCP clients apply different permission policies per categor
 
 Leave it off when using Claude Sonnet/Opus or any client with deferred tool loading; the full catalog has no idle cost there and direct calls skip the search step. If you choose to use our toolsearch then you should disable the native Claude Opus/Sonnet toolsearch, which is called deferred tools in the settings.
 
+> 🔄 **Refresh your client's tool list after changing this (or any) setting.** Toggling `ENABLE_TOOL_SEARCH` (or changing pinned/disabled tools, Read Only Mode, etc.) changes the tools the server exposes, but your AI client keeps serving its **cached** tool list until it re-fetches. Restarting the server does **not** refresh the client — reconnect or refresh the MCP server in your client (e.g. re-add/refresh the connector in ChatGPT, or close and reopen Claude Desktop). If you skip this, tools shown as available will return `Unknown tool` when called.
+
 For the HA add-on, the same option is documented in [`homeassistant-addon/DOCS.md`](homeassistant-addon/DOCS.md#enable_tool_search) along with the in-add-on settings UI for fine-grained tool enable/disable/pin.
 
 ---

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -233,6 +233,15 @@ See [Cloudflared add-on documentation](https://github.com/brenner-tobias/addon-c
 
 The add-on has minimal configuration - most settings are automatic.
 
+> 🔄 **After changing any setting, refresh your client's tool list.** When a
+> setting changes the tools the server exposes (Tool Search, Read Only Mode,
+> enabled/disabled/pinned tools, etc.), your AI client keeps serving its
+> **cached** tool list until it re-fetches. Restarting the add-on or Home
+> Assistant does **not** refresh the client — you must reconnect or refresh
+> the MCP server in your AI client (e.g. re-add/refresh the connector in
+> ChatGPT, or close and reopen Claude Desktop). Symptom if you skip this:
+> tools shown as available return `Unknown tool` when called.
+
 ### backup_hint (Advanced)
 
 **Default:** `normal`

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -27,7 +27,10 @@ configuration:
       LLMs that lack native deferred tools (e.g. Claude Haiku, local
       OpenAI-compatible models) or with smaller context windows. Tools
       are found via ha_search_tools and executed via categorized proxies
-      (read/write/delete). Requires restart to take effect.
+      (read/write/delete). Requires an add-on restart to take effect — then
+      reconnect or refresh the MCP server in your AI client so it reloads the
+      tool list. Restarting the add-on alone does NOT refresh a client's
+      cached tool list; this applies after changing any setting here.
   enable_tool_security_policies:
     name: Enable Tool Security Policies (advanced)
     description: >-

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -236,6 +236,13 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
 
         self.mcp.add_middleware(ValidationErrorMiddleware())
 
+        # Replace the opaque "Unknown tool" FastMCP raises when a client calls
+        # ha_search_tools / the ha_call_* proxies while Tool Search is off
+        # (stale client tool-list cache) with an actionable refresh hint.
+        from .tools.tool_search_hint_middleware import ToolSearchHintMiddleware
+
+        self.mcp.add_middleware(ToolSearchHintMiddleware())
+
         # Read Only Mode write blocker (discussion #1569) — always
         # installed, consults the live flag per call. Before
         # PolicyMiddleware so a write blocked by Read Only Mode never

--- a/src/ha_mcp/settings_ui.py
+++ b/src/ha_mcp/settings_ui.py
@@ -812,6 +812,10 @@ _SETTINGS_HTML = (
   <span class="restart-notice-text" id="restartNoticeText">
     ⚠ Changes saved. Restart ha-mcp for them to take effect — disabled
     tools will be fully removed from the MCP tool list on next startup.
+    Then reconnect or refresh the MCP server in your AI client (e.g.
+    re-add/refresh the connector in ChatGPT, or close and reopen Claude
+    Desktop) so it reloads the tool list — restarting the add-on or Home
+    Assistant does NOT refresh your client's cached tool list.
   </span>
   <button class="restart-btn" id="restartBtn" style="display:none">Restart Add-on</button>
 </div>
@@ -857,8 +861,10 @@ _SETTINGS_HTML = (
 </div>
 <div class="panel" id="panel-server">
   <div class="features-sub">
-    Tool Search, advanced settings. Changes require an MCP-host restart
-    to take effect (close + reopen Claude Desktop, restart the add-on, etc.).
+    Tool Search, advanced settings. Changes take effect only after you
+    restart the add-on (applies the change server-side) AND reconnect or
+    refresh the MCP server in your AI client (reloads the tool list) — e.g.
+    re-add/refresh the connector in ChatGPT, or close + reopen Claude Desktop.
   </div>
 
   <!-- Two-step note + top Save button. The Save +

--- a/src/ha_mcp/tools/tool_search_hint_middleware.py
+++ b/src/ha_mcp/tools/tool_search_hint_middleware.py
@@ -6,18 +6,19 @@ never registered (the ``CategorizedSearchTransform`` is not installed). If a
 client calls one of them anyway, FastMCP raises a bare ``NotFoundError``
 ("Unknown tool: 'ha_search_tools'") with no recovery guidance.
 
-That is exactly what happens when an MCP client (e.g. a ChatGPT connector) is
-still advertising a *cached* tool list captured from a previous session when
-Tool Search was on: the client shows ``ha_search_tools`` as available, calls
-it, and the live server — now in Tool-Search-off mode — rejects it. Restarting
-the add-on or Home Assistant does not help because the stale list lives in the
-client, not the server.
+That is exactly what happens when an MCP client that caches its tool list is
+still advertising one captured from a previous session when Tool Search was on:
+the client shows ``ha_search_tools`` as available, calls it, and the live
+server — now in Tool-Search-off mode — rejects it. Restarting the add-on or
+Home Assistant does not help because the stale list lives in the client, not
+the server.
 
 This middleware intercepts that one case and replaces the opaque "Unknown tool"
 with a structured error that tells the user their tool list is stale and to
-reconnect/refresh the MCP server. It only acts when Tool Search is off (the
-only state in which those four names fail to resolve); in every other case the
-original ``NotFoundError`` propagates unchanged.
+reconnect/refresh the MCP server. It only acts on a *top-level* resolution miss
+for one of those four names while Tool Search is off; in every other case —
+including a ``NotFoundError`` bubbling up from inside an executing tool — the
+original error propagates unchanged.
 """
 
 from __future__ import annotations
@@ -45,14 +46,20 @@ class ToolSearchHintMiddleware(Middleware):
     ) -> Any:
         try:
             return await call_next(context)
-        except NotFoundError:
+        except NotFoundError as exc:
             name = context.message.name
-            # Only the four tool-search synthetic tools are affected, and only
-            # when Tool Search is off (when it is on they resolve normally, so
-            # a NotFoundError here would be a different, real problem we must
-            # not mask).
+            # Only rewrite a TOP-LEVEL "Unknown tool" miss for one of the four
+            # tool-search synthetic names while Tool Search is off:
+            #  - match the dispatch-layer message so a NotFoundError bubbling up
+            #    from INSIDE an executing tool (a different name) is never
+            #    mislabeled as a stale cache; on any wording change this simply
+            #    fails closed and re-raises the original error.
+            #  - require Tool Search to be off (when on, the names resolve, so a
+            #    miss would be a different, real problem we must not mask).
+            top_level_miss = str(exc) == f"Unknown tool: {name!r}"
             if (
-                name in PROXY_META_TOOLS
+                top_level_miss
+                and name in PROXY_META_TOOLS
                 and not get_global_settings().enable_tool_search
             ):
                 logger.info(
@@ -76,11 +83,15 @@ class ToolSearchHintMiddleware(Middleware):
                             f"so {name} is not needed."
                         ),
                         suggestions=[
-                            "Reconnect or refresh the ha-mcp MCP server in your client "
-                            "to reload the current tool list.",
-                            "Then call the tool you need directly by its name (with "
-                            "Tool Search off, ha_search_tools and the ha_call_* "
-                            "proxies do not exist).",
+                            (
+                                "Reconnect or refresh the ha-mcp MCP server in your "
+                                "client to reload the current tool list."
+                            ),
+                            (
+                                "Then call the tool you need directly by its name "
+                                "(with Tool Search off, ha_search_tools and the "
+                                "ha_call_* proxies do not exist)."
+                            ),
                         ],
                         context={"tool_name": name, "enable_tool_search": False},
                     )

--- a/src/ha_mcp/tools/tool_search_hint_middleware.py
+++ b/src/ha_mcp/tools/tool_search_hint_middleware.py
@@ -1,0 +1,88 @@
+"""FastMCP middleware: actionable error for stale tool-search proxy/search calls.
+
+When ``enable_tool_search`` is off, the synthetic tool-search tools —
+``ha_search_tools`` and the ``ha_call_{read,write,delete}_tool`` proxies — are
+never registered (the ``CategorizedSearchTransform`` is not installed). If a
+client calls one of them anyway, FastMCP raises a bare ``NotFoundError``
+("Unknown tool: 'ha_search_tools'") with no recovery guidance.
+
+That is exactly what happens when an MCP client (e.g. a ChatGPT connector) is
+still advertising a *cached* tool list captured from a previous session when
+Tool Search was on: the client shows ``ha_search_tools`` as available, calls
+it, and the live server — now in Tool-Search-off mode — rejects it. Restarting
+the add-on or Home Assistant does not help because the stale list lives in the
+client, not the server.
+
+This middleware intercepts that one case and replaces the opaque "Unknown tool"
+with a structured error that tells the user their tool list is stale and to
+reconnect/refresh the MCP server. It only acts when Tool Search is off (the
+only state in which those four names fail to resolve); in every other case the
+original ``NotFoundError`` propagates unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.exceptions import NotFoundError
+from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
+
+from ..config import get_global_settings
+from ..errors import ErrorCode, create_error_response
+from ..policy.middleware import PROXY_META_TOOLS
+from .helpers import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+
+class ToolSearchHintMiddleware(Middleware):
+    """Turn the opaque "Unknown tool" for tool-search synthetic tools into a
+    stale-tool-list hint when Tool Search is disabled."""
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: CallNext
+    ) -> Any:
+        try:
+            return await call_next(context)
+        except NotFoundError:
+            name = context.message.name
+            # Only the four tool-search synthetic tools are affected, and only
+            # when Tool Search is off (when it is on they resolve normally, so
+            # a NotFoundError here would be a different, real problem we must
+            # not mask).
+            if (
+                name in PROXY_META_TOOLS
+                and not get_global_settings().enable_tool_search
+            ):
+                logger.info(
+                    "Stale tool-search call for %r while enable_tool_search is off "
+                    "- returning refresh-your-tool-list hint",
+                    name,
+                )
+                raise_tool_error(
+                    create_error_response(
+                        code=ErrorCode.RESOURCE_NOT_FOUND,
+                        message=(
+                            f"'{name}' only exists when Tool Search is enabled, and "
+                            "Tool Search is currently OFF on this ha-mcp server. Your "
+                            "MCP client is showing a cached tool list from when Tool "
+                            "Search was on. After changing any ha-mcp setting (Tool "
+                            "Search, pinned/disabled tools, etc.) the client must "
+                            "reconnect or refresh the MCP server to re-fetch the "
+                            "current tools — restarting the add-on or Home Assistant "
+                            "does not refresh the client's cached list. With Tool "
+                            f"Search off, every tool is available directly by name, "
+                            f"so {name} is not needed."
+                        ),
+                        suggestions=[
+                            "Reconnect or refresh the ha-mcp MCP server in your client "
+                            "to reload the current tool list.",
+                            "Then call the tool you need directly by its name (with "
+                            "Tool Search off, ha_search_tools and the ha_call_* "
+                            "proxies do not exist).",
+                        ],
+                        context={"tool_name": name, "enable_tool_search": False},
+                    )
+                )
+            raise

--- a/tests/src/unit/test_tool_search_hint_middleware.py
+++ b/tests/src/unit/test_tool_search_hint_middleware.py
@@ -65,6 +65,14 @@ async def test_stale_synthetic_tool_returns_refresh_hint(monkeypatch, name):
     msg = body["error"]["message"]
     assert "Tool Search" in msg
     assert ("reconnect" in msg.lower()) or ("refresh" in msg.lower())
+    # the counter-intuitive insight users most need: a server restart won't help
+    assert "does not refresh" in msg.lower()
+    # the actionable recovery guidance is the whole point of the change
+    suggestions = body["error"]["suggestions"]
+    assert len(suggestions) == 2
+    assert any(
+        ("reconnect" in s.lower()) or ("refresh" in s.lower()) for s in suggestions
+    )
     # context fields are spread at the top level by create_error_response
     assert body["tool_name"] == name
     assert body["enable_tool_search"] is False
@@ -91,6 +99,24 @@ async def test_synthetic_name_not_masked_when_tool_search_on(monkeypatch):
 
     with pytest.raises(NotFoundError):
         await mcp.call_tool("ha_search_tools", {"query": "x"})
+
+
+@pytest.mark.asyncio
+async def test_deep_notfound_with_other_name_not_rewritten(monkeypatch):
+    """A NotFoundError whose message names a DIFFERENT tool (e.g. one bubbling
+    up from inside an executing proxy) is not a top-level miss for the called
+    name, so it must propagate unchanged rather than be relabeled stale-cache —
+    even when the called name is synthetic and Tool Search is off."""
+    _patch_tool_search(monkeypatch, enabled=False)
+    mw = ToolSearchHintMiddleware()
+    context = SimpleNamespace(message=SimpleNamespace(name="ha_search_tools"))
+
+    async def call_next(_ctx):
+        raise NotFoundError("Unknown tool: 'some_inner_tool'")
+
+    with pytest.raises(NotFoundError) as exc_info:
+        await mw.on_call_tool(context, call_next)
+    assert "some_inner_tool" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_tool_search_hint_middleware.py
+++ b/tests/src/unit/test_tool_search_hint_middleware.py
@@ -1,0 +1,103 @@
+"""Unit tests for ToolSearchHintMiddleware.
+
+Covers the stale-tool-list scenario: a client (e.g. a ChatGPT connector)
+calls ha_search_tools / the ha_call_* proxies from a cached catalog while the
+live server has Tool Search off, so the names no longer resolve.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastmcp import FastMCP
+from fastmcp.exceptions import NotFoundError, ToolError
+
+from ha_mcp.tools.tool_search_hint_middleware import ToolSearchHintMiddleware
+
+
+def _make_mcp() -> FastMCP:
+    """A bare server with only the hint middleware and one real tool.
+
+    The tool-search transform is deliberately NOT installed, so the synthetic
+    names (ha_search_tools / ha_call_*) are unresolved — mirroring the live
+    Tool-Search-off server that a stale client keeps calling.
+    """
+    mcp = FastMCP("test")
+    mcp.add_middleware(ToolSearchHintMiddleware())
+
+    @mcp.tool()
+    async def ha_real_tool(x: int) -> dict:
+        return {"x": x}
+
+    return mcp
+
+
+def _patch_tool_search(monkeypatch, *, enabled: bool) -> None:
+    monkeypatch.setattr(
+        "ha_mcp.tools.tool_search_hint_middleware.get_global_settings",
+        lambda: SimpleNamespace(enable_tool_search=enabled),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ha_search_tools",
+        "ha_call_read_tool",
+        "ha_call_write_tool",
+        "ha_call_delete_tool",
+    ],
+)
+async def test_stale_synthetic_tool_returns_refresh_hint(monkeypatch, name):
+    """Calling a synthetic tool-search tool while Tool Search is off yields a
+    structured 'stale tool list — reconnect/refresh' ToolError, not the bare
+    FastMCP NotFoundError."""
+    _patch_tool_search(monkeypatch, enabled=False)
+    mcp = _make_mcp()
+
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool(name, {"query": "x"})
+
+    body = json.loads(str(exc_info.value))
+    assert body["success"] is False
+    assert body["error"]["code"] == "RESOURCE_NOT_FOUND"
+    msg = body["error"]["message"]
+    assert "Tool Search" in msg
+    assert ("reconnect" in msg.lower()) or ("refresh" in msg.lower())
+    # context fields are spread at the top level by create_error_response
+    assert body["tool_name"] == name
+    assert body["enable_tool_search"] is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_non_synthetic_tool_still_raises_notfound(monkeypatch):
+    """A genuinely unknown tool that is NOT a synthetic name keeps the original
+    NotFoundError — the middleware must not mask real typos/renames."""
+    _patch_tool_search(monkeypatch, enabled=False)
+    mcp = _make_mcp()
+
+    with pytest.raises(NotFoundError):
+        await mcp.call_tool("ha_definitely_not_a_tool", {})
+
+
+@pytest.mark.asyncio
+async def test_synthetic_name_not_masked_when_tool_search_on(monkeypatch):
+    """If Tool Search is ON, a NotFoundError for a synthetic name signals a
+    real problem (the transform should have registered it) and must propagate
+    unchanged rather than be mislabelled as a stale-cache hint."""
+    _patch_tool_search(monkeypatch, enabled=True)
+    mcp = _make_mcp()  # transform not installed, so the name is missing
+
+    with pytest.raises(NotFoundError):
+        await mcp.call_tool("ha_search_tools", {"query": "x"})
+
+
+@pytest.mark.asyncio
+async def test_real_tool_passes_through(monkeypatch):
+    """A normal, registered tool is unaffected by the middleware."""
+    _patch_tool_search(monkeypatch, enabled=False)
+    mcp = _make_mcp()
+
+    result = await mcp.call_tool("ha_real_tool", {"x": 5})
+    assert result.structured_content == {"x": 5}


### PR DESCRIPTION
## What does this PR do?

Two coupled changes for the stale tool-list problem behind #1598:

- **New `ToolSearchHintMiddleware`** — when Tool Search is off, `ha_search_tools` and the `ha_call_read_tool` / `ha_call_write_tool` / `ha_call_delete_tool` proxies aren't registered, so a client serving a tool list cached from when Tool Search was on gets FastMCP's bare `NotFoundError("Unknown tool: …")` with no recovery path. The middleware replaces it (only for those four synthetic names, only when `enable_tool_search` is off) with a structured error telling the user their client has a stale tool list and to reconnect/refresh the MCP server. Real unknown-tool errors and tool-search-on misses are left untouched.
- **Universal "refresh your tool list after changing settings" guidance** in the settings UI (post-save restart notice + Server Settings tab), the add-on config page (`enable_tool_search` description), and the docs (DOCS.md Configuration Options + README Tool Discovery). Restarting the add-on or Home Assistant does not refresh a client's cached tool list — only a client-side reconnect does.

Relates to #1598 (root cause is a client-side tool cache, not fixable server-side; this makes the failure self-explanatory and documents the recovery).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Adds `test_tool_search_hint_middleware.py` covering the stale-cache hint, the tool-search-on no-mask guard, and the unknown-tool passthrough.

## Checklist
- [x] I have updated documentation if needed
