### PR TITLE
feat(addon-dev): serve OAuth metadata at the RFC 8414/9728/OIDC well-known locations

### DIFF
--- a/.github/workflows/webhook-proxy-promote.yml
+++ b/.github/workflows/webhook-proxy-promote.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install ruff
-        run: pip install ruff
+      - name: Install ruff + pytest
+        run: pip install ruff pytest
 
       - name: Run the promote transform in place
         id: promote
@@ -38,6 +38,14 @@ jobs:
           NEW=$(python3 scripts/webhook_proxy_sync.py --direction promote --bump "$BUMP")
           echo "version=$NEW" >> "$GITHUB_OUTPUT"
           echo "New stable version: $NEW"
+
+      # The committed-tree drift guards are sync-point invariants: they skip in
+      # per-PR CI (dev intentionally runs ahead of stable between promotes) and
+      # run HERE, right after the transform, as its acceptance gate.
+      - name: Verify transform exactness (drift guards)
+        env:
+          WEBHOOK_PROXY_TREES_SYNCED: "1"
+        run: python3 -m pytest tests/src/unit/test_webhook_proxy_sync.py -q
 
       - name: Commit on a branch and open a draft PR
         env:

--- a/.github/workflows/webhook-proxy-reset-dev.yml
+++ b/.github/workflows/webhook-proxy-reset-dev.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install ruff
-        run: pip install ruff
+      - name: Install ruff + pytest
+        run: pip install ruff pytest
 
       - name: Run the reset transform in place
         id: reset
@@ -30,6 +30,14 @@ jobs:
           NEW=$(python3 scripts/webhook_proxy_sync.py --direction reset)
           echo "version=$NEW" >> "$GITHUB_OUTPUT"
           echo "New dev version: $NEW"
+
+      # The committed-tree drift guards are sync-point invariants: they skip in
+      # per-PR CI (dev intentionally runs ahead of stable between promotes) and
+      # run HERE, right after the transform, as its acceptance gate.
+      - name: Verify transform exactness (drift guards)
+        env:
+          WEBHOOK_PROXY_TREES_SYNCED: "1"
+        run: python3 -m pytest tests/src/unit/test_webhook_proxy_sync.py -q
 
       - name: Commit on a branch and open a draft PR
         env:

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,23 @@ history from before the fork.
 -->
 
 
