### PR TITLE
docs(internal): refresh ha_manage_addon ESPHome dashboard guidance

### DIFF
--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -93,8 +93,8 @@ def _addon_write(args: dict[str, Any]) -> str | None:
         return "array_patch modification"
     if args.get("websocket"):
         # A WebSocket session's initial message can command mutations
-        # (e.g. ESPHome /compile), so it is not statically classifiable
-        # as a read — fail closed.
+        # (e.g. an ESPHome firmware/compile or devices/update_config command),
+        # so it is not statically classifiable as a read — fail closed.
         return "WebSocket proxy session"
     method = str(args.get("method") or "GET").strip().upper()
     if method != "GET":

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -2622,7 +2622,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         body: Annotated[
             dict[str, Any] | str | None,
             Field(
-                description="Proxy mode only. Request body for POST/PUT/PATCH. Pass a JSON object or JSON string.",
+                description="Proxy mode only. Request body for POST/PUT/PATCH — or, with websocket=True, the initial WebSocket message. Pass a JSON object or JSON string.",
                 default=None,
             ),
         ] = None,
@@ -2844,18 +2844,21 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
 
         **ESPHome Device Builder dashboard (current rewrite):** config and log
         access is a WebSocket JSON-command API, NOT REST. The legacy endpoints
-        (`GET /edit?configuration=`, and the `/compile` `/validate` `/logs`
-        WebSocket paths taking `{"type": "spawn", ...}` bodies) are gone — they
-        now return the dashboard SPA. Use instead:
+        are gone — `GET /edit?configuration=` now returns the dashboard SPA, and
+        the old `/compile` `/validate` `/logs` WebSocket paths (which took
+        `{"type": "spawn", ...}` bodies) reject the upgrade (HTTP 200). Use
+        instead:
         - HTTP `GET /devices` → JSON list of configured devices; each entry's
           `configuration` field is the YAML filename to pass below.
         - WebSocket `path="/ws"` with body
           `{"command": "<cmd>", "message_id": "1", "args": {...}}`. The server
           sends a `server_info` message first, then one reply per `message_id`.
