### PR TITLE
feat: Matter & Thread support + unified ha_manage_radio management tool

### DIFF
--- a/src/ha_mcp/tools/radio/__init__.py
+++ b/src/ha_mcp/tools/radio/__init__.py
@@ -1,0 +1,6 @@
+"""Per-radio handler modules for the ``ha_manage_radio`` tool.
+
+Each radio (Z-Wave, Zigbee/ZHA, Matter, Thread) gets its own handler module so
+no single file spans every protocol (keeps modules focused per AGENTS.md). The
+``tools_radio`` module wires them together behind one MCP tool.
+"""

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -99,14 +99,75 @@ async def resolve_entry_id(client: Any, domain: str) -> str | None:
     return None
 
 
+async def resolve_update_entity(
+    client: Any, device_id: Any, *, platform: str | None = None
+) -> str:
+    """Return the device's ``update.*`` firmware entity_id from the registry.
+
+    Filters the ``update.*`` entities tied to ``device_id``, preferring the given
+    ``platform`` (e.g. "matter", "zha", "zwave_js") when a device exposes more
+    than one. Raises ENTITY_NOT_FOUND when the device exposes no update entity.
+    """
+    entities = await ws_call(
+        client, "config/entity_registry/list", context={"device_id": device_id}
+    )
+    candidates = [
+        e
+        for e in (entities or [])
+        if e.get("device_id") == device_id
+        and str(e.get("entity_id", "")).startswith("update.")
+    ]
+    if platform is not None:
+        for entity in candidates:
+            if entity.get("platform") == platform:
+                return str(entity["entity_id"])
+    if candidates:
+        return str(candidates[0]["entity_id"])
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.ENTITY_NOT_FOUND,
+            f"No update entity found for device {device_id}; no firmware update is available",
+            context={"device_id": device_id},
+            suggestions=[
+                "Firmware updates appear only when the device exposes an update.* entity",
+                "Check ha_get_device for an 'update.' entity on this device",
+            ],
+        )
+    )
+
+
 def integration_not_found(radio: str, domain: str) -> dict[str, Any]:
-    """Standard degraded payload when an integration/config-entry is absent."""
+    """Standard degraded payload when an integration/config-entry is absent.
+
+    For read-only actions (``network_status``) only — reporting the absent
+    integration as a graceful ``success: True`` degradation is correct there.
+    Write/management actions must call ``integration_required`` instead so an
+    unconfigured integration surfaces as an error rather than a silent no-op.
+    """
     return {
         "success": True,
         "radio": radio,
         "available": False,
         "warnings": [f"{domain} integration is not configured on this Home Assistant"],
     }
+
+
+def integration_required(radio: str, domain: str) -> None:
+    """Raise a ToolError when a write action's integration/config-entry is absent.
+
+    The write-action counterpart to ``integration_not_found``: management actions
+    must not report a no-op as ``success: True``, so this raises instead of
+    degrading to an ``available: False`` payload.
+    """
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            f"{domain} integration is not configured on this Home Assistant; "
+            f"cannot run this {radio} management action.",
+            context={"radio": radio, "domain": domain, "available": False},
+            suggestions=[f"Install/configure the {domain} integration first"],
+        )
+    )
 
 
 def confirm_required(radio: str, action: str) -> None:

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -1,0 +1,123 @@
+"""Shared contract and helpers for ``ha_manage_radio`` per-radio handlers.
+
+A handler module exposes:
+
+- ``SUPPORTED``: ``dict[action_name, ActionSpec]`` describing every action it
+  implements, used for validation, the destructive-confirm gate, and building
+  actionable "unsupported action" errors.
+- ``async def handle(client, action, args) -> dict``: execute one action.
+
+Handlers send raw WebSocket commands through the REST client's
+``send_websocket_message`` bridge (same path the ``ha_get_device`` enrichers
+use), or call services via ``call_service`` for the few ZHA operations that are
+service-only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+
+from ..errors import ErrorCode, create_error_response
+from ..helpers import raise_tool_error
+
+logger = logging.getLogger(__name__)
+
+RADIOS = ("zwave", "zigbee", "matter", "thread")
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    """Metadata for one radio action.
+
+    summary: one-line description (surfaced in unsupported-action errors).
+    destructive: requires ``confirm=True`` before it will run.
+    long_running: starts an operation that completes out-of-band (inclusion,
+        rebuild routes, firmware) — the result documents how to follow up.
+    required: parameter names that must be present in ``args`` (or supplied as
+        the top-level ``device_id``).
+    """
+
+    summary: str
+    destructive: bool = False
+    long_running: bool = False
+    required: tuple[str, ...] = field(default_factory=tuple)
+
+
+def ok(radio: str, action: str, **data: Any) -> dict[str, Any]:
+    """Build the standard success envelope for a radio action."""
+    return {"success": True, "radio": radio, "action": action, **data}
+
+
+def require(args: dict[str, Any], spec: ActionSpec, radio: str, action: str) -> None:
+    """Raise VALIDATION_INVALID_PARAMETER if any required arg is missing/empty."""
+    missing = [k for k in spec.required if args.get(k) in (None, "")]
+    if missing:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                f"{radio}/{action} requires: {', '.join(missing)}",
+                context={"radio": radio, "action": action, "missing": missing},
+                suggestions=[f"Pass {m} (in params or as device_id)" for m in missing],
+            )
+        )
+
+
+async def ws_call(
+    client: Any, ws_type: str, *, context: dict[str, Any] | None = None, **fields: Any
+) -> Any:
+    """Send a WebSocket command and return its ``result``; raise on failure.
+
+    Mirrors the ``send_websocket_message`` usage in the ``ha_get_device``
+    enrichers. Raises ToolError (SERVICE_CALL_FAILED) when HA reports the
+    command failed, attaching the command type and any caller context.
+    """
+    message = {"type": ws_type, **{k: v for k, v in fields.items() if v is not None}}
+    result = await client.send_websocket_message(message)
+    if not result.get("success"):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                result.get("error", f"WebSocket command '{ws_type}' failed"),
+                context={"ws_type": ws_type, **(context or {})},
+            )
+        )
+    return result.get("result")
+
+
+async def resolve_entry_id(client: Any, domain: str) -> str | None:
+    """Return the config entry_id for a single-instance integration ``domain``.
+
+    Uses ``config_entries/get`` (underscore form; the slash form is rejected as
+    "Unknown command"). Returns None when the integration is not configured.
+    """
+    entries = await ws_call(client, "config_entries/get", context={"domain": domain})
+    for entry in entries or []:
+        if entry.get("domain") == domain:
+            return entry.get("entry_id")
+    return None
+
+
+def integration_not_found(radio: str, domain: str) -> dict[str, Any]:
+    """Standard degraded payload when an integration/config-entry is absent."""
+    return {
+        "success": True,
+        "radio": radio,
+        "available": False,
+        "warnings": [f"{domain} integration is not configured on this Home Assistant"],
+    }
+
+
+def confirm_required(radio: str, action: str) -> ToolError:
+    """Build the ToolError raised when a destructive action lacks confirm=True."""
+    return raise_tool_error(  # type: ignore[return-value]  # NoReturn
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"{radio}/{action} is destructive; pass confirm=True to proceed",
+            context={"radio": radio, "action": action, "destructive": True},
+            suggestions=["Re-run with confirm=True once you intend the change"],
+        )
+    )

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -97,7 +97,8 @@ async def resolve_entry_id(client: Any, domain: str) -> str | None:
     entries = await ws_call(client, "config_entries/get", context={"domain": domain})
     for entry in entries or []:
         if entry.get("domain") == domain:
-            return entry.get("entry_id")
+            entry_id = entry.get("entry_id")
+            return str(entry_id) if entry_id is not None else None
     return None
 
 
@@ -111,9 +112,9 @@ def integration_not_found(radio: str, domain: str) -> dict[str, Any]:
     }
 
 
-def confirm_required(radio: str, action: str) -> ToolError:
-    """Build the ToolError raised when a destructive action lacks confirm=True."""
-    return raise_tool_error(  # type: ignore[return-value]  # NoReturn
+def confirm_required(radio: str, action: str) -> None:
+    """Raise the ToolError for a destructive action lacking confirm=True."""
+    raise_tool_error(
         create_error_response(
             ErrorCode.VALIDATION_INVALID_PARAMETER,
             f"{radio}/{action} is destructive; pass confirm=True to proceed",

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -9,8 +9,9 @@ A handler module exposes:
 
 Handlers send raw WebSocket commands through the REST client's
 ``send_websocket_message`` bridge (same path the ``ha_get_device`` enrichers
-use), or call services via ``call_service`` for the few ZHA operations that are
-service-only.
+use), or call services via ``call_service`` for the operations that are
+service-only (most ZHA writes, plus ``zwave_js.ping`` and ``update.install``
+firmware installs).
 """
 
 from __future__ import annotations
@@ -23,8 +24,6 @@ from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
 
 logger = logging.getLogger(__name__)
-
-RADIOS = ("zwave", "zigbee", "matter", "thread")
 
 
 @dataclass(frozen=True)

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from fastmcp.exceptions import ToolError
 
-from ..errors import ErrorCode, create_error_response
+from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
 
 logger = logging.getLogger(__name__)

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -19,8 +19,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from fastmcp.exceptions import ToolError
-
 from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
 

--- a/src/ha_mcp/tools/radio/base.py
+++ b/src/ha_mcp/tools/radio/base.py
@@ -134,6 +134,7 @@ async def resolve_update_entity(
             ],
         )
     )
