### PR TITLE
fix: auto-backup silently skipped capture on several write paths

### DIFF
--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -735,19 +735,46 @@ async def _fetch_dashboard(client: Any, entity_id: str) -> Any:
     """
     from fastmcp.exceptions import ToolError
 
-    from .tools.tools_config_dashboards import _get_dashboard_config_internal
+    from .tools.tools_config_dashboards import (
+        _get_dashboard_config_internal,
+        _resolve_dashboard,
+    )
+
+    # The set/delete tools accept BOTH the canonical hyphenated url_path
+    # AND HA's internal (underscored) dashboard id, eagerly resolving the
+    # latter before writing. ``_get_dashboard_config_internal`` does NOT
+    # lazy-resolve, so an internal-id identifier 404s with "Unknown config
+    # specified" and the pre-write snapshot is silently skipped. Pre-resolve
+    # to the canonical url_path so capture works for whichever form the
+    # caller passed (matching the form the write tool ultimately targets).
+    fetch_path = entity_id
+    try:
+        match, _ = await _resolve_dashboard(client, entity_id)
+        if match and match.get("url_path"):
+            fetch_path = match["url_path"]
+    except (HomeAssistantError, ToolError) as err:
+        # Resolver failure (transport/shape) — fall through with the
+        # original identifier; the canonical form is often already correct.
+        logger.debug(
+            "Auto-backup: dashboard resolve failed for %r: %s — using as-is",
+            entity_id,
+            err,
+        )
 
     try:
-        config, _config_hash = await _get_dashboard_config_internal(client, entity_id)
+        config, _config_hash = await _get_dashboard_config_internal(client, fetch_path)
     except ToolError as err:
-        # ToolError carries the structured failure payload; treat
-        # missing-dashboard responses as "entity doesn't exist yet".
+        # ToolError carries the structured failure payload; treat a
+        # missing/unknown dashboard as "nothing to back up" (also covers a
+        # brand-new dashboard on the create path). "Unknown config
+        # specified" is HA's message for an unresolved url_path.
         msg = str(err).lower()
-        if "not_found" in msg or "config_not_found" in msg:
+        if "not_found" in msg or "config_not_found" in msg or "unknown config" in msg:
             return None
         raise
     except HomeAssistantError as err:
-        if "not_found" in str(err).lower() or "config_not_found" in str(err).lower():
+        msg = str(err).lower()
+        if "not_found" in msg or "config_not_found" in msg or "unknown config" in msg:
             return None
         raise
     return config
@@ -1009,8 +1036,11 @@ async def _restore_area_or_floor(client: Any, entity_id: str, config: Any) -> An
 
 
 async def _fetch_todo_item(client: Any, entity_id: str) -> Any:
-    cal, _, uid = entity_id.partition("::")
-    if not cal or not uid:
+    # The second segment is whatever the tool's ``item`` param carried.
+    # ha_set_todo_item / ha_remove_todo_item accept EITHER the item uid OR
+    # its exact summary/name, so this can be either form.
+    cal, _, item_ref = entity_id.partition("::")
+    if not cal or not item_ref:
         return None
     payload = {
         "type": "execute_script",
@@ -1037,7 +1067,11 @@ async def _fetch_todo_item(client: Any, entity_id: str) -> Any:
         return None
     items = result.get("response", {}).get("items", {}).get(cal, {}).get("items", [])
     for item in items:
-        if item.get("uid") == uid:
+        # Match either form. Matching only on uid silently skipped the
+        # snapshot whenever the caller passed the human-readable summary
+        # (the documented/common case, e.g. ha_remove_todo_item(list, "Buy
+        # milk")) — uid != summary, so the loop found nothing -> None.
+        if item.get("uid") == item_ref or item.get("summary") == item_ref:
             return {"todo_entity_id": cal, **item}
     return None
 
@@ -1069,6 +1103,42 @@ async def _restore_entity_state(client: Any, entity_id: str, config: Any) -> Any
     else:
         payload = {"state": str(config)}
     return await _rest_post(client, f"states/{entity_id}", payload)
+
+
+# Devices — config/device_registry/{list,update}. ``ha_set_device`` mutates
+# the user-editable registry fields (name_by_user / area_id / disabled_by /
+# labels); restore re-applies exactly those. A device deleted by
+# ``ha_remove_device`` cannot be recreated through the registry, so for that
+# path the snapshot is an informational pre-delete record and restore is
+# best-effort.
+
+
+async def _fetch_device(client: Any, entity_id: str) -> Any:
+    items = await _ws_send(client, {"type": "config/device_registry/list"})
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if item.get("id") == entity_id:
+            return item
+    return None
+
+
+async def _restore_device(client: Any, entity_id: str, config: Any) -> Any:
+    # Re-apply the captured registry state. Uses the same field NAMES as
+    # ``_update_device_internal`` but, unlike that partial-update path, always
+    # sends all four — restore reverts the device to the snapshot, so a
+    # captured ``None`` area/name is intentionally re-applied (cleared).
+    return await _ws_send(
+        client,
+        {
+            "type": "config/device_registry/update",
+            "device_id": entity_id,
+            "name_by_user": config.get("name_by_user"),
+            "area_id": config.get("area_id"),
+            "disabled_by": config.get("disabled_by"),
+            "labels": config.get("labels", []),
+        },
+    )
 
 
 # Integration enable/disable — restore re-applies the disabled flag.
@@ -1140,6 +1210,34 @@ async def _fetch_helper(client: Any, entity_id: str, helper_type: str) -> Any:
     for item in items:
         if item.get("id") == object_id or item.get("id") == entity_id:
             return item
+    # Fallback for renamed helpers: after an entity_id rename the object_id
+    # no longer equals the storage collection id (which stays the original
+    # create-time id == the registry unique_id), so the direct match above
+    # misses and the snapshot was silently skipped. Resolve the unique_id
+    # via the entity registry and match on that — the same key the helper
+    # update tool itself resolves to.
+    eid = entity_id if "." in entity_id else f"{helper_type}.{entity_id}"
+    try:
+        entry = await _ws_send(
+            client, {"type": "config/entity_registry/get", "entity_id": eid}
+        )
+    except HomeAssistantError as err:
+        # Only a genuine "entity not found" means there's nothing to back up;
+        # transport/auth/5xx errors must propagate so maybe_snapshot logs a
+        # WARNING rather than silently skipping. Same POLICY as _fetch_automation,
+        # but matched on the message substring because config/entity_registry/get
+        # failures arrive as a WS command error with no status_code to switch on.
+        # Best-effort: if HA's not-found wording ever changes, a real miss
+        # degrades to a WARNING + skip (never a swallowed fatal error).
+        msg = str(err).lower()
+        if "not_found" in msg or "not found" in msg:
+            return None
+        raise
+    unique_id = entry.get("unique_id") if isinstance(entry, dict) else None
+    if unique_id:
+        for item in items:
+            if str(item.get("id")) == str(unique_id):
+                return item
     return None
 
 
@@ -1210,6 +1308,7 @@ def register_default_handlers(mgr: BackupManager, _client: Any) -> None:
     )
     mgr.register(DomainHandler("todo_item", _fetch_todo_item, _restore_todo_item))
     mgr.register(DomainHandler("entity", _fetch_entity_state, _restore_entity_state))
+    mgr.register(DomainHandler("device", _fetch_device, _restore_device))
     mgr.register(DomainHandler("integration", _fetch_integration, _restore_integration))
     for helper_type in _KNOWN_HELPER_TYPES:
         mgr.register(_make_helper_handler(helper_type))

--- a/src/ha_mcp/tools/auto_backup.py
+++ b/src/ha_mcp/tools/auto_backup.py
@@ -75,17 +75,20 @@ def automation_backup_target(kw: dict[str, Any]) -> str:
         config_id = config.get("id")
         if config_id:
             return str(config_id)
-    identifier = _resolve_str(kw.get("identifier"))
-    # Strip the leading ``automation.`` prefix when the caller passed an
-    # entity_id form (typical for ``python_transform`` calls that don't
-    # carry a config body). Without this, snapshot files duplicate the
-    # domain segment as ``automation.automation.<slug>.<ts>.yaml`` — the
-    # body's entity_id keeps the prefix, only the filename / list key
-    # tighten up. HA's automation upsert accepts either form for the
-    # ``identifier`` param, so restore is unaffected.
-    if identifier.startswith("automation."):
-        identifier = identifier[len("automation.") :]
-    return identifier
+    # Return the identifier UNCHANGED — do NOT strip the ``automation.``
+    # prefix. Capture and restore resolve the target through
+    # ``client.get_automation_config`` -> ``_resolve_automation_id``, which
+    # converts an entity_id ("automation.<slug>") to the real numeric
+    # ``unique_id`` via a state lookup ONLY when the prefix is present;
+    # otherwise it assumes the string already IS a unique_id. Stripping the
+    # prefix produced a bare object_id slug that the resolver mis-treats as
+    # a unique_id -> GET /config/automation/config/<slug> 404s -> the
+    # pre-write snapshot is silently skipped (and, had it resolved, restore
+    # would POST to the wrong key and create a stray automation). The
+    # doubled domain segment in the snapshot filename
+    # ("automation.automation.<slug>.<ts>.yaml") is purely cosmetic and is
+    # exactly what the remove path (id_param="identifier") already produces.
+    return _resolve_str(kw.get("identifier"))
 
 
 def with_auto_backup(

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1316,6 +1316,7 @@ def register_entity_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             "title": "Remove Entity",
         },
     )
+    @with_auto_backup(domain="entity", id_param="entity_id", client=client)
     @log_tool_usage
     async def ha_remove_entity(
         entity_id: Annotated[

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -14,6 +14,7 @@ from pydantic import Field
 
 from ..client.rest_client import HomeAssistantAPIError, HomeAssistantConnectionError
 from ..errors import ErrorCode, create_error_response
+from .auto_backup import with_auto_backup
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -599,6 +600,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         tags={"Device Registry"},
         annotations={"destructiveHint": True, "title": "Set Device"},
     )
+    @with_auto_backup(domain="device", id_param="device_id", client=client)
     @log_tool_usage
     async def ha_set_device(
         device_id: Annotated[
@@ -700,6 +702,7 @@ def register_registry_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
             "title": "Remove Device",
         },
     )
+    @with_auto_backup(domain="device", id_param="device_id", client=client)
     @log_tool_usage
     async def ha_remove_device(
         device_id: Annotated[

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -1349,44 +1349,244 @@ class TestDashboardResourceCaptureRestore:
         )
 
 
-# ---------------------------------------------------------------- calendar/todo/integration
+# ---------------------------------------------------------------- calendar/todo lanes
+#
+# calendar_event and todo_item have no entity in the base image, so these
+# create their own backing entity via the integration config flow
+# (local_calendar / local_todo both ship with HA Core) — neither is a
+# ``helper_type``, so we drive the flow through ``ha_client`` like
+# test_integration_setup.py does. Capture fires on DELETE for calendar
+# (the set tool is create-only) and on EDIT for todo. Each test tears its
+# config entry down in a finally block.
 
 
+@pytest.mark.haos_only
 @pytest.mark.calendar
 @pytest.mark.external_only
-class TestCalendarTodoIntegrationCaptureOnly:
-    """Three domains whose restore semantics aren't a true round-trip
-    and aren't safely testable end-to-end on a clean testcontainer:
+@pytest.mark.cleanup
+class TestCalendarCaptureRestore:
+    """Auto-backup for calendar events. ``ha_config_set_calendar_event``
+    only CREATES, so the pre-write snapshot fires on
+    ``ha_config_remove_calendar_event`` (pre-delete capture). Restore
+    re-creates the event from the snapshot."""
 
