### PR TITLE
feat: keep ha_manage_radio reads available in read-only mode

### DIFF
--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -133,11 +133,21 @@ def _custom_tool_write(args: dict[str, Any]) -> str | None:
 
 def _radio_write(args: dict[str, Any]) -> str | None:
     action = args.get("action")
-    # Reads: per-node diagnostics, the integration/network summary, and the
-    # active reachability probe. Everything else is a write (commission/add,
-    # remove, reinterview, firmware, fabric / credential / channel / network
-    # changes). A missing action fails closed.
-    if action in ("diagnostics", "network_status", "ping"):
+    # Reads (allowed): per-node diagnostics, the integration/network summary,
+    # the active reachability probe, a single Zigbee cluster-attribute read, and
+    # the Thread dataset listing. Everything else is a write — commission/add,
+    # remove, reinterview, firmware, fabric/credential/channel/network changes,
+    # plus the two actions that LOOK read-ish but are not: zigbee network_backup
+    # (creates a backup artifact + key material, like ha_manage_backup's blocked
+    # snapshot create) and thread discover_routers (kicks off a long-running
+    # mDNS scan). A missing action fails closed.
+    if action in (
+        "diagnostics",
+        "network_status",
+        "ping",
+        "cluster_read",
+        "list_datasets",
+    ):
         return None
     return f"action={action!r}"
 
@@ -146,8 +156,9 @@ def _radio_write(args: dict[str, Any]) -> str | None:
 # (verified per tool: ha_get_addon cannot proxy-read addon-internal
 # APIs; energy prefs and assist pipelines are reachable only through
 # these tools; edit-backup listing exists nowhere else; the saved-tools
-# cache is only listable here; ha_manage_radio's active 'ping' probe is
-# unique — its 'diagnostics'/'network_status' reads mirror ha_get_device /
+# cache is only listable here; ha_manage_radio's 'ping' probe, 'cluster_read'
+# and 'list_datasets' have no pure-read duplicate elsewhere, while its
+# 'diagnostics'/'network_status' reads mirror ha_get_device /
 # ha_get_system_health but stay reachable here mid-management). Everything
 # NOT in this table and not ``readOnlyHint=True`` is hidden and blocked
 # outright.
@@ -184,9 +195,10 @@ READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
     ),
     "ha_manage_radio": ReadOnlyExemption(
         _radio_write,
-        "node diagnostics (action='diagnostics'), the integration/network "
-        "summary (action='network_status'), and the active reachability probe "
-        "(action='ping')",
+        "node diagnostics ('diagnostics'), the integration/network summary "
+        "('network_status'), the active reachability probe ('ping'), a Zigbee "
+        "cluster-attribute read ('cluster_read'), and the Thread dataset "
+        "listing ('list_datasets')",
     ),
 }
 

--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -131,12 +131,26 @@ def _custom_tool_write(args: dict[str, Any]) -> str | None:
     return "sandbox code execution"
 
 
+def _radio_write(args: dict[str, Any]) -> str | None:
+    action = args.get("action")
+    # Reads: per-node diagnostics, the integration/network summary, and the
+    # active reachability probe. Everything else is a write (commission/add,
+    # remove, reinterview, firmware, fabric / credential / channel / network
+    # changes). A missing action fails closed.
+    if action in ("diagnostics", "network_status", "ping"):
+        return None
+    return f"action={action!r}"
+
+
 # Mixed read/write tools whose read surface has no pure-read duplicate
 # (verified per tool: ha_get_addon cannot proxy-read addon-internal
 # APIs; energy prefs and assist pipelines are reachable only through
 # these tools; edit-backup listing exists nowhere else; the saved-tools
-# cache is only listable here). Everything NOT in this table and not
-# ``readOnlyHint=True`` is hidden and blocked outright.
+# cache is only listable here; ha_manage_radio's active 'ping' probe is
+# unique — its 'diagnostics'/'network_status' reads mirror ha_get_device /
+# ha_get_system_health but stay reachable here mid-management). Everything
+# NOT in this table and not ``readOnlyHint=True`` is hidden and blocked
+# outright.
 #
 # ``MANDATORY_TOOLS`` (settings_ui/__init__.py) intentionally needs no special
 # case here: every mandatory tool is either ``readOnlyHint=True`` or