-          Useful commands: `devices/get_config` `{configuration}` → raw YAML
-          (in the reply's `result`); `devices/update_config` `{configuration,
-          content}` → save; `devices/logs` (stream) `{configuration, port:
-          "OTA"}` → live device logs; `devices/validate`; `firmware/compile`.
+          Wire-confirmed commands: `devices/get_config` `{configuration}` → raw
+          YAML (in the reply's `result`); `devices/logs` (stream)
+          `{configuration, port: "OTA"}` → live device logs. Also exposed by the
+          dashboard frontend (command/arg names not wire-tested here):
+          `devices/update_config` `{configuration, content}` → save,
+          `devices/validate`, `firmware/compile`.
         - The `/ws` channel stays open, so for a one-shot read or a bounded log
           capture pass `wait_for_close=False` with `message_limit` (and
           `message_offset` to skip the server_info / config-banner preamble).

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -958,7 +958,7 @@ async def _call_addon_ws(
     Args:
         client: Home Assistant REST client
         slug: Add-on slug (e.g., "<prefix>_esphome")
-        path: WebSocket endpoint path (e.g., "/compile", "/validate")
+        path: WebSocket endpoint path (e.g., "/ws" for the ESPHome dashboard's command channel)
         body: Message to send after connecting (JSON-encoded if dict, raw if string)
         timeout: Max seconds to wait for messages (default 60)
         debug: Include diagnostic info
@@ -2658,17 +2658,20 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         websocket: Annotated[
             bool,
             Field(
-                description="Proxy mode only. Use WebSocket instead of HTTP. For streaming endpoints "
-                "(e.g., ESPHome /compile, /validate). Sends 'body' as initial message, "
-                "collects responses. Default: false.",
+                description="Proxy mode only. Use WebSocket instead of HTTP — for an add-on's "
+                "WebSocket API (e.g. the ESPHome dashboard's '/ws' command channel; see the "
+                "docstring's ESPHome section). Sends 'body' as the initial message, collects "
+                "responses. Default: false.",
                 default=False,
             ),
         ] = False,
         wait_for_close: Annotated[
             bool,
             Field(
-                description="Proxy mode only. WebSocket: True: wait for server to close (for compile/validate). "
-                "False: return after first response batch (for quick commands). Default: true.",
+                description="Proxy mode only. WebSocket: True: wait for the server to close the stream "
+                "(run-to-completion ops like an ESPHome compile/validate). False: return after the first "
+                "response batch — use for a one-shot command/response or a bounded log capture on a channel "
+                "that stays open (e.g. ESPHome '/ws'). Default: true.",
                 default=True,
             ),
         ] = True,
@@ -2839,6 +2842,26 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         share Home Assistant's container network (i.e. only the HAOS addon).
         Use ha_get_addon(slug="...") to discover available ports and endpoints.
 
+        **ESPHome Device Builder dashboard (current rewrite):** config and log
+        access is a WebSocket JSON-command API, NOT REST. The legacy endpoints
+        (`GET /edit?configuration=`, and the `/compile` `/validate` `/logs`
+        WebSocket paths taking `{"type": "spawn", ...}` bodies) are gone — they
+        now return the dashboard SPA. Use instead:
+        - HTTP `GET /devices` → JSON list of configured devices; each entry's
+          `configuration` field is the YAML filename to pass below.
+        - WebSocket `path="/ws"` with body
+          `{"command": "<cmd>", "message_id": "1", "args": {...}}`. The server
+          sends a `server_info` message first, then one reply per `message_id`.
+          Useful commands: `devices/get_config` `{configuration}` → raw YAML
+          (in the reply's `result`); `devices/update_config` `{configuration,
+          content}` → save; `devices/logs` (stream) `{configuration, port:
+          "OTA"}` → live device logs; `devices/validate`; `firmware/compile`.
+        - The `/ws` channel stays open, so for a one-shot read or a bounded log
+          capture pass `wait_for_close=False` with `message_limit` (and
+          `message_offset` to skip the server_info / config-banner preamble).
+          Reach the dashboard through Ingress — omit `port`; direct `port=` does
+          not route to it.
+
         **Array-patch mode** (when path AND array_patch are provided):
         Atomic "GET array, mutate, POST array" workflow for addon APIs whose write
         contract is "send the whole resource collection back". Operations are applied
@@ -2847,8 +2870,8 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         full array. Designed for Node-RED /flows and similar endpoints.
 
         **Response shaping (proxy mode):**
-        - WebSocket streams can be noisy (ESPHome /validate often emits hundreds of
-          config-dump lines). By default, `summarize=True` collapses long runs of
+        - WebSocket streams can be noisy (e.g. the ESPHome dashboard's devices/logs
+          dumps the device's full config banner on connect). By default, `summarize=True` collapses long runs of
           non-signal messages into short elision markers; INFO/WARNING/ERROR/exit
           lines always pass through. Pagination via `message_offset` / `message_limit`
           works on the raw collected list before summarize runs.
@@ -2881,9 +2904,10 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         - Set boot mode: ha_manage_addon(slug="...", boot="manual")
         - Call HTTP API: ha_manage_addon(slug="...", path="/api/events")
         - Direct port: ha_manage_addon(slug="...", path="/flows", port=1880)
-        - WebSocket: ha_manage_addon(slug="...", path="/validate", port=6052, websocket=True, body={"type": "spawn", "configuration": "device.yaml"})
-        - Quick WS health check (50 msgs, raw): ha_manage_addon(slug="...", path="/logs", websocket=True, message_limit=50, summarize=False)
-        - Filter WS errors only: ha_manage_addon(slug="...", path="/validate", websocket=True, python_transform="response = [m for m in response if 'ERROR' in str(m) or 'WARN' in str(m)]")
+        - ESPHome list devices (HTTP): ha_manage_addon(slug="<prefix>_esphome", path="/devices")
+        - ESPHome read a device's YAML (WS one-shot): ha_manage_addon(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=2, body={"command": "devices/get_config", "message_id": "1", "args": {"configuration": "device.yaml"}})
+        - ESPHome live logs (WS, bounded): ha_manage_addon(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=60, body={"command": "devices/logs", "message_id": "1", "args": {"configuration": "device.yaml", "port": "OTA"}})
+        - Filter WS errors only: ha_manage_addon(slug="...", path="/ws", websocket=True, python_transform="response = [m for m in response if 'ERROR' in str(m) or 'WARN' in str(m)]")
         - HTTP subset: ha_manage_addon(slug="...", path="/flows", python_transform="response = [f['id'] for f in response]")
         - Array-patch (Node-RED, rename a node):
             ha_manage_addon(


### PR DESCRIPTION
## What does this PR do?

Refreshes the ESPHome guidance in `ha_manage_addon` so agents don't follow stale
instructions into dead ends.

The ESPHome Device Builder dashboard was rewritten (aiohttp SPA, `server_version`
0.1.0b100). Its old surface is gone and now returns the SPA shell:
- `GET /edit?configuration=<file>` (raw YAML) → SPA
- the `/compile` `/validate` `/logs` WebSocket paths with `{"type": "spawn", ...}`
  bodies → handshake rejected (HTTP 200 SPA)

The tool docstring, the `websocket` / `wait_for_close` field descriptions, and the
WS examples still documented that old protocol. Updated to the current API:
- HTTP `GET /devices` → device list (each entry's `configuration` is the YAML filename)
- WebSocket `path="/ws"` with `{"command", "message_id", "args"}`; commands
  `devices/get_config`, `devices/update_config`, `devices/logs`, `devices/validate`,
  `firmware/compile`
- the one-shot/bounded pattern (`wait_for_close=False` + `message_limit`/`message_offset`),
  and that direct `port=` does not reach this dashboard (use Ingress)

Also refreshes the one matching stale `/compile` example in `read_only.py`.

Verified against a live ESPHome 2026.5.3 dashboard: the old `/logs` WS path returns
HTTP 200 (SPA); `/ws` `devices/get_config` and `devices/logs` work.

## Type of change
- [x] 📚 Documentation

## Testing
- [x] Verified the new guidance live via agent tool calls (ESPHome 2026.5.3)
- [ ] `uv run pytest` — not run; docs-only (docstrings + one comment), no logic changed
- [x] `ruff check` + `ruff format` pass

## Checklist
- [x] Documentation updated (tool-doc JSON/README/DOCS.md regenerate via `sync-tool-docs.yml` on merge)
