### PR TITLE
fix(helpers): apply icon to flow/template helpers via the entity registry

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -737,12 +737,15 @@ def _validate_applicable_params(
 
     if helper_type in FLOW_HELPER_TYPES:
         # Flow types accept `config` (handled before this call) plus
-        # cross-cutting params (name/helper_id/area_id/labels/category/wait).
-        # Any simple-helper-typed param passed here is inapplicable.
+        # cross-cutting params (name/helper_id/area_id/labels/category/icon/wait).
+        # `icon` is applied to the resulting entity(ies) via the entity registry
+        # (like area_id/labels), so it is allowed even though the config-flow
+        # form has no icon field. Any other simple-helper-typed param passed
+        # here is inapplicable.
         inapplicable.extend(
             param_name
             for param_name in _ALL_TYPED_PARAMS
-            if passed.get(param_name) is not None
+            if param_name != "icon" and passed.get(param_name) is not None
         )
     else:
         applicable = _TYPE_TYPED_PARAMS.get(helper_type, frozenset())
@@ -760,7 +763,7 @@ def _validate_applicable_params(
     if helper_type in FLOW_HELPER_TYPES:
         applicable_msg = (
             "config (see data_schema on a validation error for the field set), "
-            "name, helper_id, area_id, labels, category, wait"
+            "name, helper_id, area_id, labels, category, icon, wait"
         )
     else:
         type_specific = sorted(_TYPE_TYPED_PARAMS.get(helper_type, frozenset()))
@@ -1453,7 +1456,11 @@ async def _get_entities_for_config_entry(
 
 
 async def _entity_registry_update_coro(
-    client: Any, entity_id: str, area_id: str | None, labels: list[str] | None
+    client: Any,
+    entity_id: str,
+    area_id: str | None,
+    labels: list[str] | None,
+    icon: str | None = None,
 ) -> Any:
     """Build and send a config/entity_registry/update WS message."""
     update_message: dict[str, Any] = {
@@ -1464,6 +1471,8 @@ async def _entity_registry_update_coro(
         update_message["area_id"] = area_id if area_id else None
     if labels is not None:
         update_message["labels"] = labels
+    if icon is not None:
+        update_message["icon"] = icon if icon else None
     return await client.send_websocket_message(update_message)
 
 
@@ -1482,6 +1491,7 @@ def _process_reg_update_result(
     reg_result: Any,
     area_id: str | None,
     labels: list[str] | None,
+    icon: str | None,
     applied: dict[str, Any],
     entity_id: str,
     warnings: list[str],
@@ -1495,9 +1505,21 @@ def _process_reg_update_result(
                 applied["area_id"] = area_id if area_id else None
             if labels is not None:
                 applied["labels"] = labels
+            if icon is not None:
+                applied["icon"] = icon if icon else None
         else:
+            # area_id/labels/icon share one WS message, so a rejection of any
+            # one sinks the others. Name the batched fields so the caller can
+            # tell which touchups didn't land instead of guessing.
+            sent_fields = [
+                f
+                for f, v in (("area_id", area_id), ("labels", labels), ("icon", icon))
+                if v is not None
+            ]
+            field_note = f" (fields: {', '.join(sent_fields)})" if sent_fields else ""
             warnings.append(
-                f"{entity_id}: entity registry update failed: {_ws_error_msg(reg_result)}"
+                f"{entity_id}: entity registry update failed{field_note}: "
+                f"{_ws_error_msg(reg_result)}"
             )
 
 
@@ -1523,9 +1545,10 @@ async def _apply_registry_updates_to_entity(
     area_id: str | None,
     labels: list[str] | None,
     category: str | None,
+    icon: str | None,
     warnings: list[str],
 ) -> dict[str, Any]:
-    """Apply area_id/labels (single WS call) and category (shared helper) to one entity.
+    """Apply area_id/labels/icon (single WS call) and category (shared helper) to one entity.
 
     Appends human-readable warning strings to `warnings` on any failure.
     Returns a small dict summarizing what was applied (for result building).
@@ -1536,13 +1559,13 @@ async def _apply_registry_updates_to_entity(
     # `is not None` distinguishes "not provided" from "explicit clear" (empty
     # string / empty list). A transient raise on either call is captured via
     # return_exceptions so a multi-entity flow helper can still report partial success.
-    needs_registry = area_id is not None or labels is not None
+    needs_registry = area_id is not None or labels is not None or icon is not None
     needs_category = bool(category)
     if not (needs_registry or needs_category):
         return applied
 
     reg_task = (
-        _entity_registry_update_coro(client, entity_id, area_id, labels)
+        _entity_registry_update_coro(client, entity_id, area_id, labels, icon)
         if needs_registry
         else None
     )
@@ -1557,7 +1580,7 @@ async def _apply_registry_updates_to_entity(
     cat_result = raw_results.pop(0) if needs_category else None
 
     _process_reg_update_result(
-        reg_result, area_id, labels, applied, entity_id, warnings
+        reg_result, area_id, labels, icon, applied, entity_id, warnings
     )
     _process_cat_apply_result(cat_result, entity_id, applied, warnings)
     return applied
@@ -1772,31 +1795,45 @@ async def _apply_flow_registry_updates(
     area_id: str | None,
     labels_list: list[str] | None,
     category: str | None,
+    icon: str | None,
     extras: dict[str, Any],
     warnings: list[str],
 ) -> None:
-    """Apply area/labels/category to every entity from a flow helper, in parallel."""
+    """Apply area/labels/category/icon to every entity from a flow helper, in parallel."""
     if not (
         entity_ids
-        and (area_id is not None or labels_list is not None or category is not None)
+        and (
+            area_id is not None
+            or labels_list is not None
+            or category is not None
+            or icon is not None
+        )
     ):
         return
     applied_per_entity = list(
         await asyncio.gather(
             *(
                 _apply_registry_updates_to_entity(
-                    client, eid, area_id, labels_list, category, warnings
+                    client, eid, area_id, labels_list, category, icon, warnings
                 )
                 for eid in entity_ids
             )
         )
     )
-    if area_id is not None:
+    # Echo a top-level convenience key only when it was actually applied to at
+    # least one entity. The per-entity ``applied`` dicts are the source of
+    # truth — a failed entity_registry/update leaves its key out and records a
+    # warning instead — so echoing straight from the inputs would assert
+    # success that the accompanying warnings contradict.
+    applied_keys = {k for entry in applied_per_entity for k in entry}
+    if area_id is not None and "area_id" in applied_keys:
         extras["area_id"] = area_id if area_id else None
-    if labels_list is not None:
+    if labels_list is not None and "labels" in applied_keys:
         extras["labels"] = labels_list
-    if category:
+    if category and "category" in applied_keys:
         extras["category"] = category
+    if icon is not None and "icon" in applied_keys:
+        extras["icon"] = icon if icon else None
     extras["applied"] = applied_per_entity
 
 
@@ -1810,16 +1847,17 @@ async def _handle_flow_helper(
     labels: str | list[str] | None,
     category: str | None,
     wait: bool,
+    icon: str | None = None,
     action: str | None = None,
 ) -> dict[str, Any]:
     """Create or update a flow-based helper and apply registry updates to all entities.
 
     Routes between create_flow_helper and update_flow_helper based on helper_id,
     then resolves the resulting config_entry_id to its entity(ies) and applies
-    area_id / labels / category across the full set.
+    area_id / labels / category / icon across the full set.
 
-    For utility_meter with tariffs, this means the same label/area is applied
-    to every tariff sensor (and the select entity) uniformly.
+    For utility_meter with tariffs, this means the same label/area/icon is
+    applied to every tariff sensor (and the select entity) uniformly.
 
     `action` may be passed by the caller (Bug 11 explicit-intent path) — when
     None, falls back to the legacy implicit discriminator (presence of
@@ -1903,7 +1941,7 @@ async def _handle_flow_helper(
         extras["updated"] = True
 
     await _apply_flow_registry_updates(
-        client, entity_ids, area_id, labels_list, category, extras, warnings
+        client, entity_ids, area_id, labels_list, category, icon, extras, warnings
     )
 
     return _helper_response(
@@ -3886,7 +3924,8 @@ class HelperConfigTools:
                     labels,
                     category,
                     wait,
-                    action,
+                    icon=icon,
+                    action=action,
                 )
                 _attach_helper_skill(flow_response, MandatoryBPS)
                 return flow_response

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -126,6 +126,58 @@ class TestConfigEntryFlow:
             {"target": entry_id, "confirm": True},
         )
 
+    async def test_create_template_sensor_with_icon(self, mcp_client):
+        """A template (flow) helper accepts `icon` and HA applies it to the
+        resulting entity via the entity-registry icon override.
+
+        This is the end-to-end proof for flow-helper icon support: the unit
+        test only checks the WS wire format against a mock; here a real
+        template sensor is created with an icon and HA's own state for the
+        entity must report that icon.
+        """
+        result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "template",
+                "name": "e2e icon template",
+                "config": {
+                    "next_step_id": "sensor",
+                    "name": "e2e icon template",
+                    "state": "{{ states('sun.sun') }}",
+                },
+                "icon": "mdi:flash",
+                "wait": True,
+            },
+        )
+        data = assert_mcp_success(result, "Create template sensor with icon")
+        assert data.get("success") is True
+        # icon is echoed back in the flow response (applied registry override).
+        assert data.get("icon") == "mdi:flash", f"icon not echoed: {data}"
+        entry_id = data.get("entry_id")
+        assert entry_id is not None
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"No entity_ids in response: {data}"
+        entity_id = entity_ids[0]
+
+        try:
+            # HA surfaces the entity-registry icon override in the entity's
+            # state attributes — poll until it propagates.
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_state",
+                arguments={"entity_id": entity_id},
+                predicate=lambda d: (
+                    d.get("data", {}).get("attributes", {}).get("icon") == "mdi:flash"
+                ),
+                description="template sensor icon override applied by HA",
+            )
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
+
     async def test_get_entity_config_entry_id_and_options_optimal_path(
         self, mcp_client
     ):

--- a/tests/src/unit/test_helper_param_rejection.py
+++ b/tests/src/unit/test_helper_param_rejection.py
@@ -826,3 +826,26 @@ class TestAllowedParamsControl:
             wait=False,
         )
         assert result["success"] is True
+
+    async def test_flow_type_accepts_icon(self, register_tools, mock_client):
+        """Flow types accept `icon` (applied to the entity via the registry)
+        rather than rejecting it like other simple-helper-typed params."""
+        mock_client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-ic",
+                "result": {"entry_id": "entry-ic", "title": "x", "domain": "min_max"},
+            }
+        )
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="min_max",
+            name="x",
+            config={"entity_ids": ["sensor.a", "sensor.b"], "type": "mean"},
+            icon="mdi:flash",
+            wait=False,
+        )
+        assert result["success"] is True

--- a/tests/src/unit/test_helper_update_persistence.py
+++ b/tests/src/unit/test_helper_update_persistence.py
@@ -609,6 +609,227 @@ class TestFlowHelperRouting:
             "sensor.daily_kwh_peak",
             "sensor.daily_kwh_offpeak",
         }
+        # icon was not passed, so no icon key may leak into the WS update.
+        assert all("icon" not in c for c in update_calls)
+
+    async def test_flow_helper_applies_icon_via_entity_registry(
+        self, register_tools, mock_client
+    ):
+        """A template (flow) helper accepts `icon` and applies it to the
+        resulting entity via config/entity_registry/update.
+
+        Flow helpers have no icon field in their config-flow form, but the
+        entity-registry icon override works for any entity (same mechanism as
+        area_id/labels), so `icon` is allowed and threaded through rather than
+        rejected as inapplicable.
+        """
+        mock_client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-tmpl",
+                "result": {
+                    "entry_id": "entry-tmpl",
+                    "title": "Flash Sensor",
+                    "domain": "template",
+                },
+            }
+        )
+        responses = [
+            # Bug 12 collision check: no existing helper with this slug.
+            {"success": True, "result": []},
+            # entity_registry/list: one entity for our config entry.
+            {
+                "success": True,
+                "result": [
+                    {
+                        "entity_id": "sensor.flash_sensor",
+                        "config_entry_id": "entry-tmpl",
+                    }
+                ],
+            },
+        ]
+        responses.extend([{"success": True}] * 5)  # entity_registry/update headroom
+        mock_client.send_websocket_message = AsyncMock(side_effect=responses)
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="template",
+            name="Flash Sensor",
+            config={"template_type": "sensor", "state": "{{ 1 }}"},
+            icon="mdi:flash",
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["method"] == "config_flow"
+        assert result["icon"] == "mdi:flash"
+
+        # The entity_registry/update for our entity must carry the icon.
+        update_calls = [
+            call.args[0]
+            for call in mock_client.send_websocket_message.call_args_list
+            if isinstance(call.args[0], dict)
+            and call.args[0].get("type") == "config/entity_registry/update"
+        ]
+        assert len(update_calls) == 1
+        assert update_calls[0]["entity_id"] == "sensor.flash_sensor"
+        assert update_calls[0]["icon"] == "mdi:flash"
+
+    async def test_flow_helper_multi_entity_icon_applies_to_all(
+        self, register_tools, mock_client
+    ):
+        """icon on a multi-entity flow helper (utility_meter + 2 tariffs => 3
+        entities) is applied to every entity, like area_id/labels."""
+        mock_client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-um-icon",
+                "result": {
+                    "entry_id": "entry-um-icon",
+                    "title": "daily_kwh",
+                    "domain": "utility_meter",
+                },
+            }
+        )
+        # icon needs no registry-ID validation (unlike area_id/labels), so the
+        # sequence is just collision-check then entity-list then the updates.
+        responses = [
+            {"success": True, "result": []},
+            {
+                "success": True,
+                "result": [
+                    {
+                        "entity_id": "select.daily_kwh",
+                        "config_entry_id": "entry-um-icon",
+                    },
+                    {
+                        "entity_id": "sensor.daily_kwh_peak",
+                        "config_entry_id": "entry-um-icon",
+                    },
+                    {
+                        "entity_id": "sensor.daily_kwh_offpeak",
+                        "config_entry_id": "entry-um-icon",
+                    },
+                ],
+            },
+        ]
+        responses.extend([{"success": True}] * 5)
+        mock_client.send_websocket_message = AsyncMock(side_effect=responses)
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="utility_meter",
+            name="daily_kwh",
+            config={
+                "source": "sensor.energy",
+                "cycle": "daily",
+                "tariffs": ["peak", "offpeak"],
+            },
+            icon="mdi:flash",
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["icon"] == "mdi:flash"
+        update_calls = [
+            call.args[0]
+            for call in mock_client.send_websocket_message.call_args_list
+            if isinstance(call.args[0], dict)
+            and call.args[0].get("type") == "config/entity_registry/update"
+        ]
+        assert {c["entity_id"] for c in update_calls} == {
+            "select.daily_kwh",
+            "sensor.daily_kwh_peak",
+            "sensor.daily_kwh_offpeak",
+        }
+        assert all(c["icon"] == "mdi:flash" for c in update_calls)
+
+    async def test_flow_helper_clears_icon_on_empty_string(
+        self, register_tools, mock_client
+    ):
+        """icon='' clears the override: the WS update carries icon=None and the
+        response echoes icon=None (mirrors the area/labels clear convention)."""
+        mock_client.start_config_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-ic-clear",
+                "result": {
+                    "entry_id": "entry-ic-clear",
+                    "title": "t",
+                    "domain": "template",
+                },
+            }
+        )
+        responses = [
+            {"success": True, "result": []},
+            {
+                "success": True,
+                "result": [
+                    {"entity_id": "sensor.t", "config_entry_id": "entry-ic-clear"}
+                ],
+            },
+        ]
+        responses.extend([{"success": True}] * 3)
+        mock_client.send_websocket_message = AsyncMock(side_effect=responses)
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="template",
+            name="t",
+            config={"next_step_id": "sensor", "name": "t", "state": "{{ 1 }}"},
+            icon="",
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["icon"] is None
+        update_calls = [
+            call.args[0]
+            for call in mock_client.send_websocket_message.call_args_list
+            if isinstance(call.args[0], dict)
+            and call.args[0].get("type") == "config/entity_registry/update"
+        ]
+        assert len(update_calls) == 1
+        assert "icon" in update_calls[0]
+        assert update_calls[0]["icon"] is None
+
+    async def test_flow_helper_update_applies_icon(self, register_tools, mock_client):
+        """icon is applied on the flow-helper UPDATE path (options flow), not
+        just create — the registry touchup is shared between both paths."""
+        mock_client.get_config_entry = AsyncMock(
+            return_value={"domain": "template", "entry_id": "entry-u-ic"}
+        )
+        mock_client.start_options_flow = AsyncMock(
+            return_value={
+                "type": "create_entry",
+                "flow_id": "flow-u-ic",
+                "result": {"entry_id": "entry-u-ic", "title": "t"},
+            }
+        )
+        responses = [
+            {
+                "success": True,
+                "result": [{"entity_id": "sensor.tu", "config_entry_id": "entry-u-ic"}],
+            },
+        ]
+        responses.extend([{"success": True}] * 3)
+        mock_client.send_websocket_message = AsyncMock(side_effect=responses)
+
+        result = await register_tools["ha_config_set_helper"](
+            helper_type="template",
+            helper_id="entry-u-ic",
+            config={"state": "{{ 2 }}"},
+            icon="mdi:flash",
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["updated"] is True
+        assert result["icon"] == "mdi:flash"
+        update_calls = [
+            call.args[0]
+            for call in mock_client.send_websocket_message.call_args_list
+            if isinstance(call.args[0], dict)
+            and call.args[0].get("type") == "config/entity_registry/update"
+        ]
+        assert any(c.get("icon") == "mdi:flash" for c in update_calls)
 
     async def test_flow_helper_registry_update_failure_collects_warning(
         self, register_tools, mock_client
@@ -641,12 +862,19 @@ class TestFlowHelperRouting:
             name="grp",
             config={"group_type": "light", "entities": [], "hide_members": False},
             area_id="hallway",
+            icon="mdi:flash",
             wait=False,
         )
 
         assert result["success"] is True
         assert "warnings" in result
         assert any("light.grp" in w for w in result["warnings"])
+        # The update failed, so the optimistic top-level echo must NOT claim
+        # area_id/icon were applied — only the warning reflects reality.
+        assert "area_id" not in result
+        assert "icon" not in result
+        # The warning names which batched fields were in the failed update.
+        assert any("area_id" in w and "icon" in w for w in result["warnings"])
 
     async def test_flow_helper_registry_list_raises_surfaces_warning(
         self, register_tools, mock_client


### PR DESCRIPTION
## What does this PR do?

`ha_config_set_helper` rejected `icon` for flow-based helper types (template, group, utility_meter, etc.) as "not applicable", and before that (≤v7.4) silently dropped it. Flow helpers have no icon field in their config-flow form, but the entity-registry icon override works for any entity — the same way `area_id`/`labels` already do for flow helpers. This applies `icon` to the resulting entity(ies) instead of rejecting it.

- `_validate_applicable_params`: allow `icon` for flow types (still rejected for person/tag, which genuinely don't support it).
- Thread `icon` through `_handle_flow_helper` → `_apply_flow_registry_updates` → `_apply_registry_updates_to_entity` → `_entity_registry_update_coro`, mirroring `area_id`/`labels`. Applied to every entity of multi-entity flow helpers (e.g. utility_meter tariffs).

Relates to #1598.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Adds `test_flow_helper_applies_icon_via_entity_registry`: a template helper with `icon` asserts the icon lands in the `config/entity_registry/update` message and the response.

## Checklist
- [x] I have updated documentation if needed
