### PR TITLE
fix(ci): authenticate HACS in the HAOS e2e suite (GitHub rate-limit flake)

### DIFF
--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -329,6 +329,11 @@ jobs:
             cat "$outdir/config.yaml" || true
           done
           ls -laR /tmp/haos-inaddon-diagnostics/ || true
+          # The HACS token injection (conftest pre-boot edit) puts GITHUB_TOKEN
+          # into core.config_entries inside the extracted storage.tar files.
+          # Redact them (fail-closed: an unredactable tar is deleted) so no
+          # credential persists into the downloadable artifact.
+          python3 scripts/redact_diagnostics_secrets.py /tmp/haos-inaddon-diagnostics
 
       - name: Upload HAOS inaddon diagnostics
         if: always()

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -259,6 +259,10 @@ jobs:
           HAMCP_ENV_FILE: "tests/.env.test"
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2
           HAOS_TEST_MODE: inaddon
+          # Feeds conftest's HACS token injection (qcow2 pre-boot edit)
+          # so HACS repo adds don't hit the unauthenticated shared-IP
+          # GitHub rate limit — the recurring HACS-install flake.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract HAOS + addon diagnostics from booted qcow2 (always)
         if: always()

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -257,6 +257,10 @@ jobs:
         env:
           HAMCP_ENV_FILE: "tests/.env.test"
           HAOS_TEST_IMAGE_PATH: /tmp/haos-test-image.qcow2
+          # Feeds conftest's HACS token injection (qcow2 pre-boot edit)
+          # so HACS repo adds don't hit the unauthenticated shared-IP
+          # GitHub rate limit — the recurring HACS-install flake.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract HA diagnostics from booted qcow2 (always)
         # First lists what's actually present in /supervisor/homeassistant

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -293,6 +293,11 @@ jobs:
           ls -la /tmp/haos-diagnostics/ || true
           echo '--- config dir listing ---'
           cat /tmp/haos-diagnostics/config-dir-listing.txt || true
+          # The HACS token injection (conftest pre-boot edit) puts GITHUB_TOKEN
+          # into core.config_entries inside the extracted storage.tar. Redact
+          # it (fail-closed: an unredactable tar is deleted) so no credential
+          # persists into the downloadable artifact.
+          python3 scripts/redact_diagnostics_secrets.py /tmp/haos-diagnostics
 
       - name: Upload HAOS diagnostics
         if: always()

--- a/scripts/extract_tools.py
+++ b/scripts/extract_tools.py
@@ -43,14 +43,20 @@ def _extract_field_info(annotation: ast.expr | None) -> dict:
         return {}
     info: dict = {}
 
-    if isinstance(annotation, ast.Subscript) and isinstance(annotation.value, ast.Attribute) and annotation.value.attr == "Annotated":
+    if (
+        isinstance(annotation, ast.Subscript)
+        and isinstance(annotation.value, ast.Attribute)
+        and annotation.value.attr == "Annotated"
+    ):
         slice_node = annotation.slice
         if isinstance(slice_node, ast.Tuple) and slice_node.elts:
             info["type"] = ast.unparse(slice_node.elts[0])
             for elt in slice_node.elts[1:]:
                 if isinstance(elt, ast.Call):
                     for kw in elt.keywords:
-                        if kw.arg == "description" and isinstance(kw.value, ast.Constant):
+                        if kw.arg == "description" and isinstance(
+                            kw.value, ast.Constant
+                        ):
                             info["description"] = kw.value.value
                         elif kw.arg == "default" and isinstance(kw.value, ast.Constant):
                             info["default"] = kw.value.value
@@ -89,7 +95,11 @@ def extract_tools() -> list[dict]:
                 # Pattern 2: @tool(name="ha_*") — class method pattern
                 if isinstance(func, ast.Name) and func.id == "tool":
                     for kw in dec.keywords:
-                        if kw.arg == "name" and isinstance(kw.value, ast.Constant) and str(kw.value.value).startswith("ha_"):
+                        if (
+                            kw.arg == "name"
+                            and isinstance(kw.value, ast.Constant)
+                            and str(kw.value.value).startswith("ha_")
+                        ):
                             tool_dec = dec
                             tool_name = str(kw.value.value)
                             break
@@ -110,7 +120,11 @@ def extract_tools() -> list[dict]:
 
             for kw in dec.keywords:
                 if kw.arg == "tags" and isinstance(kw.value, ast.Set):
-                    tags = {str(elt.value) for elt in kw.value.elts if isinstance(elt, ast.Constant)}
+                    tags = {
+                        str(elt.value)
+                        for elt in kw.value.elts
+                        if isinstance(elt, ast.Constant)
+                    }
                 elif kw.arg == "annotations" and isinstance(kw.value, ast.Dict):
                     for k, v in zip(kw.value.keys, kw.value.values, strict=True):
                         if isinstance(k, ast.Constant) and isinstance(v, ast.Constant):
@@ -145,15 +159,17 @@ def extract_tools() -> list[dict]:
                 if required:
                     input_schema["required"] = required
 
-            tools.append({
-                "name": tool_name,
-                "title": title,
-                "description": ast.get_docstring(node) or "",
-                "inputSchema": input_schema,
-                "annotations": annotations,
-                "tags": sorted(tags),
-                "source_file": f.name,
-            })
+            tools.append(
+                {
+                    "name": tool_name,
+                    "title": title,
+                    "description": ast.get_docstring(node) or "",
+                    "inputSchema": input_schema,
+                    "annotations": annotations,
+                    "tags": sorted(tags),
+                    "source_file": f.name,
+                }
+            )
 
     # Detect duplicate tool names
     seen: dict[str, str] = {}
@@ -185,18 +201,24 @@ def generate_docs_section(tools: list[dict]) -> str:
         "",
         f"The add-on provides {len(tools)}+ MCP tools for controlling Home Assistant:",
         "",
-        "> **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime. If so, calling it returns an \"unknown tool\" error until the next stable release.",
+        '> **Note:** This list is regenerated from the `master` branch on every push, but the add-on image you have installed only updates on stable releases (biweekly, Wednesdays 10:00 UTC). A tool listed below may not yet be present in your installed runtime. If so, calling it returns an "unknown tool" error until the next stable release.',
         "",
     ]
     if any("beta" in t["tags"] for t in tools):
-        lines.extend([
-            "> Tools marked **(beta — dev channel only)** are gated behind feature flags and ship with the dev channel add-on only. See [docs/beta.md](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md) for setup and caveats.",
-            "",
-        ])
+        lines.extend(
+            [
+                "> Tools marked **(beta — dev channel only)** are gated behind feature flags and ship with the dev channel add-on only. See [docs/beta.md](https://github.com/homeassistant-ai/ha-mcp/blob/master/docs/beta.md) for setup and caveats.",
+                "",
+            ]
+        )
     for cat in sorted(categories):
         lines.append(f"### {cat}")
         for tool in sorted(categories[cat], key=lambda t: t["name"]):
-            desc = tool["description"].split("\n")[0].strip() if tool["description"] else ""
+            desc = (
+                tool["description"].split("\n")[0].strip()
+                if tool["description"]
+                else ""
+            )
             entry = f"- `{tool['name']}`"
             if "beta" in tool["tags"]:
                 entry += " **(beta — dev channel only)**"
@@ -231,8 +253,12 @@ def update_docs(tools: list[dict], *, content: str | None = None) -> str:
         re.DOTALL,
     )
     updated = pattern.sub(new_section, docs)
-    updated = re.sub(r"\bprovides \d+\+ tools\b", f"provides {len(tools)}+ tools", updated)
-    updated = re.sub(r"\bcatalog \(~\d+ tools\b", f"catalog (~{len(tools)} tools", updated)
+    updated = re.sub(
+        r"\bprovides \d+\+ tools\b", f"provides {len(tools)}+ tools", updated
+    )
+    updated = re.sub(
+        r"\bcatalog \(~\d+ tools\b", f"catalog (~{len(tools)} tools", updated
+    )
     assert DOCS_START_MARKER in updated and DOCS_END_MARKER in updated
     return updated
 
@@ -253,7 +279,7 @@ def generate_readme_table(tools: list[dict]) -> str:
     lines = [
         README_START_MARKER,
         "",
-        f'<summary><b>Complete Tool List ({len(tools)} tools)</b></summary>',
+        f"<summary><b>Complete Tool List ({len(tools)} tools)</b></summary>",
         "",
         "| Category | Tools |",
         "|----------|-------|",
@@ -295,7 +321,10 @@ def update_readme(tools: list[dict], *, content: str | None = None) -> str:
         if old_pattern.search(readme):
             readme = old_pattern.sub(new_block, readme)
         else:
-            print("WARNING: Could not find tool table markers in README.md", file=sys.stderr)
+            print(
+                "WARNING: Could not find tool table markers in README.md",
+                file=sys.stderr,
+            )
             return readme
 
     readme = re.sub(r"tools-[^-]+-blue", f"tools-{count}-blue", readme)
@@ -329,8 +358,12 @@ def check_sync(tools: list[dict]) -> bool:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract MCP tool metadata (AST-based, no runtime deps)")
-    parser.add_argument("--check", action="store_true", help="CI mode: check sync without writing")
+    parser = argparse.ArgumentParser(
+        description="Extract MCP tool metadata (AST-based, no runtime deps)"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="CI mode: check sync without writing"
+    )
     args = parser.parse_args()
 
     tools = extract_tools()
@@ -341,7 +374,10 @@ def main() -> None:
         if check_sync(tools):
             print("All files in sync.")
         else:
-            print("\nRun 'python scripts/extract_tools.py' to regenerate.", file=sys.stderr)
+            print(
+                "\nRun 'python scripts/extract_tools.py' to regenerate.",
+                file=sys.stderr,
+            )
             sys.exit(1)
     else:
         TOOLS_JSON_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/redact_diagnostics_secrets.py
+++ b/scripts/redact_diagnostics_secrets.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Redact credential values from HAOS diagnostics before artifact upload.
+
+The HAOS e2e workflows tar ``.storage`` out of the booted qcow2 into a
+diagnostics artifact. Since conftest injects ``GITHUB_TOKEN`` into the HACS
+config entry pre-boot (see ``haos_runtime.inject_hacs_token_in_qcow2``),
+``core.config_entries`` inside that tar carries the token — expired by the
+time anyone can download the artifact (``GITHUB_TOKEN`` is revoked when the
+run ends), but a credential must not persist into a downloadable artifact
+regardless.
+
+Walks every ``storage.tar`` under the given root and rewrites each in place
+with credential-named values in ``core.config_entries`` replaced by
+``**REDACTED**``. FAIL-CLOSED: if a tar can't be redacted (corrupt, parse
+error), it is DELETED rather than uploaded unredacted, with a notice.
+
+Usage: python3 scripts/redact_diagnostics_secrets.py <diagnostics-root-dir>
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+
+SECRET_KEYS = frozenset(
+    {"token", "access_token", "refresh_token", "client_secret", "password", "api_key"}
+)
+CONFIG_ENTRIES_MEMBERS = ("./core.config_entries", "core.config_entries")
+REDACTED = "**REDACTED**"
+
+
+def redact_config_entries(doc: dict[str, Any]) -> int:
+    """Replace credential-named values in every config entry's ``data``.
+
+    Returns the number of values redacted. Only non-empty string values are
+    replaced, so entry shapes (which keys exist) stay diagnosable.
+    """
+    redacted = 0
+    for entry in doc.get("data", {}).get("entries", []):
+        data = entry.get("data")
+        if not isinstance(data, dict):
+            continue
+        for key, value in data.items():
+            if key in SECRET_KEYS and isinstance(value, str) and value:
+                data[key] = REDACTED
+                redacted += 1
+    return redacted
+
+
+def redact_storage_tar(tar_path: Path) -> int:
+    """Rewrite ``tar_path`` in place with ``core.config_entries`` redacted.
+
+    Returns the number of values redacted (0 when the tar has no
+    ``core.config_entries`` member or nothing to redact).
+    """
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    total = 0
+    with tarfile.open(tar_path, "r") as tf:
+        for info in tf.getmembers():
+            payload: bytes | None = None
+            if info.isfile():
+                extracted = tf.extractfile(info)
+                payload = extracted.read() if extracted is not None else b""
+                if info.name in CONFIG_ENTRIES_MEMBERS:
+                    doc = json.loads(payload.decode("utf-8"))
+                    total += redact_config_entries(doc)
+                    payload = json.dumps(doc, indent=2).encode("utf-8")
+                    info.size = len(payload)
+            members.append((info, payload))
+
+    with tarfile.open(tar_path, "w") as tf:
+        for info, payload in members:
+            tf.addfile(info, io.BytesIO(payload) if payload is not None else None)
+    return total
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    root = Path(argv[1])
+    if not root.is_dir():
+        # Nothing extracted (diagnostics step failed earlier) — nothing to
+        # redact, and nothing unredacted can be uploaded. Not an error.
+        print(f"redact: {root} does not exist — nothing to do")
+        return 0
+
+    for tar_path in sorted(root.rglob("storage.tar")):
+        try:
+            n = redact_storage_tar(tar_path)
+            print(f"redact: {tar_path} — {n} value(s) redacted")
+        except Exception as exc:
+            # Could not guarantee redaction — drop the tar so the artifact
+            # cannot carry an unredacted credential. Diagnostics loss beats
+            # credential persistence.
+            tar_path.unlink(missing_ok=True)
+            print(
+                f"redact: FAILED for {tar_path} ({type(exc).__name__}: {exc}) — "
+                "tar DELETED so the artifact can't carry unredacted credentials",
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/render_server_manifest.py
+++ b/scripts/render_server_manifest.py
@@ -44,7 +44,9 @@ def replace_placeholders(value: Any, replacements: dict[str, str]) -> Any:
     if isinstance(value, list):
         return [replace_placeholders(item, replacements) for item in value]
     if isinstance(value, dict):
-        return {key: replace_placeholders(item, replacements) for key, item in value.items()}
+        return {
+            key: replace_placeholders(item, replacements) for key, item in value.items()
+        }
     return value
 
 
@@ -61,10 +63,12 @@ def main() -> int:
     rendered_json = json.dumps(rendered, indent=2)
 
     if "{{" in rendered_json:
-        unresolved = sorted({
-            fragment.split("}}", maxsplit=1)[0] + "}}"
-            for fragment in rendered_json.split("{{")[1:]
-        })
+        unresolved = sorted(
+            {
+                fragment.split("}}", maxsplit=1)[0] + "}}"
+                for fragment in rendered_json.split("{{")[1:]
+            }
+        )
         raise ValueError(f"Unresolved manifest placeholders: {', '.join(unresolved)}")
 
     output_path.write_text(rendered_json + "\n", encoding="utf-8")

--- a/scripts/validate_server_manifest.py
+++ b/scripts/validate_server_manifest.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 from jsonschema import validate
 
-SCHEMA_URL = "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json"
+SCHEMA_URL = (
+    "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json"
+)
 
 
 def fetch_schema(url: str) -> dict:
@@ -33,7 +35,9 @@ def load_manifest(path: Path) -> dict:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("manifest", type=Path, help="Path to the server manifest JSON file")
+    parser.add_argument(
+        "manifest", type=Path, help="Path to the server manifest JSON file"
+    )
     parser.add_argument(
         "--schema-url",
         default=SCHEMA_URL,

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -51,6 +51,8 @@ from haos_runtime import (
     HA_MCP_WEBHOOK_PROXY_ADDON_SLUG,
     HAOS_IMAGE_ENV,
     boot_haos_qemu,
+    inject_hacs_token,
+    inject_hacs_token_in_qcow2,
     is_haos_backend_selected,
     is_haos_inaddon_mode,
     login_for_token,
@@ -374,7 +376,6 @@ def _refresh_recorder_timestamps(
 
 def _setup_config_permissions(config_path: Path) -> None:
     """Set up proper permissions for Home Assistant config directory."""
-    import os
     import stat
 
     # Set directory permissions recursively
@@ -407,8 +408,6 @@ def _ensure_hacs_frontend(initial_state_path: Path) -> None:
     on the lock and exit when the winner releases it.
     """
     import tarfile
-    import urllib.error
-    import urllib.request
 
     def _is_valid_frontend(path: Path) -> bool:
         """Best-effort check that ``path`` holds a complete HACS frontend.
@@ -716,7 +715,6 @@ def _wait_for_ha_api_ready(
     integration's ``async_setup_entry`` has completed lives in
     ``_wait_for_core_state_running`` below.
     """
-    import requests as _requests
 
     # Wall-clock-bound polling: ``for attempt in range(timeout)`` would let a
     # single slow request (5s HTTP timeout) plus the 1s sleep stretch each
@@ -726,12 +724,12 @@ def _wait_for_ha_api_ready(
     start_time = time.monotonic()
     while time.monotonic() - start_time < timeout:
         try:
-            response = _requests.get(f"{base_url}/api/", timeout=5, headers=headers)
+            response = requests.get(f"{base_url}/api/", timeout=5, headers=headers)
             if response.status_code == 200:
                 elapsed = int(time.monotonic() - start_time)
                 logger.info(f"🏠 Home Assistant API ready after {elapsed}s")
                 return True
-        except _requests.exceptions.RequestException:
+        except requests.exceptions.RequestException:
             # Boot-phase polling: HA API not up yet — retry until timeout (#1266).
             pass
         time.sleep(1)
@@ -760,10 +758,9 @@ def _snapshot_config_entries(
     endpoint and never fire. The endpoint hit is best-effort
     instrumentation, not a hard requirement.
     """
-    import requests as _requests
 
     try:
-        resp = _requests.get(
+        resp = requests.get(
             f"{base_url}/api/config/config_entries/entry",
             timeout=timeout,
             headers=headers,
@@ -782,7 +779,7 @@ def _snapshot_config_entries(
             1 for e in entries if isinstance(e, dict) and e.get("state") == "loaded"
         )
         return loaded, total, True
-    except (_requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
         logger.debug(f"snapshot_config_entries: {type(exc).__name__}: {exc}")
         return 0, 0, False
 
@@ -825,13 +822,12 @@ def _wait_for_core_state_running(
     ``CoreState.RUNNING`` was set, and a follow-up gate would be
     justified.
     """
-    import requests as _requests
 
     start_time = time.monotonic()
     last_state = "<no response>"
     while time.monotonic() - start_time < timeout:
         try:
-            response = _requests.get(
+            response = requests.get(
                 f"{base_url}/api/core/state", timeout=2, headers=headers
             )
             if response.status_code == 200:
@@ -866,7 +862,7 @@ def _wait_for_core_state_running(
                 # in the timeout ``pytest.fail`` message instead of the
                 # initial ``"<no response>"``.
                 last_state = f"HTTP {response.status_code}"
-        except (_requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
             last_state = type(exc).__name__
             logger.debug(f"core_state check failed: {exc}")
         time.sleep(1)
@@ -917,14 +913,13 @@ def _dump_ha_readiness_diagnostics(
     visible even with default filtering.
     """
     import docker as _docker
-    import requests as _requests
 
     logger.warning(f"📋 readiness diagnostics dump ({label}):")
 
     # /api/services snapshot — distinguishes "domain absent" from
     # "request errored at timeout edge".
     try:
-        svc_resp = _requests.get(f"{base_url}/api/services", timeout=5, headers=headers)
+        svc_resp = requests.get(f"{base_url}/api/services", timeout=5, headers=headers)
         if svc_resp.status_code == 200:
             domains = sorted(
                 {s.get("domain") for s in svc_resp.json() if s.get("domain")}
@@ -947,7 +942,7 @@ def _dump_ha_readiness_diagnostics(
     # Distinguishes "HA never imported the entry" from "HA imported but
     # async_setup_entry raised".
     try:
-        entries_resp = _requests.get(
+        entries_resp = requests.get(
             f"{base_url}/api/config/config_entries/entry",
             timeout=5,
             headers=headers,
@@ -1247,6 +1242,11 @@ def ha_container_with_fresh_config(request):
         # path's _refresh_recorder_timestamps). Must run before boot
         # because HA Core takes an exclusive lock on the DB.
         refresh_recorder_in_qcow2(image_path)
+        # Authenticate HACS with the CI GitHub token (parity with the
+        # testcontainer path's injection below) so HACS repo adds don't
+        # ride the shared-IP 60 req/h unauthenticated GitHub budget —
+        # the long-standing HACS-install flake. Must run before boot.
+        inject_hacs_token_in_qcow2(image_path)
         # Inaddon mode: overwrite the baked addon source with PR's current
         # source + bump config.yaml version so Supervisor detects an
         # update-available on next boot. The Supervisor WS API trigger
@@ -1535,11 +1535,8 @@ def ha_container_with_fresh_config(request):
         storage_file = config_path / ".storage" / "core.config_entries"
         if storage_file.exists():
             ce_data = json.loads(storage_file.read_text())
-            for entry in ce_data.get("data", {}).get("entries", []):
-                if entry.get("domain") == "hacs":
-                    entry["data"] = {"token": github_token}
-                    logger.info("Injected GITHUB_TOKEN into HACS config entry")
-                    break
+            if inject_hacs_token(ce_data, github_token):
+                logger.info("Injected GITHUB_TOKEN into HACS config entry")
             storage_file.write_text(json.dumps(ce_data, indent=2))
 
     # Install custom components from repo source
@@ -1958,7 +1955,6 @@ async def stdio_mcp_client(
     serialization issues. Without this fixture, stdio-only regressions
     can land green on CI.
     """
-    import os
 
     from fastmcp.client.transports import StdioTransport
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -476,6 +476,129 @@ def refresh_recorder_in_qcow2(
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def inject_hacs_token(config_entries_doc: dict[str, Any], token: str) -> bool:
+    """Set ``token`` as the HACS config entry's GitHub auth token.
+
+    Mutates ``config_entries_doc`` (a parsed ``.storage/core.config_entries``
+    document) in place, replacing the ``hacs`` entry's ``data`` with
+    ``{"token": token}`` — the same shape HACS' own config flow persists
+    after device-flow auth. Returns True if a ``hacs`` entry was found and
+    patched, False if the document has none (doc left untouched).
+    """
+    for entry in config_entries_doc.get("data", {}).get("entries", []):
+        if entry.get("domain") == "hacs":
+            entry["data"] = {"token": token}
+            return True
+    return False
+
+
+def inject_hacs_token_in_qcow2(image_path: Path) -> None:
+    """Authenticate HACS inside the qcow2 with the CI GitHub token.
+
+    The baked HACS config entry carries no token, so HACS calls the GitHub
+    API unauthenticated — 60 requests/hour per IP, shared across GitHub-
+    hosted runners. When that budget is exhausted every HACS repository add
+    fails ("<Integration ...> GitHub Ratelimit error" in the HA core log)
+    until the hourly window resets, which no in-test wait or rerun can
+    outlast — the long-standing source of the HACS-install e2e flake. The
+    testcontainer path already injects GITHUB_TOKEN into the seeded entry
+    (see conftest's container setup); this brings the HAOS backend to
+    parity by editing the config entry inside the per-worker qcow2 before
+    boot. GITHUB_TOKEN gets 1,000 requests/hour scoped per repository, so
+    the shared-IP limit stops applying.
+
+    Token lifecycle is safe by construction: the workflow saves the image
+    cache BEFORE the test step runs, and xdist workers boot per-run
+    overlays, so the cached base image never carries a token (which would
+    be expired next run anyway — GITHUB_TOKEN dies with the job).
+
+    No-op with a log line when GITHUB_TOKEN is unset (local runs). A
+    guestfish failure degrades LOUDLY to a warning instead of failing the
+    session: the suite then runs exactly as it did before this helper
+    existed (unauthenticated HACS, rate-limit flakes possible).
+    """
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        LOG.info(
+            "GITHUB_TOKEN not set — HACS in %s stays unauthenticated "
+            "(GitHub rate-limit flakes possible)",
+            image_path,
+        )
+        return
+
+    import shutil
+    import tempfile
+
+    storage_path = "/supervisor/homeassistant/.storage/core.config_entries"
+    workdir = Path(tempfile.mkdtemp(prefix="haos-hacs-token-"))
+    try:
+        try:
+            subprocess.run(
+                [
+                    "guestfish",
+                    "--ro",
+                    "-a",
+                    str(image_path),
+                    "run",
+                    ":",
+                    "mount",
+                    "/dev/sda8",
+                    "/",
+                    ":",
+                    "copy-out",
+                    storage_path,
+                    str(workdir),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            local = workdir / "core.config_entries"
+            doc = json.loads(local.read_text(encoding="utf-8"))
+            if not inject_hacs_token(doc, token):
+                LOG.warning(
+                    "No hacs config entry in %s — token not injected; HACS "
+                    "stays unauthenticated (GitHub rate-limit flakes possible)",
+                    image_path,
+                )
+                return
+            local.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+            subprocess.run(
+                [
+                    "guestfish",
+                    "--rw",
+                    "-a",
+                    str(image_path),
+                    "run",
+                    ":",
+                    "mount",
+                    "/dev/sda8",
+                    "/",
+                    ":",
+                    "copy-in",
+                    str(local),
+                    "/supervisor/homeassistant/.storage/",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            LOG.info("Injected GITHUB_TOKEN into HACS config entry in %s", image_path)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            stderr = (getattr(exc, "stderr", "") or "").strip()
+            LOG.warning(
+                "HACS token injection failed for %s (%s%s) — HACS stays "
+                "unauthenticated (GitHub rate-limit flakes possible)",
+                image_path,
+                type(exc).__name__,
+                f": {stderr[-300:]}" if stderr else "",
+            )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
 def _resolve_local_store_dir(image_path: Path) -> str:
     """Return the live Supervisor local add-on store path inside ``image_path``.
 

--- a/tests/src/unit/test_hacs_token_injection.py
+++ b/tests/src/unit/test_hacs_token_injection.py
@@ -1,0 +1,84 @@
+"""Unit tests for the HACS GitHub-token injection helper.
+
+``inject_hacs_token`` is the shared pure transform behind both CI
+injection paths (the testcontainer seed copy in ``e2e/conftest.py`` and
+the HAOS qcow2 pre-boot edit in ``haos_runtime.inject_hacs_token_in_qcow2``).
+It authenticates HACS in CI so repository adds don't ride the shared-IP
+60 req/h unauthenticated GitHub budget — the long-standing HACS-install
+e2e flake ("GitHub Ratelimit error" in the HA core log).
+
+``haos_runtime`` is loaded by file path: its module-level imports are
+stdlib-only, so this collects everywhere, without assuming ``tests/src``
+is importable as a package.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+HAOS_RUNTIME_PATH = Path(__file__).resolve().parents[1] / "haos_runtime.py"
+
+
+def _load_haos_runtime():
+    spec = importlib.util.spec_from_file_location("haos_runtime", HAOS_RUNTIME_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+haos_runtime = _load_haos_runtime()
+
+
+def _doc(entries):
+    return {"version": 1, "data": {"entries": entries}}
+
+
+def test_patches_hacs_entry_and_returns_true():
+    doc = _doc(
+        [
+            {"domain": "sun", "data": {}},
+            {"domain": "hacs", "data": {}, "options": {"experimental": False}},
+        ]
+    )
+    assert haos_runtime.inject_hacs_token(doc, "ghs_test_token") is True
+    hacs = doc["data"]["entries"][1]
+    # Same shape HACS' own config flow persists after device-flow auth.
+    assert hacs["data"] == {"token": "ghs_test_token"}
+    # Only ``data`` is replaced — the rest of the entry is untouched.
+    assert hacs["options"] == {"experimental": False}
+
+
+def test_replaces_existing_stale_token():
+    doc = _doc([{"domain": "hacs", "data": {"token": "stale"}}])
+    assert haos_runtime.inject_hacs_token(doc, "fresh") is True
+    assert doc["data"]["entries"][0]["data"] == {"token": "fresh"}
+
+
+def test_no_hacs_entry_returns_false_and_leaves_doc_untouched():
+    entries = [{"domain": "sun", "data": {}}, {"domain": "demo", "data": {"a": 1}}]
+    doc = _doc([dict(e) for e in entries])
+    assert haos_runtime.inject_hacs_token(doc, "tok") is False
+    assert doc == _doc(entries)
+
+
+def test_other_entries_untouched_when_hacs_patched():
+    doc = _doc(
+        [
+            {"domain": "demo", "data": {"keep": True}},
+            {"domain": "hacs", "data": {}},
+        ]
+    )
+    haos_runtime.inject_hacs_token(doc, "tok")
+    assert doc["data"]["entries"][0] == {"domain": "demo", "data": {"keep": True}}
+
+
+def test_qcow2_injector_is_noop_without_token(monkeypatch, tmp_path):
+    """No GITHUB_TOKEN -> no guestfish invocation, no exception."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("guestfish must not run without GITHUB_TOKEN")
+
+    monkeypatch.setattr(haos_runtime.subprocess, "run", _fail)
+    haos_runtime.inject_hacs_token_in_qcow2(tmp_path / "image.qcow2")

--- a/tests/src/unit/test_redact_diagnostics_secrets.py
+++ b/tests/src/unit/test_redact_diagnostics_secrets.py
@@ -1,0 +1,117 @@
+"""Unit tests for scripts/redact_diagnostics_secrets.py.
+
+The HAOS diagnostics artifact tars ``.storage`` out of the booted qcow2;
+since CI injects GITHUB_TOKEN into the HACS config entry pre-boot, the tar
+would otherwise persist a credential into a downloadable artifact. The
+script must redact credential values in place and FAIL CLOSED (delete the
+tar) when it cannot guarantee redaction.
+"""
+
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "redact_diagnostics_secrets.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "redact_diagnostics_secrets", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+redact = _load()
+
+
+def _make_storage_tar(
+    path: Path, config_entries: dict, extra_files: dict | None = None
+):
+    with tarfile.open(path, "w") as tf:
+        payload = json.dumps(config_entries).encode()
+        info = tarfile.TarInfo("./core.config_entries")
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+        for name, content in (extra_files or {}).items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+
+
+def _doc(entries):
+    return {"version": 1, "data": {"entries": entries}}
+
+
+def test_redacts_hacs_token_and_preserves_other_members(tmp_path):
+    tar = tmp_path / "storage.tar"
+    _make_storage_tar(
+        tar,
+        _doc(
+            [
+                {"domain": "hacs", "data": {"token": "ghs_secret_value"}},
+                {"domain": "sun", "data": {}},
+            ]
+        ),
+        extra_files={"./hacs.data": b'{"repositories": {}}'},
+    )
+    assert redact.redact_storage_tar(tar) == 1
+    with tarfile.open(tar) as tf:
+        doc = json.loads(tf.extractfile("./core.config_entries").read())
+        assert doc["data"]["entries"][0]["data"]["token"] == "**REDACTED**"
+        assert "ghs_secret_value" not in json.dumps(doc)
+        # Non-config-entries members ride through byte-identical.
+        assert tf.extractfile("./hacs.data").read() == b'{"repositories": {}}'
+
+
+def test_redacts_all_credential_keys_across_entries(tmp_path):
+    tar = tmp_path / "storage.tar"
+    _make_storage_tar(
+        tar,
+        _doc(
+            [
+                {"domain": "a", "data": {"password": "p", "host": "h"}},
+                {"domain": "b", "data": {"client_secret": "s", "api_key": "k"}},
+            ]
+        ),
+    )
+    assert redact.redact_storage_tar(tar) == 3
+    with tarfile.open(tar) as tf:
+        doc = json.loads(tf.extractfile("./core.config_entries").read())
+    a, b = doc["data"]["entries"]
+    assert a["data"] == {"password": "**REDACTED**", "host": "h"}
+    assert b["data"] == {"client_secret": "**REDACTED**", "api_key": "**REDACTED**"}
+
+
+def test_main_fail_closed_deletes_unparseable_tar(tmp_path, capsys):
+    bad = tmp_path / "sub" / "storage.tar"
+    bad.parent.mkdir()
+    bad.write_bytes(b"this is not a tar archive")
+    assert redact.main(["prog", str(tmp_path)]) == 0
+    assert not bad.exists(), "unredactable tar must be deleted, not uploaded"
+    assert "DELETED" in capsys.readouterr().err
+
+
+def test_main_missing_root_is_noop(tmp_path):
+    assert redact.main(["prog", str(tmp_path / "nope")]) == 0
+
+
+def test_main_redacts_recursively(tmp_path):
+    for gw in ("gw0", "gw1"):
+        d = tmp_path / f"haos-test-image-{gw}"
+        d.mkdir()
+        _make_storage_tar(
+            d / "storage.tar", _doc([{"domain": "hacs", "data": {"token": "x"}}])
+        )
+    assert redact.main(["prog", str(tmp_path)]) == 0
+    for gw in ("gw0", "gw1"):
+        with tarfile.open(tmp_path / f"haos-test-image-{gw}" / "storage.tar") as tf:
+            doc = json.loads(tf.extractfile("./core.config_entries").read())
+        assert doc["data"]["entries"][0]["data"]["token"] == "**REDACTED**"


### PR DESCRIPTION
## What does this PR do?

Reduces the intermittent HACS-install e2e flake (`test_hacs.py::TestMcpToolsInstallation` timing out with "Could not find repository ID after adding") by authenticating HACS in the HAOS suite.

The baked HACS config entry has no GitHub token (`"data": {}`), so HACS calls the GitHub API unauthenticated — 60 requests/hour per IP, shared across GitHub-hosted runners. Most runs that budget has room and the tests pass; when it happens to be exhausted, the HA core log shows `<Integration homeassistant-ai/ha-mcp> GitHub Ratelimit error` repeating until the hourly window resets (verified in a failed run's HAOS diagnostics artifact), and no wait or rerun within the run can outlast that. The testcontainer suite already injects `GITHUB_TOKEN` into the seeded HACS entry, which is likely why the flake shows up mainly on the HAOS backend. This brings HAOS to parity:

- `haos_runtime.inject_hacs_token_in_qcow2()` — guestfish pre-boot edit of the per-worker qcow2's `.storage/core.config_entries`, setting the HACS entry's `data` to `{"token": $GITHUB_TOKEN}` (the same shape HACS's own config flow persists). Mirrors the `refresh_recorder_in_qcow2` mechanics. No-op without the env var; a guestfish failure degrades to a logged warning (the suite then runs exactly as before).
- `inject_hacs_token()` — shared pure transform, now also used by the testcontainer injection in `conftest.py`; unit-tested (`tests/src/unit/test_hacs_token_injection.py`).
- Both HAOS workflows pass `GITHUB_TOKEN` (1,000 req/h, scoped per repository) to the pytest step, matching `e2e-tests.yml`.
- `scripts/redact_diagnostics_secrets.py` — the HAOS diagnostics steps tar `.storage` out of the booted overlays, which would persist the injected token into the artifact; both workflows now redact credential-named config-entry values (fail-closed: an unredactable tar is deleted) before upload.

The image cache is saved before the test step and xdist workers boot per-run overlays, so the cached base image never carries a token (which expires with the job anyway).

Also sweeps the CodeQL `py/repeated-import` findings in the touched conftest (nested `os`/`urllib`/aliased-`requests` imports shadowing module-level ones).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

