### PR TITLE
feat: default ha_get_logs to newest-first with an order toggle

### DIFF
--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -122,8 +122,14 @@ class UtilityTools:
         entity_id: str | None,
         end_time: str | None,
         slug: str | None,
+        order: str,
     ) -> list[str]:
         warnings: list[str] = []
+        if source == "logger" and order != "newest":
+            warnings.append(
+                "Parameter 'order' does not apply to source='logger' "
+                "(entries are sorted by integration name); ignored"
+            )
         if source != "logbook" and any(p is not None for p in [entity_id, end_time]):
             ignored = [
                 p
@@ -200,6 +206,7 @@ class UtilityTools:
         compact: bool,
         level: str | None,
         slug: str | None,
+        order: str,
     ) -> dict[str, Any]:
         if source == "logbook":
             return await self._get_logbook(
@@ -210,20 +217,29 @@ class UtilityTools:
                 offset=offset,
                 search=search,
                 compact=compact,
+                order=order,
             )
         if source == "system":
-            return await self._get_system_log(limit=limit, search=search, level=level)
+            return await self._get_system_log(
+                limit=limit, search=search, level=level, order=order
+            )
         if source == "error_log":
-            return await self._get_error_log(limit=limit, search=search, level=level)
+            return await self._get_error_log(
+                limit=limit, search=search, level=level, order=order
+            )
         if source == "logger":
+            # logger reports per-integration levels, not time-ordered events;
+            # 'order' does not apply (a warning is emitted upstream).
             return await self._get_logger_info(limit=limit, search=search)
         if source == "system_service":
             assert slug is not None  # guaranteed by _validate_log_slug
             return await self._get_system_service_log(
-                service=slug, limit=limit, search=search
+                service=slug, limit=limit, search=search, order=order
             )
         assert slug is not None  # guaranteed by _validate_log_slug
-        return await self._get_supervisor_log(slug=slug, limit=limit, search=search)
+        return await self._get_supervisor_log(
+            slug=slug, limit=limit, search=search, order=order
+        )
 
     async def get_logs(
         self,
@@ -237,9 +253,12 @@ class UtilityTools:
         compact: bool,
         level: str | None,
         slug: str | None,
+        order: str = "newest",
     ) -> dict[str, Any]:
         level = self._validate_log_level(level)
-        warnings = self._collect_log_warnings(source, level, entity_id, end_time, slug)
+        warnings = self._collect_log_warnings(
+            source, level, entity_id, end_time, slug, order
+        )
         self._validate_log_slug(source, slug)
         result = await self._fetch_log_source(
             source,
@@ -252,6 +271,7 @@ class UtilityTools:
             compact,
             level,
             slug,
+            order,
         )
         if warnings:
             result["warnings"] = warnings
@@ -277,6 +297,7 @@ class UtilityTools:
         entity_id: str | None,
         search: str | None,
         compact_bool: bool,
+        order: str = "newest",
     ) -> str:
         """Build reproducible pagination hint string for logbook results."""
         next_offset = offset_int + effective_limit
@@ -293,6 +314,8 @@ class UtilityTools:
             param_parts.append(f"search={search}")
         if not compact_bool:
             param_parts.append("compact=False")
+        if order != "newest":
+            param_parts.append(f"order={order}")
         param_str = ", ".join(param_parts)
         return (
             f"Showing entries {offset_int + 1}-{offset_int + len(paginated_entries)} of {total_entries}. "
@@ -308,6 +331,7 @@ class UtilityTools:
         offset: int = 0,
         search: str | None = None,
         compact: bool = True,
+        order: str = "newest",
     ) -> dict[str, Any]:
         """Fetch logbook entries with search and pagination."""
         hours_back_int, effective_limit, offset_int = self._coerce_logbook_params(
@@ -342,8 +366,20 @@ class UtilityTools:
             total_entries = len(response) if isinstance(response, list) else 1
 
             if isinstance(response, list):
-                paginated_entries = response[offset_int : offset_int + effective_limit]
-                has_more = (offset_int + effective_limit) < total_entries
+                # HA's /logbook returns entries oldest-first. Take a window from
+                # the end for newest-first (default), or from the start for
+                # oldest-first, with offset paging deeper in the chosen order.
+                if order == "newest":
+                    end = total_entries - offset_int
+                    start = max(end - effective_limit, 0)
+                    paginated_entries = (
+                        list(reversed(response[start:end])) if end > 0 else []
+                    )
+                else:
+                    paginated_entries = response[
+                        offset_int : offset_int + effective_limit
+                    ]
+                has_more = offset_int + len(paginated_entries) < total_entries
             else:
                 paginated_entries = response
                 has_more = False
@@ -368,6 +404,7 @@ class UtilityTools:
                 else 1,
                 "limit": effective_limit,
                 "offset": offset_int,
+                "order": order,
                 "has_more": has_more,
             }
             if filters_applied:
