### PR TITLE
fix(ha_restart): extend known-good error patterns to cover 502/503 from proxies

### DIFF
--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -197,7 +197,16 @@ class SystemTools:
             # Connection errors after restart initiated are expected
             # (HA closes connections during restart)
             if restart_initiated and any(
-                pattern in error_msg.lower() for pattern in ("connect", "closed", "504")
+                pattern in error_msg.lower()
+                for pattern in (
+                    "connect",
+                    "closed",
+                    "504",
+                    "502",
+                    "503",
+                    "gateway",
+                    "unavailable",
+                )
             ):
                 return {
                     "success": True,

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -46,6 +46,17 @@ def _make_client_that_fails_on_restart(exception):
     return mock_client
 
 
+def _make_client_that_fails_on_check_config(exception):
+    """Create a mock client where check_config itself raises.
+
+    Used to exercise the pre-dispatch path: the failure happens before the
+    restart service is ever called, so ``restart_initiated`` stays False.
+    """
+    mock_client = AsyncMock()
+    mock_client.check_config.side_effect = exception
+    return mock_client
+
+
 class TestGetSystemHealthHaMcpUpdate:
     """ha_get_system_health surfaces the MCP server's own update status."""
 
@@ -116,6 +127,81 @@ class TestHaRestartErrorHandling:
         assert any("Wait 1-5 minutes" in w for w in warnings), (
             f"Expected wait-for-restart warning content; got: {warnings!r}"
         )
+
+    @pytest.mark.parametrize(
+        ("error", "pattern"),
+        [
+            (
+                HomeAssistantAPIError("API error: 502 - ", status_code=502),
+                "502",
+            ),
+            (
+                HomeAssistantAPIError("API error: 503 - ", status_code=503),
+                "503",
+            ),
+            (
+                HomeAssistantConnectionError("Proxy returned: Bad Gateway"),
+                "gateway",
+            ),
+            (
+                HomeAssistantConnectionError("Upstream Service Unavailable"),
+                "unavailable",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_proxy_5xx_during_restart_treated_as_success(self, error, pattern):
+        """Reverse-proxy 502/503/'gateway'/'unavailable' responses after the
+        restart was initiated should be treated as the expected connection drop,
+        not a failure.
+
+        Reproduces issue #1666: behind nginx/Traefik/Cloudflare the proxy often
+        returns a 502/503 (or a 'Bad Gateway'/'Service Unavailable' body) while
+        HA is shutting down, even though the restart succeeded. Extends the #612
+        (504) fix to the broader set of known-good patterns in
+        ``tools_system.py`` (~L199-211).
+
+        Each case isolates a single newly added pattern so a future narrowing of
+        the match list fails loudly here.
+        """
+        client = _make_client_that_fails_on_restart(error)
+        tools = SystemTools(client)
+
+        result = await tools.ha_restart(confirm=True)
+
+        assert result["success"] is True, (
+            f"Proxy '{pattern}' error should be treated as the expected restart "
+            f"connection drop; got: {result!r}"
+        )
+        warnings = result.get("warnings")
+        assert isinstance(warnings, list) and warnings, (
+            f"Expected non-empty warnings list, got: {result!r}"
+        )
+        assert any("Wait 1-5 minutes" in w for w in warnings), (
+            f"Expected wait-for-restart warning content; got: {warnings!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_proxy_error_before_restart_dispatch_still_fails(self):
+        """A matching proxy error raised *before* the restart is dispatched must
+        still fail loudly.
+
+        The known-good branch is gated on ``restart_initiated and any(pattern ...)``.
+        The other tests all run with ``restart_initiated`` already True (the
+        failure comes from ``call_service``); this pins the ``restart_initiated
+        is False`` half of that guard. Here ``check_config`` raises a
+        ``Bad Gateway`` (which would otherwise match the ``gateway`` pattern),
+        but since the restart was never sent it must raise a ``ToolError`` rather
+        than be reported as a successful restart. Guards against a future change
+        that weakens the guard and lets a pre-restart proxy error masquerade as
+        success.
+        """
+        error = HomeAssistantConnectionError("Bad Gateway")
+        client = _make_client_that_fails_on_check_config(error)
+        tools = SystemTools(client)
+
+        with pytest.raises(ToolError):
+            await tools.ha_restart(confirm=True)
 
     @pytest.mark.asyncio
     async def test_unrelated_error_still_fails(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #1666. When Home Assistant is behind a reverse proxy (nginx, Traefik, Cloudflare, etc.), the proxy often returns a **502/503** — or a `Bad Gateway` / `Service Unavailable` body — while HA is shutting down for a restart, even though the restart itself succeeded. `ha_restart` treated those as failures and reported a false error.

This extends the known-good error patterns checked after a restart is initiated from `("connect", "closed", "504")` to also cover `502`, `503`, `gateway`, and `unavailable`, so a proxy returning any of those during shutdown is recognized as the expected connection drop rather than a failure (consistent with the existing #612 handling for 504).

Tests added in `tests/src/unit/test_tools_system.py` (`TestHaRestartErrorHandling`):
- A parametrized test pinning each newly added pattern (`502`, `503`, `gateway`, `unavailable`), mirroring the existing #612 (504) regression test.
- A pre-dispatch guard test: a matching proxy error raised from `check_config` (before the restart is dispatched, so `restart_initiated` stays `False`) must still raise `ToolError` — pinning the `restart_initiated` half of the `restart_initiated and any(...)` guard.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`uv run pytest src/unit/test_tools_system.py` → 97 passed. `uv run ruff check` and `uv run ruff format --check` are clean. I verified the new tests fail on the pre-fix pattern set / a weakened guard and pass with the fix. (I did not exercise it end-to-end against a live HA + proxy via an LLM agent — the regression is reproduced deterministically at the unit level.)

## Checklist
- [x] I have updated documentation if needed (no user-facing docs affected by this internal error-handling change)