+    raise AssertionError  # py/mixed-returns terminal: raise_tool_error is NoReturn
 
 
 def integration_not_found(radio: str, domain: str) -> dict[str, Any]:

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -83,7 +83,7 @@ async def _update_entity_for_device(client: Any, device_id: Any) -> str:
         return str(candidates[0]["entity_id"])
     raise_tool_error(
         create_error_response(
-            ErrorCode.RESOURCE_NOT_FOUND,
+            ErrorCode.ENTITY_NOT_FOUND,
             f"No firmware update entity found for device {device_id}",
             context={"device_id": device_id},
             suggestions=["The node may not expose an OTA firmware update entity"],

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -103,6 +103,12 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
             device_id=device_id,
             context={"device_id": device_id},
         )
+        # Upstream NodeDiagnostics misspells the IP field "ip_adresses" (one d);
+        # normalize so callers see the same "ip_addresses" key ha_get_device
+        # surfaces. Copy first so the upstream/result dict is not mutated.
+        if isinstance(diag, dict) and "ip_adresses" in diag:
+            diag = dict(diag)
+            diag["ip_addresses"] = diag.pop("ip_adresses")
         return ok("matter", "diagnostics", diagnostics=diag)
 
     if action == "ping":

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -1,0 +1,175 @@
+"""Matter radio handler for ``ha_manage_radio``.
+
+Wraps the Home Assistant ``matter/*`` WebSocket API: per-node diagnostics and
+ping (read), commissioning / multi-admin share-out / fabric removal / interview
+(write), and credential provisioning. All commands are single request/response
+or fire-and-return; Matter has no interactive PIN handshake (unlike Z-Wave S2).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
+
+SUPPORTED: dict[str, ActionSpec] = {
+    "diagnostics": ActionSpec(
+        "Per-node Matter diagnostics: network type (wifi/thread), availability, "
+        "IPs, node type, active fabrics.",
+        required=("device_id",),
+    ),
+    "network_status": ActionSpec("Matter fabric / integration summary."),
+    "ping": ActionSpec(
+        "Actively ping a Matter node at its known IP addresses.",
+        required=("device_id",),
+    ),
+    "commission": ActionSpec(
+        "Commission a Matter device from a setup code (QR or manual pairing code).",
+        long_running=True,
+        required=("code",),
+    ),
+    "commission_on_network": ActionSpec(
+        "Commission an already-networked Matter device by its PIN.",
+        long_running=True,
+        required=("pin",),
+    ),
+    "share_out": ActionSpec(
+        "Open a commissioning window and return a pairing code so another "
+        "controller can add this device (multi-admin).",
+        required=("device_id",),
+    ),
+    "interview": ActionSpec(
+        "Re-interview a Matter node to refresh its endpoints/clusters.",
+        long_running=True,
+        required=("device_id",),
+    ),
+    "remove_fabric": ActionSpec(
+        "Remove a controller fabric from a Matter node (defaults to this HA's "
+        "own fabric). The device stays paired to its other controllers.",
+        destructive=True,
+        required=("device_id",),
+    ),
+    "set_thread": ActionSpec(
+        "Provide Thread operational credentials used for the next commissioning.",
+        required=("thread_operation_dataset",),
+    ),
+    "set_wifi_credentials": ActionSpec(
+        "Provide WiFi credentials used for the next commissioning.",
+        required=("network_name", "password"),
+    ),
+}
+
+
+async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute one Matter action (validation/confirm already applied by caller)."""
+    device_id = args.get("device_id")
+
+    if action == "diagnostics":
+        diag = await ws_call(
+            client,
+            "matter/node_diagnostics",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        return ok("matter", "diagnostics", diagnostics=diag)
+
+    if action == "ping":
+        reachability = await ws_call(
+            client,
+            "matter/ping_node",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        return ok("matter", "ping", reachability=reachability)
+
+    if action == "network_status":
+        entry_id = await resolve_entry_id(client, "matter")
+        if not entry_id:
+            return integration_not_found("matter", "matter")
+        return ok(
+            "matter",
+            "network_status",
+            config_entry_id=entry_id,
+            note=(
+                "Matter exposes health per node; call action='diagnostics' with a "
+                "device_id for node-level network type, availability and fabrics."
+            ),
+        )
+
+    if action == "commission":
+        result = await ws_call(
+            client,
+            "matter/commission",
+            code=args.get("code"),
+            network_only=bool(args.get("network_only", False)),
+        )
+        return ok("matter", "commission", result=result, long_running=True)
+
+    if action == "commission_on_network":
+        result = await ws_call(
+            client,
+            "matter/commission_on_network",
+            pin=args.get("pin"),
+            ip_addr=args.get("ip_addr"),
+        )
+        return ok("matter", "commission_on_network", result=result, long_running=True)
+
+    if action == "share_out":
+        commissioning = await ws_call(
+            client,
+            "matter/open_commissioning_window",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        # Returns setup_pin_code, setup_manual_code, setup_qr_code.
+        return ok("matter", "share_out", commissioning=commissioning)
+
+    if action == "interview":
+        result = await ws_call(
+            client,
+            "matter/interview_node",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        return ok("matter", "interview", result=result, long_running=True)
+
+    if action == "remove_fabric":
+        fabric_index = args.get("fabric_index")
+        if fabric_index is None:
+            # Default to THIS HA's fabric so the common "detach from HA" case
+            # needs only device_id.
+            diag = await ws_call(
+                client,
+                "matter/node_diagnostics",
+                device_id=device_id,
+                context={"device_id": device_id},
+            )
+            fabric_index = (diag or {}).get("active_fabric_index")
+        result = await ws_call(
+            client,
+            "matter/remove_matter_fabric",
+            device_id=device_id,
+            fabric_index=fabric_index,
+            context={"device_id": device_id, "fabric_index": fabric_index},
+        )
+        return ok("matter", "remove_fabric", result=result, fabric_index=fabric_index)
+
+    if action == "set_thread":
+        result = await ws_call(
+            client,
+            "matter/set_thread",
+            thread_operation_dataset=args.get("thread_operation_dataset"),
+        )
+        return ok("matter", "set_thread", result=result)
+
+    if action == "set_wifi_credentials":
+        result = await ws_call(
+            client,
+            "matter/set_wifi_credentials",
+            network_name=args.get("network_name"),
+            password=args.get("password"),
+        )
+        return ok("matter", "set_wifi_credentials", result=result)
+
+    # Unreachable: dispatcher validates action against SUPPORTED first.
+    raise AssertionError(f"unhandled matter action: {action}")

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ...errors import ErrorCode, create_error_response
+from ..helpers import raise_tool_error
 from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
 
 SUPPORTED: dict[str, ActionSpec] = {
@@ -57,7 +59,37 @@ SUPPORTED: dict[str, ActionSpec] = {
         "Provide WiFi credentials used for the next commissioning.",
         required=("network_name", "password"),
     ),
+    "firmware_update": ActionSpec(
+        "Install an available OTA firmware update for this Matter node.",
+        long_running=True,
+        required=("device_id",),
+    ),
 }
+
+
+async def _update_entity_for_device(client: Any, device_id: str) -> str:
+    """Return the device's Matter firmware ``update.*`` entity_id."""
+    entities = await ws_call(client, "config/entity_registry/list")
+    candidates = [
+        e
+        for e in (entities or [])
+        if e.get("device_id") == device_id
+        and str(e.get("entity_id", "")).startswith("update.")
+    ]
+    for e in candidates:
+        if e.get("platform") == "matter":
+            return str(e["entity_id"])
+    if candidates:
+        return str(candidates[0]["entity_id"])
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            f"No firmware update entity found for device {device_id}",
+            context={"device_id": device_id},
+            suggestions=["The node may not expose an OTA firmware update entity"],
+        )
+    )
+    raise AssertionError  # unreachable: raise_tool_error always raises
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -170,6 +202,11 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
             password=args.get("password"),
         )
         return ok("matter", "set_wifi_credentials", result=result)
+
+    if action == "firmware_update":
+        entity_id = await _update_entity_for_device(client, device_id)
+        await client.call_service("update", "install", {"entity_id": entity_id})
+        return ok("matter", "firmware_update", entity_id=entity_id, long_running=True)
 
     # Unreachable: dispatcher validates action against SUPPORTED first.
     raise AssertionError(f"unhandled matter action: {action}")

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -46,8 +46,9 @@ SUPPORTED: dict[str, ActionSpec] = {
         required=("device_id",),
     ),
     "remove_fabric": ActionSpec(
-        "Remove a controller fabric from a Matter node (defaults to this HA's "
-        "own fabric). The device stays paired to its other controllers.",
+        "Remove ANOTHER controller's fabric from a Matter node (pass "
+        "params.fabric_index; see active_fabrics in diagnostics). To detach the "
+        "device from Home Assistant itself, delete it with ha_remove_device.",
         destructive=True,
         required=("device_id",),
     ),
@@ -172,17 +173,39 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         return ok("matter", "interview", result=result, long_running=True)
 
     if action == "remove_fabric":
+        diag = await ws_call(
+            client,
+            "matter/node_diagnostics",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        active = (diag or {}).get("active_fabric_index")
         fabric_index = args.get("fabric_index")
-        if fabric_index is None:
-            # Default to THIS HA's fabric so the common "detach from HA" case
-            # needs only device_id.
-            diag = await ws_call(
-                client,
-                "matter/node_diagnostics",
-                device_id=device_id,
-                context={"device_id": device_id},
+        # remove_fabric removes ANOTHER controller's fabric. Removing HA's OWN
+        # active fabric over that fabric makes the node drop the session, so the
+        # Matter server aborts the confirmation (the removal still happens, but
+        # reports as an error). The clean "detach from HA" path is deleting the
+        # device, so refuse the own-fabric case with that guidance.
+        if fabric_index is None or fabric_index == active:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "remove_fabric removes ANOTHER controller's fabric from a "
+                    "node; pass params.fabric_index (see active_fabrics). To "
+                    "detach this device from Home Assistant itself, delete the "
+                    "device with ha_remove_device — removing HA's own active "
+                    "fabric here is aborted by the Matter server.",
+                    context={
+                        "device_id": device_id,
+                        "active_fabric_index": active,
+                        "active_fabrics": (diag or {}).get("active_fabrics", []),
+                    },
+                    suggestions=[
+                        "Pass params.fabric_index = the other controller's index",
+                        "To remove Home Assistant, use ha_remove_device",
+                    ],
+                )
             )
-            fabric_index = (diag or {}).get("active_fabric_index")
         result = await ws_call(
             client,
             "matter/remove_matter_fabric",

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -67,7 +67,7 @@ SUPPORTED: dict[str, ActionSpec] = {
 }
 
 
-async def _update_entity_for_device(client: Any, device_id: str) -> str:
+async def _update_entity_for_device(client: Any, device_id: Any) -> str:
     """Return the device's Matter firmware ``update.*`` entity_id."""
     entities = await ws_call(client, "config/entity_registry/list")
     candidates = [

--- a/src/ha_mcp/tools/radio/matter.py
+++ b/src/ha_mcp/tools/radio/matter.py
@@ -12,7 +12,14 @@ from typing import Any
 
 from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
-from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
+from .base import (
+    ActionSpec,
+    integration_not_found,
+    ok,
+    resolve_entry_id,
+    resolve_update_entity,
+    ws_call,
+)
 
 SUPPORTED: dict[str, ActionSpec] = {
     "diagnostics": ActionSpec(
@@ -66,31 +73,6 @@ SUPPORTED: dict[str, ActionSpec] = {
         required=("device_id",),
     ),
 }
-
-
-async def _update_entity_for_device(client: Any, device_id: Any) -> str:
-    """Return the device's Matter firmware ``update.*`` entity_id."""
-    entities = await ws_call(client, "config/entity_registry/list")
-    candidates = [
-        e
-        for e in (entities or [])
-        if e.get("device_id") == device_id
-        and str(e.get("entity_id", "")).startswith("update.")
-    ]
-    for e in candidates:
-        if e.get("platform") == "matter":
-            return str(e["entity_id"])
-    if candidates:
-        return str(candidates[0]["entity_id"])
-    raise_tool_error(
-        create_error_response(
-            ErrorCode.ENTITY_NOT_FOUND,
-            f"No firmware update entity found for device {device_id}",
-            context={"device_id": device_id},
-            suggestions=["The node may not expose an OTA firmware update entity"],
-        )
-    )
-    raise AssertionError  # unreachable: raise_tool_error always raises
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -233,7 +215,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         return ok("matter", "set_wifi_credentials", result=result)
 
     if action == "firmware_update":
-        entity_id = await _update_entity_for_device(client, device_id)
+        entity_id = await resolve_update_entity(client, device_id, platform="matter")
         await client.call_service("update", "install", {"entity_id": entity_id})
         return ok("matter", "firmware_update", entity_id=entity_id, long_running=True)
 

--- a/src/ha_mcp/tools/radio/thread.py
+++ b/src/ha_mcp/tools/radio/thread.py
@@ -1,0 +1,14 @@
+"""Thread radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ActionSpec
+
+SUPPORTED: dict[str, ActionSpec] = {}
+
+
+async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute one thread action (validation/confirm applied by the dispatcher)."""
+    raise AssertionError(f"unhandled thread action: {action}")

--- a/src/ha_mcp/tools/radio/thread.py
+++ b/src/ha_mcp/tools/radio/thread.py
@@ -35,7 +35,9 @@ SUPPORTED: dict[str, ActionSpec] = {
         destructive=True,
     ),
     "set_network": ActionSpec(
-        "Apply a stored dataset as the OTBR's active Thread network.",
+        "Apply a stored dataset as the OTBR's active Thread network. Replaces "
+        "the current network, which can drop existing Thread devices.",
+        destructive=True,
         required=("dataset_id",),
     ),
     "set_channel": ActionSpec(

--- a/src/ha_mcp/tools/radio/thread.py
+++ b/src/ha_mcp/tools/radio/thread.py
@@ -5,15 +5,23 @@ and its border router rather than an individual node. Border-router writes use
 the ``otbr/*`` WebSocket API and take an OTBR ``extended_address`` — resolved
 from ``otbr/info`` when the caller omits it, which covers the common
 single-OTBR setup. Dataset listing and router discovery use the
-integration-wide ``thread/*`` API. When no OTBR is configured the handler
-degrades to an ``available: False`` payload instead of erroring.
+integration-wide ``thread/*`` API. When no OTBR is configured the read-only
+``network_status`` degrades to an ``available: False`` payload; the write
+actions raise instead so an unconfigured integration is not a silent no-op.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
+from .base import (
+    ActionSpec,
+    integration_not_found,
+    integration_required,
+    ok,
+    resolve_entry_id,
+    ws_call,
+)
 
 SUPPORTED: dict[str, ActionSpec] = {
     "network_status": ActionSpec(
@@ -106,10 +114,12 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         )
         return ok("thread", "add_dataset", result=result)
 
-    # Remaining actions target a specific OTBR border router.
+    # Remaining actions (create_network / set_network / set_channel) are writes
+    # targeting a specific OTBR border router; an absent OTBR must error, not
+    # degrade to a no-op success.
     extended_address = await _resolve_extended_address(client, args)
     if not extended_address:
-        return integration_not_found("thread", "otbr")
+        integration_required("thread", "otbr")
     ctx = {"extended_address": extended_address}
 
     if action == "create_network":

--- a/src/ha_mcp/tools/radio/thread.py
+++ b/src/ha_mcp/tools/radio/thread.py
@@ -1,14 +1,149 @@
-"""Thread radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+"""Thread / OpenThread Border Router (OTBR) handler for ``ha_manage_radio``.
+
+Thread is network-scoped, not per-device: operations target the Thread network
+and its border router rather than an individual node. Border-router writes use
+the ``otbr/*`` WebSocket API and take an OTBR ``extended_address`` — resolved
+from ``otbr/info`` when the caller omits it, which covers the common
+single-OTBR setup. Dataset listing and router discovery use the
+integration-wide ``thread/*`` API. When no OTBR is configured the handler
+degrades to an ``available: False`` payload instead of erroring.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-from .base import ActionSpec
+from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
 
-SUPPORTED: dict[str, ActionSpec] = {}
+SUPPORTED: dict[str, ActionSpec] = {
+    "network_status": ActionSpec(
+        "OTBR border-router status keyed by extended address (channel, active "
+        "dataset TLVs, extended PAN id, border agent id)."
+    ),
+    "list_datasets": ActionSpec(
+        "List stored Thread operational datasets (the preferred network + others)."
+    ),
+    "discover_routers": ActionSpec(
+        "Start mDNS discovery of Thread border routers. Results arrive as an "
+        "out-of-band event stream; this kicks off the scan.",
+        long_running=True,
+    ),
+    "create_network": ActionSpec(
+        "Form a brand-new Thread network on the OTBR. Factory-resets the border "
+        "router and replaces its current dataset. Targets the only OTBR when "
+        "extended_address is omitted.",
+        destructive=True,
+    ),
+    "set_network": ActionSpec(
+        "Apply a stored dataset as the OTBR's active Thread network.",
+        required=("dataset_id",),
+    ),
+    "set_channel": ActionSpec(
+        "Migrate the OTBR's Thread network to a different radio channel.",
+        destructive=True,
+        required=("channel",),
+    ),
+    "add_dataset": ActionSpec(
+        "Import a Thread operational dataset (hex TLV) from a named source.",
+        required=("source", "tlv"),
+    ),
+}
+
+
+async def _resolve_extended_address(client: Any, args: dict[str, Any]) -> str | None:
+    """Return the target OTBR extended address.
+
+    Uses the caller-supplied value, else the first (typically only) border
+    router reported by ``otbr/info``. Returns None when no OTBR is present.
+    """
+    addr = args.get("extended_address")
+    if addr:
+        return str(addr)
+    info = await ws_call(client, "otbr/info")
+    return next(iter(info or {}), None)
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Execute one thread action (validation/confirm applied by the dispatcher)."""
+    """Execute one Thread/OTBR action (validation/confirm applied by caller)."""
+    if action == "network_status":
+        entry_id = await resolve_entry_id(client, "otbr")
+        if not entry_id:
+            return integration_not_found("thread", "otbr")
+        info = await ws_call(client, "otbr/info")
+        return ok(
+            "thread",
+            "network_status",
+            config_entry_id=entry_id,
+            border_routers=info,
+        )
+
+    if action == "list_datasets":
+        datasets = await ws_call(client, "thread/list_datasets")
+        return ok("thread", "list_datasets", datasets=datasets)
+
+    if action == "discover_routers":
+        # Subscription command: it streams discovered routers as events. Kick
+        # off the scan and report it started; consumers watch the event stream.
+        await ws_call(client, "thread/discover_routers")
+        return ok(
+            "thread",
+            "discover_routers",
+            long_running=True,
+            note=(
+                "Router discovery started; results are delivered as an event "
+                "stream, not in this response."
+            ),
+        )
+
+    if action == "add_dataset":
+        result = await ws_call(
+            client,
+            "thread/add_dataset_tlv",
+            source=args.get("source"),
+            tlv=args.get("tlv"),
+        )
+        return ok("thread", "add_dataset", result=result)
+
+    # Remaining actions target a specific OTBR border router.
+    extended_address = await _resolve_extended_address(client, args)
+    if not extended_address:
+        return integration_not_found("thread", "otbr")
+    ctx = {"extended_address": extended_address}
+
+    if action == "create_network":
+        result = await ws_call(
+            client,
+            "otbr/create_network",
+            extended_address=extended_address,
+            context=ctx,
+        )
+        return ok(
+            "thread", "create_network", result=result, extended_address=extended_address
+        )
+
+    if action == "set_network":
+        result = await ws_call(
+            client,
+            "otbr/set_network",
+            extended_address=extended_address,
+            dataset_id=args.get("dataset_id"),
+            context=ctx,
+        )
+        return ok(
+            "thread", "set_network", result=result, extended_address=extended_address
+        )
+
+    if action == "set_channel":
+        result = await ws_call(
+            client,
+            "otbr/set_channel",
+            extended_address=extended_address,
+            channel=args.get("channel"),
+            context=ctx,
+        )
+        return ok(
+            "thread", "set_channel", result=result, extended_address=extended_address
+        )
+
+    # Unreachable: dispatcher validates action against SUPPORTED first.
     raise AssertionError(f"unhandled thread action: {action}")

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -156,6 +156,7 @@ async def _resolve_ieee(client: Any, device_id: Any) -> str:
             ],
         )
     )
+    raise AssertionError  # py/mixed-returns terminal: raise_tool_error is NoReturn
 
 
 async def _call_service(client: Any, domain: str, service: str, **data: Any) -> Any:

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -13,11 +13,14 @@ network- and group-scoped actions act on the coordinator.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
 from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED: dict[str, ActionSpec] = {
     "diagnostics": ActionSpec(
@@ -166,7 +169,7 @@ async def _resolve_update_entity(client: Any, device_id: Any) -> str:
         return str(candidates[0]["entity_id"])
     raise_tool_error(
         create_error_response(
-            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            ErrorCode.ENTITY_NOT_FOUND,
             f"No update entity found for device '{device_id}'; no firmware update is available",
             context={"device_id": device_id, "radio": "zigbee"},
             suggestions=[
@@ -204,10 +207,10 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         network = await ws_call(client, "zha/network/settings")
         try:
             await ws_call(client, "zha/topology/update")
-        except Exception:
+        except Exception as exc:
             # Topology refresh is best-effort: stale routes are acceptable and
             # must not fail an otherwise-successful network_status read.
-            pass
+            logger.debug("zha/topology/update refresh failed (non-fatal): %s", exc)
         return ok("zigbee", "network_status", config_entry_id=entry_id, network=network)
 
     if action == "cluster_read":

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -1,0 +1,14 @@
+"""Zigbee radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ActionSpec
+
+SUPPORTED: dict[str, ActionSpec] = {}
+
+
+async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute one zigbee action (validation/confirm applied by the dispatcher)."""
+    raise AssertionError(f"unhandled zigbee action: {action}")

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -109,7 +109,7 @@ SUPPORTED: dict[str, ActionSpec] = {
 }
 
 
-async def _resolve_ieee(client: Any, device_id: str) -> str:
+async def _resolve_ieee(client: Any, device_id: Any) -> str:
     """Resolve a ``device_id`` to its ZHA IEEE address via the device registry.
 
     Parses the ``["zha", "<ieee>"]`` registry identifier (falling back to an
@@ -147,7 +147,7 @@ async def _resolve_ieee(client: Any, device_id: str) -> str:
     raise AssertionError  # unreachable: raise_tool_error always raises
 
 
-async def _resolve_update_entity(client: Any, device_id: str) -> str:
+async def _resolve_update_entity(client: Any, device_id: Any) -> str:
     """Find the device's ``update.*`` firmware entity via the entity registry."""
     entities = await ws_call(
         client, "config/entity_registry/list", context={"device_id": device_id}
@@ -202,10 +202,11 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         if not entry_id:
             return integration_not_found("zigbee", "zha")
         network = await ws_call(client, "zha/network/settings")
-        # Best-effort topology refresh; never fail network_status if it errors.
         try:
             await ws_call(client, "zha/topology/update")
         except Exception:
+            # Topology refresh is best-effort: stale routes are acceptable and
+            # must not fail an otherwise-successful network_status read.
             pass
         return ok("zigbee", "network_status", config_entry_id=entry_id, network=network)
 
@@ -227,15 +228,17 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
     # --- node management --------------------------------------------------- #
     if action == "permit_join":
         duration = args.get("duration", 60)
-        ieee = await _resolve_ieee(client, device_id) if device_id else None
+        permit_ieee = await _resolve_ieee(client, device_id) if device_id else None
         result = await ws_call(
             client,
             "zha/devices/permit",
             duration=duration,
-            ieee=ieee,
-            context={"duration": duration, "ieee": ieee},
+            ieee=permit_ieee,
+            context={"duration": duration, "ieee": permit_ieee},
         )
-        return ok("zigbee", "permit_join", duration=duration, ieee=ieee, result=result)
+        return ok(
+            "zigbee", "permit_join", duration=duration, ieee=permit_ieee, result=result
+        )
 
     if action == "reconfigure":
         ieee = await _resolve_ieee(client, device_id)

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -95,7 +95,9 @@ SUPPORTED: dict[str, ActionSpec] = {
     ),
     "cluster_command": ActionSpec(
         "Issue a Zigbee cluster command (endpoint_id, cluster_id, command, "
-        "command_type; optional params/args; cluster_type defaults to 'in').",
+        "command_type; cluster_type defaults to 'in'). Pass command arguments "
+        "via params — HA deprecated 'args' in favor of 'params' (both are still "
+        "accepted), so prefer params.",
         destructive=True,
         required=("device_id", "endpoint_id", "cluster_id", "command", "command_type"),
     ),
@@ -238,12 +240,11 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
 
     if action == "firmware_update":
         entity_id = await resolve_update_entity(client, device_id, platform="zha")
-        result = await _call_service(client, "update", "install", entity_id=entity_id)
+        await _call_service(client, "update", "install", entity_id=entity_id)
         return ok(
             "zigbee",
             "firmware_update",
             entity_id=entity_id,
-            result=result,
             long_running=True,
         )
 
@@ -344,6 +345,8 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
             cluster_type=cluster_type,
             command=args.get("command"),
             command_type=args.get("command_type"),
+            # HA deprecated 'args' in favor of 'params' (both still accepted);
+            # forward both for back-compat — callers should prefer params.
             params=args.get("params"),
             args=args.get("args"),
             manufacturer=args.get("manufacturer"),

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -1,14 +1,391 @@
-"""Zigbee radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+"""Zigbee (ZHA) radio handler for ``ha_manage_radio``.
+
+Wraps the Home Assistant ``zha/*`` WebSocket API plus the handful of ZHA
+operations that are service-only (``zha.remove``,
+``zha.set_zigbee_cluster_attribute``, ``zha.issue_zigbee_cluster_command`` and
+``update.install`` for OTA firmware). Service calls go through the REST client's
+``call_service`` bridge (the same path ``ha_call_service`` uses).
+
+Node-scoped actions take ``device_id`` and resolve it to the device's Zigbee
+IEEE address via the device registry (identifier ``["zha", "<ieee>"]``);
+network- and group-scoped actions act on the coordinator.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-from .base import ActionSpec
+from ...errors import ErrorCode, create_error_response
+from ..helpers import raise_tool_error
+from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
 
-SUPPORTED: dict[str, ActionSpec] = {}
+SUPPORTED: dict[str, ActionSpec] = {
+    "diagnostics": ActionSpec(
+        "Per-node ZHA diagnostics: LQI, RSSI, availability, last-seen, "
+        "neighbors and routes.",
+        required=("device_id",),
+    ),
+    "network_status": ActionSpec(
+        "ZHA network settings (channel, PAN id, coordinator). Also kicks a "
+        "topology scan so the next read reflects current routes."
+    ),
+    "permit_join": ActionSpec(
+        "Open the Zigbee network for joining for `duration` seconds (default "
+        "60). Pass a device_id to permit via a specific router."
+    ),
+    "remove_device": ActionSpec(
+        "Remove (leave) a Zigbee node from the network.",
+        destructive=True,
+        required=("device_id",),
+    ),
+    "reconfigure": ActionSpec(
+        "Re-interview a Zigbee node and re-apply its bindings/reporting.",
+        required=("device_id",),
+    ),
+    "group_add": ActionSpec(
+        "Create a Zigbee group. Optional group_id and members "
+        "([{ieee, endpoint_id}, ...]).",
+        required=("group_name",),
+    ),
+    "group_remove": ActionSpec(
+        "Delete Zigbee groups by id (group_ids: list[int]).",
+        destructive=True,
+        required=("group_ids",),
+    ),
+    "group_members_add": ActionSpec(
+        "Add members ([{ieee, endpoint_id}, ...]) to a Zigbee group.",
+        required=("group_id", "members"),
+    ),
+    "group_members_remove": ActionSpec(
+        "Remove members ([{ieee, endpoint_id}, ...]) from a Zigbee group.",
+        required=("group_id", "members"),
+    ),
+    "bind": ActionSpec(
+        "Create a binding from source_ieee to target_ieee (direct device-to-"
+        "device control).",
+        required=("source_ieee", "target_ieee"),
+    ),
+    "unbind": ActionSpec(
+        "Remove the binding from source_ieee to target_ieee.",
+        destructive=True,
+        required=("source_ieee", "target_ieee"),
+    ),
+    "cluster_read": ActionSpec(
+        "Read a Zigbee cluster attribute (endpoint_id, cluster_id, attribute; "
+        "cluster_type defaults to 'in').",
+        required=("device_id", "endpoint_id", "cluster_id", "attribute"),
+    ),
+    "cluster_write": ActionSpec(
+        "Write a Zigbee cluster attribute (endpoint_id, cluster_id, attribute, "
+        "value; cluster_type defaults to 'in').",
+        destructive=True,
+        required=("device_id", "endpoint_id", "cluster_id", "attribute", "value"),
+    ),
+    "cluster_command": ActionSpec(
+        "Issue a Zigbee cluster command (endpoint_id, cluster_id, command, "
+        "command_type; optional params/args; cluster_type defaults to 'in').",
+        destructive=True,
+        required=("device_id", "endpoint_id", "cluster_id", "command", "command_type"),
+    ),
+    "network_backup": ActionSpec(
+        "Create a ZHA network backup (coordinator + network key material)."
+    ),
+    "network_restore": ActionSpec(
+        "Restore a ZHA network from a backup payload.",
+        destructive=True,
+        required=("backup",),
+    ),
+    "change_channel": ActionSpec(
+        "Move the ZHA network to a new Zigbee channel (new_channel: 11-26).",
+        destructive=True,
+        required=("new_channel",),
+    ),
+    "firmware_update": ActionSpec(
+        "Install the available OTA firmware on a Zigbee node (via its update.* "
+        "entity).",
+        long_running=True,
+        required=("device_id",),
+    ),
+}
+
+
+async def _resolve_ieee(client: Any, device_id: str) -> str:
+    """Resolve a ``device_id`` to its ZHA IEEE address via the device registry.
+
+    Parses the ``["zha", "<ieee>"]`` registry identifier (falling back to an
+    ``("ieee", ...)`` connection). Raises VALIDATION_INVALID_PARAMETER when the
+    device is not a ZHA device.
+    """
+    devices = await ws_call(
+        client, "config/device_registry/list", context={"device_id": device_id}
+    )
+    for device in devices or []:
+        if device.get("id") != device_id:
+            continue
+        for ident in device.get("identifiers", []):
+            if (
+                isinstance(ident, (list, tuple))
+                and len(ident) >= 2
+                and ident[0] == "zha"
+            ):
+                return str(ident[1])
+        for conn in device.get("connections", []):
+            if isinstance(conn, (list, tuple)) and len(conn) >= 2 and conn[0] == "ieee":
+                return str(conn[1])
+        break
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"Device '{device_id}' is not a ZHA Zigbee device (no IEEE address found)",
+            context={"device_id": device_id, "radio": "zigbee"},
+            suggestions=[
+                "Pass a ZHA device_id (ha_get_device reports integration_type 'zha')",
+                "Zigbee2MQTT devices are not managed here — use the MQTT/Z2M tools",
+            ],
+        )
+    )
+    raise AssertionError  # unreachable: raise_tool_error always raises
+
+
+async def _resolve_update_entity(client: Any, device_id: str) -> str:
+    """Find the device's ``update.*`` firmware entity via the entity registry."""
+    entities = await ws_call(
+        client, "config/entity_registry/list", context={"device_id": device_id}
+    )
+    candidates = [
+        e
+        for e in (entities or [])
+        if e.get("device_id") == device_id
+        and str(e.get("entity_id", "")).startswith("update.")
+    ]
+    # Prefer the ZHA-platform update entity when a device exposes several.
+    for entity in candidates:
+        if entity.get("platform") == "zha":
+            return str(entity["entity_id"])
+    if candidates:
+        return str(candidates[0]["entity_id"])
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            f"No update entity found for device '{device_id}'; no firmware update is available",
+            context={"device_id": device_id, "radio": "zigbee"},
+            suggestions=[
+                "Firmware updates appear only when the device exposes an update.* entity",
+                "Check ha_get_device for an 'update.' entity on this device",
+            ],
+        )
+    )
+    raise AssertionError  # unreachable: raise_tool_error always raises
+
+
+async def _call_service(client: Any, domain: str, service: str, **data: Any) -> Any:
+    """Call an HA service via the REST client, dropping ``None`` fields."""
+    payload = {k: v for k, v in data.items() if v is not None}
+    return await client.call_service(domain, service, payload)
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Execute one zigbee action (validation/confirm applied by the dispatcher)."""
+    """Execute one Zigbee/ZHA action (validation/confirm already applied by caller)."""
+    device_id = args.get("device_id")
+    cluster_type = args.get("cluster_type", "in")
+
+    # --- read -------------------------------------------------------------- #
+    if action == "diagnostics":
+        ieee = await _resolve_ieee(client, device_id)
+        diagnostics = await ws_call(
+            client, "zha/device", ieee=ieee, context={"ieee": ieee}
+        )
+        return ok("zigbee", "diagnostics", ieee=ieee, diagnostics=diagnostics)
+
+    if action == "network_status":
+        entry_id = await resolve_entry_id(client, "zha")
+        if not entry_id:
+            return integration_not_found("zigbee", "zha")
+        network = await ws_call(client, "zha/network/settings")
+        # Best-effort topology refresh; never fail network_status if it errors.
+        try:
+            await ws_call(client, "zha/topology/update")
+        except Exception:
+            pass
+        return ok("zigbee", "network_status", config_entry_id=entry_id, network=network)
+
+    if action == "cluster_read":
+        ieee = await _resolve_ieee(client, device_id)
+        value = await ws_call(
+            client,
+            "zha/devices/clusters/attributes/value",
+            ieee=ieee,
+            endpoint_id=args.get("endpoint_id"),
+            cluster_id=args.get("cluster_id"),
+            cluster_type=cluster_type,
+            attribute=args.get("attribute"),
+            manufacturer=args.get("manufacturer"),
+            context={"ieee": ieee, "cluster_id": args.get("cluster_id")},
+        )
+        return ok("zigbee", "cluster_read", ieee=ieee, value=value)
+
+    # --- node management --------------------------------------------------- #
+    if action == "permit_join":
+        duration = args.get("duration", 60)
+        ieee = await _resolve_ieee(client, device_id) if device_id else None
+        result = await ws_call(
+            client,
+            "zha/devices/permit",
+            duration=duration,
+            ieee=ieee,
+            context={"duration": duration, "ieee": ieee},
+        )
+        return ok("zigbee", "permit_join", duration=duration, ieee=ieee, result=result)
+
+    if action == "reconfigure":
+        ieee = await _resolve_ieee(client, device_id)
+        result = await ws_call(
+            client, "zha/devices/reconfigure", ieee=ieee, context={"ieee": ieee}
+        )
+        return ok("zigbee", "reconfigure", ieee=ieee, result=result)
+
+    if action == "remove_device":
+        ieee = await _resolve_ieee(client, device_id)
+        result = await _call_service(client, "zha", "remove", ieee=ieee)
+        return ok("zigbee", "remove_device", ieee=ieee, result=result)
+
+    if action == "firmware_update":
+        entity_id = await _resolve_update_entity(client, device_id)
+        result = await _call_service(client, "update", "install", entity_id=entity_id)
+        return ok(
+            "zigbee",
+            "firmware_update",
+            entity_id=entity_id,
+            result=result,
+            long_running=True,
+        )
+
+    # --- groups ------------------------------------------------------------ #
+    if action == "group_add":
+        group = await ws_call(
+            client,
+            "zha/group/add",
+            group_name=args.get("group_name"),
+            group_id=args.get("group_id"),
+            members=args.get("members"),
+            context={"group_name": args.get("group_name")},
+        )
+        return ok("zigbee", "group_add", group=group)
+
+    if action == "group_remove":
+        result = await ws_call(
+            client,
+            "zha/group/remove",
+            group_ids=args.get("group_ids"),
+            context={"group_ids": args.get("group_ids")},
+        )
+        return ok("zigbee", "group_remove", result=result)
+
+    if action == "group_members_add":
+        group = await ws_call(
+            client,
+            "zha/group/members/add",
+            group_id=args.get("group_id"),
+            members=args.get("members"),
+            context={"group_id": args.get("group_id")},
+        )
+        return ok("zigbee", "group_members_add", group=group)
+
+    if action == "group_members_remove":
+        group = await ws_call(
+            client,
+            "zha/group/members/remove",
+            group_id=args.get("group_id"),
+            members=args.get("members"),
+            context={"group_id": args.get("group_id")},
+        )
+        return ok("zigbee", "group_members_remove", group=group)
+
+    # --- bindings ---------------------------------------------------------- #
+    if action == "bind":
+        result = await ws_call(
+            client,
+            "zha/devices/bind",
+            source_ieee=args.get("source_ieee"),
+            target_ieee=args.get("target_ieee"),
+            context={
+                "source_ieee": args.get("source_ieee"),
+                "target_ieee": args.get("target_ieee"),
+            },
+        )
+        return ok("zigbee", "bind", result=result)
+
+    if action == "unbind":
+        result = await ws_call(
+            client,
+            "zha/devices/unbind",
+            source_ieee=args.get("source_ieee"),
+            target_ieee=args.get("target_ieee"),
+            context={
+                "source_ieee": args.get("source_ieee"),
+                "target_ieee": args.get("target_ieee"),
+            },
+        )
+        return ok("zigbee", "unbind", result=result)
+
+    # --- cluster writes (service-only) ------------------------------------- #
+    if action == "cluster_write":
+        ieee = await _resolve_ieee(client, device_id)
+        result = await _call_service(
+            client,
+            "zha",
+            "set_zigbee_cluster_attribute",
+            ieee=ieee,
+            endpoint_id=args.get("endpoint_id"),
+            cluster_id=args.get("cluster_id"),
+            cluster_type=cluster_type,
+            attribute=args.get("attribute"),
+            value=args.get("value"),
+            manufacturer=args.get("manufacturer"),
+        )
+        return ok("zigbee", "cluster_write", ieee=ieee, result=result)
+
+    if action == "cluster_command":
+        ieee = await _resolve_ieee(client, device_id)
+        result = await _call_service(
+            client,
+            "zha",
+            "issue_zigbee_cluster_command",
+            ieee=ieee,
+            endpoint_id=args.get("endpoint_id"),
+            cluster_id=args.get("cluster_id"),
+            cluster_type=cluster_type,
+            command=args.get("command"),
+            command_type=args.get("command_type"),
+            params=args.get("params"),
+            args=args.get("args"),
+            manufacturer=args.get("manufacturer"),
+        )
+        return ok("zigbee", "cluster_command", ieee=ieee, result=result)
+
+    # --- network ----------------------------------------------------------- #
+    if action == "network_backup":
+        backup = await ws_call(client, "zha/network/backups/create")
+        return ok("zigbee", "network_backup", backup=backup)
+
+    if action == "network_restore":
+        result = await ws_call(
+            client,
+            "zha/network/backups/restore",
+            backup=args.get("backup"),
+            context={"radio": "zigbee"},
+        )
+        return ok("zigbee", "network_restore", result=result)
+
+    if action == "change_channel":
+        new_channel = args.get("new_channel")
+        result = await ws_call(
+            client,
+            "zha/network/change_channel",
+            new_channel=new_channel,
+            context={"new_channel": new_channel},
+        )
+        return ok("zigbee", "change_channel", new_channel=new_channel, result=result)
+
+    # Unreachable: dispatcher validates action against SUPPORTED first.
     raise AssertionError(f"unhandled zigbee action: {action}")

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -20,7 +20,14 @@ from fastmcp.exceptions import ToolError
 
 from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
-from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
+from .base import (
+    ActionSpec,
+    integration_not_found,
+    ok,
+    resolve_entry_id,
+    resolve_update_entity,
+    ws_call,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -149,38 +156,6 @@ async def _resolve_ieee(client: Any, device_id: Any) -> str:
             ],
         )
     )
-    raise AssertionError  # unreachable: raise_tool_error always raises
-
-
-async def _resolve_update_entity(client: Any, device_id: Any) -> str:
-    """Find the device's ``update.*`` firmware entity via the entity registry."""
-    entities = await ws_call(
-        client, "config/entity_registry/list", context={"device_id": device_id}
-    )
-    candidates = [
-        e
-        for e in (entities or [])
-        if e.get("device_id") == device_id
-        and str(e.get("entity_id", "")).startswith("update.")
-    ]
-    # Prefer the ZHA-platform update entity when a device exposes several.
-    for entity in candidates:
-        if entity.get("platform") == "zha":
-            return str(entity["entity_id"])
-    if candidates:
-        return str(candidates[0]["entity_id"])
-    raise_tool_error(
-        create_error_response(
-            ErrorCode.ENTITY_NOT_FOUND,
-            f"No update entity found for device '{device_id}'; no firmware update is available",
-            context={"device_id": device_id, "radio": "zigbee"},
-            suggestions=[
-                "Firmware updates appear only when the device exposes an update.* entity",
-                "Check ha_get_device for an 'update.' entity on this device",
-            ],
-        )
-    )
-    raise AssertionError  # unreachable: raise_tool_error always raises
 
 
 async def _call_service(client: Any, domain: str, service: str, **data: Any) -> Any:
@@ -261,7 +236,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         return ok("zigbee", "remove_device", ieee=ieee, result=result)
 
     if action == "firmware_update":
-        entity_id = await _resolve_update_entity(client, device_id)
+        entity_id = await resolve_update_entity(client, device_id, platform="zha")
         result = await _call_service(client, "update", "install", entity_id=entity_id)
         return ok(
             "zigbee",

--- a/src/ha_mcp/tools/radio/zigbee.py
+++ b/src/ha_mcp/tools/radio/zigbee.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from fastmcp.exceptions import ToolError
+
 from ...errors import ErrorCode, create_error_response
 from ..helpers import raise_tool_error
 from .base import ActionSpec, integration_not_found, ok, resolve_entry_id, ws_call
@@ -207,9 +209,12 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         network = await ws_call(client, "zha/network/settings")
         try:
             await ws_call(client, "zha/topology/update")
-        except Exception as exc:
-            # Topology refresh is best-effort: stale routes are acceptable and
-            # must not fail an otherwise-successful network_status read.
+        except ToolError as exc:
+            # Topology refresh is best-effort: a command-level failure (the
+            # ToolError ws_call raises on success=False) leaves routes stale but
+            # must not fail an otherwise-successful network_status read. Transport
+            # errors are normalized to that ToolError by send_websocket_message;
+            # anything unexpected (a real bug) still propagates.
             logger.debug("zha/topology/update refresh failed (non-fatal): %s", exc)
         return ok("zigbee", "network_status", config_entry_id=entry_id, network=network)
 

--- a/src/ha_mcp/tools/radio/zwave.py
+++ b/src/ha_mcp/tools/radio/zwave.py
@@ -353,15 +353,9 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         update_entity = await resolve_update_entity(
             client, device_id, platform="zwave_js"
         )
-        result = await client.call_service(
-            "update", "install", {"entity_id": update_entity}
-        )
+        await client.call_service("update", "install", {"entity_id": update_entity})
         return ok(
-            "zwave",
-            "firmware_update",
-            entity_id=update_entity,
-            result=result,
-            long_running=True,
+            "zwave", "firmware_update", entity_id=update_entity, long_running=True
         )
 
     if action == "hard_reset":

--- a/src/ha_mcp/tools/radio/zwave.py
+++ b/src/ha_mcp/tools/radio/zwave.py
@@ -1,0 +1,14 @@
+"""Zwave radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import ActionSpec
+
+SUPPORTED: dict[str, ActionSpec] = {}
+
+
+async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute one zwave action (validation/confirm applied by the dispatcher)."""
+    raise AssertionError(f"unhandled zwave action: {action}")

--- a/src/ha_mcp/tools/radio/zwave.py
+++ b/src/ha_mcp/tools/radio/zwave.py
@@ -1,14 +1,391 @@
-"""Zwave radio handler for ``ha_manage_radio`` — placeholder pending implementation."""
+"""Z-Wave JS radio handler for ``ha_manage_radio``.
+
+Wraps the Home Assistant ``zwave_js/*`` WebSocket API and the ``zwave_js.ping``
+service: per-node diagnostics (read), controller/network summary (read),
+non-interactive inclusion / exclusion, re-interview, mesh route rebuilds,
+configuration-parameter writes, firmware install, and the network-wiping
+controller hard reset.
+
+Node-scoped actions key on ``device_id``; controller-scoped actions resolve the
+single ``zwave_js`` config entry via ``resolve_entry_id``. Interactive S2 secure
+inclusion (the read-the-PIN handshake) is *not* scriptable here — provide
+SmartStart/QR/DSK provisioning data, or use the Home Assistant UI.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-from .base import ActionSpec
+from ...errors import ErrorCode, create_error_response
+from ..helpers import raise_tool_error
+from .base import (
+    ActionSpec,
+    integration_not_found,
+    ok,
+    require,
+    resolve_entry_id,
+    ws_call,
+)
 
-SUPPORTED: dict[str, ActionSpec] = {}
+# Cap surfaced node summaries (mirrors ha_get_system_health's zwave_network).
+_NODE_LIMIT = 50
+
+# Pre-shared credential forms that make active inclusion non-interactive (no S2
+# read-the-PIN handshake). One of these is required for action='add' unless
+# SmartStart provisioning is used.
+_ADD_CREDENTIALS = (
+    "qr_provisioning_information",
+    "qr_code_string",
+    "planned_provisioning_entry",
+    "dsk",
+)
+
+SUPPORTED: dict[str, ActionSpec] = {
+    "diagnostics": ActionSpec(
+        "Per-node Z-Wave status: node_id, status, routing, security class, "
+        "Z-Wave Plus version, controller flag.",
+        required=("device_id",),
+    ),
+    "network_status": ActionSpec(
+        "Z-Wave controller summary plus per-node status/security/routing "
+        "(capped at 50 nodes)."
+    ),
+    "ping": ActionSpec(
+        "Actively ping a Z-Wave node to check it is reachable.",
+        required=("device_id",),
+    ),
+    "add": ActionSpec(
+        "Include a Z-Wave node non-interactively via SmartStart provisioning "
+        "(params.smart_start=True) or active inclusion with pre-shared "
+        "QR/DSK credentials. Interactive S2 read-the-PIN pairing is not "
+        "supported here — use the Home Assistant UI for that.",
+        long_running=True,
+    ),
+    "remove_device": ActionSpec(
+        "Remove a Z-Wave node: open an exclusion window (default) or "
+        "force-remove a known-failed node (params.failed=True).",
+        destructive=True,
+        long_running=True,
+    ),
+    "reinterview": ActionSpec(
+        "Re-interview a Z-Wave node to refresh its command classes and values.",
+        long_running=True,
+        required=("device_id",),
+    ),
+    "rebuild_routes": ActionSpec(
+        "Rebuild mesh routes for one node (default) or the whole network "
+        "(params.scope='network').",
+        long_running=True,
+    ),
+    "set_config_param": ActionSpec(
+        "Set a Z-Wave configuration parameter on a node.",
+        required=("device_id", "property", "value"),
+    ),
+    "firmware_update": ActionSpec(
+        "Install a pending firmware update for a Z-Wave node via its update entity.",
+        long_running=True,
+        required=("device_id",),
+    ),
+    "hard_reset": ActionSpec(
+        "Factory-reset the Z-Wave controller, wiping the entire network.",
+        destructive=True,
+        long_running=True,
+    ),
+}
+
+
+async def _zwave_entry_id(client: Any) -> str | None:
+    """Resolve the single ``zwave_js`` config entry_id (None if not configured)."""
+    return await resolve_entry_id(client, "zwave_js")
+
+
+async def _find_update_entity(client: Any, device_id: str | None) -> str | None:
+    """Return the device's ``update.*`` entity_id from the entity registry.
+
+    Z-Wave JS exposes one firmware ``update`` entity per updatable node, tied to
+    the node's device. We resolve it here so firmware_update only needs a
+    device_id (the same id every other node-scoped action uses).
+    """
+    entities = await ws_call(client, "config/entity_registry/list")
+    return next(
+        (
+            e.get("entity_id")
+            for e in entities or []
+            if e.get("device_id") == device_id
+            and str(e.get("entity_id", "")).startswith("update.")
+        ),
+        None,
+    )
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Execute one zwave action (validation/confirm applied by the dispatcher)."""
+    """Execute one Z-Wave action (validation/confirm already applied by caller)."""
+    device_id = args.get("device_id")
+
+    if action == "diagnostics":
+        node = (
+            await ws_call(
+                client,
+                "zwave_js/node_status",
+                device_id=device_id,
+                context={"device_id": device_id},
+            )
+            or {}
+        )
+        node_status = {
+            "node_id": node.get("node_id"),
+            "status": node.get("status"),
+            "is_routing": node.get("is_routing"),
+            "is_secure": node.get("is_secure"),
+            "highest_security_class": node.get("highest_security_class"),
+            "zwave_plus_version": node.get("zwave_plus_version"),
+            "is_controller_node": node.get("is_controller_node"),
+        }
+        return ok("zwave", "diagnostics", node_status=node_status)
+
+    if action == "network_status":
+        entry_id = await _zwave_entry_id(client)
+        if not entry_id:
+            return integration_not_found("zwave", "zwave_js")
+        net = (
+            await ws_call(
+                client,
+                "zwave_js/network_status",
+                entry_id=entry_id,
+                context={"entry_id": entry_id},
+            )
+            or {}
+        )
+        controller = net.get("controller", {}) or {}
+        nodes = controller.get("nodes", []) or []
+        # Drop the (potentially huge) embedded node list from the controller
+        # view; the capped per-node summaries below carry the node detail.
+        controller_view = {k: v for k, v in controller.items() if k != "nodes"}
+        node_summaries = [
+            {
+                "node_id": n.get("node_id"),
+                "status": n.get("status"),
+                "is_routing": n.get("is_routing"),
+                "is_secure": n.get("is_secure"),
+                "zwave_plus_version": n.get("zwave_plus_version"),
+                "is_controller_node": n.get("is_controller_node"),
+            }
+            for n in nodes[:_NODE_LIMIT]
+        ]
+        out = ok(
+            "zwave",
+            "network_status",
+            config_entry_id=entry_id,
+            controller=controller_view,
+            nodes=node_summaries,
+            count=len(node_summaries),
+            total_count=len(nodes),
+        )
+        if len(nodes) > _NODE_LIMIT:
+            out["truncated"] = True
+        return out
+
+    if action == "ping":
+        # zwave_js.ping is a plain service (no response support); it targets the
+        # node by device_id and returns the list of affected states.
+        result = await client.call_service("zwave_js", "ping", {"device_id": device_id})
+        return ok("zwave", "ping", result=result)
+
+    if action == "add":
+        entry_id = await _zwave_entry_id(client)
+        if not entry_id:
+            return integration_not_found("zwave", "zwave_js")
+
+        if args.get("smart_start"):
+            # SmartStart: add the provisioning info to the controller's list; the
+            # node joins automatically (and securely) the next time it is powered.
+            require(
+                args,
+                ActionSpec("", required=("qr_provisioning_information",)),
+                "zwave",
+                "add",
+            )
+            result = await ws_call(
+                client,
+                "zwave_js/provision_smart_start_node",
+                entry_id=entry_id,
+                qr_provisioning_information=args.get("qr_provisioning_information"),
+                device_name=args.get("device_name"),
+                area_id=args.get("area_id"),
+                context={"entry_id": entry_id},
+            )
+            return ok(
+                "zwave", "add", mode="smart_start", result=result, long_running=True
+            )
+
+        # Active inclusion. Non-interactive only: require a pre-shared credential
+        # so no S2 read-the-PIN handshake is needed.
+        if not any(args.get(c) for c in _ADD_CREDENTIALS):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "zwave/add requires one of "
+                    + ", ".join(_ADD_CREDENTIALS)
+                    + " (or params.smart_start=True). Interactive S2 "
+                    "read-the-PIN pairing is not scriptable — use the Home "
+                    "Assistant UI.",
+                    context={"radio": "zwave", "action": "add"},
+                    suggestions=[
+                        "Pass qr_provisioning_information for a scanned device",
+                        "Set params.smart_start=True to add to the SmartStart list",
+                        "Use the Home Assistant UI for interactive S2 PIN pairing",
+                    ],
+                )
+            )
+        result = await ws_call(
+            client,
+            "zwave_js/add_node",
+            entry_id=entry_id,
+            inclusion_strategy=args.get("inclusion_strategy"),
+            qr_provisioning_information=args.get("qr_provisioning_information"),
+            qr_code_string=args.get("qr_code_string"),
+            planned_provisioning_entry=args.get("planned_provisioning_entry"),
+            dsk=args.get("dsk"),
+            context={"entry_id": entry_id},
+        )
+        return ok("zwave", "add", mode="add_node", result=result, long_running=True)
+
+    if action == "remove_device":
+        if args.get("failed"):
+            # remove_failed_node targets a specific (already-dead) node.
+            require(
+                args,
+                ActionSpec("", required=("device_id",)),
+                "zwave",
+                "remove_device",
+            )
+            result = await ws_call(
+                client,
+                "zwave_js/remove_failed_node",
+                device_id=device_id,
+                context={"device_id": device_id},
+            )
+            return ok("zwave", "remove_device", mode="failed", result=result)
+
+        # Default: open an exclusion window on the controller (long-running; the
+        # user triggers exclusion on the physical device to complete it).
+        entry_id = await _zwave_entry_id(client)
+        if not entry_id:
+            return integration_not_found("zwave", "zwave_js")
+        result = await ws_call(
+            client,
+            "zwave_js/remove_node",
+            entry_id=entry_id,
+            context={"entry_id": entry_id},
+        )
+        return ok(
+            "zwave",
+            "remove_device",
+            mode="exclusion",
+            result=result,
+            long_running=True,
+        )
+
+    if action == "reinterview":
+        result = await ws_call(
+            client,
+            "zwave_js/refresh_node_info",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        return ok("zwave", "reinterview", result=result, long_running=True)
+
+    if action == "rebuild_routes":
+        if args.get("scope") == "network":
+            entry_id = await _zwave_entry_id(client)
+            if not entry_id:
+                return integration_not_found("zwave", "zwave_js")
+            result = await ws_call(
+                client,
+                "zwave_js/begin_rebuilding_routes",
+                entry_id=entry_id,
+                context={"entry_id": entry_id},
+            )
+            return ok(
+                "zwave",
+                "rebuild_routes",
+                scope="network",
+                result=result,
+                long_running=True,
+            )
+        require(
+            args,
+            ActionSpec("", required=("device_id",)),
+            "zwave",
+            "rebuild_routes",
+        )
+        result = await ws_call(
+            client,
+            "zwave_js/rebuild_node_routes",
+            device_id=device_id,
+            context={"device_id": device_id},
+        )
+        return ok(
+            "zwave",
+            "rebuild_routes",
+            scope="node",
+            result=result,
+            long_running=True,
+        )
+
+    if action == "set_config_param":
+        result = await ws_call(
+            client,
+            "zwave_js/set_config_parameter",
+            device_id=device_id,
+            property=args.get("property"),
+            endpoint=args.get("endpoint", 0),
+            property_key=args.get("property_key"),
+            value=args.get("value"),
+            context={"device_id": device_id, "property": args.get("property")},
+        )
+        return ok("zwave", "set_config_param", result=result)
+
+    if action == "firmware_update":
+        update_entity = await _find_update_entity(client, device_id)
+        if not update_entity:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.ENTITY_NOT_FOUND,
+                    f"No update entity found for device {device_id}",
+                    context={
+                        "radio": "zwave",
+                        "action": "firmware_update",
+                        "device_id": device_id,
+                    },
+                    suggestions=[
+                        "Confirm the device has a firmware update available",
+                        "Use ha_get_device() to inspect the device's entities",
+                    ],
+                )
+            )
+        result = await client.call_service(
+            "update", "install", {"entity_id": update_entity}
+        )
+        return ok(
+            "zwave",
+            "firmware_update",
+            entity_id=update_entity,
+            result=result,
+            long_running=True,
+        )
+
+    if action == "hard_reset":
+        entry_id = await _zwave_entry_id(client)
+        if not entry_id:
+            return integration_not_found("zwave", "zwave_js")
+        result = await ws_call(
+            client,
+            "zwave_js/hard_reset_controller",
+            entry_id=entry_id,
+            context={"entry_id": entry_id},
+        )
+        return ok("zwave", "hard_reset", result=result, long_running=True)
+
+    # Unreachable: dispatcher validates action against SUPPORTED first.
     raise AssertionError(f"unhandled zwave action: {action}")

--- a/src/ha_mcp/tools/radio/zwave.py
+++ b/src/ha_mcp/tools/radio/zwave.py
@@ -21,9 +21,11 @@ from ..helpers import raise_tool_error
 from .base import (
     ActionSpec,
     integration_not_found,
+    integration_required,
     ok,
     require,
     resolve_entry_id,
+    resolve_update_entity,
     ws_call,
 )
 
@@ -97,25 +99,6 @@ SUPPORTED: dict[str, ActionSpec] = {
 async def _zwave_entry_id(client: Any) -> str | None:
     """Resolve the single ``zwave_js`` config entry_id (None if not configured)."""
     return await resolve_entry_id(client, "zwave_js")
-
-
-async def _find_update_entity(client: Any, device_id: str | None) -> str | None:
-    """Return the device's ``update.*`` entity_id from the entity registry.
-
-    Z-Wave JS exposes one firmware ``update`` entity per updatable node, tied to
-    the node's device. We resolve it here so firmware_update only needs a
-    device_id (the same id every other node-scoped action uses).
-    """
-    entities = await ws_call(client, "config/entity_registry/list")
-    return next(
-        (
-            e.get("entity_id")
-            for e in entities or []
-            if e.get("device_id") == device_id
-            and str(e.get("entity_id", "")).startswith("update.")
-        ),
-        None,
-    )
 
 
 async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -194,7 +177,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
     if action == "add":
         entry_id = await _zwave_entry_id(client)
         if not entry_id:
-            return integration_not_found("zwave", "zwave_js")
+            integration_required("zwave", "zwave_js")
 
         if args.get("smart_start"):
             # SmartStart: add the provisioning info to the controller's list; the
@@ -218,9 +201,10 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
                 "zwave", "add", mode="smart_start", result=result, long_running=True
             )
 
-        # Active inclusion. Non-interactive only: require a pre-shared credential
-        # so no S2 read-the-PIN handshake is needed.
-        if not any(args.get(c) for c in _ADD_CREDENTIALS):
+        # Active inclusion. Non-interactive only: require exactly one pre-shared
+        # credential so no S2 read-the-PIN handshake is needed.
+        provided = [c for c in _ADD_CREDENTIALS if args.get(c)]
+        if not provided:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -234,6 +218,25 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
                         "Pass qr_provisioning_information for a scanned device",
                         "Set params.smart_start=True to add to the SmartStart list",
                         "Use the Home Assistant UI for interactive S2 PIN pairing",
+                    ],
+                )
+            )
+        if len(provided) > 1:
+            # HA's add_node schema marks these as vol.Exclusive — passing more
+            # than one is rejected upstream, so fail fast with a clear conflict.
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "zwave/add accepts only one inclusion credential, but "
+                    + str(len(provided))
+                    + " were provided: "
+                    + ", ".join(provided)
+                    + ". "
+                    + ", ".join(_ADD_CREDENTIALS)
+                    + " are mutually exclusive.",
+                    context={"radio": "zwave", "action": "add", "conflict": provided},
+                    suggestions=[
+                        "Pass exactly one of " + ", ".join(_ADD_CREDENTIALS),
                     ],
                 )
             )
@@ -271,7 +274,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         # user triggers exclusion on the physical device to complete it).
         entry_id = await _zwave_entry_id(client)
         if not entry_id:
-            return integration_not_found("zwave", "zwave_js")
+            integration_required("zwave", "zwave_js")
         result = await ws_call(
             client,
             "zwave_js/remove_node",
@@ -299,7 +302,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         if args.get("scope") == "network":
             entry_id = await _zwave_entry_id(client)
             if not entry_id:
-                return integration_not_found("zwave", "zwave_js")
+                integration_required("zwave", "zwave_js")
             result = await ws_call(
                 client,
                 "zwave_js/begin_rebuilding_routes",
@@ -347,23 +350,9 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
         return ok("zwave", "set_config_param", result=result)
 
     if action == "firmware_update":
-        update_entity = await _find_update_entity(client, device_id)
-        if not update_entity:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.ENTITY_NOT_FOUND,
-                    f"No update entity found for device {device_id}",
-                    context={
-                        "radio": "zwave",
-                        "action": "firmware_update",
-                        "device_id": device_id,
-                    },
-                    suggestions=[
-                        "Confirm the device has a firmware update available",
-                        "Use ha_get_device() to inspect the device's entities",
-                    ],
-                )
-            )
+        update_entity = await resolve_update_entity(
+            client, device_id, platform="zwave_js"
+        )
         result = await client.call_service(
             "update", "install", {"entity_id": update_entity}
         )
@@ -378,7 +367,7 @@ async def handle(client: Any, action: str, args: dict[str, Any]) -> dict[str, An
     if action == "hard_reset":
         entry_id = await _zwave_entry_id(client)
         if not entry_id:
-            return integration_not_found("zwave", "zwave_js")
+            integration_required("zwave", "zwave_js")
         result = await ws_call(
             client,
             "zwave_js/hard_reset_controller",

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -244,8 +244,23 @@ class McpComponentTools:
             if not existing_repo:
                 existing_repo = await self._add_repo_to_hacs(ws_client)
 
-            # Now download/install the repository
-            repo_id = await self._resolve_repo_id(ws_client, existing_repo)
+            # Resolve the repo ID. A freshly-added repo can miss the first
+            # registration budget on a loaded runner or slow GitHub; on that
+            # timeout, re-add to re-nudge HACS and wait once more before
+            # surfacing the failure. Best-effort: a genuinely stuck add still
+            # fails on the retry. A repo that already had an ID is a real
+            # failure, not a slow add, so it is re-raised immediately.
+            try:
+                repo_id = await self._resolve_repo_id(ws_client, existing_repo)
+            except ToolError:
+                if existing_repo.get("id"):
+                    raise
+                logger.warning(
+                    "HACS repo registration timed out; re-adding %s and retrying once",
+                    MCP_TOOLS_REPO,
+                )
+                await self._add_repo_to_hacs(ws_client)
+                repo_id = await self._resolve_repo_id(ws_client, None)
 
             logger.info(f"Installing {MCP_TOOLS_REPO} (ID: {repo_id})")
             # HACS' download often returns a generic "Command failed:

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -66,7 +66,6 @@ class RadioTools:
                 suggestions=["Use ha_search() to find a valid entity_id"],
             )
         )
-        raise AssertionError  # unreachable: raise_tool_error always raises
 
     @tool(
         name="ha_manage_radio",

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -66,6 +66,7 @@ class RadioTools:
                 suggestions=["Use ha_search() to find a valid entity_id"],
             )
         )
+        raise AssertionError  # py/mixed-returns terminal: raise_tool_error is NoReturn
 
     @tool(
         name="ha_manage_radio",

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -148,10 +148,7 @@ class RadioTools:
             handler = HANDLERS[radio]
             spec = handler.SUPPORTED.get(action)
             if spec is None:
-                supported = {
-                    name: handler.SUPPORTED[name].summary
-                    for name in sorted(handler.SUPPORTED)
-                }
+                supported = sorted(handler.SUPPORTED)
                 raise_tool_error(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -161,7 +158,12 @@ class RadioTools:
                             "action": action,
                             "supported": supported,
                         },
-                        suggestions=[f"Use one of: {', '.join(supported)}"],
+                        # Surface each action's one-line summary so the caller
+                        # can pick the right one without another round-trip.
+                        suggestions=[
+                            f"{name}: {handler.SUPPORTED[name].summary}"
+                            for name in supported
+                        ],
                     )
                 )
 

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -1,0 +1,183 @@
+"""Unified radio management tool: ``ha_manage_radio``.
+
+One multi-modal tool for managing every radio Home Assistant speaks — Z-Wave
+(zwave_js), Zigbee (ZHA), Matter, and Thread/OTBR. Read-only diagnostics also
+live in ``ha_get_device`` and ``ha_get_system_health`` (next to the existing
+Z-Wave/Zigbee surfaces); they are mirrored here so they are at hand mid-
+management. This tool additionally performs writes those read tools do not, so
+it is not a subset of either.
+
+Per-radio logic lives in ``radio/<name>.py``; this module is the dispatcher.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any, Literal
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import tool
+from pydantic import Field
+
+from ..errors import ErrorCode, create_error_response
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    register_tool_methods,
+)
+from .radio import matter as matter_handler
+from .radio import thread as thread_handler
+from .radio import zigbee as zigbee_handler
+from .radio import zwave as zwave_handler
+from .radio.base import confirm_required, require
+from .util_helpers import JSON_STRING_COERCION
+
+logger = logging.getLogger(__name__)
+
+HANDLERS: dict[str, Any] = {
+    "zwave": zwave_handler,
+    "zigbee": zigbee_handler,
+    "matter": matter_handler,
+    "thread": thread_handler,
+}
+
+
+class RadioTools:
+    """``ha_manage_radio`` and its dispatch helpers."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def _resolve_entity_device(self, entity_id: str) -> str:
+        """Resolve an entity_id to its device_id via the entity registry."""
+        result = await self._client.send_websocket_message(
+            {"type": "config/entity_registry/list"}
+        )
+        if result.get("success"):
+            for entry in result.get("result", []):
+                if entry.get("entity_id") == entity_id and entry.get("device_id"):
+                    return str(entry["device_id"])
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.ENTITY_NOT_FOUND,
+                f"Entity '{entity_id}' not found or has no associated device",
+                context={"entity_id": entity_id},
+                suggestions=["Use ha_search() to find a valid entity_id"],
+            )
+        )
+        raise AssertionError  # unreachable: raise_tool_error always raises
+
+    @tool(
+        name="ha_manage_radio",
+        tags={"Radio Management", "Z-Wave", "Zigbee", "Matter", "Thread"},
+        annotations={
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "title": "Manage Radios (Z-Wave / Zigbee / Matter / Thread)",
+        },
+    )
+    @log_tool_usage
+    async def ha_manage_radio(
+        self,
+        radio: Annotated[
+            Literal["zwave", "zigbee", "matter", "thread"],
+            Field(description="Which radio to manage."),
+        ],
+        action: Annotated[
+            str,
+            Field(
+                description=(
+                    "Operation to perform. Actions vary per radio; an unknown "
+                    "action returns the supported list for that radio. Common: "
+                    "'diagnostics', 'network_status', 'ping', 'add'/'commission', "
+                    "'remove_device', 'reinterview'/'reconfigure', 'firmware_update'."
+                )
+            ),
+        ],
+        device_id: Annotated[
+            str | None,
+            Field(
+                description="Target device (node) for node-scoped actions.",
+                default=None,
+            ),
+        ] = None,
+        entity_id: Annotated[
+            str | None,
+            Field(
+                description="Resolve the device from this entity for node-scoped actions.",
+                default=None,
+            ),
+        ] = None,
+        params: Annotated[
+            dict[str, Any] | None,
+            JSON_STRING_COERCION,
+            Field(
+                description=(
+                    "Action-specific parameters (e.g. code, pin, channel, "
+                    "config_param). See ha_get_skill_guide for per-action schemas."
+                ),
+                default=None,
+            ),
+        ] = None,
+        confirm: Annotated[
+            bool,
+            Field(
+                description="Required (True) to run destructive actions.", default=False
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Manage Home Assistant radios — Z-Wave, Zigbee, Matter, and Thread.
+
+        Read actions ('diagnostics', 'network_status', 'ping') are also available
+        via ha_get_device and ha_get_system_health. Write actions perform
+        inclusion/commissioning, removal, healing, reconfiguration, firmware
+        updates and credential provisioning.
+
+        Caveats: destructive actions (remove_device, network restore,
+        change_channel, hard_reset) require confirm=True. Long-running actions
+        (inclusion, rebuild routes, firmware) start the operation and return its
+        handle. Interactive Z-Wave S2 secure inclusion (read-the-PIN pairing) is
+        not scriptable — use SmartStart/QR provisioning here or the HA UI.
+        """
+        try:
+            handler = HANDLERS[radio]
+            spec = handler.SUPPORTED.get(action)
+            if spec is None:
+                supported = sorted(handler.SUPPORTED)
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Unknown action '{action}' for radio '{radio}'",
+                        context={
+                            "radio": radio,
+                            "action": action,
+                            "supported": supported,
+                        },
+                        suggestions=[f"Use one of: {', '.join(supported)}"],
+                    )
+                )
+
+            args: dict[str, Any] = dict(params or {})
+            if device_id:
+                args.setdefault("device_id", device_id)
+            if entity_id and not args.get("device_id"):
+                args["device_id"] = await self._resolve_entity_device(entity_id)
+
+            require(args, spec, radio, action)
+            if spec.destructive and not confirm:
+                confirm_required(radio, action)
+
+            return await handler.handle(self._client, action, args)
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error("ha_manage_radio %s/%s failed: %s", radio, action, e)
+            exception_to_structured_error(e, context={"radio": radio, "action": action})
+            return None  # unreachable: exception_to_structured_error always raises
+
+
+def register_radio_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register the radio management tool (auto-discovered by the registry)."""
+    register_tool_methods(mcp, RadioTools(client))

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -115,7 +115,8 @@ class RadioTools:
             Field(
                 description=(
                     "Action-specific parameters (e.g. code, pin, channel, "
-                    "config_param). See ha_get_skill_guide for per-action schemas."
+                    "property, value). An unknown action returns that radio's "
+                    "supported action list with one-line summaries."
                 ),
                 default=None,
             ),
@@ -129,22 +130,28 @@ class RadioTools:
     ) -> dict[str, Any]:
         """Manage Home Assistant radios — Z-Wave, Zigbee, Matter, and Thread.
 
-        Read actions ('diagnostics', 'network_status', 'ping') are also available
-        via ha_get_device and ha_get_system_health. Write actions perform
-        inclusion/commissioning, removal, healing, reconfiguration, firmware
-        updates and credential provisioning.
+        For read-only inspection prefer ha_get_device / ha_get_system_health,
+        which mirror the 'diagnostics' and 'network_status' actions; use this
+        tool for writes and the active 'ping' probe (unique to this tool). Write
+        actions perform inclusion/commissioning, removal, healing,
+        reconfiguration, firmware updates and credential provisioning.
 
-        Caveats: destructive actions (remove_device, network restore,
-        change_channel, hard_reset) require confirm=True. Long-running actions
-        (inclusion, rebuild routes, firmware) start the operation and return its
-        handle. Interactive Z-Wave S2 secure inclusion (read-the-PIN pairing) is
-        not scriptable — use SmartStart/QR provisioning here or the HA UI.
+        Caveats: destructive actions (e.g. remove_device, network restore,
+        change_channel, hard_reset, remove_fabric) require confirm=True.
+        Long-running actions (inclusion, rebuild routes, firmware) start the
+        operation and return immediately with long_running=true; completion
+        happens out-of-band. Interactive Z-Wave S2 secure inclusion (read-the-
+        PIN pairing) is not scriptable — use SmartStart/QR provisioning here or
+        the HA UI.
         """
         try:
             handler = HANDLERS[radio]
             spec = handler.SUPPORTED.get(action)
             if spec is None:
-                supported = sorted(handler.SUPPORTED)
+                supported = {
+                    name: handler.SUPPORTED[name].summary
+                    for name in sorted(handler.SUPPORTED)
+                }
                 raise_tool_error(
                     create_error_response(
                         ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -169,12 +176,18 @@ class RadioTools:
                 confirm_required(radio, action)
 
             result: dict[str, Any] = await handler.handle(self._client, action, args)
+            # ActionSpec is the single source of truth for long-running; fill it
+            # in even on branches that did not set it (e.g. force-remove paths).
+            if spec.long_running:
+                result.setdefault("long_running", True)
             return result
 
         except ToolError:
             raise
         except Exception as e:
-            logger.error("ha_manage_radio %s/%s failed: %s", radio, action, e)
+            # exception_to_structured_error owns logging (it stays quiet for
+            # classified errors and logs unclassified ones with a traceback);
+            # a manual log here would double-log. Let the helper own it.
             exception_to_structured_error(e, context={"radio": radio, "action": action})
             return None  # unreachable: exception_to_structured_error always raises
 

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -168,7 +168,8 @@ class RadioTools:
             if spec.destructive and not confirm:
                 confirm_required(radio, action)
 
-            return await handler.handle(self._client, action, args)
+            result: dict[str, Any] = await handler.handle(self._client, action, args)
+            return result
 
         except ToolError:
             raise

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -255,6 +255,43 @@ async def _enrich_zwave_status(
         )
 
 
+async def _enrich_matter_diagnostics(
+    client: Any, device_id: str, device_info: dict[str, Any]
+) -> None:
+    """Fetch Matter node diagnostics and add to device_info in-place.
+
+    Mirrors _enrich_zwave_status: surfaces the Matter equivalent of Z-Wave node
+    status — network type (wifi/thread), reachability, IPs and joined fabrics.
+    """
+    try:
+        result = await client.send_websocket_message(
+            {"type": "matter/node_diagnostics", "device_id": device_id}
+        )
+        if result.get("success"):
+            data = result.get("result", {})
+            device_info["node_diagnostics"] = {
+                "network_type": data.get("network_type"),
+                "node_type": data.get("node_type"),
+                "available": data.get("available"),
+                "network_name": data.get("network_name"),
+                "ip_addresses": data.get("ip_addresses"),
+                "mac_address": data.get("mac_address"),
+                "active_fabrics": data.get("active_fabrics"),
+                "active_fabric_index": data.get("active_fabric_index"),
+            }
+    except (
+        HomeAssistantConnectionError,
+        HomeAssistantAPIError,
+        TimeoutError,
+        OSError,
+    ) as e:
+        logger.warning(
+            "Could not fetch Matter node diagnostics for device %s: %s",
+            device_info.get("device_id"),
+            e,
+        )
+
+
 async def _get_single_device_result(
     client: Any,
     device_id: str,
@@ -296,6 +333,8 @@ async def _get_single_device_result(
         await _enrich_zha_metrics(client, device_info)
     if device_info.get("integration_type") == "zwave_js" and device_info.get("node_id"):
         await _enrich_zwave_status(client, device_id, device_info)
+    if device_info.get("integration_type") == "matter":
+        await _enrich_matter_diagnostics(client, device_id, device_info)
 
     entities = device_info.get("entities", [])
     return {
@@ -573,11 +612,11 @@ class RegistryTools:
 
     @tool(
         name="ha_get_device",
-        tags={"Device Registry", "Zigbee", "Z-Wave"},
+        tags={"Device Registry", "Zigbee", "Z-Wave", "Matter"},
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
-            "title": "Get Device (incl. Zigbee/ZHA/Z2M and Z-Wave)",
+            "title": "Get Device (incl. Zigbee/ZHA/Z2M, Z-Wave and Matter)",
         },
     )
     @log_tool_usage
@@ -665,6 +704,8 @@ class RegistryTools:
 
         **Zigbee:** integration="zha" or "zigbee2mqtt". Returns ieee_address, radio metrics.
         **Z-Wave:** integration="zwave_js". Returns node_id, node_status.
+        **Matter:** integration="matter". Returns node_diagnostics (network type,
+        reachability, IPs, fabrics). For management use ha_manage_radio.
         """
         try:
             all_devices, all_entities = await _fetch_registries(self._client)

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -274,7 +274,9 @@ async def _enrich_matter_diagnostics(
                 "node_type": data.get("node_type"),
                 "available": data.get("available"),
                 "network_name": data.get("network_name"),
-                "ip_addresses": data.get("ip_addresses"),
+                # Upstream NodeDiagnostics misspells the field "ip_adresses"
+                # (single d); read that key but surface it correctly.
+                "ip_addresses": data.get("ip_adresses"),
                 "mac_address": data.get("mac_address"),
                 "active_fabrics": data.get("active_fabrics"),
                 "active_fabric_index": data.get("active_fabric_index"),

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -356,7 +356,7 @@ class SystemTools:
 
     @tool(
         name="ha_get_system_health",
-        tags={"System", "Zigbee", "Z-Wave", "Integrations"},
+        tags={"System", "Zigbee", "Z-Wave", "Thread", "Matter", "Integrations"},
         annotations={
             "idempotentHint": True,
             "readOnlyHint": True,
@@ -399,6 +399,8 @@ class SystemTools:
           - "zha_network": ZHA Zigbee devices with radio signal summary (name, LQI, RSSI)
           - "zha_network_full": ZHA Zigbee devices with all device details (can be large on 100+ device networks; prefer "zha_network" for summary)
           - "zwave_network": Z-Wave JS network status and node summary (status, security, routing)
+          - "thread_network": Thread/OpenThread Border Router (OTBR) summary — per border-router channel, extended_pan_id, and border_agent_id (integration-presence + radio-network view, not per-node Thread health)
+          - "matter_network": Matter integration presence summary — config_entry_id, state, and title (per-node health is exposed separately via Matter node diagnostics, not here)
           - "themes": Installed theme names and defaults (sorted list of theme names, count, default_theme, default_dark_theme)
           - "diagnostics": Per-integration diagnostics dump — integration-defined JSON
             (commonly includes redacted config, device list, state snapshots; exact
@@ -467,6 +469,8 @@ class SystemTools:
             "zha_network",
             "zha_network_full",
             "zwave_network",
+            "thread_network",
+            "matter_network",
             "themes",
         }
 
@@ -517,6 +521,8 @@ class SystemTools:
                 "zha_network",
                 "zha_network_full",
                 "zwave_network",
+                "thread_network",
+                "matter_network",
                 "diagnostics",
                 "config_check",
                 "themes",
@@ -542,6 +548,8 @@ class SystemTools:
             want_repairs = "repairs" in includes
             want_zha = zha_full or zha_summary
             want_zwave = "zwave_network" in includes
+            want_thread = "thread_network" in includes
+            want_matter = "matter_network" in includes
             want_themes = "themes" in includes
 
             if ws_client is None:
@@ -557,6 +565,10 @@ class SystemTools:
                     result["zha_network"] = {"error": ws_error}
                 if want_zwave:
                     result["zwave_network"] = {"error": ws_error}
+                if want_thread:
+                    result["thread_network"] = {"error": ws_error}
+                if want_matter:
+                    result["matter_network"] = {"error": ws_error}
                 if want_themes:
                     result["themes"] = {"error": ws_error}
                 unavailable = sorted(includes & ws_backed)
@@ -565,7 +577,9 @@ class SystemTools:
                         "These sections require the system_health WebSocket, "
                         f"which is unavailable: {', '.join(unavailable)}"
                     )
-                want_repairs = want_zha = want_zwave = want_themes = False
+                want_repairs = want_zha = want_zwave = want_thread = want_matter = (
+                    want_themes
+                ) = False
 
             sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]] = []
             if want_repairs:
@@ -584,6 +598,14 @@ class SystemTools:
                 )
             if want_zwave:
                 sections.append(("zwave_network", self._fetch_zwave_network(ws_client)))
+            if want_thread:
+                sections.append(
+                    ("thread_network", self._fetch_thread_network(ws_client))
+                )
+            if want_matter:
+                sections.append(
+                    ("matter_network", self._fetch_matter_network(ws_client))
+                )
             if want_themes:
                 sections.append(("themes", self._fetch_themes(ws_client)))
 
@@ -971,6 +993,95 @@ class SystemTools:
                 f"Z-Wave JS integration not available or error: {e}"
             )
         return zwave_network
+
+    @staticmethod
+    async def _fetch_thread_network(ws_client: Any) -> dict[str, Any]:
+        """Fetch a Thread/OpenThread Border Router (OTBR) summary.
+
+        Calls the ``otbr/info`` WebSocket command (HA's Thread/OTBR
+        integration) and returns a lightweight per-border-router summary —
+        ``channel``, ``extended_pan_id`` and ``border_agent_id`` keyed by the
+        OTBR's ``extended_address``. Per-node Thread health is not exposed by
+        this command, so this section is an integration-presence + radio-network
+        view rather than a per-device dump. ``otbr/info`` responds
+        ``success=false`` (code ``not_loaded``) when no OTBR is configured;
+        that surfaces as an ``error`` sub-dict like the other sections.
+        """
+        thread_network: dict[str, Any] = {"border_routers": [], "count": 0}
+        try:
+            info_result = await ws_client.send_command("otbr/info")
+            if info_result.get("success"):
+                # ``otbr/info`` returns a dict keyed by each border router's
+                # extended address; the value carries the per-OTBR fields.
+                routers_raw = info_result.get("result") or {}
+                border_routers = [
+                    {
+                        "extended_address": ext_addr,
+                        "channel": (info or {}).get("channel"),
+                        "extended_pan_id": (info or {}).get("extended_pan_id"),
+                        "border_agent_id": (info or {}).get("border_agent_id"),
+                    }
+                    for ext_addr, info in routers_raw.items()
+                ]
+                thread_network = {
+                    "border_routers": border_routers,
+                    "count": len(border_routers),
+                }
+            else:
+                err = info_result.get("error") or {}
+                err_msg = (
+                    err.get("message") if isinstance(err, dict) else str(err)
+                ) or "unknown error"
+                thread_network["error"] = (
+                    f"Thread/OTBR integration not available: {err_msg}"
+                )
+        except Exception as e:
+            _reraise_if_fatal(e)
+            logger.warning("Failed to fetch Thread network data: %s", e)
+            thread_network["error"] = (
+                f"Thread/OTBR integration not available or error: {e}"
+            )
+        return thread_network
+
+    @staticmethod
+    async def _fetch_matter_network(ws_client: Any) -> dict[str, Any]:
+        """Fetch a lightweight Matter integration-presence summary.
+
+        Resolves the Matter config entry via ``config_entries/get`` (filtering
+        ``domain == "matter"``) and returns its ``config_entry_id``, ``state``
+        and ``title``. Matter exposes health *per node* via the
+        ``matter/node_diagnostics`` command, so this section is deliberately an
+        integration presence/state summary, not a per-device dump. Returns
+        ``{"error": "Matter integration not found"}`` when no Matter entry
+        exists.
+        """
+        matter_network: dict[str, Any] = {}
+        try:
+            # ``config_entries/get`` (underscore) is the canonical command —
+            # the slash form is rejected as "Unknown command" (same caveat the
+            # zwave helper documents above).
+            entries_result = await ws_client.send_command("config_entries/get")
+            matter_entry = None
+            if entries_result.get("success"):
+                for entry in entries_result.get("result", []):
+                    if entry.get("domain") == "matter":
+                        matter_entry = entry
+                        break
+
+            if matter_entry is None:
+                matter_network["error"] = "Matter integration not found"
+                return matter_network
+
+            matter_network = {
+                "config_entry_id": matter_entry.get("entry_id"),
+                "state": matter_entry.get("state"),
+                "title": matter_entry.get("title"),
+            }
+        except Exception as e:
+            _reraise_if_fatal(e)
+            logger.warning("Failed to fetch Matter network data: %s", e)
+            matter_network["error"] = f"Matter integration not available or error: {e}"
+        return matter_network
 
     @staticmethod
     async def _fetch_themes(ws_client: Any) -> dict[str, Any]:

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -999,9 +999,10 @@ class SystemTools:
         """Fetch a Thread/OpenThread Border Router (OTBR) summary.
 
         Calls the ``otbr/info`` WebSocket command (HA's Thread/OTBR
-        integration) and returns a lightweight per-border-router summary —
-        ``channel``, ``extended_pan_id`` and ``border_agent_id`` keyed by the
-        OTBR's ``extended_address``. Per-node Thread health is not exposed by
+        integration) and returns a lightweight list of per-border-router
+        summaries — each with its ``extended_address``, ``channel``,
+        ``extended_pan_id`` and ``border_agent_id``. Per-node Thread health is
+        not exposed by
         this command, so this section is an integration-presence + radio-network
         view rather than a per-device dump. ``otbr/info`` responds
         ``success=false`` (code ``not_loaded``) when no OTBR is configured;

--- a/tests/src/e2e/tools/test_radio_management.py
+++ b/tests/src/e2e/tools/test_radio_management.py
@@ -1,0 +1,213 @@
+"""E2E tests for the ``ha_manage_radio`` tool and the system-health radio includes.
+
+The E2E testcontainer is a bare Home Assistant Core image with NO radio
+integrations configured (no ``zwave_js`` / ``zha`` / ``matter`` / ``otbr``), so
+node-level radio commands cannot succeed end-to-end here. What this suite *can*
+verify deterministically over the real MCP/WebSocket/REST plumbing is:
+
+1. Tool registration — ``ha_manage_radio`` is discoverable and callable.
+2. The pre-flight validation gates that never reach Home Assistant (unknown
+   action, missing required param, destructive-without-confirm). These are
+   deterministic regardless of which integrations are installed.
+3. Graceful degradation: ``network_status`` on a radio whose config entry is
+   absent resolves the entry first and returns the documented
+   ``available: False`` / ``not configured`` envelope instead of erroring.
+4. The new ``thread_network`` / ``matter_network`` includes on
+   ``ha_get_system_health`` return their sections without crashing (each may
+   carry an ``error`` marker on a radio-less container).
+
+The happy-path write actions (commission, inclusion, fabric removal, firmware,
+channel migration, ...) require a live radio and are out of reach for CI; they
+are exercised by the unit tests instead.
+"""
+
+import json
+import logging
+
+import pytest
+
+from ..utilities.assertions import (
+    extract_error_message,
+    parse_mcp_result,
+    safe_call_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_ha_manage_radio_is_registered(mcp_client):
+    """ha_manage_radio is auto-discovered and exposed by the MCP server."""
+    tools = await mcp_client.list_tools()
+    tool_names = [tool.name for tool in tools]
+    assert "ha_manage_radio" in tool_names, (
+        f"ha_manage_radio not registered; available tools: {sorted(tool_names)}"
+    )
+    logger.info("ha_manage_radio is registered and callable")
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_lists_supported_actions(mcp_client):
+    """An unknown action fails before reaching HA and surfaces the supported list.
+
+    The dispatcher rejects any action not in the radio's SUPPORTED map and
+    attaches the sorted supported actions (in the ``supported`` context field and
+    the ``Use one of: ...`` suggestion) so the agent can self-correct.
+    """
+    data = await safe_call_tool(
+        mcp_client,
+        "ha_manage_radio",
+        {"radio": "matter", "action": "not_an_action"},
+    )
+    logger.info(f"Unknown-action result: {data}")
+
+    assert data.get("success") is False, "Unknown action must fail"
+
+    # The supported actions are surfaced via the context ``supported`` list and
+    # the suggestion text. Assert on the whole error surface so the test stays
+    # robust to exactly where they land.
+    haystack = json.dumps(data).lower()
+    for expected_action in ("commission", "network_status", "diagnostics"):
+        assert expected_action in haystack, (
+            f"Expected supported action '{expected_action}' in error surface: {data}"
+        )
+
+    supported = data.get("supported")
+    if supported is not None:
+        assert isinstance(supported, list) and "commission" in supported, (
+            f"'supported' should list the radio's actions, got: {supported}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_required_param_errors(mcp_client):
+    """A missing required param fails before reaching HA and names the param.
+
+    ``matter/commission`` requires a setup ``code``; omitting it trips the
+    required-arg gate, which lists the missing parameter name.
+    """
+    data = await safe_call_tool(
+        mcp_client,
+        "ha_manage_radio",
+        {"radio": "matter", "action": "commission"},
+    )
+    logger.info(f"Missing-param result: {data}")
+
+    assert data.get("success") is False, "Missing required param must fail"
+
+    error_msg = extract_error_message(data)
+    assert "code" in error_msg.lower(), (
+        f"Error should name the missing 'code' param, got: {error_msg}"
+    )
+    # ``missing`` is attached at the top level via the error context.
+    missing = data.get("missing")
+    if missing is not None:
+        assert "code" in missing, f"'missing' should list 'code', got: {missing}"
+
+
+@pytest.mark.asyncio
+async def test_destructive_without_confirm_errors(mcp_client):
+    """A destructive action without confirm=True is refused before reaching HA.
+
+    ``matter/remove_fabric`` is destructive: with its required ``device_id``
+    present but ``confirm`` defaulting to False, the confirm gate rejects it and
+    the error tells the caller to pass confirm=True.
+    """
+    data = await safe_call_tool(
+        mcp_client,
+        "ha_manage_radio",
+        {"radio": "matter", "action": "remove_fabric", "device_id": "x"},
+    )
+    logger.info(f"Destructive-no-confirm result: {data}")
+
+    assert data.get("success") is False, "Destructive action without confirm must fail"
+
+    error_msg = extract_error_message(data)
+    assert "confirm" in error_msg.lower(), (
+        f"Error should mention confirm, got: {error_msg}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_network_status_degrades_gracefully(mcp_client):
+    """thread/network_status returns available=False when no OTBR is configured.
+
+    The handler resolves the ``otbr`` config entry first; with none present on a
+    bare container it returns the documented degraded envelope rather than
+    erroring.
+    """
+    result = await mcp_client.call_tool(
+        "ha_manage_radio",
+        {"radio": "thread", "action": "network_status"},
+    )
+    data = parse_mcp_result(result)
+    logger.info(f"thread/network_status result: {data}")
+
+    assert data.get("success") is True, (
+        f"thread/network_status should degrade gracefully, got: {data}"
+    )
+    assert data.get("available") is False, (
+        f"No OTBR configured -> available should be False, got: {data}"
+    )
+    assert data.get("radio") == "thread"
+    warnings = data.get("warnings") or []
+    assert any("otbr" in str(w).lower() for w in warnings), (
+        f"Degraded payload should warn about the absent otbr integration: {warnings}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_zwave_network_status_degrades_gracefully(mcp_client):
+    """zwave/network_status returns available=False when zwave_js is not configured."""
+    result = await mcp_client.call_tool(
+        "ha_manage_radio",
+        {"radio": "zwave", "action": "network_status"},
+    )
+    data = parse_mcp_result(result)
+    logger.info(f"zwave/network_status result: {data}")
+
+    assert data.get("success") is True, (
+        f"zwave/network_status should degrade gracefully, got: {data}"
+    )
+    assert data.get("available") is False, (
+        f"No zwave_js entry -> available should be False, got: {data}"
+    )
+    assert data.get("radio") == "zwave"
+    warnings = data.get("warnings") or []
+    assert any("zwave_js" in str(w).lower() for w in warnings), (
+        f"Degraded payload should warn about the absent zwave_js integration: {warnings}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_health_thread_and_matter_includes(mcp_client):
+    """ha_get_system_health surfaces the thread_network/matter_network sections.
+
+    Both are WebSocket-backed sections. On a container whose system_health
+    baseline is unavailable the whole call surfaces a "not available" error
+    (skip, mirroring the sibling zwave_network/zha_network tests). When the
+    baseline is up, both sections are present; on a radio-less container each may
+    carry an ``error`` marker, which is acceptable.
+    """
+    result = await mcp_client.call_tool(
+        "ha_get_system_health", {"include": "thread_network,matter_network"}
+    )
+    data = parse_mcp_result(result)
+    logger.info(f"system_health thread+matter result: {data}")
+
+    if not data.get("success"):
+        error_msg = str(data.get("error", ""))
+        if "not available" in error_msg.lower():
+            pytest.skip("system_health not available in test environment")
+        pytest.fail(f"system_health thread+matter include failed: {error_msg}")
+
+    assert "thread_network" in data, (
+        "Missing 'thread_network' when include='thread_network'"
+    )
+    assert "matter_network" in data, (
+        "Missing 'matter_network' when include='matter_network'"
+    )
+    # Both sections are dicts; on a radio-less container they legitimately carry
+    # an absent-integration ``error`` marker, so assert shape, not content.
+    assert isinstance(data["thread_network"], dict)
+    assert isinstance(data["matter_network"], dict)

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -1,0 +1,234 @@
+"""Unit tests for radio management: the ha_manage_radio dispatcher and the
+Matter diagnostics enrichment added to ha_get_device.
+
+The per-radio handler modules (zwave/zigbee/thread) are exercised by their own
+tests once implemented; this module covers the dispatcher contract (action
+validation, required-param + destructive-confirm gates, entity resolution) and
+the Matter handler + enricher end to end against a mocked WebSocket client.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_radio import register_radio_tools
+from ha_mcp.tools.tools_registry import register_registry_tools
+
+
+def _capture(register, mock_client):
+    """Register tools onto a mock MCP and return {tool_name: bound_method}."""
+    mock_mcp = MagicMock()
+    captured: dict = {}
+
+    def capture_add_tool(method):
+        fmcp = getattr(method, "__fastmcp__", None)
+        name = (fmcp.name if fmcp else None) or method.__name__
+        captured[name] = method
+
+    mock_mcp.add_tool = capture_add_tool
+    register(mock_mcp, mock_client)
+    return captured
+
+
+def _client(routes: dict, *, record: list | None = None):
+    """Mock client whose send_websocket_message routes by message ``type``.
+
+    ``routes`` maps a ``type`` string to either a response dict or a callable
+    taking the message and returning/raising. ``record`` (if given) collects
+    every outgoing message for call assertions.
+    """
+    mock_client = MagicMock()
+
+    async def mock_ws(msg, **kwargs):
+        msg_type = msg.get("type", "") if isinstance(msg, dict) else ""
+        if record is not None:
+            record.append(msg)
+        handler = routes.get(msg_type)
+        if callable(handler):
+            return handler(msg)
+        if handler is not None:
+            return handler
+        return {"success": False, "error": f"Unknown type: {msg_type}"}
+
+    mock_client.send_websocket_message = AsyncMock(side_effect=mock_ws)
+    return mock_client
+
+
+def _matter_device(device_id: str = "m1"):
+    return {
+        "id": device_id,
+        "name": "Matter Bulb",
+        "name_by_user": None,
+        "manufacturer": "Acme",
+        "model": "Bulb",
+        "sw_version": "1.0",
+        "hw_version": None,
+        "serial_number": None,
+        "area_id": None,
+        "via_device_id": None,
+        "disabled_by": None,
+        "labels": [],
+        "config_entries": ["e1"],
+        "connections": [],
+        "identifiers": [["matter", "deadbeef-1"]],
+    }
+
+
+_DIAG = {
+    "node_id": 1,
+    "network_type": "THREAD",
+    "node_type": "END_DEVICE",
+    "network_name": "my-thread",
+    "ip_addresses": ["fe80::1"],
+    "mac_address": "aa:bb",
+    "available": True,
+    "active_fabrics": [{"fabric_index": 2, "fabric_id": 99}],
+    "active_fabric_index": 2,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Matter enrichment in ha_get_device
+# --------------------------------------------------------------------------- #
+
+
+class TestMatterEnrichment:
+    @pytest.mark.asyncio
+    async def test_matter_device_gets_node_diagnostics(self):
+        device = _matter_device()
+        client = _client(
+            {
+                "config/device_registry/list": {"success": True, "result": [device]},
+                "config/entity_registry/list": {"success": True, "result": []},
+                "matter/node_diagnostics": {"success": True, "result": _DIAG},
+            }
+        )
+        captured = _capture(register_registry_tools, client)
+        result = await captured["ha_get_device"](device_id="m1")
+
+        dev = result["device"]
+        assert dev["integration_type"] == "matter"
+        assert dev["node_diagnostics"]["network_type"] == "THREAD"
+        assert dev["node_diagnostics"]["available"] is True
+        assert dev["node_diagnostics"]["active_fabric_index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_matter_enrichment_oserror_still_returns_device(self):
+        device = _matter_device()
+
+        def boom(_msg):
+            raise OSError("Network unreachable")
+
+        client = _client(
+            {
+                "config/device_registry/list": {"success": True, "result": [device]},
+                "config/entity_registry/list": {"success": True, "result": []},
+                "matter/node_diagnostics": boom,
+            }
+        )
+        captured = _capture(register_registry_tools, client)
+        result = await captured["ha_get_device"](device_id="m1")
+
+        assert result["success"] is True
+        assert "node_diagnostics" not in result["device"]
+
+
+# --------------------------------------------------------------------------- #
+# ha_manage_radio dispatcher + Matter handler
+# --------------------------------------------------------------------------- #
+
+
+class TestManageRadioDispatcher:
+    @pytest.mark.asyncio
+    async def test_matter_diagnostics(self):
+        client = _client({"matter/node_diagnostics": {"success": True, "result": _DIAG}})
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="diagnostics", device_id="m1")
+        assert out["success"] is True
+        assert out["radio"] == "matter"
+        assert out["diagnostics"]["network_type"] == "THREAD"
+
+    @pytest.mark.asyncio
+    async def test_matter_ping(self):
+        client = _client(
+            {"matter/ping_node": {"success": True, "result": {"fe80::1": True}}}
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="ping", device_id="m1")
+        assert out["reachability"] == {"fe80::1": True}
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_lists_supported(self):
+        client = _client({})
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="nope", device_id="m1")
+        assert "diagnostics" in str(exc.value)  # supported list surfaced
+
+    @pytest.mark.asyncio
+    async def test_missing_required_param(self):
+        client = _client({})
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="commission")  # missing code
+        assert "code" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_destructive_requires_confirm(self):
+        client = _client({})
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="remove_fabric", device_id="m1")
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_remove_fabric_autoresolves_fabric_index(self):
+        record: list = []
+        client = _client(
+            {
+                "matter/node_diagnostics": {"success": True, "result": _DIAG},
+                "matter/remove_matter_fabric": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(
+            radio="matter", action="remove_fabric", device_id="m1", confirm=True
+        )
+        assert out["fabric_index"] == 2  # resolved from node diagnostics
+        removed = [m for m in record if m["type"] == "matter/remove_matter_fabric"]
+        assert removed and removed[0]["fabric_index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_share_out_returns_codes(self):
+        codes = {
+            "setup_pin_code": 1234,
+            "setup_manual_code": "111-22",
+            "setup_qr_code": "MT:ABC",
+        }
+        client = _client(
+            {"matter/open_commissioning_window": {"success": True, "result": codes}}
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="share_out", device_id="m1")
+        assert out["commissioning"]["setup_manual_code"] == "111-22"
+
+    @pytest.mark.asyncio
+    async def test_entity_id_resolves_to_device(self):
+        record: list = []
+        client = _client(
+            {
+                "config/entity_registry/list": {
+                    "success": True,
+                    "result": [{"entity_id": "light.m", "device_id": "m1"}],
+                },
+                "matter/node_diagnostics": {"success": True, "result": _DIAG},
+            },
+            record=record,
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="diagnostics", entity_id="light.m")
+        assert out["diagnostics"]["network_type"] == "THREAD"
+        diag = [m for m in record if m["type"] == "matter/node_diagnostics"]
+        assert diag and diag[0]["device_id"] == "m1"

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -192,7 +192,21 @@ class TestManageRadioDispatcher:
         assert "confirm" in str(exc.value).lower()
 
     @pytest.mark.asyncio
-    async def test_remove_fabric_autoresolves_fabric_index(self):
+    async def test_remove_fabric_own_or_missing_index_errors(self):
+        # _DIAG.active_fabric_index == 2; removing HA's own fabric (or omitting
+        # fabric_index) must be refused with guidance toward ha_remove_device.
+        client = _client(
+            {"matter/node_diagnostics": {"success": True, "result": _DIAG}}
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(
+                radio="matter", action="remove_fabric", device_id="m1", confirm=True
+            )
+        assert "ha_remove_device" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_remove_fabric_other_index_removed(self):
         record: list = []
         client = _client(
             {
@@ -203,11 +217,15 @@ class TestManageRadioDispatcher:
         )
         radio = _capture(register_radio_tools, client)["ha_manage_radio"]
         out = await radio(
-            radio="matter", action="remove_fabric", device_id="m1", confirm=True
+            radio="matter",
+            action="remove_fabric",
+            device_id="m1",
+            params={"fabric_index": 1},  # a DIFFERENT controller's fabric
+            confirm=True,
         )
-        assert out["fabric_index"] == 2  # resolved from node diagnostics
+        assert out["fabric_index"] == 1
         removed = [m for m in record if m["type"] == "matter/remove_matter_fabric"]
-        assert removed and removed[0]["fabric_index"] == 2
+        assert removed and removed[0]["fabric_index"] == 1
 
     @pytest.mark.asyncio
     async def test_share_out_returns_codes(self):

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.tools.tools_radio import register_radio_tools
+from ha_mcp.tools.tools_radio import HANDLERS, register_radio_tools
 from ha_mcp.tools.tools_registry import register_registry_tools
 
 
@@ -267,3 +267,277 @@ class TestManageRadioDispatcher:
 
         assert out["entity_id"] == "update.bulb_fw"
         assert svc == [("update", "install", {"entity_id": "update.bulb_fw"})]
+
+    # ---- commission --------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_commission_forwards_code_and_network_only(self):
+        record: list = []
+        client = _client(
+            {"matter/commission": {"success": True, "result": {"node_id": 5}}},
+            record=record,
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(
+            radio="matter", action="commission", params={"code": "MT:CODE"}
+        )
+        assert out["action"] == "commission"
+        assert out["long_running"] is True
+        assert out["result"] == {"node_id": 5}
+        sent = next(m for m in record if m["type"] == "matter/commission")
+        assert sent["code"] == "MT:CODE"
+        # network_only defaults to False — and a literal False is forwarded
+        # (ws_call only drops None fields).
+        assert sent["network_only"] is False
+
+    @pytest.mark.asyncio
+    async def test_commission_on_network_forwards_pin(self):
+        record: list = []
+        client = _client(
+            {"matter/commission_on_network": {"success": True, "result": {}}},
+            record=record,
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(
+            radio="matter",
+            action="commission_on_network",
+            params={"pin": "12345678"},
+        )
+        assert out["action"] == "commission_on_network"
+        assert out["long_running"] is True
+        sent = next(m for m in record if m["type"] == "matter/commission_on_network")
+        assert sent["pin"] == "12345678"
+        assert "ip_addr" not in sent  # None field dropped by ws_call
+
+    @pytest.mark.asyncio
+    async def test_commission_on_network_requires_pin(self):
+        radio = _capture(register_radio_tools, _client({}))["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="commission_on_network")
+        assert "pin" in str(exc.value)
+
+    # ---- interview ---------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_interview_forwards_device_id(self):
+        record: list = []
+        client = _client(
+            {"matter/interview_node": {"success": True, "result": {}}}, record=record
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="interview", device_id="m1")
+        assert out["action"] == "interview"
+        assert out["long_running"] is True
+        sent = next(m for m in record if m["type"] == "matter/interview_node")
+        assert sent["device_id"] == "m1"
+
+    # ---- set_thread --------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_set_thread_forwards_dataset(self):
+        record: list = []
+        client = _client(
+            {"matter/set_thread": {"success": True, "result": {}}}, record=record
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(
+            radio="matter",
+            action="set_thread",
+            params={"thread_operation_dataset": "0e080000"},
+        )
+        assert out["action"] == "set_thread"
+        sent = next(m for m in record if m["type"] == "matter/set_thread")
+        assert sent["thread_operation_dataset"] == "0e080000"
+
+    @pytest.mark.asyncio
+    async def test_set_thread_requires_dataset(self):
+        radio = _capture(register_radio_tools, _client({}))["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="set_thread")
+        assert "thread_operation_dataset" in str(exc.value)
+
+    # ---- set_wifi_credentials ----------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_set_wifi_credentials_forwards_both(self):
+        record: list = []
+        client = _client(
+            {"matter/set_wifi_credentials": {"success": True, "result": {}}},
+            record=record,
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(
+            radio="matter",
+            action="set_wifi_credentials",
+            params={"network_name": "Home", "password": "secret"},
+        )
+        assert out["action"] == "set_wifi_credentials"
+        sent = next(m for m in record if m["type"] == "matter/set_wifi_credentials")
+        assert sent["network_name"] == "Home"
+        assert sent["password"] == "secret"
+
+    @pytest.mark.asyncio
+    async def test_set_wifi_credentials_requires_name_and_password(self):
+        radio = _capture(register_radio_tools, _client({}))["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="set_wifi_credentials")
+        msg = str(exc.value)
+        assert "network_name" in msg
+        assert "password" in msg
+
+    # ---- network_status ----------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_network_status_loaded_returns_note(self):
+        client = _client(
+            {
+                "config_entries/get": {
+                    "success": True,
+                    "result": [{"domain": "matter", "entry_id": "e1"}],
+                }
+            }
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="network_status")
+        assert out["success"] is True
+        assert out["config_entry_id"] == "e1"
+        assert "note" in out
+
+    @pytest.mark.asyncio
+    async def test_network_status_integration_not_found(self):
+        client = _client({"config_entries/get": {"success": True, "result": []}})
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="network_status")
+        assert out["available"] is False
+        assert out["warnings"]
+
+    # ---- firmware_update no entity ------------------------------------------ #
+    @pytest.mark.asyncio
+    async def test_firmware_update_no_update_entity(self):
+        client = _client(
+            {
+                "config/entity_registry/list": {
+                    "success": True,
+                    "result": [{"entity_id": "light.m1", "device_id": "m1"}],
+                }
+            }
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="firmware_update", device_id="m1")
+        assert "update entity" in str(exc.value).lower()
+
+
+# --------------------------------------------------------------------------- #
+# Dispatcher contract: ws_call failure surfacing, SUPPORTED<->handle drift,
+# and entity resolution.
+# --------------------------------------------------------------------------- #
+
+
+# Superset of every required-param name across all radio handlers, so require()
+# passes for every action and handle() is actually exercised (the drift check
+# relies on reaching the handler body, not the require gate). Extra keys are
+# ignored by each handler's args.get() lookups.
+_CONTRACT_PARAMS: dict = {
+    # matter
+    "code": "MT:CODE",
+    "pin": "12345678",
+    "thread_operation_dataset": "0e080000",
+    "network_name": "Net",
+    "password": "secret",
+    # zigbee
+    "group_name": "G",
+    "group_ids": [1],
+    "group_id": 1,
+    "members": [{"ieee": "aa:bb", "endpoint_id": 1}],
+    "source_ieee": "aa:bb",
+    "target_ieee": "cc:dd",
+    "endpoint_id": 1,
+    "cluster_id": 6,
+    "attribute": "on_off",
+    "value": 1,
+    "command": 0,
+    "command_type": "server",
+    "backup": {"backup": "payload"},
+    "new_channel": 20,
+    # thread
+    "dataset_id": "d1",
+    "channel": 20,
+    "source": "Google",
+    "tlv": "0e080000",
+    # zwave
+    "property": 5,
+}
+
+
+def _permissive_client():
+    """Client that succeeds for any WS type and any service call.
+
+    ``otbr/info`` returns a non-empty border-router map so the Thread per-OTBR
+    actions resolve an extended_address and reach their dedicated branches
+    instead of short-circuiting on integration_not_found.
+    """
+    mock_client = MagicMock()
+
+    async def mock_ws(msg, **kwargs):
+        msg_type = msg.get("type", "") if isinstance(msg, dict) else ""
+        if msg_type == "otbr/info":
+            return {"success": True, "result": {"otbr-1": {"channel": 15}}}
+        return {"success": True, "result": {}}
+
+    mock_client.send_websocket_message = AsyncMock(side_effect=mock_ws)
+    mock_client.call_service = AsyncMock(return_value={})
+    return mock_client
+
+
+class TestRadioDispatcherContract:
+    @pytest.mark.asyncio
+    async def test_ws_call_failure_surfaces_tool_error(self):
+        # A primary WS command reporting success=False must surface as a
+        # ToolError (SERVICE_CALL_FAILED), carrying HA's error text.
+        client = _client(
+            {"matter/node_diagnostics": {"success": False, "error": "boom"}}
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="diagnostics", device_id="m1")
+        assert "boom" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_every_supported_action_is_handled(self):
+        # SUPPORTED<->handle drift guard: every action in every handler's
+        # SUPPORTED must reach a real branch in handle(), never the terminal
+        # "unhandled <radio> action" AssertionError (the dispatcher re-wraps
+        # that AssertionError as an INTERNAL_ERROR ToolError carrying the text).
+        for radio_name, handler in HANDLERS.items():
+            for action in handler.SUPPORTED:
+                client = _permissive_client()
+                tool = _capture(register_radio_tools, client)["ha_manage_radio"]
+                try:
+                    await tool(
+                        radio=radio_name,
+                        action=action,
+                        device_id="d1",
+                        params=dict(_CONTRACT_PARAMS),
+                        confirm=True,
+                    )
+                except ToolError as exc:
+                    msg = str(exc)
+                    assert "unhandled" not in msg, (
+                        f"{radio_name}/{action} fell through handle(): {msg}"
+                    )
+                    # A "requires:" error means _CONTRACT_PARAMS lacks a
+                    # newly-added required arg, so handle() was never reached
+                    # and the drift check above is vacuous for this action.
+                    assert "requires:" not in msg, (
+                        f"{radio_name}/{action} needs a required arg absent from "
+                        f"_CONTRACT_PARAMS; add it: {msg}"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_resolve_entity_device_not_found(self):
+        # An entity_id the registry doesn't contain -> ENTITY_NOT_FOUND.
+        client = _client(
+            {"config/entity_registry/list": {"success": True, "result": []}}
+        )
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        with pytest.raises(ToolError) as exc:
+            await radio(radio="matter", action="diagnostics", entity_id="light.ghost")
+        msg = str(exc.value)
+        assert "light.ghost" in msg
+        assert "not found" in msg.lower()

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -154,6 +154,9 @@ class TestManageRadioDispatcher:
         assert out["success"] is True
         assert out["radio"] == "matter"
         assert out["diagnostics"]["network_type"] == "THREAD"
+        # Normalized from the upstream "ip_adresses" typo (matches ha_get_device).
+        assert out["diagnostics"]["ip_addresses"] == ["fe80::1"]
+        assert "ip_adresses" not in out["diagnostics"]
 
     @pytest.mark.asyncio
     async def test_matter_ping(self):

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -142,7 +142,9 @@ class TestMatterEnrichment:
 class TestManageRadioDispatcher:
     @pytest.mark.asyncio
     async def test_matter_diagnostics(self):
-        client = _client({"matter/node_diagnostics": {"success": True, "result": _DIAG}})
+        client = _client(
+            {"matter/node_diagnostics": {"success": True, "result": _DIAG}}
+        )
         radio = _capture(register_radio_tools, client)["ha_manage_radio"]
         out = await radio(radio="matter", action="diagnostics", device_id="m1")
         assert out["success"] is True
@@ -232,3 +234,32 @@ class TestManageRadioDispatcher:
         assert out["diagnostics"]["network_type"] == "THREAD"
         diag = [m for m in record if m["type"] == "matter/node_diagnostics"]
         assert diag and diag[0]["device_id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_firmware_update_installs_update_entity(self):
+        svc: list = []
+        client = _client(
+            {
+                "config/entity_registry/list": {
+                    "success": True,
+                    "result": [
+                        {
+                            "entity_id": "update.bulb_fw",
+                            "device_id": "m1",
+                            "platform": "matter",
+                        }
+                    ],
+                }
+            }
+        )
+
+        async def fake_call_service(domain, service, data=None, return_response=False):
+            svc.append((domain, service, data))
+            return {"success": True}
+
+        client.call_service = AsyncMock(side_effect=fake_call_service)
+        radio = _capture(register_radio_tools, client)["ha_manage_radio"]
+        out = await radio(radio="matter", action="firmware_update", device_id="m1")
+
+        assert out["entity_id"] == "update.bulb_fw"
+        assert svc == [("update", "install", {"entity_id": "update.bulb_fw"})]

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -80,7 +80,9 @@ _DIAG = {
     "network_type": "THREAD",
     "node_type": "END_DEVICE",
     "network_name": "my-thread",
-    "ip_addresses": ["fe80::1"],
+    # Upstream NodeDiagnostics misspells this field (single 'd'); the mock must
+    # match reality so the enricher's corrected lookup is actually exercised.
+    "ip_adresses": ["fe80::1"],
     "mac_address": "aa:bb",
     "available": True,
     "active_fabrics": [{"fabric_index": 2, "fabric_id": 99}],
@@ -112,6 +114,8 @@ class TestMatterEnrichment:
         assert dev["node_diagnostics"]["network_type"] == "THREAD"
         assert dev["node_diagnostics"]["available"] is True
         assert dev["node_diagnostics"]["active_fabric_index"] == 2
+        # Regression: IPs come through despite the upstream 'ip_adresses' typo.
+        assert dev["node_diagnostics"]["ip_addresses"] == ["fe80::1"]
 
     @pytest.mark.asyncio
     async def test_matter_enrichment_oserror_still_returns_device(self):

--- a/tests/src/unit/test_radio_thread.py
+++ b/tests/src/unit/test_radio_thread.py
@@ -143,7 +143,10 @@ class TestThreadHandler:
             record=record,
         )
         out = await _radio(client)(
-            radio="thread", action="set_network", params={"dataset_id": "d1"}
+            radio="thread",
+            action="set_network",
+            params={"dataset_id": "d1"},
+            confirm=True,
         )
         assert out["extended_address"] == "f00dcafe"
         sent = [m for m in record if m["type"] == "otbr/set_network"]
@@ -154,9 +157,21 @@ class TestThreadHandler:
     async def test_set_network_no_otbr_degrades(self):
         client = _client({"otbr/info": {"success": True, "result": {}}})
         out = await _radio(client)(
-            radio="thread", action="set_network", params={"dataset_id": "d1"}
+            radio="thread",
+            action="set_network",
+            params={"dataset_id": "d1"},
+            confirm=True,
         )
         assert out["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_set_network_requires_confirm(self):
+        client = _client({"otbr/info": _INFO})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="thread", action="set_network", params={"dataset_id": "d1"}
+            )
+        assert "confirm" in str(exc.value).lower()
 
     @pytest.mark.asyncio
     async def test_create_network_requires_confirm(self):

--- a/tests/src/unit/test_radio_thread.py
+++ b/tests/src/unit/test_radio_thread.py
@@ -1,0 +1,228 @@
+"""Unit tests for the Thread/OTBR handler behind ``ha_manage_radio``.
+
+Mirrors test_radio_management.py's dispatcher-level style: register the tool via
+``register_radio_tools`` against a mock client that routes
+``send_websocket_message`` by message ``type``, then assert success envelopes
+and that the destructive / required-param gates raise ``ToolError``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_radio import register_radio_tools
+
+
+def _capture(register, mock_client):
+    """Register tools onto a mock MCP and return {tool_name: bound_method}."""
+    mock_mcp = MagicMock()
+    captured: dict = {}
+
+    def capture_add_tool(method):
+        fmcp = getattr(method, "__fastmcp__", None)
+        name = (fmcp.name if fmcp else None) or method.__name__
+        captured[name] = method
+
+    mock_mcp.add_tool = capture_add_tool
+    register(mock_mcp, mock_client)
+    return captured
+
+
+def _client(routes: dict, *, record: list | None = None):
+    """Mock client whose send_websocket_message routes by message ``type``."""
+    mock_client = MagicMock()
+
+    async def mock_ws(msg, **kwargs):
+        msg_type = msg.get("type", "") if isinstance(msg, dict) else ""
+        if record is not None:
+            record.append(msg)
+        handler = routes.get(msg_type)
+        if callable(handler):
+            return handler(msg)
+        if handler is not None:
+            return handler
+        return {"success": False, "error": f"Unknown type: {msg_type}"}
+
+    mock_client.send_websocket_message = AsyncMock(side_effect=mock_ws)
+    return mock_client
+
+
+def _radio(client):
+    return _capture(register_radio_tools, client)["ha_manage_radio"]
+
+
+# config_entries/get reply with a single OTBR entry (resolve_entry_id input).
+_OTBR_ENTRY = {"success": True, "result": [{"domain": "otbr", "entry_id": "otbr1"}]}
+_INFO = {
+    "success": True,
+    "result": {
+        "f00dcafe": {
+            "border_agent_id": "ba1",
+            "channel": 15,
+            "extended_pan_id": "1111222233334444",
+            "active_dataset_tlvs": "0e08abcd",
+        }
+    },
+}
+
+
+class TestThreadHandler:
+    @pytest.mark.asyncio
+    async def test_network_status(self):
+        client = _client({"config_entries/get": _OTBR_ENTRY, "otbr/info": _INFO})
+        out = await _radio(client)(radio="thread", action="network_status")
+        assert out["success"] is True
+        assert out["radio"] == "thread"
+        assert out["config_entry_id"] == "otbr1"
+        assert out["border_routers"]["f00dcafe"]["channel"] == 15
+
+    @pytest.mark.asyncio
+    async def test_network_status_no_otbr_degrades(self):
+        client = _client({"config_entries/get": {"success": True, "result": []}})
+        out = await _radio(client)(radio="thread", action="network_status")
+        assert out["success"] is True
+        assert out["available"] is False
+        assert out["warnings"]
+
+    @pytest.mark.asyncio
+    async def test_list_datasets(self):
+        datasets = {"datasets": [{"dataset_id": "d1", "preferred": True}]}
+        client = _client(
+            {"thread/list_datasets": {"success": True, "result": datasets}}
+        )
+        out = await _radio(client)(radio="thread", action="list_datasets")
+        assert out["datasets"] == datasets
+
+    @pytest.mark.asyncio
+    async def test_discover_routers_started(self):
+        record: list = []
+        client = _client(
+            {"thread/discover_routers": {"success": True, "result": None}},
+            record=record,
+        )
+        out = await _radio(client)(radio="thread", action="discover_routers")
+        assert out["success"] is True
+        assert out["long_running"] is True
+        assert any(m["type"] == "thread/discover_routers" for m in record)
+
+    @pytest.mark.asyncio
+    async def test_add_dataset(self):
+        record: list = []
+        client = _client(
+            {"thread/add_dataset_tlv": {"success": True, "result": None}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="thread",
+            action="add_dataset",
+            params={"source": "Google", "tlv": "0e08abcd"},
+        )
+        assert out["success"] is True
+        sent = [m for m in record if m["type"] == "thread/add_dataset_tlv"]
+        assert sent and sent[0]["source"] == "Google"
+        assert sent[0]["tlv"] == "0e08abcd"
+
+    @pytest.mark.asyncio
+    async def test_add_dataset_missing_params_raises(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="thread", action="add_dataset", params={"source": "Google"}
+            )
+        assert "tlv" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_set_network_resolves_extended_address(self):
+        record: list = []
+        client = _client(
+            {
+                "otbr/info": _INFO,
+                "otbr/set_network": {"success": True, "result": None},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="thread", action="set_network", params={"dataset_id": "d1"}
+        )
+        assert out["extended_address"] == "f00dcafe"
+        sent = [m for m in record if m["type"] == "otbr/set_network"]
+        assert sent and sent[0]["extended_address"] == "f00dcafe"
+        assert sent[0]["dataset_id"] == "d1"
+
+    @pytest.mark.asyncio
+    async def test_set_network_no_otbr_degrades(self):
+        client = _client({"otbr/info": {"success": True, "result": {}}})
+        out = await _radio(client)(
+            radio="thread", action="set_network", params={"dataset_id": "d1"}
+        )
+        assert out["available"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_network_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="thread", action="create_network")
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_create_network_confirmed_uses_explicit_address(self):
+        record: list = []
+        client = _client(
+            {"otbr/create_network": {"success": True, "result": None}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="thread",
+            action="create_network",
+            params={"extended_address": "abcd1234"},
+            confirm=True,
+        )
+        assert out["extended_address"] == "abcd1234"
+        sent = [m for m in record if m["type"] == "otbr/create_network"]
+        assert sent and sent[0]["extended_address"] == "abcd1234"
+        # Explicit address provided -> no otbr/info lookup needed.
+        assert not any(m["type"] == "otbr/info" for m in record)
+
+    @pytest.mark.asyncio
+    async def test_set_channel_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="thread", action="set_channel", params={"channel": 20}
+            )
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_set_channel_missing_channel_raises(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="thread", action="set_channel", confirm=True)
+        assert "channel" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_set_channel_confirmed(self):
+        record: list = []
+        client = _client(
+            {
+                "otbr/info": _INFO,
+                "otbr/set_channel": {"success": True, "result": None},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="thread",
+            action="set_channel",
+            params={"channel": 20},
+            confirm=True,
+        )
+        assert out["success"] is True
+        sent = [m for m in record if m["type"] == "otbr/set_channel"]
+        assert sent and sent[0]["channel"] == 20
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_lists_supported(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="thread", action="nope")
+        assert "network_status" in str(exc.value)

--- a/tests/src/unit/test_radio_thread.py
+++ b/tests/src/unit/test_radio_thread.py
@@ -154,15 +154,18 @@ class TestThreadHandler:
         assert sent[0]["dataset_id"] == "d1"
 
     @pytest.mark.asyncio
-    async def test_set_network_no_otbr_degrades(self):
+    async def test_set_network_no_otbr_raises(self):
+        # set_network is a write action: an absent OTBR must raise (not degrade
+        # to a no-op success the way the read-only network_status does).
         client = _client({"otbr/info": {"success": True, "result": {}}})
-        out = await _radio(client)(
-            radio="thread",
-            action="set_network",
-            params={"dataset_id": "d1"},
-            confirm=True,
-        )
-        assert out["available"] is False
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="thread",
+                action="set_network",
+                params={"dataset_id": "d1"},
+                confirm=True,
+            )
+        assert "otbr" in str(exc.value).lower()
 
     @pytest.mark.asyncio
     async def test_set_network_requires_confirm(self):

--- a/tests/src/unit/test_radio_zigbee.py
+++ b/tests/src/unit/test_radio_zigbee.py
@@ -1,0 +1,503 @@
+"""Unit tests for the Zigbee (ZHA) handler behind ``ha_manage_radio``.
+
+Mirrors ``test_radio_management.py``'s ``TestManageRadioDispatcher`` style: tools
+are registered onto a mock MCP via ``register_radio_tools`` and a mock client
+routes WebSocket commands by message ``type`` (and records service calls). Tests
+assert the success envelopes plus the destructive-confirm / required-param gates
+the dispatcher enforces against the handler's ``SUPPORTED`` specs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_radio import register_radio_tools
+
+_IEEE = "00:11:22:33:44:55:66:77"
+
+
+def _capture(register, mock_client):
+    """Register tools onto a mock MCP and return {tool_name: bound_method}."""
+    mock_mcp = MagicMock()
+    captured: dict = {}
+
+    def capture_add_tool(method):
+        fmcp = getattr(method, "__fastmcp__", None)
+        name = (fmcp.name if fmcp else None) or method.__name__
+        captured[name] = method
+
+    mock_mcp.add_tool = capture_add_tool
+    register(mock_mcp, mock_client)
+    return captured
+
+
+def _client(
+    routes: dict,
+    *,
+    record: list | None = None,
+    service_result=None,
+    service_calls: list | None = None,
+):
+    """Mock client: ``send_websocket_message`` routes by ``type``; ``call_service``
+    records (domain, service, data) and returns ``service_result`` (default [])."""
+    mock_client = MagicMock()
+
+    async def mock_ws(msg, **kwargs):
+        msg_type = msg.get("type", "") if isinstance(msg, dict) else ""
+        if record is not None:
+            record.append(msg)
+        handler = routes.get(msg_type)
+        if callable(handler):
+            return handler(msg)
+        if handler is not None:
+            return handler
+        return {"success": False, "error": f"Unknown type: {msg_type}"}
+
+    mock_client.send_websocket_message = AsyncMock(side_effect=mock_ws)
+
+    async def mock_service(domain, service, data=None, return_response=False):
+        if service_calls is not None:
+            service_calls.append(
+                {"domain": domain, "service": service, "data": data or {}}
+            )
+        return service_result if service_result is not None else []
+
+    mock_client.call_service = AsyncMock(side_effect=mock_service)
+    return mock_client
+
+
+def _zha_device(device_id: str = "z1", ieee: str = _IEEE):
+    return {
+        "id": device_id,
+        "name": "Zigbee Bulb",
+        "identifiers": [["zha", ieee]],
+        "connections": [],
+    }
+
+
+def _device_registry(*devices):
+    return {"success": True, "result": list(devices)}
+
+
+def _radio(client):
+    return _capture(register_radio_tools, client)["ha_manage_radio"]
+
+
+# --------------------------------------------------------------------------- #
+# Read actions
+# --------------------------------------------------------------------------- #
+
+
+class TestZigbeeReads:
+    @pytest.mark.asyncio
+    async def test_diagnostics_resolves_ieee_and_returns_metrics(self):
+        record: list = []
+        client = _client(
+            {
+                "config/device_registry/list": _device_registry(_zha_device()),
+                "zha/device": {
+                    "success": True,
+                    "result": {
+                        "ieee": _IEEE,
+                        "lqi": 200,
+                        "rssi": -55,
+                        "available": True,
+                    },
+                },
+            },
+            record=record,
+        )
+        out = await _radio(client)(radio="zigbee", action="diagnostics", device_id="z1")
+        assert out["success"] is True
+        assert out["radio"] == "zigbee"
+        assert out["ieee"] == _IEEE
+        assert out["diagnostics"]["lqi"] == 200
+        # zha/device keyed on the resolved IEEE, not the device_id.
+        dev = [m for m in record if m["type"] == "zha/device"]
+        assert dev and dev[0]["ieee"] == _IEEE
+
+    @pytest.mark.asyncio
+    async def test_network_status_returns_settings_and_kicks_topology(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": {
+                    "success": True,
+                    "result": [{"domain": "zha", "entry_id": "e1"}],
+                },
+                "zha/network/settings": {
+                    "success": True,
+                    "result": {"network": {"channel": 15, "pan_id": 4660}},
+                },
+                "zha/topology/update": {"success": True, "result": None},
+            },
+            record=record,
+        )
+        out = await _radio(client)(radio="zigbee", action="network_status")
+        assert out["config_entry_id"] == "e1"
+        assert out["network"]["network"]["channel"] == 15
+        assert any(m["type"] == "zha/topology/update" for m in record)
+
+    @pytest.mark.asyncio
+    async def test_network_status_topology_failure_is_swallowed(self):
+        client = _client(
+            {
+                "config_entries/get": {
+                    "success": True,
+                    "result": [{"domain": "zha", "entry_id": "e1"}],
+                },
+                "zha/network/settings": {"success": True, "result": {"channel": 20}},
+                "zha/topology/update": {"success": False, "error": "scan busy"},
+            }
+        )
+        out = await _radio(client)(radio="zigbee", action="network_status")
+        assert out["success"] is True
+        assert out["network"]["channel"] == 20
+
+    @pytest.mark.asyncio
+    async def test_network_status_not_configured_is_degraded(self):
+        client = _client({"config_entries/get": {"success": True, "result": []}})
+        out = await _radio(client)(radio="zigbee", action="network_status")
+        assert out["available"] is False
+        assert out["warnings"]
+
+    @pytest.mark.asyncio
+    async def test_cluster_read_defaults_cluster_type_in(self):
+        record: list = []
+        client = _client(
+            {
+                "config/device_registry/list": _device_registry(_zha_device()),
+                "zha/devices/clusters/attributes/value": {
+                    "success": True,
+                    "result": {"value": True},
+                },
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="cluster_read",
+            device_id="z1",
+            params={"endpoint_id": 1, "cluster_id": 6, "attribute": "on_off"},
+        )
+        assert out["value"]["value"] is True
+        reads = [
+            m for m in record if m["type"] == "zha/devices/clusters/attributes/value"
+        ]
+        assert reads and reads[0]["cluster_type"] == "in"
+        assert reads[0]["ieee"] == _IEEE
+
+
+# --------------------------------------------------------------------------- #
+# Node management (WS + service)
+# --------------------------------------------------------------------------- #
+
+
+class TestZigbeeNodeManagement:
+    @pytest.mark.asyncio
+    async def test_permit_join_defaults_duration_no_ieee(self):
+        record: list = []
+        client = _client(
+            {"zha/devices/permit": {"success": True, "result": None}}, record=record
+        )
+        out = await _radio(client)(radio="zigbee", action="permit_join")
+        assert out["duration"] == 60
+        assert out["ieee"] is None
+        permits = [m for m in record if m["type"] == "zha/devices/permit"]
+        assert permits and permits[0]["duration"] == 60
+        # ws_call drops None fields — no per-device ieee on a network-wide permit.
+        assert "ieee" not in permits[0]
+
+    @pytest.mark.asyncio
+    async def test_permit_join_with_device_resolves_ieee(self):
+        record: list = []
+        client = _client(
+            {
+                "config/device_registry/list": _device_registry(_zha_device()),
+                "zha/devices/permit": {"success": True, "result": None},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="permit_join",
+            device_id="z1",
+            params={"duration": 30},
+        )
+        assert out["duration"] == 30
+        assert out["ieee"] == _IEEE
+        permits = [m for m in record if m["type"] == "zha/devices/permit"]
+        assert permits and permits[0]["ieee"] == _IEEE
+
+    @pytest.mark.asyncio
+    async def test_remove_device_calls_service_with_ieee(self):
+        calls: list = []
+        client = _client(
+            {"config/device_registry/list": _device_registry(_zha_device())},
+            service_calls=calls,
+        )
+        out = await _radio(client)(
+            radio="zigbee", action="remove_device", device_id="z1", confirm=True
+        )
+        assert out["ieee"] == _IEEE
+        assert calls == [
+            {"domain": "zha", "service": "remove", "data": {"ieee": _IEEE}}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_remove_device_requires_confirm(self):
+        client = _client(
+            {"config/device_registry/list": _device_registry(_zha_device())}
+        )
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zigbee", action="remove_device", device_id="z1")
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_uses_websocket(self):
+        record: list = []
+        client = _client(
+            {
+                "config/device_registry/list": _device_registry(_zha_device()),
+                "zha/devices/reconfigure": {"success": True, "result": None},
+            },
+            record=record,
+        )
+        out = await _radio(client)(radio="zigbee", action="reconfigure", device_id="z1")
+        assert out["ieee"] == _IEEE
+        assert any(m["type"] == "zha/devices/reconfigure" for m in record)
+
+    @pytest.mark.asyncio
+    async def test_non_zha_device_raises(self):
+        client = _client(
+            {
+                "config/device_registry/list": _device_registry(
+                    {"id": "z1", "identifiers": [["hue", "abc"]], "connections": []}
+                )
+            }
+        )
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zigbee", action="diagnostics", device_id="z1")
+        assert "ZHA" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_firmware_update_installs_update_entity(self):
+        calls: list = []
+        client = _client(
+            {
+                "config/entity_registry/list": {
+                    "success": True,
+                    "result": [
+                        {
+                            "entity_id": "sensor.z1_lqi",
+                            "device_id": "z1",
+                            "platform": "zha",
+                        },
+                        {
+                            "entity_id": "update.z1_firmware",
+                            "device_id": "z1",
+                            "platform": "zha",
+                        },
+                    ],
+                }
+            },
+            service_calls=calls,
+        )
+        out = await _radio(client)(
+            radio="zigbee", action="firmware_update", device_id="z1", confirm=True
+        )
+        assert out["entity_id"] == "update.z1_firmware"
+        assert out["long_running"] is True
+        assert calls == [
+            {
+                "domain": "update",
+                "service": "install",
+                "data": {"entity_id": "update.z1_firmware"},
+            }
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# Groups / bindings
+# --------------------------------------------------------------------------- #
+
+
+class TestZigbeeGroupsAndBindings:
+    @pytest.mark.asyncio
+    async def test_group_add(self):
+        client = _client(
+            {"zha/group/add": {"success": True, "result": {"group_id": 1}}}
+        )
+        out = await _radio(client)(
+            radio="zigbee", action="group_add", params={"group_name": "Kitchen"}
+        )
+        assert out["group"]["group_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_group_add_missing_name_raises(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zigbee", action="group_add")
+        assert "group_name" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_group_remove_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee", action="group_remove", params={"group_ids": [1]}
+            )
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_bind_sends_both_ieees(self):
+        record: list = []
+        client = _client(
+            {"zha/devices/bind": {"success": True, "result": None}}, record=record
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="bind",
+            params={"source_ieee": "aa", "target_ieee": "bb"},
+        )
+        assert out["success"] is True
+        binds = [m for m in record if m["type"] == "zha/devices/bind"]
+        assert binds and binds[0]["source_ieee"] == "aa"
+        assert binds[0]["target_ieee"] == "bb"
+
+    @pytest.mark.asyncio
+    async def test_unbind_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="unbind",
+                params={"source_ieee": "aa", "target_ieee": "bb"},
+            )
+        assert "confirm" in str(exc.value).lower()
+
+
+# --------------------------------------------------------------------------- #
+# Cluster writes / network ops (service + destructive WS)
+# --------------------------------------------------------------------------- #
+
+
+class TestZigbeeClusterAndNetwork:
+    @pytest.mark.asyncio
+    async def test_cluster_write_calls_service(self):
+        calls: list = []
+        client = _client(
+            {"config/device_registry/list": _device_registry(_zha_device())},
+            service_calls=calls,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="cluster_write",
+            device_id="z1",
+            params={
+                "endpoint_id": 1,
+                "cluster_id": 8,
+                "attribute": "current_level",
+                "value": 0,
+            },
+            confirm=True,
+        )
+        assert out["ieee"] == _IEEE
+        data = calls[0]["data"]
+        assert calls[0]["service"] == "set_zigbee_cluster_attribute"
+        assert data["cluster_type"] == "in"
+        assert data["value"] == 0  # falsy value is preserved
+        assert data["ieee"] == _IEEE
+
+    @pytest.mark.asyncio
+    async def test_cluster_write_missing_value_raises(self):
+        client = _client(
+            {"config/device_registry/list": _device_registry(_zha_device())}
+        )
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="cluster_write",
+                device_id="z1",
+                params={
+                    "endpoint_id": 1,
+                    "cluster_id": 8,
+                    "attribute": "current_level",
+                },
+                confirm=True,
+            )
+        assert "value" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_cluster_command_calls_service(self):
+        calls: list = []
+        client = _client(
+            {"config/device_registry/list": _device_registry(_zha_device())},
+            service_calls=calls,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="cluster_command",
+            device_id="z1",
+            params={
+                "endpoint_id": 1,
+                "cluster_id": 6,
+                "command": 0,
+                "command_type": "server",
+            },
+            confirm=True,
+        )
+        assert out["success"] is True
+        assert calls[0]["service"] == "issue_zigbee_cluster_command"
+        assert calls[0]["data"]["command_type"] == "server"
+
+    @pytest.mark.asyncio
+    async def test_network_backup(self):
+        client = _client(
+            {
+                "zha/network/backups/create": {
+                    "success": True,
+                    "result": {"backup_time": "now"},
+                }
+            }
+        )
+        out = await _radio(client)(radio="zigbee", action="network_backup")
+        assert out["backup"]["backup_time"] == "now"
+
+    @pytest.mark.asyncio
+    async def test_change_channel_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee", action="change_channel", params={"new_channel": 25}
+            )
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_change_channel_with_confirm(self):
+        record: list = []
+        client = _client(
+            {"zha/network/change_channel": {"success": True, "result": None}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="change_channel",
+            params={"new_channel": 25},
+            confirm=True,
+        )
+        assert out["new_channel"] == 25
+        changes = [m for m in record if m["type"] == "zha/network/change_channel"]
+        assert changes and changes[0]["new_channel"] == 25
+
+    @pytest.mark.asyncio
+    async def test_network_restore_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="network_restore",
+                params={"backup": {"some": "backup"}},
+            )
+        assert "confirm" in str(exc.value).lower()

--- a/tests/src/unit/test_radio_zigbee.py
+++ b/tests/src/unit/test_radio_zigbee.py
@@ -317,6 +317,31 @@ class TestZigbeeNodeManagement:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_firmware_update_no_update_entity(self):
+        client = _client(
+            {
+                "config/entity_registry/list": {
+                    "success": True,
+                    "result": [
+                        {
+                            "entity_id": "sensor.z1_lqi",
+                            "device_id": "z1",
+                            "platform": "zha",
+                        }
+                    ],
+                }
+            }
+        )
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="firmware_update",
+                device_id="z1",
+                confirm=True,
+            )
+        assert "update entity" in str(exc.value).lower()
+
 
 # --------------------------------------------------------------------------- #
 # Groups / bindings
@@ -377,6 +402,73 @@ class TestZigbeeGroupsAndBindings:
             )
         assert "confirm" in str(exc.value).lower()
 
+    @pytest.mark.asyncio
+    async def test_unbind_with_confirm(self):
+        record: list = []
+        client = _client(
+            {"zha/devices/unbind": {"success": True, "result": None}}, record=record
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="unbind",
+            params={"source_ieee": "aa", "target_ieee": "bb"},
+            confirm=True,
+        )
+        assert out["success"] is True
+        sent = next(m for m in record if m["type"] == "zha/devices/unbind")
+        assert sent["source_ieee"] == "aa"
+        assert sent["target_ieee"] == "bb"
+
+    @pytest.mark.asyncio
+    async def test_group_remove_with_confirm(self):
+        record: list = []
+        client = _client(
+            {"zha/group/remove": {"success": True, "result": {"removed": [1]}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="group_remove",
+            params={"group_ids": [1]},
+            confirm=True,
+        )
+        assert out["success"] is True
+        sent = next(m for m in record if m["type"] == "zha/group/remove")
+        assert sent["group_ids"] == [1]
+
+    @pytest.mark.asyncio
+    async def test_group_members_add(self):
+        record: list = []
+        client = _client(
+            {"zha/group/members/add": {"success": True, "result": {"group_id": 5}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="group_members_add",
+            params={"group_id": 5, "members": [{"ieee": "aa", "endpoint_id": 1}]},
+        )
+        assert out["group"]["group_id"] == 5
+        sent = next(m for m in record if m["type"] == "zha/group/members/add")
+        assert sent["group_id"] == 5
+        assert sent["members"] == [{"ieee": "aa", "endpoint_id": 1}]
+
+    @pytest.mark.asyncio
+    async def test_group_members_remove(self):
+        record: list = []
+        client = _client(
+            {"zha/group/members/remove": {"success": True, "result": {"group_id": 5}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="group_members_remove",
+            params={"group_id": 5, "members": [{"ieee": "aa", "endpoint_id": 1}]},
+        )
+        assert out["group"]["group_id"] == 5
+        sent = next(m for m in record if m["type"] == "zha/group/members/remove")
+        assert sent["group_id"] == 5
+
 
 # --------------------------------------------------------------------------- #
 # Cluster writes / network ops (service + destructive WS)
@@ -409,6 +501,41 @@ class TestZigbeeClusterAndNetwork:
         assert data["cluster_type"] == "in"
         assert data["value"] == 0  # falsy value is preserved
         assert data["ieee"] == _IEEE
+
+    @pytest.mark.asyncio
+    async def test_cluster_write_requires_confirm(self):
+        # cluster_write is destructive: all required params present, no confirm.
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="cluster_write",
+                device_id="z1",
+                params={
+                    "endpoint_id": 1,
+                    "cluster_id": 8,
+                    "attribute": "current_level",
+                    "value": 0,
+                },
+            )
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_cluster_command_requires_confirm(self):
+        client = _client({})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zigbee",
+                action="cluster_command",
+                device_id="z1",
+                params={
+                    "endpoint_id": 1,
+                    "cluster_id": 6,
+                    "command": 0,
+                    "command_type": "server",
+                },
+            )
+        assert "confirm" in str(exc.value).lower()
 
     @pytest.mark.asyncio
     async def test_cluster_write_missing_value_raises(self):
@@ -501,3 +628,20 @@ class TestZigbeeClusterAndNetwork:
                 params={"backup": {"some": "backup"}},
             )
         assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_network_restore_with_confirm(self):
+        record: list = []
+        client = _client(
+            {"zha/network/backups/restore": {"success": True, "result": {"ok": True}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zigbee",
+            action="network_restore",
+            params={"backup": {"some": "backup"}},
+            confirm=True,
+        )
+        assert out["success"] is True
+        sent = next(m for m in record if m["type"] == "zha/network/backups/restore")
+        assert sent["backup"] == {"some": "backup"}

--- a/tests/src/unit/test_radio_zwave.py
+++ b/tests/src/unit/test_radio_zwave.py
@@ -1,0 +1,407 @@
+"""Unit tests for the Z-Wave JS handler behind ``ha_manage_radio``.
+
+Mirrors ``test_radio_management.py``'s ``TestManageRadioDispatcher`` style: tools
+are registered onto a mock MCP via ``register_radio_tools`` and the mock client
+routes ``send_websocket_message`` by message ``type`` (and ``call_service`` for
+the service-backed actions: ``ping`` and ``firmware_update``). Tests assert the
+success envelopes and that the destructive/required/conditional gates raise
+``ToolError``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_radio import register_radio_tools
+
+
+def _capture(register, mock_client):
+    """Register tools onto a mock MCP and return {tool_name: bound_method}."""
+    mock_mcp = MagicMock()
+    captured: dict = {}
+
+    def capture_add_tool(method):
+        fmcp = getattr(method, "__fastmcp__", None)
+        name = (fmcp.name if fmcp else None) or method.__name__
+        captured[name] = method
+
+    mock_mcp.add_tool = capture_add_tool
+    register(mock_mcp, mock_client)
+    return captured
+
+
+def _client(routes: dict, *, record: list | None = None, service_result=None):
+    """Mock client routing ``send_websocket_message`` by ``type``.
+
+    ``routes`` maps a ``type`` string to a response dict or a callable. ``record``
+    (if given) collects every outgoing WS message. ``call_service`` is an
+    AsyncMock returning ``service_result`` (default ``[]``).
+    """
+    mock_client = MagicMock()
+
+    async def mock_ws(msg, **kwargs):
+        msg_type = msg.get("type", "") if isinstance(msg, dict) else ""
+        if record is not None:
+            record.append(msg)
+        handler = routes.get(msg_type)
+        if callable(handler):
+            return handler(msg)
+        if handler is not None:
+            return handler
+        return {"success": False, "error": f"Unknown type: {msg_type}"}
+
+    mock_client.send_websocket_message = AsyncMock(side_effect=mock_ws)
+    mock_client.call_service = AsyncMock(
+        return_value=[] if service_result is None else service_result
+    )
+    return mock_client
+
+
+def _radio(client):
+    return _capture(register_radio_tools, client)["ha_manage_radio"]
+
+
+def _entries(present: bool = True):
+    """A ``config_entries/get`` response (resolve_entry_id source)."""
+    result = [{"domain": "zwave_js", "entry_id": "e1"}] if present else []
+    return {"success": True, "result": result}
+
+
+_NODE = {
+    "node_id": 7,
+    "status": "alive",
+    "is_routing": True,
+    "is_secure": True,
+    "highest_security_class": 1,
+    "zwave_plus_version": 2,
+    "is_controller_node": False,
+}
+
+
+class TestZwaveRadio:
+    # ---- diagnostics -------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_diagnostics_projects_node_status(self):
+        client = _client({"zwave_js/node_status": {"success": True, "result": _NODE}})
+        out = await _radio(client)(radio="zwave", action="diagnostics", device_id="z1")
+        assert out["success"] is True
+        assert out["radio"] == "zwave"
+        assert out["node_status"]["node_id"] == 7
+        assert out["node_status"]["highest_security_class"] == 1
+        assert out["node_status"]["is_controller_node"] is False
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_requires_device_id(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(radio="zwave", action="diagnostics")
+        assert "device_id" in str(exc.value)
+
+    # ---- network_status ----------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_network_status_summary(self):
+        net = {
+            "success": True,
+            "result": {
+                "controller": {
+                    "home_id": 1234,
+                    "is_primary": True,
+                    "nodes": [_NODE, {**_NODE, "node_id": 8}],
+                }
+            },
+        }
+        client = _client(
+            {"config_entries/get": _entries(), "zwave_js/network_status": net}
+        )
+        out = await _radio(client)(radio="zwave", action="network_status")
+        assert out["config_entry_id"] == "e1"
+        assert out["count"] == 2
+        assert out["total_count"] == 2
+        assert out["nodes"][1]["node_id"] == 8
+        # The heavy embedded node list is dropped from the controller view.
+        assert "nodes" not in out["controller"]
+        assert out["controller"]["home_id"] == 1234
+        assert "truncated" not in out
+
+    @pytest.mark.asyncio
+    async def test_network_status_caps_and_truncates(self):
+        nodes = [{**_NODE, "node_id": i} for i in range(60)]
+        net = {"success": True, "result": {"controller": {"nodes": nodes}}}
+        client = _client(
+            {"config_entries/get": _entries(), "zwave_js/network_status": net}
+        )
+        out = await _radio(client)(radio="zwave", action="network_status")
+        assert out["count"] == 50
+        assert out["total_count"] == 60
+        assert out["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_network_status_integration_absent(self):
+        client = _client({"config_entries/get": _entries(present=False)})
+        out = await _radio(client)(radio="zwave", action="network_status")
+        assert out["available"] is False
+        assert out["warnings"]
+
+    # ---- ping --------------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_ping_calls_service(self):
+        client = _client({})
+        out = await _radio(client)(radio="zwave", action="ping", device_id="z1")
+        assert out["success"] is True
+        client.call_service.assert_awaited_once_with(
+            "zwave_js", "ping", {"device_id": "z1"}
+        )
+
+    # ---- add ---------------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_add_node_requires_a_credential(self):
+        client = _client({"config_entries/get": _entries()})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zwave", action="add")
+        assert "qr_provisioning_information" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_add_node_with_qr_code_string(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/add_node": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave",
+            action="add",
+            params={"qr_code_string": "90010...", "inclusion_strategy": 2},
+        )
+        assert out["mode"] == "add_node"
+        sent = next(m for m in record if m["type"] == "zwave_js/add_node")
+        assert sent["entry_id"] == "e1"
+        assert sent["qr_code_string"] == "90010..."
+        assert sent["inclusion_strategy"] == 2
+        assert "dsk" not in sent  # None fields filtered out
+
+    @pytest.mark.asyncio
+    async def test_add_smart_start_requires_qr(self):
+        client = _client({"config_entries/get": _entries()})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zwave", action="add", params={"smart_start": True}
+            )
+        assert "qr_provisioning_information" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_add_smart_start_success(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/provision_smart_start_node": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave",
+            action="add",
+            params={"smart_start": True, "qr_provisioning_information": {"dsk": "x"}},
+        )
+        assert out["mode"] == "smart_start"
+        assert any(m["type"] == "zwave_js/provision_smart_start_node" for m in record)
+
+    # ---- remove_device ------------------------------------------------------ #
+    @pytest.mark.asyncio
+    async def test_remove_device_requires_confirm(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(
+                radio="zwave", action="remove_device", device_id="z1"
+            )
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_remove_failed_node(self):
+        record: list = []
+        client = _client(
+            {"zwave_js/remove_failed_node": {"success": True, "result": {}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave",
+            action="remove_device",
+            device_id="z1",
+            params={"failed": True},
+            confirm=True,
+        )
+        assert out["mode"] == "failed"
+        sent = next(m for m in record if m["type"] == "zwave_js/remove_failed_node")
+        assert sent["device_id"] == "z1"
+
+    @pytest.mark.asyncio
+    async def test_remove_failed_requires_device_id(self):
+        client = _client({"config_entries/get": _entries()})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zwave",
+                action="remove_device",
+                params={"failed": True},
+                confirm=True,
+            )
+        assert "device_id" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_remove_device_exclusion(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/remove_node": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        out = await _radio(client)(radio="zwave", action="remove_device", confirm=True)
+        assert out["mode"] == "exclusion"
+        sent = next(m for m in record if m["type"] == "zwave_js/remove_node")
+        assert sent["entry_id"] == "e1"
+
+    # ---- reinterview -------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_reinterview(self):
+        record: list = []
+        client = _client(
+            {"zwave_js/refresh_node_info": {"success": True, "result": {}}},
+            record=record,
+        )
+        out = await _radio(client)(radio="zwave", action="reinterview", device_id="z1")
+        assert out["success"] is True
+        assert any(m["type"] == "zwave_js/refresh_node_info" for m in record)
+
+    # ---- rebuild_routes ----------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_rebuild_routes_node(self):
+        record: list = []
+        client = _client(
+            {"zwave_js/rebuild_node_routes": {"success": True, "result": {}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave", action="rebuild_routes", device_id="z1"
+        )
+        assert out["scope"] == "node"
+        assert any(m["type"] == "zwave_js/rebuild_node_routes" for m in record)
+
+    @pytest.mark.asyncio
+    async def test_rebuild_routes_network(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/begin_rebuilding_routes": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave", action="rebuild_routes", params={"scope": "network"}
+        )
+        assert out["scope"] == "network"
+        sent = next(
+            m for m in record if m["type"] == "zwave_js/begin_rebuilding_routes"
+        )
+        assert sent["entry_id"] == "e1"
+
+    @pytest.mark.asyncio
+    async def test_rebuild_routes_node_requires_device_id(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(radio="zwave", action="rebuild_routes")
+        assert "device_id" in str(exc.value)
+
+    # ---- set_config_param --------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_set_config_param_requires_value(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(
+                radio="zwave",
+                action="set_config_param",
+                device_id="z1",
+                params={"property": 5},
+            )
+        assert "value" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_set_config_param_accepts_zero_value(self):
+        record: list = []
+        client = _client(
+            {"zwave_js/set_config_parameter": {"success": True, "result": {}}},
+            record=record,
+        )
+        out = await _radio(client)(
+            radio="zwave",
+            action="set_config_param",
+            device_id="z1",
+            params={"property": 5, "value": 0},
+        )
+        assert out["success"] is True
+        sent = next(m for m in record if m["type"] == "zwave_js/set_config_parameter")
+        assert sent["property"] == 5
+        assert sent["value"] == 0
+        assert sent["endpoint"] == 0  # default applied
+
+    # ---- firmware_update ---------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_firmware_update_installs_via_update_entity(self):
+        registry = {
+            "success": True,
+            "result": [
+                {"entity_id": "sensor.node_temp", "device_id": "z1"},
+                {"entity_id": "update.node_fw", "device_id": "z1"},
+            ],
+        }
+        client = _client({"config/entity_registry/list": registry})
+        out = await _radio(client)(
+            radio="zwave", action="firmware_update", device_id="z1"
+        )
+        assert out["entity_id"] == "update.node_fw"
+        client.call_service.assert_awaited_once_with(
+            "update", "install", {"entity_id": "update.node_fw"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_firmware_update_no_update_entity(self):
+        registry = {
+            "success": True,
+            "result": [{"entity_id": "sensor.node_temp", "device_id": "z1"}],
+        }
+        client = _client({"config/entity_registry/list": registry})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zwave", action="firmware_update", device_id="z1"
+            )
+        assert "update entity" in str(exc.value).lower()
+
+    # ---- hard_reset --------------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_hard_reset_requires_confirm(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(radio="zwave", action="hard_reset")
+        assert "confirm" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_hard_reset_success(self):
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/hard_reset_controller": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        out = await _radio(client)(radio="zwave", action="hard_reset", confirm=True)
+        assert out["success"] is True
+        sent = next(m for m in record if m["type"] == "zwave_js/hard_reset_controller")
+        assert sent["entry_id"] == "e1"
+
+    # ---- unknown action ----------------------------------------------------- #
+    @pytest.mark.asyncio
+    async def test_unknown_action_lists_supported(self):
+        with pytest.raises(ToolError) as exc:
+            await _radio(_client({}))(radio="zwave", action="nope")
+        assert "diagnostics" in str(exc.value)

--- a/tests/src/unit/test_radio_zwave.py
+++ b/tests/src/unit/test_radio_zwave.py
@@ -209,6 +209,31 @@ class TestZwaveRadio:
         assert out["mode"] == "smart_start"
         assert any(m["type"] == "zwave_js/provision_smart_start_node" for m in record)
 
+    @pytest.mark.asyncio
+    async def test_add_rejects_multiple_credentials(self):
+        # HA's add_node schema marks the inclusion credentials as vol.Exclusive;
+        # passing more than one must raise (the single-credential path is fine).
+        record: list = []
+        client = _client(
+            {
+                "config_entries/get": _entries(),
+                "zwave_js/add_node": {"success": True, "result": {}},
+            },
+            record=record,
+        )
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zwave",
+                action="add",
+                params={"qr_code_string": "90010...", "dsk": "11111-22222"},
+            )
+        msg = str(exc.value)
+        assert "qr_code_string" in msg
+        assert "dsk" in msg
+        assert "mutually exclusive" in msg.lower()
+        # The conflicting call must never reach add_node.
+        assert not any(m["type"] == "zwave_js/add_node" for m in record)
+
     # ---- remove_device ------------------------------------------------------ #
     @pytest.mark.asyncio
     async def test_remove_device_requires_confirm(self):

--- a/tests/src/unit/test_radio_zwave.py
+++ b/tests/src/unit/test_radio_zwave.py
@@ -234,6 +234,15 @@ class TestZwaveRadio:
         # The conflicting call must never reach add_node.
         assert not any(m["type"] == "zwave_js/add_node" for m in record)
 
+    @pytest.mark.asyncio
+    async def test_add_integration_absent_raises(self):
+        # add is a write action: an absent zwave_js config entry must raise
+        # (integration_required) before the credential check is reached.
+        client = _client({"config_entries/get": _entries(present=False)})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zwave", action="add")
+        assert "zwave_js" in str(exc.value)
+
     # ---- remove_device ------------------------------------------------------ #
     @pytest.mark.asyncio
     async def test_remove_device_requires_confirm(self):
@@ -288,6 +297,15 @@ class TestZwaveRadio:
         sent = next(m for m in record if m["type"] == "zwave_js/remove_node")
         assert sent["entry_id"] == "e1"
 
+    @pytest.mark.asyncio
+    async def test_remove_device_exclusion_integration_absent_raises(self):
+        # The exclusion path (no params.failed) opens a controller window, so an
+        # absent zwave_js config entry must raise rather than no-op.
+        client = _client({"config_entries/get": _entries(present=False)})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zwave", action="remove_device", confirm=True)
+        assert "zwave_js" in str(exc.value)
+
     # ---- reinterview -------------------------------------------------------- #
     @pytest.mark.asyncio
     async def test_reinterview(self):
@@ -338,6 +356,19 @@ class TestZwaveRadio:
         with pytest.raises(ToolError) as exc:
             await _radio(_client({}))(radio="zwave", action="rebuild_routes")
         assert "device_id" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_rebuild_routes_network_integration_absent_raises(self):
+        # The network scope rebuilds via the controller, so an absent zwave_js
+        # config entry must raise (integration_required), not silently no-op.
+        client = _client({"config_entries/get": _entries(present=False)})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(
+                radio="zwave",
+                action="rebuild_routes",
+                params={"scope": "network"},
+            )
+        assert "zwave_js" in str(exc.value)
 
     # ---- set_config_param --------------------------------------------------- #
     @pytest.mark.asyncio
@@ -423,6 +454,15 @@ class TestZwaveRadio:
         assert out["success"] is True
         sent = next(m for m in record if m["type"] == "zwave_js/hard_reset_controller")
         assert sent["entry_id"] == "e1"
+
+    @pytest.mark.asyncio
+    async def test_hard_reset_integration_absent_raises(self):
+        # hard_reset wipes the controller, so an absent zwave_js config entry
+        # must raise (integration_required) rather than no-op.
+        client = _client({"config_entries/get": _entries(present=False)})
+        with pytest.raises(ToolError) as exc:
+            await _radio(client)(radio="zwave", action="hard_reset", confirm=True)
+        assert "zwave_js" in str(exc.value)
 
     # ---- unknown action ----------------------------------------------------- #
     @pytest.mark.asyncio

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -395,6 +395,255 @@ class TestFetchZwaveNetwork:
         assert result["nodes"][0]["node_id"] == 1
 
 
+class TestFetchThreadNetwork:
+    """``_fetch_thread_network`` calls ``otbr/info`` and summarizes each border
+    router (channel, extended_pan_id, border_agent_id) keyed by extended
+    address — mirrors the Z-Wave/ZHA never-raise section convention."""
+
+    def _thread_ws_client(self, info_resp):
+        """ws_client whose send_command('otbr/info') returns ``info_resp``."""
+        ws = MagicMock()
+
+        async def _send(command, **kwargs):
+            if command == "otbr/info":
+                return info_resp
+            return {"success": False, "error": {"message": "Unknown command."}}
+
+        ws.send_command = AsyncMock(side_effect=_send)
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_summarizes_border_routers(self):
+        """A loaded OTBR maps to one border-router summary with the three
+        documented fields, keyed by its extended address."""
+        ws = self._thread_ws_client(
+            {
+                "success": True,
+                "result": {
+                    "f00dcafef00dcafe": {
+                        "active_dataset_tlvs": "0e08...",
+                        "border_agent_id": "deadbeefdeadbeef",
+                        "channel": 15,
+                        "extended_address": "f00dcafef00dcafe",
+                        "extended_pan_id": "abcdef0123456789",
+                        "url": "http://core-silabs-multiprotocol:8081",
+                    }
+                },
+            }
+        )
+        result = await SystemTools._fetch_thread_network(ws)
+
+        sent = [call.args[0] for call in ws.send_command.call_args_list]
+        assert "otbr/info" in sent
+        assert "error" not in result
+        assert result["count"] == 1
+        br = result["border_routers"][0]
+        assert br["extended_address"] == "f00dcafef00dcafe"
+        assert br["channel"] == 15
+        assert br["extended_pan_id"] == "abcdef0123456789"
+        assert br["border_agent_id"] == "deadbeefdeadbeef"
+
+    @pytest.mark.asyncio
+    async def test_not_loaded_surfaces_error(self):
+        """``otbr/info`` answers success=false (code not_loaded) when no OTBR is
+        configured; the section surfaces the message as an error sub-dict."""
+        ws = self._thread_ws_client(
+            {
+                "success": False,
+                "error": {"code": "not_loaded", "message": "No OTBR API loaded"},
+            }
+        )
+        result = await SystemTools._fetch_thread_network(ws)
+
+        assert result["count"] == 0
+        assert result["border_routers"] == []
+        assert "No OTBR API loaded" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_ws_exception_captured_as_error(self):
+        """Exceptions during the WS call are caught and surfaced via ``error``."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = RuntimeError("ws disconnect")
+
+        result = await SystemTools._fetch_thread_network(ws)
+
+        assert result["count"] == 0
+        assert "ws disconnect" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_fatal_cancellation_propagates_not_embedded(self):
+        """A CancelledError must unwind, not demote to a section error — guards
+        the ``_reraise_if_fatal`` gate."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await SystemTools._fetch_thread_network(ws)
+
+
+class TestFetchMatterNetwork:
+    """``_fetch_matter_network`` resolves the matter config entry via
+    ``config_entries/get`` and returns a lightweight presence summary."""
+
+    def _matter_ws_client(self, entries_resp):
+        """ws_client whose send_command('config_entries/get') returns
+        ``entries_resp``."""
+        ws = MagicMock()
+
+        async def _send(command, **kwargs):
+            if command == "config_entries/get":
+                return entries_resp
+            return {"success": False, "error": {"message": "Unknown command."}}
+
+        ws.send_command = AsyncMock(side_effect=_send)
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_resolves_matter_entry(self):
+        """The matter entry is selected by domain and reduced to
+        {config_entry_id, state, title}. Pins the canonical (underscore)
+        command name like the zwave helper test."""
+        ws = self._matter_ws_client(
+            {
+                "success": True,
+                "result": [
+                    {
+                        "domain": "hue",
+                        "entry_id": "hue1",
+                        "state": "loaded",
+                        "title": "Hue",
+                    },
+                    {
+                        "domain": "matter",
+                        "entry_id": "m1",
+                        "state": "loaded",
+                        "title": "Matter Server",
+                    },
+                ],
+            }
+        )
+        result = await SystemTools._fetch_matter_network(ws)
+
+        sent = [call.args[0] for call in ws.send_command.call_args_list]
+        assert "config_entries/get" in sent
+        assert "config/entries/get" not in sent
+        assert result == {
+            "config_entry_id": "m1",
+            "state": "loaded",
+            "title": "Matter Server",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_matter_entry_returns_not_found(self):
+        """No matter entry → the documented not-found error sub-dict."""
+        ws = self._matter_ws_client(
+            {"success": True, "result": [{"domain": "hue", "entry_id": "hue1"}]}
+        )
+        result = await SystemTools._fetch_matter_network(ws)
+
+        assert result == {"error": "Matter integration not found"}
+
+    @pytest.mark.asyncio
+    async def test_ws_exception_captured_as_error(self):
+        """Exceptions during the WS call are caught and surfaced via ``error``."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = RuntimeError("ws disconnect")
+
+        result = await SystemTools._fetch_matter_network(ws)
+
+        assert "ws disconnect" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_fatal_cancellation_propagates_not_embedded(self):
+        """A CancelledError must unwind, not demote to a section error."""
+        ws = AsyncMock()
+        ws.send_command.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await SystemTools._fetch_matter_network(ws)
+
+
+class TestGetSystemHealthThreadMatterWiring:
+    """``ha_get_system_health`` wires the thread_network / matter_network
+    include sections into the concurrent gather and the WS-unavailable branch,
+    mirroring the zwave_network plumbing."""
+
+    @pytest.mark.asyncio
+    async def test_both_sections_populated_when_requested(self):
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_thread = AsyncMock(return_value={"border_routers": [], "count": 0})
+        mock_matter = AsyncMock(
+            return_value={"config_entry_id": "m1", "state": "loaded", "title": "M"}
+        )
+
+        with (
+            _patch_health_info_baseline() as (_, ws_client),
+            patch.object(SystemTools, "_fetch_thread_network", new=mock_thread),
+            patch.object(SystemTools, "_fetch_matter_network", new=mock_matter),
+        ):
+            result = await tools.ha_get_system_health(
+                include="thread_network,matter_network"
+            )
+
+        assert result["thread_network"] == {"border_routers": [], "count": 0}
+        assert result["matter_network"]["config_entry_id"] == "m1"
+        mock_thread.assert_awaited_once()
+        mock_matter.assert_awaited_once()
+        ws_client.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unrequested_sections_not_called(self):
+        client = MagicMock()
+        tools = SystemTools(client)
+        mock_thread = AsyncMock()
+        mock_matter = AsyncMock()
+
+        with (
+            _patch_health_info_baseline(),
+            patch.object(
+                SystemTools,
+                "_fetch_repairs",
+                new=AsyncMock(return_value={"issues": [], "count": 0}),
+            ),
+            patch.object(SystemTools, "_fetch_thread_network", new=mock_thread),
+            patch.object(SystemTools, "_fetch_matter_network", new=mock_matter),
+        ):
+            result = await tools.ha_get_system_health(include="repairs")
+
+        assert "thread_network" not in result
+        assert "matter_network" not in result
+        mock_thread.assert_not_awaited()
+        mock_matter.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sections_reported_unavailable_when_ws_fails(self):
+        """With the health WS baseline down but a REST section also requested,
+        thread_network/matter_network carry the {error} sub-dict shape and a
+        summary warning rather than crashing the tool."""
+        client = MagicMock()
+        client.check_config = AsyncMock(return_value={"result": "valid"})
+        tools = SystemTools(client)
+
+        with patch.object(
+            SystemTools,
+            "_fetch_health_info",
+            new=AsyncMock(side_effect=ToolError("system_health WebSocket down")),
+        ):
+            result = await tools.ha_get_system_health(
+                include="thread_network,matter_network,config_check"
+            )
+
+        assert result["success"] is True
+        assert result["baseline_available"] is False
+        assert "error" in result["thread_network"]
+        assert "error" in result["matter_network"]
+        assert any(
+            "thread_network" in w or "matter_network" in w
+            for w in result.get("warnings", [])
+        )
+
+
 class TestGetSystemHealthGather:
     """``ha_get_system_health`` runs optional sections concurrently via ``asyncio.gather``.
 


### PR DESCRIPTION
## What does this PR do?

Closes #1693. Adds first-class Matter and Thread support, plus a unified radio **management** surface across all four radios Home Assistant speaks (Z-Wave, Zigbee/ZHA, Matter, Thread). Before this, radio diagnostics existed only for Z-Wave/Zigbee and nothing existed for Matter/Thread; the only way to *manage* a radio was a raw `ha_call_service` pass-through with no validation. The issue asked for Matter node-status inspection — this delivers that and the broader management capability.

**Three surfaces (one new tool, two extended):**

**1. `ha_manage_radio` (new)** — one multi-modal tool, 46 actions:

| Radio | Actions |
|---|---|
| Matter (11) | diagnostics, network_status, ping, commission, commission_on_network, share_out, interview, remove_fabric, set_thread, set_wifi_credentials, firmware_update |
| Z-Wave (10) | diagnostics, network_status, ping, add, remove_device, reinterview, rebuild_routes, set_config_param, firmware_update, hard_reset |
| Zigbee/ZHA (18) | diagnostics, network_status, permit_join, remove_device, reconfigure, group+member CRUD, bind/unbind, cluster read/write/command, backup/restore, change_channel, firmware_update |
| Thread/OTBR (7) | network_status, list_datasets, discover_routers, create_network, set_network, set_channel, add_dataset |

**2. `ha_get_device`** — Matter devices enrich with `node_diagnostics` (network type wifi/thread, reachability, IPs, joined fabrics), next to the Z-Wave/ZHA enrichers.

**3. `ha_get_system_health`** — new `matter_network` + `thread_network` includes, next to `zwave_network`/`zha_network`.

**Design notes for reviewers:**
- Read diagnostics intentionally live in *both* `ha_manage_radio` and the read tools (diagnostics at hand mid-management). Not a consolidation violation: `ha_manage_radio` carries destructive write actions the read tools don't, so it's not a strict subset of either.
- Destructive actions (remove_device, network restore, change_channel, hard_reset, remove_fabric) require `confirm=True`; long-running actions (inclusion, rebuild routes, firmware) return immediately with `long_running=true` (completion is out-of-band).
- One documented exclusion: interactive Z-Wave S2 secure inclusion streams a DSK and blocks on a human-typed PIN, so a stateless tool can't drive it — the non-interactive SmartStart/QR provisioning paths are included and the docstring routes interactive pairing to the HA UI.
- `remove_fabric` removes **another** controller's fabric (explicit `fabric_index`); detaching the device from Home Assistant itself uses `ha_remove_device` (removing HA's own active fabric is aborted by the Matter server).
- Bundled Boy-Scout fix: a best-effort HACS registration-retry in `tools_mcp_component.py` for the flaky `test_install_mcp_tools` timeout that surfaced on this PR's CI.

## Type of change
- [x] New feature

## Testing
- [x] Live-tested on real Matter hardware (caught and fixed 2 bugs)
- [ ] All automated tests pass — CI runs the full pytest unit suite + Docker e2e
- [x] Code follows style guidelines (`ruff check` / `ruff format` clean)

103 unit tests (dispatcher contract + all four handlers, mock-WS) + 7 bare-container e2e (registration, validation gates, graceful degradation, system-health includes). All WS command strings verified against HA core.

## Checklist
- [x] Tool docstrings/tags updated; `tools.json`/README/DOCS auto-regenerate on merge.


