### PR TITLE
fix: accept proxy restart errors

### DIFF
--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -197,7 +197,16 @@ class SystemTools:
             # Connection errors after restart initiated are expected
             # (HA closes connections during restart)
             if restart_initiated and any(
-                pattern in error_msg.lower() for pattern in ("connect", "closed", "504")
+                pattern in error_msg.lower()
+                for pattern in (
+                    "connect",
+                    "closed",
+                    "502",
+                    "503",
+                    "504",
+                    "gateway",
+                    "unavailable",
+                )
             ):
                 return {
                     "success": True,

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -1,7 +1,6 @@
 """Unit tests for tools_system module.
 
-Regression tests for https://github.com/homeassistant-ai/ha-mcp/issues/612
-ha_restart reports failure when a reverse proxy returns 504 during restart.
+Regression tests for ha_restart handling reverse proxy errors during restart.
 """
 
 import asyncio
@@ -91,18 +90,34 @@ class TestGetSystemHealthHaMcpUpdate:
 class TestHaRestartErrorHandling:
     """Tests for ha_restart handling of expected errors during restart."""
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            HomeAssistantAPIError("API error: 504 - ", status_code=504),
+            HomeAssistantAPIError("API error: 502 - Bad Gateway", status_code=502),
+            HomeAssistantAPIError(
+                "API error: 503 - Service Unavailable", status_code=503
+            ),
+            Exception("Bad Gateway"),
+            Exception("Service unavailable"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_504_gateway_timeout_treated_as_success(self):
-        """A 504 from a reverse proxy after restart initiated should be success.
+    async def test_proxy_errors_after_restart_treated_as_success(
+        self, error: Exception
+    ):
+        """Reverse proxy errors after restart initiated should be success.
 
         Reproduces issue #612: user behind a reverse proxy gets 504 when HA
         shuts down, but HA actually restarted successfully.
+
+        Also covers issue #1666: some proxies return 502/503 or textual
+        gateway/unavailable errors for the same post-restart shutdown window.
 
         Also pins the post-#1332 warnings-list contract on the
         restart-initiated-but-connection-dropped branch
         (``tools_system.py`` ~L208-214).
         """
-        error = HomeAssistantAPIError("API error: 504 - ", status_code=504)
         client = _make_client_that_fails_on_restart(error)
         tools = SystemTools(client)
 


### PR DESCRIPTION
## What does this PR do?

Closes #1666.

Extends `ha_restart`'s post-dispatch restart shutdown handling so reverse proxy 502/503 responses and textual gateway/unavailable errors are treated like the existing connection/closed/504 cases after restart has already been initiated.

The existing unrelated-error test still verifies that errors outside this expected restart window raise normally.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Commands run:
- `uv run pytest tests/src/unit/test_tools_system.py -q`
- `uv run pytest tests/src/unit/test_helper_response_shape.py -q`
- `uv run pytest tests/src/unit -q` (`5203 passed, 115 skipped`)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run ast-grep scan`

Attempted relevant e2e coverage:
- `cd tests && uv run pytest src/e2e/workflows/system/test_system_tools.py -v --tb=short`

That e2e command did not run locally because Docker is not available on this machine: `Docker is not available: Error while fetching server API version` / `FileNotFoundError(2, 'No such file or directory')`.

## Checklist
- [ ] I have updated documentation if needed
