### PR TITLE
feat: add diff action to ha_manage_backup(scope="edits")

### DIFF
--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -47,7 +47,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import yaml  # type: ignore[import-untyped]
 from fastmcp.exceptions import ToolError
@@ -546,7 +546,7 @@ class BackupManager:
 
     # ----- diff ----------------------------------------------------------
 
-    async def diff_snapshot(self, name: str) -> dict[str, Any]:
+    async def diff_snapshot(self, name: str) -> DiffResponse:
         """Compare a stored snapshot against the live config of the same entity.
 
         Returns an RFC 6902-shaped JSON-Patch — the ops a client would
@@ -557,12 +557,11 @@ class BackupManager:
         patch exceeded ``_MAX_PATCH_OPS`` and was cut short to keep the
         tool response bounded.
 
-        ``unchanged`` tracks the empty-patch invariant (``len(patch)==0``)
-        across both branches — including ``entity_missing=True``, where
-        no live target exists and the patch is therefore empty. Callers
-        MUST check ``entity_missing`` first; ``unchanged`` is only
-        meaningful relative to the empty-patch claim, not as evidence
-        that the stored config matches a live state.
+        ``unchanged`` means the live config matches the snapshot — it is
+        ``True`` only when the entity exists *and* the patch is empty.
+        Under ``entity_missing=True`` it is ``False``: there is no live
+        target to match, so "no action needed" would be wrong (the
+        empty patch is an artefact of the missing entity, not a match).
         """
         data = await asyncio.to_thread(self.read_snapshot, name)
         domain = data["domain"]
@@ -574,36 +573,91 @@ class BackupManager:
         current = await handler.fetch(self._client, entity_id)
         captured_at = data.get("captured")
         if current is None:
-            return {
-                "kind": "dict",
-                "backup_name": name,
-                "domain": domain,
-                "entity_id": entity_id,
-                "captured_at": captured_at,
-                "entity_missing": True,
-                "patch": [],
-                "counts": {"add": 0, "remove": 0, "replace": 0, "total": 0},
-                "unchanged": True,
-                "truncated": False,
-            }
+            return _build_diff_response(
+                name,
+                domain,
+                entity_id,
+                captured_at,
+                entity_missing=True,
+                patch=[],
+                counts=_summarize_patch_counts([]),
+                truncated=False,
+            )
         patch: list[dict[str, Any]] = []
         truncated = _compute_json_patch(stored, current, _MAX_PATCH_OPS, patch)
-        counts = _summarize_patch_counts(patch)
-        return {
-            "kind": "dict",
-            "backup_name": name,
-            "domain": domain,
-            "entity_id": entity_id,
-            "captured_at": captured_at,
-            "entity_missing": False,
-            "patch": patch,
-            "counts": counts,
-            "unchanged": counts["total"] == 0,
-            "truncated": truncated,
-        }
+        return _build_diff_response(
+            name,
+            domain,
+            entity_id,
+            captured_at,
+            entity_missing=False,
+            patch=patch,
+            counts=_summarize_patch_counts(patch),
+            truncated=truncated,
+        )
 
 
 # --------------------------- diff helpers -----------------------------------
+
+
+class DiffCounts(TypedDict):
+    """Per-op-class tallies for a diff patch. ``total`` is the op count;
+    ``add + remove + replace`` equals it today (see ``_summarize_patch_counts``)."""
+
+    add: int
+    remove: int
+    replace: int
+    total: int
+
+
+class DiffResponse(TypedDict):
+    """Return shape of ``BackupManager.diff_snapshot``. Both the
+    entity-present and ``entity_missing`` branches build this through
+    ``_build_diff_response`` so the key set can't drift between them."""
+
+    kind: str
+    backup_name: str
+    domain: str
+    entity_id: str
+    captured_at: str | None
+    entity_missing: bool
+    patch: list[dict[str, Any]]
+    counts: DiffCounts
+    unchanged: bool
+    truncated: bool
+
+
+def _build_diff_response(
+    name: str,
+    domain: str,
+    entity_id: str,
+    captured_at: str | None,
+    *,
+    entity_missing: bool,
+    patch: list[dict[str, Any]],
+    counts: DiffCounts,
+    truncated: bool,
+) -> DiffResponse:
+    """Assemble the diff return payload for either branch.
+
+    ``unchanged`` means "live config matches the snapshot" — only true
+    when the entity exists and the patch is empty. Under
+    ``entity_missing`` it is forced ``False``: the empty patch is an
+    artefact of the absent target, not evidence of a match.
+    """
+    return {
+        "kind": "dict",
+        "backup_name": name,
+        "domain": domain,
+        "entity_id": entity_id,
+        "captured_at": captured_at,
+        "entity_missing": entity_missing,
+        "patch": patch,
+        "counts": counts,
+        "unchanged": not entity_missing and counts["total"] == 0,
+        "truncated": truncated,
+    }
+
 
 # Output cap for diff_snapshot. Bounded payload keeps the tool response
 # token-friendly even when the user diffs against a freshly-rewritten
