### PR TITLE
test: lock config-check guard against behavioral recurrence (#1660)

### DIFF
--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -663,9 +663,14 @@ class TestYamlConfigSafeguards:
             )
             inner = data
             assert inner.get("success") is True, f"Add should succeed: {data}"
-            # config_check should be present (ok, errors, or unavailable)
-            assert "config_check" in inner, (
-                f"Config check result should be in response: {data}"
+            # The seeded config is valid, so the guard must actually run and
+            # report "ok" — asserting mere presence accepts "unavailable" and
+            # would stay green if the check regressed to the silently-dead mode
+            # (#1660). This is the only test that exercises the real HA
+            # config-check path; the unit tests stub async_check_ha_config_file.
+            assert inner.get("config_check") == "ok", (
+                f"Config check should be 'ok' for a valid seeded config "
+                f"(behavioral regression guard for #1660): {data}"
             )
             logger.info(f"Config check result: {inner.get('config_check')}")
 

--- a/tests/src/unit/test_yaml_dashboards.py
+++ b/tests/src/unit/test_yaml_dashboards.py
@@ -41,8 +41,7 @@ def _stub_config_check(monkeypatch):
     """Stub the post-write config check (``async_check_ha_config_file``) to pass.
 
     Dashboard edits route through ``_run_config_check``; without a stub the
-    handler would await a bare mock. Tests that need a failing check override
-    this locally.
+    handler would await a bare mock.
     """
     monkeypatch.setattr(
         "custom_components.ha_mcp_tools.async_check_ha_config_file",

--- a/tests/src/unit/test_yaml_themes.py
+++ b/tests/src/unit/test_yaml_themes.py
@@ -29,7 +29,7 @@ def _stub_config_check(monkeypatch):
     """Default: the post-write config check passes (valid config).
 
     Theme edits route through ``_run_config_check``; without a stub the handler
-    would await a bare mock. Tests that need a failing check override locally.
+    would await a bare mock.
     """
     monkeypatch.setattr(
         "custom_components.ha_mcp_tools.async_check_ha_config_file",

--- a/tests/src/unit/test_yaml_whole_file_replace.py
+++ b/tests/src/unit/test_yaml_whole_file_replace.py
@@ -301,6 +301,38 @@ class TestReplaceFileAction:
         assert result["config_check"] == "errors"
         assert result["config_check_errors"] == "boom: bad config"
 
+    def test_surfaces_config_check_unavailable_on_failure(
+        self, tmp_path, hass, call_factory, monkeypatch
+    ):
+        """A config check that cannot run surfaces as "unavailable" while the
+        (already atomic) write still stands. Behavioral guard for the #1660
+        locus — the swallowed-exception branch that the source-string guard
+        below cannot catch."""
+        monkeypatch.setattr(
+            "custom_components.ha_mcp_tools.async_check_ha_config_file",
+            AsyncMock(side_effect=RuntimeError("check boom")),
+        )
+        cfg = Path(tmp_path) / "configuration.yaml"
+        cfg.write_text("default_config:\n")
+
+        handler = _build_edit_yaml_config_handler(hass)
+        result = self._run(
+            handler(
+                call_factory(
+                    {
+                        "file": "configuration.yaml",
+                        "action": "replace_file",
+                        "yaml_path": "",
+                        "content": "template: []\n",
+                    }
+                )
+            )
+        )
+
+        assert result["success"] is True
+        assert result["config_check"] == "unavailable", result
+        assert "check boom" in result.get("config_check_error", ""), result
+
 
 def test_run_config_check_does_not_misuse_return_response():
     """Regression for #1660: the post-write config check must validate via


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1661 (post-merge test-rigor review). The merged config-check fix had no test that fails on a *behavioral* regression of the guard:

- `test_config_check_included_in_response` (e2e) only asserted the `config_check` key was present, which accepts `"unavailable"` — a regression back to the silently-dead mode would stay green. It seeds a valid config, so it now asserts `config_check == "ok"`. This is the only test that exercises the real HA config-check path; the unit tests stub `async_check_ha_config_file`.
- Added a behavioral unit test for the swallowed-exception branch: stub `async_check_ha_config_file` with a `side_effect` and assert `config_check == "unavailable"` plus `config_check_error`. The existing source-string guard catches a verbatim revert but not a behavioral one.
- Dropped the misleading "tests that need a failing check override this locally" line from the theme/dashboard autouse-stub docstrings — no test there overrides it.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed