### PR TITLE
feat: notify when a newer ha-mcp release is available

### DIFF
--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -671,10 +671,18 @@ def main() -> int:
         StatelessSessionLogFilter,
         _get_server,
         _get_timestamped_uvicorn_log_config,
+        _log_startup_version,
         mcp,
         register_browser_landing,
     )
     from ha_mcp.settings_ui import register_settings_routes
+
+    # Log the ha-mcp version + a self-update banner if a newer release is on
+    # PyPI. The addon runs its own startup here (it doesn't go through
+    # __main__.main_web), so without this the ha-mcp banner never reaches the
+    # addon logs — only FastMCP's own banner does (via run_async). Mirrors how
+    # FastMCP surfaces its update notice in these same startup logs.
+    _log_startup_version()
 
     if advanced_debug_logging:
         # Defers SA_SIGINFO install until uvicorn's capture_signals has

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -677,8 +677,10 @@ def main() -> int:
     )
     from ha_mcp.settings_ui import register_settings_routes
 
-    # Log the ha-mcp version + a self-update banner if a newer release is on
-    # PyPI. The addon runs its own startup here (it doesn't go through
+    # Log the ha-mcp version + a self-update banner when a newer release is
+    # available. In the add-on that comes from the Supervisor add-on store, not
+    # PyPI (see update_check._resolve_update_info's is_running_in_addon branch).
+    # The addon runs its own startup here (it doesn't go through
     # __main__.main_web), so without this the ha-mcp banner never reaches the
     # addon logs — only FastMCP's own banner does (via run_async). Mirrors how
     # FastMCP surfaces its update notice in these same startup logs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "cryptography==49.0.0",
     "pydantic-monty==0.0.18",
     "tzdata>=2024.1",
+    "packaging>=24.0",
 ]
 
 [project.urls]

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -485,13 +485,12 @@ def _log_startup_version() -> None:
     ``:latest``, or ``pip install ha-mcp-dev``). It is suppressed under the HA
     Supervisor because add-on users already pick dev vs stable in the HAOS UI.
 
-    The update banner fires on *every* startup when a newer release is on PyPI —
-    in every deployment including the add-on — mirroring FastMCP's
-    ``log_server_banner``, which announces an available update on each start
-    regardless of how it's run. It covers both the stable (``ha-mcp``) and dev
-    (``ha-mcp-dev``) channels, so a dev install hears about newer dev builds too.
-    ``get_update_info`` is a no-op for the ``unknown`` version and the
-    ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out, and never raises.
+    The update banner fires on every startup when a newer release is available,
+    on every deployment — pip/Docker/stdio compare against PyPI, the HA add-on
+    (stable AND dev) against the Supervisor add-on store — mirroring FastMCP's
+    ``log_server_banner``. ``get_update_info`` is a no-op for the ``unknown``
+    version (PyPI path) and the ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out, and
+    never raises.
     """
     from ha_mcp._version import get_version, is_dev_version, is_running_in_addon
 

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -479,21 +479,44 @@ def _setup_logging(log_level_str: str, force: bool = False) -> None:
 
 
 def _log_startup_version() -> None:
-    """Log ha-mcp version at startup, plus a dev-channel banner when relevant.
+    """Log ha-mcp version at startup, plus dev-channel / update banners.
 
     The dev banner only fires for standalone dev installs (Docker ``:dev`` /
     ``:latest``, or ``pip install ha-mcp-dev``). It is suppressed under the HA
     Supervisor because add-on users already pick dev vs stable in the HAOS UI.
+
+    A second banner surfaces a newer release if PyPI has one — for both the
+    stable channel (``ha-mcp``) and the dev channel (``ha-mcp-dev``), so a dev
+    install hears about newer dev builds too. The banner is suppressed under the
+    add-on (the Supervisor already prompts there, and logs are noisy) — but the
+    in-chat tool fields still surface it, so an add-on user who missed the prompt
+    isn't left in the dark. ``get_update_info`` is a no-op for the ``unknown``
+    version and the ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out, and never raises.
     """
     from ha_mcp._version import get_version, is_dev_version, is_running_in_addon
 
     version = get_version()
     logger.info(f"ha-mcp {version}")
-    if is_dev_version(version) and not is_running_in_addon():
+    if is_running_in_addon():
+        return
+
+    if is_dev_version(version):
         logger.warning(
             "This is the dev channel. For the stable release use the "
             "'ghcr.io/homeassistant-ai/ha-mcp:stable' Docker tag "
             "(or 'pip install ha-mcp' on PyPI)."
+        )
+        # Fall through: dev installs still get a newer-dev-build banner below.
+
+    from ha_mcp.update_check import get_update_info, update_command_hint
+
+    info = get_update_info()
+    if info is not None and info.update_available:
+        logger.warning(
+            "A newer ha-mcp release is available: %s (you have %s). %s",
+            info.latest,
+            info.current,
+            update_command_hint(info.current),
         )
 
 

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -485,28 +485,25 @@ def _log_startup_version() -> None:
     ``:latest``, or ``pip install ha-mcp-dev``). It is suppressed under the HA
     Supervisor because add-on users already pick dev vs stable in the HAOS UI.
 
-    A second banner surfaces a newer release if PyPI has one — for both the
-    stable channel (``ha-mcp``) and the dev channel (``ha-mcp-dev``), so a dev
-    install hears about newer dev builds too. The banner is suppressed under the
-    add-on (the Supervisor already prompts there, and logs are noisy) — but the
-    in-chat tool fields still surface it, so an add-on user who missed the prompt
-    isn't left in the dark. ``get_update_info`` is a no-op for the ``unknown``
-    version and the ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out, and never raises.
+    The update banner fires on *every* startup when a newer release is on PyPI —
+    in every deployment including the add-on — mirroring FastMCP's
+    ``log_server_banner``, which announces an available update on each start
+    regardless of how it's run. It covers both the stable (``ha-mcp``) and dev
+    (``ha-mcp-dev``) channels, so a dev install hears about newer dev builds too.
+    ``get_update_info`` is a no-op for the ``unknown`` version and the
+    ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out, and never raises.
     """
     from ha_mcp._version import get_version, is_dev_version, is_running_in_addon
 
     version = get_version()
     logger.info(f"ha-mcp {version}")
-    if is_running_in_addon():
-        return
 
-    if is_dev_version(version):
+    if is_dev_version(version) and not is_running_in_addon():
         logger.warning(
             "This is the dev channel. For the stable release use the "
             "'ghcr.io/homeassistant-ai/ha-mcp:stable' Docker tag "
             "(or 'pip install ha-mcp' on PyPI)."
         )
-        # Fall through: dev installs still get a newer-dev-build banner below.
 
     from ha_mcp.update_check import get_update_info, update_command_hint
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1940,10 +1940,10 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
         The response also carries an ``ha_mcp_update`` object
         ``{current, latest, update_available}`` reporting whether a newer ha-mcp
-        release is on PyPI for the running channel (stable or dev) — proactively
-        tell the user when ``update_available`` is true. Emitted regardless of
-        ``fields=``; omitted only for the ``unknown`` version and when
-        ``HA_MCP_DISABLE_UPDATE_CHECK`` is set.
+        release is available (PyPI for pip/Docker, the Supervisor add-on store
+        for the add-on) — proactively tell the user when ``update_available`` is
+        true. Emitted regardless of ``fields=``; omitted only for the
+        ``unknown`` version and when ``HA_MCP_DISABLE_UPDATE_CHECK`` is set.
         """
         # Validate fields= early so a malformed value returns VALIDATION_FAILED
         # with parameter="fields" (ha_get_overview has no outer try/except, so

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1896,13 +1896,14 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                     "notification_count, notifications, repair_count, "
                     "dismissed_repair_count, repairs, repairs_error, "
                     "tool_discovery, settings_url, settings_url_hint, "
-                    "read_only_mode, read_only_mode_hint. Note: "
+                    "read_only_mode, read_only_mode_hint, ha_mcp_update. Note: "
                     "``settings_url`` (stdio mode), ``settings_url_hint`` "
-                    "(HTTP/Docker/OAuth mode), and the ``read_only_mode`` / "
+                    "(HTTP/Docker/OAuth mode), the ``read_only_mode`` / "
                     "``read_only_mode_hint`` pair (only while Read Only Mode "
-                    "is on) are emitted regardless of ``fields=`` projection "
-                    "so the settings page and the active mode stay "
-                    "discoverable; see the tool description."
+                    "is on), and ``ha_mcp_update`` (when an update check applies) "
+                    "are emitted regardless of ``fields=`` projection so the "
+                    "settings page, the active mode, and a newer ha-mcp release "
+                    "stay discoverable; see the tool description."
                 ),
             ),
         ] = None,
@@ -1936,6 +1937,13 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         instead carries a ``settings_url_hint`` string telling the user where
         the page is mounted and to read the full URL from the startup logs.
         Hand whichever of the two fields is present to the user.