@@ -383,6 +420,7 @@ class UtilityTools:
                     entity_id,
                     search,
                     compact,
+                    order,
                 )
 
             return await add_timezone_metadata(self._client, logbook_data)
@@ -421,6 +459,7 @@ class UtilityTools:
         limit: int | None = None,
         search: str | None = None,
         level: str | None = None,
+        order: str = "newest",
     ) -> dict[str, Any]:
         """Fetch structured system log entries via system_log/list."""
         effective_limit = self._coerce_limit(limit)
@@ -461,6 +500,14 @@ class UtilityTools:
                 ]
                 filters_applied["search"] = search
 
+            # system_log/list entries carry a 'timestamp' (epoch float, last
+            # occurrence). Sort explicitly so 'order' is deterministic regardless
+            # of HA's native ordering: newest-first by default.
+            entries.sort(
+                key=lambda e: e.get("timestamp") or 0,
+                reverse=(order == "newest"),
+            )
+
             total_entries = len(entries)
             entries = entries[:effective_limit]
 
@@ -471,6 +518,7 @@ class UtilityTools:
                 "total_entries": total_entries,
                 "returned_entries": len(entries),
                 "limit": effective_limit,
+                "order": order,
             }
             if filters_applied:
                 data["filters_applied"] = filters_applied
@@ -500,6 +548,7 @@ class UtilityTools:
         limit: int | None = None,
         search: str | None = None,
         level: str | None = None,
+        order: str = "newest",
     ) -> dict[str, Any]:
         """Fetch raw error log text from home-assistant.log."""
         effective_limit = self._coerce_limit(
@@ -527,8 +576,11 @@ class UtilityTools:
                 filters_applied["search"] = search
 
             total_lines = len(lines)
-            # Return the LAST N lines (most recent)
+            # Always take the most-recent window (the tail of the chronological
+            # file); 'order' controls only the display direction of that window.
             lines = lines[-effective_limit:]
+            if order == "newest":
+                lines = list(reversed(lines))
 
             data: dict[str, Any] = {
                 "success": True,
@@ -537,6 +589,7 @@ class UtilityTools:
                 "total_lines": total_lines,
                 "returned_lines": len(lines),
                 "limit": effective_limit,
+                "order": order,
                 "note": "Returned the most recent log lines matching filters",
             }
             if filters_applied:
@@ -665,6 +718,7 @@ class UtilityTools:
         slug: str,
         limit: int | None = None,
         search: str | None = None,
+        order: str = "newest",
     ) -> dict[str, Any]:
         """Fetch add-on container logs.
 
@@ -692,8 +746,11 @@ class UtilityTools:
                 filters_applied["search"] = search
 
             total_lines = len(lines)
-            # Return the LAST N lines (most recent)
+            # Always take the most-recent window (the tail); 'order' controls
+            # only the display direction of that window.
             lines = lines[-effective_limit:]
+            if order == "newest":
+                lines = list(reversed(lines))
 
             data: dict[str, Any] = {
                 "success": True,
@@ -703,6 +760,7 @@ class UtilityTools:
                 "total_lines": total_lines,
                 "returned_lines": len(lines),
                 "limit": effective_limit,
+                "order": order,
             }
             if filters_applied:
                 data["filters_applied"] = filters_applied
@@ -797,6 +855,7 @@ class UtilityTools:
         service: str,
         limit: int | None = None,
         search: str | None = None,
+        order: str = "newest",
     ) -> dict[str, Any]:
         """Fetch HA system-service logs from Supervisor's per-service endpoint.
 
@@ -826,8 +885,11 @@ class UtilityTools:
                 filters_applied["search"] = search
 
             total_lines = len(lines)
-            # Return the LAST N lines (most recent)
+            # Always take the most-recent window (the tail); 'order' controls
+            # only the display direction of that window.
             lines = lines[-effective_limit:]
+            if order == "newest":
+                lines = list(reversed(lines))
 
             data: dict[str, Any] = {
                 "success": True,
@@ -837,6 +899,7 @@ class UtilityTools:
                 "total_lines": total_lines,
                 "returned_lines": len(lines),
                 "limit": effective_limit,
+                "order": order,
             }
             if filters_applied:
                 data["filters_applied"] = filters_applied
@@ -1035,6 +1098,17 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         # Shared parameters
         limit: int | None = None,
         search: str | None = None,
+        order: Annotated[
+            Literal["newest", "oldest"],
+            Field(
+                description=(
+                    "Sort order for time-ordered sources (logbook, system, "
+                    "error_log, supervisor, system_service): 'newest' (default) "
+                    "returns most-recent first; 'oldest' returns chronological-"
+                    "first. Ignored for source='logger'."
+                )
+            ),
+        ] = "newest",
         # Logbook-specific (ignored for other sources)
         hours_back: Annotated[int, Field(ge=1)] = 1,
         entity_id: str | None = None,
@@ -1059,6 +1133,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - "logger": Effective log level per integration via logger/log_info (confirms logger.set_level changes took effect)
 
         **Shared params:** limit, search (keyword filter on entries/lines; matches integration domain for source='logger')
+        **Order:** order='newest' (default) returns most-recent first; order='oldest' returns chronological-first. Applies to all time-ordered sources (logbook, system, error_log, supervisor, system_service); ignored for source='logger'. For raw-text sources (error_log, supervisor, system_service) it sets the read direction of the most-recent window.
         **Logbook params:** hours_back, entity_id, end_time, offset, compact (default True — strips attribute dicts to save context)
         **System/error_log params:** level (ERROR, WARNING, INFO, DEBUG)
         **Supervisor params:** slug = add-on slug, e.g. "core_mosquitto" (use
@@ -1078,6 +1153,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             compact=compact,
             level=level,
             slug=slug,
+            order=order,
         )
 
     @mcp.tool(

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -122,7 +122,7 @@ class UtilityTools:
         entity_id: str | None,
         end_time: str | None,
         slug: str | None,
-        order: str,
+        order: Literal["newest", "oldest"],
     ) -> list[str]:
         warnings: list[str] = []
         if source == "logger" and order != "newest":
@@ -206,7 +206,7 @@ class UtilityTools:
         compact: bool,
         level: str | None,
         slug: str | None,
-        order: str,
+        order: Literal["newest", "oldest"],
     ) -> dict[str, Any]:
         if source == "logbook":
             return await self._get_logbook(
@@ -253,7 +253,7 @@ class UtilityTools:
         compact: bool,
         level: str | None,
         slug: str | None,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         level = self._validate_log_level(level)
         warnings = self._collect_log_warnings(
@@ -297,7 +297,7 @@ class UtilityTools:
         entity_id: str | None,
         search: str | None,
         compact_bool: bool,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> str:
         """Build reproducible pagination hint string for logbook results."""
         next_offset = offset_int + effective_limit
@@ -331,7 +331,7 @@ class UtilityTools:
         offset: int = 0,
         search: str | None = None,
         compact: bool = True,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         """Fetch logbook entries with search and pagination."""
         hours_back_int, effective_limit, offset_int = self._coerce_logbook_params(
@@ -454,12 +454,28 @@ class UtilityTools:
             )
             raise  # unreachable: exception_to_structured_error always raises
 
+    @staticmethod
+    def _system_log_sort_key(entry: Any) -> float:
+        """Total-order-safe sort key for system_log entries.
+
+        ``system_log/list`` does not guarantee a numeric ``timestamp`` on every
+        record. Coerce a missing / non-numeric / non-dict entry to ``0.0`` so
+        sorting never raises a cross-type ``TypeError`` (bools are excluded so
+        a stray ``True`` doesn't read as ``1.0``).
+        """
+        if not isinstance(entry, dict):
+            return 0.0
+        ts = entry.get("timestamp")
+        if isinstance(ts, bool) or not isinstance(ts, (int, float)):
+            return 0.0
+        return float(ts)
+
     async def _get_system_log(
         self,
         limit: int | None = None,
         search: str | None = None,
         level: str | None = None,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         """Fetch structured system log entries via system_log/list."""
         effective_limit = self._coerce_limit(limit)
@@ -501,10 +517,13 @@ class UtilityTools:
                 filters_applied["search"] = search
 
             # system_log/list entries carry a 'timestamp' (epoch float, last
-            # occurrence). Sort explicitly so 'order' is deterministic regardless
-            # of HA's native ordering: newest-first by default.
+            # occurrence), but HA does not guarantee it on every record. Sort
+            # with a total-order-safe key so 'order' is deterministic regardless
+            # of HA's native ordering (newest-first by default) and a missing /
+            # non-numeric / non-dict entry can never raise a cross-type
+            # TypeError out of this method's narrow except clause.
             entries.sort(
-                key=lambda e: e.get("timestamp") or 0,
+                key=self._system_log_sort_key,
                 reverse=(order == "newest"),
             )
 
@@ -548,7 +567,7 @@ class UtilityTools:
         limit: int | None = None,
         search: str | None = None,
         level: str | None = None,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         """Fetch raw error log text from home-assistant.log."""
         effective_limit = self._coerce_limit(
@@ -718,7 +737,7 @@ class UtilityTools:
         slug: str,
         limit: int | None = None,
         search: str | None = None,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         """Fetch add-on container logs.
 
@@ -855,7 +874,7 @@ class UtilityTools:
         service: str,
         limit: int | None = None,
         search: str | None = None,
-        order: str = "newest",
+        order: Literal["newest", "oldest"] = "newest",
     ) -> dict[str, Any]:
         """Fetch HA system-service logs from Supervisor's per-service endpoint.
 

--- a/tests/src/unit/test_tools_utility_log_order.py
+++ b/tests/src/unit/test_tools_utility_log_order.py
@@ -100,6 +100,58 @@ class TestLogbookOrder:
         result = await tools.get_logs(**_call_kwargs(source="logbook", limit=2))
         assert "order=" not in result["data"]["pagination_hint"]
 
+    @pytest.mark.asyncio
+    async def test_newest_offset_beyond_total_returns_empty(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=2, offset=10)
+        )
+        data = result["data"]
+        # end = 5 - 10 < 0 -> guarded to []; no negative-index slice.
+        assert data["entries"] == []
+        assert data["has_more"] is False
+        assert data["offset"] == 10
+
+    @pytest.mark.asyncio
+    async def test_newest_limit_exceeds_total_returns_all_reversed(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(**_call_kwargs(source="logbook", limit=100))
+        data = result["data"]
+        # start clamped to 0 via max(end - limit, 0).
+        assert [e["state"] for e in data["entries"]] == ["s4", "s3", "s2", "s1", "s0"]
+        assert data["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_newest_last_page_sets_has_more_false(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=2, offset=4)
+        )
+        data = result["data"]
+        # total=5, offset=4 -> end=1, start=0, response[0:1]=[s0] reversed.
+        assert [e["state"] for e in data["entries"]] == ["s0"]
+        assert data["has_more"] is False
+
+    @pytest.mark.asyncio
+    async def test_newest_filters_by_search_then_orders(self):
+        entries = [
+            {
+                "when": f"2026-06-16T00:0{i}:00+00:00",
+                "entity_id": "light.match" if i % 2 == 0 else "light.other",
+                "state": f"s{i}",
+            }
+            for i in range(5)
+        ]
+        tools = UtilityTools(self._client(entries))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=10, search="match")
+        )
+        data = result["data"]
+        # s0,s2,s4 match (oldest-first); newest order reverses to s4,s2,s0.
+        assert [e["state"] for e in data["entries"]] == ["s4", "s2", "s0"]
+        assert data["total_entries"] == 3
+        assert data["filters_applied"]["search"] == "match"
+
 
 class TestSystemOrder:
     """source='system' — sorted deterministically by entry timestamp."""
@@ -147,6 +199,30 @@ class TestSystemOrder:
         result = await tools.get_logs(**_call_kwargs(source="system", order="oldest"))
         assert result["order"] == "oldest"
         assert [e["timestamp"] for e in result["entries"]] == [100.0, 200.0, 300.0]
+
+    @pytest.mark.asyncio
+    async def test_tolerates_missing_none_and_non_dict_entries(self):
+        # system_log/list does not guarantee a numeric timestamp on every
+        # record; the sort key must not raise a cross-type TypeError.
+        client = AsyncMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {"name": "has_ts", "level": "ERROR", "timestamp": 100.0},
+                    {"name": "no_ts", "level": "ERROR"},
+                    {"name": "none_ts", "level": "ERROR", "timestamp": None},
+                    "not-a-dict",
+                ],
+            }
+        )
+        tools = UtilityTools(client)
+        result = await tools.get_logs(**_call_kwargs(source="system"))
+        assert result["order"] == "newest"
+        assert result["returned_entries"] == 4
+        # The only timestamped entry sorts newest-first; keyless/non-dict
+        # entries collapse to 0.0 and trail it.
+        assert result["entries"][0]["timestamp"] == 100.0
 
 
 class TestRawTextOrder:

--- a/tests/src/unit/test_tools_utility_log_order.py
+++ b/tests/src/unit/test_tools_utility_log_order.py
@@ -152,6 +152,20 @@ class TestLogbookOrder:
         assert data["total_entries"] == 3
         assert data["filters_applied"]["search"] == "match"
 
+    @pytest.mark.asyncio
+    async def test_non_list_response_still_echoes_order(self):
+        # If HA returns a non-list shape, the windowing is skipped but the
+        # response must still echo `order` and not page.
+        client = AsyncMock()
+        client.get_logbook = AsyncMock(return_value={"unexpected": "shape"})
+        client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        tools = UtilityTools(client)
+        result = await tools.get_logs(**_call_kwargs(source="logbook", limit=2))
+        data = result["data"]
+        assert data["order"] == "newest"
+        assert data["has_more"] is False
+        assert data["total_entries"] == 1
+
 
 class TestSystemOrder:
     """source='system' — sorted deterministically by entry timestamp."""

--- a/tests/src/unit/test_tools_utility_log_order.py
+++ b/tests/src/unit/test_tools_utility_log_order.py
@@ -1,0 +1,228 @@
+"""Unit tests for the ``order`` parameter of ``ha_get_logs`` across sources.
+
+Covers newest-first (default) vs oldest-first ordering for every time-ordered
+source, plus the warning emitted when ``order`` is supplied to the non
+time-ordered ``logger`` source. The logbook windowing mirrors the traces
+newest-first fix (#1178).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.tools.tools_utility import UtilityTools
+
+
+def _call_kwargs(**overrides):
+    """Full keyword set for ``UtilityTools.get_logs`` with sensible defaults."""
+    base = {
+        "source": "logbook",
+        "limit": None,
+        "search": None,
+        "hours_back": 1,
+        "entity_id": None,
+        "end_time": None,
+        "offset": 0,
+        "compact": True,
+        "level": None,
+        "slug": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestLogbookOrder:
+    """source='logbook' — offset pagination over a reversible window."""
+
+    @staticmethod
+    def _client(entries):
+        client = AsyncMock()
+        client.get_logbook = AsyncMock(return_value=entries)
+        client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        return client
+
+    @staticmethod
+    def _entries():
+        # Oldest-first, exactly as HA's /logbook REST endpoint returns them.
+        return [
+            {
+                "when": f"2026-06-16T00:0{i}:00+00:00",
+                "entity_id": "light.x",
+                "state": f"s{i}",  # s0 oldest ... s4 newest
+            }
+            for i in range(5)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_newest_is_default_and_reverses_window(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(**_call_kwargs(source="logbook", limit=2))
+        data = result["data"]
+        assert data["order"] == "newest"
+        assert [e["state"] for e in data["entries"]] == ["s4", "s3"]
+        assert data["offset"] == 0
+        assert data["total_entries"] == 5
+        assert data["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_oldest_returns_chronological_window(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=2, order="oldest")
+        )
+        data = result["data"]
+        assert data["order"] == "oldest"
+        assert [e["state"] for e in data["entries"]] == ["s0", "s1"]
+        assert data["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_newest_offset_pages_into_older_entries(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=2, offset=2)
+        )
+        data = result["data"]
+        # total=5, offset=2 -> end=3, start=1, response[1:3]=[s1,s2] reversed.
+        assert [e["state"] for e in data["entries"]] == ["s2", "s1"]
+        assert data["has_more"] is True  # offset(2) + len(2) = 4 < 5
+
+    @pytest.mark.asyncio
+    async def test_oldest_pagination_hint_carries_order(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(
+            **_call_kwargs(source="logbook", limit=2, order="oldest")
+        )
+        assert "order=oldest" in result["data"]["pagination_hint"]
+
+    @pytest.mark.asyncio
+    async def test_newest_default_hint_omits_order(self):
+        tools = UtilityTools(self._client(self._entries()))
+        result = await tools.get_logs(**_call_kwargs(source="logbook", limit=2))
+        assert "order=" not in result["data"]["pagination_hint"]
+
+
+class TestSystemOrder:
+    """source='system' — sorted deterministically by entry timestamp."""
+
+    @staticmethod
+    def _client():
+        client = AsyncMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {
+                        "name": "a",
+                        "message": ["m"],
+                        "level": "ERROR",
+                        "timestamp": 100.0,
+                    },
+                    {
+                        "name": "b",
+                        "message": ["m"],
+                        "level": "ERROR",
+                        "timestamp": 300.0,
+                    },
+                    {
+                        "name": "c",
+                        "message": ["m"],
+                        "level": "ERROR",
+                        "timestamp": 200.0,
+                    },
+                ],
+            }
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_newest_sorts_timestamp_descending(self):
+        tools = UtilityTools(self._client())
+        result = await tools.get_logs(**_call_kwargs(source="system"))
+        assert result["order"] == "newest"
+        assert [e["timestamp"] for e in result["entries"]] == [300.0, 200.0, 100.0]
+
+    @pytest.mark.asyncio
+    async def test_oldest_sorts_timestamp_ascending(self):
+        tools = UtilityTools(self._client())
+        result = await tools.get_logs(**_call_kwargs(source="system", order="oldest"))
+        assert result["order"] == "oldest"
+        assert [e["timestamp"] for e in result["entries"]] == [100.0, 200.0, 300.0]
+
+
+class TestRawTextOrder:
+    """error_log / supervisor / system_service — reversible most-recent window."""
+
+    @pytest.mark.asyncio
+    async def test_error_log_newest_reverses_recent_window(self):
+        client = AsyncMock()
+        client.get_error_log = AsyncMock(return_value="l0\nl1\nl2\nl3")
+        tools = UtilityTools(client)
+        result = await tools.get_logs(**_call_kwargs(source="error_log", limit=2))
+        assert result["order"] == "newest"
+        assert result["log"] == "l3\nl2"  # newest line first
+        assert result["returned_lines"] == 2
+        assert result["total_lines"] == 4
+
+    @pytest.mark.asyncio
+    async def test_error_log_oldest_keeps_chronological_window(self):
+        client = AsyncMock()
+        client.get_error_log = AsyncMock(return_value="l0\nl1\nl2\nl3")
+        tools = UtilityTools(client)
+        result = await tools.get_logs(
+            **_call_kwargs(source="error_log", limit=2, order="oldest")
+        )
+        assert result["order"] == "oldest"
+        assert result["log"] == "l2\nl3"  # recent window, ascending
+
+    @pytest.mark.asyncio
+    async def test_supervisor_newest_reverses(self):
+        client = AsyncMock()
+        client.get_addon_logs = AsyncMock(return_value="a\nb\nc\nd")
+        tools = UtilityTools(client)
+        result = await tools.get_logs(
+            **_call_kwargs(source="supervisor", slug="core_x", limit=2)
+        )
+        assert result["order"] == "newest"
+        assert result["log"] == "d\nc"
+        assert result["slug"] == "core_x"
+
+    @pytest.mark.asyncio
+    async def test_system_service_oldest_keeps_chronological(self):
+        client = AsyncMock()
+        client._get_system_service_logs = AsyncMock(return_value="a\nb\nc\nd")
+        tools = UtilityTools(client)
+        result = await tools.get_logs(
+            **_call_kwargs(
+                source="system_service", slug="supervisor", limit=2, order="oldest"
+            )
+        )
+        assert result["order"] == "oldest"
+        assert result["log"] == "c\nd"
+
+
+class TestLoggerOrderWarning:
+    """source='logger' is not time-ordered: 'order' is ignored, with a warning."""
+
+    @staticmethod
+    def _client():
+        client = AsyncMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [{"domain": "homeassistant", "level": 20}],
+            }
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_non_default_order_warns_and_is_ignored(self):
+        tools = UtilityTools(self._client())
+        result = await tools.get_logs(**_call_kwargs(source="logger", order="oldest"))
+        assert "order" not in result  # logger response has no order field
+        assert any("order" in w for w in result.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_default_order_emits_no_warning(self):
+        tools = UtilityTools(self._client())
+        result = await tools.get_logs(**_call_kwargs(source="logger"))
+        assert "warnings" not in result

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -883,7 +883,7 @@ class TestGetSupervisorLogWrapper:
         assert result["success"] is True
         assert result["source"] == "supervisor"
         assert result["slug"] == "core_mosquitto"
-        assert result["log"] == "line 1\nline 2\nline 3"
+        assert result["log"] == "line 3\nline 2\nline 1"  # newest-first default
         assert result["total_lines"] == 3
         assert result["returned_lines"] == 3
         assert "limit" in result
@@ -904,7 +904,8 @@ class TestGetSupervisorLogWrapper:
         )
 
         returned = result["log"].splitlines()
-        assert returned == ["line 16", "line 17", "line 18", "line 19", "line 20"]
+        # Still the last 5 lines (recent window), now newest-first by default.
+        assert returned == ["line 20", "line 19", "line 18", "line 17", "line 16"]
         assert result["total_lines"] == 20
         assert result["returned_lines"] == 5
         assert result["limit"] == 5


### PR DESCRIPTION
## What does this PR do?

`ha_get_logs` returned its time-ordered sources oldest-first. That mismatches
the Home Assistant Logbook UI (which shows most-recent first) and forces an
agent to page to the end of the window to see recent activity.

This adds an `order` parameter — `"newest"` (new default) or `"oldest"` —
applied across every time-ordered source:

- **logbook**: the window is taken from the newest end by default; `offset`
  pages into older entries. `order="oldest"` restores the prior chronological
  paging. Mirrors the traces newest-first fix (#1178).
- **system**: sorted deterministically by entry `timestamp` (newest-first default).
- **error_log / supervisor / system_service**: still returns the most-recent
  window; `order` sets only its read direction (newest line first by default).

`logger` is not time-ordered (sorted by integration name) — a non-default
`order` there is ignored with a warning. Every response echoes the applied
`order`, and the logbook pagination hint carries it when non-default.

The default-order change is recoverable via `order="oldest"`.

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Added `tests/src/unit/test_tools_utility_log_order.py` (13 tests) covering
newest/oldest for every source, offset paging, the pagination hint, and the
logger warning.

## Checklist
- [x] I have updated documentation if needed