+## v1.2.3.dev2 (2026-07-02)
+
+### Added
+
+- Serve the OAuth metadata at the RFC 8414 / RFC 9728 / OIDC well-known
+  locations (issue #1714): the authorization-server document at
+  `/.well-known/oauth-authorization-server/api/mcp_proxy_dev/oauth` (plus the
+  `openid-configuration` variants), and the protected-resource document at the
+  path-scoped `/.well-known/oauth-protected-resource/api/webhook/<id>`.
+  Captured live against claude.ai: the path-scoped document is its first
+  fallback probe when the 401's `WWW-Authenticate` pointer is missing, and a
+  valid authorization-server document at the well-known path overrides a
+  previously mis-cached (HA-core) per-URL client config — healing a broken
+  connector with no client-side action. Purely additive routes; HA core's
+  root well-known endpoints are untouched.
+
+
 ## v1.2.2 (2026-06-29)
 
 ### Fixed

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "1.2.3.dev1"
+version: "1.2.3.dev2"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.3.dev1"
+  "version": "1.2.3.dev2"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -311,6 +311,10 @@ class OAuthProvider:
     def client_id(self) -> str:
         return self._client_id
 
+    @property
+    def webhook_id(self) -> str:
+        return self._webhook_id
+
     def client_id_masked(self) -> str:
         if len(self._client_id) <= 4:
             return "***"
@@ -330,13 +334,42 @@ class OAuthProvider:
     # -----------------------------------------------------------------
 
     def register_views(self) -> None:
-        """Register the OAuth endpoints with HA's HTTP layer."""
-        for view in (
+        """Register the OAuth endpoints with HA's HTTP layer.
+
+        Besides the four core views, the metadata documents are also served
+        at the RFC 8414 / RFC 9728 / OIDC-discovery well-known locations —
+        see the WellKnown* view docstrings for the live-captured client
+        behavior (issue #1714) that makes those locations load-bearing.
+        """
+        views: list[HomeAssistantView] = [
             ProtectedResourceMetadataView(self),
             AuthorizationServerMetadataView(self),
             AuthorizeView(self),
             TokenView(self),
+            WellKnownProtectedResourceView(self),
+        ]
+        for url, name in (
+            (
+                f"/.well-known/oauth-authorization-server{OAUTH_BASE}",
+                "mcp_proxy_dev:oauth:wellknown-as-rfc8414",
+            ),
+            (
+                f"/.well-known/openid-configuration{OAUTH_BASE}",
+                "mcp_proxy_dev:oauth:wellknown-oidc-prefixed",
+            ),
+            (
+                f"{OAUTH_BASE}/.well-known/openid-configuration",
+                "mcp_proxy_dev:oauth:wellknown-oidc-suffixed",
+            ),
+            (
+                f"{OAUTH_BASE}/.well-known/oauth-authorization-server",
+                "mcp_proxy_dev:oauth:wellknown-as-suffixed",
+            ),
         ):
+            views.append(
+                WellKnownAuthorizationServerMetadataView(self, url=url, name=name)
+            )
+        for view in views:
             self._hass.http.register_view(view)
 
     # -----------------------------------------------------------------
@@ -532,6 +565,60 @@ class AuthorizationServerMetadataView(HomeAssistantView):
                 ],
             }
         )
+
+
+class WellKnownProtectedResourceView(ProtectedResourceMetadataView):
+    """RFC 9728 §3.1 path-scoped Protected Resource Metadata.
+
+    Same document as `ProtectedResourceMetadataView`, served at the
+    well-known location derived from the webhook resource URL
+    (`/.well-known/oauth-protected-resource/api/webhook/<id>`). Captured
+    live in issue #1714: when the 401's `WWW-Authenticate`
+    `resource_metadata` pointer is missing (stripped by a proxy in front,
+    or a transient setup window), this path is claude.ai's FIRST fallback
+    probe — and when it 404s the client falls through to the HOST-ROOT
+    `/.well-known/oauth-protected-resource`, which HA core itself serves
+    whenever it can resolve an external URL, steering the flow into
+    HA-core native OAuth (`/auth/authorize`) where the proxy's client_id
+    can never work. Serving this view keeps discovery on the proxy even
+    without the pointer.
+    """
+
+    name = "mcp_proxy_dev:oauth:wellknown-protected-resource"
+
+    def __init__(self, provider: OAuthProvider) -> None:
+        super().__init__(provider)
+        # Instance-level URL: the well-known path embeds this install's
+        # webhook id, which is only known at runtime.
+        self.url = (
+            f"/.well-known/oauth-protected-resource/api/webhook/{provider.webhook_id}"
+        )
+
+
+class WellKnownAuthorizationServerMetadataView(AuthorizationServerMetadataView):
+    """RFC 8414 / OIDC-discovery locations for the AS metadata document.
+
+    Same document as `AuthorizationServerMetadataView`, registered at the
+    well-known URLs MCP clients actually probe for the issuer
+    `<base>/api/mcp_proxy_dev/oauth` (request sequence captured live in
+    issue #1714). Two findings make these load-bearing:
+
+    * claude.ai caches a per-URL authorization config; when discovery ran
+      once against a URL while the pointer was missing, the cached (wrong,
+      HA-core) config survives connector delete/re-create and overrides
+      every later pointer-based re-discovery — UNLESS the AS metadata
+      resolves at these locations, in which case the fresh document
+      overrides the cache and the connector heals with no client action.
+    * A fresh URL survives these 404ing only via the client's
+      origin-default `/authorize`+`/token` fallback; serving the real
+      document removes that fragility (and gives PKCE-capable clients the
+      `code_challenge_methods_supported` they otherwise never see).
+    """
+
+    def __init__(self, provider: OAuthProvider, url: str, name: str) -> None:
+        super().__init__(provider)
+        self.url = url
+        self.name = name
 
 
 class AuthorizeView(HomeAssistantView):

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -2067,6 +2067,29 @@ class TestOAuthProvider:
         assert provider.validate_access_token(token) is False
 
 