@@ -620,11 +674,18 @@ def _compute_json_patch(
 
     The patch is the op sequence a client would apply to ``current`` to
     recover ``stored`` (the captured snapshot is the target state).
-    Appends ops to ``out`` in place. Returns True if generation stopped
-    at ``max_ops`` ops (output truncated, not the source of truth).
+    Appends ops to ``out`` in place (capped at ``max_ops`` entries).
+
+    Returns True only when the diff genuinely exceeded ``max_ops``. The
+    generator collects one op beyond the cap so an exactly-full patch
+    (``len == max_ops``) isn't mistaken for a truncated one; the
+    overflow op is trimmed before returning.
     """
-    _diff_node(stored, current, "", out, max_ops)
-    return len(out) >= max_ops
+    _diff_node(stored, current, "", out, max_ops + 1)
+    truncated = len(out) > max_ops
+    if truncated:
+        del out[max_ops:]
+    return truncated
 
 
 def _diff_node(
@@ -695,20 +756,38 @@ def _diff_node(
 def _pointer_segment(key: str) -> str:
     """Escape one JSON-Pointer reference token per RFC 6901 §3.
 
-    ``~`` becomes ``~0`` first so that the subsequent ``/`` substitution
-    cannot eat freshly-written escapes.
+    Order matters: ``~`` → ``~0`` must run before ``/`` → ``~1``. The
+    reverse order would first turn a literal ``/`` into ``~1``, and the
+    following ``~`` pass would then corrupt that fresh ``~1`` into
+    ``~01``.
     """
     return key.replace("~", "~0").replace("/", "~1")
 
 
-def _summarize_patch_counts(patch: list[dict[str, Any]]) -> dict[str, int]:
-    counts: dict[str, int] = {"add": 0, "remove": 0, "replace": 0}
+def _summarize_patch_counts(patch: list[dict[str, Any]]) -> DiffCounts:
+    """Tally op classes. ``add + remove + replace == total`` holds today
+    because ``_diff_node`` only emits those three ops; if a future change
+    starts emitting ``move``/``copy``/``test``, the class counts would sum
+    to less than ``total``. Warn on any unrecognized op so that drift is
+    visible instead of silently undercounting.
+    """
+    classes: dict[str, int] = {"add": 0, "remove": 0, "replace": 0}
     for op in patch:
         op_type = op.get("op")
-        if isinstance(op_type, str) and op_type in counts:
-            counts[op_type] += 1
-    counts["total"] = len(patch)
-    return counts
+        if isinstance(op_type, str) and op_type in classes:
+            classes[op_type] += 1
+        else:
+            logger.warning(
+                "diff: unrecognized JSON-Patch op %r — not reflected in "
+                "per-class counts (add/remove/replace)",
+                op_type,
+            )
+    return {
+        "add": classes["add"],
+        "remove": classes["remove"],
+        "replace": classes["replace"],
+        "total": len(patch),
+    }
 
 
 # --------------------------- attach to client -------------------------------
@@ -817,8 +896,8 @@ async def _ws_send(client: Any, message: dict[str, Any]) -> Any:
     # — unwrap so fetch / restore handlers downstream see the inner
     # shape directly (list for ``<type>/list`` calls, dict for
     # ``execute_script`` calls, etc.). Without the unwrap the
-    # ``isinstance(items, list)`` guards in every fetch handler would
-    # treat the envelope as a non-list and silently return None.
+    # ``_require_list`` checks in every fetch handler would see the
+    # envelope as a non-list and raise a spurious degraded-fetch error.
     if isinstance(envelope, dict) and "result" in envelope:
         return envelope["result"]
     return envelope
@@ -930,13 +1009,32 @@ async def _restore_dashboard(client: Any, entity_id: str, config: Any) -> Any:
     )
 
 
+def _require_list(value: Any, endpoint: str) -> list[Any]:
+    """Return ``value`` if it's a list, else raise.
+
+    The WS registry-list fetchers below distinguish two cases that used
+    to both collapse to ``None`` (which the diff/capture callers read as
+    "entity missing"): a genuine miss (entity not in the list) stays
+    ``None``, but an unexpected non-list envelope — a degraded response
+    from an auth-scope change or API drift — raises instead. The raise
+    funnels through the diff tool's ``exception_to_structured_error`` and
+    the capture pipeline's ``_CAPTURE_TRANSIENT_ERRORS`` warning, so a
+    broken fetch is never reported as a confident ``entity_missing``.
+    """
+    if not isinstance(value, list):
+        raise HomeAssistantError(
+            f"Expected a list from {endpoint!r}, got {type(value).__name__}"
+        )
+    return value
+
+
 # Dashboard resources — WS lovelace_resources commands.
 
 
 async def _fetch_dashboard_resource(client: Any, entity_id: str) -> Any:
-    resources = await _ws_send(client, {"type": "lovelace/resources"})
-    if not isinstance(resources, list):
-        return None
+    resources = _require_list(
+        await _ws_send(client, {"type": "lovelace/resources"}), "lovelace/resources"
+    )
     for res in resources:
         if str(res.get("id")) == entity_id:
             return res
@@ -974,9 +1072,10 @@ def _strip_readonly(config: dict[str, Any], *extra: str) -> dict[str, Any]:
 
 
 async def _fetch_label(client: Any, entity_id: str) -> Any:
-    items = await _ws_send(client, {"type": "config/label_registry/list"})
-    if not isinstance(items, list):
-        return None
+    items = _require_list(
+        await _ws_send(client, {"type": "config/label_registry/list"}),
+        "config/label_registry/list",
+    )
     for item in items:
         if item.get("label_id") == entity_id:
             return item
@@ -997,11 +1096,12 @@ async def _fetch_category(client: Any, entity_id: str) -> Any:
     scope, _, cat_id = entity_id.partition(":")
     if not cat_id:
         return None
-    items = await _ws_send(
-        client, {"type": "config/category_registry/list", "scope": scope}
+    items = _require_list(
+        await _ws_send(
+            client, {"type": "config/category_registry/list", "scope": scope}
+        ),
+        "config/category_registry/list",
     )
-    if not isinstance(items, list):
-        return None
     for item in items:
         if item.get("category_id") == cat_id:
             return {"scope": scope, **item}
@@ -1117,9 +1217,7 @@ async def _restore_calendar_event(client: Any, entity_id: str, config: Any) -> A
 
 
 async def _fetch_zone(client: Any, entity_id: str) -> Any:
-    items = await _ws_send(client, {"type": "zone/list"})
-    if not isinstance(items, list):
-        return None
+    items = _require_list(await _ws_send(client, {"type": "zone/list"}), "zone/list")
     for item in items:
         if item.get("id") == entity_id or item.get("name") == entity_id:
             return item
@@ -1141,16 +1239,18 @@ async def _fetch_area_or_floor(client: Any, entity_id: str) -> Any:
     if not real_id:
         return None
     if kind == "area":
-        items = await _ws_send(client, {"type": "config/area_registry/list"})
-        if not isinstance(items, list):
-            return None
+        items = _require_list(
+            await _ws_send(client, {"type": "config/area_registry/list"}),
+            "config/area_registry/list",
+        )
         for item in items:
             if item.get("area_id") == real_id:
                 return {"kind": "area", **item}
     elif kind == "floor":
-        items = await _ws_send(client, {"type": "config/floor_registry/list"})
-        if not isinstance(items, list):
-            return None
+        items = _require_list(
+            await _ws_send(client, {"type": "config/floor_registry/list"}),
+            "config/floor_registry/list",
+        )
         for item in items:
             if item.get("floor_id") == real_id:
                 return {"kind": "floor", **item}
@@ -1241,9 +1341,9 @@ async def _restore_entity_state(client: Any, entity_id: str, config: Any) -> Any
 
 
 async def _fetch_integration(client: Any, entity_id: str) -> Any:
-    items = await _ws_send(client, {"type": "config_entries/get"})
-    if not isinstance(items, list):
-        return None
+    items = _require_list(
+        await _ws_send(client, {"type": "config_entries/get"}), "config_entries/get"
+    )
     for item in items:
         if item.get("entry_id") == entity_id:
             return item
@@ -1299,9 +1399,9 @@ async def _fetch_helper(client: Any, entity_id: str, helper_type: str) -> Any:
             helper_type,
         )
         return None
-    items = await _ws_send(client, {"type": f"{helper_type}/list"})
-    if not isinstance(items, list):
-        return None
+    items = _require_list(
+        await _ws_send(client, {"type": f"{helper_type}/list"}), f"{helper_type}/list"
+    )
     object_id = entity_id.split(".", 1)[-1] if "." in entity_id else entity_id
     for item in items:
         if item.get("id") == object_id or item.get("id") == entity_id:

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -1039,6 +1039,26 @@ def _require_list(value: Any, endpoint: str) -> list[Any]:
     return value
 
 
+def _require_dict(value: Any, endpoint: str) -> dict[str, Any]:
+    """Return ``value`` if it's a dict, else raise.
+
+    Dict-shaped counterpart to :func:`_require_list` for the
+    ``execute_script``-backed fetchers (calendar / todo). Their service
+    response is a dict envelope; a non-dict body is a degraded/malformed
+    200 (auth-scope change, API drift), not a genuine miss. Raising
+    funnels it through the diff tool's ``exception_to_structured_error``
+    and the capture pipeline's ``_CAPTURE_TRANSIENT_ERRORS`` warning,
+    instead of collapsing to ``None`` — which callers read as
+    ``entity_missing``. The genuine-miss signal stays the nested ``uid``
+    lookup returning ``None``.
+    """
+    if not isinstance(value, dict):
+        raise HomeAssistantError(
+            f"Expected a dict from {endpoint!r}, got {type(value).__name__}"
+        )
+    return value
+
+
 # Dashboard resources — WS lovelace_resources commands.
 
 
@@ -1202,8 +1222,7 @@ async def _fetch_calendar_event(client: Any, entity_id: str) -> Any:
         if getattr(err, "status_code", None) == 404:
             return None
         raise
-    if not isinstance(result, dict):
-        return None
+    result = _require_dict(result, "execute_script")
     events = result.get("response", {}).get("events", {}).get(cal, {}).get("events", [])
     for ev in events:
         if ev.get("uid") == uid:
@@ -1310,8 +1329,7 @@ async def _fetch_todo_item(client: Any, entity_id: str) -> Any:
         if getattr(err, "status_code", None) == 404:
             return None
         raise
-    if not isinstance(result, dict):
-        return None
+    result = _require_dict(result, "execute_script")
     items = result.get("response", {}).get("items", {}).get(cal, {}).get("items", [])
     for item in items:
         if item.get("uid") == uid:

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -544,6 +544,163 @@ class BackupManager:
             "result": result,
         }
 
+    # ----- diff ----------------------------------------------------------
+
+    async def diff_snapshot(self, name: str) -> dict[str, Any]:
+        """Compare a stored snapshot against the live config of the same entity.
+
+        Returns an RFC 6902-shaped JSON-Patch — the ops a client would
+        apply to ``current`` to recover ``stored`` (i.e. what
+        ``restore_snapshot`` would functionally do). ``entity_missing``
+        flags the case where the entity is gone from HA, so the diff has
+        no live target to compare against; ``truncated`` flags that the
+        patch exceeded ``_MAX_PATCH_OPS`` and was cut short to keep the
+        tool response bounded.
+        """
+        data = self.read_snapshot(name)
+        domain = data["domain"]
+        entity_id = data["entity_id"]
+        stored = data["config"]
+        handler = self._handlers.get(domain)
+        if handler is None:
+            raise LookupError(f"No diff handler registered for domain {domain!r}")
+        current = await handler.fetch(self._client, entity_id)
+        captured_at = data.get("captured")
+        if current is None:
+            return {
+                "kind": "dict",
+                "backup_name": name,
+                "domain": domain,
+                "entity_id": entity_id,
+                "captured_at": captured_at,
+                "entity_missing": True,
+                "patch": [],
+                "counts": {"add": 0, "remove": 0, "replace": 0, "total": 0},
+                "unchanged": False,
+                "truncated": False,
+            }
+        patch: list[dict[str, Any]] = []
+        truncated = _compute_json_patch(stored, current, _MAX_PATCH_OPS, patch)
+        counts = _summarize_patch_counts(patch)
+        return {
+            "kind": "dict",
+            "backup_name": name,
+            "domain": domain,
+            "entity_id": entity_id,
+            "captured_at": captured_at,
+            "entity_missing": False,
+            "patch": patch,
+            "counts": counts,
+            "unchanged": counts["total"] == 0,
+            "truncated": truncated,
+        }
+
+
+# --------------------------- diff helpers -----------------------------------
+
+# Output cap for diff_snapshot. Bounded payload keeps the tool response
+# token-friendly even when the user diffs against a freshly-rewritten
+# automation. Picked to comfortably cover typical edits (a handful of
+# field changes) while still cutting off pathological cases like "I
+# renamed every step of a 500-step script".
+_MAX_PATCH_OPS = 200
+
+
+def _compute_json_patch(
+    stored: Any, current: Any, max_ops: int, out: list[dict[str, Any]]
+) -> bool:
+    """Generate an RFC 6902 JSON-Patch from ``current`` to ``stored``.
+
+    The patch is the op sequence a client would apply to ``current`` to
+    recover ``stored`` (the captured snapshot is the target state).
+    Appends ops to ``out`` in place. Returns True if generation stopped
+    at ``max_ops`` ops (output truncated, not the source of truth).
+    """
+    _diff_node(stored, current, "", out, max_ops)
+    return len(out) >= max_ops
+
+
+def _diff_node(
+    stored: Any,
+    current: Any,
+    path: str,
+    out: list[dict[str, Any]],
+    max_ops: int,
+) -> None:
+    if len(out) >= max_ops:
+        return
+    # ``type(s) is type(c)`` keeps ``True``/``1`` apart (both compare
+    # equal but represent different states for HA toggles); YAML loaders
+    # only emit plain dict/list/scalar containers, so subclass surprises
+    # aren't in scope.
+    if type(stored) is type(current):
+        if isinstance(stored, dict):
+            assert isinstance(current, dict)
+            for key in stored:
+                seg = _pointer_segment(str(key))
+                sub_path = f"{path}/{seg}"
+                if key not in current:
+                    out.append({"op": "add", "path": sub_path, "value": stored[key]})
+                    if len(out) >= max_ops:
+                        return
+                else:
+                    _diff_node(stored[key], current[key], sub_path, out, max_ops)
+                    if len(out) >= max_ops:
+                        return
+            for key in current:
+                if key not in stored:
+                    seg = _pointer_segment(str(key))
+                    out.append({"op": "remove", "path": f"{path}/{seg}"})
+                    if len(out) >= max_ops:
+                        return
+            return
+        if isinstance(stored, list):
+            assert isinstance(current, list)
+            min_len = min(len(stored), len(current))
+            for i in range(min_len):
+                _diff_node(stored[i], current[i], f"{path}/{i}", out, max_ops)
+                if len(out) >= max_ops:
+                    return
+            if len(stored) > len(current):
+                for value in stored[len(current) :]:
+                    out.append({"op": "add", "path": f"{path}/-", "value": value})
+                    if len(out) >= max_ops:
+                        return
+            elif len(current) > len(stored):
+                # Remove tail entries from highest to lowest index so
+                # successive removes stay valid (RFC 6902 reindexes
+                # after each op).
+                for i in range(len(current) - 1, len(stored) - 1, -1):
+                    out.append({"op": "remove", "path": f"{path}/{i}"})
+                    if len(out) >= max_ops:
+                        return
+            return
+    # ``True == 1`` and ``False == 0`` in Python — ``!=`` alone would let
+    # a bool/int type swap pass silently even though they represent
+    # different states for HA toggles. Force a replace whenever the
+    # concrete type changes, even if the equality check is happy.
+    if stored != current or type(stored) is not type(current):
+        out.append({"op": "replace", "path": path or "", "value": stored})
+
+
+def _pointer_segment(key: str) -> str:
+    """Escape one JSON-Pointer reference token per RFC 6901 §3.
+
+    ``~`` becomes ``~0`` first so that the subsequent ``/`` substitution
+    cannot eat freshly-written escapes.
+    """
+    return key.replace("~", "~0").replace("/", "~1")
+
+
+def _summarize_patch_counts(patch: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {"add": 0, "remove": 0, "replace": 0}
+    for op in patch:
+        op_type = op.get("op")
+        if isinstance(op_type, str) and op_type in counts:
+            counts[op_type] += 1
+    counts["total"] = len(patch)
+    return counts
+
 
 # --------------------------- attach to client -------------------------------
 

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -522,7 +522,7 @@ class BackupManager:
     async def restore_snapshot(
         self, name: str, *, take_safety_backup: bool = True
     ) -> dict[str, Any]:
-        data = self.read_snapshot(name)
+        data = await asyncio.to_thread(self.read_snapshot, name)
         domain = data["domain"]
         entity_id = data["entity_id"]
         config = data["config"]
@@ -556,8 +556,15 @@ class BackupManager:
         no live target to compare against; ``truncated`` flags that the
         patch exceeded ``_MAX_PATCH_OPS`` and was cut short to keep the
         tool response bounded.
+
+        ``unchanged`` tracks the empty-patch invariant (``len(patch)==0``)
+        across both branches — including ``entity_missing=True``, where
+        no live target exists and the patch is therefore empty. Callers
+        MUST check ``entity_missing`` first; ``unchanged`` is only
+        meaningful relative to the empty-patch claim, not as evidence
+        that the stored config matches a live state.
         """
-        data = self.read_snapshot(name)
+        data = await asyncio.to_thread(self.read_snapshot, name)
         domain = data["domain"]
         entity_id = data["entity_id"]
         stored = data["config"]
@@ -576,7 +583,7 @@ class BackupManager:
                 "entity_missing": True,
                 "patch": [],
                 "counts": {"add": 0, "remove": 0, "replace": 0, "total": 0},
-                "unchanged": False,
+                "unchanged": True,
                 "truncated": False,
             }
         patch: list[dict[str, Any]] = []
