### PR TITLE
fix: await pre-restore safety backup and forward password on snapshot restore

### DIFF
--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -541,13 +541,17 @@ async def _create_safety_backup(
     password: str | None,
     agent_id: str,
 ) -> str | None:
-    """Create a pre-restore safety backup.
+    """Create a pre-restore safety backup and wait for it to complete.
 
     ``agent_id`` is the local backup agent (Supervisor's ``hassio.local`` or
     Core's ``backup.local``) discovered by the caller.
 
-    Returns the safety backup ID, or None when password is None (backup intentionally
-    skipped). Raises ToolError if backup creation fails.
+    Blocks until the safety backup finishes. HA's ``backup/generate`` returns
+    on job initiation, not completion, so waiting here lets the caller issue
+    ``backup/restore`` afterwards without colliding with a still-running
+    backup. Returns the safety backup job ID, or None when password is None
+    (backup intentionally skipped). Raises ToolError if the backup fails to
+    start or does not complete in time.
     """
     if password is None:
         return None
@@ -579,7 +583,25 @@ async def _create_safety_backup(
         )
 
     safety_backup_id = safety_backup.get("result", {}).get("backup_job_id")
-    logger.info(f"Safety backup created: {safety_backup_id}")
+    logger.info(f"Safety backup started: {safety_backup_id}, waiting for completion...")
+
+    # Wait for the safety backup to finish before returning. HA's
+    # backup/generate WS command returns as soon as the job is *initiated*,
+    # not when it completes, and the backup manager rejects any new operation
+    # while a backup is running ("Backup manager busy: create_backup"). If the
+    # caller issued backup/restore right after this returned, it would collide
+    # with the safety backup this same call just started – a self-induced
+    # deadlock (#1681). Reuse the same completion poll create_backup already
+    # uses rather than adding a second wait mechanism.
+    await _poll_backup_completion(
+        ws_client,
+        safety_backup_name,
+        cast(str, safety_backup_id),
+        max_wait_seconds=_BACKUP_MAX_WAIT_S,
+        poll_interval=_BACKUP_POLL_INTERVAL_S,
+        agent_id=agent_id,
+    )
+    logger.info(f"Safety backup completed: {safety_backup_id}")
     return cast(str, safety_backup_id)
 
 
@@ -658,7 +680,7 @@ async def restore_backup(
         safety_backup_id = await _create_safety_backup(ws_client, password, local_agent)
 
         # Perform restore
-        restore_params = {
+        restore_params: dict[str, Any] = {
             "backup_id": backup_id,
             "agent_id": local_agent,
             "restore_database": restore_database,
@@ -666,6 +688,15 @@ async def restore_backup(
             "restore_addons": [],  # Restore all addons from backup
             "restore_folders": [],  # Restore all folders from backup
         }
+        # Forward the default backup password so protected (encrypted) backups
+        # decrypt on restore – this is the same password already fetched above
+        # for the safety backup. HA's backup/restore schema types `password` as
+        # `str` (not `str | None`), so only include the key when we actually
+        # have one; passing None would fail voluptuous validation. Without this,
+        # a `protected: true` backup cannot be restored even though the HA UI –
+        # which applies the stored key – succeeds (#1681).
+        if password is not None:
+            restore_params["password"] = password
 
         result = await ws_client.send_command("backup/restore", **restore_params)
 

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -52,6 +52,12 @@ logger = logging.getLogger(__name__)
 # happy-path wait noticeable.
 _BACKUP_MAX_WAIT_S = 300
 _BACKUP_POLL_INTERVAL_S = 2
+# The pre-restore safety backup is a *full* backup (include_database=True, plus
+# all add-ons on Supervised), unlike the fast create_backup path. A multi-GB
+# full backup on constrained hardware (~2.1 GB on a Pi 5, #1681) can run well
+# past the fast-backup window, so its completion poll gets a larger budget —
+# timing out here aborts the restore and the retry spawns another full backup.
+_SAFETY_BACKUP_MAX_WAIT_S = 1800
 # Clock-skew tolerance when filtering backup entries by date vs job-start.
 _BACKUP_DATE_FILTER_TOLERANCE_S = 5
 
@@ -540,7 +546,7 @@ async def _create_safety_backup(
     ws_client: HomeAssistantWebSocketClient,
     password: str | None,
     agent_id: str,
-) -> str | None:
+) -> tuple[str | None, list[str]]:
     """Create a pre-restore safety backup and wait for it to complete.
 
     ``agent_id`` is the local backup agent (Supervisor's ``hassio.local`` or
@@ -549,12 +555,14 @@ async def _create_safety_backup(
     Blocks until the safety backup finishes. HA's ``backup/generate`` returns
     on job initiation, not completion, so waiting here lets the caller issue
     ``backup/restore`` afterwards without colliding with a still-running
-    backup. Returns the safety backup job ID, or None when password is None
-    (backup intentionally skipped). Raises ToolError if the backup fails to
-    start or does not complete in time.
+    backup. Returns ``(job_id, warnings)`` — ``job_id`` is None when password
+    is None (backup intentionally skipped); ``warnings`` carries any late-
+    completion notice from the poll so the caller can surface it before the
+    destructive restore. Raises ToolError if the backup fails to start or does
+    not complete in time.
     """
     if password is None:
-        return None
+        return None, []
 
     now = datetime.now()
     safety_backup_name = f"PreRestore_Safety_{now.strftime('%Y-%m-%d_%H:%M:%S')}"
@@ -593,16 +601,16 @@ async def _create_safety_backup(
     # with the safety backup this same call just started – a self-induced
     # deadlock (#1681). Reuse the same completion poll create_backup already
     # uses rather than adding a second wait mechanism.
-    await _poll_backup_completion(
+    poll_result = await _poll_backup_completion(
         ws_client,
         safety_backup_name,
         cast(str, safety_backup_id),
-        max_wait_seconds=_BACKUP_MAX_WAIT_S,
+        max_wait_seconds=_SAFETY_BACKUP_MAX_WAIT_S,
         poll_interval=_BACKUP_POLL_INTERVAL_S,
         agent_id=agent_id,
     )
     logger.info(f"Safety backup completed: {safety_backup_id}")
-    return cast(str, safety_backup_id)
+    return cast(str, safety_backup_id), poll_result.get("warnings", [])
 
 
 async def restore_backup(
@@ -616,7 +624,10 @@ async def restore_backup(
     Args:
         client: Home Assistant REST client
         backup_id: Backup ID to restore
-        restore_database: Whether to restore database (historical data)
+        restore_database: Whether to restore database (historical data).
+            Reconciled against the target backup's ``database_included`` flag,
+            which HA requires to match when restoring Home Assistant; a warning
+            is returned if the value is overridden.
 
     Returns:
         Dictionary with restore result including safety_backup_id, status, etc.
@@ -649,9 +660,9 @@ async def restore_backup(
             )
 
         backups = backup_info.get("result", {}).get("backups", [])
-        backup_exists = any(b.get("backup_id") == backup_id for b in backups)
+        matched = next((b for b in backups if b.get("backup_id") == backup_id), None)
 
-        if not backup_exists:
+        if matched is None:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.RESOURCE_NOT_FOUND,
@@ -677,25 +688,45 @@ async def restore_backup(
             logger.warning("No default password - proceeding without safety backup")
             password = None
 
-        safety_backup_id = await _create_safety_backup(ws_client, password, local_agent)
+        safety_backup_id, safety_warnings = await _create_safety_backup(
+            ws_client, password, local_agent
+        )
+
+        # When restoring Home Assistant, HA requires restore_database to match
+        # the target backup's database_included flag, otherwise Supervisor
+        # raises "Restore database must match backup". Derive the effective
+        # value from the target (database_included is in the same backup/info
+        # entry); fall back to the caller's request only when the field is
+        # absent. Surface a warning when the derived value overrides what the
+        # caller asked for so the override isn't silent on a destructive op.
+        target_database_included = matched.get("database_included")
+        if target_database_included is None:
+            effective_restore_database = restore_database
+        else:
+            effective_restore_database = target_database_included
 
         # Perform restore
         restore_params: dict[str, Any] = {
             "backup_id": backup_id,
             "agent_id": local_agent,
-            "restore_database": restore_database,
+            "restore_database": effective_restore_database,
             "restore_homeassistant": True,
             "restore_addons": [],  # Restore all addons from backup
             "restore_folders": [],  # Restore all folders from backup
         }
-        # Forward the default backup password so protected (encrypted) backups
-        # decrypt on restore – this is the same password already fetched above
-        # for the safety backup. HA's backup/restore schema types `password` as
-        # `str` (not `str | None`), so only include the key when we actually
-        # have one; passing None would fail voluptuous validation. Without this,
-        # a `protected: true` backup cannot be restored even though the HA UI –
-        # which applies the stored key – succeeds (#1681).
-        if password is not None:
+        # Forward the default backup password ONLY for a protected (encrypted)
+        # target. `password` here is HA's default create_backup.password, which
+        # is independent of whether *this* backup is encrypted: HA validates the
+        # password against the target unconditionally and rejects a password on
+        # an unprotected backup ("Invalid password for backup" →
+        # IncorrectPasswordError). Gate on the target's `protected` flag (from
+        # the same backup/info entry) so an unprotected snapshot still restores
+        # on a default-password instance. HA's backup/restore schema types
+        # `password` as `str` (not `str | None`), so only include the key when
+        # we actually forward one — passing None would fail voluptuous
+        # validation. Without this a `protected: true` backup cannot be restored
+        # even though the HA UI, which applies the stored key, succeeds (#1681).
+        if password is not None and matched.get("protected"):
             restore_params["password"] = password
 
         result = await ws_client.send_command("backup/restore", **restore_params)
@@ -709,6 +740,17 @@ async def restore_backup(
             warnings = [
                 "Home Assistant is restarting. Connection will be temporarily lost."
             ]
+            # Surface any late-completion notice from the safety-backup poll —
+            # a slow backup subsystem right before a destructive restore is
+            # exactly the signal a caller wants to see.
+            warnings.extend(safety_warnings)
+            if effective_restore_database != restore_database:
+                warnings.append(
+                    "restore_database was adjusted to "
+                    f"{effective_restore_database} to match the target backup "
+                    "(Home Assistant requires it to match the backup's "
+                    "database_included flag when restoring Home Assistant)."
+                )
             if safety_backup_id is None:
                 warnings.append(
                     "No safety backup was created (the default backup "
@@ -728,7 +770,7 @@ async def restore_backup(
                 "backup_id": backup_id,
                 "status": "Restore initiated - Home Assistant will restart",
                 "safety_backup_id": safety_backup_id,
-                "restore_database": restore_database,
+                "restore_database": effective_restore_database,
                 "warnings": warnings,
                 "note": note,
             }

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -613,6 +613,25 @@ async def _create_safety_backup(
     return cast(str, safety_backup_id), poll_result.get("warnings", [])
 
 
+def _backup_protected(entry: dict[str, Any]) -> bool | None:
+    """Whether a ``backup/info`` entry is encrypted.
+
+    ``protected`` is a per-agent field (AgentBackupStatus), not top-level. A
+    backup is encrypted as a whole, so any agent reporting it makes the backup
+    protected; returns None when the ``agents`` map is absent/malformed or no
+    agent reports the flag (unknown rather than "unprotected").
+    """
+    agents = entry.get("agents")
+    if not isinstance(agents, dict):
+        return None
+    flags = [
+        a.get("protected")
+        for a in agents.values()
+        if isinstance(a, dict) and a.get("protected") is not None
+    ]
+    return any(flags) if flags else None
+
+
 async def restore_backup(
     client: HomeAssistantClient, backup_id: str, restore_database: bool = False
 ) -> dict[str, Any]:
@@ -625,9 +644,11 @@ async def restore_backup(
         client: Home Assistant REST client
         backup_id: Backup ID to restore
         restore_database: Whether to restore database (historical data).
-            Reconciled against the target backup's ``database_included`` flag,
-            which HA requires to match when restoring Home Assistant; a warning
-            is returned if the value is overridden.
+            On Supervised installs this is reconciled against the target
+            backup's ``database_included`` flag, which Supervisor requires to
+            match when restoring Home Assistant; a warning is returned if the
+            value is overridden. On Core installs the caller's value is honoured
+            as-is (Core enforces no such match).
 
     Returns:
         Dictionary with restore result including safety_backup_id, status, etc.
@@ -692,18 +713,29 @@ async def restore_backup(
             ws_client, password, local_agent
         )
 
-        # When restoring Home Assistant, HA requires restore_database to match
-        # the target backup's database_included flag, otherwise Supervisor
-        # raises "Restore database must match backup". Derive the effective
-        # value from the target (database_included is in the same backup/info
-        # entry); fall back to the caller's request only when the field is
-        # absent. Surface a warning when the derived value overrides what the
-        # caller asked for so the override isn't silent on a destructive op.
+        # `backup/info` returns ManagerBackup entries: `database_included` is a
+        # top-level field (inherited from BaseBackup), but `protected` is NOT —
+        # it lives per-agent under the entry's `agents` map (AgentBackupStatus),
+        # so a top-level `matched.get("protected")` is always None against real
+        # HA. Derive it from the agents map (shared with _summarize_backup).
+        target_protected = _backup_protected(matched)
+
+        # Reconcile restore_database with the target only on Supervised. HA's
+        # Supervisor raises "Restore database must match backup" when
+        # restore_homeassistant is set and restore_database != the backup's
+        # database_included flag (hassio/backup.py). HA Core's restore path
+        # (CoreBackupReaderWriter) has no such constraint and writes the caller's
+        # value verbatim, so overriding it there would silently discard an
+        # explicit request for no HA-side reason. Fall back to the caller's
+        # request when not Supervised or when the field is absent. Surface a
+        # warning when the derived value overrides what the caller asked for so
+        # the override isn't silent on a destructive op.
+        is_supervised = local_agent == "hassio.local"
         target_database_included = matched.get("database_included")
-        if target_database_included is None:
-            effective_restore_database = restore_database
-        else:
+        if is_supervised and target_database_included is not None:
             effective_restore_database = target_database_included
+        else:
+            effective_restore_database = restore_database
 
         # Perform restore
         restore_params: dict[str, Any] = {
@@ -719,14 +751,14 @@ async def restore_backup(
         # is independent of whether *this* backup is encrypted: HA validates the
         # password against the target unconditionally and rejects a password on
         # an unprotected backup ("Invalid password for backup" →
-        # IncorrectPasswordError). Gate on the target's `protected` flag (from
-        # the same backup/info entry) so an unprotected snapshot still restores
-        # on a default-password instance. HA's backup/restore schema types
-        # `password` as `str` (not `str | None`), so only include the key when
-        # we actually forward one — passing None would fail voluptuous
-        # validation. Without this a `protected: true` backup cannot be restored
-        # even though the HA UI, which applies the stored key, succeeds (#1681).
-        if password is not None and matched.get("protected"):
+        # IncorrectPasswordError). Gate on the target's per-agent `protected`
+        # flag (read above) so an unprotected snapshot still restores on a
+        # default-password instance. HA's backup/restore schema types `password`
+        # as `str` (not `str | None`), so only include the key when we actually
+        # forward one — passing None would fail voluptuous validation. Without
+        # this a protected backup cannot be restored even though the HA UI,
+        # which applies the stored key, succeeds (#1681).
+        if password is not None and target_protected:
             restore_params["password"] = password
 
         result = await ws_client.send_command("backup/restore", **restore_params)
@@ -748,8 +780,9 @@ async def restore_backup(
                 warnings.append(
                     "restore_database was adjusted to "
                     f"{effective_restore_database} to match the target backup "
-                    "(Home Assistant requires it to match the backup's "
-                    "database_included flag when restoring Home Assistant)."
+                    "(Home Assistant's Supervisor requires it to match the "
+                    "backup's database_included flag when restoring Home "
+                    "Assistant)."
                 )
             if safety_backup_id is None:
                 warnings.append(
@@ -834,7 +867,8 @@ def _summarize_backup(entry: dict[str, Any]) -> dict[str, Any]:
         "name": entry.get("name"),
         "date": entry.get("date"),
         "size_bytes": size_bytes,
-        "protected": entry.get("protected"),
+        # per-agent field, derived from the agents map (see _backup_protected)
+        "protected": _backup_protected(entry),
         "database_included": entry.get("database_included"),
         "homeassistant_included": entry.get("homeassistant_included"),
         "homeassistant_version": entry.get("homeassistant_version"),

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -157,15 +157,6 @@ class TestRestoreBackupWarnings:
             },
             # _create_safety_backup → backup/generate
             {"success": True, "result": {"backup_job_id": "safety_job_1"}},
-            # _create_safety_backup polling → backup/info loop
-            {
-                "success": True,
-                "result": {
-                    "backups": [
-                        {"name": "Pre_Restore_Safety", "backup_id": "safety_xyz"}
-                    ]
-                },
-            },
             # backup/restore — the actual restore call
             {"success": True},
         ]
@@ -175,9 +166,17 @@ class TestRestoreBackupWarnings:
         client.token = "token"
         client.verify_ssl = False
 
-        with patch(
-            "ha_mcp.tools.backup.get_connected_ws_client",
-            new=AsyncMock(return_value=(ws, None)),
+        # The safety-backup completion poll is exercised by test_backup_restore;
+        # stub it here so this test stays focused on the warnings contract.
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
         ):
             result = await restore_backup(client, "abc123")
 

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -11,11 +11,39 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.backup import (
+    _backup_protected,
     _get_local_backup_agent_id,
     _summarize_backup,
     list_backups,
     restore_backup,
 )
+
+
+class TestBackupProtected:
+    """`_backup_protected` derives the encrypted flag from the per-agent map."""
+
+    def test_any_agent_protected_makes_it_protected(self):
+        entry = {
+            "agents": {
+                "backup.local": {"protected": False},
+                "google_drive.cloud": {"protected": True},
+            }
+        }
+        assert _backup_protected(entry) is True
+
+    def test_all_agents_unprotected(self):
+        entry = {"agents": {"backup.local": {"protected": False}}}
+        assert _backup_protected(entry) is False
+
+    def test_missing_agents_is_unknown(self):
+        assert _backup_protected({}) is None
+
+    def test_no_agent_reports_protected_is_unknown(self):
+        # agents present but none carry the field → unknown, not "unprotected".
+        assert _backup_protected({"agents": {"backup.local": {"size": 1}}}) is None
+
+    def test_non_dict_agents_is_unknown(self):
+        assert _backup_protected({"agents": ["unexpected"]}) is None
 
 
 def _ws_client(agents_payload: dict) -> AsyncMock:
@@ -199,14 +227,14 @@ class TestSummarizeBackup:
             "backup_id": "abc",
             "name": "Nightly",
             "date": "2026-06-14T02:00:00+00:00",
-            "protected": True,
             "database_included": False,
             "homeassistant_included": True,
             "homeassistant_version": "2026.6.0",
             "with_automatic_settings": True,
+            # `protected` is a per-agent field (AgentBackupStatus), not top-level.
             "agents": {
-                "backup.local": {"size": 100},
-                "google_drive.cloud": {"size": 250},
+                "backup.local": {"size": 100, "protected": True},
+                "google_drive.cloud": {"size": 250, "protected": True},
             },
         }
         out = _summarize_backup(entry)

--- a/tests/src/unit/test_backup_restore.py
+++ b/tests/src/unit/test_backup_restore.py
@@ -64,16 +64,31 @@ def _restore_responses(
     with_password: bool = True,
     protected: bool = True,
     database_included: bool | None = None,
+    agent_id: str = "backup.local",
+    restore_success: bool = True,
 ) -> dict[str, Any]:
     """Canned WS responses for a full restore_backup run.
 
     ``protected`` / ``database_included`` populate the target backup/info entry
-    so the param-reconciliation logic can be exercised.
+    so the param-reconciliation logic can be exercised. ``protected`` is nested
+    under the target's ``agents`` map (keyed by ``agent_id``) to mirror HA's real
+    ``backup/info`` shape — AgentBackupStatus carries ``protected`` per agent,
+    not at the top level. ``agent_id`` selects the local backup agent
+    (``backup.local`` = Core, ``hassio.local`` = Supervised). ``restore_success``
+    toggles the ``backup/restore`` outcome for failure-path coverage.
     """
     config_block = {"create_backup": {"password": "pw"}} if with_password else {}
-    target_entry: dict[str, Any] = {"backup_id": "target-slug", "protected": protected}
+    target_entry: dict[str, Any] = {
+        "backup_id": "target-slug",
+        "agents": {agent_id: {"size": 1024, "protected": protected}},
+    }
     if database_included is not None:
         target_entry["database_included"] = database_included
+    restore_response: dict[str, Any] = (
+        {"success": True}
+        if restore_success
+        else {"success": False, "error": "restore exploded"}
+    )
     return {
         # backup/info — backup-exists verification + target metadata
         "backup/info": {
@@ -83,7 +98,7 @@ def _restore_responses(
         # backup/agents/info — local agent discovery
         "backup/agents/info": {
             "success": True,
-            "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]},
+            "result": {"agents": [{"agent_id": agent_id, "name": "local"}]},
         },
         # backup/config/info — default-password lookup
         "backup/config/info": {
@@ -96,7 +111,7 @@ def _restore_responses(
             "result": {"backup_job_id": "safety-job-1"},
         },
         # backup/restore — the actual restore
-        "backup/restore": {"success": True},
+        "backup/restore": restore_response,
     }
 
 
@@ -192,6 +207,35 @@ class TestRestoreForwardsPassword:
         assert _restore_call(ws).kwargs["password"] == "pw"
 
     @pytest.mark.asyncio
+    async def test_password_forwarded_when_only_remote_agent_protected(self) -> None:
+        """A backup is encrypted as a whole, so `protected` reported by *any*
+        agent forwards the password — not only the local restore agent. Guards
+        the case where the local agent's entry omits/clears the flag."""
+        call_log: list[str] = []
+        responses = _restore_responses(with_password=True, protected=False)
+        # Local agent reports unprotected, a cloud agent reports protected.
+        responses["backup/info"]["result"]["backups"][0]["agents"] = {
+            "backup.local": {"size": 1024, "protected": False},
+            "google_drive.cloud": {"size": 2048, "protected": True},
+        }
+        ws = _scripted_ws(responses, call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            await restore_backup(client, "target-slug", restore_database=False)
+
+        assert _restore_call(ws).kwargs["password"] == "pw"
+
+    @pytest.mark.asyncio
     async def test_password_omitted_for_unprotected_target(self) -> None:
         """An unprotected target must NOT receive the password even when a
         default password is configured — HA validates it against the target and
@@ -217,6 +261,8 @@ class TestRestoreForwardsPassword:
         assert result["success"] is True
         # A safety backup is still created (the default password drives that),
         # but it must not leak into the restore of an unprotected target.
+        assert result["safety_backup_id"] is not None
+        assert "backup/generate" in call_log
         assert "password" not in _restore_call(ws).kwargs
 
     @pytest.mark.asyncio
@@ -253,12 +299,14 @@ class TestRestoreForwardsPassword:
 class TestRestoreReconcilesDatabase:
     @pytest.mark.asyncio
     async def test_restore_database_derived_from_target(self) -> None:
-        """A `database_included: true` target forces `restore_database=True`
-        even when the caller defaulted it to False — HA requires the flag to
-        match the backup when restoring Home Assistant, otherwise Supervisor
-        raises "Restore database must match backup"."""
+        """On Supervised, a `database_included: true` target forces
+        `restore_database=True` even when the caller defaulted it to False —
+        Supervisor raises "Restore database must match backup" otherwise."""
         call_log: list[str] = []
-        ws = _scripted_ws(_restore_responses(database_included=True), call_log)
+        ws = _scripted_ws(
+            _restore_responses(database_included=True, agent_id="hassio.local"),
+            call_log,
+        )
         client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
 
         with (
@@ -280,11 +328,15 @@ class TestRestoreReconcilesDatabase:
 
     @pytest.mark.asyncio
     async def test_restore_database_overridden_to_false(self) -> None:
-        """A `database_included: false` target forces `restore_database=False`
-        even when the caller requested True — the symmetric override of the
-        True case, since HA requires the flag to match either way."""
+        """On Supervised, a `database_included: false` target forces
+        `restore_database=False` even when the caller requested True — the
+        symmetric override of the True case, since Supervisor requires the flag
+        to match either way."""
         call_log: list[str] = []
-        ws = _scripted_ws(_restore_responses(database_included=False), call_log)
+        ws = _scripted_ws(
+            _restore_responses(database_included=False, agent_id="hassio.local"),
+            call_log,
+        )
         client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
 
         with (
@@ -325,6 +377,62 @@ class TestRestoreReconcilesDatabase:
 
         assert _restore_call(ws).kwargs["restore_database"] is True
         assert not any("restore_database was adjusted" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_restore_database_not_overridden_on_core(self) -> None:
+        """On Core (`backup.local`), the caller's `restore_database` is honoured
+        even when it differs from the target's `database_included` — Core's
+        restore path enforces no match (only Supervisor does), so overriding it
+        would silently discard an explicit request."""
+        call_log: list[str] = []
+        ws = _scripted_ws(
+            _restore_responses(database_included=True, agent_id="backup.local"),
+            call_log,
+        )
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=False)
+
+        assert _restore_call(ws).kwargs["restore_database"] is False
+        assert result["restore_database"] is False
+        assert not any("restore_database was adjusted" in w for w in result["warnings"])
+
+
+class TestRestoreFailurePath:
+    @pytest.mark.asyncio
+    async def test_restore_failure_raises_with_backup_id_context(self) -> None:
+        """A `backup/restore` that returns `success: False` must raise ToolError
+        carrying the backup_id, not return a partial success."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(restore_success=False), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await restore_backup(client, "target-slug", restore_database=False)
+
+        # The safety backup ran; only the restore itself failed.
+        assert "backup/restore" in call_log
+        assert "target-slug" in str(exc_info.value)
 
 
 class TestRestoreSurfacesSafetyBackupWarnings:

--- a/tests/src/unit/test_backup_restore.py
+++ b/tests/src/unit/test_backup_restore.py
@@ -13,7 +13,17 @@ Regression coverage for #1681:
 2. **Missing decryption key** — `restore_params` omitted `password`, so a
    `protected: true` backup could not be decrypted on restore even though the
    default password was already fetched for the safety backup. The fix forwards
-   that password into the `backup/restore` call when one is available.
+   that password into the `backup/restore` call — but only for a *protected*
+   target, since HA rejects a password on an unprotected backup.
+
+3. **Param reconciliation** — `password` and `restore_database` are forwarded
+   based on the target backup's own metadata (`protected`, `database_included`)
+   rather than ambient config / caller default, so an unprotected or
+   DB-inclusive target restores cleanly instead of hitting an opaque HA error.
+
+4. **Safety-backup poll budget + late-completion warnings** — the full safety
+   backup polls with its own (larger) timeout and its late-completion warnings
+   surface in the restore response.
 """
 
 from typing import Any
@@ -22,7 +32,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.backup import _create_safety_backup, restore_backup
+from ha_mcp.tools.backup import (
+    _SAFETY_BACKUP_MAX_WAIT_S,
+    _create_safety_backup,
+    restore_backup,
+)
 
 
 def _scripted_ws(responses: dict[str, Any], call_log: list[str]) -> AsyncMock:
@@ -45,14 +59,26 @@ def _scripted_ws(responses: dict[str, Any], call_log: list[str]) -> AsyncMock:
     return ws
 
 
-def _restore_responses(*, with_password: bool = True) -> dict[str, Any]:
-    """Canned WS responses for a full restore_backup run."""
+def _restore_responses(
+    *,
+    with_password: bool = True,
+    protected: bool = True,
+    database_included: bool | None = None,
+) -> dict[str, Any]:
+    """Canned WS responses for a full restore_backup run.
+
+    ``protected`` / ``database_included`` populate the target backup/info entry
+    so the param-reconciliation logic can be exercised.
+    """
     config_block = {"create_backup": {"password": "pw"}} if with_password else {}
+    target_entry: dict[str, Any] = {"backup_id": "target-slug", "protected": protected}
+    if database_included is not None:
+        target_entry["database_included"] = database_included
     return {
-        # backup/info — backup-exists verification
+        # backup/info — backup-exists verification + target metadata
         "backup/info": {
             "success": True,
-            "result": {"backups": [{"backup_id": "target-slug"}]},
+            "result": {"backups": [target_entry]},
         },
         # backup/agents/info — local agent discovery
         "backup/agents/info": {
@@ -74,6 +100,13 @@ def _restore_responses(*, with_password: bool = True) -> dict[str, Any]:
     }
 
 
+def _restore_call(ws: AsyncMock) -> Any:
+    """Return the recorded ``backup/restore`` call."""
+    return next(
+        c for c in ws.send_command.call_args_list if c.args[0] == "backup/restore"
+    )
+
+
 class TestRestoreAwaitsSafetyBackup:
     @pytest.mark.asyncio
     async def test_restore_issued_only_after_safety_backup_completes(self) -> None:
@@ -83,9 +116,11 @@ class TestRestoreAwaitsSafetyBackup:
         ws = _scripted_ws(_restore_responses(), call_log)
         client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
 
-        poll_order_marker = AsyncMock(
-            side_effect=lambda *a, **k: call_log.append("poll-completed")
-        )
+        def _marker(*_a: Any, **_k: Any) -> dict[str, Any]:
+            call_log.append("poll-completed")
+            return {}
+
+        poll_order_marker = AsyncMock(side_effect=_marker)
 
         with (
             patch(
@@ -134,10 +169,12 @@ class TestRestoreAwaitsSafetyBackup:
 
 class TestRestoreForwardsPassword:
     @pytest.mark.asyncio
-    async def test_password_forwarded_into_restore_params(self) -> None:
+    async def test_password_forwarded_for_protected_target(self) -> None:
         """A `protected: true` backup needs the default password on restore."""
         call_log: list[str] = []
-        ws = _scripted_ws(_restore_responses(with_password=True), call_log)
+        ws = _scripted_ws(
+            _restore_responses(with_password=True, protected=True), call_log
+        )
         client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
 
         with (
@@ -152,10 +189,35 @@ class TestRestoreForwardsPassword:
         ):
             await restore_backup(client, "target-slug", restore_database=False)
 
-        restore_call = next(
-            c for c in ws.send_command.call_args_list if c.args[0] == "backup/restore"
+        assert _restore_call(ws).kwargs["password"] == "pw"
+
+    @pytest.mark.asyncio
+    async def test_password_omitted_for_unprotected_target(self) -> None:
+        """An unprotected target must NOT receive the password even when a
+        default password is configured — HA validates it against the target and
+        rejects a password on an unprotected backup (#1681 reconciliation)."""
+        call_log: list[str] = []
+        ws = _scripted_ws(
+            _restore_responses(with_password=True, protected=False), call_log
         )
-        assert restore_call.kwargs["password"] == "pw"
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=False)
+
+        assert result["success"] is True
+        # A safety backup is still created (the default password drives that),
+        # but it must not leak into the restore of an unprotected target.
+        assert "password" not in _restore_call(ws).kwargs
 
     @pytest.mark.asyncio
     async def test_password_omitted_when_unavailable(self) -> None:
@@ -183,12 +245,118 @@ class TestRestoreForwardsPassword:
 
         assert result["success"] is True
         assert result["safety_backup_id"] is None
-        restore_call = next(
-            c for c in ws.send_command.call_args_list if c.args[0] == "backup/restore"
-        )
-        assert "password" not in restore_call.kwargs
+        assert "password" not in _restore_call(ws).kwargs
         # No safety backup means no generate call at all.
         assert "backup/generate" not in call_log
+
+
+class TestRestoreReconcilesDatabase:
+    @pytest.mark.asyncio
+    async def test_restore_database_derived_from_target(self) -> None:
+        """A `database_included: true` target forces `restore_database=True`
+        even when the caller defaulted it to False — HA requires the flag to
+        match the backup when restoring Home Assistant, otherwise Supervisor
+        raises "Restore database must match backup"."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(database_included=True), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=False)
+
+        assert _restore_call(ws).kwargs["restore_database"] is True
+        assert result["restore_database"] is True
+        # The silent override is surfaced as a warning.
+        assert any("restore_database was adjusted" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_restore_database_overridden_to_false(self) -> None:
+        """A `database_included: false` target forces `restore_database=False`
+        even when the caller requested True — the symmetric override of the
+        True case, since HA requires the flag to match either way."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(database_included=False), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=True)
+
+        assert _restore_call(ws).kwargs["restore_database"] is False
+        assert result["restore_database"] is False
+        assert any("restore_database was adjusted" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_restore_database_falls_back_when_field_absent(self) -> None:
+        """When the target omits `database_included`, the caller's value is
+        honoured unchanged and no override warning is emitted."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=True)
+
+        assert _restore_call(ws).kwargs["restore_database"] is True
+        assert not any("restore_database was adjusted" in w for w in result["warnings"])
+
+
+class TestRestoreSurfacesSafetyBackupWarnings:
+    @pytest.mark.asyncio
+    async def test_late_completion_warning_folded_into_response(self) -> None:
+        """A late-completion warning from the safety-backup poll must reach the
+        restore response — it is the signal that the backup subsystem is slow,
+        right before a destructive restore."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "warnings": ["Backup completion observed only after ..."],
+                    }
+                ),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=True)
+
+        assert any(
+            "Backup completion observed only after" in w for w in result["warnings"]
+        )
 
 
 class TestCreateSafetyBackup:
@@ -196,24 +364,28 @@ class TestCreateSafetyBackup:
     async def test_polls_to_completion_before_returning(self) -> None:
         """`_create_safety_backup` must await the backup it starts — passing
         the generated job id, the safety-backup name, and the local agent into
-        the completion poll."""
+        the completion poll — and use the dedicated safety-backup timeout."""
         ws = AsyncMock()
         ws.send_command = AsyncMock(
             return_value={"success": True, "result": {"backup_job_id": "safety-job-1"}}
         )
 
         with patch(
-            "ha_mcp.tools.backup._poll_backup_completion", new=AsyncMock()
+            "ha_mcp.tools.backup._poll_backup_completion",
+            new=AsyncMock(return_value={"warnings": ["late"]}),
         ) as poll:
-            result = await _create_safety_backup(ws, "pw", "backup.local")
+            job_id, warnings = await _create_safety_backup(ws, "pw", "backup.local")
 
-        assert result == "safety-job-1"
+        assert job_id == "safety-job-1"
+        assert warnings == ["late"]
         poll.assert_awaited_once()
         # job id is forwarded positionally; agent id is forwarded by keyword.
         assert poll.await_args.args[2] == "safety-job-1"
         assert poll.await_args.kwargs["agent_id"] == "backup.local"
         # the polled name is the PreRestore_Safety_* backup just created.
         assert poll.await_args.args[1].startswith("PreRestore_Safety_")
+        # the full safety backup gets the larger timeout, not the fast-backup one.
+        assert poll.await_args.kwargs["max_wait_seconds"] == _SAFETY_BACKUP_MAX_WAIT_S
 
     @pytest.mark.asyncio
     async def test_skips_creation_and_poll_when_password_none(self) -> None:
@@ -223,8 +395,9 @@ class TestCreateSafetyBackup:
         with patch(
             "ha_mcp.tools.backup._poll_backup_completion", new=AsyncMock()
         ) as poll:
-            result = await _create_safety_backup(ws, None, "backup.local")
+            job_id, warnings = await _create_safety_backup(ws, None, "backup.local")
 
-        assert result is None
+        assert job_id is None
+        assert warnings == []
         ws.send_command.assert_not_awaited()
         poll.assert_not_awaited()

--- a/tests/src/unit/test_backup_restore.py
+++ b/tests/src/unit/test_backup_restore.py
@@ -1,0 +1,230 @@
+"""Unit tests for the snapshot-restore path in `backup.py`.
+
+Regression coverage for #1681:
+
+1. **Self-induced deadlock** — `restore_backup` created a pre-restore safety
+   backup and issued `backup/restore` back-to-back without waiting. HA's
+   `backup/generate` returns once the job is *initiated*, not finished, and the
+   backup manager rejects any new operation while a backup runs
+   ("Backup manager busy: create_backup"). The restore therefore collided with
+   the safety backup the same call had just started. The fix awaits the safety
+   backup (via `_poll_backup_completion`) before restoring.
+
+2. **Missing decryption key** — `restore_params` omitted `password`, so a
+   `protected: true` backup could not be decrypted on restore even though the
+   default password was already fetched for the safety backup. The fix forwards
+   that password into the `backup/restore` call when one is available.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.backup import _create_safety_backup, restore_backup
+
+
+def _scripted_ws(responses: dict[str, Any], call_log: list[str]) -> AsyncMock:
+    """Build a mock WS client that maps each WS command to a canned response
+    and appends the command name to ``call_log`` in call order.
+
+    A missing command raises, so an unexpected extra call fails loudly instead
+    of silently returning a generic success.
+    """
+    ws = AsyncMock()
+
+    async def _send(command: str, **_kwargs: Any) -> Any:
+        call_log.append(command)
+        if command not in responses:
+            raise AssertionError(f"unexpected WS command: {command!r}")
+        return responses[command]
+
+    ws.send_command.side_effect = _send
+    ws.disconnect = AsyncMock()
+    return ws
+
+
+def _restore_responses(*, with_password: bool = True) -> dict[str, Any]:
+    """Canned WS responses for a full restore_backup run."""
+    config_block = {"create_backup": {"password": "pw"}} if with_password else {}
+    return {
+        # backup/info — backup-exists verification
+        "backup/info": {
+            "success": True,
+            "result": {"backups": [{"backup_id": "target-slug"}]},
+        },
+        # backup/agents/info — local agent discovery
+        "backup/agents/info": {
+            "success": True,
+            "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]},
+        },
+        # backup/config/info — default-password lookup
+        "backup/config/info": {
+            "success": True,
+            "result": {"config": config_block},
+        },
+        # backup/generate — the safety backup
+        "backup/generate": {
+            "success": True,
+            "result": {"backup_job_id": "safety-job-1"},
+        },
+        # backup/restore — the actual restore
+        "backup/restore": {"success": True},
+    }
+
+
+class TestRestoreAwaitsSafetyBackup:
+    @pytest.mark.asyncio
+    async def test_restore_issued_only_after_safety_backup_completes(self) -> None:
+        """The core #1681 regression: `backup/restore` must be sent strictly
+        after the safety-backup completion poll returns, never before."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        poll_order_marker = AsyncMock(
+            side_effect=lambda *a, **k: call_log.append("poll-completed")
+        )
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=poll_order_marker,
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=True)
+
+        assert result["success"] is True
+        # The safety backup was awaited exactly once.
+        poll_order_marker.assert_awaited_once()
+        # Ordering is the actual fix: poll completion precedes the restore call.
+        assert "poll-completed" in call_log
+        assert "backup/restore" in call_log
+        assert call_log.index("poll-completed") < call_log.index("backup/restore")
+
+    @pytest.mark.asyncio
+    async def test_restore_aborts_when_safety_backup_times_out(self) -> None:
+        """If the safety backup never completes, `_poll_backup_completion`
+        raises and the restore must NOT be issued — better to abort than
+        restore without a confirmed safety net (or into a busy manager)."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(side_effect=ToolError("timed out")),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await restore_backup(client, "target-slug", restore_database=True)
+
+        assert "backup/restore" not in call_log
+
+
+class TestRestoreForwardsPassword:
+    @pytest.mark.asyncio
+    async def test_password_forwarded_into_restore_params(self) -> None:
+        """A `protected: true` backup needs the default password on restore."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(with_password=True), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            await restore_backup(client, "target-slug", restore_database=False)
+
+        restore_call = next(
+            c for c in ws.send_command.call_args_list if c.args[0] == "backup/restore"
+        )
+        assert restore_call.kwargs["password"] == "pw"
+
+    @pytest.mark.asyncio
+    async def test_password_omitted_when_unavailable(self) -> None:
+        """When no default password is configured, `password` must be absent
+        from the restore params entirely — HA types it as `str`, so passing
+        None would fail voluptuous validation. (Safety backup is also skipped
+        in this case, mirroring the existing no-password behaviour.)"""
+        call_log: list[str] = []
+        # backup/config/info reports no create_backup password → helper raises
+        # → restore_backup falls back to password=None.
+        ws = _scripted_ws(_restore_responses(with_password=False), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
+        ):
+            result = await restore_backup(client, "target-slug", restore_database=False)
+
+        assert result["success"] is True
+        assert result["safety_backup_id"] is None
+        restore_call = next(
+            c for c in ws.send_command.call_args_list if c.args[0] == "backup/restore"
+        )
+        assert "password" not in restore_call.kwargs
+        # No safety backup means no generate call at all.
+        assert "backup/generate" not in call_log
+
+
+class TestCreateSafetyBackup:
+    @pytest.mark.asyncio
+    async def test_polls_to_completion_before_returning(self) -> None:
+        """`_create_safety_backup` must await the backup it starts — passing
+        the generated job id, the safety-backup name, and the local agent into
+        the completion poll."""
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            return_value={"success": True, "result": {"backup_job_id": "safety-job-1"}}
+        )
+
+        with patch(
+            "ha_mcp.tools.backup._poll_backup_completion", new=AsyncMock()
+        ) as poll:
+            result = await _create_safety_backup(ws, "pw", "backup.local")
+
+        assert result == "safety-job-1"
+        poll.assert_awaited_once()
+        # job id is forwarded positionally; agent id is forwarded by keyword.
+        assert poll.await_args.args[2] == "safety-job-1"
+        assert poll.await_args.kwargs["agent_id"] == "backup.local"
+        # the polled name is the PreRestore_Safety_* backup just created.
+        assert poll.await_args.args[1].startswith("PreRestore_Safety_")
+
+    @pytest.mark.asyncio
+    async def test_skips_creation_and_poll_when_password_none(self) -> None:
+        """No default password → no safety backup, and crucially no poll."""
+        ws = AsyncMock()
+
+        with patch(
+            "ha_mcp.tools.backup._poll_backup_completion", new=AsyncMock()
+        ) as poll:
+            result = await _create_safety_backup(ws, None, "backup.local")
+
+        assert result is None
+        ws.send_command.assert_not_awaited()
+        poll.assert_not_awaited()

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -1117,21 +1117,23 @@ class TestSweepWarningsShape:
                 "result": {"config": {"create_backup": {"password": "pw"}}},
             },
             {"success": True, "result": {"backup_job_id": "job"}},
-            {
-                "success": True,
-                "result": {
-                    "backups": [{"name": "Pre_Restore_Safety", "backup_id": "sxyz"}]
-                },
-            },
             {"success": True},
         ]
         client = MagicMock()
         client.base_url = "http://test"
         client.token = "t"
         client.verify_ssl = False
-        with patch(
-            "ha_mcp.tools.backup.get_connected_ws_client",
-            new=AsyncMock(return_value=(ws, None)),
+        # Stub the safety-backup completion poll (exercised by test_backup_restore)
+        # so this test stays focused on the warnings-list shape contract.
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch(
+                "ha_mcp.tools.backup._poll_backup_completion",
+                new=AsyncMock(return_value={"success": True}),
+            ),
         ):
             result = await restore_backup(client, "abc")
         _assert_warnings_list_shape(result)


### PR DESCRIPTION
## What does this PR do?

`ha_manage_backup(scope="snapshot", action="restore")` could never complete a restore. It created a pre-restore safety backup via `backup/generate` and issued `backup/restore` back-to-back without waiting. HA's `backup/generate` returns once the job is initiated, not finished, and the backup manager rejects any new operation while a backup runs ("Backup manager busy: create_backup"), so the restore collided with the safety backup the same call had just started – a self-induced deadlock; each retry spawned another safety backup.

This awaits the safety backup through the existing `_poll_backup_completion` helper before issuing `backup/restore`, and forwards the default backup password into the restore call (only when one is configured) so `protected: true` backups decrypt on restore.

Closes #1681

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed