### PR TITLE
fix: stop logging confusing "Terminating session: None" noise in stateless HTTP

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -372,21 +372,26 @@ class StatelessSessionLogFilter(logging.Filter):
     confused users into thinking the connection is broken.
 
     Returning ``False`` drops the record at this logger before it reaches any
-    handler. (Merely downgrading the level to DEBUG did not work: the record
-    was still emitted -- just relabelled -- because the root handler has no
-    level threshold of its own.) Real session terminations carry an actual id
-    and are not matched, so they still log.
+    handler. (Merely downgrading the level to DEBUG did not work: the level
+    gate is applied before the filter runs, so the record was already admitted
+    and still emitted -- just relabelled.) Real session terminations carry an
+    actual id and are not matched, so they still log.
 
     # TODO: remove when modelcontextprotocol/python-sdk#2329 is resolved
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        is_stateless_teardown = (
-            record.name == "mcp.server.streamable_http"
-            and "Terminating session: None" in record.getMessage()
-        )
+        if record.name != "mcp.server.streamable_http":
+            return True
+        try:
+            message = record.getMessage()
+        except (ValueError, TypeError):
+            # A malformed %-format record on this logger is not our target, and
+            # a filter must not raise: filters run in Logger.handle() with no
+            # exception handling, so a raise would crash the logging call.
+            return True
         # Drop the stateless teardown noise; keep everything else.
-        return not is_stateless_teardown
+        return "Terminating session: None" not in message
 
 
 class ToolValidationLogFilter(logging.Filter):

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -363,24 +363,30 @@ _LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 class StatelessSessionLogFilter(logging.Filter):
-    """Downgrade 'Terminating session: None' to DEBUG to reduce user confusion.
+    """Suppress the routine 'Terminating session: None' log from the MCP SDK.
 
     In stateless HTTP mode every request creates and tears down a temporary
-    session, producing an INFO log that looks alarming but is routine.
-    This filter lowers the level to DEBUG so the message only appears with
-    verbose logging enabled.
+    session whose id is ``None``, so the SDK emits an INFO
+    ``Terminating session: None`` (mcp/server/streamable_http.py) on *every*
+    request. The line is routine but looks alarming and has repeatedly
+    confused users into thinking the connection is broken.
+
+    Returning ``False`` drops the record at this logger before it reaches any
+    handler. (Merely downgrading the level to DEBUG did not work: the record
+    was still emitted -- just relabelled -- because the root handler has no
+    level threshold of its own.) Real session terminations carry an actual id
+    and are not matched, so they still log.
 
     # TODO: remove when modelcontextprotocol/python-sdk#2329 is resolved
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if (
+        is_stateless_teardown = (
             record.name == "mcp.server.streamable_http"
             and "Terminating session: None" in record.getMessage()
-        ):
-            record.levelno = logging.DEBUG
-            record.levelname = "DEBUG"
-        return True
+        )
+        # Drop the stateless teardown noise; keep everything else.
+        return not is_stateless_teardown
 
 
 class ToolValidationLogFilter(logging.Filter):

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -114,6 +114,27 @@ def is_hacs_unavailable(data: dict) -> tuple[bool, str]:
     return False, ""
 
 
+def is_transient_hacs_install_error(error: object) -> bool:
+    """True for transient HACS *install* failures that warrant a skip, not a fail.
+
+    The install tests target a known-good repo (``ha_mcp_tools``), so an install
+    failure there is environmental — a GitHub rate-limit/token issue or a flaky
+    repository download (HACS surfaces the latter as e.g. "Failed to download
+    repository after 3 attempts: Command failed: Unknown error", which carries
+    no "rate"/"token" substring and so slipped past the old ad-hoc check). This
+    is for the install path ONLY; negative tests that *expect* a download error
+    assert on it directly and must not use this.
+    """
+    s = str(error).lower()
+    return (
+        "401" in s
+        or "token" in s
+        or "rate limit" in s
+        or "failed to download repository" in s
+        or "command failed" in s
+    )
+
+
 @pytest.mark.hacs
 class TestHacsSearchInstalled:
     """Test HACS search with installed_only filter functionality."""
@@ -654,12 +675,8 @@ class TestMcpToolsInstallation:
 
             # Check for GitHub token issues
             error = str(data.get("error", ""))
-            if (
-                "401" in error
-                or "token" in error.lower()
-                or "rate limit" in error.lower()
-            ):
-                pytest.skip(f"GitHub access issue: {error}")
+            if is_transient_hacs_install_error(error):
+                pytest.skip(f"Transient HACS install issue: {error}")
 
             pytest.fail(f"Installation failed: {data.get('error')}")
 
@@ -711,8 +728,8 @@ class TestMcpToolsInstallation:
             if unavailable:
                 pytest.skip(f"HACS not available: {reason}")
             error = str(data1.get("error", ""))
-            if "401" in error or "token" in error.lower():
-                pytest.skip(f"GitHub access issue: {error}")
+            if is_transient_hacs_install_error(error):
+                pytest.skip(f"Transient HACS install issue: {error}")
             pytest.fail(f"First install failed: {data1.get('error')}")
 
         # Second install should also succeed
@@ -757,8 +774,8 @@ class TestMcpToolsInstallation:
             if unavailable:
                 pytest.skip(f"HACS not available: {reason}")
             error = str(install_data.get("error", ""))
-            if "401" in error or "token" in error.lower():
-                pytest.skip(f"GitHub access issue: {error}")
+            if is_transient_hacs_install_error(error):
+                pytest.skip(f"Transient HACS install issue: {error}")
             pytest.fail(f"Install failed: {install_data.get('error')}")
 
         # Now check HACS search for installed integrations
@@ -834,6 +851,22 @@ def test_unit_is_hacs_unavailable_catches_unknown_command() -> None:
     unavailable, reason = is_hacs_unavailable(data)
     assert unavailable is True
     assert reason == "Unknown command"
+
+
+def test_unit_is_transient_hacs_install_error_catches_download_failure() -> None:
+    """The real flaky-download shape must trip the install-path skip guard.
+
+    "Failed to download repository after N attempts: Command failed: Unknown
+    error" carries no "rate"/"token" substring, so the old ad-hoc check let it
+    hard-fail TestMcpToolsInstallation instead of skipping.
+    """
+    assert is_transient_hacs_install_error(
+        "Failed to download repository after 3 attempts: Command failed: Unknown error"
+    )
+    assert is_transient_hacs_install_error("401 Unauthorized")
+    assert is_transient_hacs_install_error("GitHub rate limit exceeded")
+    # A genuine, non-transient install error must NOT be skipped.
+    assert not is_transient_hacs_install_error("Repository 'x/y' not found in HACS")
 
 
 def test_unit_is_hacs_unavailable_catches_hacs_not_available_code() -> None:

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -124,6 +124,11 @@ def is_transient_hacs_install_error(error: object) -> bool:
     no "rate"/"token" substring and so slipped past the old ad-hoc check). This
     is for the install path ONLY; negative tests that *expect* a download error
     assert on it directly and must not use this.
+
+    Matches the anchored "failed to download repository" phrase rather than a
+    bare "command failed": the latter is too broad and would silently skip a
+    genuine, non-transient install regression that happened to surface that
+    common subprocess phrasing.
     """
     s = str(error).lower()
     return (
@@ -131,7 +136,6 @@ def is_transient_hacs_install_error(error: object) -> bool:
         or "token" in s
         or "rate limit" in s
         or "failed to download repository" in s
-        or "command failed" in s
     )
 
 
@@ -865,8 +869,13 @@ def test_unit_is_transient_hacs_install_error_catches_download_failure() -> None
     )
     assert is_transient_hacs_install_error("401 Unauthorized")
     assert is_transient_hacs_install_error("GitHub rate limit exceeded")
-    # A genuine, non-transient install error must NOT be skipped.
+    # Genuine, non-transient install errors must NOT be skipped — including one
+    # that merely contains the bare phrase "command failed" (the over-broad
+    # clause that was removed so real regressions still fail loudly).
     assert not is_transient_hacs_install_error("Repository 'x/y' not found in HACS")
+    assert not is_transient_hacs_install_error(
+        "Install aborted: post-install command failed (manifest invalid)"
+    )
 
 
 def test_unit_is_hacs_unavailable_catches_hacs_not_available_code() -> None:

--- a/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
@@ -267,6 +267,15 @@ class TestSettingsUiRestartReal:
 
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(restart_url, json={"slug": SSH_ADDON_SLUG})
+            # The restart routes through Supervisor + Ingress; while the target
+            # addon bounces, the proxy can transiently answer 5xx (observed:
+            # 502 Bad Gateway). The restart is idempotent, so retry a few times
+            # on a 5xx before asserting.
+            for _ in range(5):
+                if resp.status_code < 500:
+                    break
+                await asyncio.sleep(3)
+                resp = await client.post(restart_url, json={"slug": SSH_ADDON_SLUG})
 
         assert resp.status_code == 200, (
             f"Expected 200 from settings restart with slug={SSH_ADDON_SLUG!r}, "

--- a/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
@@ -127,6 +127,42 @@ class TestGetLogsSupervisorReal:
             f"{log_text[:200]!r}"
         )
 
+    async def test_dev_addon_log_omits_stateless_teardown_noise(
+        self, mcp_client
+    ) -> None:
+        """The stateless ``Terminating session: None`` teardown line must NOT
+        appear in the dev addon's own Supervisor log.
+
+        The MCP SDK logs ``Terminating session: None`` at INFO on every
+        stateless-HTTP request teardown; ``StatelessSessionLogFilter`` must drop
+        it (regression guard: it previously only downgraded it to DEBUG and
+        still emitted it). The inaddon tier is the only lane where ha-mcp
+        actually serves stateless HTTP, so it is the only lane where this line
+        can appear — and every ``mcp_client`` call below is such a request.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            # Each call is a stateless HTTP request whose teardown would log the
+            # line if it were not suppressed.
+            for _ in range(3):
+                await mcp.call_tool_success("ha_get_overview", {})
+            result = await mcp.call_tool_success(
+                "ha_get_logs",
+                {
+                    "source": "supervisor",
+                    "slug": HA_MCP_DEV_ADDON_SLUG,
+                    "search": "Terminating session",
+                },
+            )
+
+        assert result.get("success") is True
+        # ``search`` returns only matching lines, so a suppressed filter yields
+        # an empty log; any hit here is the regression.
+        log_text = result.get("log", "") or ""
+        assert "Terminating session" not in log_text, (
+            "Stateless teardown noise leaked into the dev addon's Supervisor "
+            f"log:\n{log_text[:1000]}"
+        )
+
 
 # NOTE on inaddon coverage scope:
 #

--- a/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
+++ b/tests/src/e2e/workflows/system/test_supervisor_inaddon.py
@@ -145,6 +145,14 @@ class TestGetLogsSupervisorReal:
             # line if it were not suppressed.
             for _ in range(3):
                 await mcp.call_tool_success("ha_get_overview", {})
+            # Positive control: confirm the dev addon IS emitting Supervisor
+            # logs, so an empty filtered result below means "suppressed" -- not
+            # "log pipeline broken / SDK wording drifted", which would make the
+            # regression check pass vacuously.
+            unfiltered = await mcp.call_tool_success(
+                "ha_get_logs",
+                {"source": "supervisor", "slug": HA_MCP_DEV_ADDON_SLUG, "limit": 20},
+            )
             result = await mcp.call_tool_success(
                 "ha_get_logs",
                 {
@@ -154,6 +162,10 @@ class TestGetLogsSupervisorReal:
                 },
             )
 
+        assert (unfiltered.get("log") or "").strip(), (
+            "No Supervisor logs retrieved for the dev addon -- the teardown-noise "
+            "absence assertion below would be vacuous."
+        )
         assert result.get("success") is True
         # ``search`` returns only matching lines, so a suppressed filter yields
         # an empty log; any hit here is the regression.

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -1276,6 +1276,50 @@ def trigger_dev_addon_update(
             f"supervisor/api {op_endpoint} did not complete before its deadline"
         )
 
+    def _supervisor_post_with_job_retry(
+        endpoint: str, op_timeout: int, *, data: dict | None = None
+    ) -> None:
+        """POST a Supervisor endpoint, retrying the transient per-addon
+        ``Another job is running for job group ...`` collision.
+
+        Supervisor serialises jobs per job-group, so the dev-addon refresh's
+        ``/update`` and ``/start`` are rejected outright when a still-settling
+        job (the ``/store/reload`` above, a watchdog restart, or a prior update)
+        holds the ``addon_<slug>`` group. The conflicting job clears within
+        seconds — re-issue until it does, bounded to a handful of attempts.
+        Each attempt uses a fresh ``_next_id()`` so HA Core's ERR_ID_REUSE
+        guard never trips.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            mid = _next_id()
+            payload: dict[str, Any] = {
+                "id": mid,
+                "type": "supervisor/api",
+                "endpoint": endpoint,
+                "method": "post",
+                "timeout": op_timeout,
+            }
+            if data is not None:
+                payload["data"] = data
+            ws.send(json.dumps(payload))
+            try:
+                _await_supervisor_result(mid, endpoint, time.monotonic() + op_timeout)
+                return
+            except RuntimeError as err:
+                if "another job is running" in str(err).lower() and attempt < 12:
+                    LOG.warning(
+                        "Supervisor %s collided with an in-flight job-group job "
+                        "(attempt %d): %s; waiting 5s and retrying",
+                        endpoint,
+                        attempt,
+                        err,
+                    )
+                    time.sleep(5)
+                    continue
+                raise
+
     with websockets.sync.client.connect(ws_url, max_size=None, open_timeout=30) as ws:
         first_frame = json.loads(ws.recv())
         if first_frame.get("type") != "auth_required":
@@ -1332,38 +1376,15 @@ def trigger_dev_addon_update(
 
         # Trigger the update. ``backup=false`` skips Supervisor's pre-update
         # snapshot (saves ~30s, irrelevant for CI).
-        msg_id = _next_id()
         update_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/update"
-        ws.send(
-            json.dumps(
-                {
-                    "id": msg_id,
-                    "type": "supervisor/api",
-                    "endpoint": update_endpoint,
-                    "method": "post",
-                    "timeout": timeout,
-                    "data": {"backup": False},
-                }
-            )
+        _supervisor_post_with_job_retry(
+            update_endpoint, timeout, data={"backup": False}
         )
-        _await_supervisor_result(msg_id, update_endpoint, time.monotonic() + timeout)
         LOG.info("Dev addon update completed via Supervisor WS; starting addon")
 
         # Explicit start after update — Supervisor leaves the addon in
         # boot_fail state otherwise, with the new image built but no
         # running container. See docstring for the CI log evidence.
-        msg_id = _next_id()
         start_endpoint = f"/addons/{HA_MCP_DEV_ADDON_SLUG}/start"
-        ws.send(
-            json.dumps(
-                {
-                    "id": msg_id,
-                    "type": "supervisor/api",
-                    "endpoint": start_endpoint,
-                    "method": "post",
-                    "timeout": 120,
-                }
-            )
-        )
-        _await_supervisor_result(msg_id, start_endpoint, time.monotonic() + 120)
+        _supervisor_post_with_job_retry(start_endpoint, 120)
         LOG.info("Dev addon started via Supervisor WS")

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -1286,10 +1286,17 @@ def trigger_dev_addon_update(
         ``/update`` and ``/start`` are rejected outright when a still-settling
         job (the ``/store/reload`` above, a watchdog restart, or a prior update)
         holds the ``addon_<slug>`` group. The conflicting job clears within
-        seconds — re-issue until it does, bounded to a handful of attempts.
-        Each attempt uses a fresh ``_next_id()`` so HA Core's ERR_ID_REUSE
-        guard never trips.
+        seconds, so retry within a single bounded ~60s wall-clock window (not a
+        per-attempt budget, so a genuinely silent Supervisor can't stretch this
+        to N*op_timeout). Each attempt uses a fresh ``_next_id()`` so HA Core's
+        ERR_ID_REUSE guard never trips.
+
+        The collision is matched as a case-insensitive substring on the error
+        text Supervisor returns (surfaced by ``_await_supervisor_result`` as the
+        ``RuntimeError`` message); any other failure is re-raised immediately,
+        so this never masks a real error.
         """
+        retry_deadline = time.monotonic() + 60
         attempt = 0
         while True:
             attempt += 1
@@ -1308,7 +1315,10 @@ def trigger_dev_addon_update(
                 _await_supervisor_result(mid, endpoint, time.monotonic() + op_timeout)
                 return
             except RuntimeError as err:
-                if "another job is running" in str(err).lower() and attempt < 12:
+                if (
+                    "another job is running" in str(err).lower()
+                    and time.monotonic() < retry_deadline
+                ):
                     LOG.warning(
                         "Supervisor %s collided with an in-flight job-group job "
                         "(attempt %d): %s; waiting 5s and retrying",

--- a/tests/src/unit/test_stateless_session_log_filter.py
+++ b/tests/src/unit/test_stateless_session_log_filter.py
@@ -55,7 +55,22 @@ class TestStatelessSessionLogFilter:
         assert self.log_filter.filter(record) is True
         assert record.levelno == logging.INFO
 
-    def test_setup_logging_wires_filter_and_suppresses_output(self):
+    def test_keeps_record_with_unrenderable_format(self):
+        """A record whose %-format can't be rendered (more specifiers than args)
+        must not raise out of the filter -- filters run in Logger.handle() with
+        no exception guard -- and is kept (fail-open)."""
+        record = logging.LogRecord(
+            name="mcp.server.streamable_http",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="malformed %s %s",
+            args=("only-one",),
+            exc_info=None,
+        )
+        assert self.log_filter.filter(record) is True
+
+    def test_setup_logging_wires_filter_and_suppresses_output(self, monkeypatch):
         """Integration: ``_setup_logging`` attaches the filter to the SDK logger,
         so the real ``Terminating session: None`` INFO call (the stateless
         per-request teardown) produces NO log output, while a real-id
@@ -65,19 +80,29 @@ class TestStatelessSessionLogFilter:
         on -- both start via ``ha-mcp-web`` -> ``_setup_logging`` -> this
         ``addFilter`` call -- so it guards the actual user-visible behaviour, not
         just the filter in isolation.
+
+        ``logging.basicConfig`` is stubbed to a no-op: only ``_setup_logging``'s
+        ``addFilter`` wiring matters here, and its real ``basicConfig(force=True)``
+        would tear down and *close* the root logger's handlers -- including
+        pytest's capture handlers -- polluting other tests in the same worker.
         """
         import io
 
-        from ha_mcp.__main__ import _setup_logging
+        from ha_mcp import __main__ as ha_main
 
         sdk_logger = logging.getLogger("mcp.server.streamable_http")
-        root = logging.getLogger()
-        saved_filters = sdk_logger.filters[:]
+        # _setup_logging also attaches ToolValidationLogFilter to the
+        # fastmcp.server.server logger; save/restore it too or it leaks.
+        fastmcp_logger = logging.getLogger("fastmcp.server.server")
+        saved_sdk_filters = sdk_logger.filters[:]
+        saved_fastmcp_filters = fastmcp_logger.filters[:]
         saved_propagate = sdk_logger.propagate
-        saved_root_handlers = root.handlers[:]
-        saved_root_level = root.level
+        saved_level = sdk_logger.level
+        # Keep _setup_logging from reconfiguring (and closing the handlers of)
+        # the root logger; we only exercise its addFilter() wiring here.
+        monkeypatch.setattr(ha_main.logging, "basicConfig", lambda *a, **k: None)
         try:
-            _setup_logging("INFO", force=True)
+            ha_main._setup_logging("INFO", force=True)
             assert any(
                 isinstance(f, StatelessSessionLogFilter) for f in sdk_logger.filters
             ), "_setup_logging must attach StatelessSessionLogFilter to the SDK logger"
@@ -85,6 +110,7 @@ class TestStatelessSessionLogFilter:
             buf = io.StringIO()
             handler = logging.StreamHandler(buf)
             sdk_logger.addHandler(handler)
+            sdk_logger.setLevel(logging.INFO)  # basicConfig stubbed; enable INFO here
             sdk_logger.propagate = False  # isolate capture to our handler
             try:
                 # Exactly what mcp/server/streamable_http.py emits per request:
@@ -97,7 +123,7 @@ class TestStatelessSessionLogFilter:
             assert "Terminating session: None" not in out  # suppressed
             assert "7c3f-real-session" in out  # real terminations still logged
         finally:
-            sdk_logger.filters[:] = saved_filters
+            sdk_logger.filters[:] = saved_sdk_filters
+            fastmcp_logger.filters[:] = saved_fastmcp_filters
             sdk_logger.propagate = saved_propagate
-            root.handlers[:] = saved_root_handlers
-            root.level = saved_root_level
+            sdk_logger.setLevel(saved_level)

--- a/tests/src/unit/test_stateless_session_log_filter.py
+++ b/tests/src/unit/test_stateless_session_log_filter.py
@@ -6,7 +6,7 @@ from ha_mcp.__main__ import StatelessSessionLogFilter
 
 
 class TestStatelessSessionLogFilter:
-    """Verify the filter downgrades stateless termination logs to DEBUG."""
+    """Verify the filter suppresses routine stateless termination logs."""
 
     def setup_method(self):
         self.log_filter = StatelessSessionLogFilter()
@@ -22,41 +22,82 @@ class TestStatelessSessionLogFilter:
             exc_info=None,
         )
 
-    def test_downgrades_stateless_termination_to_debug(self):
+    def test_suppresses_stateless_termination(self):
         record = self._make_record(
             "mcp.server.streamable_http", "Terminating session: None"
         )
-        result = self.log_filter.filter(record)
-        assert result is True
-        assert record.levelno == logging.DEBUG
-        assert record.levelname == "DEBUG"
+        # Dropped entirely (not just relabelled): filter returns False.
+        assert self.log_filter.filter(record) is False
 
-    def test_downgrades_printf_style_termination(self):
+    def test_suppresses_printf_style_termination(self):
         record = self._make_record(
             "mcp.server.streamable_http", "Terminating session: %s"
         )
         record.args = (None,)
-        result = self.log_filter.filter(record)
-        assert result is True
-        assert record.levelno == logging.DEBUG
-        assert record.levelname == "DEBUG"
+        assert self.log_filter.filter(record) is False
 
-    def test_leaves_real_session_termination_unchanged(self):
+    def test_keeps_real_session_termination(self):
         record = self._make_record(
             "mcp.server.streamable_http", "Terminating session: abc123"
         )
-        result = self.log_filter.filter(record)
-        assert result is True
+        # A real session id is meaningful — keep it, unchanged.
+        assert self.log_filter.filter(record) is True
         assert record.levelno == logging.INFO
 
-    def test_leaves_other_loggers_unchanged(self):
+    def test_keeps_other_loggers(self):
         record = self._make_record("some.other.logger", "Terminating session: None")
-        result = self.log_filter.filter(record)
-        assert result is True
+        # Only suppress on the SDK's streamable_http logger.
+        assert self.log_filter.filter(record) is True
         assert record.levelno == logging.INFO
 
-    def test_leaves_unrelated_messages_unchanged(self):
+    def test_keeps_unrelated_messages(self):
         record = self._make_record("mcp.server.streamable_http", "Processing request")
-        result = self.log_filter.filter(record)
-        assert result is True
+        assert self.log_filter.filter(record) is True
         assert record.levelno == logging.INFO
+
+    def test_setup_logging_wires_filter_and_suppresses_output(self):
+        """Integration: ``_setup_logging`` attaches the filter to the SDK logger,
+        so the real ``Terminating session: None`` INFO call (the stateless
+        per-request teardown) produces NO log output, while a real-id
+        termination still does.
+
+        This is the mechanism the HAOS add-on and the Docker HTTP lane both rely
+        on -- both start via ``ha-mcp-web`` -> ``_setup_logging`` -> this
+        ``addFilter`` call -- so it guards the actual user-visible behaviour, not
+        just the filter in isolation.
+        """
+        import io
+
+        from ha_mcp.__main__ import _setup_logging
+
+        sdk_logger = logging.getLogger("mcp.server.streamable_http")
+        root = logging.getLogger()
+        saved_filters = sdk_logger.filters[:]
+        saved_propagate = sdk_logger.propagate
+        saved_root_handlers = root.handlers[:]
+        saved_root_level = root.level
+        try:
+            _setup_logging("INFO", force=True)
+            assert any(
+                isinstance(f, StatelessSessionLogFilter) for f in sdk_logger.filters
+            ), "_setup_logging must attach StatelessSessionLogFilter to the SDK logger"
+
+            buf = io.StringIO()
+            handler = logging.StreamHandler(buf)
+            sdk_logger.addHandler(handler)
+            sdk_logger.propagate = False  # isolate capture to our handler
+            try:
+                # Exactly what mcp/server/streamable_http.py emits per request:
+                sdk_logger.info("Terminating session: None")
+                sdk_logger.info("Terminating session: 7c3f-real-session")
+            finally:
+                sdk_logger.removeHandler(handler)
+
+            out = buf.getvalue()
+            assert "Terminating session: None" not in out  # suppressed
+            assert "7c3f-real-session" in out  # real terminations still logged
+        finally:
+            sdk_logger.filters[:] = saved_filters
+            sdk_logger.propagate = saved_propagate
+            root.handlers[:] = saved_root_handlers
+            root.level = saved_root_level


### PR DESCRIPTION
## What does this PR do?

Two related changes — a log-noise fix, plus hardening of the flaky CI lanes that
fix surfaced while being validated.

### 1. Suppress the routine "Terminating session: None" log

In stateless HTTP mode the MCP SDK logs `Terminating session: None` at **INFO on
every request** — each request gets a throwaway session (id `None`) torn down
immediately (`mcp/server/streamable_http.py`). It's routine but alarming, and
has repeatedly confused users into thinking their connection is broken.

`StatelessSessionLogFilter` was meant to tame this, but it only **downgraded**
the record to DEBUG and still returned `True`, so the line was still emitted
(just relabelled) and printed anyway. It now **drops** the record outright.
Scope is narrow two independent ways: it's attached to **only** the
`mcp.server.streamable_http` logger, and it drops **only** records containing
`Terminating session: None` — real session terminations (with an id) and every
other message are kept. `record.getMessage()` is guarded so the filter can never
raise out of `Logger.handle()`. This applies to both HTTP lanes (the HAOS add-on
and the Docker `ha-mcp-web` image, both via `_setup_logging`); stdio never emits
it.

### 2. Harden flaky HAOS-inaddon CI lanes

Validating (1) on the `inaddon` e2e tier surfaced three pre-existing transient
infra flakes (the change under test passed every run); fixed in-place:

- **`haos_runtime.py`** — the per-commit dev-addon `/update` + `/start` race a
  still-settling Supervisor job for the addon's job-group (`Another job is
  running for job group …`). Retry within a bounded ~60s window.
- **`test_supervisor_inaddon.py`** — the `/api/settings/restart` of the SSH
  add-on can transiently 502 through Ingress while it bounces. Retry on 5xx.
- **`test_hacs.py`** — `TestMcpToolsInstallation` hard-failed on a flaky GitHub
  repository download; route the install path through a new
  `is_transient_hacs_install_error()` so it skips (not fails) **only** on the
  transient download / rate-limit shape, leaving genuine install bugs loud.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent <!-- N/A: log-filter + CI-harness change -->
- [x] All automated tests pass (`uv run pytest`) <!-- full CI green, incl. Unit Tests + HAOS-inaddon e2e -->
- [x] Code follows style guidelines (`uv run ruff check`)

- `tests/src/unit/test_stateless_session_log_filter.py`: the stateless `None`
  teardown (plain + printf `%s` forms) is dropped; real-id terminations, other
  loggers, unrelated messages, and unrenderable-`%`-format records are kept; plus
  a wiring test that `_setup_logging` actually suppresses the SDK's exact INFO
  call from output.
- `tests/src/e2e/workflows/system/test_supervisor_inaddon.py`
  (`TestGetLogsSupervisorReal`): the inaddon tier is the only e2e lane where
  ha-mcp serves stateless HTTP — after exercising the transport, the dev add-on's
  own Supervisor log contains no `Terminating session` line (with a positive
  control so the absence can't pass vacuously).
- `tests/src/e2e/workflows/hacs/test_hacs.py`: unit tests for
  `is_transient_hacs_install_error()` — transient download/401/rate-limit shapes
  skip; genuine errors (incl. ones merely containing "command failed") still fail.

## Checklist
- [x] I have updated documentation if needed <!-- filter + helper docstrings; no user-facing docs affected -->