@@ -675,12 +682,14 @@ def _diff_node(
                     if len(out) >= max_ops:
                         return
             return
-    # ``True == 1`` and ``False == 0`` in Python — ``!=`` alone would let
-    # a bool/int type swap pass silently even though they represent
-    # different states for HA toggles. Force a replace whenever the
-    # concrete type changes, even if the equality check is happy.
-    if stored != current or type(stored) is not type(current):
-        out.append({"op": "replace", "path": path or "", "value": stored})
+        if stored != current:
+            out.append({"op": "replace", "path": path or "", "value": stored})
+        return
+    # ``True == 1`` / ``False == 0`` in Python, so equality alone would
+    # let a bool/int type swap pass silently even though it represents
+    # a different state for HA toggles. The different-type branch
+    # forces a replace unconditionally.
+    out.append({"op": "replace", "path": path or "", "value": stored})
 
 
 def _pointer_segment(key: str) -> str:

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -293,6 +293,14 @@ class BackupManager:
             try:
                 config = await handler.fetch(self._client, entity_id)
             except _CAPTURE_TRANSIENT_ERRORS as err:
+                # Degraded fetches (a non-list WS envelope from an
+                # auth-scope change or API drift) raise rather than return
+                # None — see ``_require_list``. During auto-backup we skip
+                # the snapshot with a WARNING (operator-visible) instead of
+                # crashing the pipeline; the same error during a diff/
+                # restore propagates to the tool layer as a structured
+                # error. The warning level (vs the debug log below) is what
+                # distinguishes "fetch broke" from "entity didn't exist".
                 logger.warning(
                     "Auto-backup: fetch failed for %s — %s: %s",
                     key,
@@ -749,7 +757,10 @@ def _diff_node(
     # ``True == 1`` / ``False == 0`` in Python, so equality alone would
     # let a bool/int type swap pass silently even though it represents
     # a different state for HA toggles. The different-type branch
-    # forces a replace unconditionally.
+    # forces a replace unconditionally. No post-append length guard here
+    # (unlike the loop sites above): this append is terminal, and
+    # ``_compute_json_patch`` budgets ``max_ops + 1`` precisely to absorb
+    # one final overflow op before trimming.
     out.append({"op": "replace", "path": path or "", "value": stored})
 
 

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -1185,7 +1185,18 @@ def register_backup_tools(
                 )
             warnings: list[str] = []
             if diff.get("entity_missing"):
-                warnings.append("Entity is missing from HA; restore would re-create it")
+                # ``restore_snapshot`` outcome on a missing entity is
+                # domain-dependent: upsert paths (automation, script,
+                # dashboard) recreate it, but helper / label / category
+                # restores go through ``<domain>/update`` WS commands
+                # that expect the entity to exist and would surface a
+                # WS error if it does not. Hedge rather than promise
+                # one specific outcome.
+                warnings.append(
+                    "Entity is missing from HA; restore behaviour is "
+                    "domain-dependent (upsert paths recreate it; "
+                    "update-only paths return an error)"
+                )
             if diff.get("truncated"):
                 warnings.append(
                     "Patch truncated; entity has more changes than the bounded "

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -855,6 +855,7 @@ _VALID_COMBOS: set[tuple[str, str]] = {
     ("edits", "create"),
     ("edits", "list"),
     ("edits", "view"),
+    ("edits", "diff"),
     ("edits", "restore"),
     ("edits", "delete"),
 }
@@ -920,6 +921,7 @@ def register_backup_tools(
 | `edits` | `create` | On-demand snapshot of one entity (`domain` + `entity_id` required). Use before the user manually edits in the HA UI. Same handler path the decorator takes on writes; bypasses the `enable_auto_backup` toggle. |
 | `edits` | `list` | List per-entity auto-backups (lightweight). Filter by `domain` and/or `entity_id`. |
 | `edits` | `view` | Read one auto-backup file by name; returns YAML and parsed `config`. |
+| `edits` | `diff` | Compare one auto-backup against the entity's current config. RFC 6902 JSON-Patch + add/remove/replace counts; bounded output. Read-only — fetches the live config, makes no changes. |
 | `edits` | `restore` | Re-apply one auto-backup. Creates a fresh safety snapshot first. **No HA restart.** |
 | `edits` | `delete` | Delete one auto-backup by `backup_name`, or bulk-delete by filter. |
 
@@ -939,6 +941,7 @@ def register_backup_tools(
 - On-demand entity snapshot before a manual UI edit: `ha_manage_backup(scope="edits", action="create", domain="helper_input_boolean", entity_id="kitchen_lights_active")`
 - List recent auto-backups for one automation: `ha_manage_backup(scope="edits", action="list", domain="automation", entity_id="kitchen_lights")`
 - View an auto-backup: `ha_manage_backup(scope="edits", action="view", backup_name="automation.kitchen_lights.20260521_153000.yaml")`
+- Diff an auto-backup vs current state: `ha_manage_backup(scope="edits", action="diff", backup_name="automation.kitchen_lights.20260521_153000.yaml")`
 - Restore an auto-backup: `ha_manage_backup(scope="edits", action="restore", backup_name="automation.kitchen_lights.20260521_153000.yaml")`
 - Delete one auto-backup: `ha_manage_backup(scope="edits", action="delete", backup_name="...")`
 - Bulk-delete old auto-backups: `ha_manage_backup(scope="edits", action="delete", older_than_days=30)`
@@ -958,7 +961,7 @@ def register_backup_tools(
             ),
         ],
         action: Annotated[
-            Literal["create", "restore", "list", "view", "delete"],
+            Literal["create", "restore", "list", "view", "diff", "delete"],
             Field(
                 description="Operation to perform. Valid (scope, action) combinations are listed in the tool description."
             ),
@@ -1139,6 +1142,60 @@ def register_backup_tools(
                     )
                 )
             return {"success": True, "data": data}
+
+        if action == "diff":
+            bname = _require("backup_name", backup_name, scope, action)
+            try:
+                diff = await mgr.diff_snapshot(bname)
+            except FileNotFoundError:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"Backup {bname!r} not found",
+                        context={"backup_name": bname},
+                    )
+                )
+            except (ValueError, LookupError) as err:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        str(err),
+                        context={"backup_name": bname},
+                    )
+                )
+            except ToolError:
+                raise
+            except Exception as err:
+                # Fetching the live config for diff goes through the
+                # same domain handler ``restore`` uses, so the same
+                # HA-side failure modes (4xx/5xx, WS errors, schema
+                # drift) apply. Funnel through
+                # ``exception_to_structured_error`` so the structured
+                # response carries enough context to retry.
+                exception_to_structured_error(
+                    err,
+                    context={"backup_name": bname, "action": "diff"},
+                    suggestions=[
+                        "Verify the entity referenced by the backup still "
+                        + "exists; diff fetches its current config",
+                        "Inspect the snapshot YAML via "
+                        + "ha_manage_backup(scope='edits', action='view', "
+                        + "backup_name=...) to confirm it parses",
+                    ],
+                )
+            warnings: list[str] = []
+            if diff.get("entity_missing"):
+                warnings.append("Entity is missing from HA; restore would re-create it")
+            if diff.get("truncated"):
+                warnings.append(
+                    "Patch truncated; entity has more changes than the bounded "
+                    "diff captures — view the snapshot for the full state"
+                )
+            return {
+                "success": True,
+                "data": diff,
+                **({"warnings": warnings} if warnings else {}),
+            }
 
         if action == "restore":
             bname = _require("backup_name", backup_name, scope, action)

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -1183,6 +1183,7 @@ def register_backup_tools(
                         + "backup_name=...) to confirm it parses",
                     ],
                 )