+
+        The response also carries an ``ha_mcp_update`` object
+        ``{current, latest, update_available}`` reporting whether a newer ha-mcp
+        release is on PyPI for the running channel (stable or dev) — proactively
+        tell the user when ``update_available`` is true. Emitted regardless of
+        ``fields=``; omitted only for the ``unknown`` version and when
+        ``HA_MCP_DISABLE_UPDATE_CHECK`` is set.
         """
         # Validate fields= early so a malformed value returns VALIDATION_FAILED
         # with parameter="fields" (ha_get_overview has no outer try/except, so
@@ -2171,6 +2179,17 @@ def register_search_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
                 "the ha-mcp settings UI (Tools tab) or the add-on "
                 "configuration."
             )
+
+        # Surface the MCP server's own update status after projection (like
+        # settings_url / read_only_mode) so it survives any fields= filter — the
+        # model should learn about a newer ha-mcp release even from a minimal
+        # overview, the most common session-start call. Best-effort and never
+        # raises; see ha_mcp.update_check.
+        from ..update_check import get_update_field
+
+        mcp_update = await get_update_field()
+        if mcp_update is not None:
+            projected["ha_mcp_update"] = mcp_update
 
         return projected
 

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -375,6 +375,14 @@ class SystemTools:
         Returns health check results from integrations, system resources, and connectivity.
         Available information varies by installation type and loaded integrations.
 
+        The result also carries an ``ha_mcp_update`` object —
+        ``{current, latest, update_available}`` — reporting whether a newer
+        ha-mcp release is on PyPI for the running channel (stable or dev), so you
+        can proactively tell the user to upgrade. Present on every install type
+        including the HA add-on (so a user who missed the Supervisor's update
+        prompt still hears about it); omitted only for the ``unknown`` version
+        and when ``HA_MCP_DISABLE_UPDATE_CHECK`` is set.
+
         **Parameters:**
         - include: Optional comma-separated list of additional data to include.
           - "repairs": Repair items from Settings > System > Repairs (active only by default; pass `include_dismissed_repairs=True` for all)
@@ -699,6 +707,16 @@ class SystemTools:
                 if section_warnings:
                     result.setdefault("warnings", []).extend(section_warnings)
                 result["dead_entities"] = dead_section
+
+            # Surface the MCP server's own update status so the model can relay
+            # it in chat. ``get_update_field`` is best-effort, thread-offloaded,
+            # and never raises (omits the field on any hiccup); see
+            # ha_mcp.update_check for gating/throttle details.
+            from ..update_check import get_update_field
+
+            mcp_update = await get_update_field()
+            if mcp_update is not None:
+                result["ha_mcp_update"] = mcp_update
 
             return result
 

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -377,11 +377,12 @@ class SystemTools:
 
         The result also carries an ``ha_mcp_update`` object —
         ``{current, latest, update_available}`` — reporting whether a newer
-        ha-mcp release is on PyPI for the running channel (stable or dev), so you
-        can proactively tell the user to upgrade. Present on every install type
-        including the HA add-on (so a user who missed the Supervisor's update
-        prompt still hears about it); omitted only for the ``unknown`` version
-        and when ``HA_MCP_DISABLE_UPDATE_CHECK`` is set.
+        ha-mcp release is available (from PyPI for pip/Docker, or the Supervisor
+        add-on store for the add-on), so you can proactively tell the user to
+        upgrade. Present on every install type including the HA add-on (so a user
+        who missed the Supervisor's update prompt still hears about it); omitted
+        only for the ``unknown`` version and when ``HA_MCP_DISABLE_UPDATE_CHECK``
+        is set.
 
         **Parameters:**
         - include: Optional comma-separated list of additional data to include.

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -524,7 +524,7 @@ class UpdateTools:
 
         categories = {k: v for k, v in categories.items() if v}
 
-        return {
+        result: dict[str, Any] = {
             "success": True,
             "updates_available": len(available_updates),
             "skipped_count": len(skipped_updates),
@@ -532,6 +532,19 @@ class UpdateTools:
             "categories": categories,
             "include_skipped": include_skipped,
         }
+
+        # Surface the MCP server's OWN update status alongside HA's updates so the
+        # model is more likely to mention "you're on X, but Y is out" — this tool
+        # is HA-centric, but spreading the ha-mcp self-update signal across the
+        # status surfaces raises the odds an AI relays it. ``get_update_field`` is
+        # best-effort and never raises; see ha_mcp.update_check for details.
+        from ..update_check import get_update_field
+
+        mcp_update = await get_update_field()
+        if mcp_update is not None:
+            result["ha_mcp_update"] = mcp_update
+
+        return result
 
     async def _get_update_details(
         self, entity_id: str, include_release_notes: bool = False
@@ -702,6 +715,11 @@ class UpdateTools:
         - updates_available: Count of available updates
         - updates: List of update entities with version info
         - categories: Updates grouped by category (core, addons, devices, hacs, os)
+        - ha_mcp_update: This MCP server's own update status
+          {current, latest, update_available} — so you can flag a newer ha-mcp
+          release (stable or dev, matching the running channel). Present on all
+          install types; omitted only for the unknown version and when
+          HA_MCP_DISABLE_UPDATE_CHECK is set.
 
         RETURNS (when getting specific update):
         - Update details including installed/latest versions

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -717,9 +717,9 @@ class UpdateTools:
         - categories: Updates grouped by category (core, addons, devices, hacs, os)
         - ha_mcp_update: This MCP server's own update status
           {current, latest, update_available} — so you can flag a newer ha-mcp
-          release (stable or dev, matching the running channel). Present on all
-          install types; omitted only for the unknown version and when
-          HA_MCP_DISABLE_UPDATE_CHECK is set.
+          release (from PyPI for pip/Docker, the Supervisor add-on store for the
+          add-on). Present on all install types; omitted only for the unknown
+          version and when HA_MCP_DISABLE_UPDATE_CHECK is set.
 
         RETURNS (when getting specific update):
         - Update details including installed/latest versions

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -14,12 +14,14 @@ latest dev build.
 
 The check runs once per process — memoized in memory, no disk, no throttle. For
 stdio that is once per session (the server is spawned per conversation); for a
-long-running Docker/web server, once at boot. It is suppressed only for the
+long-running Docker/web server, once at boot. It is a no-op only for the
 ``unknown`` version (nothing to compare) and the ``HA_MCP_DISABLE_UPDATE_CHECK``
-opt-out. Separately, only the startup *banner* is suppressed under the add-on
-(the Supervisor already prompts there) — the tool fields still surface it, for a
-user who missed the prompt. Every network call is best-effort: any failure
-yields "no update info" rather than raising, so callers never need to guard it.
+opt-out. The startup banner (see ``__main__``) and the tool fields surface the
+result on every deployment including the add-on — copying FastMCP, whose
+``log_server_banner`` announces an available update on each startup regardless of
+how it's run, so an add-on user who missed the Supervisor prompt still sees it.
+Every network call is best-effort: any failure yields "no update info" rather
+than raising, so callers never need to guard it.
 """
 
 from __future__ import annotations
@@ -33,7 +35,7 @@ from dataclasses import dataclass
 import httpx
 from packaging.version import InvalidVersion, Version
 
-from ._version import get_version, is_dev_version
+from ._version import get_version, is_dev_version, is_running_in_addon
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +167,9 @@ def _running_in_docker() -> bool:
 
 def update_command_hint(current: str) -> str:
     """Return a deployment- and channel-aware one-liner for how to upgrade."""