-    - **calendar_event**: ``/api/services/calendar/create_event`` —
-      creates a *new* event rather than overwriting the captured one
-      (uid mismatch by design). Restore "succeeds" by re-creating, not
-      by reverting. The unit tests cover the payload shape.
-    - **todo_item**: ``/api/services/todo/add_item`` — same shape;
-      adds rather than overwrites. Both share Group 3 service-call
-      mechanics which is exercised by the group/entity full-loop
-      tests above.
-    - **integration**: ``config_entries/disable`` — needs a real
-      integration installed that can be safely toggled. Default-image
-      integrations (``frontend``, ``homeassistant``) are unsafe to
-      disable; the demo integration is auto-set-up and not guaranteed
-      present. Unit test in ``test_backup_manager.py`` covers the
-      payload shape.
+    async def test_calendar_capture_on_delete(
+        self, mcp_client, ha_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from datetime import datetime, timedelta
 
-    Documented here so future maintainers reach for the unit tests
-    rather than re-discovering why these three lanes don't have a
-    real-HA full-loop test.
-    """
+        _enable_auto_backup(monkeypatch)
+        unique = uuid.uuid4().hex[:8]
+        cal_name = f"BK Cal {unique}"
+        entity_id = f"calendar.bk_cal_{unique}"
 
-    async def test_documentation_marker(self) -> None:
-        """Skipped anchor so pytest -v lists this class explicitly,
-        making the documented coverage gap visible alongside passes/
-        fails. ``pytest.skip(reason=...)`` is the right surface for
-        "deliberately not tested" — a passing no-op assertion would
-        misleadingly inflate the green-bar count.
-        """
-        pytest.skip(
-            "calendar_event / todo_item / integration have no real-HA "
-            "full-loop e2e — see class docstring for why; payload-shape "
-            "coverage lives in tests/src/unit/test_backup_manager.py"
-        )
+        entry_id: str | None = None
+        try:
+            flow_init = await ha_client.start_config_flow("local_calendar")
+            if not isinstance(flow_init, dict) or flow_init.get("type") != "form":
+                pytest.skip(f"local_calendar config flow unavailable: {flow_init}")
+            flow_done = await ha_client.submit_config_flow_step(
+                flow_init["flow_id"],
+                {"calendar_name": cal_name, "import": "create_empty"},
+            )
+            if flow_done.get("type") != "create_entry":
+                pytest.skip(f"local_calendar entry not created: {flow_done}")
+            entry_id = flow_done["result"]["entry_id"]
+
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_entity",
+                arguments={"entity_id": entity_id},
+                predicate=lambda d: d.get("success") is True,
+                description=f"{entity_id} registers in entity registry",
+                timeout=20,
+            )
+
+            now = datetime.now()
+            start = (now + timedelta(days=1)).replace(
+                hour=10, minute=0, second=0, microsecond=0
+            )
+            end = start + timedelta(hours=1)
+            summary = f"bk-evt-{unique}"
+            created = await safe_call_tool(
+                mcp_client,
+                "ha_config_set_calendar_event",
+                {
+                    "entity_id": entity_id,
+                    "summary": summary,
+                    "start": start.isoformat(),
+                    "end": end.isoformat(),
+                },
+            )
+            if created.get("success") is False:
+                pytest.skip(f"calendar event create unsupported: {created}")
+
+            got = await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_config_get_calendar_events",
+                arguments={
+                    "entity_id": entity_id,
+                    "start": start.isoformat(),
+                    "end": (end + timedelta(hours=1)).isoformat(),
+                },
+                predicate=lambda d: any(
+                    e.get("summary") == summary for e in d.get("events", [])
+                ),
+                description=f"event {summary!r} visible",
+                timeout=45,
+            )
+            uid = next(
+                (
+                    e.get("uid")
+                    for e in got.get("events", [])
+                    if e.get("summary") == summary
+                ),
+                None,
+            )
+            assert uid, f"created event has no uid: {got.get('events')}"
+
+            # Let HA's calendar store settle before the pre-delete fetch
+            # (the decorator runs its own calendar.get_events lookup; a
+            # freshly-written iCal event can lag behind the create response).
+            await asyncio.sleep(_HA_PROPAGATION_SETTLE_SECONDS)
+
+            # Delete the event — pre-delete capture fires (calendar_event).
+            removed = await safe_call_tool(
+                mcp_client,
+                "ha_config_remove_calendar_event",
+                {"entity_id": entity_id, "uid": uid},
+            )
+            assert removed.get("success") is not False, f"remove failed: {removed}"
+
+            try:
+                backup_name = await _wait_for_backup(
+                    mcp_client,
+                    domain="calendar_event",
+                    entity_id=f"{entity_id}::{uid}",
+                    timeout=20,
+                )
+            except TimeoutError:
+                pytest.skip(
+                    "calendar_event snapshot not observed within timeout on "
+                    "this HA rig (calendar capture/indexing timing); the unit "
+                    "test test_backup_manager covers the payload shape"
+                )
+            view = await safe_call_tool(
+                mcp_client,
+                "ha_manage_backup",
+                {"scope": "edits", "action": "view", "backup_name": backup_name},
+            )
+            assert view.get("success") is True
+
+            restore = await safe_call_tool(
+                mcp_client,
+                "ha_manage_backup",
+                {"scope": "edits", "action": "restore", "backup_name": backup_name},
+            )
+            assert restore.get("success") is True
+        finally:
+            if entry_id is not None:
+                await safe_call_tool(
+                    mcp_client,
+                    "ha_remove_helpers_integrations",
+                    {"target": entry_id, "confirm": True},
+                )
+
+
+@pytest.mark.haos_only
+@pytest.mark.external_only
+@pytest.mark.cleanup
+class TestTodoCaptureRestore:
+    """Auto-backup for todo items. The pre-write snapshot fires when an
+    existing item is edited (update by summary) or removed. Regression
+    guard for the fetch matching only on uid — the tool passes the item
+    summary, so capture was silently skipped before the fix."""
+
+    async def test_todo_capture_on_edit(
+        self, mcp_client, ha_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _enable_auto_backup(monkeypatch)
+        unique = uuid.uuid4().hex[:8]
+        list_name = f"BK Todo {unique}"
+        entity_id = f"todo.bk_todo_{unique}"
+
+        entry_id: str | None = None
+        try:
+            flow_init = await ha_client.start_config_flow("local_todo")
+            if not isinstance(flow_init, dict) or flow_init.get("type") != "form":
+                pytest.skip(f"local_todo config flow unavailable: {flow_init}")
+            # local_todo's single field mirrors local_calendar's naming
+            # convention (``<integration>_name``). If the schema differs on
+            # this HA version the flow won't create an entry and we skip.
+            flow_done = await ha_client.submit_config_flow_step(
+                flow_init["flow_id"], {"todo_list_name": list_name}
+            )
+            if flow_done.get("type") != "create_entry":
+                pytest.skip(f"local_todo entry not created: {flow_done}")
+            entry_id = flow_done["result"]["entry_id"]
+
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_entity",
+                arguments={"entity_id": entity_id},
+                predicate=lambda d: d.get("success") is True,
+                description=f"{entity_id} registers in entity registry",
+                timeout=20,
+            )
+
+            summary = f"bk-item-{unique}"
+            added = await safe_call_tool(
+                mcp_client,
+                "ha_set_todo_item",
+                {"entity_id": entity_id, "summary": summary},
+            )
+            if added.get("success") is False:
+                pytest.skip(f"todo add_item unsupported: {added}")
+
+            # Let HA index the new item before the edit fires; the pre-edit
+            # fetch (todo.get_items) may otherwise miss the fresh item and
+            # silently skip the snapshot.
+            await asyncio.sleep(_HA_PROPAGATION_SETTLE_SECONDS)
+
+            # Edit the item BY SUMMARY — the exact form that was silently
+            # skipped before the fetch matched on summary as well as uid.
+            edited = await safe_call_tool(
+                mcp_client,
+                "ha_set_todo_item",
+                {"entity_id": entity_id, "item": summary, "status": "completed"},
+            )
+            assert edited.get("success") is not False, f"todo edit failed: {edited}"
+
+            try:
+                backup_name = await _wait_for_backup(
+                    mcp_client,
+                    domain="todo_item",
+                    entity_id=f"{entity_id}::{summary}",
+                    timeout=20,
+                )
+            except TimeoutError:
+                pytest.skip(
+                    "todo_item snapshot not observed within timeout on this HA "
+                    "rig (capture/indexing timing); the unit test "
+                    "test_fetch_todo_item_matches_by_summary is the hard guard "
+                    "for the summary-match fix"
+                )
+            view = await safe_call_tool(
+                mcp_client,
+                "ha_manage_backup",
+                {"scope": "edits", "action": "view", "backup_name": backup_name},
+            )
+            assert view.get("success") is True
+        finally:
+            if entry_id is not None:
+                await safe_call_tool(
+                    mcp_client,
+                    "ha_remove_helpers_integrations",
+                    {"target": entry_id, "confirm": True},
+                )
+
+
+# ``integration`` (config_entries/disable) still has no full-loop e2e here:
+# it needs a real integration that is safe to disable/re-enable, and the
+# base image's core integrations are unsafe to toggle. Payload-shape
+# coverage lives in tests/src/unit/test_backup_manager.py.

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -98,16 +98,19 @@ class TestAutomationBackupTarget:
         # config.id wins: BBB is the actual storage target HA will overwrite.
         assert target == "BBB"
 
-    def test_falls_back_to_identifier_when_no_config_id(self) -> None:
+    def test_falls_back_to_identifier_entity_id_form_preserved(self) -> None:
         from ha_mcp.tools.auto_backup import automation_backup_target
 
-        # The fallback path strips a leading ``automation.`` so the
-        # snapshot filename doesn't end up with a doubled domain segment
-        # like ``automation.automation.foo.<ts>.yaml``.
+        # Regression (#auto-backup-capture): the fallback path must NOT
+        # strip the ``automation.`` prefix. The capture/restore fetch
+        # resolves the target via _resolve_automation_id, which only does
+        # the entity_id -> numeric unique_id state lookup when the prefix
+        # is present. Stripping it to a bare slug made the resolver treat
+        # the slug as a unique_id -> 404 -> snapshot silently skipped.
         target = automation_backup_target(
             {"identifier": "automation.foo", "config": {"alias": "x"}}
         )
-        assert target == "foo"
+        assert target == "automation.foo"
 
     def test_falls_back_to_identifier_bare_id_unchanged(self) -> None:
         from ha_mcp.tools.auto_backup import automation_backup_target
@@ -134,12 +137,13 @@ class TestAutomationBackupTarget:
     def test_invalid_json_falls_back_to_identifier(self) -> None:
         from ha_mcp.tools.auto_backup import automation_backup_target
 
-        # Falls through to the identifier fallback path, which strips
-        # the leading ``automation.`` prefix.
+        # Falls through to the identifier fallback path, which preserves
+        # the entity_id form (prefix kept so the fetch resolver can map it
+        # to the numeric unique_id).
         target = automation_backup_target(
             {"identifier": "automation.foo", "config": "not-json"}
         )
-        assert target == "foo"
+        assert target == "automation.foo"
 
     def test_no_identifier_no_config_id_returns_empty(self) -> None:
         from ha_mcp.tools.auto_backup import automation_backup_target
@@ -156,6 +160,384 @@ class TestAutomationBackupTarget:
             {"identifier": "automation.foo", "config": {"id": "automation.foo"}}
         )
         assert target == "automation.foo"
+
+
+# ---------------------------------------------------- fetcher id resolution
+#
+# Regression tests for the silent-skip capture bugs: each fetch handler must
+# resolve the id form a realistic caller passes so a pre-write snapshot is
+# actually written (a fetch that returns None makes maybe_snapshot skip
+# silently). These monkeypatch the module-level ``_ws_send`` so no real HA
+# instance is needed.
+
+
+class TestFetcherIdResolution:
+    async def test_fetch_todo_item_matches_by_summary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The decorator passes "<entity_id>::<item>" where <item> is the
+        # human-readable summary (the documented form). Matching only uid
+        # silently skipped the snapshot; the fix matches uid OR summary.
+        async def fake_ws(_client: Any, _msg: dict[str, Any]) -> Any:
+            return {
+                "response": {
+                    "items": {
+                        "todo.shopping": {
+                            "items": [
+                                {
+                                    "uid": "abc-123",
+                                    "summary": "Buy milk",
+                                    "status": "needs_action",
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_todo_item(_StubClient(), "todo.shopping::Buy milk")
+        assert got is not None
+        assert got["uid"] == "abc-123"
+        assert got["todo_entity_id"] == "todo.shopping"
+
+    async def test_fetch_todo_item_still_matches_by_uid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_ws(_client: Any, _msg: dict[str, Any]) -> Any:
+            return {
+                "response": {
+                    "items": {"todo.x": {"items": [{"uid": "u-9", "summary": "Pay"}]}}
+                }
+            }
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_todo_item(_StubClient(), "todo.x::u-9")
+        assert got is not None
+        assert got["uid"] == "u-9"
+
+    async def test_fetch_helper_resolves_renamed_via_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # After an entity_id rename the object_id no longer equals the
+        # collection id; the fix falls back to the registry unique_id.
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            if msg.get("type") == "input_boolean/list":
+                return [{"id": "original_slug", "name": "X"}]
+            if msg.get("type") == "config/entity_registry/get":
+                assert msg.get("entity_id") == "input_boolean.renamed_slug"
+                return {"unique_id": "original_slug"}
+            raise AssertionError(f"unexpected ws message: {msg}")
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_helper(
+            _StubClient(), "input_boolean.renamed_slug", "input_boolean"
+        )
+        assert got is not None
+        assert got["id"] == "original_slug"
+
+    async def test_fetch_helper_direct_match_skips_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            if msg.get("type") == "input_boolean/list":
+                return [{"id": "my_bool", "name": "X"}]
+            raise AssertionError("registry fallback must not run on a direct hit")
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_helper(
+            _StubClient(), "input_boolean.my_bool", "input_boolean"
+        )
+        assert got is not None
+        assert got["id"] == "my_bool"
+
+    async def test_fetch_helper_propagates_non_notfound_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Rename-fallback registry lookup: a transport/5xx error must
+        # propagate (so maybe_snapshot logs a WARNING) rather than be
+        # swallowed as a not-found and silently skip the snapshot.
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            if msg.get("type") == "input_boolean/list":
+                return [{"id": "original_slug", "name": "X"}]
+            raise bm.HomeAssistantError("Internal Server Error")
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        with pytest.raises(bm.HomeAssistantError):
+            await bm._fetch_helper(
+                _StubClient(), "input_boolean.renamed_slug", "input_boolean"
+            )
+
+    async def test_fetch_device_returns_registry_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            assert msg.get("type") == "config/device_registry/list"
+            return [
+                {
+                    "id": "dev-1",
+                    "name_by_user": "Hub",
+                    "area_id": "lr",
+                    "disabled_by": None,
+                    "labels": ["x"],
+                },
+                {"id": "dev-2"},
+            ]
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_device(_StubClient(), "dev-1")
+        assert got is not None
+        assert got["name_by_user"] == "Hub"
+
+    async def test_restore_device_sends_update_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sent: dict[str, Any] = {}
+
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            sent.update(msg)
+            return {"success": True}
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        await bm._restore_device(
+            _StubClient(),
+            "dev-1",
+            {
+                "name_by_user": "Hub",
+                "area_id": "lr",
+                "disabled_by": None,
+                "labels": ["x"],
+            },
+        )
+        assert sent["type"] == "config/device_registry/update"
+        assert sent["device_id"] == "dev-1"
+        assert sent["name_by_user"] == "Hub"
+        assert sent["labels"] == ["x"]
+
+    async def test_fetch_dashboard_resolves_internal_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The internal (underscored) id must be pre-resolved to the canonical
+        # url_path before the lovelace/config fetch, else it 404s and the
+        # snapshot is silently skipped.
+        import ha_mcp.tools.tools_config_dashboards as dash
+
+        seen: dict[str, Any] = {}
+
+        async def fake_resolve(_client: Any, identifier: str) -> Any:
+            return {"url_path": "my-dash", "id": identifier}, None
+
+        async def fake_get_internal(_client: Any, url_path: str | None) -> Any:
+            seen["url_path"] = url_path
+            return {"views": []}, "hash"
+
+        monkeypatch.setattr(dash, "_resolve_dashboard", fake_resolve)
+        monkeypatch.setattr(dash, "_get_dashboard_config_internal", fake_get_internal)
+        got = await bm._fetch_dashboard(_StubClient(), "my_dash")
+        assert got == {"views": []}
+        # fetched via the canonical url_path, not the raw internal id
+        assert seen["url_path"] == "my-dash"
+
+    async def test_fetch_dashboard_unknown_config_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # HA's "Unknown config specified" for an unresolved url_path (also the
+        # brand-new-dashboard create path) must map to None ("nothing to back
+        # up"), not propagate as a hard failure.
+        from fastmcp.exceptions import ToolError
+
+        import ha_mcp.tools.tools_config_dashboards as dash
+
+        async def fake_resolve(_client: Any, _identifier: str) -> Any:
+            return None, None  # no registry match -> fall through with raw id
+
+        async def fake_get_internal(_client: Any, _url_path: str | None) -> Any:
+            raise ToolError("Dashboard fetch failed: Unknown config specified: x")
+
+        monkeypatch.setattr(dash, "_resolve_dashboard", fake_resolve)
+        monkeypatch.setattr(dash, "_get_dashboard_config_internal", fake_get_internal)
+        assert await bm._fetch_dashboard(_StubClient(), "x_dash") is None
+
+    async def test_fetch_dashboard_propagates_other_toolerror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A non-not-found failure must propagate (so maybe_snapshot logs a
+        # WARNING) rather than be misclassified as "nothing to back up".
+        from fastmcp.exceptions import ToolError
+
+        import ha_mcp.tools.tools_config_dashboards as dash
+
+        async def fake_resolve(_client: Any, _identifier: str) -> Any:
+            return None, None
+
+        async def fake_get_internal(_client: Any, _url_path: str | None) -> Any:
+            raise ToolError("Dashboard fetch failed: 500 Internal Server Error")
+
+        monkeypatch.setattr(dash, "_resolve_dashboard", fake_resolve)
+        monkeypatch.setattr(dash, "_get_dashboard_config_internal", fake_get_internal)
+        with pytest.raises(ToolError):
+            await bm._fetch_dashboard(_StubClient(), "x_dash")
+
+    async def test_fetch_calendar_event_matches_uid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Hard guard for the calendar lane (the e2e is skippable): the
+        # pre-delete fetch must find the event by uid and tag the calendar.
+        async def fake_ws(_client: Any, _msg: dict[str, Any]) -> Any:
+            return {
+                "response": {
+                    "events": {
+                        "calendar.fam": {
+                            "events": [{"uid": "evt-1", "summary": "Dinner"}]
+                        }
+                    }
+                }
+            }
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_calendar_event(_StubClient(), "calendar.fam::evt-1")
+        assert got is not None
+        assert got["uid"] == "evt-1"
+        assert got["calendar_entity_id"] == "calendar.fam"
+
+    async def test_fetch_helper_registry_without_unique_id_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Rename fallback tail: registry entry exists but carries no
+        # resolvable unique_id (or it matches nothing) -> genuine not-found.
+        async def fake_ws(_client: Any, msg: dict[str, Any]) -> Any:
+            if msg.get("type") == "input_boolean/list":
+                return [{"id": "original_slug", "name": "X"}]
+            if msg.get("type") == "config/entity_registry/get":
+                return {}  # no unique_id
+            raise AssertionError(f"unexpected ws message: {msg}")
+
+        monkeypatch.setattr(bm, "_ws_send", fake_ws)
+        got = await bm._fetch_helper(
+            _StubClient(), "input_boolean.renamed_slug", "input_boolean"
+        )
+        assert got is None
+
+    async def test_fetch_automation_preserves_entity_id_form(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Headline bug at the FETCH layer: the entity_id form must reach
+        # client.get_automation_config UNSTRIPPED so its resolver maps it to
+        # the numeric unique_id (a bare slug would 404 -> silent skip).
+        import ha_mcp.tools.tools_config_automations as autos
+
+        seen: dict[str, Any] = {}
+
+        class _FakeClient:
+            async def get_automation_config(self, identifier: str) -> Any:
+                seen["id"] = identifier
+                return {"id": "1781613420568", "alias": "X"}
+
+        monkeypatch.setattr(autos, "_normalize_config_for_roundtrip", lambda c: c)
+        got = await bm._fetch_automation(_FakeClient(), "automation.kitchen_lights")
+        assert seen["id"] == "automation.kitchen_lights"
+        assert got == {"id": "1781613420568", "alias": "X"}
+
+    async def test_fetch_automation_returns_none_on_404(self) -> None:
+        from ha_mcp.client.rest_client import HomeAssistantAPIError
+
+        class _FakeClient:
+            async def get_automation_config(self, identifier: str) -> Any:
+                raise HomeAssistantAPIError("Automation not found", status_code=404)
+
+        assert await bm._fetch_automation(_FakeClient(), "automation.gone") is None
+
+
+# --------------------------------------------- with_auto_backup decorator wiring
+
+
+class TestWithAutoBackupDecorator:
+    """The @with_auto_backup wiring the new destructive tools rely on."""
+
+    async def test_id_param_fires_maybe_snapshot(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ha_mcp.tools.auto_backup import with_auto_backup
+
+        calls: list[tuple[str, str, str | None]] = []
+
+        class _FakeMgr:
+            async def maybe_snapshot(
+                self, domain: str, entity_id: str, *, tool_name: str | None = None
+            ) -> None:
+                calls.append((domain, entity_id, tool_name))
+
+        class _Settings:
+            enable_auto_backup = True
+
+        monkeypatch.setattr(
+            "ha_mcp.tools.auto_backup.get_global_settings", lambda: _Settings()
+        )
+        monkeypatch.setattr(
+            "ha_mcp.tools.auto_backup.get_backup_manager", lambda _c, _s: _FakeMgr()
+        )
+
+        ran: list[str] = []
+
+        @with_auto_backup(domain="device", id_param="device_id", client=object())
+        async def fake_tool(*, device_id: str) -> str:
+            ran.append(device_id)
+            return "ok"
+
+        assert await fake_tool(device_id="dev-1") == "ok"
+        assert ran == ["dev-1"]  # wrapped write still runs
+        assert calls == [("device", "dev-1", "fake_tool")]
+
+    async def test_capture_failure_does_not_block_write(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ha_mcp.tools.auto_backup import with_auto_backup
+
+        class _FakeMgr:
+            async def maybe_snapshot(self, *a: Any, **k: Any) -> None:
+                raise bm.HomeAssistantError("transient capture failure")
+
+        class _Settings:
+            enable_auto_backup = True
+
+        monkeypatch.setattr(
+            "ha_mcp.tools.auto_backup.get_global_settings", lambda: _Settings()
+        )
+        monkeypatch.setattr(
+            "ha_mcp.tools.auto_backup.get_backup_manager", lambda _c, _s: _FakeMgr()
+        )
+
+        ran: list[str] = []
+
+        @with_auto_backup(domain="device", id_param="device_id", client=object())
+        async def fake_tool(*, device_id: str) -> str:
+            ran.append(device_id)
+            return "ok"
+
+        # best-effort contract: a capture error must NOT block the write
+        assert await fake_tool(device_id="dev-1") == "ok"
+        assert ran == ["dev-1"]
+
+
+def test_destructive_tools_carry_auto_backup_decorator() -> None:
+    """Source guard: the three destructive tools this PR wired must keep
+    their @with_auto_backup decorator — a deleted line would silently stop
+    capturing without failing any behavioral test."""
+    from pathlib import Path
+
+    tools_dir = Path(__file__).resolve().parents[3] / "src" / "ha_mcp" / "tools"
+    checks = [
+        ("tools_entities.py", "ha_remove_entity", "entity", "entity_id"),
+        ("tools_registry.py", "ha_set_device", "device", "device_id"),
+        ("tools_registry.py", "ha_remove_device", "device", "device_id"),
+    ]
+    for fname, func, domain, id_param in checks:
+        src = (tools_dir / fname).read_text(encoding="utf-8")
+        idx = src.index(f"async def {func}(")
+        head = src[max(0, idx - 600) : idx]  # the decorator block above the def
+        assert "with_auto_backup(" in head, f"{func} lost @with_auto_backup"
+        assert f'domain="{domain}"' in head, f"{func} wrong/missing backup domain"
+        assert f'id_param="{id_param}"' in head, f"{func} wrong/missing id_param"
 
 
 # ---------------------------------------------------------------- filenames
@@ -480,6 +862,7 @@ class TestFactory:
             "todo_item",
             "calendar_event",
             "entity",
+            "device",
             "integration",
             "helper_input_boolean",
             "helper_timer",

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -43,8 +43,18 @@ def _parse_decorator_args(decorator_args: str, func_name: str, file_name: str) -
 def extract_tool_decorators(file_path: Path) -> list[dict]:
     """Extract @mcp.tool and @tool decorator information from a Python file."""
     content = file_path.read_text(encoding="utf-8")
-    # Pattern 1: @mcp.tool(...) — closure pattern
-    pattern = r"@mcp\.tool\(([^)]*)\)\s*(?:@\w+\s*)*async def (\w+)"
+    # Pattern 1: @mcp.tool(...) — closure pattern.
+    # The decorator-skip ``(?:@\w+(?:\([^()]*\))?\s*)*`` accepts bare
+    # decorators (``@log_tool_usage``) AND SINGLE-LEVEL parenthesized ones
+    # such as ``@with_auto_backup(domain="entity", id_param="entity_id",
+    # client=client)`` between ``@mcp.tool`` and ``async def``; the old
+    # bare-only ``(?:@\w+\s*)*`` dropped those backed-up tools from the count.
+    # ``\([^()]*\)`` does NOT span nested parens, so a decorator whose args
+    # contain them (e.g. ``ha_set_entity``'s ``id_fn=lambda``) stays unmatched
+    # — pre-existing, not introduced here. Requiring decorators-then-
+    # ``async def`` (not arbitrary text) keeps docstring ``@mcp.tool(...)``
+    # mentions from matching.
+    pattern = r"@mcp\.tool\(([^)]*)\)\s*(?:@\w+(?:\([^()]*\))?\s*)*async def (\w+)"
     tools = [
         _parse_decorator_args(m.group(1), m.group(2), file_path.name)
         for m in re.finditer(pattern, content, re.DOTALL)


### PR DESCRIPTION
## What does this PR do?

Fixes the pre-write auto-backup (#1288) silently skipping snapshots on several
write/destructive paths. In each case the id handed to the domain's fetch
handler couldn't be resolved to the existing entity, so the fetch returned
None and `maybe_snapshot` skipped with no error — no backup, no warning.

Fixed capture paths:
- **automation** — `automation_backup_target` stripped the `automation.`
  prefix → bare slug that `_resolve_automation_id` mis-treats as a numeric
  unique_id → 404. The recommended `python_transform` edit path hit this on
  every UI-created automation. Now passes the identifier unchanged (also
  fixes a latent wrong-target restore the strip would have caused).
- **todo_item** — `_fetch_todo_item` matched only on `uid`, but the set/remove
  tools pass the item summary (the documented form). Now matches uid OR summary.
- **dashboard** — `_fetch_dashboard` didn't lazy-resolve HA's internal
  (underscored) dashboard id. Now pre-resolves to the canonical `url_path`
  like the set/delete tools.
- **helper** — `_fetch_helper` missed storage helpers after an entity_id
  rename (object_id ≠ collection id). Now falls back to the registry unique_id.

Coverage gaps closed (the feature promises a snapshot before destructive
writes, so the absence was a bug):
- **ha_remove_entity** had no `@with_auto_backup` → now snapshots state
  before the registry delete.
- **ha_set_device / ha_remove_device** had no coverage → added a `device`
  DomainHandler (capture + restore of name_by_user/area_id/disabled_by/labels)
  and decorated both tools.

Based on the `stable` tag (v7.8.0) per the hotfix process; targets `master`.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] Automated tests pass (`uv run pytest` — 56 backup tests incl. new regressions)
- [x] Style clean (`uv run ruff check`)
- [ ] Live-verified on a real HA add-on — pending; will live-test after the PR is up

Regression tests added for every fetch path (automation prefix preservation,
todo summary-match, dashboard internal-id resolve, helper rename fallback,
device fetch/restore, device handler registration).

## Checklist
- [x] Documentation: no user-facing docs affected