@@ -167,6 +181,12 @@ READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
     "ha_manage_custom_tool": ReadOnlyExemption(
         _custom_tool_write,
         "listing saved tools (list_saved=True)",
+    ),
+    "ha_manage_radio": ReadOnlyExemption(
+        _radio_write,
+        "node diagnostics (action='diagnostics'), the integration/network "
+        "summary (action='network_status'), and the active reachability probe "
+        "(action='ping')",
     ),
 }
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -56,7 +56,6 @@ markers =
     container_only: skip when HAOS backend is active (testcontainer-specific behavior; #1281)
     external_only: HAOS external mode only — skip on inaddon (HAOS_TEST_MODE=inaddon); #1349
     inaddon_only: HAOS inaddon mode only — exercises is_running_in_addon()=True paths; #1349
-    run_last: force this test to the end of collection (pytest_collection_modifyitems) so its --dist loadscope scope is dispatched last; used by the inaddon read-only test, which leaves its worker's add-on in read-only mode
 
 # Async support — session-scoped loop lets session-scoped fixtures
 # (mcp_server, mcp_client, ha_client) share one event loop with tests.

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -56,6 +56,7 @@ markers =
     container_only: skip when HAOS backend is active (testcontainer-specific behavior; #1281)
     external_only: HAOS external mode only — skip on inaddon (HAOS_TEST_MODE=inaddon); #1349
     inaddon_only: HAOS inaddon mode only — exercises is_running_in_addon()=True paths; #1349
+    run_last: force this test to the end of collection (pytest_collection_modifyitems) so its --dist loadscope scope is dispatched last; used by the inaddon read-only test, which leaves its worker's add-on in read-only mode
 
 # Async support — session-scoped loop lets session-scoped fixtures
 # (mcp_server, mcp_client, ha_client) share one event loop with tests.

--- a/tests/src/doomed_run.py
+++ b/tests/src/doomed_run.py
@@ -1,0 +1,40 @@
+"""Doomed-run detector for the e2e fail-fast hook.
+
+Extracted from ``tests/src/e2e/conftest.py`` so the streak logic is unit-testable
+without importing the heavy e2e conftest. See
+``tests/src/e2e/conftest.py::pytest_runtest_logreport`` for the wiring and
+``tests/src/unit/test_doomed_run.py`` for the tests.
+"""
+
+from __future__ import annotations
+
+DOOMED_RUN_ERROR_STREAK = 50
+
+
+class DoomedRunDetector:
+    """Counts CONSECUTIVE setup/teardown errors with zero call-phase pass/fail
+    between them.
+
+    ``record(when, outcome)`` returns ``True`` once the streak reaches
+    ``threshold`` — the signal that the run is producing nothing but errors and
+    should be aborted. A genuine call-phase ``passed``/``failed`` resets the
+    streak, so an isolated flaky-setup test never trips it. pytest-rerunfailures'
+    intermediate ``rerun`` outcome is ignored (neither resets nor increments), as
+    is ``skipped`` and a non-failing setup/teardown.
+    """
+
+    def __init__(self, threshold: int = DOOMED_RUN_ERROR_STREAK) -> None:
+        self.threshold = threshold
+        self.streak = 0
+
+    def record(self, when: str, outcome: str) -> bool:
+        # A real test body ran -> the run is alive; reset.
+        if when == "call" and outcome in ("passed", "failed"):
+            self.streak = 0
+            return False
+        # A setup/teardown error (an "error", not a "fail"). ``== "failed"``
+        # excludes the "rerun" outcome, which must not extend a doomed streak.
+        if when in ("setup", "teardown") and outcome == "failed":
+            self.streak += 1
+            return self.streak >= self.threshold
+        return False

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -80,8 +80,8 @@ _SKIP_CEILING_PER_LANE = {
     # Baselines are the observed skip counts as of 2026-05-22 (container=46,
     # haos=14, haos_inaddon=39 from the prose above), plus this PR's new
     # marker-gated skips, plus a 5-9 growth buffer.
-    "container": 65,  # was 62; +3 self-update-notice inaddon tests (@inaddon_only, skip here)
-    "haos": 32,  # was 29; +3 self-update-notice inaddon tests (@inaddon_only, skip here)
+    "container": 66,  # was 65; +1 inaddon read-only test (@inaddon_only, skips here)
+    "haos": 33,  # was 32; +1 inaddon read-only test (@inaddon_only, skips here)
     "haos_inaddon": 58,  # was 55; +3 self-update notice tests (TestSelfUpdateNoticeSurfacedInTools, @external_only)
 }
 

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -167,14 +167,6 @@ def pytest_collection_modifyitems(config, items):
         elif "external_only" in keywords and inaddon:
             item.add_marker(skip_external_only)
 
-    # Push run_last-marked tests to the very end so that under --dist loadscope
-    # their scope is the last one dispatched. Each xdist worker owns an isolated
-    # add-on (see _haos_worker_setup), so the last-dispatched scope runs with
-    # nothing after it on that worker. The inaddon read-only test relies on this:
-    # it leaves the add-on in read-only mode and must not precede a write test on
-    # its worker. Stable sort preserves the existing order otherwise.
-    items.sort(key=lambda it: 1 if it.get_closest_marker("run_last") else 0)
-
 
 # Fail fast on a doomed run, on EVERY e2e lane (this conftest is shared by the
 # testcontainer / external-HAOS / inaddon suites, so the hook guards all three).

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -167,6 +167,51 @@ def pytest_collection_modifyitems(config, items):
         elif "external_only" in keywords and inaddon:
             item.add_marker(skip_external_only)
 
+    # Push run_last-marked tests to the very end so that under --dist loadscope
+    # their scope is the last one dispatched. Each xdist worker owns an isolated
+    # add-on (see _haos_worker_setup), so the last-dispatched scope runs with
+    # nothing after it on that worker. The inaddon read-only test relies on this:
+    # it leaves the add-on in read-only mode and must not precede a write test on
+    # its worker. Stable sort preserves the existing order otherwise.
+    items.sort(key=lambda it: 1 if it.get_closest_marker("run_last") else 0)
+
+
+# Fail fast on a doomed run, on EVERY e2e lane (this conftest is shared by the
+# testcontainer / external-HAOS / inaddon suites, so the hook guards all three).
+# When session-scoped setup breaks systemically — a Supervisor add-on-update
+# flake did exactly this on PR #1699, erroring all 997 inaddon tests at setup
+# (0 passed, 0 failed) while the run ground on 11m39s producing nothing but
+# errors — abort the moment we've seen this many
+# consecutive setup/teardown errors with ZERO call-phase pass/fail in between —
+# that streak means no test body is executing, so the run is doomed. A genuine
+# pass or fail resets the streak, so an isolated flaky-setup test never trips
+# it; this is NOT --maxfail (that counts real test FAILURES, which we still run
+# through in full). On xdist this hook runs on the controller, which receives
+# every worker's reports, so the streak is global across workers.
+_DOOMED_RUN_ERROR_STREAK = 50
+_doomed_run_state = {"streak": 0}
+
+
+def pytest_runtest_logreport(report):
+    # A real test body ran (passed or failed) -> the run is alive; reset. The
+    # outcome check excludes pytest-rerunfailures' intermediate "rerun" reports,
+    # which must NOT reset a doomed streak.
+    if report.when == "call" and report.outcome in ("passed", "failed"):
+        _doomed_run_state["streak"] = 0
+        return
+    # A setup/teardown error (an "error", not a "fail"). outcome=="failed" here
+    # likewise excludes the "rerun" outcome.
+    if report.when in ("setup", "teardown") and report.outcome == "failed":
+        _doomed_run_state["streak"] += 1
+        if _doomed_run_state["streak"] >= _DOOMED_RUN_ERROR_STREAK:
+            pytest.exit(
+                f"Aborting: {_doomed_run_state['streak']} consecutive setup/"
+                f"teardown errors with no test passing or failing — the run is "
+                f"doomed by a systemic setup failure (e.g. add-on/container "
+                f"setup). Failing fast instead of grinding through the suite.",
+                returncode=1,
+            )
+
 
 def pytest_sessionfinish(session, exitstatus):
     """xdist worker hook: hand collected timings up to the master.

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -44,6 +44,7 @@ from testcontainers.core.container import DockerContainer
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 sys.path.insert(0, str(Path(__file__).parent.parent))  # tests/src/ for haos_runtime
 
+from doomed_run import DoomedRunDetector
 from fastmcp import Client
 from haos_runtime import (
     HA_MCP_DEV_ADDON_SLUG,
@@ -170,39 +171,32 @@ def pytest_collection_modifyitems(config, items):
 
 # Fail fast on a doomed run, on EVERY e2e lane (this conftest is shared by the
 # testcontainer / external-HAOS / inaddon suites, so the hook guards all three).
-# When session-scoped setup breaks systemically — a Supervisor add-on-update
-# flake did exactly this on PR #1699, erroring all 997 inaddon tests at setup
-# (0 passed, 0 failed) while the run ground on 11m39s producing nothing but
-# errors — abort the moment we've seen this many
-# consecutive setup/teardown errors with ZERO call-phase pass/fail in between —
-# that streak means no test body is executing, so the run is doomed. A genuine
-# pass or fail resets the streak, so an isolated flaky-setup test never trips
-# it; this is NOT --maxfail (that counts real test FAILURES, which we still run
-# through in full). On xdist this hook runs on the controller, which receives
-# every worker's reports, so the streak is global across workers.
-_DOOMED_RUN_ERROR_STREAK = 50
-_doomed_run_state = {"streak": 0}
+# A Supervisor add-on-update flake did exactly this on PR #1699: all 997 inaddon
+# tests ERRORed at setup (0 passed, 0 failed) while the run ground on 11m39s
+# producing nothing but errors. DoomedRunDetector aborts once it sees 50
+# consecutive setup/teardown errors with zero call-phase pass/fail between them;
+# a genuine pass/fail resets the streak, so real failures still run through in
+# full (this is NOT --maxfail). The detector logic is unit-tested in
+# tests/src/unit/test_doomed_run.py.
+#
+# Under xdist, pytest_runtest_logreport fires in EACH process — the controller
+# (which receives every worker's reports) AND each worker for its own tests — so
+# every process keeps its own module-global detector; the streak is per-process,
+# not global. That is fine: a doomed run errors on every process, so whichever
+# reaches 50 first calls pytest.exit and ends the session (validated under -n2:
+# a 150-test all-error run aborts at 50 in ~2s).
+_doomed_detector = DoomedRunDetector()
 
 
 def pytest_runtest_logreport(report):
-    # A real test body ran (passed or failed) -> the run is alive; reset. The
-    # outcome check excludes pytest-rerunfailures' intermediate "rerun" reports,
-    # which must NOT reset a doomed streak.
-    if report.when == "call" and report.outcome in ("passed", "failed"):
-        _doomed_run_state["streak"] = 0
-        return
-    # A setup/teardown error (an "error", not a "fail"). outcome=="failed" here
-    # likewise excludes the "rerun" outcome.
-    if report.when in ("setup", "teardown") and report.outcome == "failed":
-        _doomed_run_state["streak"] += 1
-        if _doomed_run_state["streak"] >= _DOOMED_RUN_ERROR_STREAK:
-            pytest.exit(
-                f"Aborting: {_doomed_run_state['streak']} consecutive setup/"
-                f"teardown errors with no test passing or failing — the run is "
-                f"doomed by a systemic setup failure (e.g. add-on/container "
-                f"setup). Failing fast instead of grinding through the suite.",
-                returncode=1,
-            )
+    if _doomed_detector.record(report.when, report.outcome):
+        pytest.exit(
+            f"Aborting: {_doomed_detector.streak} consecutive setup/teardown "
+            f"errors with no test passing or failing — the run is doomed by a "
+            f"systemic setup failure (e.g. add-on/container setup). Failing fast "
+            f"instead of grinding through the suite.",
+            returncode=1,
+        )
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/src/e2e/policy/test_readonly_mode.py
+++ b/tests/src/e2e/policy/test_readonly_mode.py
@@ -429,7 +429,6 @@ async def test_code_mode_tool_read_works_and_execution_blocked(readonly_codemode
 
 
 @pytest.mark.inaddon_only
-@pytest.mark.run_last
 @pytest.mark.asyncio
 async def test_inaddon_read_only_mode_blocks_radio_writes(
     ha_container_with_fresh_config,
@@ -440,15 +439,17 @@ async def test_inaddon_read_only_mode_blocks_radio_writes(
 
     Enables read_only_mode through the add-on's OWN settings API — which merges it
     into the Supervisor add-on options the production way (a bare options POST is
-    full-replacement and would drop required keys) — then self-restarts ONLY the
-    add-on (~10s; Home Assistant is untouched) so it boots with
-    ``READ_ONLY_MODE=true``, and asserts ha_manage_radio's read action still works
-    while a write is blocked with the structured READ_ONLY_MODE error.
+    full-replacement and would drop required keys) — self-restarts ONLY the add-on
+    (~10s; Home Assistant is untouched) so it boots with ``READ_ONLY_MODE=true``,
+    asserts ha_manage_radio's read action still works while a write is blocked with
+    the structured READ_ONLY_MODE error, then RESTORES read-only to off.
 
-    Runs LAST (``run_last``): it leaves the add-on in read-only mode, and the
-    option does not persist across e2e runs, so nothing needs undoing. Each xdist
-    worker owns an isolated add-on (``_haos_worker_setup``), so last-in-scope means
-    no write test runs after it on this worker.
+    Self-contained: xdist runs a worker's tests serially and each worker owns an
+    isolated add-on (``_haos_worker_setup``), so enabling read-only for just this
+    test and restoring it in ``finally`` is safe at any position. Ordering tricks
+    do NOT help — ``--dist loadscope`` groups tests by module, so a single
+    "run last" marker can't make this the last thing on its worker; leaving
+    read-only on once cascaded READ_ONLY_MODE into every later write test.
     """
     import asyncio
     import time
@@ -463,53 +464,72 @@ async def test_inaddon_read_only_mode_blocks_radio_writes(
     # The settings UI is mounted at the secret-path root (see TestSettingsUiRestartReal).
     base = addon_mcp_url.split("/mcp", 1)[0]
     settings = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings"
+    _transient = (AssertionError, TimeoutError, OSError, httpx.HTTPError, RuntimeError)
 
-    async with httpx.AsyncClient(timeout=30.0) as http:
-        resp = await http.post(
-            f"{settings}/features", json={"flags": {"read_only_mode": True}}
-        )
-        assert resp.status_code == 200, (
-            f"enable read_only_mode: {resp.status_code} {resp.text[:300]!r}"
-        )
-        # Empty body -> target_slug='self': the handler schedules the Supervisor
-        # restart from a background task and returns 200 first, so the add-on
-        # boots fresh with the new option without cutting this response.
-        resp = await http.post(f"{settings}/restart", json={})
-        assert resp.status_code == 200, (
-            f"restart add-on: {resp.status_code} {resp.text[:300]!r}"
-        )
+    async def _set_read_only(enabled: bool) -> None:
+        """POST the flag (handler merges into Supervisor options) + self-restart
+        the add-on. Empty restart body -> target='self', which the handler
+        schedules in the background so this 200 flushes before the bounce."""
+        async with httpx.AsyncClient(timeout=30.0) as http:
+            resp = await http.post(
+                f"{settings}/features", json={"flags": {"read_only_mode": enabled}}
+            )
+            assert resp.status_code == 200, (
+                f"set read_only_mode={enabled}: {resp.status_code} {resp.text[:300]!r}"
+            )
+            resp = await http.post(f"{settings}/restart", json={})
+            assert resp.status_code == 200, (
+                f"restart add-on: {resp.status_code} {resp.text[:300]!r}"
+            )
 
-    # The add-on bounces (~10s). Poll, reconnecting each round, until read-only
-    # mode is actually in effect: a write returns READ_ONLY_MODE and a read still
-    # works. This also rides out the brief window where the pre-restart process is
-    # still answering and the post-restart endpoint is not yet back up.
-    deadline = time.monotonic() + 180.0
-    last_err: Exception | None = None
-    while time.monotonic() < deadline:
-        try:
-            url = wait_for_addon_mcp_ready(timeout=30.0)
-            async with Client(StreamableHttpTransport(url=url)) as mcp:
-                blocked = await _expect_read_only_blocked(
-                    mcp, "ha_manage_radio", {"radio": "zwave", "action": "add"}
-                )
-                assert blocked.get("tool_name") == "ha_manage_radio", blocked
-                result = await mcp.call_tool(
-                    "ha_manage_radio",
-                    {"radio": "zwave", "action": "network_status"},
-                )
-                assert parse_mcp_result(result).get("success") is True, result
-            return
-        except (
-            AssertionError,
-            TimeoutError,
-            OSError,
-            httpx.HTTPError,
-            RuntimeError,
-        ) as err:
-            # Pre-restart process still answering (write not yet blocked), endpoint
-            # not back yet, or a transient during the bounce — wait and retry.
-            last_err = err
+    async def _await_read_only(expected: bool) -> None:
+        """Poll, reconnecting each round, until ha_get_overview reports
+        read_only_mode == expected — i.e. the restart actually took effect. Rides
+        out the bounce and the window where the pre-restart process still answers.
+        ha_get_overview is read-only, so it works in both states."""
+        deadline = time.monotonic() + 180.0
+        last: object = None
+        while time.monotonic() < deadline:
+            try:
+                url = wait_for_addon_mcp_ready(timeout=30.0)
+                async with Client(StreamableHttpTransport(url=url)) as mcp:
+                    overview = parse_mcp_result(
+                        await mcp.call_tool("ha_get_overview", {})
+                    )
+                if bool(overview.get("read_only_mode")) is expected:
+                    return
+                last = overview.get("read_only_mode")
+            except _transient as err:
+                last = err
             await asyncio.sleep(3)
-    raise AssertionError(
-        f"read_only_mode did not take effect on the add-on within 180s: {last_err!r}"
-    )
+        raise AssertionError(
+            f"read_only_mode did not become {expected} within 180s (last={last!r})"
+        )
+
+    try:
+        await _set_read_only(True)
+        await _await_read_only(True)
+        url = wait_for_addon_mcp_ready(timeout=30.0)
+        async with Client(StreamableHttpTransport(url=url)) as mcp:
+            result = await mcp.call_tool(
+                "ha_manage_radio", {"radio": "zwave", "action": "network_status"}
+            )
+            assert parse_mcp_result(result).get("success") is True, result
+            blocked = await _expect_read_only_blocked(
+                mcp, "ha_manage_radio", {"radio": "zwave", "action": "add"}
+            )
+            assert blocked.get("tool_name") == "ha_manage_radio", blocked
+    finally:
+        # Restore read-only OFF: this worker's remaining tests share the add-on
+        # and need writes, so a leaked read-only would cascade READ_ONLY_MODE into
+        # all of them. Retry the whole set+restart until it's confirmed off.
+        restore_deadline = time.monotonic() + 300.0
+        while True:
+            try:
+                await _set_read_only(False)
+                await _await_read_only(False)
+                break
+            except _transient:
+                if time.monotonic() >= restore_deadline:
+                    raise
+                await asyncio.sleep(3)

--- a/tests/src/e2e/policy/test_readonly_mode.py
+++ b/tests/src/e2e/policy/test_readonly_mode.py
@@ -147,6 +147,7 @@ async def test_write_tools_hidden_exempt_and_read_tools_listed(readonly_mcp):
         "ha_manage_backup",
         "ha_manage_pipeline",
         "ha_manage_energy_prefs",
+        "ha_manage_radio",
     ):
         assert kept in names, f"{kept} should stay listed"
 
@@ -235,6 +236,32 @@ async def test_exempt_tool_write_action_blocked(readonly_mcp):
     assert body["blocked_operation"], body
     # The error teaches what remains available on this tool.
     assert "list" in body["error"]["message"], body
+
+
+@pytest.mark.asyncio
+async def test_radio_read_action_works(readonly_mcp):
+    """ha_manage_radio is exempt: a read action (network_status) stays
+    callable in read-only mode. Z-Wave JS is not configured on the test
+    container, so this also exercises the graceful integration-absent read
+    path (available=False but success=True)."""
+    client, _server = readonly_mcp
+    result = await client.call_tool(
+        "ha_manage_radio", {"radio": "zwave", "action": "network_status"}
+    )
+    body = parse_mcp_result(result)
+    assert body.get("success") is True, body
+
+
+@pytest.mark.asyncio
+async def test_radio_write_action_blocked(readonly_mcp):
+    """A ha_manage_radio write action (zwave 'add') is blocked with the
+    structured READ_ONLY_MODE error before the handler runs."""
+    client, _server = readonly_mcp
+    body = await _expect_read_only_blocked(
+        client, "ha_manage_radio", {"radio": "zwave", "action": "add"}
+    )
+    assert body["tool_name"] == "ha_manage_radio", body
+    assert body["blocked_operation"], body
 
 
 @pytest.mark.asyncio

--- a/tests/src/e2e/policy/test_readonly_mode.py
+++ b/tests/src/e2e/policy/test_readonly_mode.py
@@ -426,3 +426,90 @@ async def test_code_mode_tool_read_works_and_execution_blocked(readonly_codemode
         {"code": "1 + 1", "justification": "read-only mode test"},
     )
     assert body["tool_name"] == "ha_manage_custom_tool", body
+
+
+@pytest.mark.inaddon_only
+@pytest.mark.run_last
+@pytest.mark.asyncio
+async def test_inaddon_read_only_mode_blocks_radio_writes(
+    ha_container_with_fresh_config,
+):
+    """Read-only mode on the REAL inaddon add-on (every test above skips inaddon
+    via ``_build_readonly_server``, which can only inject ``READ_ONLY_MODE`` into
+    a fresh in-process server).
+
+    Enables read_only_mode through the add-on's OWN settings API — which merges it
+    into the Supervisor add-on options the production way (a bare options POST is
+    full-replacement and would drop required keys) — then self-restarts ONLY the
+    add-on (~10s; Home Assistant is untouched) so it boots with
+    ``READ_ONLY_MODE=true``, and asserts ha_manage_radio's read action still works
+    while a write is blocked with the structured READ_ONLY_MODE error.
+
+    Runs LAST (``run_last``): it leaves the add-on in read-only mode, and the
+    option does not persist across e2e runs, so nothing needs undoing. Each xdist
+    worker owns an isolated add-on (``_haos_worker_setup``), so last-in-scope means
+    no write test runs after it on this worker.
+    """
+    import asyncio
+    import time
+
+    import httpx
+    from fastmcp.client.transports import StreamableHttpTransport
+    from haos_runtime import HA_MCP_TEST_SECRET_PATH, wait_for_addon_mcp_ready
+
+    container_info = ha_container_with_fresh_config
+    addon_mcp_url = container_info.get("addon_mcp_url")
+    assert addon_mcp_url, "inaddon backend should expose addon_mcp_url"
+    # The settings UI is mounted at the secret-path root (see TestSettingsUiRestartReal).
+    base = addon_mcp_url.split("/mcp", 1)[0]
+    settings = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings"
+
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.post(
+            f"{settings}/features", json={"flags": {"read_only_mode": True}}
+        )
+        assert resp.status_code == 200, (
+            f"enable read_only_mode: {resp.status_code} {resp.text[:300]!r}"
+        )
+        # Empty body -> target_slug='self': the handler schedules the Supervisor
+        # restart from a background task and returns 200 first, so the add-on
+        # boots fresh with the new option without cutting this response.
+        resp = await http.post(f"{settings}/restart", json={})
+        assert resp.status_code == 200, (
+            f"restart add-on: {resp.status_code} {resp.text[:300]!r}"
+        )
+
+    # The add-on bounces (~10s). Poll, reconnecting each round, until read-only
+    # mode is actually in effect: a write returns READ_ONLY_MODE and a read still
+    # works. This also rides out the brief window where the pre-restart process is
+    # still answering and the post-restart endpoint is not yet back up.
+    deadline = time.monotonic() + 180.0
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            url = wait_for_addon_mcp_ready(timeout=30.0)
+            async with Client(StreamableHttpTransport(url=url)) as mcp:
+                blocked = await _expect_read_only_blocked(
+                    mcp, "ha_manage_radio", {"radio": "zwave", "action": "add"}
+                )
+                assert blocked.get("tool_name") == "ha_manage_radio", blocked
+                result = await mcp.call_tool(
+                    "ha_manage_radio",
+                    {"radio": "zwave", "action": "network_status"},
+                )
+                assert parse_mcp_result(result).get("success") is True, result
+            return
+        except (
+            AssertionError,
+            TimeoutError,
+            OSError,
+            httpx.HTTPError,
+            RuntimeError,
+        ) as err:
+            # Pre-restart process still answering (write not yet blocked), endpoint
+            # not back yet, or a transient during the bounce — wait and retry.
+            last_err = err
+            await asyncio.sleep(3)
+    raise AssertionError(
+        f"read_only_mode did not take effect on the add-on within 180s: {last_err!r}"
+    )

--- a/tests/src/e2e/policy/test_readonly_mode.py
+++ b/tests/src/e2e/policy/test_readonly_mode.py
@@ -431,7 +431,7 @@ async def test_code_mode_tool_read_works_and_execution_blocked(readonly_codemode
 @pytest.mark.inaddon_only
 @pytest.mark.asyncio
 async def test_inaddon_read_only_mode_blocks_radio_writes(
-    ha_container_with_fresh_config,
+    ha_container_with_fresh_config, mcp_client
 ):
     """Read-only mode on the REAL inaddon add-on (every test above skips inaddon
     via ``_build_readonly_server``, which can only inject ``READ_ONLY_MODE`` into
@@ -444,12 +444,15 @@ async def test_inaddon_read_only_mode_blocks_radio_writes(
     asserts ha_manage_radio's read action still works while a write is blocked with
     the structured READ_ONLY_MODE error, then RESTORES read-only to off.
 
-    Self-contained: xdist runs a worker's tests serially and each worker owns an
-    isolated add-on (``_haos_worker_setup``), so enabling read-only for just this
-    test and restoring it in ``finally`` is safe at any position. Ordering tricks
-    do NOT help — ``--dist loadscope`` groups tests by module, so a single
-    "run last" marker can't make this the last thing on its worker; leaving
-    read-only on once cascaded READ_ONLY_MODE into every later write test.
+    xdist runs a worker's tests serially and each worker owns an isolated add-on
+    (``_haos_worker_setup``), so bracketing read-only around just this test and
+    restoring it in ``finally`` is safe at any position. (Ordering tricks do NOT
+    help — ``--dist loadscope`` groups tests by module, so a single "run last"
+    marker can't make this the last thing on its worker.) The two dev-add-on
+    restarts also drop the SHARED session ``mcp_client`` connection
+    (test_supervisor_inaddon.py documents that restarting the dev add-on kills
+    mcp_client for later tests), so the ``finally`` also warms that client back up
+    so whatever module loadscope hands this worker next gets a live session.
     """
     import asyncio
     import time
@@ -483,27 +486,28 @@ async def test_inaddon_read_only_mode_blocks_radio_writes(
             )
 
     async def _await_read_only(expected: bool) -> None:
-        """Poll, reconnecting each round, until ha_get_overview reports
-        read_only_mode == expected — i.e. the restart actually took effect. Rides
-        out the bounce and the window where the pre-restart process still answers.
-        ha_get_overview is read-only, so it works in both states."""
+        """Poll, reconnecting each round, until the add-on's CATALOG reflects
+        read_only_mode == expected — i.e. the restart actually took effect. In
+        read-only mode the catalog filter hides write tools, so ``ha_call_service``
+        is absent iff read-only is on. Keying on a positive signal from a real
+        ``list_tools`` response (rather than the absence of an overview key, which
+        a degraded payload could also fake) ensures we only confirm against a
+        healthy, fully-booted add-on."""
         deadline = time.monotonic() + 180.0
         last: object = None
         while time.monotonic() < deadline:
             try:
                 url = wait_for_addon_mcp_ready(timeout=30.0)
                 async with Client(StreamableHttpTransport(url=url)) as mcp:
-                    overview = parse_mcp_result(
-                        await mcp.call_tool("ha_get_overview", {})
-                    )
-                if bool(overview.get("read_only_mode")) is expected:
+                    names = {t.name for t in await mcp.list_tools()}
+                if ("ha_call_service" not in names) is expected:
                     return
-                last = overview.get("read_only_mode")
+                last = len(names)
             except _transient as err:
                 last = err
             await asyncio.sleep(3)
         raise AssertionError(
-            f"read_only_mode did not become {expected} within 180s (last={last!r})"
+            f"read-only catalog did not become {expected} within 180s (last={last!r})"
         )
 
     try:
@@ -531,5 +535,18 @@ async def test_inaddon_read_only_mode_blocks_radio_writes(
                 break
             except _transient:
                 if time.monotonic() >= restore_deadline:
+                    raise
+                await asyncio.sleep(3)
+        # The dev-add-on restarts above dropped the SHARED session mcp_client's
+        # connection. Warm it back up so the next test loadscope schedules on this
+        # worker gets a live session rather than a stale one (a read tool is enough
+        # to force re-establishment; retry while the add-on finishes coming up).
+        warm_deadline = time.monotonic() + 120.0
+        while True:
+            try:
+                await mcp_client.call_tool("ha_get_overview", {})
+                break
+            except _transient:
+                if time.monotonic() >= warm_deadline:
                     raise
                 await asyncio.sleep(3)

--- a/tests/src/unit/test_doomed_run.py
+++ b/tests/src/unit/test_doomed_run.py
@@ -1,0 +1,69 @@
+"""Unit tests for the e2e fail-fast ``DoomedRunDetector``.
+
+Covers the abort threshold, the reset-on-real-pass/fail semantics, and the
+rerun/skip exclusions — the branching the e2e hook relies on (which is otherwise
+only exercised incidentally on real e2e runs).
+"""
+
+from tests.src.doomed_run import DoomedRunDetector
+
+
+def test_call_pass_resets_streak():
+    d = DoomedRunDetector(threshold=5)
+    for _ in range(4):
+        assert d.record("setup", "failed") is False
+    assert d.streak == 4
+    assert d.record("call", "passed") is False
+    assert d.streak == 0
+
+
+def test_call_fail_resets_streak():
+    d = DoomedRunDetector(threshold=5)
+    for _ in range(4):
+        d.record("setup", "failed")
+    assert d.record("call", "failed") is False
+    assert d.streak == 0
+
+
+def test_rerun_outcome_neither_resets_nor_increments():
+    d = DoomedRunDetector(threshold=5)
+    d.record("setup", "failed")
+    d.record("setup", "failed")
+    assert d.streak == 2
+    assert d.record("setup", "rerun") is False  # pytest-rerunfailures
+    assert d.record("call", "rerun") is False
+    assert d.streak == 2
+
+
+def test_aborts_exactly_at_threshold():
+    d = DoomedRunDetector(threshold=50)
+    for _ in range(49):
+        assert d.record("setup", "failed") is False
+    assert d.record("setup", "failed") is True
+    assert d.streak == 50
+
+
+def test_interleaved_pass_prevents_abort():
+    d = DoomedRunDetector(threshold=5)
+    for _ in range(10):
+        for _ in range(4):
+            assert d.record("setup", "failed") is False
+        assert d.record("call", "passed") is False
+    assert d.streak == 0
+
+
+def test_teardown_error_counts_toward_streak():
+    d = DoomedRunDetector(threshold=2)
+    assert d.record("teardown", "failed") is False
+    assert d.record("teardown", "failed") is True
+
+
+def test_skip_and_passing_setup_do_not_increment():
+    d = DoomedRunDetector(threshold=2)
+    assert d.record("setup", "skipped") is False
+    assert d.record("setup", "passed") is False
+    assert d.streak == 0
+
+
+def test_default_threshold_is_50():
+    assert DoomedRunDetector().threshold == 50

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -204,10 +204,17 @@ class TestExemptionRules:
             ({"radio": "matter", "action": "diagnostics", "device_id": "d1"}, True),
             ({"radio": "zwave", "action": "network_status"}, True),
             ({"radio": "matter", "action": "ping", "device_id": "d1"}, True),
+            ({"radio": "zigbee", "action": "cluster_read", "device_id": "d1"}, True),
+            ({"radio": "thread", "action": "list_datasets"}, True),
             ({"radio": "zwave", "action": "add"}, False),
             ({"radio": "matter", "action": "remove_fabric", "device_id": "d1"}, False),
             ({"radio": "thread", "action": "set_network", "confirm": True}, False),
             ({"radio": "zwave", "action": "firmware_update", "device_id": "d1"}, False),
+            # Non-mutating but intentionally blocked: network_backup creates a
+            # backup artifact (mirrors ha_manage_backup), discover_routers starts
+            # a long-running mDNS scan.
+            ({"radio": "zigbee", "action": "network_backup"}, False),
+            ({"radio": "thread", "action": "discover_routers"}, False),
             # A missing action fails closed — never a silent read.
             ({"radio": "zwave"}, False),
             ({}, False),

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -198,6 +198,25 @@ class TestExemptionRules:
         rule = READ_ONLY_EXEMPT_TOOLS["ha_manage_custom_tool"].blocked_write
         assert (rule(args) is None) is allowed
 
+    @pytest.mark.parametrize(
+        ("args", "allowed"),
+        [
+            ({"radio": "matter", "action": "diagnostics", "device_id": "d1"}, True),
+            ({"radio": "zwave", "action": "network_status"}, True),
+            ({"radio": "matter", "action": "ping", "device_id": "d1"}, True),
+            ({"radio": "zwave", "action": "add"}, False),
+            ({"radio": "matter", "action": "remove_fabric", "device_id": "d1"}, False),
+            ({"radio": "thread", "action": "set_network", "confirm": True}, False),
+            ({"radio": "zwave", "action": "firmware_update", "device_id": "d1"}, False),
+            # A missing action fails closed — never a silent read.
+            ({"radio": "zwave"}, False),
+            ({}, False),
+        ],
+    )
+    def test_manage_radio(self, args, allowed):
+        rule = READ_ONLY_EXEMPT_TOOLS["ha_manage_radio"].blocked_write
+        assert (rule(args) is None) is allowed
+
 
 @pytest.mark.anyio
 class TestMiddleware:
@@ -438,6 +457,7 @@ class TestExemptTableContract:
             "ha_manage_energy_prefs",
             "ha_manage_pipeline",
             "ha_manage_custom_tool",
+            "ha_manage_radio",
         }
 
     def test_every_exemption_describes_whats_allowed(self):
@@ -458,6 +478,7 @@ _EXEMPT_TOOL_MODULES = {
     "ha_manage_energy_prefs": "tools_energy.py",
     "ha_manage_pipeline": "tools_voice_assistant.py",
     "ha_manage_custom_tool": "tools_code.py",
+    "ha_manage_radio": "tools_radio.py",
 }
 
 # INDEPENDENT, hardcoded manifests of the argument names each exempt
@@ -484,6 +505,7 @@ _EXEMPT_INSPECTED_ARGS = {
     "ha_manage_energy_prefs": {"mode", "dry_run"},
     "ha_manage_pipeline": {"action"},
     "ha_manage_custom_tool": {"list_saved", "code", "run_saved"},
+    "ha_manage_radio": {"action"},
 }
 
 # The subset of the addon manifest that ``_addon_write`` iterates as
@@ -583,6 +605,17 @@ _EXEMPT_GATED_OR_READ_ARGS = {
         # Modifiers of the code-execution path, which is blocked outright.
         "justification",
         "save_as",
+    },
+    "ha_manage_radio": {
+        # Node/network targeting + the confirm gate are all consumed only
+        # under the inspected ``action`` dispatch (reads need no confirm;
+        # writes are blocked before they run), so none is independently
+        # write-capable.
+        "radio",
+        "device_id",
+        "entity_id",
+        "params",
+        "confirm",
     },
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes `ha_manage_radio` (added in #1696) participate in Read Only Mode
per-action, like the other mixed read/write `manage` tools. It was not in
`READ_ONLY_EXEMPT_TOOLS`, so read-only mode treated it as a plain write tool —
hidden from the catalog and every call blocked, including its read actions. Its
active `ping` probe has no pure-read duplicate in
`ha_get_device`/`ha_get_system_health`, so it became unreachable in read-only
mode entirely.

This adds a `_radio_write` predicate classifying `diagnostics` /
`network_status` / `ping` as reads (allowed) and every other action as a write
(blocked with the structured `READ_ONLY_MODE` error before the handler runs),
and registers `ha_manage_radio` in the exempt table — the same treatment as
`ha_manage_energy_prefs` / `ha_manage_pipeline` / `ha_manage_backup`.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit: `test_read_only.py` 104 passed — new parametrized `test_manage_radio`
plus all four schema-drift manifests updated (exempt set, module map, inspected
args, gated/read partition). The settings-UI exempt-list test compares against
the live constant and adapts automatically. The e2e read-only suite gains
`ha_manage_radio` in the still-listed set plus read-allowed / write-blocked
cases (run in CI). ruff + mypy clean.

## Checklist
- [x] I have updated documentation if needed