+                return None  # unreachable: exception_to_structured_error always raises
             warnings: list[str] = []
             if diff.get("entity_missing"):
                 # ``restore_snapshot`` outcome on a missing entity is
@@ -1253,6 +1254,7 @@ def register_backup_tools(
                         + "backup_name=...)",
                     ],
                 )
+                return None  # unreachable: exception_to_structured_error always raises
             return {
                 "success": True,
                 "data": result,

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -82,7 +82,7 @@ _SKIP_CEILING_PER_LANE = {
     # marker-gated skips, plus a 5-9 growth buffer.
     "container": 62,  # was 55 (observed 57 with the 5 addon tests added)
     "haos": 29,  # 14 + 5 addon-test + 5 sidecar skips = 24, + buffer
-    "haos_inaddon": 49,  # 39 + 5 sidecar skips = 44, + buffer (addon tests run here)
+    "haos_inaddon": 55,  # 44 + 3 new auto-backup diff tests (TestAutomationDiff, @external_only) + buffer
 }
 
 

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -165,6 +165,20 @@ class TestManageBackupGating:
         )
         assert result.get("success") is False
 
+    async def test_edits_diff_requires_backup_name(self, mcp_client) -> None:
+        # Same shape as restore — diff needs a concrete backup to compare
+        # against, so the bare call must fail with a structured
+        # validation error rather than dispatching against nothing.
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "diff"},
+        )
+        assert result.get("success") is False
+        error = result.get("error", {})
+        msg = error.get("message", "") if isinstance(error, dict) else ""
+        assert "backup_name" in msg
+
 
 # ---------------------------------------------------------------- list
 
@@ -380,6 +394,193 @@ class TestAutomationCaptureRestore:
             "ha_config_remove_automation",
             {"identifier": identifier},
         )