+    if is_running_in_addon():
+        # Add-on users update through the Supervisor UI, not pip/docker.
+        return "Update from Settings -> Add-ons -> Home Assistant MCP Server."
     dev = is_dev_version(current)
     if _running_in_docker():
         # Dev images are tagged :dev (rolling); :stable is the stable channel.

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -1,0 +1,177 @@
+"""Self-update notifier for standalone ha-mcp deployments.
+
+The HA add-on is kept current by the Supervisor, but the standalone channels
+(pip / Docker / stdio) have no auto-update — an operator can sit on an old build
+without ever knowing. This does a fail-silent PyPI check, holds the result in
+memory for the process, and surfaces a newer release via a startup log banner
+and the ``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates`` tool
+fields.
+
+Both channels are covered, matching the HA add-on (which surfaces every dev
+update): a stable install (the ``ha-mcp`` package) is compared against the latest
+stable on PyPI; a dev install (``ha-mcp-dev``, a ``.dev`` version) against the
+latest dev build.
+
+The check runs once per process — memoized in memory, no disk, no throttle. For
+stdio that is once per session (the server is spawned per conversation); for a
+long-running Docker/web server, once at boot. It is suppressed only for the
+``unknown`` version (nothing to compare) and the ``HA_MCP_DISABLE_UPDATE_CHECK``
+opt-out. Separately, only the startup *banner* is suppressed under the add-on
+(the Supervisor already prompts there) — the tool fields still surface it, for a
+user who missed the prompt. Every network call is best-effort: any failure
+yields "no update info" rather than raising, so callers never need to guard it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+from dataclasses import dataclass
+
+import httpx
+from packaging.version import InvalidVersion, Version
+
+from ._version import get_version, is_dev_version
+
+logger = logging.getLogger(__name__)
+
+DISABLE_ENV = "HA_MCP_DISABLE_UPDATE_CHECK"
+_PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+_STABLE_PACKAGE = "ha-mcp"
+_DEV_PACKAGE = "ha-mcp-dev"
+# Tight timeout so the once-per-process check can never add more than a blip of
+# latency to a cold stdio spawn.
+_HTTP_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    """Result of a self-update check.
+
+    ``update_available`` is the field callers branch on; ``current`` and
+    ``latest`` are carried so a banner or tool field can show both versions.
+    """
+
+    current: str
+    latest: str
+    update_available: bool
+
+
+def _is_disabled() -> bool:
+    return bool(os.environ.get(DISABLE_ENV))
+
+
+def _is_newer(latest: str, current: str) -> bool:
+    """Return True only when ``latest`` is a strictly higher PEP 440 release.
+
+    ``packaging.version`` orders dev/pre/post correctly — e.g.
+    ``7.8.0.dev714 < 7.8.0.dev720 < 7.8.0`` and ``7.8.0 < 7.9.0`` — so this works
+    for both the stable and dev channels. An unparseable version on either side
+    reads as "can't compare" → not newer (never a bogus banner).
+    """
+    try:
+        return Version(latest) > Version(current)
+    except InvalidVersion:
+        return False
+
+
+def _fetch_latest_from_pypi(package: str) -> str | None:
+    """Fetch ``package``'s latest published version from PyPI, or None on failure."""
+    try:
+        # follow_redirects=True mirrors the sibling fetch in tools_updates.py and
+        # survives any future PyPI redirect (the JSON API serves 200 directly today).
+        resp = httpx.get(
+            _PYPI_JSON_URL.format(package=package),
+            timeout=_HTTP_TIMEOUT_SECONDS,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        version = resp.json()["info"]["version"]
+        return version if isinstance(version, str) else None
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as err:
+        logger.debug("ha-mcp update check skipped (PyPI fetch failed: %s)", err)
+        return None
+
+
+def _resolve_update_info() -> UpdateInfo | None:
+    """Update-check logic; see ``get_update_info`` for the memo + never-raises wrapper."""
+    if _is_disabled():
+        return None
+    current = get_version()
+    if current == "unknown":
+        return None
+    # A dev install (``.dev`` version) tracks the renamed ``ha-mcp-dev`` package;
+    # a stable install tracks ``ha-mcp``. Compare like-for-like so dev users get
+    # newer-dev-build parity with the add-on's dev channel.
+    package = _DEV_PACKAGE if is_dev_version(current) else _STABLE_PACKAGE
+    latest = _fetch_latest_from_pypi(package)
+    if latest is None:
+        return None
+    return UpdateInfo(
+        current=current,
+        latest=latest,
+        update_available=_is_newer(latest, current),
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def get_update_info() -> UpdateInfo | None:
+    """Return self-update info for this process, or None when no check applies.
+
+    Memoized in memory (``lru_cache``) so the network check runs once per process
+    — the startup banner warms it and the tool fields reuse it without re-hitting
+    PyPI. No disk, no throttle: a long-running server reflects its boot-time check
+    until restart, which is fine (those operators aren't watching startup logs).
+    Never raises — an unexpected failure degrades to None so the unguarded
+    startup-banner call can't break startup. Tests reset via
+    ``get_update_info.cache_clear()``.
+    """
+    try:
+        return _resolve_update_info()
+    except Exception as err:  # pragma: no cover - contract backstop
+        logger.debug("ha-mcp update check skipped (unexpected error: %s)", err)
+        return None
+
+
+async def get_update_field() -> dict[str, str | bool] | None:
+    """Return an embeddable self-update dict for tool responses, or None.
+
+    Off-loads the (memoized, networks-at-most-once-per-process) check to a thread
+    so it never blocks the event loop, and shapes the result for embedding under
+    an ``ha_mcp_update`` key. Never raises — a hiccup yields None (the tool omits
+    the field) and is logged at debug. Shared by every status tool that surfaces
+    the notice (``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates``)
+    so the shaping and event-loop offload live in one place.
+    """
+    try:
+        info = await asyncio.to_thread(get_update_info)
+    except Exception as err:  # pragma: no cover - defensive
+        logger.debug("ha-mcp self-update check skipped: %s", err)
+        return None
+    if info is None:
+        return None
+    return {
+        "current": info.current,
+        "latest": info.latest,
+        "update_available": info.update_available,
+    }
+
+
+def _running_in_docker() -> bool:
+    return os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+
+
+def update_command_hint(current: str) -> str:
+    """Return a deployment- and channel-aware one-liner for how to upgrade."""
+    dev = is_dev_version(current)
+    if _running_in_docker():
+        # Dev images are tagged :dev (rolling); :stable is the stable channel.
+        tag = "dev" if dev else "stable"
+        return (
+            f"Pull the new image: docker pull "
+            f"ghcr.io/homeassistant-ai/ha-mcp:{tag} (then restart)."
+        )
+    package = _DEV_PACKAGE if dev else _STABLE_PACKAGE
+    return f"Upgrade with: pip install -U {package}."

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -33,7 +33,7 @@ import functools
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypedDict
 
 import httpx
 from packaging.version import InvalidVersion, Version
@@ -201,7 +201,15 @@ def get_update_info() -> UpdateInfo | None:
         return None
 
 
-async def get_update_field() -> dict[str, str | bool] | None:
+class UpdateField(TypedDict):
+    """The ``ha_mcp_update`` object embedded in status-tool responses."""
+
+    current: str
+    latest: str
+    update_available: bool
+
+
+async def get_update_field() -> UpdateField | None:
     """Return an embeddable self-update dict for tool responses, or None.
 
     Off-loads the (memoized, networks-at-most-once-per-process) check to a thread

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -1,25 +1,27 @@
-"""Self-update notifier for standalone ha-mcp deployments.
+"""Self-update notifier for ha-mcp.
 
-The HA add-on is kept current by the Supervisor, but the standalone channels
-(pip / Docker / stdio) have no auto-update — an operator can sit on an old build
-without ever knowing. This does a fail-silent PyPI check, holds the result in
-memory for the process, and surfaces a newer release via a startup log banner
-and the ``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates`` tool
-fields.
+An operator can sit on an old build without ever knowing. This does a
+fail-silent check, holds the result in memory for the process, and surfaces a
+newer release via a startup log banner and the ``ha_get_overview`` /
+``ha_get_system_health`` / ``ha_get_updates`` tool fields.
 
-Both channels are covered, matching the HA add-on (which surfaces every dev
-update): a stable install (the ``ha-mcp`` package) is compared against the latest
-stable on PyPI; a dev install (``ha-mcp-dev``, a ``.dev`` version) against the
-latest dev build.
+The comparison reference depends on how ha-mcp is deployed, because the running
+version only means something against the matching source:
+
+* **pip / Docker / stdio** — the running version IS a PyPI version, so it is
+  compared against PyPI: stable installs against ``ha-mcp``, dev installs
+  (``.dev``) against ``ha-mcp-dev``.
+* **HA add-on (stable AND dev)** — the add-on is built from source and updated
+  through the Supervisor add-on store, so its ``HA_MCP_BUILD_VERSION`` is on the
+  add-on's own counter, NOT PyPI's. The reference is therefore the Supervisor
+  add-on store (``GET /addons/self/info`` → ``version`` / ``version_latest`` /
+  ``update_available``), which is the same counter — so the dev add-on, like
+  every other deployment, correctly says "you're on X, Y is out."
 
 The check runs once per process — memoized in memory, no disk, no throttle. For
 stdio that is once per session (the server is spawned per conversation); for a
-long-running Docker/web server, once at boot. It is a no-op only for the
-``unknown`` version (nothing to compare) and the ``HA_MCP_DISABLE_UPDATE_CHECK``
-opt-out. The startup banner (see ``__main__``) and the tool fields surface the
-result on every deployment including the add-on — copying FastMCP, whose
-``log_server_banner`` announces an available update on each startup regardless of
-how it's run, so an add-on user who missed the Supervisor prompt still sees it.
+long-running Docker/web server or the add-on, once at boot. It is a no-op for the
+``unknown`` version (PyPI path) and the ``HA_MCP_DISABLE_UPDATE_CHECK`` opt-out.
 Every network call is best-effort: any failure yields "no update info" rather
 than raising, so callers never need to guard it.
 """
@@ -31,11 +33,17 @@ import functools
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 from packaging.version import InvalidVersion, Version
 
-from ._version import get_version, is_dev_version, is_running_in_addon
+from ._version import (
+    get_supervisor_base_url,
+    get_version,
+    is_dev_version,
+    is_running_in_addon,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -106,16 +114,67 @@ def _fetch_latest_from_pypi(package: str) -> str | None:
         return None
 
 
+def _fetch_supervisor_addon_info() -> dict[str, Any] | None:
+    """Return this add-on's Supervisor info dict, or None on any failure.
+
+    GET ``/addons/self/info`` carries ``version`` (installed), ``version_latest``
+    (the add-on store's latest), and ``update_available`` — all on the add-on's
+    own version counter. Sync + fail-silent, mirroring ``_fetch_latest_from_pypi``.
+    """
+    token = os.environ.get("SUPERVISOR_TOKEN")
+    if not token:
+        return None
+    try:
+        resp = httpx.get(
+            f"{get_supervisor_base_url()}/addons/self/info",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        # Supervisor REST envelope is {"result": "ok", "data": {...}}; some mocks
+        # return the data dict directly — handle both (mirrors settings_ui).
+        data = body.get("data") if isinstance(body, dict) and "data" in body else body
+        return data if isinstance(data, dict) else None
+    except (httpx.HTTPError, ValueError, TypeError) as err:
+        logger.debug("ha-mcp update check skipped (Supervisor fetch failed: %s)", err)
+        return None
+
+
+def _resolve_from_supervisor() -> UpdateInfo | None:
+    """Build UpdateInfo for the add-on from the Supervisor add-on store."""
+    info = _fetch_supervisor_addon_info()
+    if info is None:
+        return None
+    current = info.get("version")
+    latest = info.get("version_latest")
+    if not isinstance(current, str) or not isinstance(latest, str):
+        return None
+    return UpdateInfo(
+        current=current,
+        latest=latest,
+        update_available=bool(info.get("update_available")),
+    )
+
+
 def _resolve_update_info() -> UpdateInfo | None:
     """Update-check logic; see ``get_update_info`` for the memo + never-raises wrapper."""
     if _is_disabled():
         return None
+    # In the add-on (stable OR dev), the authoritative reference is the
+    # Supervisor add-on store, which tracks the SAME version counter as the
+    # installed add-on. PyPI is the wrong reference there: the add-on builds
+    # ha-mcp from source on its own cadence (HA_MCP_BUILD_VERSION), unrelated to
+    # the ha-mcp/ha-mcp-dev PyPI counters — comparing them yields false
+    # positives/negatives. Non-add-on deployments (pip / Docker / stdio) report a
+    # real PyPI version and take the PyPI path below.
+    if is_running_in_addon():
+        return _resolve_from_supervisor()
     current = get_version()
     if current == "unknown":
         return None
     # A dev install (``.dev`` version) tracks the renamed ``ha-mcp-dev`` package;
-    # a stable install tracks ``ha-mcp``. Compare like-for-like so dev users get
-    # newer-dev-build parity with the add-on's dev channel.
+    # a stable install tracks ``ha-mcp``.
     package = _DEV_PACKAGE if is_dev_version(current) else _STABLE_PACKAGE
     latest = _fetch_latest_from_pypi(package)
     if latest is None:

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -44,6 +44,7 @@ from ._version import (
     is_dev_version,
     is_running_in_addon,
 )
+from .stdio_settings_sidecar import _TRUTHY  # shared HA_MCP_DISABLE_* truthy set
 
 logger = logging.getLogger(__name__)
 
@@ -70,16 +71,11 @@ class UpdateInfo:
 
 
 def _is_disabled() -> bool:
-    # Treat 0/false/no/off (and empty/unset) as NOT disabled, so a user who sets
-    # HA_MCP_DISABLE_UPDATE_CHECK=0 or =false to "keep it on" isn't surprised by
-    # any non-empty value silently disabling the check.
-    return os.environ.get(DISABLE_ENV, "").strip().lower() not in (
-        "",
-        "0",
-        "false",
-        "no",
-        "off",
-    )
+    # Reuse the shared _TRUTHY set so HA_MCP_DISABLE_UPDATE_CHECK parses
+    # identically to the sibling HA_MCP_DISABLE_SETTINGS_UI flag: only a truthy
+    # value disables; 0/false/no/off/blank (and anything unrecognized) keep the
+    # check enabled, so a user who sets =0 to "keep it on" isn't surprised.
+    return os.environ.get(DISABLE_ENV, "").strip().lower() in _TRUTHY
 
 
 def _is_newer(latest: str, current: str) -> bool:

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -62,7 +62,16 @@ class UpdateInfo:
 
 
 def _is_disabled() -> bool:
-    return bool(os.environ.get(DISABLE_ENV))
+    # Treat 0/false/no/off (and empty/unset) as NOT disabled, so a user who sets
+    # HA_MCP_DISABLE_UPDATE_CHECK=0 or =false to "keep it on" isn't surprised by
+    # any non-empty value silently disabling the check.
+    return os.environ.get(DISABLE_ENV, "").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+    )
 
 
 def _is_newer(latest: str, current: str) -> bool:
@@ -148,7 +157,14 @@ async def get_update_field() -> dict[str, str | bool] | None:
     so the shaping and event-loop offload live in one place.
     """
     try:
-        info = await asyncio.to_thread(get_update_info)
+        # Once the lru_cache is warm (normally at startup), the result is a
+        # sub-microsecond cache hit, so call it directly. Only the cold first
+        # call — which may hit PyPI — is offloaded to a thread so it can't block
+        # the event loop.
+        if get_update_info.cache_info().currsize > 0:
+            info = get_update_info()
+        else:
+            info = await asyncio.to_thread(get_update_info)
     except Exception as err:  # pragma: no cover - defensive
         logger.debug("ha-mcp self-update check skipped: %s", err)
         return None

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -80,8 +80,8 @@ _SKIP_CEILING_PER_LANE = {
     # Baselines are the observed skip counts as of 2026-05-22 (container=46,
     # haos=14, haos_inaddon=39 from the prose above), plus this PR's new
     # marker-gated skips, plus a 5-9 growth buffer.
-    "container": 62,  # was 55 (observed 57 with the 5 addon tests added)
-    "haos": 29,  # 14 + 5 addon-test + 5 sidecar skips = 24, + buffer
+    "container": 65,  # was 62; +3 self-update-notice inaddon tests (@inaddon_only, skip here)
+    "haos": 32,  # was 29; +3 self-update-notice inaddon tests (@inaddon_only, skip here)
     "haos_inaddon": 58,  # was 55; +3 self-update notice tests (TestSelfUpdateNoticeSurfacedInTools, @external_only)
 }
 

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -82,7 +82,7 @@ _SKIP_CEILING_PER_LANE = {
     # marker-gated skips, plus a 5-9 growth buffer.
     "container": 62,  # was 55 (observed 57 with the 5 addon tests added)
     "haos": 29,  # 14 + 5 addon-test + 5 sidecar skips = 24, + buffer
-    "haos_inaddon": 55,  # 44 + 3 new auto-backup diff tests (TestAutomationDiff, @external_only) + buffer
+    "haos_inaddon": 58,  # was 55; +3 self-update notice tests (TestSelfUpdateNoticeSurfacedInTools, @external_only)
 }
 
 

--- a/tests/src/e2e/workflows/system/test_self_update_notice.py
+++ b/tests/src/e2e/workflows/system/test_self_update_notice.py
@@ -13,9 +13,11 @@ and ``latest`` is a known constant. The lru-cached check is cleared so the next
 call re-resolves with the patched fetch.
 
 External-only: the monkeypatch reaches the server only when it runs in-process
-(testcontainer / HAOS external). In inaddon mode ``mcp_client`` is an HTTP
-transport into a separate addon container the test process can't patch — and the
-add-on is auto-updated by the Supervisor there anyway.
+(testcontainer / HAOS external), where the running version is a PyPI version. In
+inaddon mode ``mcp_client`` is an HTTP transport into a separate add-on container
+the test process can't patch, AND the add-on takes a different code path (it
+sources the notice from the Supervisor add-on store, not PyPI). The inaddon path
+is covered by ``test_self_update_notice_inaddon.py``.
 """
 
 from __future__ import annotations

--- a/tests/src/e2e/workflows/system/test_self_update_notice.py
+++ b/tests/src/e2e/workflows/system/test_self_update_notice.py
@@ -1,0 +1,89 @@
+"""E2E tests for the self-update notice (``ha_mcp_update``) across status tools.
+
+The standalone channels (pip / Docker / stdio) have no Supervisor-driven
+auto-update, so the server surfaces a newer-release notice via
+``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates``. These tests
+exercise the real MCP client -> server -> tool -> ``update_check`` path against a
+live HA and assert the field actually reaches the response.
+
+Determinism without timing or a live PyPI dependency: the in-process server's
+``_fetch_latest_from_pypi`` is monkeypatched to return a version far higher than
+anything the test build could be running, so ``update_available`` is always true
+and ``latest`` is a known constant. The lru-cached check is cleared so the next
+call re-resolves with the patched fetch.
+
+External-only: the monkeypatch reaches the server only when it runs in-process
+(testcontainer / HAOS external). In inaddon mode ``mcp_client`` is an HTTP
+transport into a separate addon container the test process can't patch — and the
+add-on is auto-updated by the Supervisor there anyway.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from ha_mcp import update_check
+
+from ...utilities.assertions import MCPAssertions
+
+pytestmark = [pytest.mark.external_only]
+
+logger = logging.getLogger(__name__)
+
+# Far above any real or dev build version, so ``_is_newer`` is always true
+# regardless of what the test build reports as its current version.
+_FAKE_LATEST = "99.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_memo():
+    """Clear the process-wide update-check memo after each test.
+
+    ``get_update_info`` is ``lru_cache``-memoized for the process; without this a
+    patched ``99.0.0`` result would leak into other e2e tests sharing the
+    in-process server.
+    """
+    yield
+    update_check.get_update_info.cache_clear()
+
+
+@pytest.mark.system
+class TestSelfUpdateNoticeSurfacedInTools:
+    """Every status surface carries ``ha_mcp_update`` when an update is available."""
+
+    @pytest.mark.parametrize(
+        "tool,args",
+        [
+            ("ha_get_overview", {}),
+            ("ha_get_system_health", {}),
+            ("ha_get_updates", {}),
+        ],
+    )
+    async def test_update_available_surfaced(
+        self,
+        mcp_client,
+        monkeypatch: pytest.MonkeyPatch,
+        tool: str,
+        args: dict,
+    ) -> None:
+        monkeypatch.delenv("HA_MCP_DISABLE_UPDATE_CHECK", raising=False)
+        # Patch the in-process server's PyPI fetch to a version guaranteed newer
+        # than whatever this build reports, then clear the memo so the next tool
+        # call re-resolves through the patched fetch.
+        monkeypatch.setattr(
+            update_check, "_fetch_latest_from_pypi", lambda _package: _FAKE_LATEST
+        )
+        update_check.get_update_info.cache_clear()
+
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(tool, args)
+
+        assert "ha_mcp_update" in result, (
+            f"{tool} did not surface ha_mcp_update: {sorted(result)}"
+        )
+        update = result["ha_mcp_update"]
+        assert update["latest"] == _FAKE_LATEST
+        assert update["update_available"] is True
+        assert isinstance(update["current"], str) and update["current"]

--- a/tests/src/e2e/workflows/system/test_self_update_notice_inaddon.py
+++ b/tests/src/e2e/workflows/system/test_self_update_notice_inaddon.py
@@ -1,0 +1,45 @@
+"""Inaddon E2E for the self-update notice — the add-on (Supervisor-store) path.
+
+The HA add-on (stable AND dev) is built from source and updated via the
+Supervisor add-on store, so its update notice is sourced from
+``GET /addons/self/info`` (``version`` / ``version_latest`` / ``update_available``
+on the add-on's own counter), NOT PyPI. This test exercises that real path: it
+calls the status tools over the running dev add-on's HTTP MCP endpoint and
+asserts each carries a well-formed ``ha_mcp_update`` object.
+
+It asserts presence + shape, not a forced ``update_available`` value (that
+reflects the real add-on store; after the lane updates the add-on to the PR
+version it is typically up to date). The value-mapping logic is unit-tested in
+``test_update_check.py`` (TestAddonSupervisorSource); the complementary
+``test_self_update_notice.py`` covers the PyPI path on the external/container
+lanes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ...utilities.assertions import MCPAssertions
+
+pytestmark = [pytest.mark.inaddon_only, pytest.mark.system]
+
+
+@pytest.mark.parametrize(
+    "tool", ["ha_get_overview", "ha_get_system_health", "ha_get_updates"]
+)
+async def test_dev_addon_surfaces_update_field_from_supervisor(
+    mcp_client, tool: str
+) -> None:
+    async with MCPAssertions(mcp_client) as mcp:
+        result = await mcp.call_tool_success(tool, {})
+
+    # Anti-vacuous: the tool really ran and returned its normal payload.
+    assert isinstance(result, dict) and result, f"{tool} returned no payload"
+    assert "ha_mcp_update" in result, (
+        f"{tool} did not surface ha_mcp_update on the dev add-on "
+        f"(it should come from Supervisor /addons/self/info): {sorted(result)}"
+    )
+    update = result["ha_mcp_update"]
+    assert isinstance(update.get("current"), str) and update["current"]
+    assert isinstance(update.get("latest"), str) and update["latest"]
+    assert isinstance(update.get("update_available"), bool)

--- a/tests/src/unit/conftest.py
+++ b/tests/src/unit/conftest.py
@@ -87,5 +87,6 @@ def _clear_update_check_memo():
 
         get_update_info.cache_clear()
     except ImportError:
+        # ha_mcp not importable in this test run; nothing to clear.
         pass
     yield

--- a/tests/src/unit/conftest.py
+++ b/tests/src/unit/conftest.py
@@ -50,3 +50,42 @@ def _unit_test_default_auto_backup_off():
         os.environ.pop("ENABLE_AUTO_BACKUP", None)
     else:
         os.environ["ENABLE_AUTO_BACKUP"] = previous
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _unit_test_disable_update_check():
+    """Disable the PyPI self-update check for the unit-test process.
+
+    The status tools and ``_log_startup_version`` call
+    ``update_check.get_update_info``, which would otherwise reach out to
+    pypi.org during unrelated unit tests (flaky, slow, and network-coupled).
+    Set ``HA_MCP_DISABLE_UPDATE_CHECK`` once at session start; the dedicated
+    ``test_update_check.py`` / banner tests opt back in via ``monkeypatch``
+    (``delenv`` or by patching ``get_update_info``/``get_update_field``
+    directly), which reverts on teardown.
+    """
+    previous = os.environ.get("HA_MCP_DISABLE_UPDATE_CHECK")
+    os.environ["HA_MCP_DISABLE_UPDATE_CHECK"] = "1"
+    yield
+    if previous is None:
+        os.environ.pop("HA_MCP_DISABLE_UPDATE_CHECK", None)
+    else:
+        os.environ["HA_MCP_DISABLE_UPDATE_CHECK"] = previous
+
+
+@pytest.fixture(autouse=True)
+def _clear_update_check_memo():
+    """Clear ``get_update_info``'s in-memory ``lru_cache`` before each test.
+
+    ``get_update_info`` memoizes its result process-wide (the check runs once per
+    process, no disk). Without clearing, a result memoized by ``test_update_check``
+    (which opts back into the check) would leak into unrelated tests in the same
+    process. Cleared before each test so every test starts from a cold memo.
+    """
+    try:
+        from ha_mcp.update_check import get_update_info
+
+        get_update_info.cache_clear()
+    except ImportError:
+        pass
+    yield

--- a/tests/src/unit/test_overview_system_info.py
+++ b/tests/src/unit/test_overview_system_info.py
@@ -546,6 +546,86 @@ class TestHaGetOverviewReadOnlyMode:
         assert "Read Only Mode is ON" in result.get("read_only_mode_hint", "")
 
 
+class TestHaGetOverviewHaMcpUpdate:
+    """ha_get_overview surfaces the MCP server's own update status."""
+
+    @pytest.fixture
+    def mock_mcp(self):
+        mcp = MagicMock()
+        self.registered_tools: dict = {}
+
+        def tool_decorator(*args, **kwargs):
+            def wrapper(func):
+                self.registered_tools[func.__name__] = func
+                return func
+
+            return wrapper
+
+        mcp.tool = tool_decorator
+        return mcp
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.base_url = "http://localhost:8123"
+        client.get_config = AsyncMock(return_value={})
+        client.send_websocket_message = AsyncMock(return_value={"success": False})
+        return client
+
+    @pytest.fixture
+    def mock_smart_tools(self):
+        smart = MagicMock()
+        smart.get_system_overview = AsyncMock(return_value={"success": True})
+        return smart
+
+    @pytest.fixture
+    def overview_tool(self, mock_mcp, mock_client, mock_smart_tools):
+        register_search_tools(mock_mcp, mock_client, smart_tools=mock_smart_tools)
+        return self.registered_tools["ha_get_overview"]
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_present_and_survives_projection(
+        self, overview_tool, monkeypatch
+    ):
+        """When a notice applies, ``ha_mcp_update`` is emitted AND survives a
+        narrow ``fields=["system_info"]`` projection (like ``settings_url`` /
+        ``read_only_mode``) so a minimal overview still surfaces it."""
+        from ha_mcp import update_check
+
+        monkeypatch.setattr(
+            update_check,
+            "get_update_field",
+            AsyncMock(
+                return_value={
+                    "current": "7.8.0",
+                    "latest": "7.9.0",
+                    "update_available": True,
+                }
+            ),
+        )
+        result = await overview_tool(fields=["system_info"])
+        assert "system_info" in result
+        assert result["ha_mcp_update"] == {
+            "current": "7.8.0",
+            "latest": "7.9.0",
+            "update_available": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_absent_when_check_not_applicable(
+        self, overview_tool, monkeypatch
+    ):
+        """No notice (dev/unknown/opt-out → ``get_update_field`` returns None) →
+        the key is omitted entirely, not emitted as null."""
+        from ha_mcp import update_check
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        result = await overview_tool(detail_level="minimal")
+        assert "ha_mcp_update" not in result
+
+
 class TestHaGetOverviewAlwaysEmittedKeys:
     """Keys advertised in the ``fields=`` docstring must always be in
     the result so ``fields=[<key>]`` never trips the ``project_fields``

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -46,6 +46,48 @@ def _make_client_that_fails_on_restart(exception):
     return mock_client
 
 
+class TestGetSystemHealthHaMcpUpdate:
+    """ha_get_system_health surfaces the MCP server's own update status."""
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_present_when_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from ha_mcp import update_check
+
+        monkeypatch.setattr(
+            update_check,
+            "get_update_field",
+            AsyncMock(
+                return_value={
+                    "current": "7.8.0",
+                    "latest": "7.9.0",
+                    "update_available": True,
+                }
+            ),
+        )
+        with _patch_health_info_baseline():
+            result = await SystemTools(AsyncMock()).ha_get_system_health()
+        assert result["ha_mcp_update"] == {
+            "current": "7.8.0",
+            "latest": "7.9.0",
+            "update_available": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_absent_when_not_applicable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from ha_mcp import update_check
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        with _patch_health_info_baseline():
+            result = await SystemTools(AsyncMock()).ha_get_system_health()
+        assert "ha_mcp_update" not in result
+
+
 class TestHaRestartErrorHandling:
     """Tests for ha_restart handling of expected errors during restart."""
 

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -18,6 +18,48 @@ from ha_mcp.tools.tools_updates import (
 )
 
 
+class TestListUpdatesHaMcpUpdate:
+    """ha_get_updates (list mode) surfaces the MCP server's own update status."""
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_present_when_available(self, monkeypatch):
+        from ha_mcp import update_check
+        from ha_mcp.tools.tools_updates import UpdateTools
+
+        monkeypatch.setattr(
+            update_check,
+            "get_update_field",
+            AsyncMock(
+                return_value={
+                    "current": "7.8.0",
+                    "latest": "7.9.0",
+                    "update_available": True,
+                }
+            ),
+        )
+        client = MagicMock()
+        client.get_states = AsyncMock(return_value=[])
+        result = await UpdateTools(client).ha_get_updates()
+        assert result["ha_mcp_update"] == {
+            "current": "7.8.0",
+            "latest": "7.9.0",
+            "update_available": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_ha_mcp_update_absent_when_not_applicable(self, monkeypatch):
+        from ha_mcp import update_check
+        from ha_mcp.tools.tools_updates import UpdateTools
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        client = MagicMock()
+        client.get_states = AsyncMock(return_value=[])
+        result = await UpdateTools(client).ha_get_updates()
+        assert "ha_mcp_update" not in result
+
+
 class TestCategorizeUpdate:
     """Test _categorize_update function."""
 

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -24,8 +24,11 @@ def _isolate(monkeypatch: pytest.MonkeyPatch):
 
     The real ``is_dev_version`` is left in place (it just inspects the string),
     so a test can flip the channel simply by setting ``get_version``.
+    ``SUPERVISOR_TOKEN`` is cleared so the default path is non-add-on (PyPI);
+    add-on tests set it explicitly.
     """
     monkeypatch.delenv(update_check.DISABLE_ENV, raising=False)
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
     monkeypatch.setattr(update_check, "get_version", lambda: "7.8.0")
     get_update_info.cache_clear()
     yield
@@ -104,15 +107,24 @@ class TestGetUpdateInfoGating:
         else:
             assert result is None  # disabled
 
-    def test_addon_env_does_not_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The add-on no longer suppresses the check itself — only the startup
-        banner is add-on-suppressed (in __main__). The in-chat tool fields must
-        still surface the notice for an add-on user who missed the Supervisor
-        prompt, so SUPERVISOR_TOKEN being set must NOT zero out the result."""
+    def test_addon_sources_from_supervisor_not_pypi(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In the add-on the check reads the Supervisor add-on store, never PyPI
+        (whose counter is unrelated to the add-on's own version)."""
         monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
-        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.9.0")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
+        monkeypatch.setattr(
+            update_check,
+            "_fetch_supervisor_addon_info",
+            lambda: {
+                "version": "7.8.0.dev443",
+                "version_latest": "7.8.0.dev450",
+                "update_available": True,
+            },
+        )
         info = get_update_info()
-        assert info is not None and info.update_available is True
+        assert info == UpdateInfo("7.8.0.dev443", "7.8.0.dev450", True)
 
 
 class TestGetUpdateInfoChannels:
@@ -175,6 +187,119 @@ class TestGetUpdateInfoChannels:
         monkeypatch.setattr(update_check, "get_version", boom)
         get_update_info.cache_clear()
         assert get_update_info() is None
+
+
+class TestAddonSupervisorSource:
+    """In the add-on (stable OR dev), the update reference is the Supervisor
+    add-on store (same counter as the installed add-on), not PyPI."""
+
+    def test_dev_addon_update_from_supervisor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dev add-on gets a real 'you're on X, Y is out' from the store."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        monkeypatch.setattr(update_check, "get_version", lambda: "7.8.0.dev443")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
+        monkeypatch.setattr(
+            update_check,
+            "_fetch_supervisor_addon_info",
+            lambda: {
+                "version": "7.8.0.dev443",
+                "version_latest": "7.8.0.dev450",
+                "update_available": True,
+            },
+        )
+        info = get_update_info()
+        assert info == UpdateInfo("7.8.0.dev443", "7.8.0.dev450", True)
+
+    def test_addon_up_to_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
+        monkeypatch.setattr(
+            update_check,
+            "_fetch_supervisor_addon_info",
+            lambda: {
+                "version": "7.8.1",
+                "version_latest": "7.8.1",
+                "update_available": False,
+            },
+        )
+        info = get_update_info()
+        assert info is not None and info.update_available is False
+
+    def test_addon_supervisor_unreachable_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        monkeypatch.setattr(update_check, "_fetch_supervisor_addon_info", lambda: None)
+        assert get_update_info() is None
+
+    def test_addon_disable_env_short_circuits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The opt-out is honored before any add-on source is consulted."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        monkeypatch.setenv(update_check.DISABLE_ENV, "1")
+
+        def boom() -> dict | None:
+            raise AssertionError("disabled check must not consult Supervisor")
+
+        monkeypatch.setattr(update_check, "_fetch_supervisor_addon_info", boom)
+        assert get_update_info() is None
+
+    def test_dev_non_addon_still_uses_pypi(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Docker :dev / pip ha-mcp-dev (a .dev version, NO add-on token) IS a real
+        PyPI version, so it stays on the PyPI path against ha-mcp-dev."""
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setattr(update_check, "get_version", lambda: "7.8.0.dev443")
+        monkeypatch.setattr(
+            update_check, "_fetch_latest_from_pypi", lambda _p: "7.8.0.dev500"
+        )
+        info = get_update_info()
+        assert info is not None and info.update_available is True
+
+
+class TestFetchSupervisorAddonInfo:
+    """The Supervisor /addons/self/info fetch: envelope handling + fail-silent."""
+
+    def test_unwraps_data_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "tok")
+
+        class FakeResp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {
+                    "result": "ok",
+                    "data": {
+                        "version": "1",
+                        "version_latest": "2",
+                        "update_available": True,
+                    },
+                }
+
+        monkeypatch.setattr(update_check.httpx, "get", lambda *a, **k: FakeResp())
+        assert update_check._fetch_supervisor_addon_info() == {
+            "version": "1",
+            "version_latest": "2",
+            "update_available": True,
+        }
+
+    def test_no_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        assert update_check._fetch_supervisor_addon_info() is None
+
+    def test_http_error_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "tok")
+
+        def boom(*a: object, **k: object) -> object:
+            raise httpx.ConnectError("no supervisor")
+
+        monkeypatch.setattr(update_check.httpx, "get", boom)
+        assert update_check._fetch_supervisor_addon_info() is None
 
 
 class TestInMemoryMemo:

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -1,0 +1,259 @@
+"""Unit tests for ha_mcp.update_check — the self-update notifier."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ha_mcp import update_check
+from ha_mcp.update_check import (
+    UpdateInfo,
+    _is_newer,
+    get_update_info,
+    update_command_hint,
+)
+
+
+def _no_network(package: str) -> str | None:
+    raise AssertionError("_fetch_latest_from_pypi should not be called on this path")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch):
+    """Default every test to: enabled, stable 7.8.0, fresh in-memory memo.
+
+    The real ``is_dev_version`` is left in place (it just inspects the string),
+    so a test can flip the channel simply by setting ``get_version``.
+    """
+    monkeypatch.delenv(update_check.DISABLE_ENV, raising=False)
+    monkeypatch.setattr(update_check, "get_version", lambda: "7.8.0")
+    get_update_info.cache_clear()
+    yield
+    get_update_info.cache_clear()
+
+
+class TestVersionCompare:
+    """PEP 440 comparison — correctness across both the stable and dev channels."""
+
+    @pytest.mark.parametrize(
+        "latest,current,expected",
+        [
+            ("7.8.1", "7.8.0", True),
+            ("7.9.0", "7.8.5", True),
+            ("7.10.0", "7.9.0", True),  # numeric, not lexical (".10" > ".9")
+            ("7.8.0", "7.8.0", False),
+            ("7.8.0", "7.8.1", False),
+            # dev channel ordering
+            ("7.8.0.dev720", "7.8.0.dev714", True),
+            ("7.8.0.dev714", "7.8.0.dev714", False),
+            ("7.8.0", "7.8.0.dev714", True),  # final release > its dev builds
+            ("7.8.0.dev714", "7.8.0", False),
+            ("7.9.0.dev1", "7.8.0", True),  # next minor's dev > prior final
+        ],
+    )
+    def test_is_newer(self, latest: str, current: str, expected: bool) -> None:
+        assert _is_newer(latest, current) is expected
+
+    @pytest.mark.parametrize("bad", ["unknown", "garbage", "7.x", ""])
+    def test_unparseable_is_never_newer(self, bad: str) -> None:
+        assert _is_newer(bad, "7.8.0") is False
+        assert _is_newer("7.8.0", bad) is False
+
+
+class TestGetUpdateInfoGating:
+    """No-op (no network) for the excluded cases."""
+
+    def test_disabled_env_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(update_check.DISABLE_ENV, "1")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
+        assert get_update_info() is None
+
+    def test_unknown_version_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "get_version", lambda: "unknown")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
+        assert get_update_info() is None
+
+    def test_addon_env_does_not_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The add-on no longer suppresses the check itself — only the startup
+        banner is add-on-suppressed (in __main__). The in-chat tool fields must
+        still surface the notice for an add-on user who missed the Supervisor
+        prompt, so SUPERVISOR_TOKEN being set must NOT zero out the result."""
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.9.0")
+        info = get_update_info()
+        assert info is not None and info.update_available is True
+
+
+class TestGetUpdateInfoChannels:
+    """Stable vs dev: each channel compares against its own PyPI package."""
+
+    def test_stable_install_queries_ha_mcp_and_reports_update(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, str] = {}
+
+        def fetch(package: str) -> str | None:
+            captured["package"] = package
+            return "7.9.0"
+
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+        info = get_update_info()
+        assert captured["package"] == "ha-mcp"
+        assert info == UpdateInfo("7.8.0", "7.9.0", True)
+
+    def test_dev_install_queries_ha_mcp_dev_and_reports_update(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dev parity: a ``.dev`` install compares against the ``ha-mcp-dev``
+        package and surfaces newer dev builds (matching the add-on dev channel)."""
+        captured: dict[str, str] = {}
+
+        def fetch(package: str) -> str | None:
+            captured["package"] = package
+            return "7.8.0.dev720"
+
+        monkeypatch.setattr(update_check, "get_version", lambda: "7.8.0.dev714")
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+        get_update_info.cache_clear()
+        info = get_update_info()
+        assert captured["package"] == "ha-mcp-dev"
+        assert info == UpdateInfo("7.8.0.dev714", "7.8.0.dev720", True)
+
+    def test_up_to_date_reports_not_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.8.0")
+        info = get_update_info()
+        assert info is not None and info.update_available is False
+
+    def test_network_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: None)
+        assert get_update_info() is None
+
+    def test_never_raises_on_unexpected_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contract backstop: an unexpected helper failure degrades to None so
+        the unguarded startup-banner call can never break server startup."""
+
+        def boom() -> str:
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(update_check, "get_version", boom)
+        get_update_info.cache_clear()
+        assert get_update_info() is None
+
+
+class TestInMemoryMemo:
+    """The check runs once per process (memoized), not on every call."""
+
+    def test_memoized_until_cleared(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def fetch(package: str) -> str | None:
+            calls.append(package)
+            return "7.9.0"
+
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", fetch)
+        get_update_info()
+        get_update_info()
+        assert len(calls) == 1  # second call reused the in-memory result
+        get_update_info.cache_clear()
+        get_update_info()
+        assert len(calls) == 2  # re-checked after cache_clear
+
+
+class TestFetchLatestFromPypi:
+    """The PyPI fetch itself — correct package URL, fail-silent on any error."""
+
+    def test_parses_info_version_for_package(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict[str, str] = {}
+
+        class FakeResp:
+            def raise_for_status(self) -> None: ...
+
+            def json(self) -> dict:
+                return {"info": {"version": "7.8.0.dev720"}}
+
+        def fake_get(url: str, **kwargs: object) -> FakeResp:
+            seen["url"] = url
+            return FakeResp()
+
+        monkeypatch.setattr(update_check.httpx, "get", fake_get)
+        assert update_check._fetch_latest_from_pypi("ha-mcp-dev") == "7.8.0.dev720"
+        assert seen["url"] == "https://pypi.org/pypi/ha-mcp-dev/json"
+
+    def test_http_error_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*a: object, **k: object) -> object:
+            raise httpx.ConnectError("no network")
+
+        monkeypatch.setattr(update_check.httpx, "get", boom)
+        assert update_check._fetch_latest_from_pypi("ha-mcp") is None
+
+    def test_malformed_payload_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeResp:
+            def raise_for_status(self) -> None: ...
+
+            def json(self) -> dict:
+                return {"info": {}}  # missing "version" -> KeyError -> None
+
+        monkeypatch.setattr(update_check.httpx, "get", lambda *a, **k: FakeResp())
+        assert update_check._fetch_latest_from_pypi("ha-mcp") is None
+
+
+class TestGetUpdateField:
+    """The async tool-facing helper: shapes the dict and never raises."""
+
+    async def test_returns_dict_when_update_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.9.0")
+        field = await update_check.get_update_field()
+        assert field == {
+            "current": "7.8.0",
+            "latest": "7.9.0",
+            "update_available": True,
+        }
+
+    async def test_returns_none_when_not_applicable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(update_check.DISABLE_ENV, "1")
+        assert await update_check.get_update_field() is None
+
+    async def test_swallows_unexpected_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom() -> UpdateInfo | None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(update_check, "get_update_info", boom)
+        assert await update_check.get_update_field() is None
+
+
+class TestUpdateCommandHint:
+    """Deployment- and channel-aware upgrade hint."""
+
+    def test_stable_pip_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "_running_in_docker", lambda: False)
+        assert update_command_hint("7.9.0") == "Upgrade with: pip install -U ha-mcp."
+
+    def test_dev_pip_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "_running_in_docker", lambda: False)
+        assert "pip install -U ha-mcp-dev" in update_command_hint("7.8.0.dev720")
+
+    def test_stable_docker_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "_running_in_docker", lambda: True)
+        assert "ha-mcp:stable" in update_command_hint("7.9.0")
+
+    def test_dev_docker_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_check, "_running_in_docker", lambda: True)
+        assert "ha-mcp:dev" in update_command_hint("7.8.0.dev720")

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -176,7 +176,8 @@ class TestFetchLatestFromPypi:
         seen: dict[str, str] = {}
 
         class FakeResp:
-            def raise_for_status(self) -> None: ...
+            def raise_for_status(self) -> None:
+                pass
 
             def json(self) -> dict:
                 return {"info": {"version": "7.8.0.dev720"}}
@@ -200,7 +201,8 @@ class TestFetchLatestFromPypi:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         class FakeResp:
-            def raise_for_status(self) -> None: ...
+            def raise_for_status(self) -> None:
+                pass
 
             def json(self) -> dict:
                 return {"info": {}}  # missing "version" -> KeyError -> None

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -75,6 +75,35 @@ class TestGetUpdateInfoGating:
         monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", _no_network)
         assert get_update_info() is None
 
+    @pytest.mark.parametrize(
+        "val,enabled",
+        [
+            ("1", False),
+            ("true", False),
+            ("TRUE", False),
+            ("yes", False),
+            ("on", False),
+            ("0", True),
+            ("false", True),
+            ("no", True),
+            ("off", True),
+            ("   ", True),
+        ],
+    )
+    def test_disable_env_parses_falsy_values(
+        self, monkeypatch: pytest.MonkeyPatch, val: str, enabled: bool
+    ) -> None:
+        """HA_MCP_DISABLE_UPDATE_CHECK=0/false/no/off (or blank) keeps the check
+        ENABLED — only truthy values disable it, so a user setting =0/=false to
+        'keep it on' isn't surprised."""
+        monkeypatch.setenv(update_check.DISABLE_ENV, val)
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.9.0")
+        result = get_update_info()
+        if enabled:
+            assert result is not None  # the check ran
+        else:
+            assert result is None  # disabled
+
     def test_addon_env_does_not_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The add-on no longer suppresses the check itself — only the startup
         banner is add-on-suppressed (in __main__). The in-chat tool fields must
@@ -234,6 +263,12 @@ class TestGetUpdateField:
     async def test_swallows_unexpected_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        import functools
+
+        # lru_cache so get_update_field's cache_info() check works; it never
+        # caches (the call raises), so currsize stays 0 -> the to_thread path
+        # runs it and the error is swallowed.
+        @functools.lru_cache(maxsize=1)
         def boom() -> UpdateInfo | None:
             raise RuntimeError("boom")
 

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 import pytest
 
@@ -399,6 +401,33 @@ class TestGetUpdateField:
 
         monkeypatch.setattr(update_check, "get_update_info", boom)
         assert await update_check.get_update_field() is None
+
+    async def test_warm_cache_skips_thread_offload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once the memo is warm (currsize > 0 — the common post-startup case),
+        get_update_field calls get_update_info directly and must NOT offload to a
+        thread (only the cold first call does)."""
+        monkeypatch.setattr(update_check, "_fetch_latest_from_pypi", lambda _p: "7.9.0")
+        # Prime the memo so the warm branch is the one exercised below.
+        assert update_check.get_update_info() is not None
+        assert update_check.get_update_info.cache_info().currsize == 1
+
+        offloaded = False
+
+        async def tracking_to_thread(func: Any) -> Any:
+            nonlocal offloaded
+            offloaded = True
+            return func()
+
+        monkeypatch.setattr(update_check.asyncio, "to_thread", tracking_to_thread)
+        field = await update_check.get_update_field()
+        assert offloaded is False, "warm cache must not offload to a thread"
+        assert field == {
+            "current": "7.8.0",
+            "latest": "7.9.0",
+            "update_available": True,
+        }
 
 
 class TestUpdateCommandHint:

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -259,3 +259,12 @@ class TestUpdateCommandHint:
     def test_dev_docker_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(update_check, "_running_in_docker", lambda: True)
         assert "ha-mcp:dev" in update_command_hint("7.8.0.dev720")
+
+    def test_addon_hint_points_to_supervisor_ui(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In the add-on, the hint points at the Supervisor UI, not pip/docker."""
+        monkeypatch.setattr(update_check, "is_running_in_addon", lambda: True)
+        hint = update_command_hint("7.9.0")
+        assert "Add-ons" in hint
+        assert "pip install" not in hint and "docker pull" not in hint

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -143,6 +143,8 @@ class TestLogStartupVersion:
     ) -> None:
         monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0")
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        # Disable the self-update check so this dev-banner test stays offline.
+        monkeypatch.setenv("HA_MCP_DISABLE_UPDATE_CHECK", "1")
         self._call(caplog)
         info_messages = [
             r.getMessage() for r in caplog.records if r.levelno == logging.INFO
@@ -180,14 +182,81 @@ class TestLogStartupVersion:
         # Version line still fires — add-on users should still see what they're running.
         assert any("7.3.0.dev42" in msg for msg in info_messages), info_messages
 
-    def test_stable_version_never_emits_banner(
+    def test_stable_version_never_emits_dev_banner(
         self,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Guard against an inverted is_dev_version check leaking the banner to stable users."""
+        """Guard against an inverted is_dev_version check leaking the dev-channel
+        banner to stable users. The self-update check is disabled here so this
+        stays focused on the dev banner (the update banner has its own tests)."""
         monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.3.0")
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setenv("HA_MCP_DISABLE_UPDATE_CHECK", "1")
+        self._call(caplog)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+
+    def test_stable_emits_update_banner_when_newer_available(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A standalone stable install with a newer PyPI release gets an
+        update banner (the dev-channel banner stays silent)."""
+        from ha_mcp import update_check
+
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.8.0")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setattr(
+            update_check,
+            "get_update_info",
+            lambda: update_check.UpdateInfo("7.8.0", "7.9.0", True),
+        )
+        self._call(caplog)
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("available: 7.9.0" in m for m in warnings), warnings
+        assert not any("dev channel" in m for m in warnings), warnings
+
+    def test_stable_no_update_banner_when_current(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No banner when already on the latest stable."""
+        from ha_mcp import update_check
+
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.9.0")
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setattr(
+            update_check,
+            "get_update_info",
+            lambda: update_check.UpdateInfo("7.9.0", "7.9.0", False),
+        )
+        self._call(caplog)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+
+    def test_update_banner_suppressed_under_supervisor_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The startup banner is add-on-suppressed even when an update IS
+        available — the in-chat tool fields carry the notice for add-on users
+        instead, so the log stays quiet (Supervisor already prompts there)."""
+        from ha_mcp import update_check
+
+        monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.8.0")
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
+        # Even if a check would report an update, the add-on early-return wins.
+        monkeypatch.setattr(
+            update_check,
+            "get_update_info",
+            lambda: update_check.UpdateInfo("7.8.0", "7.9.0", True),
+        )
         self._call(caplog)
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings == []

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -100,6 +100,29 @@ class TestIsDevVersion:
         assert is_dev_version(version) is False
 
 
+class TestAddonStartLogsVersionBanner:
+    """The add-on must log the ha-mcp version + update banner at startup."""
+
+    def test_addon_start_invokes_log_startup_version(self) -> None:
+        """``homeassistant-addon/start.py`` runs its own startup (it does NOT go
+        through ``__main__.main_web``), so it must call ``_log_startup_version()``
+        itself — otherwise the ha-mcp version + self-update banner never reach the
+        add-on logs (only FastMCP's banner does, via ``run_async``). Regression
+        guard for that wiring."""
+        from pathlib import Path
+
+        start_py = (
+            Path(__file__).resolve().parents[3] / "homeassistant-addon" / "start.py"
+        )
+        source = start_py.read_text(encoding="utf-8")
+        assert "_log_startup_version" in source, (
+            "start.py must import _log_startup_version"
+        )
+        assert "_log_startup_version()" in source, (
+            "start.py must call _log_startup_version() during add-on startup"
+        )
+
+
 class TestIsRunningInAddon:
     """Tests for HA add-on environment detection."""
 

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -239,24 +239,29 @@ class TestLogStartupVersion:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings == []
 
-    def test_update_banner_suppressed_under_supervisor_token(
+    def test_update_banner_fires_under_supervisor_token(
         self,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """The startup banner is add-on-suppressed even when an update IS
-        available — the in-chat tool fields carry the notice for add-on users
-        instead, so the log stays quiet (Supervisor already prompts there)."""
+        """The update banner fires in the add-on too (copying FastMCP, which
+        announces on every startup regardless of deployment) — an add-on user who
+        ignored the Supervisor prompt still sees it in the logs. The add-on
+        upgrade hint points at the Supervisor UI, not pip/docker."""
         from ha_mcp import update_check
 
         monkeypatch.setenv("HA_MCP_BUILD_VERSION", "7.8.0")
         monkeypatch.setenv("SUPERVISOR_TOKEN", "hassio-abc")
-        # Even if a check would report an update, the add-on early-return wins.
         monkeypatch.setattr(
             update_check,
             "get_update_info",
             lambda: update_check.UpdateInfo("7.8.0", "7.9.0", True),
         )
         self._call(caplog)
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert warnings == []
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("available: 7.9.0" in m for m in warnings), warnings
+        # add-on upgrade hint, not the dev-channel banner (suppressed in add-on)
+        assert any("Settings -> Add-ons" in m for m in warnings), warnings
+        assert not any("dev channel" in m for m in warnings), warnings

--- a/uv.lock
+++ b/uv.lock
@@ -464,12 +464,13 @@ wheels = [
 
 [[package]]
 name = "ha-mcp"
-version = "7.8.0"
+version = "7.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx", extra = ["socks"] },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-monty" },
     { name = "python-dotenv" },
@@ -504,6 +505,7 @@ requires-dist = [
     { name = "cryptography", specifier = "==49.0.0" },
     { name = "fastmcp", specifier = "==3.4.2" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-monty", specifier = "==0.0.18" },
     { name = "python-dotenv", specifier = "==1.2.2" },


### PR DESCRIPTION
## What does this PR do?

Surfaces a self-update notice so an operator learns when a newer ha-mcp release is out — a startup log banner plus an `ha_mcp_update` object (`{current, latest, update_available}`) on `ha_get_overview`, `ha_get_system_health`, and `ha_get_updates`. Fail-silent, memoized once per process; opt out with `HA_MCP_DISABLE_UPDATE_CHECK`.

The comparison source matches how ha-mcp is deployed (the running version only means something against the matching reference):

- **pip / Docker / stdio** — the running version is a PyPI version, compared against PyPI (`ha-mcp` for stable, `ha-mcp-dev` for dev), PEP 440 ordering.
- **HA add-on (stable and dev)** — built from source on the add-on's own version counter, so it reads `version` / `version_latest` / `update_available` from the Supervisor add-on store (`GET /addons/self/info`) — the same counter — and correctly announces "you're on X, Y is out" in the banner and the tool fields.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit: `test_update_check.py` (PyPI + Supervisor-store paths, version compare, opt-out, fail-silent) + per-tool integration tests + startup-banner tests. E2E: `test_self_update_notice.py` (`external_only`, PyPI path) and `test_self_update_notice_inaddon.py` (`inaddon_only`, asserts the dev add-on surfaces the field from Supervisor). ruff + mypy clean.

## Checklist
- [x] I have updated documentation if needed
