### PR TITLE
fix(deps): bump vite to 7.3.5 in site/ (Dependabot #62 #63)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -21,9 +21,6 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "jsdom": "^25.0.1",
         "typescript": "^6.0.3"
-      },
-      "overrides": {
-        "vite": "^7.3.5"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9557,9 +9557,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -21,6 +21,9 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "jsdom": "^25.0.1",
         "typescript": "^6.0.3"
+      },
+      "overrides": {
+        "vite": "^7.3.5"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,9 @@
     "astro": "^6.4.6",
     "tailwindcss": "^3.4.18"
   },
+  "overrides": {
+    "vite": "^7.3.5"
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@typescript-eslint/parser": "^8.61.0",


### PR DESCRIPTION
## What does this PR do?

Fixes two Dependabot security alerts by forcing vite to resolve to 7.3.5 in the `site/` npm workspace.

**Alerts closed:**
- #62: `vite` — `server.fs.deny` bypass on Windows alternate paths
- #63: `vite` — NTLMv2 hash disclosure via UNC path handling on Windows

Both alerts share the same vulnerable range (`>= 7.0.0, <= 7.3.4`) and patched version (`7.3.5`).

**Why Dependabot couldn't auto-fix:** `@astrojs/tailwind@6.0.2` only declares peer dep support for `astro@^3-5` (not v6). Dependabot's strict resolver cascaded this into a conflict when trying to bump vite past 7.3.2, reporting `security_update_not_possible`. The `overrides` field bypasses the transitive conflict by forcing the resolution directly.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Verified: `site/package-lock.json` resolves `node_modules/vite` to `7.3.5` with no duplicate copy in the tree.

## Checklist
- [x] I have updated documentation if needed