+def _wellknown_oauth_urls(oauth_mod, webhook_id):
+    """Extra well-known metadata URLs a flavor registers (issue #1714), or an
+    empty set when the flavor doesn't ship them yet.
+
+    Feature-DETECTED from the oauth module rather than recorded in
+    WEBHOOK_PROXY_VARIANTS: the promote workflow mechanically copies dev's
+    code onto stable without touching tests, so a static per-variant flag
+    would go stale (and fail CI) at the exact moment stable gains the
+    feature. Detection keeps the expectation in lockstep with the code under
+    test in both flavors.
+    """
+    if not hasattr(oauth_mod, "WellKnownAuthorizationServerMetadataView"):
+        return set()
+    base = oauth_mod.OAUTH_BASE
+    return {
+        f"/.well-known/oauth-protected-resource/api/webhook/{webhook_id}",
+        f"/.well-known/oauth-authorization-server{base}",
+        f"/.well-known/openid-configuration{base}",
+        f"{base}/.well-known/openid-configuration",
+        f"{base}/.well-known/oauth-authorization-server",
+    }
+
+
 class TestOAuthSetupEntry:
     """async_setup_entry creates and registers an OAuthProvider when the
     config has an oauth section with non-empty creds."""
@@ -2118,8 +2141,10 @@ class TestOAuthSetupEntry:
         provider = hass.data[mod.DOMAIN]["oauth"]
         assert provider is not None
         assert provider.client_id == "client-1234567890ABCDEF"
-        # 4 OAuth views registered
-        assert hass.http.register_view.call_count == 4
+        # 4 core OAuth views, plus the well-known metadata variants on flavors
+        # that ship them (feature-detected — see _wellknown_oauth_urls).
+        expected_views = 4 + len(_wellknown_oauth_urls(oauth, "mcp_test"))
+        assert hass.http.register_view.call_count == expected_views
         # Successful OAuth setup records that THIS flavor owns the root routes,
         # so the sibling flavor refuses loudly instead of shadowing them.
         assert hass.data[mod.OAUTH_ROUTE_OWNER_KEY] == mod.DOMAIN
@@ -3058,6 +3083,66 @@ class TestAuthorizationServerView:
         assert "S256" in body["code_challenge_methods_supported"]
         assert "client_secret_basic" in body["token_endpoint_auth_methods_supported"]
         assert "client_secret_post" in body["token_endpoint_auth_methods_supported"]
+
+
+class TestWellKnownMetadataViews:
+    """The RFC 8414 / RFC 9728 / OIDC well-known variants (issue #1714) must
+    serve documents identical to the canonical metadata views, at the exact
+    URLs claude.ai was captured probing. Skips on flavors that don't ship the
+    views yet."""
+
+    @staticmethod
+    def _skip_unless_shipped(oauth):
+        if not hasattr(oauth, "WellKnownAuthorizationServerMetadataView"):
+            pytest.skip("flavor does not ship the well-known metadata views yet")
+
+    async def test_path_scoped_prm_embeds_webhook_id_and_matches_canonical(
+        self, tmp_path
+    ):
+        oauth, provider = _provider_for_view_tests(
+            tmp_path, public_base_url="https://legit.example"
+        )
+        self._skip_unless_shipped(oauth)
+        view = oauth.WellKnownProtectedResourceView(provider)
+        # RFC 9728 §3.1: the well-known path is derived from the resource URL,
+        # so it must embed this install's actual webhook id.
+        assert view.url == (
+            "/.well-known/oauth-protected-resource/api/webhook/mcp_webhook_id_aaaa"
+        )
+        request = _make_view_request(headers={"Host": "ignored"})
+        with patch.object(oauth.web, "json_response") as json_resp:
+            await view.get(request)
+        wellknown_body = json_resp.call_args.args[0]
+        with patch.object(oauth.web, "json_response") as json_resp:
+            await oauth.ProtectedResourceMetadataView(provider).get(request)
+        assert wellknown_body == json_resp.call_args.args[0]
+
+    async def test_wellknown_as_variants_match_canonical_document(self, tmp_path):
+        oauth, provider = _provider_for_view_tests(
+            tmp_path, public_base_url="https://legit.example"
+        )
+        self._skip_unless_shipped(oauth)
+        request = _make_view_request(headers={"Host": "ignored"})
+        with patch.object(oauth.web, "json_response") as json_resp:
+            await oauth.AuthorizationServerMetadataView(provider).get(request)
+        canonical = json_resp.call_args.args[0]
+        base = oauth.OAUTH_BASE
+        for url in (
+            f"/.well-known/oauth-authorization-server{base}",
+            f"/.well-known/openid-configuration{base}",
+            f"{base}/.well-known/openid-configuration",
+            f"{base}/.well-known/oauth-authorization-server",
+        ):
+            view = oauth.WellKnownAuthorizationServerMetadataView(
+                provider, url=url, name=f"test:{url}"
+            )
+            assert view.url == url
+            with patch.object(oauth.web, "json_response") as json_resp:
+                await view.get(request)
+            assert json_resp.call_args.args[0] == canonical
+        # No DCR: the proxy has fixed credentials, so the document must not
+        # advertise a registration endpoint (clients would try it and fail).
+        assert "registration_endpoint" not in canonical
 
 
 class TestAuthorizeViewGet:
@@ -4047,7 +4132,7 @@ class TestOAuthSetupEntryRegistersExpectedViews:
         h.async_add_executor_job = AsyncMock(side_effect=fake_executor)
         return h
 
-    async def test_registers_all_four_oauth_endpoints(self, hass, tmp_path):
+    async def test_registers_expected_oauth_endpoints(self, hass, tmp_path):
         oauth = _import_oauth(tmp_secret_dir=tmp_path)
         mod = _import_mcp_proxy(preload_oauth=oauth)
         # Boot-time setup (is_running False) exercises the first-registration
@@ -4074,13 +4159,16 @@ class TestOAuthSetupEntryRegistersExpectedViews:
         }
         # Authorize/token live at the root because Claude.ai constructs
         # those URLs from the resource host without consulting the
-        # authorization-server metadata document.
-        assert registered_urls == {
+        # authorization-server metadata document. Flavors that ship the
+        # issue-#1714 well-known metadata variants register those too
+        # (feature-detected — see _wellknown_oauth_urls).
+        expected = {
             f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
             "/authorize",
             "/token",
-        }
+        } | _wellknown_oauth_urls(oauth, "mcp_test")
+        assert registered_urls == expected
 
 
 class TestUnauthorizedResponseShape:

--- a/tests/src/unit/test_webhook_proxy_sync.py
+++ b/tests/src/unit/test_webhook_proxy_sync.py
@@ -10,11 +10,29 @@ a clean tree) is guaranteed by the acceptance gate in the build spec, not here.
 """
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SYNC_PATH = REPO_ROOT / "scripts" / "webhook_proxy_sync.py"
+
+# The committed-tree drift guards below are SYNC-POINT invariants, not
+# development-time invariants: PRs land on the DEV flavor only (the stable
+# guard blocks direct stable edits), so dev intentionally runs AHEAD of stable
+# between promotes, and the two committed trees are only supposed to be
+# identity-equal right after the promote/reset transform has run. Those
+# workflows set WEBHOOK_PROXY_TREES_SYNCED=1 and run this file as the
+# transform's acceptance gate; in regular per-PR CI the drift guards skip
+# (every pure transform-engine test above them still runs everywhere).
+_sync_point_only = pytest.mark.skipif(
+    os.environ.get("WEBHOOK_PROXY_TREES_SYNCED") != "1",
+    reason="committed-tree drift guards apply only at promote/reset sync "
+    "points (WEBHOOK_PROXY_TREES_SYNCED=1); the dev flavor intentionally "
+    "runs ahead of stable between promotes",
+)
 
 
 def _load_sync():
@@ -270,8 +288,9 @@ def _assert_committed_equals_transform(tmp_path, direction, src, dst, bump=None)
     )
 
 
+@_sync_point_only
 def test_committed_dev_equals_reset_transform_of_stable(tmp_path):
-    """Drift guard: the committed dev tree MUST equal reset(stable) — the
+    """Sync-point drift guard: the committed dev tree MUST equal reset(stable) — the
     identity transform applied to the committed stable tree — modulo the version
     lines and the hand-maintained doc allowlist. Any silent divergence between
     the two hand-maintained copies (a stable fix not mirrored into dev, or an
@@ -283,8 +302,9 @@ def test_committed_dev_equals_reset_transform_of_stable(tmp_path):
     _assert_committed_equals_transform(tmp_path, "reset", sync.STABLE, sync.DEV)
 
 
+@_sync_point_only
 def test_committed_stable_equals_promote_transform_of_dev(tmp_path):
-    """Reverse drift guard: the committed stable tree MUST equal promote(dev) —
+    """Sync-point reverse drift guard: the committed stable tree MUST equal promote(dev) —
     the inverse identity transform applied to the committed dev tree — modulo
     the version lines and the hand-maintained doc allowlist. Mirrors the reset
     drift guard for the promote direction, confirming the reverse transform


### PR DESCRIPTION
## What does this PR do?

Refs #1714. Adds the OAuth discovery documents at the well-known locations MCP clients actually probe, on the **dev flavor** (first dev-channel feature since #1719; stable untouched):

- **AS metadata** at `/.well-known/oauth-authorization-server/api/mcp_proxy_dev/oauth`, both `openid-configuration` variants, and the issuer-suffixed RFC 8414 form — same document as the existing non-standard path, no `registration_endpoint`.
- **Path-scoped PRM** (RFC 9728 §3.1) at `/.well-known/oauth-protected-resource/api/webhook/<id>` — same document as the `WWW-Authenticate` pointer target.

Both are load-bearing per the live-captured claude.ai request logs in #1714: the path-scoped PRM is claude.ai's *first* fallback probe when the 401 pointer is missing (preventing fall-through to HA core's root well-known → `/auth/authorize`, where the proxy's client_id can never work), and a valid AS document at the well-known path overrides claude.ai's poisoned per-URL cache — healing a broken connector with no client-side action (that cache survives connector delete/re-create). Purely additive routes; HA core's root well-knowns untouched; the views register inside `register_views()` so the #1719 route-owner/fingerprint/restart-Repair guards cover them.

Also fixes a #1719 design bug this PR trips: the committed-tree drift guards asserted `dev == transform(stable)` on every PR, but the release flow develops on dev only — the first dev-ahead PR could never pass CI. They're now sync-point gates (`WEBHOOK_PROXY_TREES_SYNCED=1`), run by the promote/reset workflows right after the transform as its acceptance gate; the pure transform-engine tests still run per-PR. Verified both ways: skip in normal CI, fail on an intentionally divergent tree with the env set.

Tests are feature-detected per flavor (`_wellknown_oauth_urls`) so the mechanical promote keeps CI green the moment stable gains the feature. Dev version bumped to `1.2.3.dev2` + CHANGELOG entry.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