+
+
+# ---------------------------------------------------------------- diff
+
+
+@pytest.mark.automation
+@pytest.mark.cleanup
+@pytest.mark.external_only
+class TestAutomationDiff:
+    """``ha_manage_backup(scope='edits', action='diff', ...)`` against the
+    live entity state.
+
+    Read-only — fetches the current config the same way the capture path
+    does, computes an RFC 6902 patch, and returns it bounded. Doesn't
+    touch any entity, doesn't take a safety snapshot. Sibling test to
+    ``TestAutomationCaptureRestore`` to keep both halves of the
+    "captured vs current" loop covered.
+    """
+
+    async def test_diff_against_unchanged_returns_no_ops(
+        self, mcp_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Capture and immediately diff — the live config matches the
+        # snapshot, so the response carries an empty patch and
+        # ``unchanged: true``.
+        _enable_auto_backup(monkeypatch)
+        suffix = uuid.uuid4().hex[:8]
+        identifier = f"e2e_diff_noop_{suffix}"
+        original = {
+            "alias": f"E2E Diff Noop {suffix}",
+            "trigger": [{"platform": "time", "at": "12:00:00"}],
+            "action": [{"service": "homeassistant.no_op"}],
+        }
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": original, "identifier": identifier},
+        )
+        # Mutate once so the decorator captures pre-edit state (a fresh
+        # entity has no pre-state to snapshot).
+        edited = {**original, "alias": f"E2E Diff Noop Edited {suffix}"}
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": edited, "identifier": identifier},
+        )
+        # Restore the original so live matches the snapshot for the diff
+        # we're about to take.
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": original, "identifier": identifier},
+        )
+        backup_name = await _wait_for_backup(
+            mcp_client, domain="automation", entity_id=identifier
+        )
+
+        diff = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "diff", "backup_name": backup_name},
+        )
+        assert diff.get("success") is True
+        data = diff.get("data", {})
+        assert data["kind"] == "dict"
+        assert data["entity_missing"] is False
+        assert data["unchanged"] is True
+        assert data["patch"] == []
+        assert data["counts"]["total"] == 0
+        assert data["truncated"] is False
+
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": identifier},
+        )
+
+    async def test_diff_after_edit_reports_changes(
+        self, mcp_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Capture pre-edit state, then leave the live config diverged.
+        # The diff must report the alias change as a replace op.
+        _enable_auto_backup(monkeypatch)
+        suffix = uuid.uuid4().hex[:8]
+        identifier = f"e2e_diff_edit_{suffix}"
+        original_alias = f"E2E Diff Original {suffix}"
+        edited_alias = f"E2E Diff Edited {suffix}"
+        original = {
+            "alias": original_alias,
+            "trigger": [{"platform": "time", "at": "12:00:00"}],
+            "action": [{"service": "homeassistant.no_op"}],
+        }
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": original, "identifier": identifier},
+        )
+        # Edit — the decorator snapshots the pre-edit state (alias =
+        # original_alias). Live state ends at alias = edited_alias.
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": {**original, "alias": edited_alias}, "identifier": identifier},
+        )
+        backup_name = await _wait_for_backup(
+            mcp_client, domain="automation", entity_id=identifier
+        )
+
+        diff = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "diff", "backup_name": backup_name},
+        )
+        assert diff.get("success") is True
+        data = diff.get("data", {})
+        assert data["entity_missing"] is False
+        assert data["unchanged"] is False
+        assert data["counts"]["total"] >= 1
+        # The alias delta is the load-bearing assertion; restrict to
+        # ``replace`` ops on a path ending in ``/alias`` to stay robust
+        # against HA-side schema enrichment (added defaults, ordering).
+        alias_op = next(
+            (
+                op
+                for op in data["patch"]
+                if op["op"] == "replace" and op["path"].endswith("/alias")
+            ),
+            None,
+        )
+        assert alias_op is not None
+        assert alias_op["value"] == original_alias
+
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": identifier},
+        )
+
+    async def test_diff_flags_entity_missing_after_delete(
+        self, mcp_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Capture, then delete the entity — diff must report
+        # ``entity_missing: true`` with an empty patch and no
+        # ``LookupError``-style failure (the snapshot still exists, it's
+        # the live target that's gone).
+        _enable_auto_backup(monkeypatch)
+        suffix = uuid.uuid4().hex[:8]
+        identifier = f"e2e_diff_missing_{suffix}"
+        original = {
+            "alias": f"E2E Diff Missing {suffix}",
+            "trigger": [{"platform": "time", "at": "12:00:00"}],
+            "action": [{"service": "homeassistant.no_op"}],
+        }
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": original, "identifier": identifier},
+        )
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {
+                "config": {**original, "alias": f"E2E Diff Missing Edited {suffix}"},
+                "identifier": identifier,
+            },
+        )
+        backup_name = await _wait_for_backup(
+            mcp_client, domain="automation", entity_id=identifier
+        )
+
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": identifier},
+        )
+
+        diff = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "diff", "backup_name": backup_name},
+        )
+        assert diff.get("success") is True
+        data = diff.get("data", {})
+        assert data["entity_missing"] is True
+        assert data["patch"] == []
+        warnings = diff.get("warnings") or []
+        assert any("missing" in w.lower() for w in warnings)
 
 
 # ---------------------------------------------------------------- helper lane

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -462,6 +462,7 @@ class TestAutomationDiff:
         assert data["patch"] == []
         assert data["counts"]["total"] == 0
         assert data["truncated"] is False
+        assert data["captured_at"] is not None
 
         await safe_call_tool(
             mcp_client,
@@ -577,8 +578,73 @@ class TestAutomationDiff:
         data = diff.get("data", {})
         assert data["entity_missing"] is True
         assert data["patch"] == []
+        # ``unchanged`` is False under entity_missing — the empty patch
+        # is an artefact of the absent target, not a "matches live" match.
+        assert data["unchanged"] is False
+        assert data["captured_at"] is not None
         warnings = diff.get("warnings") or []
         assert any("missing" in w.lower() for w in warnings)
+
+    async def test_diff_truncated_surfaces_tool_layer_warning(
+        self, mcp_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Drive the tool-layer ``truncated`` warning end-to-end: cap the
+        # patch budget at 1 op so a real multi-field edit overflows it.
+        # Asserts both the manager-level ``truncated: true`` and the
+        # tool-layer warning string the manager flag drives.
+        _enable_auto_backup(monkeypatch)
+        import ha_mcp.backup_manager as bm
+
+        monkeypatch.setattr(bm, "_MAX_PATCH_OPS", 1)
+        suffix = uuid.uuid4().hex[:8]
+        identifier = f"e2e_diff_trunc_{suffix}"
+        original = {
+            "alias": f"E2E Diff Trunc {suffix}",
+            "trigger": [{"platform": "time", "at": "12:00:00"}],
+            "action": [{"service": "homeassistant.no_op"}],
+        }
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {"config": original, "identifier": identifier},
+        )
+        # Edit several fields so the captured-vs-live diff is > 1 op.
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_set_automation",
+            {
+                "config": {
+                    **original,
+                    "alias": f"E2E Diff Trunc Edited {suffix}",
+                    "trigger": [
+                        {"platform": "time", "at": "13:00:00"},
+                        {"platform": "time", "at": "14:00:00"},
+                    ],
+                },
+                "identifier": identifier,
+            },
+        )
+        backup_name = await _wait_for_backup(
+            mcp_client, domain="automation", entity_id=identifier
+        )
+
+        diff = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "diff", "backup_name": backup_name},
+        )
+        assert diff.get("success") is True
+        data = diff.get("data", {})
+        assert data["truncated"] is True
+        assert len(data["patch"]) == 1
+        warnings = diff.get("warnings") or []
+        assert any("truncated" in w.lower() for w in warnings)
+
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_remove_automation",
+            {"identifier": identifier},
+        )
 
 
 # ---------------------------------------------------------------- helper lane

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -593,9 +593,7 @@ class TestAutomationDiff:
         # Asserts both the manager-level ``truncated: true`` and the
         # tool-layer warning string the manager flag drives.
         _enable_auto_backup(monkeypatch)
-        import ha_mcp.backup_manager as bm
-
-        monkeypatch.setattr(bm, "_MAX_PATCH_OPS", 1)
+        monkeypatch.setattr("ha_mcp.backup_manager._MAX_PATCH_OPS", 1)
         suffix = uuid.uuid4().hex[:8]
         identifier = f"e2e_diff_trunc_{suffix}"
         original = {

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import pytest
 
-from ...utilities.assertions import safe_call_tool
+from ...utilities.assertions import extract_error_message, safe_call_tool
 from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
@@ -175,8 +175,7 @@ class TestManageBackupGating:
             {"scope": "edits", "action": "diff"},
         )
         assert result.get("success") is False
