### PR TITLE
chore: sync pyproject version to the published 7.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-mcp"
-version = "7.8.0"
+version = "7.8.1"
 description = "Home Assistant MCP Server - Complete control of Home Assistant through MCP"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"


### PR DESCRIPTION
## What does this PR do?

Bumps `pyproject.toml` `[project].version` from `7.8.0` to `7.8.1` so it matches the published add-on version.

The 7.8.1 add-on hotfix publish (`dbc0d1e2`, `[skip ci]`) bumped `homeassistant-addon/config.yaml` and created the `v7.8.1` tag but left `pyproject.toml` at `7.8.0`. `test_addon_structure.py::test_config_yaml_valid` asserts the two match, so the required `Docker & Add-on Validation` check fails on every PR cut from this master state. This one-line sync clears it.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Notes: `test_addon_structure.py::test_config_yaml_valid` now passes (7.8.1 == 7.8.1); no code change.

## Checklist
- [x] I have updated documentation if needed
