### PR TITLE
fix: SSE stateless_http startup, plus transient-5xx retry and HACS add timeout

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -290,17 +290,29 @@ def _setup_standard_mode() -> None:
     _log_startup_version()
 
 
-def _http_run_kwargs(transport: str, host: str, port: int, path: str) -> dict:
-    """Build common run_async kwargs for HTTP-based transports."""
-    return {
+def _http_run_kwargs(transport: str, host: str, port: int, path: str) -> dict[str, Any]:
+    """Build common run_async kwargs for HTTP-based transports.
+
+    ``stateless_http`` is a Streamable-HTTP concept and is only valid for the
+    ``http``/``streamable-http`` transports. Passing it alongside
+    ``transport="sse"`` makes fastmcp's ``run_async`` raise
+    ``ValueError("SSE transport does not support stateless mode")``. That raise
+    is swallowed (the server task is already done, so ``_cancel_tasks`` skips it
+    and the exception is never retrieved), so ``_run_entrypoint`` exits 0 and the
+    SSE entrypoint appears to start, then silently dies. Gate it to non-SSE
+    transports. See #1544.
+    """
+    kwargs: dict[str, Any] = {
         "transport": transport,
         "host": host,
         "port": port,
         "path": path,
         "show_banner": _get_show_banner(),
-        "stateless_http": True,
         "uvicorn_config": {"log_config": _get_timestamped_uvicorn_log_config()},
     }
+    if transport != "sse":
+        kwargs["stateless_http"] = True
+    return kwargs
 
 
 def _create_server() -> "HomeAssistantSmartMCPServer":
@@ -532,6 +544,12 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
                 # Expected: we just cancelled server_task above; swallow its
                 # CancelledError so shutdown can proceed to cleanup.
                 pass
+        elif server_task in done:
+            # Server task finished on its own (no shutdown signal). Re-raise any
+            # exception it captured so a hard startup failure surfaces as a
+            # logged sys.exit(1) instead of a silent exit 0 — without this the
+            # exception on the already-done task is never retrieved. See #1544.
+            server_task.result()
 
     except asyncio.CancelledError:
         logger.info("Server task cancelled")

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -296,11 +296,10 @@ def _http_run_kwargs(transport: str, host: str, port: int, path: str) -> dict[st
     ``stateless_http`` is a Streamable-HTTP concept and is only valid for the
     ``http``/``streamable-http`` transports. Passing it alongside
     ``transport="sse"`` makes fastmcp's ``run_async`` raise
-    ``ValueError("SSE transport does not support stateless mode")``. That raise
-    is swallowed (the server task is already done, so ``_cancel_tasks`` skips it
-    and the exception is never retrieved), so ``_run_entrypoint`` exits 0 and the
-    SSE entrypoint appears to start, then silently dies. Gate it to non-SSE
-    transports. See #1544.
+    ``ValueError("SSE transport does not support stateless mode")``. Gating it to
+    non-SSE transports keeps SSE startup working. (Before this fix that raise was
+    also swallowed into a silent exit 0; ``_run_with_shutdown`` now surfaces a
+    self-terminating server task's exception instead.) See #1544.
     """
     kwargs: dict[str, Any] = {
         "transport": transport,
@@ -552,7 +551,15 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
             server_task.result()
 
     except asyncio.CancelledError:
-        logger.info("Server task cancelled")
+        # A shutdown-initiated cancel is a graceful stop. A cancel without a
+        # shutdown signal — including one re-raised by server_task.result()
+        # above — is a hard stop masquerading as success; re-raise it so it
+        # becomes a logged sys.exit(1) rather than a silent exit 0. See #1544.
+        if _shutdown_event is not None and _shutdown_event.is_set():
+            logger.info("Server task cancelled")
+        else:
+            logger.error("Server task cancelled without a shutdown signal")
+            raise
     finally:
         try:
             await asyncio.wait_for(
@@ -561,7 +568,12 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
         except TimeoutError:
             logger.warning("Resource cleanup timed out")
 
-        await _cancel_tasks(server_task, shutdown_task)
+        try:
+            await _cancel_tasks(server_task, shutdown_task)
+        except Exception as e:
+            # Teardown must never mask the exception being propagated from the
+            # try block (Python drops the original if finally raises).
+            logger.warning(f"Task cancellation during shutdown failed: {e}")
 
 
 def _run_entrypoint(coro: Coroutine[Any, Any, Any], label: str) -> None:
@@ -575,7 +587,7 @@ def _run_entrypoint(coro: Coroutine[Any, Any, Any], label: str) -> None:
     except SystemExit:
         raise
     except Exception as e:
-        logger.error(f"{label} error: {e}")
+        logger.error(f"{label} error: {e}", exc_info=True)
         sys.exit(1)
 
     sys.exit(0)

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -33,6 +33,12 @@ def _is_ssl_error(exc: BaseException) -> bool:
 
 logger = logging.getLogger(__name__)
 
+# Transient gateway statuses from a reverse proxy / Supervisor ingress — HA Core
+# restarting or briefly overloaded behind it. The upstream couldn't be reached,
+# so the request did not execute and retrying is safe even for writes.
+_RETRYABLE_STATUS = frozenset({502, 503, 504})
+_MAX_REQUEST_ATTEMPTS = 3
+
 
 class HomeAssistantError(Exception):
     """Base exception for Home Assistant API errors."""
@@ -180,7 +186,8 @@ class HomeAssistantClient:
 
         Handles auth, HTTP 4xx/5xx, and transport errors in one place.
         Callers parse the body themselves (JSON via `_request`, text via
-        `get_addon_logs`, etc.).
+        `get_addon_logs`, etc.). Transient gateway errors (502/503/504) are
+        retried with bounded exponential backoff before surfacing.
 
         Raises:
             HomeAssistantAuthError: 401 response.
@@ -188,44 +195,62 @@ class HomeAssistantClient:
                 response_data set from JSON body when possible).
             HomeAssistantConnectionError: Network, timeout, or transport error.
         """
-        try:
-            response = await self.httpx_client.request(method, endpoint, **kwargs)
+        backoff = 0.5
+        for attempt in range(1, _MAX_REQUEST_ATTEMPTS + 1):
+            try:
+                response = await self.httpx_client.request(method, endpoint, **kwargs)
 
-            if response.status_code == 401:
-                raise HomeAssistantAuthError("Invalid authentication token")
+                if response.status_code == 401:
+                    raise HomeAssistantAuthError("Invalid authentication token")
 
-            if response.status_code >= 400:
-                try:
-                    error_data = response.json()
-                except Exception:
-                    error_data = {"message": response.text}
+                if response.status_code >= 400:
+                    try:
+                        error_data = response.json()
+                    except Exception:
+                        error_data = {"message": response.text}
 
-                message = error_data.get("message")
-                if not message or not message.strip():
-                    message = response.reason_phrase or "<empty body>"
+                    message = error_data.get("message")
+                    if not message or not message.strip():
+                        message = response.reason_phrase or "<empty body>"
 
-                raise HomeAssistantAPIError(
-                    f"API error: {response.status_code} - {message}",
-                    status_code=response.status_code,
-                    response_data=error_data,
-                )
+                    if (
+                        response.status_code in _RETRYABLE_STATUS
+                        and attempt < _MAX_REQUEST_ATTEMPTS
+                    ):
+                        logger.warning(
+                            f"Transient {response.status_code} from Home Assistant "
+                            f"(attempt {attempt}/{_MAX_REQUEST_ATTEMPTS}), retrying "
+                            f"in {backoff}s: {message}"
+                        )
+                        await asyncio.sleep(backoff)
+                        backoff *= 2
+                        continue
 
-            return response
+                    raise HomeAssistantAPIError(
+                        f"API error: {response.status_code} - {message}",
+                        status_code=response.status_code,
+                        response_data=error_data,
+                    )
 
-        except httpx.ConnectError as e:
-            if _is_ssl_error(e) and self.verify_ssl:
+                return response
+
+            except httpx.ConnectError as e:
+                if _is_ssl_error(e) and self.verify_ssl:
+                    raise HomeAssistantConnectionError(
+                        f"TLS verification failed for {self.base_url}: {e}. "
+                        "If this is a self-signed certificate or hostname "
+                        "mismatch, set HA_VERIFY_SSL=false to skip verification."
+                    ) from e
                 raise HomeAssistantConnectionError(
-                    f"TLS verification failed for {self.base_url}: {e}. "
-                    "If this is a self-signed certificate or hostname "
-                    "mismatch, set HA_VERIFY_SSL=false to skip verification."
+                    f"Failed to connect to Home Assistant: {e}"
                 ) from e
-            raise HomeAssistantConnectionError(
-                f"Failed to connect to Home Assistant: {e}"
-            ) from e
-        except httpx.TimeoutException as e:
-            raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
-        except httpx.HTTPError as e:
-            raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+            except httpx.TimeoutException as e:
+                raise HomeAssistantConnectionError(f"Request timeout: {e}") from e
+            except httpx.HTTPError as e:
+                raise HomeAssistantConnectionError(f"HTTP error: {e}") from e
+
+        # Unreachable: the final attempt takes the non-retry branch and raises.
+        raise AssertionError("_raw_request retry loop exhausted without returning")
 
     async def _request(
         self, method: str, endpoint: str, **kwargs: Any

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -674,12 +674,14 @@ def _filter_and_score_repos(
 HACS_REPOSITORY_SIGNAL = "hacs_dispatch_repository"
 
 # Wall-clock budget for ``wait_for_repo_registration``. Generous
-# because the constraint is "HACS finishes registration"; the prior
-# 10 s budget (10 attempts × 1.0 s) was exhausted on the HAOS E2E
-# channel under load, so a 3× headroom backstop avoids re-tripping
-# the same flake. The subscription nudges us, so this is a wall-
-# clock cap rather than the dominant cost.
-HACS_REPO_REGISTRATION_TIMEOUT = 30.0
+# because the constraint is "HACS finishes registration": adding a
+# fresh repo makes HACS clone/index it over the network, which on a
+# slow link (or a loaded HAOS E2E runner) can exceed 30 s — the prior
+# value, which flaked ``test_install_mcp_tools_*`` with "Could not
+# find repository ID after adding". The subscription nudges us the
+# instant registration lands, so the happy path returns in seconds and
+# this larger cap only ever costs wall-clock on a genuinely slow add.
+HACS_REPO_REGISTRATION_TIMEOUT = 60.0
 
 # Budget for the initial ``hacs/subscribe`` ack. Smaller than the
 # overall registration timeout so a slow subscribe doesn't consume

--- a/tests/src/unit/test_http_run_kwargs.py
+++ b/tests/src/unit/test_http_run_kwargs.py
@@ -11,6 +11,8 @@ Two independent guards:
    ``sys.exit(1)`` instead of a silent exit 0.
 """
 
+import asyncio
+
 import pytest
 
 from ha_mcp.__main__ import _http_run_kwargs, _run_with_shutdown
@@ -64,3 +66,56 @@ async def test_run_with_shutdown_surfaces_server_exception():
 
     with pytest.raises(ValueError, match="does not support stateless mode"):
         await _run_with_shutdown(failing_server())
+
+
+async def test_run_with_shutdown_returns_when_server_finishes_cleanly():
+    """A server task that returns normally (no shutdown signal) must not raise.
+
+    Exercises the same new ``elif server_task in done`` branch as the exception
+    test, but for the clean-return case: ``server_task.result()`` returns
+    harmlessly and _run_with_shutdown completes without error.
+    """
+
+    async def clean_server():
+        return None
+
+    await _run_with_shutdown(clean_server())  # must not raise
+
+
+async def test_run_with_shutdown_cleans_up_when_server_fails(monkeypatch):
+    """Resources are still cleaned up when a self-terminating server fails.
+
+    The failure surfaces (covered above), but the finally block must still run
+    _cleanup_resources so a crash on startup doesn't leak resources.
+    """
+    import ha_mcp.__main__ as main_mod
+
+    cleaned = False
+
+    async def fake_cleanup():
+        nonlocal cleaned
+        cleaned = True
+
+    monkeypatch.setattr(main_mod, "_cleanup_resources", fake_cleanup)
+
+    async def failing_server():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await _run_with_shutdown(failing_server())
+    assert cleaned, "cleanup must run even when the server task fails"
+
+
+async def test_run_with_shutdown_surfaces_unexpected_cancellation():
+    """Regression #1544: a server task cancelled with no shutdown signal is a
+    hard stop, not a graceful one — it must propagate rather than exit 0.
+
+    Without the _shutdown_event.is_set() gate, the re-raised CancelledError is
+    caught and logged as a benign "Server task cancelled", silently exiting 0.
+    """
+
+    async def self_cancelling_server():
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_with_shutdown(self_cancelling_server())

--- a/tests/src/unit/test_http_run_kwargs.py
+++ b/tests/src/unit/test_http_run_kwargs.py
@@ -1,0 +1,66 @@
+"""Regression coverage for #1544 (SSE entrypoint silently exits 0).
+
+Two independent guards:
+
+1. ``_http_run_kwargs`` must not pass ``stateless_http=True`` for ``transport="sse"``.
+   On the pinned fastmcp, that combination raises
+   ``ValueError("SSE transport does not support stateless mode")``, which ha-mcp
+   swallowed — leaving the SSE entrypoint to exit 0 without binding.
+2. ``_run_with_shutdown`` must re-raise the exception of a server task that
+   finishes on its own, so *any* hard startup failure becomes a logged
+   ``sys.exit(1)`` instead of a silent exit 0.
+"""
+
+import pytest
+
+from ha_mcp.__main__ import _http_run_kwargs, _run_with_shutdown
+
+
+def test_http_transport_includes_stateless_http():
+    kw = _http_run_kwargs("http", "127.0.0.1", 8086, "/mcp")
+    assert kw["stateless_http"] is True
+
+
+def test_streamable_http_transport_includes_stateless_http():
+    kw = _http_run_kwargs("streamable-http", "127.0.0.1", 8086, "/mcp")
+    assert kw["stateless_http"] is True
+
+
+def test_sse_transport_omits_stateless_http():
+    """Regression #1544: stateless_http must be absent for SSE.
+
+    fastmcp's run_async raises ValueError for ``stateless_http=True`` +
+    ``transport="sse"``; gating it out of the SSE kwargs is what lets the
+    SSE entrypoint bind instead of silently exiting 0.
+    """
+    kw = _http_run_kwargs("sse", "127.0.0.1", 8087, "/sse")
+    assert "stateless_http" not in kw
+
+
+def test_common_kwargs_present_across_transports():
+    """Non-stateless kwargs are identical regardless of transport."""
+    common_keys = {"transport", "host", "port", "path", "show_banner", "uvicorn_config"}
+    for transport in ("http", "sse", "streamable-http"):
+        kw = _http_run_kwargs(transport, "127.0.0.1", 8086, "/p")
+        assert common_keys.issubset(kw.keys()), (
+            f"missing keys for transport={transport}"
+        )
+        assert kw["transport"] == transport
+        assert kw["host"] == "127.0.0.1"
+        assert kw["port"] == 8086
+        assert kw["path"] == "/p"
+
+
+async def test_run_with_shutdown_surfaces_server_exception():
+    """Regression #1544: a self-terminating server task must not exit 0.
+
+    When the server task finishes on its own (no shutdown signal),
+    _run_with_shutdown re-raises its exception so _run_entrypoint logs it
+    and exits 1 — instead of swallowing it into a silent exit 0.
+    """
+
+    async def failing_server():
+        raise ValueError("SSE transport does not support stateless mode")
+
+    with pytest.raises(ValueError, match="does not support stateless mode"):
+        await _run_with_shutdown(failing_server())

--- a/tests/src/unit/test_http_run_kwargs.py
+++ b/tests/src/unit/test_http_run_kwargs.py
@@ -88,15 +88,13 @@ async def test_run_with_shutdown_cleans_up_when_server_fails(monkeypatch):
     The failure surfaces (covered above), but the finally block must still run
     _cleanup_resources so a crash on startup doesn't leak resources.
     """
-    import ha_mcp.__main__ as main_mod
-
     cleaned = False
 
     async def fake_cleanup():
         nonlocal cleaned
         cleaned = True
 
-    monkeypatch.setattr(main_mod, "_cleanup_resources", fake_cleanup)
+    monkeypatch.setattr("ha_mcp.__main__._cleanup_resources", fake_cleanup)
 
     async def failing_server():
         raise ValueError("boom")

--- a/tests/src/unit/test_rest_client_retry.py
+++ b/tests/src/unit/test_rest_client_retry.py
@@ -1,0 +1,94 @@
+"""Unit tests for ``_raw_request`` transient-gateway retry (502/503/504).
+
+A reverse proxy / Supervisor ingress returns 502/503/504 when HA Core is
+restarting or briefly overloaded behind it; the request never reached the
+backend, so ``_raw_request`` retries with bounded backoff instead of hard-
+failing the call (which previously surfaced as SERVICE_CALL_FAILED on every
+HA-restart window and flaked the in-addon E2E suite).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from ha_mcp.client.rest_client import (
+    _MAX_REQUEST_ATTEMPTS,
+    HomeAssistantAPIError,
+    HomeAssistantClient,
+)
+
+
+@pytest.fixture
+def client():
+    """``HomeAssistantClient`` with stubbed internals — no real network."""
+    with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+        c = HomeAssistantClient()
+        c.base_url = "http://test.local:8123"
+        c.token = "test-token"
+        c.timeout = 30
+        c.verify_ssl = True
+        c.httpx_client = MagicMock()
+        c._supervised_detected = None
+        return c
+
+
+def _response(status_code, *, json_body=None, text=""):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.reason_phrase = "Bad Gateway"
+    resp.text = text
+    if json_body is None:
+        resp.json = MagicMock(side_effect=ValueError("no json"))
+    else:
+        resp.json = MagicMock(return_value=json_body)
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_raw_request_retries_transient_502_then_succeeds(client):
+    ok = _response(200, json_body={"ok": True})
+    client.httpx_client.request = AsyncMock(side_effect=[_response(502), ok])
+    with patch("ha_mcp.client.rest_client.asyncio.sleep", new=AsyncMock()) as sleep:
+        result = await client._raw_request("GET", "/api/states")
+    assert result is ok
+    assert client.httpx_client.request.await_count == 2
+    sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_raw_request_exhausts_retries_then_raises(client):
+    client.httpx_client.request = AsyncMock(return_value=_response(503))
+    with (
+        patch("ha_mcp.client.rest_client.asyncio.sleep", new=AsyncMock()),
+        pytest.raises(HomeAssistantAPIError) as exc,
+    ):
+        await client._raw_request("GET", "/api/states")
+    assert exc.value.status_code == 503
+    assert client.httpx_client.request.await_count == _MAX_REQUEST_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_raw_request_does_not_retry_non_gateway_4xx(client):
+    client.httpx_client.request = AsyncMock(
+        return_value=_response(400, json_body={"message": "bad request"})
+    )
+    with (
+        patch("ha_mcp.client.rest_client.asyncio.sleep", new=AsyncMock()) as sleep,
+        pytest.raises(HomeAssistantAPIError) as exc,
+    ):
+        await client._raw_request("GET", "/api/states")
+    assert exc.value.status_code == 400
+    assert client.httpx_client.request.await_count == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_request_success_first_try_no_retry(client):
+    ok = _response(200, json_body={})
+    client.httpx_client.request = AsyncMock(return_value=ok)
+    with patch("ha_mcp.client.rest_client.asyncio.sleep", new=AsyncMock()) as sleep:
+        result = await client._raw_request("GET", "/api/")
+    assert result is ok
+    assert client.httpx_client.request.await_count == 1
+    sleep.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Primary fix: the SSE entrypoint silently exits 0 (#1544). `_http_run_kwargs`
unconditionally passed `stateless_http=True` to `mcp.run_async()`; with
`transport="sse"` fastmcp raises `ValueError("SSE transport does not support
stateless mode")`, which was swallowed, so `_run_entrypoint` hit its
unconditional `sys.exit(0)` — SSE appeared to start, then silently died.

Changes:
- **SSE gate** — `_http_run_kwargs` includes `stateless_http=True` only for
  non-SSE transports (HTTP/streamable-http unchanged); return type → `dict[str, Any]`.
- **Silent-exit hardening** — `_run_with_shutdown` re-raises a self-terminating
  server task's exception (and treats a signal-less cancel as a hard stop), so any
  startup failure becomes a logged `sys.exit(1)`; `_run_entrypoint` logs `exc_info`.
- **Transient gateway retry** — `_raw_request` retries 502/503/504 with bounded
  backoff (HA Core restarts / Supervisor ingress blips no longer hard-fail every
  call; also kills the e2e 502-storm flake).
- **HACS registration timeout** — widened 30s→60s so a slow repo clone/index
  doesn't flake `test_install_mcp_tools_*` (event-driven, happy path unaffected).

Keeps `__main__.py`'s CRLF line endings, so that file's diff stays minimal.

Replaces #1546. Closes #1544.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent — N/A (startup + HTTP-client paths; covered by new unit tests)
- [x] All automated tests pass (touched unit suites; ruff + mypy clean on changed files)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed — docstrings/comments on `_http_run_kwargs`, `_raw_request`, and the HACS timeout explain the rationale and reference #1544