-        error = result.get("error", {})
-        msg = error.get("message", "") if isinstance(error, dict) else ""
+        msg = extract_error_message(result)
         assert "backup_name" in msg
 
 
@@ -432,24 +431,23 @@ class TestAutomationDiff:
             "ha_config_set_automation",
             {"config": original, "identifier": identifier},
         )
-        # Mutate once so the decorator captures pre-edit state (a fresh
-        # entity has no pre-state to snapshot).
-        edited = {**original, "alias": f"E2E Diff Noop Edited {suffix}"}
-        await safe_call_tool(
+        # Capture via (edits, create) so stored == current by
+        # construction. The decorator's auto-on-write path is
+        # unreliable here: snapshot filenames are seconds-resolution,
+        # so a mutate-then-restore inside the same second clobbers
+        # the first capture.
+        create_result = await safe_call_tool(
             mcp_client,
-            "ha_config_set_automation",
-            {"config": edited, "identifier": identifier},
+            "ha_manage_backup",
+            {
+                "scope": "edits",
+                "action": "create",
+                "domain": "automation",
+                "entity_id": identifier,
+            },
         )
-        # Restore the original so live matches the snapshot for the diff
-        # we're about to take.
-        await safe_call_tool(
-            mcp_client,
-            "ha_config_set_automation",
-            {"config": original, "identifier": identifier},
-        )
-        backup_name = await _wait_for_backup(
-            mcp_client, domain="automation", entity_id=identifier
-        )
+        assert create_result.get("success") is True
+        backup_name = create_result["data"]["backup_name"]
 
         diff = await safe_call_tool(
             mcp_client,
@@ -1456,6 +1454,7 @@ class TestEntityStateCaptureRestore:
             # POST) on some HA versions; if so the entity-domain handler
             # won't fire. Surface clearly rather than asserting wrong.
             pytest.skip("entity-domain handler did not capture for this edit")
+            return  # unreachable: pytest.skip raises Skipped
 
         restore = await safe_call_tool(
             mcp_client,

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -28,10 +28,12 @@ from ha_mcp.backup_manager import (
     DomainHandler,
     _compute_json_patch,
     _pointer_segment,
+    _require_list,
     _safe_entity_id,
     _summarize_patch_counts,
     get_backup_manager,
 )
+from ha_mcp.client.rest_client import HomeAssistantError
 
 # ---------------------------------------------------------------- fixtures
 
@@ -661,9 +663,10 @@ class TestPointerSegment:
         assert _pointer_segment("a~b") == "a~0b"
 
     def test_tilde_one_in_input_round_trips(self) -> None:
-        # Without escaping ``~`` before ``/``, the literal ``~1`` in the
-        # input would conflict with the slash substitution and decode
-        # back to ``/`` on the consumer side. ``~`` first prevents that.
+        # Forward order escapes ``~`` → ``~0`` first, so the literal
+        # ``~1`` becomes ``~01``. The reverse order is the real hazard:
+        # a literal ``/`` escaped to ``~1`` would then be corrupted to
+        # ``~01`` by the ``~`` pass (see ``_pointer_segment``).
         assert _pointer_segment("~1") == "~01"
 
 
@@ -747,6 +750,80 @@ class TestDiffNode:
         # All three are adds since current is empty.
         assert {op["op"] for op in out} == {"add"}
 
+    def test_patch_exactly_at_cap_is_not_truncated(self) -> None:
+        # A patch that lands on exactly ``max_ops`` ops is complete, not
+        # cut short — ``len(out) >= max_ops`` would have flagged it as a
+        # false-positive truncation. The generator collects one beyond
+        # the cap to tell "exactly full" from "overflowed".
+        stored = {f"k{i}": i for i in range(3)}
+        current: dict[str, Any] = {}
+        out: list[dict[str, Any]] = []
+        truncated = _compute_json_patch(stored, current, 3, out)
+        assert truncated is False
+        assert len(out) == 3
+        assert {op["op"] for op in out} == {"add"}
+
+    def test_nested_list_of_dicts_grows_emits_append(self) -> None:
+        # A real trigger add: the stored automation has two triggers, the
+        # live one only has the first — recovering ``stored`` means
+        # appending the second trigger.
+        stored = {
+            "trigger": [
+                {"platform": "state", "entity_id": "binary_sensor.a"},
+                {"platform": "time", "at": "12:00:00"},
+            ]
+        }
+        current = {"trigger": [{"platform": "state", "entity_id": "binary_sensor.a"}]}
+        out: list[dict[str, Any]] = []
+        _compute_json_patch(stored, current, 50, out)
+        assert out == [
+            {
+                "op": "add",
+                "path": "/trigger/-",
+                "value": {"platform": "time", "at": "12:00:00"},
+            }
+        ]
+
+    def test_nested_list_of_dicts_shrinks_emits_reverse_remove(self) -> None:
+        # A real action removal: the stored script has one action, the
+        # live one grew a second — recovering ``stored`` means removing
+        # the extra tail entry.
+        stored = {"action": [{"service": "light.turn_on"}]}
+        current = {
+            "action": [
+                {"service": "light.turn_on"},
+                {"service": "light.turn_off"},
+            ]
+        }
+        out: list[dict[str, Any]] = []
+        _compute_json_patch(stored, current, 50, out)
+        assert out == [{"op": "remove", "path": "/action/1"}]
+
+    def test_tilde_in_key_escapes_end_to_end(self) -> None:
+        # ``~`` in a dict key must be escaped to ``~0`` in the pointer
+        # path — exercised through ``_compute_json_patch`` (not just
+        # ``_pointer_segment``) to cover the full diff path.
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a~b": 2}, {"a~b": 1}, 50, out)
+        assert out == [{"op": "replace", "path": "/a~0b", "value": 2}]
+
+
+class TestRequireList:
+    """``_require_list`` distinguishes a degraded fetch from a real miss."""
+
+    def test_returns_list_unchanged(self) -> None:
+        items = [{"id": "x"}]
+        assert _require_list(items, "config/label_registry/list") is items
+
+    @pytest.mark.parametrize("bad", [None, {"error": "denied"}, "oops", 42])
+    def test_non_list_envelope_raises(self, bad: Any) -> None:
+        # A non-list envelope is an unexpected/degraded response, not a
+        # missing entity — it must raise (funnelling to a structured
+        # error / capture warning) rather than return None, which callers
+        # read as ``entity_missing``.
+        with pytest.raises(HomeAssistantError):
+            _require_list(bad, "config/label_registry/list")
+
 
 class TestSummarizePatchCounts:
     def test_counts_each_op_class_and_total(self) -> None:
@@ -770,6 +847,25 @@ class TestSummarizePatchCounts:
             "replace": 0,
             "total": 0,
         }
+
+    def test_unrecognized_op_warns_and_undercounts_classes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # ``_diff_node`` only emits add/remove/replace today; if a future
+        # op type (move/copy/test) ever appears, the class counts sum to
+        # less than ``total``. The warning makes that drift visible.
+        patch = [
+            {"op": "add", "path": "/x", "value": 1},
+            {"op": "move", "from": "/a", "path": "/b"},
+        ]
+        with caplog.at_level("WARNING"):
+            counts = _summarize_patch_counts(patch)
+        assert counts == {"add": 1, "remove": 0, "replace": 0, "total": 2}
+        assert counts["add"] + counts["remove"] + counts["replace"] < counts["total"]
+        assert any(
+            "unrecognized JSON-Patch op" in r.message and "move" in r.message
+            for r in caplog.records
+        )
 
 
 class TestDiffSnapshot:
@@ -796,6 +892,7 @@ class TestDiffSnapshot:
             "total": 0,
         }
         assert result["truncated"] is False
+        assert result["captured_at"] is not None
 
     async def test_diff_reports_scalar_replace(self, tmp_path: Path) -> None:
         # Capture, then mutate the handler's "current" so a subsequent
@@ -844,10 +941,15 @@ class TestDiffSnapshot:
         # restore would re-create this", not "apply N ops".
         assert result["patch"] == []
         assert result["truncated"] is False
-        # ``unchanged`` tracks the empty-patch invariant across both
-        # branches; ``entity_missing=True`` callers must check
-        # ``entity_missing`` first (see ``diff_snapshot`` docstring).
-        assert result["unchanged"] is True
+        # ``unchanged`` must be False under ``entity_missing``: the empty
+        # patch is an artefact of the absent target, not a "live config
+        # matches snapshot" signal. An agent scanning ``unchanged`` to
+        # skip action would otherwise be wrong.
+        assert result["unchanged"] is False
+        # ``captured_at`` is the snapshot timestamp, present in both
+        # branches — asserted so a rename to a non-existent key surfaces
+        # as a failure instead of silently yielding None.
+        assert result["captured_at"] is not None
 
     async def test_diff_raises_lookup_error_on_unknown_domain(
         self, tmp_path: Path

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -27,7 +27,10 @@ from ha_mcp.backup_manager import (
     BackupManager,
     DomainHandler,
     _compute_json_patch,
+    _fetch_calendar_event,
+    _fetch_todo_item,
     _pointer_segment,
+    _require_dict,
     _require_list,
     _safe_entity_id,
     _summarize_patch_counts,
@@ -823,6 +826,51 @@ class TestRequireList:
         # read as ``entity_missing``.
         with pytest.raises(HomeAssistantError):
             _require_list(bad, "config/label_registry/list")
+
+
+class TestRequireDict:
+    """``_require_dict`` distinguishes a degraded fetch from a real miss."""
+
+    def test_returns_dict_unchanged(self) -> None:
+        envelope = {"response": {}}
+        assert _require_dict(envelope, "execute_script") is envelope
+
+    @pytest.mark.parametrize("bad", [None, [1, 2], "oops", 42])
+    def test_non_dict_envelope_raises(self, bad: Any) -> None:
+        # Mirror of ``_require_list`` for the execute_script fetchers: a
+        # non-dict envelope is a degraded/malformed 200, not a miss.
+        with pytest.raises(HomeAssistantError):
+            _require_dict(bad, "execute_script")
+
+
+class TestExecuteScriptFetchers:
+    """Calendar / todo fetchers route the ``execute_script`` envelope
+    through ``_require_dict`` (Boy-Scout parity with the registry
+    fetchers): a malformed 200 raises instead of masquerading as
+    ``entity_missing``, while a genuine uid miss still returns ``None``."""
+
+    @pytest.mark.parametrize("fetcher", [_fetch_calendar_event, _fetch_todo_item])
+    async def test_non_dict_envelope_raises(
+        self, fetcher: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _ws_send(_client: Any, _message: dict[str, Any]) -> Any:
+            return ["unexpected", "list", "body"]
+
+        monkeypatch.setattr(bm, "_ws_send", _ws_send)
+        with pytest.raises(HomeAssistantError, match="Expected a dict"):
+            await fetcher(object(), "calendar.x::uid-1")
+
+    @pytest.mark.parametrize("fetcher", [_fetch_calendar_event, _fetch_todo_item])
+    async def test_missing_uid_still_returns_none(
+        self, fetcher: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A well-formed dict whose nested lookup finds no matching uid is a
+        # real miss — it must stay ``None`` (entity_missing), not raise.
+        async def _ws_send(_client: Any, _message: dict[str, Any]) -> Any:
+            return {"response": {}}
+
+        monkeypatch.setattr(bm, "_ws_send", _ws_send)
+        assert await fetcher(object(), "calendar.x::absent-uid") is None
 
 
 class TestSummarizePatchCounts:

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -22,10 +22,14 @@ import yaml
 
 from ha_mcp import backup_manager as bm
 from ha_mcp.backup_manager import (
+    _MAX_PATCH_OPS,
     SCHEMA_VERSION,
     BackupManager,
     DomainHandler,
+    _compute_json_patch,
+    _pointer_segment,
     _safe_entity_id,
+    _summarize_patch_counts,
     get_backup_manager,
 )
 
@@ -639,3 +643,252 @@ class TestSupportedDomains:
     def test_empty_when_no_handlers(self, tmp_path: Path) -> None:
         mgr = _mk_manager(tmp_path)
         assert mgr.supported_domains() == []
+
+
+# ---------------------------------------------------------------- diff helpers
+
+
+class TestPointerSegment:
+    """RFC 6901 §3 escape order: ``~`` first, then ``/``."""
+
+    def test_plain_segment_passes_through(self) -> None:
+        assert _pointer_segment("alias") == "alias"
+
+    def test_slash_escapes_to_tilde_one(self) -> None:
+        assert _pointer_segment("a/b") == "a~1b"
+
+    def test_tilde_escapes_to_tilde_zero(self) -> None:
+        assert _pointer_segment("a~b") == "a~0b"
+
+    def test_tilde_one_in_input_round_trips(self) -> None:
+        # Without escaping ``~`` before ``/``, the literal ``~1`` in the
+        # input would conflict with the slash substitution and decode
+        # back to ``/`` on the consumer side. ``~`` first prevents that.
+        assert _pointer_segment("~1") == "~01"
+
+
+class TestDiffNode:
+    """``_compute_json_patch`` patch shape against representative configs."""
+
+    def test_identical_configs_produce_empty_patch(self) -> None:
+        out: list[dict[str, Any]] = []
+        truncated = _compute_json_patch({"a": 1}, {"a": 1}, 50, out)
+        assert out == []
+        assert truncated is False
+
+    def test_scalar_change_is_replace(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a": 2}, {"a": 1}, 50, out)
+        assert out == [{"op": "replace", "path": "/a", "value": 2}]
+
+    def test_missing_key_in_current_is_add(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a": 1, "b": 2}, {"a": 1}, 50, out)
+        assert out == [{"op": "add", "path": "/b", "value": 2}]
+
+    def test_extra_key_in_current_is_remove(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a": 1}, {"a": 1, "b": 2}, 50, out)
+        assert out == [{"op": "remove", "path": "/b"}]
+
+    def test_bool_vs_int_does_not_collapse(self) -> None:
+        # ``True == 1`` in Python but they represent different states for
+        # HA-side toggles; the diff must treat the type change as a
+        # replace, not silently equate them.
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"enabled": True}, {"enabled": 1}, 50, out)
+        assert out == [{"op": "replace", "path": "/enabled", "value": True}]
+
+    def test_list_length_grew_in_current_emits_remove_in_reverse(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch([1, 2], [1, 2, 3, 4], 50, out)
+        # Removes in reverse index order so each op stays valid against
+        # the document state it gets applied to.
+        assert out == [
+            {"op": "remove", "path": "/3"},
+            {"op": "remove", "path": "/2"},
+        ]
+
+    def test_list_length_shrunk_in_current_emits_append(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch([1, 2, 3], [1, 2], 50, out)
+        assert out == [{"op": "add", "path": "/-", "value": 3}]
+
+    def test_nested_change_uses_pointer_path(self) -> None:
+        stored = {"trigger": [{"platform": "state", "entity_id": "binary_sensor.x"}]}
+        current = {"trigger": [{"platform": "time", "entity_id": "binary_sensor.x"}]}
+        out: list[dict[str, Any]] = []
+        _compute_json_patch(stored, current, 50, out)
+        assert out == [
+            {"op": "replace", "path": "/trigger/0/platform", "value": "state"}
+        ]
+
+    def test_key_with_slash_gets_escaped(self) -> None:
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a/b": 2}, {"a/b": 1}, 50, out)
+        assert out == [{"op": "replace", "path": "/a~1b", "value": 2}]
+
+    def test_root_type_swap_emits_root_replace(self) -> None:
+        # When the captured shape is a dict but HA now returns a list
+        # (schema migration, integration replaced), the only sane patch
+        # is "replace whole doc" — JSON-Pointer ``""`` per RFC 6901 §6.
+        out: list[dict[str, Any]] = []
+        _compute_json_patch({"a": 1}, [1, 2], 50, out)
+        assert out == [{"op": "replace", "path": "", "value": {"a": 1}}]
+
+    def test_truncation_flag_set_when_max_ops_reached(self) -> None:
+        # Build a config that produces > max_ops change ops.
+        stored = {f"k{i}": i for i in range(10)}
+        current: dict[str, Any] = {}
+        out: list[dict[str, Any]] = []
+        truncated = _compute_json_patch(stored, current, 3, out)
+        assert truncated is True
+        assert len(out) == 3
+        # All three are adds since current is empty.
+        assert {op["op"] for op in out} == {"add"}
+
+
+class TestSummarizePatchCounts:
+    def test_counts_each_op_class_and_total(self) -> None:
+        patch = [
+            {"op": "add", "path": "/x", "value": 1},
+            {"op": "remove", "path": "/y"},
+            {"op": "replace", "path": "/z", "value": 2},
+            {"op": "add", "path": "/q", "value": 3},
+        ]
+        assert _summarize_patch_counts(patch) == {
+            "add": 2,
+            "remove": 1,
+            "replace": 1,
+            "total": 4,
+        }
+
+    def test_empty_patch_zero_counts(self) -> None:
+        assert _summarize_patch_counts([]) == {
+            "add": 0,
+            "remove": 0,
+            "replace": 0,
+            "total": 0,
+        }
+
+
+class TestDiffSnapshot:
+    """``BackupManager.diff_snapshot`` end-to-end against stub handlers."""
+
+    async def test_diff_against_unchanged_current_returns_empty_patch(
+        self, tmp_path: Path
+    ) -> None:
+        mgr = _mk_manager(tmp_path)
+        mgr.register(_mk_handler(fetched={"alias": "kitchen"}))
+        path = await mgr.maybe_snapshot("automation", "x")
+        assert path is not None
+        result = await mgr.diff_snapshot(path.name)
+        assert result["kind"] == "dict"
+        assert result["domain"] == "automation"
+        assert result["entity_id"] == "x"
+        assert result["entity_missing"] is False
+        assert result["unchanged"] is True
+        assert result["patch"] == []
+        assert result["counts"] == {
+            "add": 0,
+            "remove": 0,
+            "replace": 0,
+            "total": 0,
+        }
+        assert result["truncated"] is False
+
+    async def test_diff_reports_scalar_replace(self, tmp_path: Path) -> None:
+        # Capture, then mutate the handler's "current" so a subsequent
+        # diff sees a divergent live state.
+        captured = {"alias": "kitchen", "mode": "single"}
+        current = {"alias": "kitchen", "mode": "queued"}
+        handler_fetch_results: list[Any] = [captured, current]
+
+        async def fetch(_client: Any, _entity_id: str) -> Any:
+            return handler_fetch_results.pop(0)
+
+        async def restore(_client: Any, _entity_id: str, _config: Any) -> Any:
+            return None
+
+        mgr = _mk_manager(tmp_path)
+        mgr.register(DomainHandler(domain="automation", fetch=fetch, restore=restore))
+        path = await mgr.maybe_snapshot("automation", "x")
+        assert path is not None
+        result = await mgr.diff_snapshot(path.name)
+        assert result["unchanged"] is False
+        assert result["patch"] == [
+            {"op": "replace", "path": "/mode", "value": "single"}
+        ]
+        assert result["counts"]["replace"] == 1
+
+    async def test_diff_flags_entity_missing_when_fetch_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        # First fetch (capture) returns config; second (diff) returns None
+        # to simulate the entity being deleted after capture.
+        results: list[Any] = [{"alias": "x"}, None]
+
+        async def fetch(_client: Any, _entity_id: str) -> Any:
+            return results.pop(0)
+
+        async def restore(_client: Any, _entity_id: str, _config: Any) -> Any:
+            return None
+
+        mgr = _mk_manager(tmp_path)
+        mgr.register(DomainHandler(domain="automation", fetch=fetch, restore=restore))
+        path = await mgr.maybe_snapshot("automation", "x")
+        assert path is not None
+        result = await mgr.diff_snapshot(path.name)
+        assert result["entity_missing"] is True
+        # No patch when entity is gone — the consumer-side action is "the
+        # restore would re-create this", not "apply N ops".
+        assert result["patch"] == []
+        assert result["truncated"] is False
+
+    async def test_diff_raises_lookup_error_on_unknown_domain(
+        self, tmp_path: Path
+    ) -> None:
+        mgr = _mk_manager(tmp_path)
+        bogus = tmp_path / "alien.x.20260521_120000.yaml"
+        bogus.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "domain": "alien",
+                    "entity_id": "x",
+                    "config": {"v": 1},
+                }
+            )
+        )
+        with pytest.raises(LookupError):
+            await mgr.diff_snapshot(bogus.name)
+
+    async def test_diff_raises_file_not_found_on_missing_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        mgr = _mk_manager(tmp_path)
+        mgr.register(_mk_handler(fetched={"alias": "x"}))
+        with pytest.raises(FileNotFoundError):
+            await mgr.diff_snapshot("automation.x.20260521_120000.yaml")
+
+    async def test_diff_truncation_flagged_when_patch_exceeds_cap(
+        self, tmp_path: Path
+    ) -> None:
+        # Capture a large config, then return a divergent one to force
+        # >_MAX_PATCH_OPS ops.
+        big_stored = {f"k{i}": i for i in range(_MAX_PATCH_OPS + 50)}
+        results: list[Any] = [big_stored, {}]
+
+        async def fetch(_client: Any, _entity_id: str) -> Any:
+            return results.pop(0)
+
+        async def restore(_client: Any, _entity_id: str, _config: Any) -> Any:
+            return None
+
+        mgr = _mk_manager(tmp_path)
+        mgr.register(DomainHandler(domain="automation", fetch=fetch, restore=restore))
+        path = await mgr.maybe_snapshot("automation", "x")
+        assert path is not None
+        result = await mgr.diff_snapshot(path.name)
+        assert result["truncated"] is True
+        assert len(result["patch"]) == _MAX_PATCH_OPS

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -951,6 +951,29 @@ class TestDiffSnapshot:
         # as a failure instead of silently yielding None.
         assert result["captured_at"] is not None
 
+    async def test_diff_raises_on_degraded_fetch_envelope(self, tmp_path: Path) -> None:
+        # Item #1 end-to-end: a degraded fetch (non-list envelope from an
+        # auth-scope change / API drift) must propagate out of
+        # ``diff_snapshot`` as a raise, NOT be misread as
+        # ``entity_missing``. The capture fetch succeeds; the diff fetch
+        # routes a dict envelope through ``_require_list`` and raises.
+        results: list[Any] = [{"alias": "x"}]
+
+        async def fetch(_client: Any, _entity_id: str) -> Any:
+            if results:
+                return results.pop(0)
+            return _require_list({"error": "permission denied"}, "automation/list")
+
+        async def restore(_client: Any, _entity_id: str, _config: Any) -> Any:
+            return None
+
+        mgr = _mk_manager(tmp_path)
+        mgr.register(DomainHandler(domain="automation", fetch=fetch, restore=restore))
+        path = await mgr.maybe_snapshot("automation", "x")
+        assert path is not None
+        with pytest.raises(HomeAssistantError, match="Expected a list"):
+            await mgr.diff_snapshot(path.name)
+
     async def test_diff_raises_lookup_error_on_unknown_domain(
         self, tmp_path: Path
     ) -> None:

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -844,6 +844,10 @@ class TestDiffSnapshot:
         # restore would re-create this", not "apply N ops".
         assert result["patch"] == []
         assert result["truncated"] is False
+        # ``unchanged`` tracks the empty-patch invariant across both
+        # branches; ``entity_missing=True`` callers must check
+        # ``entity_missing`` first (see ``diff_snapshot`` docstring).
+        assert result["unchanged"] is True
 
     async def test_diff_raises_lookup_error_on_unknown_domain(
         self, tmp_path: Path


### PR DESCRIPTION
## What does this PR do?

Adds `action="diff"` to `ha_manage_backup(scope="edits")`. Pure-read, additive — compares a stored auto-backup against the entity's current config via the existing domain-handler `fetch` path, returns an RFC 6902 JSON-Patch with add/remove/replace counts.

Response shape is forward-compatible: carries a `kind: "dict"` discriminator now, leaving room for `kind: "text"` / `kind: "binary"` when the file-fold (issue #1579 point 2 / PR2) lands. PR1 is intentionally standalone — no code path here depends on PR2.

Bounded output: patch is capped at `_MAX_PATCH_OPS = 200`; the response carries `truncated: true` when the cap fires. `entity_missing: true` flags the case where the entity is gone from HA since capture (the diff has no live target to compare against) — the response stays structured rather than raising, so callers can branch on it.

Refs #1579 (only the first of two PRs for this issue; YAML / file-fold lands in PR2).

## Type of change
- [x] ✨ New feature

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
