### PR TITLE
fix: remove slash from webhook proxy add-on name (#1707)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -311,6 +311,15 @@ jobs:
     - name: Run unit tests
       run: uv run pytest tests/src/unit/ -n auto --tb=short -v
 
+    - name: Run add-on structure tests
+      # tests/addon/ validates add-on packaging / config.yaml structure (e.g.
+      # the backup-filename-safe name guard, #1707) — previously these ran
+      # nowhere in CI. Excludes test_addon_startup.py, which spins up real
+      # Docker containers (testcontainers) this lint/unit runner doesn't have.
+      run: >-
+        uv run pytest tests/addon/ -n auto --tb=short -v
+        --ignore=tests/addon/test_addon_startup.py
+
   # Comprehensive E2E validation for all PRs
   e2e-validation:
     name: E2E Validation (${{ matrix.os }})

--- a/homeassistant-addon-webhook-proxy/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy/CHANGELOG.md
@@ -13,6 +13,13 @@
   `^[^/]+\.tar$`, so the slash made "Update" with "Create backup before update"
   enabled fail with `does not match regular expression` (issue #1707).
 
+### Documentation
+
+- Correct the "Log inbound requests" option description. It still said requests
+  are logged to the Home Assistant log "NOT this addon log", which contradicts
+  the v1.2.1 mirroring — the lines now appear in this addon's own log as well
+  (issue #1708).
+
 
 ## v1.2.1 (2026-06-28)
 

--- a/homeassistant-addon-webhook-proxy/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy/CHANGELOG.md
@@ -3,6 +3,17 @@
 <!-- version list -->
 
 
+## v1.2.2 (2026-06-29)
+
+### Fixed
+
+- Remove the `/` from the add-on name ("Nabu Casa / Webhook Proxy for HA MCP" ->
+  "Nabu Casa - Webhook Proxy for HA MCP"). Home Assistant Supervisor builds the
+  pre-update backup filename from the add-on name and validates it against
+  `^[^/]+\.tar$`, so the slash made "Update" with "Create backup before update"
+  enabled fail with `does not match regular expression` (issue #1707).
+
+
 ## v1.2.1 (2026-06-28)
 
 ### Added

--- a/homeassistant-addon-webhook-proxy/config.yaml
+++ b/homeassistant-addon-webhook-proxy/config.yaml
@@ -1,6 +1,6 @@
-name: "Nabu Casa / Webhook Proxy for HA MCP"
+name: "Nabu Casa - Webhook Proxy for HA MCP"
 description: "Remote access proxy via Nabu Casa or any reverse proxy (Cloudflare, DuckDNS, nginx)"
-version: "1.2.1"
+version: "1.2.2"
 slug: "ha_mcp_webhook_proxy"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 arch:

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/manifest.json
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/homeassistant-addon-webhook-proxy/translations/en.yaml
+++ b/homeassistant-addon-webhook-proxy/translations/en.yaml
@@ -70,12 +70,13 @@ configuration:
   debug_logging:
     name: Log inbound requests (Beta)
     description: |
-      Logs every request that reaches this webhook to the Home Assistant log
-      (Settings -> System -> Logs, filter for "mcp_proxy") — NOT this addon
-      log, because requests hit Home Assistant directly rather than passing
-      through this addon. Each line shows the method, a masked webhook path,
-      the source address, whether an Authorization header was present, and the
-      upstream response status.
+      Logs every request that reaches this webhook. The lines appear in this
+      addon's own log (below) AND in the Home Assistant log (Settings ->
+      System -> Logs, filter for "mcp_proxy"). The webhook is served inside
+      Home Assistant rather than this addon, so the integration logs each
+      request there and the addon mirrors those lines into this log. Each line
+      shows the method, a masked webhook path, the source address, whether an
+      Authorization header was present, and the upstream response status.
 
       Use this to confirm whether your MCP client (e.g. Claude.ai) is actually
       reaching the server: turn it on, restart the addon, try to connect from

--- a/tests/addon/test_addon_structure.py
+++ b/tests/addon/test_addon_structure.py
@@ -257,3 +257,24 @@ class TestAddonStructure:
                 "needs a non-empty `description` (Supervisor renders it "
                 "as the help tooltip under the toggle)"
             )
+
+    def test_addon_names_are_backup_filename_safe(self):
+        r"""No add-on ``name`` may contain ``/``.
+
+        Home Assistant Supervisor builds the pre-update backup filename from
+        the add-on name (spaces -> underscores, other characters kept) and
+        validates it against ``^[^/]+\.tar$``. A ``/`` in the name therefore
+        makes "Update" with "Create backup before update" enabled crash with
+        ``does not match regular expression`` (issue #1707). Covers every
+        ``homeassistant-addon*`` flavour so a new add-on can't reintroduce it.
+        """
+        configs = sorted(_REPO_ROOT.glob("homeassistant-addon*/config.yaml"))
+        assert configs, "no add-on config.yaml files found to validate"
+        for config_path in configs:
+            name = yaml.safe_load(config_path.read_text())["name"]
+            assert "/" not in name, (
+                f"{config_path.parent.name}: add-on name {name!r} contains "
+                r"'/', which breaks the Supervisor pre-update backup filename "
+                r"(^[^/]+\.tar$, issue #1707). Use a different separator "
+                "such as '-'."
+            )

--- a/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
+++ b/tests/src/e2e/haos_only/test_webhook_proxy_addon.py
@@ -63,7 +63,7 @@ LOG = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.haos_only]
 
-WEBHOOK_PROXY_NAME = "Nabu Casa / Webhook Proxy for HA MCP"
+WEBHOOK_PROXY_NAME = "Nabu Casa - Webhook Proxy for HA MCP"
 WEBHOOK_PROXY_SLUG = "local_ha_mcp_webhook_proxy"
 DEV_ADDON_SLUG = "local_ha_mcp_dev"
 


### PR DESCRIPTION
Closes #1707
Closes #1708

## What does this PR do?

HA Supervisor builds the pre-update backup filename from the add-on `name` (spaces → underscores, other characters kept) and validates it against `^[^/]+\.tar$`. The `/` in the webhook proxy add-on's name — `"Nabu Casa / Webhook Proxy for HA MCP"` — produced `Nabu_Casa_/_Webhook_Proxy_for_HA_MCP_…_.tar`, which fails that regex, so updating the add-on with **"Create backup before update"** enabled crashed with `does not match regular expression ^[^/]+\.tar$`.

- **Rename** `"Nabu Casa / Webhook Proxy for HA MCP"` → `"Nabu Casa - Webhook Proxy for HA MCP"`. Display-name only — slug `ha_mcp_webhook_proxy` is unchanged, so existing installs are unaffected.
- **Bump** the proxy add-on + integration `1.2.1` → `1.2.2`.
- **Guard against recurrence** (the CI part): a new `test_addon_names_are_backup_filename_safe` asserts no `homeassistant-addon*` name contains `/`, and `tests/addon/` now runs in the CI unit job (excluding the Docker-only `test_addon_startup.py`). These add-on structure tests previously ran **nowhere** in CI — which is how the slash shipped.
- **Correct the "Log inbound requests" toggle text** (`translations/en.yaml`, #1708): it still said requests log to the HA log "NOT this add-on log", contradicting the v1.2.1 mirroring. Reworded to state the lines appear in **both** the add-on's own log and the HA log. (The mirror itself works — confirmed on Nabu Casa and another reverse proxy; the original report appears environment-specific.)

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`test_addon_structure.py` (incl. the new name guard + the translation-parity check) and the proxy version-match test pass locally; the full `tests/addon/` + unit/e2e matrix runs in CI now that the add-on tests are wired in. CI is green (the earlier inaddon `test_logbook` failures were a transient Supervisor 502 — `ha_get_logs` verified working against a live instance).

## Checklist
- [x] I have updated documentation if needed (CHANGELOG)
