### PR TITLE
feat: allow filesystem tools to access HAOS sibling volumes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -148,7 +148,7 @@ jobs:
       run: uv sync --dev
 
     - name: Run ruff check
-      run: uv run ruff check src/ tests/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ scripts/
+      run: uv run ruff check src/ tests/ custom_components/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ scripts/
 
     - name: Run ruff format check on changed Python files
       run: |
@@ -210,7 +210,7 @@ jobs:
 
     - name: Run mypy
       run: |
-        uv run mypy src/ homeassistant-addon/ scripts/
+        uv run mypy src/ custom_components/ homeassistant-addon/ scripts/
         uv run mypy homeassistant-addon-webhook-proxy/start.py
 
   # Fast unit tests (no Docker, no HA instance needed)

--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Some tools require a companion custom component installed in Home Assistant. Sta
 | Tool | Description |
 |------|-------------|
 | `ha_config_set_yaml` *(beta)* | Safely add, replace, or remove top-level YAML keys in `configuration.yaml` and package files (automatic backup, validation, and config check) |
-| `ha_list_files` *(beta)* | List files in allowed directories (www/, themes/, custom_templates/) |
-| `ha_read_file` *(beta)* | Read files from allowed paths (config YAML, logs, www/, themes/, custom_templates/, custom_components/) |
+| `ha_list_files` *(beta)* | List files in allowed directories |
+| `ha_read_file` *(beta)* | Read files from allowed paths (config YAML, logs, and allowed directories) |
 | `ha_write_file` *(beta)* | Write files to allowed directories |
 | `ha_delete_file` *(beta)* | Delete files from allowed directories |
 

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -492,7 +492,14 @@ def _is_volume_path_allowed(abs_path: str, extra_dirs: list[str] | None) -> bool
         return False
     if _violates_volume_deny_floor(normalized):
         return False
-    if not _matches_extra_dir(normalized, extra_dirs):
+    # POSIX-explicit allowlist match (not _matches_extra_dir, which joins on
+    # os.sep): a volume path is inherently "/"-separated, so match on a "/"
+    # boundary so a configured "/share" grants "/share" and "/share/..." but
+    # never "/shared". Config-relative entries in the mixed list never match an
+    # absolute path here.
+    if not extra_dirs or not any(
+        normalized == d or normalized.startswith(d + "/") for d in extra_dirs
+    ):
         return False
     return _resolves_within(Path(root), abs_path)
 

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -10,11 +10,13 @@ import errno
 import fnmatch
 import logging
 import os
+import posixpath
 import secrets
 import shutil
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from io import StringIO
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import voluptuous as vol
@@ -33,6 +35,7 @@ from ruamel.yaml import YAMLError
 
 from .const import (
     ALLOWED_READ_DIRS,
+    ALLOWED_VOLUME_ROOTS,
     ALLOWED_WRITE_DIRS,
     ALLOWED_YAML_CONFIG_FILES,
     ALLOWED_YAML_KEYS,
@@ -142,10 +145,11 @@ SERVICE_GET_CALLER_TOKEN_SCHEMA = vol.Schema(
 )
 
 # get_allowed_paths / set_allowed_paths back the ha-mcp settings UI's custom
-# filesystem-directory editor (issue #1567). Both are caller-token + admin
-# gated. set_allowed_paths receives the FULL replacement list (mirrors how
+# filesystem-directory editor (issues #1567, #1586). Both are caller-token +
+# admin gated. set_allowed_paths receives the FULL replacement list (mirrors how
 # disabled_packages_keys sends the whole set each call); the handler validates
-# and drops any entry that hits the deny floor or escapes the config dir.
+# and drops any entry that hits the deny floor, or that escapes the config dir
+# without being one of the fixed HAOS sibling-volume roots (#1586).
 SERVICE_GET_ALLOWED_PATHS_SCHEMA = vol.Schema(
     {
         vol.Optional(CALLER_TOKEN_FIELD): cv.string,
@@ -390,18 +394,139 @@ def _violates_deny_floor(config_dir: Path, normalized: str) -> bool:
     ) and normalized != "secrets.yaml"
 
 
-def _normalize_extra_dir(entry: str, config_dir: Path) -> str | None:
-    """Validate and normalize one user-supplied extra directory (issue #1567).
+def _volume_root_for(abs_path: str) -> str | None:
+    """Return the HAOS sibling-volume root (``const.ALLOWED_VOLUME_ROOTS``) that
+    ``abs_path`` falls within, or ``None`` (issue #1586).
 
-    Returns the cleaned, config-relative directory, or ``None`` if the entry
-    must be rejected: not a string, empty, the config root, absolute, uses
-    ``..`` traversal, resolves outside the config dir, or hits the deny floor.
+    Boundary-aware on a path-separator: ``/share`` and ``/share/x`` match
+    ``/share``; ``/shared`` and ``/backups`` do NOT (a string-prefix match would
+    wrongly admit them). ``abs_path`` must already be ``posixpath.normpath``'d —
+    the volume roots are inherently POSIX and the component only runs on HA Core
+    (Linux), so we never use the host ``os.sep`` here.
+    """
+    for root in ALLOWED_VOLUME_ROOTS:
+        if abs_path == root or abs_path.startswith(root + "/"):
+            return root
+    return None
+
+
+def _resolves_within(base: Path, raw_path: str) -> bool:
+    """Resolve ``raw_path`` exactly as ``open(2)`` will — following symlinks,
+    THEN applying ``..`` against the real target — and confirm it stays within
+    ``base`` (symlink-safe containment; issue #1586 review).
+
+    The lexical allow checks run on ``os.path.normpath(raw_path)``, which
+    collapses ``..`` *textually* and so erases an intermediate symlink component
+    (``<allowed>/<symlink>/..``) that the kernel would actually traverse at open
+    time — the divergence that let a configured volume reach arbitrary files.
+    Resolving the RAW input (not the normpath-collapsed form) closes it, because
+    the handlers open ``config_dir / raw_path`` and the OS resolves it the same
+    way ``Path.resolve()`` does. Fails closed on any resolution error.
+    """
+    try:
+        candidate = Path(raw_path) if raw_path.startswith("/") else base / raw_path
+        real = candidate.resolve()
+        base_real = base.resolve()
+    except (OSError, ValueError):
+        return False
+    return real == base_real or real.is_relative_to(base_real)
+
+
+def _violates_volume_deny_floor(abs_path: str) -> bool:
+    """True if an absolute HAOS volume path hits the non-overridable deny floor
+    (issue #1586).
+
+    The same floor as the config dir — a ``.storage`` segment anywhere, or a
+    ``secrets.yaml`` basename — applied to both the requested path and its
+    symlink-resolved target, case-insensitively. Unlike the config dir there is
+    NO canonical ``secrets.yaml`` exception: volume reads are never masked, so a
+    ``secrets.yaml`` on any volume is always denied. Fails closed on any
+    resolution error.
+    """
+    req = PurePosixPath(abs_path)
+    if any(seg.lower() in DENY_PATH_SEGMENTS for seg in req.parts):
+        return True
+    if req.name.lower() in DENY_READ_BASENAMES:
+        return True
+    try:
+        resolved = Path(abs_path).resolve()
+    except (OSError, ValueError):
+        return True
+    if any(seg.lower() in DENY_PATH_SEGMENTS for seg in resolved.parts):
+        return True
+    return resolved.name.lower() in DENY_READ_BASENAMES
+
+
+def _normalize_volume_dir(entry: str) -> str | None:
+    """Validate one absolute HAOS sibling-volume directory (issue #1586).
+
+    Returns the cleaned absolute path, or ``None`` if it is not at/under a known
+    volume root or hits the deny floor. POSIX-normalized regardless of host OS
+    (the roots are inherently POSIX and the component only runs on HA Core).
+    Existence is NOT required (mirrors config-relative extra dirs); an unmounted
+    volume just yields ``not found`` at use time.
+    """
+    normalized = posixpath.normpath(entry)
+    root = _volume_root_for(normalized)
+    if root is None:
+        return None
+    if _violates_volume_deny_floor(normalized):
+        return None
+    return normalized
+
+
+def _is_volume_path_allowed(abs_path: str, extra_dirs: list[str] | None) -> bool:
+    """Enforce a read/write/list/delete against an absolute HAOS volume path
+    (issue #1586).
+
+    Allowed iff the path is at/under a configured extra dir that is itself a
+    volume path, clears the deny floor, and — after FULL symlink + ``..``
+    resolution of the RAW path (matching ``open(2)``) — stays within its volume
+    root. Resolving the raw path rather than the lexically ``normpath``'d form
+    closes the ``<volume>/<symlink>/..`` escape (issue #1586 review). Read and
+    write share this gate — a configured volume grants read+write (#1567).
+    """
+    normalized = posixpath.normpath(abs_path)
+    root = _volume_root_for(normalized)
+    if root is None:
+        return False
+    if _violates_volume_deny_floor(normalized):
+        return False
+    if not _matches_extra_dir(normalized, extra_dirs):
+        return False
+    return _resolves_within(Path(root), abs_path)
+
+
+def _normalize_extra_dir(entry: str, config_dir: Path) -> str | None:
+    """Validate and normalize one user-supplied extra directory (issues #1567,
+    #1586).
+
+    Returns the cleaned directory, or ``None`` if the entry must be rejected.
+    Two accepted shapes:
+
+    * A config-relative directory (issue #1567) — rejected if empty, the config
+      root, uses ``..`` traversal, resolves outside the config dir, or hits the
+      deny floor.
+    * An absolute HAOS sibling-volume path (issue #1586) — kept absolute and
+      validated against its volume root (``const.ALLOWED_VOLUME_ROOTS``) instead
+      of the config dir. Any other absolute path is still rejected.
+
     Rejected entries are dropped (mirrors the filter-to-known-good discipline
     used for ``disabled_packages_keys``).
     """
-    if not isinstance(entry, str) or os.path.isabs(entry):
+    if not isinstance(entry, str):
         return None
-    cleaned = entry.strip().strip("/")
+    stripped = entry.strip()
+    if not stripped:
+        return None
+    # Absolute HAOS sibling-volume path (issue #1586) — validated against its
+    # volume root, not the config dir. Detected by a POSIX-absolute leading "/"
+    # (not os.path.isabs, which is False for "/share" on a non-POSIX host) so the
+    # logic is identical on every OS the tests run on. Any non-volume absolute
+    # path is rejected inside _normalize_volume_dir.
+    if stripped.startswith("/"):
+        return _normalize_volume_dir(stripped)
+    cleaned = stripped.strip("/")
     if not cleaned:
         return None
     normalized = os.path.normpath(cleaned)
@@ -445,6 +570,14 @@ def _is_path_allowed_for_dir(
     checked first, so a custom directory can never grant access to ``.storage``
     or other floored paths.
     """
+    # Absolute HAOS sibling-volume path (issue #1586) — enforced against its
+    # volume root rather than the config dir. Detected by a POSIX-absolute
+    # leading "/" and passed RAW (not normpath'd) so symlink resolution matches
+    # what the handler's open() does. Any non-volume absolute path is rejected
+    # inside the helper.
+    if rel_path.startswith("/"):
+        return _is_volume_path_allowed(rel_path, extra_dirs)
+
     # Normalize the path
     normalized = os.path.normpath(rel_path)
 
@@ -461,6 +594,14 @@ def _is_path_allowed_for_dir(
     parts = normalized.split(os.sep)
     builtin_ok = bool(parts) and parts[0] in allowed_dirs
     if not builtin_ok and not _matches_extra_dir(normalized, extra_dirs):
+        return False
+
+    # Symlink-safe containment on the REAL path the handler will open (issue
+    # #1586 review): resolve the RAW rel_path — open(2) follows symlinks then
+    # applies "..", which the lexical normpath above cannot model — and confirm
+    # it stays under the config dir. Closes the `<allowed>/<symlink>/../escape`
+    # traversal the lexical checks miss.
+    if not _resolves_within(config_dir, rel_path):
         return False
 
     # Resolve full path and verify it's still under config_dir
@@ -482,6 +623,14 @@ def _is_path_allowed_for_read(
     The non-overridable deny floor is checked first, so a custom directory can
     never reach ``.storage`` or an unmasked ``secrets.yaml``.
     """
+    # Absolute HAOS sibling-volume path (issue #1586) — enforced against its
+    # volume root rather than the config dir. Detected by a POSIX-absolute
+    # leading "/" and passed RAW so symlink resolution matches the handler's
+    # open(). A configured volume grants read too, so reads route through the
+    # same gate as dir/write.
+    if rel_path.startswith("/"):
+        return _is_volume_path_allowed(rel_path, extra_dirs)
+
     normalized = os.path.normpath(rel_path)
 
     # Check for path traversal attempts
@@ -494,6 +643,12 @@ def _is_path_allowed_for_read(
 
     # NON-OVERRIDABLE deny floor — before any allow decision (issue #1567).
     if _violates_deny_floor(config_dir, normalized):
+        return False
+
+    # Symlink-safe containment on the REAL path the handler will open (issue
+    # #1586 review): resolve the RAW rel_path so a `<allowed>/<symlink>/..` that
+    # lexically stays inside but physically escapes is rejected.
+    if not _resolves_within(config_dir, rel_path):
         return False
 
     # Check if it's one of the explicitly allowed files in config root
@@ -601,10 +756,17 @@ def _list_files_sync(
         if pattern and not fnmatch.fnmatch(item.name, pattern):
             continue
         stat = item.stat()
+        # Config-relative paths report relative to the config dir; absolute
+        # HAOS sibling-volume paths (issue #1586) are not under it, so report
+        # them absolute (the caller passes absolute paths for volumes too).
+        try:
+            reported_path = str(item.relative_to(config_dir))
+        except ValueError:
+            reported_path = str(item)
         files.append(
             {
                 "name": item.name,
-                "path": str(item.relative_to(config_dir)),
+                "path": reported_path,
                 "is_dir": item.is_dir(),
                 "size": stat.st_size if item.is_file() else 0,
                 "modified": stat.st_mtime,
@@ -639,9 +801,16 @@ def _write_file_sync(
     if create_dirs:
         target_file.parent.mkdir(parents=True, exist_ok=True)
     elif not target_file.parent.exists():
+        # Config-relative parents report relative to the config dir; an absolute
+        # HAOS sibling-volume parent (issue #1586) is not under it, so report it
+        # absolute rather than raising ValueError on relative_to.
+        try:
+            parent = str(target_file.parent.relative_to(config_dir))
+        except ValueError:
+            parent = str(target_file.parent)
         return {
             "_error": "no_parent",
-            "parent": str(target_file.parent.relative_to(config_dir)),
+            "parent": parent,
         }
     target_file.write_text(content)
     stat = target_file.stat()
@@ -659,7 +828,9 @@ def _delete_file_sync(target_file: Path) -> dict[str, Any]:
     return {"size": stat.st_size}
 
 
-def _build_edit_yaml_config_handler(hass):
+def _build_edit_yaml_config_handler(
+    hass: HomeAssistant,
+) -> Callable[[ServiceCall], Awaitable[dict[str, Any]]]:
     """Build and return the async handle_edit_yaml_config handler.
 
     Extracted to module level so it can be tested without registering
@@ -1712,13 +1883,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         }
 
     async def handle_set_allowed_paths(call: ServiceCall) -> ServiceResponse:
-        """Replace the user-configurable extra directories (issue #1567).
+        """Replace the user-configurable extra directories (issues #1567, #1586).
 
         Receives the FULL replacement list. Each entry is validated and
-        normalized; entries that use traversal, are absolute, escape the config
-        directory, or hit the non-overridable deny floor are dropped and
-        reported in ``rejected``. Persists to .storage AND updates hass.data so
-        enforcement applies live with no HA restart. Caller-token + admin gated.
+        normalized; entries that use traversal, escape the config directory, or
+        hit the non-overridable deny floor are dropped and reported in
+        ``rejected``. Config-relative dirs (#1567) and the fixed HAOS
+        sibling-volume roots (#1586 — see ``const.ALLOWED_VOLUME_ROOTS``) are
+        accepted; any other absolute path is dropped. Persists to .storage AND
+        updates hass.data so enforcement applies live with no HA restart.
+        Caller-token + admin gated.
         """
         if not _caller_token_ok(hass, call):
             return _unauthorized_response(SERVICE_SET_ALLOWED_PATHS, paths=[])

--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -20,7 +20,7 @@ _ENTRY_TITLE = "Home Assistant MCP Server Custom Component"
 _CONF_INSTALL_ADDON = "install_addon"
 
 
-class HaMcpToolsConfigFlow(ConfigFlow, domain=DOMAIN):
+class HaMcpToolsConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Handle a config flow for HA MCP Tools."""
 
     VERSION = 1

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -28,6 +28,21 @@ DENY_PATH_SEGMENTS = frozenset({".storage"})
 # the floor blocks the basename everywhere except that one canonical location.
 DENY_READ_BASENAMES = frozenset({"secrets.yaml"})
 
+# HAOS sibling-volume mounts (issue #1586). These live OUTSIDE the config dir,
+# so the config-relative custom-directory allowlist (issue #1567) cannot reach
+# them — its normalizer rejects every absolute path. A user may instead add one
+# of these fixed absolute roots — or a subdirectory of one — to the custom
+# directory list; access is then enforced against the volume root exactly as a
+# config-relative entry is enforced against the config dir (issue #1586).
+#
+# The component runs inside HA Core, so a volume is reachable only if the HA
+# Core container actually mounts it (the standard HAOS/Supervised mounts are
+# config/share/media/ssl/backup). An unmounted or non-existent root simply
+# yields a "not found" at use time — adding it is harmless. As with the
+# config-relative list, a configured volume grants BOTH read and write, and the
+# non-overridable deny floor (.storage / secrets.yaml) still applies.
+ALLOWED_VOLUME_ROOTS = ("/share", "/media", "/ssl", "/backup")
+
 # Files allowed for managed YAML editing
 ALLOWED_YAML_CONFIG_FILES = ["configuration.yaml"]
 # Also allows packages/*.yaml via pattern matching

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/homeassistant-ai/ha-mcp/issues",
     "requirements": ["ruamel.yaml>=0.18.0"],
-    "version": "0.8.0"
+    "version": "0.9.0"
 }

--- a/custom_components/ha_mcp_tools/yaml_rt.py
+++ b/custom_components/ha_mcp_tools/yaml_rt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from io import StringIO
 from typing import Any
 
@@ -43,16 +44,16 @@ _HA_TAGS = (
 )
 
 
-def _make_tag_constructor(tag: str):
+def _make_tag_constructor(tag: str) -> Callable[[Any, Any], _TaggedScalar]:
     """Return a ruamel.yaml constructor function for *tag*."""
 
-    def _construct(loader, node):
+    def _construct(loader: Any, node: Any) -> _TaggedScalar:
         return _TaggedScalar(tag, loader.construct_scalar(node))
 
     return _construct
 
 
-def _represent_tagged_scalar(dumper, data: _TaggedScalar):
+def _represent_tagged_scalar(dumper: Any, data: _TaggedScalar) -> Any:
     """Representer that emits the original tag + scalar value."""
     return dumper.represent_scalar(data.tag, data.value)
 

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -7,7 +7,7 @@ Some ha-mcp tools are gated behind feature flags and disabled by default. They c
 | Tool | Toggle / env var | Description |
 |---|---|---|
 | `ha_config_set_yaml` | `enable_yaml_config_editing` (dev add-on Configuration tab); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `ENABLE_YAML_CONFIG_EDITING=true` env vars | Raw YAML editing of `configuration.yaml` and packages/*.yaml for YAML-only integrations. |
-| `ha_list_files` | `enable_filesystem_tools` (dev add-on); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` env vars | List files in allowed directories (www/, themes/, custom_templates/). Requires `ha_mcp_tools` custom component. |
+| `ha_list_files` | `enable_filesystem_tools` (dev add-on); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` env vars | List files in allowed directories. Requires `ha_mcp_tools` custom component. |
 | `ha_read_file` | `enable_filesystem_tools` (dev add-on); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` env vars | Read files from allowed paths. Requires `ha_mcp_tools` custom component. |
 | `ha_write_file` | `enable_filesystem_tools` (dev add-on); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` env vars | Write files to allowed directories. Requires `ha_mcp_tools` custom component. |
 | `ha_delete_file` | `enable_filesystem_tools` (dev add-on); or web Settings UI master + sub-toggle; or `ENABLE_BETA_FEATURES=true` + `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` env vars | Delete files from allowed directories. Requires `ha_mcp_tools` custom component. |
@@ -62,7 +62,7 @@ This tool edits `configuration.yaml` and package files directly, bypassing Home 
 
 **Recovery requires filesystem access.** If an edit causes HA to enter recovery mode (e.g., a bad `!include` reference), `ha_config_set_yaml` cannot fix its own damage since the custom component doesn't load in recovery mode. Recovery requires SSH, the File Editor add-on, or `docker exec`.
 
-**Backups are filesystem-only.** Per-edit backups are written to `.ha_mcp_tools_backups/` (at the Home Assistant config root) but no ha-mcp tool can restore them. They are a safety net for manual recovery.
+**Per-edit backups are restorable via `ha_manage_backup`.** Per-edit auto-backups are written to `.ha_mcp_tools_backups/` (at the Home Assistant config root) and can be listed, viewed, restored, and deleted with `ha_manage_backup(scope="edits", ...)`. Full HA snapshot tarballs are separate — create, list, and restore them with `scope="snapshot"`.
 
 **Recommended prerequisites:**
 - Comfort with editing `configuration.yaml` via SSH or File Editor when things go wrong
@@ -74,7 +74,7 @@ These tools provide direct file access to your Home Assistant filesystem and req
 
 `HAMCP_ENABLE_CUSTOM_COMPONENT_INTEGRATION=true` is only needed if you want to allow the `ha_install_mcp_tools` installer tool; it is not required for the filesystem tools themselves.
 
-**Access is restricted but sensitive.** Only `www/`, `themes/`, and `custom_templates/` are writable. `ha_read_file` additionally allows reading config YAML files, logs, and `custom_components/`. An AI assistant with these tools enabled has meaningful read access to your HA configuration.
+**Access is restricted but sensitive.** The built-in writable directories are `www/`, `themes/`, `custom_templates/`, and `dashboards/`; `ha_read_file` additionally allows reading config YAML files, logs, and `custom_components/`. Power users can grant further read+write access to extra config-relative directories or the HAOS sibling volumes (`/share`, `/media`, `/ssl`, `/backup`) via the web Settings UI — each is opt-in and enforced by the `ha_mcp_tools` component. An AI assistant with these tools enabled has meaningful read and write access to your HA configuration.
 
 **No undo.** `ha_delete_file` and `ha_write_file` (with `overwrite=True`) are irreversible. There is no recycle bin or automatic backup for file operations.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "homeassistant.*",
+    "aiohasupervisor",
+    "aiohasupervisor.*",
     "aiohttp",
     "voluptuous",
     "jsonschema",

--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -66,7 +66,11 @@ class ReadOnlyExemption(NamedTuple):
 def _backup_write(args: dict[str, Any]) -> str | None:
     scope = args.get("scope")
     action = args.get("action")
+    # Read-only-safe: per-edit backup listing/viewing, and snapshot listing
+    # (issue #1586 — pure ``backup/info`` read, no tarball mutation).
     if scope == "edits" and action in ("list", "view"):
+        return None
+    if scope == "snapshot" and action == "list":
         return None
     return f"scope={scope!r}, action={action!r}"
 
@@ -144,7 +148,8 @@ def _custom_tool_write(args: dict[str, Any]) -> str | None:
 READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
     "ha_manage_backup": ReadOnlyExemption(
         _backup_write,
-        "listing and viewing per-edit backups (scope='edits', action='list' or 'view')",
+        "listing and viewing per-edit backups (scope='edits', action='list' or "
+        "'view') and listing snapshots (scope='snapshot', action='list')",
     ),
     "ha_manage_addon": ReadOnlyExemption(
         _addon_write,

--- a/src/ha_mcp/settings.js
+++ b/src/ha_mcp/settings.js
@@ -1014,8 +1014,8 @@ function renderFsCustomPathsSubForm(parentEl, masterOn, fsOn) {
       : '.storage, secrets.yaml';
   info.innerHTML =
     `<div class="feature-name">Custom filesystem directories (advanced)</div>` +
-    `<div class="feature-help">Extra directories (one per line, relative to your config dir) that the file tools may READ and WRITE — e.g. <code>pyscript</code>, <code>python_scripts</code>. Each entry grants both read and write. Applies immediately; no restart needed.</div>` +
-    `<div class="feature-help">Always blocked (cannot be added): <code>${escapeHtml(denyList)}</code>, path traversal (<code>..</code>), and absolute paths.</div>`;
+    `<div class="feature-help">Extra directories (one per line) that the file tools may READ and WRITE — either relative to your config dir (e.g. <code>pyscript</code>, <code>python_scripts</code>) or an absolute HAOS sibling volume <code>/share</code>, <code>/media</code>, <code>/ssl</code>, <code>/backup</code> (or a subdirectory of one). Each entry grants both read and write. Applies immediately; no restart needed.</div>` +
+    `<div class="feature-help">Always blocked (cannot be added): <code>${escapeHtml(denyList)}</code>, path traversal (<code>..</code>), and any absolute path outside the HAOS sibling volumes.</div>`;
 
   const control = document.createElement('div');
   control.className = 'feature-control';

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -746,8 +746,10 @@ def _summarize_backup(entry: dict[str, Any]) -> dict[str, Any]:
         for a in agents.values():
             if isinstance(a, dict):
                 size = a.get("size")
-                if isinstance(size, int):
-                    sizes.append(size)
+                # Accept int or float (some agents report byte counts as float);
+                # bool is an int subclass but never a real size, so exclude it.
+                if isinstance(size, (int, float)) and not isinstance(size, bool):
+                    sizes.append(int(size))
         if sizes:
             size_bytes = max(sizes)
     return {

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -731,10 +731,125 @@ async def restore_backup(
     return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
+def _summarize_backup(entry: dict[str, Any]) -> dict[str, Any]:
+    """Project one HA ``backup/info`` entry to the fields a caller needs to
+    identify and choose a snapshot (issue #1586).
+
+    Size is reported per backup agent; we surface the largest reported size
+    across agents. Every field is ``.get`` so a schema the running HA version
+    doesn't populate yields ``None`` rather than raising.
+    """
+    agents = entry.get("agents") or {}
+    size_bytes: int | None = None
+    if isinstance(agents, dict):
+        sizes: list[int] = []
+        for a in agents.values():
+            if isinstance(a, dict):
+                size = a.get("size")
+                if isinstance(size, int):
+                    sizes.append(size)
+        if sizes:
+            size_bytes = max(sizes)
+    return {
+        "backup_id": entry.get("backup_id"),
+        "name": entry.get("name"),
+        "date": entry.get("date"),
+        "size_bytes": size_bytes,
+        "protected": entry.get("protected"),
+        "database_included": entry.get("database_included"),
+        "homeassistant_included": entry.get("homeassistant_included"),
+        "homeassistant_version": entry.get("homeassistant_version"),
+        "with_automatic_settings": entry.get("with_automatic_settings"),
+        "agent_ids": list(agents.keys()) if isinstance(agents, dict) else [],
+    }
+
+
+async def list_backups(client: HomeAssistantClient, limit: int = 200) -> dict[str, Any]:
+    """List the full HA snapshot tarballs known to Home Assistant (issue #1586).
+
+    Surfaces the inventory HA already returns from its WebSocket ``backup/info``
+    command — the same data ``restore_backup`` uses internally to verify a
+    ``backup_id`` exists. Before this, the snapshot scope exposed only
+    ``create`` and ``restore``, so a caller had no way to discover backup IDs or
+    confirm a specific backup landed; they had to already know the ID. Newest
+    first. Read-only: no safety backup, no restart.
+    """
+    ws_client = None
+    try:
+        ws_client, error = await get_connected_ws_client(
+            client.base_url, client.token, verify_ssl=client.verify_ssl
+        )
+        if error:
+            raise_tool_error(
+                error
+                or create_error_response(
+                    ErrorCode.CONNECTION_FAILED,
+                    "Failed to connect to Home Assistant WebSocket to list backups",
+                )
+            )
+        ws_client = cast(HomeAssistantWebSocketClient, ws_client)
+
+        info = await ws_client.send_command("backup/info")
+        if not info.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    info.get("error", "Failed to retrieve backup information"),
+                )
+            )
+
+        result_block = info.get("result") or {}
+        raw_backups = result_block.get("backups") or []
+        summarized = [_summarize_backup(b) for b in raw_backups]
+        # Newest first so "did my backup land?" is answered by the top entry.
+        # Parse via _parse_backup_date (handles `Z`/naive) rather than sorting
+        # the raw strings lexicographically — `'Z'` > `'+'` would misorder a mix
+        # of `...Z` and `...+00:00`. Undated entries sink to the bottom.
+        _date_floor = datetime.min.replace(tzinfo=UTC)
+        summarized.sort(
+            key=lambda b: _parse_backup_date(b.get("date")) or _date_floor,
+            reverse=True,
+        )
+        total = len(summarized)
+        if limit and total > limit:
+            summarized = summarized[:limit]
+        return {
+            "success": True,
+            "count": len(summarized),
+            "total": total,
+            "backups": summarized,
+        }
+
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f"Error listing backups: {e}")
+        exception_to_structured_error(
+            e,
+            context={"tool": "list_backups"},
+            suggestions=["Check Home Assistant connection and the backup integration"],
+        )
+        return None  # unreachable: exception_to_structured_error always raises
+    finally:
+        # Always disconnect WebSocket — narrow to transport errors; a
+        # programming error during cleanup should still surface.
+        if ws_client:
+            try:
+                await ws_client.disconnect()
+            except (TimeoutError, OSError, ConnectionError) as err:
+                logger.debug(
+                    "ws disconnect (cleanup) transport error: %s: %s",
+                    type(err).__name__,
+                    err,
+                )
+    return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
+
+
 # Valid (scope, action) combinations. Anything outside this set is
 # rejected with a structured VALIDATION_INVALID_PARAMETER error.
 _VALID_COMBOS: set[tuple[str, str]] = {
     ("snapshot", "create"),
+    ("snapshot", "list"),
     ("snapshot", "restore"),
     ("edits", "create"),
     ("edits", "list"),
@@ -799,6 +914,7 @@ def register_backup_tools(
 | scope | action | What it does |
 |---|---|---|
 | `snapshot` | `create` | Create a full HA tarball (config + addons, no DB by default). Heavy, seconds-long. |
+| `snapshot` | `list` | List full HA tarball snapshots (id, name, date, size). Read-only — use to discover a `backup_id` or confirm a backup landed. |
 | `snapshot` | `restore` | Restore a full HA tarball. **Restarts HA.** Last-resort recovery. |
 | `edits` | `create` | On-demand snapshot of one entity (`domain` + `entity_id` required). Use before the user manually edits in the HA UI. Same handler path the decorator takes on writes; bypasses the `enable_auto_backup` toggle. |
 | `edits` | `list` | List per-entity auto-backups (lightweight). Filter by `domain` and/or `entity_id`. |
@@ -817,6 +933,7 @@ def register_backup_tools(
 
 **Examples:**
 - Snapshot before risky op: `ha_manage_backup(scope="snapshot", action="create", name="Before_Big_Change")`
+- List snapshots (to discover a backup_id or confirm one landed): `ha_manage_backup(scope="snapshot", action="list")`
 - Restore full snapshot: `ha_manage_backup(scope="snapshot", action="restore", backup_id="dd7550ed")`
 - On-demand entity snapshot before a manual UI edit: `ha_manage_backup(scope="edits", action="create", domain="helper_input_boolean", entity_id="kitchen_lights_active")`
 - List recent auto-backups for one automation: `ha_manage_backup(scope="edits", action="list", domain="automation", entity_id="kitchen_lights")`
@@ -906,7 +1023,7 @@ def register_backup_tools(
                 default=200,
                 ge=1,
                 le=10_000,
-                description="(edits.list) Maximum number of entries to return.",
+                description="(edits.list / snapshot.list) Maximum number of entries to return.",
             ),
         ] = 200,
     ) -> dict[str, Any]:
@@ -916,6 +1033,8 @@ def register_backup_tools(
         if scope == "snapshot":
             if action == "create":
                 return await create_backup(client, name)
+            if action == "list":
+                return await list_backups(client, limit)
             # action == "restore"
             bid = _require("backup_id", backup_id, scope, action)
             return await restore_backup(client, bid, restore_database)

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -842,7 +842,6 @@ async def list_backups(client: HomeAssistantClient, limit: int = 200) -> dict[st
                     type(err).__name__,
                     err,
                 )
-    return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
 
 
 # Valid (scope, action) combinations. Anything outside this set is

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -57,7 +57,11 @@ CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
 # ``themes/*.yaml`` yaml_path scope; a <0.8.0 component reaches the old
 # handler and rejects ``themes/<name>.yaml`` with a misleading "not
 # allowed" message instead of this actionable update prompt.
-MIN_COMPONENT_VERSION = "0.8.0"
+# 0.9.0: the file tools accept absolute HAOS sibling-volume paths (/share,
+# /media, /ssl, /backup — issue #1586). A <0.9.0 component's allowlist
+# normalizer rejects every absolute path, so adding a volume would silently
+# do nothing; the version gate surfaces an actionable "update" prompt instead.
+MIN_COMPONENT_VERSION = "0.9.0"
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
@@ -333,9 +337,12 @@ class FilesystemTools:
             str,
             Field(
                 description=(
-                    "Relative directory path from config directory. "
-                    "Allowed paths: www/, themes/, custom_templates/, dashboards/. "
-                    "Example: 'www/' or 'themes/my_theme'"
+                    "Directory path. Relative to the config dir for the built-in "
+                    "allowlist (www/, themes/, custom_templates/, dashboards/). "
+                    "Custom directories and HAOS sibling volumes "
+                    "(/share, /media, /ssl, /backup) configured in the ha-mcp "
+                    "settings UI are also allowed (pass the absolute path). "
+                    "Example: 'www/' or '/share/llm'"
                 ),
             ),
         ],
@@ -360,7 +367,9 @@ class FilesystemTools:
         - `themes/` - Theme files
         - `custom_templates/` - Jinja2 template files
         - `dashboards/` - YAML-mode dashboard files
-        - Plus any custom directories configured in the ha-mcp settings UI
+        - Plus any custom directories OR HAOS sibling volumes (`/share`,
+          `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI
+          (pass the absolute path for volumes)
 
         **Security:** Only directories in the allowed list can be accessed.
         Path traversal attempts (../) are blocked.
@@ -435,8 +444,10 @@ class FilesystemTools:
             str,
             Field(
                 description=(
-                    "Relative path from config directory. "
-                    "Examples: 'configuration.yaml', 'www/custom.css', 'home-assistant.log'"
+                    "File path. Relative to the config dir for the built-in "
+                    "allowlist; absolute for a configured HAOS sibling volume "
+                    "(/share, /media, /ssl, /backup). Examples: "
+                    "'configuration.yaml', 'www/custom.css', '/share/llm/notes.md'"
                 ),
             ),
         ],
@@ -468,7 +479,9 @@ class FilesystemTools:
         - `home-assistant.log` (tail only)
         - `www/**`, `themes/**`, `custom_templates/**`, `dashboards/**`
         - `custom_components/**/*.py` (read-only)
-        - Plus any custom directories configured in the ha-mcp settings UI
+        - Plus any custom directories OR HAOS sibling volumes (`/share`,
+          `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI
+          (pass the absolute path for volumes)
 
         **Security:**
         - Path traversal (../) is blocked
@@ -546,9 +559,11 @@ class FilesystemTools:
             str,
             Field(
                 description=(
-                    "Relative path from config directory. "
-                    "Must be in www/, themes/, custom_templates/, or dashboards/. "
-                    "Example: 'www/custom.css', 'themes/my_theme.yaml'"
+                    "File path. Must be in a writable built-in dir (www/, "
+                    "themes/, custom_templates/, dashboards/), a configured "
+                    "custom directory, or a configured HAOS sibling volume "
+                    "(/share, /media, /ssl, /backup — pass the absolute path). "
+                    "Example: 'www/custom.css', '/share/llm/out.txt'"
                 ),
             ),
         ],
@@ -590,7 +605,9 @@ class FilesystemTools:
         - `themes/` - Theme YAML files
         - `custom_templates/` - Jinja2 template files
         - `dashboards/` - YAML-mode dashboard files
-        - Plus any custom directories configured in the ha-mcp settings UI
+        - Plus any custom directories OR HAOS sibling volumes (`/share`,
+          `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI
+          (pass the absolute path for volumes)
 
         **Security:**
         - Only the directories above allow writes
@@ -678,8 +695,10 @@ class FilesystemTools:
             str,
             Field(
                 description=(
-                    "Relative path from config directory. "
-                    "Must be in www/, themes/, custom_templates/, or dashboards/. "
+                    "File path. Must be in a writable built-in dir (www/, "
+                    "themes/, custom_templates/, dashboards/), a configured "
+                    "custom directory, or a configured HAOS sibling volume "
+                    "(/share, /media, /ssl, /backup — pass the absolute path). "
                     "Example: 'www/old-file.css'"
                 ),
             ),
@@ -705,7 +724,9 @@ class FilesystemTools:
         - `themes/` - Theme files
         - `custom_templates/` - Template files
         - `dashboards/` - YAML-mode dashboard files
-        - Plus any custom directories configured in the ha-mcp settings UI
+        - Plus any custom directories OR HAOS sibling volumes (`/share`,
+          `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI
+          (pass the absolute path for volumes)
 
         **Security:**
         - Only the directories above allow deletions

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -117,11 +117,12 @@ class TestManageBackupGating:
     """Strong gating against wrong-mode usage on the merged tool."""
 
     async def test_rejects_invalid_combo(self, mcp_client) -> None:
-        # (snapshot, list) is not a valid combo — snapshot only supports create/restore.
+        # (snapshot, view) is not a valid combo — snapshot supports only
+        # create/list/restore ((snapshot, list) became valid in #1586).
         result = await safe_call_tool(
             mcp_client,
             "ha_manage_backup",
-            {"scope": "snapshot", "action": "list"},
+            {"scope": "snapshot", "action": "view"},
         )
         assert result.get("success") is False
         error = result.get("error", {})

--- a/tests/src/e2e/workflows/convenience/test_backup.py
+++ b/tests/src/e2e/workflows/convenience/test_backup.py
@@ -220,6 +220,36 @@ class TestBackupTools:
             logger.error(f"❌ Backup restore validation test failed: {e}")
             raise
 
+    async def test_snapshot_list(self, mcp_client):
+        """
+        Test: List full HA snapshot tarballs (scope='snapshot', action='list').
+
+        Read-only inventory via HA's WebSocket ``backup/info`` (issue #1586) —
+        lets a caller discover backup IDs / confirm a backup landed without
+        already knowing an ID. No restart, no mutation.
+        """
+
+        logger.info("📋 Testing snapshot list...")
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "snapshot", "action": "list"},
+        )
+
+        logger.info(f"📋 Snapshot list result: {data}")
+
+        assert data.get("success") is True, f"Snapshot list failed: {data}"
+        assert "backups" in data, "No 'backups' key in list result"
+        assert isinstance(data["backups"], list), "'backups' should be a list"
+        assert "count" in data and "total" in data, "Missing count/total keys"
+        # Each entry exposes the discovery fields a caller needs.
+        for entry in data["backups"]:
+            assert "backup_id" in entry
+            assert "date" in entry
+
+        logger.info(f"✅ Snapshot list returned {data['count']} backup(s)")
+
     async def test_backup_config_password_retrieval(self, mcp_client):
         """
         Test: Verify backup configuration and password retrieval

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -10,7 +10,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.backup import _get_local_backup_agent_id, restore_backup
+from ha_mcp.tools.backup import (
+    _get_local_backup_agent_id,
+    _summarize_backup,
+    list_backups,
+    restore_backup,
+)
 
 
 def _ws_client(agents_payload: dict) -> AsyncMock:
@@ -185,3 +190,125 @@ class TestRestoreBackupWarnings:
         assert any("Connection will be temporarily lost" in w for w in warnings), (
             f"Expected connection-lost warning content; got: {warnings!r}"
         )
+
+
+class TestSummarizeBackup:
+    """_summarize_backup projects a backup/info entry to caller-facing fields (#1586)."""
+
+    def test_projects_core_fields_and_largest_agent_size(self):
+        entry = {
+            "backup_id": "abc",
+            "name": "Nightly",
+            "date": "2026-06-14T02:00:00+00:00",
+            "protected": True,
+            "database_included": False,
+            "homeassistant_included": True,
+            "homeassistant_version": "2026.6.0",
+            "with_automatic_settings": True,
+            "agents": {
+                "backup.local": {"size": 100},
+                "google_drive.cloud": {"size": 250},
+            },
+        }
+        out = _summarize_backup(entry)
+        assert out["backup_id"] == "abc"
+        assert out["name"] == "Nightly"
+        assert out["date"] == "2026-06-14T02:00:00+00:00"
+        # Size is per-agent; surface the largest reported size across agents
+        # (here the cloud agent's 250, not the local 100).
+        assert out["size_bytes"] == 250
+        assert out["protected"] is True
+        assert set(out["agent_ids"]) == {"backup.local", "google_drive.cloud"}
+
+    def test_missing_fields_become_none(self):
+        out = _summarize_backup({})
+        assert out["backup_id"] is None
+        assert out["size_bytes"] is None
+        assert out["agent_ids"] == []
+
+    def test_non_int_sizes_ignored(self):
+        out = _summarize_backup({"agents": {"a": {"size": None}, "b": {}}})
+        assert out["size_bytes"] is None
+
+
+class TestListBackups:
+    """list_backups surfaces HA's backup/info inventory, newest first (#1586)."""
+
+    @staticmethod
+    def _client() -> MagicMock:
+        client = MagicMock()
+        client.base_url = "http://test"
+        client.token = "token"
+        client.verify_ssl = False
+        return client
+
+    @pytest.mark.asyncio
+    async def test_lists_backups_newest_first(self):
+        ws = AsyncMock()
+        ws.send_command.return_value = {
+            "success": True,
+            "result": {
+                "backups": [
+                    {
+                        "backup_id": "old",
+                        "name": "Old",
+                        "date": "2026-06-01T00:00:00+00:00",
+                        "agents": {"backup.local": {"size": 10}},
+                    },
+                    {
+                        "backup_id": "new",
+                        "name": "New",
+                        "date": "2026-06-10T00:00:00+00:00",
+                        "agents": {"backup.local": {"size": 20}},
+                    },
+                ]
+            },
+        }
+        with patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ):
+            result = await list_backups(self._client())
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["total"] == 2
+        assert [b["backup_id"] for b in result["backups"]] == ["new", "old"]
+        ws.send_command.assert_awaited_with("backup/info")
+
+    @pytest.mark.asyncio
+    async def test_limit_truncates_but_reports_total(self):
+        ws = AsyncMock()
+        ws.send_command.return_value = {
+            "success": True,
+            "result": {
+                "backups": [
+                    {
+                        "backup_id": f"b{i}",
+                        "date": f"2026-06-{i + 1:02d}T00:00:00+00:00",
+                    }
+                    for i in range(5)
+                ]
+            },
+        }
+        with patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ):
+            result = await list_backups(self._client(), limit=2)
+
+        assert result["count"] == 2
+        assert result["total"] == 5
+
+    @pytest.mark.asyncio
+    async def test_backup_info_failure_raises(self):
+        ws = AsyncMock()
+        ws.send_command.return_value = {"success": False, "error": "nope"}
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await list_backups(self._client())

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -230,6 +230,17 @@ class TestSummarizeBackup:
         out = _summarize_backup({"agents": {"a": {"size": None}, "b": {}}})
         assert out["size_bytes"] is None
 
+    def test_float_size_coerced_to_int(self):
+        out = _summarize_backup({"agents": {"a": {"size": 123.0}}})
+        assert out["size_bytes"] == 123
+
+    def test_non_dict_agents_handled(self):
+        # HA WS payloads aren't schema-guaranteed; a non-dict ``agents`` must
+        # not raise — size unknown, no agent ids.
+        out = _summarize_backup({"agents": ["unexpected"]})
+        assert out["size_bytes"] is None
+        assert out["agent_ids"] == []
+
 
 class TestListBackups:
     """list_backups surfaces HA's backup/info inventory, newest first (#1586)."""
@@ -312,3 +323,26 @@ class TestListBackups:
             pytest.raises(ToolError),
         ):
             await list_backups(self._client())
+
+    @pytest.mark.asyncio
+    async def test_undated_entry_sinks_last(self):
+        # An entry with a missing/unparseable date must not crash the sort
+        # (datetime vs None) — it sinks below dated entries via the floor.
+        ws = AsyncMock()
+        ws.send_command.return_value = {
+            "success": True,
+            "result": {
+                "backups": [
+                    {"backup_id": "undated"},
+                    {"backup_id": "dated", "date": "2026-06-10T00:00:00+00:00"},
+                ]
+            },
+        }
+        with patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ):
+            result = await list_backups(self._client())
+
+        assert result["success"] is True
+        assert [b["backup_id"] for b in result["backups"]] == ["dated", "undated"]

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -37,11 +37,14 @@ from custom_components.ha_mcp_tools import (  # noqa: E402
     _migrate_legacy_backup_dir,
     _normalize_extra_dir,
     _read_file_sync,
+    _resolves_within,
     _violates_deny_floor,
+    _volume_root_for,
     _write_file_sync,
 )
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     ALLOWED_READ_DIRS,
+    ALLOWED_VOLUME_ROOTS,
     ALLOWED_WRITE_DIRS,
 )
 
@@ -549,6 +552,23 @@ class TestWriteFileSync:
         assert result["_error"] == "no_parent"
         assert result["parent"] == "missing_dir"
 
+    def test_no_parent_reports_absolute_for_out_of_config_dir(self, tmp_path):
+        # #1586: a missing parent on a HAOS sibling volume is NOT under the
+        # config dir, so relative_to would raise — the parent is reported
+        # absolute instead (mirrors _list_files_sync's volume handling).
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "share"
+        volume.mkdir()
+        target = volume / "missing" / "x.txt"
+
+        result = _write_file_sync(
+            target, "data", overwrite=False, create_dirs=False, config_dir=config_dir
+        )
+
+        assert result["_error"] == "no_parent"
+        assert result["parent"] == str(volume / "missing")
+
 
 class TestDeleteFileSync:
     """Test _delete_file_sync helper."""
@@ -785,6 +805,22 @@ class TestDenyFloor:
         )
         # A real .storage UNDER this config is still denied (relative-input scan).
         assert _violates_deny_floor(config_dir, ".storage/auth") is True
+
+    def test_symlink_dotdot_lexical_erase_escape_blocked(self, tmp_path):
+        # #1586 review (HIGH): a symlink under an allowed dir + ``..`` escapes
+        # the config dir even though os.path.normpath lexically collapses
+        # ``link/..`` to a safe-looking in-config path. open(2) resolves the
+        # symlink THEN applies ``..``, landing outside — _resolves_within
+        # resolves the RAW path so enforcement matches the real open target.
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "www").mkdir()
+        # www/link -> config_dir; "www/link/../escaped" -> config_dir/../escaped
+        # = tmp_path/escaped, OUTSIDE the config dir.
+        (config_dir / "www" / "link").symlink_to(config_dir)
+        escape = os.path.join("www", "link", "..", "escaped.txt")
+        assert _is_path_allowed_for_read(config_dir, escape) is False
+        assert _is_path_allowed_for_dir(config_dir, escape, ALLOWED_WRITE_DIRS) is False
         assert _is_path_allowed_for_read(config_dir, ".storage/auth") is False
 
 
@@ -989,3 +1025,240 @@ class TestIsWithinConfigDir:
 
     def test_plain_subpath_is_inside(self, tmp_path):
         assert _is_within_config_dir(tmp_path, "www/x.css") is True
+
+
+class TestVolumeRootFor:
+    """_volume_root_for: which HAOS sibling volume an absolute path falls in (#1586)."""
+
+    def test_matches_each_volume_root_exactly(self):
+        for root in ALLOWED_VOLUME_ROOTS:
+            assert _volume_root_for(root) == root
+
+    def test_matches_path_under_root(self):
+        assert _volume_root_for("/share/llm/notes.md") == "/share"
+        assert _volume_root_for("/media/tts/out.mp3") == "/media"
+        assert _volume_root_for("/ssl/fullchain.pem") == "/ssl"
+        assert _volume_root_for("/backup/abc.tar") == "/backup"
+
+    def test_rejects_non_volume_absolute(self):
+        assert _volume_root_for("/etc/passwd") is None
+        assert _volume_root_for("/config/configuration.yaml") is None
+        assert _volume_root_for("/") is None
+
+    def test_respects_separator_boundary(self):
+        # A sibling sharing a name prefix must NOT match (would be a string-
+        # prefix bug): '/shared' is not '/share', '/backups' is not '/backup'.
+        assert _volume_root_for("/shared") is None
+        assert _volume_root_for("/shared/x") is None
+        assert _volume_root_for("/backups") is None
+        assert _volume_root_for("/ssl_extra/x") is None
+
+
+class TestNormalizeVolumeDir:
+    """_normalize_extra_dir accepts the fixed HAOS sibling-volume roots (#1586)."""
+
+    def test_accepts_each_volume_root(self, tmp_path):
+        for root in ("/share", "/media", "/ssl", "/backup"):
+            assert _normalize_extra_dir(root, tmp_path) == root
+
+    def test_accepts_subdir_of_volume(self, tmp_path):
+        assert _normalize_extra_dir("/share/llm", tmp_path) == "/share/llm"
+
+    def test_strips_whitespace_and_trailing_slash(self, tmp_path):
+        assert _normalize_extra_dir("  /media/tts/  ", tmp_path) == "/media/tts"
+
+    def test_still_rejects_non_volume_absolute(self, tmp_path):
+        assert _normalize_extra_dir("/etc/passwd", tmp_path) is None
+        assert _normalize_extra_dir("/pyscript", tmp_path) is None
+        assert _normalize_extra_dir("/config/secrets.yaml", tmp_path) is None
+
+    def test_respects_volume_boundary(self, tmp_path):
+        assert _normalize_extra_dir("/shared", tmp_path) is None
+
+    def test_rejects_deny_floor_under_volume(self, tmp_path):
+        assert _normalize_extra_dir("/share/.storage", tmp_path) is None
+        assert _normalize_extra_dir("/share/.storage/auth", tmp_path) is None
+        # secrets.yaml is always denied on a volume (volume reads are unmasked).
+        assert _normalize_extra_dir("/backup/secrets.yaml", tmp_path) is None
+
+    def test_traversal_collapsing_outside_volume_rejected(self, tmp_path):
+        # normpath collapses '/share/../etc' -> '/etc', no longer a volume root.
+        assert _normalize_extra_dir("/share/../etc", tmp_path) is None
+
+
+class TestVolumePathEnforcement:
+    """Read/write/list enforcement for configured HAOS volume paths (#1586).
+
+    A configured volume grants BOTH read and write, matching the config-relative
+    extra-dir model — and the deny floor + path boundaries still hold.
+    """
+
+    def test_configured_volume_grants_read(self, tmp_path):
+        extra = ["/share"]
+        assert _is_path_allowed_for_read(tmp_path, "/share/llm/n.md", extra) is True
+        assert _is_path_allowed_for_read(tmp_path, "/share", extra) is True
+
+    def test_configured_volume_grants_write_and_list(self, tmp_path):
+        extra = ["/share"]
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "/share/x.txt", ALLOWED_WRITE_DIRS, extra
+            )
+            is True
+        )
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "/share", ALLOWED_READ_DIRS, extra)
+            is True
+        )
+
+    def test_unconfigured_volume_blocked(self, tmp_path):
+        # /media is a known root but was never added to the allowlist.
+        assert _is_path_allowed_for_read(tmp_path, "/media/x", ["/share"]) is False
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "/media/x", ALLOWED_WRITE_DIRS, ["/share"]
+            )
+            is False
+        )
+
+    def test_no_extra_dirs_blocks_all_volumes(self, tmp_path):
+        assert _is_path_allowed_for_read(tmp_path, "/share/x", None) is False
+        assert _is_path_allowed_for_read(tmp_path, "/backup/x", []) is False
+
+    def test_subdir_entry_respects_boundary(self, tmp_path):
+        extra = ["/share/llm"]
+        assert _is_path_allowed_for_read(tmp_path, "/share/llm/a", extra) is True
+        assert _is_path_allowed_for_read(tmp_path, "/share/other/a", extra) is False
+        # '/share/llmx' is not under '/share/llm' (separator boundary).
+        assert _is_path_allowed_for_read(tmp_path, "/share/llmx/a", extra) is False
+
+    def test_deny_floor_enforced_on_volume(self, tmp_path):
+        extra = ["/share"]
+        assert (
+            _is_path_allowed_for_read(tmp_path, "/share/.storage/auth", extra) is False
+        )
+        assert (
+            _is_path_allowed_for_read(tmp_path, "/share/secrets.yaml", extra) is False
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "/share/.storage/x", ALLOWED_WRITE_DIRS, extra
+            )
+            is False
+        )
+
+    def test_non_volume_absolute_blocked_even_if_listed(self, tmp_path):
+        # Defense in depth: even if a non-volume absolute path reached the live
+        # list (the normalizer drops it), enforcement still refuses it.
+        assert _is_path_allowed_for_read(tmp_path, "/etc/passwd", ["/etc"]) is False
+
+    def test_config_relative_unaffected_by_volume_entries(self, tmp_path):
+        # A mixed allowlist (config-relative + volume) keeps both behaviors.
+        extra = ["pyscript", "/share"]
+        assert _is_path_allowed_for_read(tmp_path, "pyscript/foo.py", extra) is True
+        assert _is_path_allowed_for_read(tmp_path, "/share/foo", extra) is True
+        assert _is_path_allowed_for_read(tmp_path, "esphome/x", extra) is False
+
+
+class TestListFilesSyncVolumePaths:
+    """_list_files_sync reports absolute paths for dirs outside the config dir (#1586)."""
+
+    def test_reports_absolute_path_for_out_of_config_dir(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "share"
+        volume.mkdir()
+        (volume / "note.txt").write_text("hi")
+        result = _list_files_sync(volume, config_dir, None)
+        assert "_error" not in result
+        paths = {f["name"]: f["path"] for f in result["files"]}
+        # Not relative_to(config_dir) (would raise) — reported absolute instead.
+        assert paths["note.txt"] == str(volume / "note.txt")
+
+    def test_config_relative_listing_still_relative(self, tmp_path):
+        (tmp_path / "www").mkdir()
+        (tmp_path / "www" / "a.css").write_text("x")
+        result = _list_files_sync(tmp_path / "www", tmp_path, None)
+        paths = {f["name"]: f["path"] for f in result["files"]}
+        assert paths["a.css"] == os.path.join("www", "a.css")
+
+
+class TestResolvesWithin:
+    """The symlink-safe containment primitive that backs both the config and
+    volume gates (#1586 review). Resolves the RAW path (symlinks + ``..`` as
+    open(2) does), not the lexically-normalized form."""
+
+    def test_plain_subpath_within(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        assert _resolves_within(tmp_path, "sub/file.txt") is True
+
+    def test_nonexistent_subpath_within(self, tmp_path):
+        # resolve() tolerates non-existent leaves; a path that lexically stays
+        # under base is allowed (creation paths must work).
+        assert _resolves_within(tmp_path, "does/not/exist.txt") is True
+
+    def test_absolute_raw_path_handled(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        assert _resolves_within(tmp_path, str(sub / "f")) is True
+        assert _resolves_within(sub, str(tmp_path / "other")) is False
+
+    def test_symlink_escaping_out_rejected(self, tmp_path):
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (base / "link").symlink_to(outside)
+        # base/link/x resolves to outside/x — escapes base.
+        assert _resolves_within(base, "link/x") is False
+
+    def test_symlink_dotdot_lexical_erase_escape_rejected(self, tmp_path):
+        # The HIGH finding's core: `<base>/<symlink>/..`. normpath lexically
+        # collapses `link/..` back to base, but open(2) resolves link first,
+        # then `..`, landing in link's REAL parent — outside base.
+        base = tmp_path / "base"
+        base.mkdir()
+        target = tmp_path / "target"
+        target.mkdir()
+        (base / "link").symlink_to(target)
+        # base/link/../escape -> target/../escape -> tmp_path/escape (outside base)
+        assert _resolves_within(base, "link/../escape") is False
+
+
+class TestVolumeSymlinkEscape:
+    """End-to-end #1586 review HIGH regression: a symlink under a configured
+    volume that escapes the volume root is denied for read AND write/delete."""
+
+    def test_volume_symlink_dotdot_escape_blocked(self, tmp_path, monkeypatch):
+        import custom_components.ha_mcp_tools as comp
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "vol"
+        volume.mkdir()
+        # Treat the tmp volume as a recognized HAOS sibling-volume root.
+        monkeypatch.setattr(comp, "ALLOWED_VOLUME_ROOTS", (str(volume),))
+        # vol/link -> volume's parent; vol/link/../escaped escapes the volume.
+        (volume / "link").symlink_to(tmp_path)
+        extra = [str(volume)]
+        escape = str(volume / "link" / ".." / "escaped.txt")
+        assert _is_path_allowed_for_read(config_dir, escape, extra) is False
+        assert (
+            _is_path_allowed_for_dir(config_dir, escape, ALLOWED_WRITE_DIRS, extra)
+            is False
+        )
+
+    def test_volume_symlink_within_root_allowed(self, tmp_path, monkeypatch):
+        import custom_components.ha_mcp_tools as comp
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "vol"
+        volume.mkdir()
+        (volume / "real").mkdir()
+        monkeypatch.setattr(comp, "ALLOWED_VOLUME_ROOTS", (str(volume),))
+        # A symlink that stays inside the volume is fine.
+        (volume / "link").symlink_to(volume / "real")
+        extra = [str(volume)]
+        ok = str(volume / "link" / "f.txt")
+        assert _is_path_allowed_for_read(config_dir, ok, extra) is True

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -1262,3 +1262,63 @@ class TestVolumeSymlinkEscape:
         extra = [str(volume)]
         ok = str(volume / "link" / "f.txt")
         assert _is_path_allowed_for_read(config_dir, ok, extra) is True
+
+    def test_volume_renamed_symlink_to_secrets_within_root_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        # The dangerous case the volume deny-floor's RESOLVED-target branch
+        # exists for: an innocuously-named symlink that stays INSIDE the volume
+        # root (so _resolves_within allows it) but points at secrets.yaml. Only
+        # the resolved-basename floor check catches it (volume reads are never
+        # masked, so this must be denied).
+        import custom_components.ha_mcp_tools as comp
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "vol"
+        volume.mkdir()
+        monkeypatch.setattr(comp, "ALLOWED_VOLUME_ROOTS", (str(volume),))
+        (volume / "secrets.yaml").write_text("api_key: SECRET\n")
+        (volume / "notes.txt").symlink_to(volume / "secrets.yaml")
+        extra = [str(volume)]
+        assert (
+            _is_path_allowed_for_read(config_dir, str(volume / "notes.txt"), extra)
+            is False
+        )
+
+    def test_volume_symlink_into_storage_within_root_blocked(
+        self, tmp_path, monkeypatch
+    ):
+        # A symlink that resolves to a .storage dir WITHIN the volume root stays
+        # inside the root (passes _resolves_within) — only the resolved-segment
+        # deny floor blocks it. Read AND write/delete must be denied.
+        import custom_components.ha_mcp_tools as comp
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        volume = tmp_path / "vol"
+        volume.mkdir()
+        monkeypatch.setattr(comp, "ALLOWED_VOLUME_ROOTS", (str(volume),))
+        (volume / ".storage").mkdir()
+        (volume / "link").symlink_to(volume / ".storage")
+        extra = [str(volume)]
+        target = str(volume / "link" / "auth")
+        assert _is_path_allowed_for_read(config_dir, target, extra) is False
+        assert (
+            _is_path_allowed_for_dir(config_dir, target, ALLOWED_WRITE_DIRS, extra)
+            is False
+        )
+
+    def test_normalize_volume_dir_rejects_symlink_to_secrets(
+        self, tmp_path, monkeypatch
+    ):
+        # Validation-time (store) deny floor: adding an innocuously-named entry
+        # that resolves to secrets.yaml must be rejected before persisting.
+        import custom_components.ha_mcp_tools as comp
+
+        volume = tmp_path / "vol"
+        volume.mkdir()
+        monkeypatch.setattr(comp, "ALLOWED_VOLUME_ROOTS", (str(volume),))
+        (volume / "secrets.yaml").write_text("x: y\n")
+        (volume / "innocent").symlink_to(volume / "secrets.yaml")
+        assert _normalize_extra_dir(str(volume / "innocent"), tmp_path) is None

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -106,6 +106,7 @@ class TestExemptionRules:
             ({"scope": "edits", "action": "restore"}, False),
             ({"scope": "edits", "action": "delete"}, False),
             ({"scope": "snapshot", "action": "create"}, False),
+            ({"scope": "snapshot", "action": "list"}, True),
             ({"scope": "snapshot", "action": "restore"}, False),
             ({}, False),
         ],


### PR DESCRIPTION
## What does this PR do?

Closes #1586.

**Sibling-volume access (#1586).** The custom-directory allowlist (#1568)
rejected every absolute path, so the HAOS volumes the container already mounts
(`/share`, `/media`, `/ssl`, `/backup`) were unreachable. Users can now add one
of those roots — or a subdirectory — in the existing "Custom filesystem
directories" settings editor; the `ha_mcp_tools` component enforces access
against the volume root exactly as it does config-relative dirs (read+write; the
`.storage`/`secrets.yaml` deny floor still applies). Component → 0.9.0, with
`MIN_COMPONENT_VERSION` raised to match.

**`ha_manage_backup` snapshot list.** Adds `(snapshot, list)`, exposing HA's
`backup/info` inventory so a caller can discover backup IDs / confirm a backup
landed (read-only, exempt in read-only mode) — the maintainer-requested fold-in
from #1586.

**Security hardening.** Permission was checked on the lexically-normalized path
(which erases an intermediate symlink), but the file was opened from the raw
path the kernel resolves physically — so a `<allowed>/<symlink>/..` could escape
the allowlist to arbitrary files (read/write/delete). Enforcement now resolves
the RAW path (symlinks then `..`, as `open(2)` does) and re-checks containment,
closing it for the new volume paths and the existing config-relative allowlist.
The fix is entirely in the custom component (the server does no file I/O), so it
ships with the component update.

**CI + docs.** `custom_components/` is now covered by CI's ruff and mypy (it was
`src/`-only); latent mypy findings fixed. Corrected stale beta/README docs
(per-edit backups *are* restorable via `ha_manage_backup`; writable dirs include
`dashboards/` plus configured custom dirs/volumes).

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
