### PR TITLE
feat(addon-dev): add HA-native OAuth mode (ha_auth) to the Webhook Proxy

### DIFF
--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,37 @@ history from before the fork.
 -->
 
 
+## v1.2.3.dev4 (2026-07-02)
+
+> **POTENTIAL BREAKING CHANGE (OAuth users).** This release changes the default
+> OAuth mode for *new* enables. Upgrades are engineered to be safe — existing
+> OAuth setups are auto-detected and kept on the old (legacy) mode — but if you
+> use OAuth, read the notes below. `enable_oauth` stays OFF by default; nothing
+> changes for anyone not using OAuth.
+
+### Added
+
+- New default OAuth mode `ha_auth` that delegates authorization to Home
+  Assistant's built-in OAuth: you sign in with your Home Assistant account and
+  the connector's OAuth fields stay blank (the add-on advertises Client ID
+  Metadata Documents, so no client id/secret is needed). It works with any
+  hostname regardless of Home Assistant's external URL, and needs no Home
+  Assistant restart to enable or disable. Validated live against claude.ai; also
+  enables ChatGPT (#1725). Follow-up to #1714.
+
+### Changed
+
+- OAuth's default for a first-time enable is now `ha_auth`. What this means for
+  OAuth users:
+  - OAuth setups from before this update keep working unchanged — legacy mode is
+    auto-detected (from a configured or stored Client ID/Secret) and kept.
+  - New / first-time OAuth enables default to the new `ha_auth` mode.
+  - Anyone switching modes must delete and re-add their MCP connector: set
+    `oauth_mode: ha_auth` (blank credentials) to move to the new mode, or
+    `oauth_mode: legacy` to pin the previous client-id/secret flow.
+  The legacy flow is unchanged and still available (deprecated).
+
+
 ## v1.2.3.dev3 (2026-07-02)
 
 ### Added

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -113,18 +113,36 @@ The old webhook ID is not retained anywhere on disk after the file is deleted, a
 
 #### Enable OAuth (Beta) for stronger protection
 
-If you want a real auth layer on top of the URL secret, turn on **Enable OAuth (Beta)**.
+If you want a real auth layer on top of the URL secret, turn on **Enable OAuth (Beta)**. It is OFF by default; leaving it off keeps the webhook working exactly as before with no auth check.
 
-**What it does:** the integration runs a minimal OAuth 2.1 authorization-code-with-PKCE flow on top of the same webhook URL. MCP clients that support OAuth (Claude.ai, ChatGPT, Cursor, etc.) will discover the OAuth endpoints automatically from a 401 response, send the user through a one-screen consent page, and exchange a code for a bearer token. The webhook then requires the bearer token on every request.
+There are two modes, chosen with the **OAuth Mode (Beta)** option:
 
-**How to enable:**
+- **`ha_auth` (recommended, the default for a first-time enable)** — Home Assistant itself is the authorization server. You sign in with your Home Assistant account and **leave the connector's OAuth fields blank**. No Client ID or Client Secret, works with any hostname/URL, and no Home Assistant restart is needed to enable or disable it.
+- **`legacy` (deprecated)** — the previous flow, where the add-on generates a Client ID + Secret you paste into the connector.
+
+> **Upgrading? Your OAuth setup is not changed.** If you already used the legacy flow (you set a Client ID/Secret, or the add-on stored one), leaving **OAuth Mode** unset keeps you on **legacy** — nothing breaks. New/first-time enables default to **ha_auth**. Switching modes is an explicit action (set **OAuth Mode**) and, because Claude.ai binds the auth mode per connector, requires **deleting and re-adding your MCP connector**.
+
+##### Recommended: sign in with Home Assistant (`ha_auth`)
 
 1. Toggle **Show unused optional configuration options** at the bottom of the Configuration tab.
-2. Set **Enable OAuth (Beta)** to on. Leave **OAuth Client ID** and **OAuth Client Secret** blank — the addon will generate strong values for you on first start.
-3. Save and **restart the addon**.
+2. Set **Enable OAuth (Beta)** to on. Leave **OAuth Mode** unset (or set it to `ha_auth`) for a first-time enable.
+3. Save and **restart the addon**. (No Home Assistant restart is required for this mode.)
+4. In your MCP client, add the connector with the webhook URL and **leave the OAuth Client ID and Client Secret fields blank**. When you connect, you sign in with your Home Assistant account and approve access — that is the whole flow.
+   - **Claude.ai:** if its UI insists on a Client Secret, any value works — Home Assistant ignores it.
+5. **Revoking access:** open your Home Assistant profile and remove the session/refresh token for the connector (Settings → your user → Security). No add-on action needed.
+
+Why this mode is host-agnostic: the add-on serves the OAuth discovery documents itself, so they work on any hostname even when Home Assistant's own metadata would not (e.g. an external URL mismatch). All the actual OAuth protocol steps are Home Assistant core's own `/auth/authorize` + `/auth/token`.
+
+##### Legacy mode (client id + secret)
+
+Set **OAuth Mode** to `legacy` (or leave it unset if you are upgrading an existing legacy setup). The add-on runs a minimal OAuth 2.1 authorization-code-with-PKCE flow on the same webhook URL, discoverable from a 401 response, with a one-screen consent page.
+
+1. Toggle **Show unused optional configuration options** at the bottom of the Configuration tab.
+2. Set **Enable OAuth (Beta)** to on and **OAuth Mode** to `legacy`. Leave **OAuth Client ID** and **OAuth Client Secret** blank — the addon will generate strong values for you on first start.
+3. Save and **restart the addon**. Legacy mode requires a full **Home Assistant** restart to take effect (a Repair with a restart button appears); disabling does not.
 4. Open the addon log and copy the displayed Client ID and Client Secret. Both values are printed in plaintext exactly as Claude.ai needs them — copy them straight from the log:
    ```
-   OAuth (Beta) is ENABLED for this URL.
+   OAuth (Beta) is ENABLED for this URL (legacy mode).
      OAuth Client ID:     hamcp-1a2b3c4d5e6f7890abcdef1234567890
      OAuth Client Secret: kX9pQ4mZ2vL8nR3sT6uW1yA5cB7dF0gH...
      Paste both into the OAuth fields of your MCP client's
@@ -136,28 +154,34 @@ If you want a real auth layer on top of the URL secret, turn on **Enable OAuth (
 
 The generated values are persisted at `/data/oauth_creds.json` inside the addon, so they stay the same across restarts.
 
-**Rotating the credentials** — three options:
+**Rotating the legacy credentials** — three options:
 
 1. **Pick your own new values:** type new strings into the Client ID and Client Secret fields, save, restart the addon. Your values overwrite the persisted file. Update your MCP client to match.
 2. **Get fresh random values via the UI** (no filesystem access needed): turn on **Regenerate OAuth Credentials on Next Start** in the addon configuration, save, restart. The addon wipes the stored creds, generates a fresh pair, prints them in the log, and flips the regenerate toggle back to off. Update your MCP client to match.
 3. **Get fresh random values manually:** stop the addon, delete `/data/oauth_creds.json` (e.g. via SSH/Terminal addon), start the addon. Equivalent to option 2 but requires filesystem access.
 
-**To disable:** set **Enable OAuth (Beta)** back to off and restart the addon. The webhook returns to plain unauthenticated behavior — the URL works as before with no token required.
+**To disable OAuth (either mode):** set **Enable OAuth (Beta)** back to off and restart the addon. The webhook returns to plain unauthenticated behavior — the URL works as before with no token required.
 
 **Endpoints exposed when enabled:**
 
+Both modes serve the discovery documents from the add-on's own host, so they work on any hostname:
+
 - `/.../api/webhook/<id>` — MCP webhook (now bearer-protected)
 - `/.../api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 metadata
-- `/.../api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 metadata
-- `/.../authorize` — consent screen (root path; Claude.ai expects it here)
-- `/.../token` — token endpoint (root path; Claude.ai expects it here)
+- `/.../api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 metadata (contents differ per mode)
 
-**Notes:**
+The authorize/token endpoints depend on the mode:
+
+- **`ha_auth`:** Home Assistant core's own `/auth/authorize` + `/auth/token`. The add-on registers no root routes and needs no HA restart.
+- **`legacy`:** the add-on's own `/.../authorize` (consent screen) + `/.../token` at the host root, where Claude.ai expects them.
+
+**Notes (legacy mode):**
 
 - Tokens are HMAC-signed and stateless — they survive HA restarts. Access tokens expire after 1 hour; refresh tokens after 30 days.
 - Rotating the Client ID invalidates all outstanding tokens (the client_id is part of the token's signed payload).
 - The signing key is generated once and persisted at `/config/.mcp_proxy_dev_oauth_secret`. Delete that file to invalidate every token in one shot.
-- **Beta status:** the OAuth flow is implemented against the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) but real-world MCP-client coverage varies. The URL-as-secret mode (default) is the stable, documented path. Treat OAuth as opt-in until tested with your client. Report problems on GitHub.
+
+**Beta status:** OAuth is Beta in both modes; the URL-as-secret mode (default) is the stable, documented path. `ha_auth` delegates all protocol steps to Home Assistant's own OAuth (validated live against claude.ai); `legacy` is implemented against the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Real-world MCP-client coverage varies, so treat OAuth as opt-in until tested with your client, and report problems on GitHub.
 
 ### End-to-end flow (what happens when Claude.ai connects)
 

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "1.2.3.dev3"
+version: "1.2.3.dev4"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental
@@ -26,6 +26,7 @@ schema:
   mcp_server_url: str?
   mcp_port: port?
   enable_oauth: bool?
+  oauth_mode: list(ha_auth|legacy)?
   oauth_client_id: str?
   oauth_client_secret: password?
   regenerate_oauth_creds: bool?

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -50,6 +50,16 @@ _LOGGER_LEVEL_RAISED = False
 DOMAIN = "mcp_proxy_dev"
 CONFIG_FILE = Path("/config/.mcp_proxy_dev_config.json")
 
+# OAuth mode markers written into hass.data["oauth_mode"] and read by the
+# webhook gate + the mode-aware discovery views. Mirrored as
+# auth_native.HA_AUTH_MODE / oauth.MODE_* (a test pins them in agreement).
+#   ha_auth — HA core is the authorization server (auth_native.ResourceServer);
+#             the add-on only serves the discovery documents + validates bearers.
+#   legacy  — this integration's embedded authorization server (oauth.py).
+# The two are mutually exclusive: exactly one marker is ever set for an entry.
+OAUTH_MODE_HA_AUTH = "ha_auth"
+OAUTH_MODE_LEGACY = "legacy"
+
 # Service the add-on calls (via the HA Core API) to raise/clear the
 # click-to-restart Repair issues from outside HA — see async_setup.
 SERVICE_REFRESH_REPAIRS = "refresh_repairs"
@@ -368,7 +378,98 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # leave them with an open endpoint they think is locked.
     oauth_restart_needed = False
     oauth_section = proxy_config.get("oauth")
-    if isinstance(oauth_section, dict):
+    oauth_mode = oauth_section.get("mode") if isinstance(oauth_section, dict) else None
+    if isinstance(oauth_section, dict) and oauth_mode == OAUTH_MODE_HA_AUTH:
+        # ── ha_auth: HA core is the authorization server (see auth_native) ──
+        # Hard mutual exclusion: a ha_auth section carries NO legacy credentials.
+        # If client_id/client_secret keys are present the config is ambiguous
+        # (a bad hand-edit or a bug) — refuse to guess which mode was intended
+        # rather than risk serving with the wrong auth model.
+        if "client_id" in oauth_section or "client_secret" in oauth_section:
+            async_unregister(hass, webhook_id)
+            await session.close()
+            raise ConfigEntryError(
+                "Ambiguous OAuth config: the oauth section is mode 'ha_auth' "
+                "but also carries legacy client_id/client_secret keys. ha_auth "
+                "signs in with your Home Assistant account and takes no add-on "
+                "credentials. Restart the Webhook Proxy addon to regenerate "
+                "/config/.mcp_proxy_dev_config.json."
+            )
+        # Log the HA version. No minimum-version gate: everything ha_auth calls
+        # at runtime is long-stable HA API — /auth/*, same-origin URL-shaped
+        # IndieAuth client_ids, and hass.auth bearer validation. The advertised
+        # client_id_metadata_document_supported flag is advertisement-only (HA
+        # never fetches a CIMD document; the field just signals capability),
+        # and home-assistant/core#153820 is field evidence that claude.ai /
+        # ChatGPT custom connectors work against HA's native OAuth, not a
+        # runtime code dependency of this add-on — hence nothing to gate on.
+        try:
+            from homeassistant.const import __version__ as _hass_version
+        except ImportError:  # pragma: no cover - defensive
+            _hass_version = "unknown"
+        _LOGGER.info(
+            "MCP Proxy: OAuth mode 'ha_auth' — Home Assistant (version %s) is "
+            "the authorization server; this add-on serves only the OAuth "
+            "discovery documents and validates bearer tokens via hass.auth. No "
+            "HA restart is needed to enable or disable this mode.",
+            _hass_version,
+        )
+        # ha_auth is ALWAYS host-derived: the SAME install must work via the
+        # Nabu Casa cloud URL AND any other external URL, so the base URL is
+        # built per-request from the host and never pinned. Pass None explicitly
+        # and ignore any public_base_url a hand-edited config might carry (the
+        # ambiguity guard above only rejects stray client_id/client_secret keys,
+        # so a stray public_base_url would otherwise wrongly pin the base URL).
+        try:
+            from .auth_native import ResourceServer
+            from .oauth import register_metadata_views
+
+            resource_server = ResourceServer(hass, webhook_id, None)
+            # Registers the seven discovery-document views at most once per HA
+            # session (register_metadata_views no-ops when either mode already
+            # bound them — see oauth._METADATA_VIEWS_REGISTERED_KEY), so a
+            # config-entry reload or a live legacy->ha_auth switch doesn't
+            # stack shadowed duplicates. ha_auth binds NO root views (HA core
+            # owns /authorize + /token), so there is no owner-key / fingerprint
+            # bookkeeping and no restart concept — hence oauth_restart_needed
+            # stays False and the marker-CLEAR path runs below.
+            register_metadata_views(hass, resource_server)
+        except Exception as err:
+            _LOGGER.exception(
+                "MCP Proxy: failed to initialise ha_auth OAuth (%s)",
+                type(err).__name__,
+            )
+            # OAuth setup failed — unregister the webhook we registered above so
+            # we don't leave an unauthenticated endpoint live.
+            async_unregister(hass, webhook_id)
+            await session.close()
+            raise ConfigEntryError(
+                f"Failed to enable OAuth on the MCP webhook: {err}. "
+                "Auth is not being enforced — refusing to start the "
+                "integration so the webhook URL is not silently exposed "
+                "without the protection the user requested."
+            ) from err
+        hass_data["oauth"] = resource_server
+        hass_data["oauth_mode"] = OAUTH_MODE_HA_AUTH
+    elif isinstance(oauth_section, dict) and oauth_mode not in (
+        None,
+        OAUTH_MODE_LEGACY,
+    ):
+        # Unknown mode value — refuse loudly rather than silently guessing.
+        async_unregister(hass, webhook_id)
+        await session.close()
+        raise ConfigEntryError(
+            f"Unknown OAuth mode {oauth_mode!r} in "
+            "/config/.mcp_proxy_dev_config.json. Valid values are 'ha_auth' and "
+            "'legacy'. Restart the Webhook Proxy addon to regenerate the "
+            "config file."
+        )
+    elif isinstance(oauth_section, dict):
+        # ── legacy: this integration's embedded authorization server ──────
+        # Reached for mode 'legacy' OR an absent mode key (creds-only
+        # back-compat with pre-ha_auth config files, which guarantees every
+        # existing legacy test keeps passing unchanged). Byte-for-byte the
+        # pre-ha_auth behavior below.
         client_id = str(oauth_section.get("client_id", ""))
         client_secret = str(oauth_section.get("client_secret", ""))
         if not client_id or not client_secret:
@@ -498,6 +599,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             oauth_provider.client_id_masked(),
         )
         hass_data["oauth"] = oauth_provider
+        hass_data["oauth_mode"] = OAUTH_MODE_LEGACY
 
     hass.data[DOMAIN] = hass_data
 
@@ -605,18 +707,26 @@ async def _handle_webhook(
 
     # OAuth gate. When OAuth isn't configured, `oauth_provider` is None and
     # this branch is a single attribute lookup with zero behavior change vs
-    # the original handler.
+    # the original handler. When it is configured, the bearer check dispatches
+    # by mode: ha_auth validates against HA core via the ResourceServer (async),
+    # legacy validates this integration's own signed bearer (sync). Either way
+    # an invalid/missing bearer yields the SAME 401 discovery challenge.
     oauth_provider = data.get("oauth")
-    if oauth_provider is not None and not oauth_provider.validate_bearer(request):
-        if debug:
-            await _debug_log(
-                hass,
-                "MCP Proxy [inbound]: -> 401 Unauthorized (no/invalid OAuth "
-                "bearer; expected for the initial discovery probe)",
-            )
-        from .oauth import build_unauthorized_response
+    if oauth_provider is not None:
+        if data.get("oauth_mode") == OAUTH_MODE_HA_AUTH:
+            authorized = await oauth_provider.validate_request(request)
+        else:
+            authorized = oauth_provider.validate_bearer(request)
+        if not authorized:
+            if debug:
+                await _debug_log(
+                    hass,
+                    "MCP Proxy [inbound]: -> 401 Unauthorized (no/invalid OAuth "
+                    "bearer; expected for the initial discovery probe)",
+                )
+            from .oauth import build_unauthorized_response
 
-        return build_unauthorized_response(request, oauth_provider)
+            return build_unauthorized_response(request, oauth_provider)
 
     body = await request.read()
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -429,10 +429,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # session (register_metadata_views no-ops when either mode already
             # bound them — see oauth._METADATA_VIEWS_REGISTERED_KEY), so a
             # config-entry reload or a live legacy->ha_auth switch doesn't
-            # stack shadowed duplicates. ha_auth binds NO root views (HA core
-            # owns /authorize + /token), so there is no owner-key / fingerprint
-            # bookkeeping and no restart concept — hence oauth_restart_needed
-            # stays False and the marker-CLEAR path runs below.
+            # stack shadowed duplicates. ha_auth binds NO root views (HA core is
+            # the authorization server, serving its own /auth/authorize +
+            # /auth/token; the bare /authorize + /token are the legacy flavor's
+            # own root views), so there is no owner-key / fingerprint bookkeeping
+            # and no restart concept — hence oauth_restart_needed stays False and
+            # the marker-CLEAR path runs below.
             register_metadata_views(hass, resource_server)
         except Exception as err:
             _LOGGER.exception(

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
@@ -1,0 +1,152 @@
+"""HA-native OAuth ("ha_auth" mode) resource-server support for the MCP Webhook Proxy.
+
+In this mode Home Assistant core is the OAuth authorization server and this
+add-on is a pure resource server. The add-on's only OAuth responsibility is
+serving the two discovery documents (host-agnostically, exactly as it already
+does) and validating bearer tokens via `hass.auth`; every protocol step —
+`/auth/authorize`, `/auth/token`, PKCE, refresh — is Home Assistant core's own
+maintained OAuth. That is what makes this mode "standardized": there is no
+bespoke authorization-server code here to review or keep in step with the spec,
+only the discovery documents plus a bearer check.
+
+Validated end-to-end against live claude.ai (a follow-up to issue #1714). Because
+the authorization-server document advertises Client ID Metadata Documents, it
+also unblocks ChatGPT (issue #1725): clients present a URL-shaped `client_id`
+(CIMD) with a same-origin redirect, which Home Assistant core's long-standing
+IndieAuth handling accepts, so the user never has to paste any add-on credential.
+home-assistant/core#153820 is field evidence that claude.ai and ChatGPT custom
+connectors work against this flow — the add-on has no code dependency on it and
+no minimum HA version is required.
+
+It works on ANY hostname regardless of Home Assistant's `external_url` — the whole
+reason the add-on serves the documents itself rather than relying on HA's own
+metadata, which degrades on hostnames HA does not recognize. And because ha_auth
+never binds any root HTTP view, enabling or disabling it never requires a Home
+Assistant restart (contrast the legacy embedded authorization server in `oauth.py`,
+whose `/authorize` + `/token` root views only bind cleanly at HA boot).
+
+This module is lazy-imported by `__init__.py` ONLY on the ha_auth code path, so
+the OAuth-off path stays behaviorally identical to the unauthenticated proxy and
+the legacy path never loads it. It reuses `oauth.py`'s base-URL helper and
+`OAUTH_BASE` rather than duplicating them.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+from aiohttp import web
+from homeassistant.core import HomeAssistant
+
+from .oauth import OAUTH_BASE, _build_base_url
+
+_LOGGER = logging.getLogger(__name__)
+
+# Value of the add-on's `oauth.mode` selector that activates HA-native auth.
+# Mirrored as the literal `"ha_auth"` in `oauth.py` (view mode dispatch) and
+# `__init__.py` (config dispatch); a test pins the three in agreement.
+HA_AUTH_MODE = "ha_auth"
+
+# Sanity marker asserted once by the ha_auth literal-agreement test. The test
+# suite feature-detects whether a webhook-proxy flavor ships ha_auth support by
+# the presence of this module file, not by this symbol (the stable flavor skips
+# the ha_auth tests until this module is promoted).
+AUTH_V2 = True
+
+
+def authorization_server_document(base: str) -> dict:
+    """Return the RFC 8414 authorization-server metadata for ha_auth mode.
+
+    Points MCP clients at Home Assistant core's own OAuth endpoints
+    (`/auth/authorize` + `/auth/token`) while keeping the issuer on the add-on's
+    host-agnostic `OAUTH_BASE`. `token_endpoint_auth_methods_supported` is
+    `["none"]` (a public client — HA ignores `client_secret`) and
+    `client_id_metadata_document_supported` is advertised so clients such as
+    claude.ai and ChatGPT present a URL-shaped `client_id` (CIMD). The flag is
+    advertisement-only: HA never fetches a CIMD document — a same-origin
+    URL-shaped `client_id` plus redirect is long-standing IndieAuth behavior
+    (home-assistant/core#153820 is field evidence of claude.ai and ChatGPT
+    working against it, not a dependency). No `registration_endpoint`:
+    dynamic client registration would hit Home Assistant, which offers none —
+    CIMD replaces it. The field contents were validated live against claude.ai.
+    """
+    return {
+        "issuer": f"{base}{OAUTH_BASE}",
+        "authorization_endpoint": f"{base}/auth/authorize",
+        "token_endpoint": f"{base}/auth/token",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "client_id_metadata_document_supported": True,
+    }
+
+
+class ResourceServer:
+    """Resource-server half of ha_auth mode.
+
+    Holds the per-install identity the discovery-document views need (the webhook
+    id plus the operator-pinned public base URL, if any) and validates inbound
+    bearer tokens against `hass.auth`. Unlike `oauth.OAuthProvider` it owns NO
+    signing key, NO client credentials, and registers NO root views — Home
+    Assistant core is the authorization server, so there is nothing here that a
+    restart would need to rebind.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        webhook_id: str,
+        public_base_url: str | None = None,
+    ) -> None:
+        self._hass = hass
+        self._webhook_id = webhook_id
+        self._public_base_url = public_base_url
+
+    @property
+    def webhook_id(self) -> str:
+        return self._webhook_id
+
+    def resource_url(self, base_url: str) -> str:
+        return f"{base_url}/api/webhook/{self._webhook_id}"
+
+    def authorization_server_url(self, base_url: str) -> str:
+        """The issuer / authorization-server URL embedded in the metadata
+        documents. Named to match what the shared discovery-document views in
+        `oauth.py` call (so ha_auth reuses them unchanged)."""
+        return f"{base_url}{OAUTH_BASE}"
+
+    def base_url_for(self, request: web.Request) -> str:
+        return _build_base_url(request, self._public_base_url)
+
+    async def validate_request(self, request: web.Request) -> bool:
+        """Return True iff the request carries a Bearer token Home Assistant accepts.
+
+        A missing or malformed `Authorization` header is rejected WITHOUT
+        touching the validator. Otherwise the token is handed to
+        `hass.auth.async_validate_access_token`, which returns the backing
+        `RefreshToken` (truthy) or `None` — but it is not exception-proof (a
+        crafted unsigned token can make it raise outside `jwt.InvalidTokenError`),
+        so any raise here is treated as unauthorized and the caller emits its
+        normal 401 challenge instead of a 500. That method is a synchronous
+        `@callback` in HA core (`homeassistant/auth/__init__.py`); we still await
+        defensively iff a future Home Assistant turns it into a coroutine.
+        """
+        header = request.headers.get("Authorization", "")
+        if not header.lower().startswith("bearer "):
+            return False
+        token = header[7:].strip()
+        if not token:
+            return False
+        try:
+            result = self._hass.auth.async_validate_access_token(token)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception:
+            _LOGGER.debug(
+                "ha_auth: bearer validation raised; treating as unauthorized",
+                exc_info=True,
+            )
+            return False
+        return result is not None

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.3.dev3"
+  "version": "1.2.3.dev4"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -315,13 +315,18 @@ class MetadataProvider(Protocol):
     """
 
     @property
-    def webhook_id(self) -> str: ...
+    def webhook_id(self) -> str:
+        """This install's private webhook id."""
 
-    def resource_url(self, base_url: str) -> str: ...
+    def resource_url(self, base_url: str) -> str:
+        """Absolute URL of the protected webhook resource under ``base_url``."""
 
-    def authorization_server_url(self, base_url: str) -> str: ...
+    def authorization_server_url(self, base_url: str) -> str:
+        """Issuer / authorization-server URL under ``base_url``."""
 
-    def base_url_for(self, request: web.Request) -> str: ...
+    def base_url_for(self, request: web.Request) -> str:
+        """Public base URL for ``request`` per the provider's policy
+        (legacy: pinned to the configured URL; ha_auth: request-host-derived)."""
 
 
 def _active_oauth_mode(provider: object) -> str | None:

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -65,11 +65,13 @@ DOMAIN = "mcp_proxy_dev"
 # TOP-LEVEL hass.data key (deliberately NOT under DOMAIN, so it survives
 # async_unload_entry's hass.data.pop(DOMAIN)) recording that the seven
 # discovery-document metadata views are bound to aiohttp for this HA session.
-# aiohttp raises ValueError on a duplicate view name and HA cannot unregister a
-# bound view until it restarts, so register_metadata_views must bind the seven
-# at most once: a same-mode ha_auth reload, a legacy->ha_auth switch, or a
-# ha_auth->legacy switch all reuse the already-bound views instead of
-# re-registering them (which would raise and fail the reload).
+# HA registers views with no route name and leaves the router unfrozen, so a
+# duplicate registration does NOT raise — aiohttp lets the first-registered
+# path win and silently shadows the later one; HA also can't unregister a bound
+# view until it restarts. So register_metadata_views must bind the seven at
+# most once: a same-mode ha_auth reload, a legacy->ha_auth switch, or a
+# ha_auth->legacy switch all reuse the already-bound views instead of stacking
+# silently-shadowed duplicate routes on every reload/switch.
 #
 # Suffixed with DOMAIN so each add-on flavor gets its OWN top-level flag: the
 # metadata-view URLs and names embed the flavor's DOMAIN and therefore never
@@ -448,12 +450,16 @@ class OAuthProvider:
         flag-guarded `register_metadata_views` (which binds them at most once
         per HA session — see `_METADATA_VIEWS_REGISTERED_KEY`), then registers
         ONLY the two root views (`AuthorizeView` + `TokenView`). ha_auth mode
-        registers just the seven metadata views (HA core owns `/authorize` +
-        `/token`, so it binds no root views); routing both modes through the
-        same registrar means a legacy<->ha_auth switch or a same-mode reload
-        never re-registers the seven and trips aiohttp's duplicate-view
-        ValueError. The two root views stay gated by the caller's route-owner /
-        fingerprint logic in __init__.py.
+        registers just the seven metadata views (HA core is the authorization
+        server, serving its own `/auth/authorize` + `/auth/token`, so the
+        add-on binds no root views); the bare `/authorize` + `/token` here are
+        this add-on's OWN legacy root views. Routing both modes through the same
+        registrar means a legacy<->ha_auth switch or a same-mode reload reuses
+        the already-bound seven instead of stacking silently-shadowed duplicate
+        routes (a duplicate registration does not raise — aiohttp lets the
+        first-registered path win — and HA can't unregister a bound view until
+        it restarts). The two root views stay gated by the caller's route-owner
+        / fingerprint logic in __init__.py.
         """
         register_metadata_views(self._hass, self)
         for view in (AuthorizeView(self), TokenView(self)):
@@ -483,11 +489,17 @@ class OAuthProvider:
             return False
         try:
             actual_sig = _b64url_decode(sig_part)
-        except (ValueError, binascii.Error):
+            # body.encode("ascii") is inside the try: a bearer whose
+            # pre-signature segment carries a non-ASCII char raises
+            # UnicodeEncodeError, which must be caught here (return False)
+            # rather than escaping the webhook gate — HA core's
+            # async_handle_webhook would swallow the exception into a 200 OK
+            # and never emit the 401 discovery challenge.
+            expected_sig = hmac.new(
+                self._signing_key, body.encode("ascii"), hashlib.sha256
+            ).digest()
+        except (ValueError, binascii.Error, UnicodeEncodeError):
             return False
-        expected_sig = hmac.new(
-            self._signing_key, body.encode("ascii"), hashlib.sha256
-        ).digest()
         if not hmac.compare_digest(actual_sig, expected_sig):
             return False
         try:
@@ -756,11 +768,12 @@ class AuthorizeView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
-            # Serve ONLY when legacy is the live mode. Both ha_auth (HA core owns
-            # /authorize) and None (entry unloaded / OAuth off) mean this
-            # stale-bound root view must not serve: HA can't rebind or drop root
-            # views without a restart, so a legacy->ha_auth switch OR an unload
-            # leaves it bound. Refuse it.
+            # Serve ONLY when legacy is the live mode. Both ha_auth (HA core is
+            # the authorization server on its own /auth/authorize; this bare
+            # /authorize is the add-on's own legacy view) and None (entry
+            # unloaded / OAuth off) mean this stale-bound root view must not
+            # serve: HA can't rebind or drop root views without a restart, so a
+            # legacy->ha_auth switch OR an unload leaves it bound. Refuse it.
             return _text_error(404, "not found")
         params = request.query
         client_id = params.get("client_id", "")
@@ -815,7 +828,9 @@ class AuthorizeView(HomeAssistantView):
     async def post(self, request: web.Request) -> web.Response:
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is live (see the GET defense above): ha_auth
-            # (HA core owns /authorize) and the unloaded/None case both 404.
+            # (HA core is the authorization server on its own /auth/authorize;
+            # this bare /authorize is the add-on's own legacy view) and the
+            # unloaded/None case both 404.
             return _text_error(404, "not found")
         data = await request.post()
         action = str(data.get("action", ""))
@@ -912,9 +927,11 @@ class TokenView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
-            # Serve ONLY when legacy is live. Both ha_auth (HA core owns /token)
-            # and the unloaded/None case must not mint tokens from this
-            # stale-bound view (see AuthorizeView for the switch scenario).
+            # Serve ONLY when legacy is live. Both ha_auth (HA core is the
+            # authorization server on its own /auth/token; this bare /token is
+            # the add-on's own legacy view) and the unloaded/None case must not
+            # mint tokens from this stale-bound view (see AuthorizeView for the
+            # switch scenario).
             return _json_not_found()
         form = dict(await request.post())
         client_id, client_secret = self._extract_client_creds(request, form)
@@ -1011,20 +1028,22 @@ def _metadata_views(provider: MetadataProvider) -> list[HomeAssistantView]:
 def register_metadata_views(hass: HomeAssistant, provider: MetadataProvider) -> None:
     """Register ONLY the seven discovery-document views (ha_auth mode).
 
-    ha_auth serves just these — Home Assistant core owns `/authorize` +
-    `/token`, so the add-on binds no root views and no HA restart is ever needed
-    to enable or disable the mode. ``provider`` is an
-    `auth_native.ResourceServer` (ha_auth) or an `OAuthProvider` (legacy, which
-    routes its seven views through here); the views read its `base_url_for`,
-    `resource_url`, `authorization_server_url`, `webhook_id`, and `_hass` (read
-    by `_active_oauth_mode` AND `_active_provider` for per-request mode/provider
-    dispatch).
+    ha_auth serves just these — Home Assistant core is the authorization server,
+    serving its own `/auth/authorize` + `/auth/token`, so the add-on binds no
+    root views (the bare `/authorize` + `/token` are the legacy flavor's own
+    root views) and no HA restart is ever needed to enable or disable the mode.
+    ``provider`` is an `auth_native.ResourceServer` (ha_auth) or an
+    `OAuthProvider` (legacy, which routes its seven views through here); the
+    views read its `base_url_for`, `resource_url`, `authorization_server_url`,
+    `webhook_id`, and `_hass` (read by `_active_oauth_mode` AND
+    `_active_provider` for per-request mode/provider dispatch).
 
     Idempotent per HA session: the seven views bind at most once — a same-mode
     reload or a legacy<->ha_auth switch reuses the already-bound views rather
-    than re-registering them (aiohttp raises ValueError on a duplicate view name
-    and HA can't drop a bound view until it restarts). The guard flag lives at a
-    top-level hass.data key so it survives async_unload_entry's pop(DOMAIN).
+    than stacking silently-shadowed duplicate routes (a duplicate registration
+    does not raise — aiohttp lets the first-registered path win — and HA can't
+    drop a bound view until it restarts). The guard flag lives at a top-level
+    hass.data key so it survives async_unload_entry's pop(DOMAIN).
     """
     if hass.data.get(_METADATA_VIEWS_REGISTERED_KEY):
         return

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -56,6 +56,36 @@ AUTHORIZE_PATH = "/authorize"
 TOKEN_PATH = "/token"
 SECRET_FILE = Path("/config/.mcp_proxy_dev_oauth_secret")
 
+# Shared hass.data key for the integration (matches __init__.py DOMAIN). The
+# mode-aware discovery-document views read the ACTIVE OAuth mode from
+# hass.data[DOMAIN] at request time (see _active_oauth_mode) so the SAME
+# registered view instances serve whichever mode is live now.
+DOMAIN = "mcp_proxy_dev"
+
+# TOP-LEVEL hass.data key (deliberately NOT under DOMAIN, so it survives
+# async_unload_entry's hass.data.pop(DOMAIN)) recording that the seven
+# discovery-document metadata views are bound to aiohttp for this HA session.
+# aiohttp raises ValueError on a duplicate view name and HA cannot unregister a
+# bound view until it restarts, so register_metadata_views must bind the seven
+# at most once: a same-mode ha_auth reload, a legacy->ha_auth switch, or a
+# ha_auth->legacy switch all reuse the already-bound views instead of
+# re-registering them (which would raise and fail the reload).
+#
+# Suffixed with DOMAIN so each add-on flavor gets its OWN top-level flag: the
+# metadata-view URLs and names are domain-specific (mcp_proxy_dev vs mcp_proxy)
+# and therefore never collide across flavors, so one flavor's flag must not
+# suppress the other flavor's (non-colliding) registration if both run ha_auth
+# once this dev code promotes to stable.
+_METADATA_VIEWS_REGISTERED_KEY = (
+    f"webhook_proxy_oauth_metadata_views_registered_{DOMAIN}"
+)
+
+# OAuth mode markers. Mirrored as auth_native.HA_AUTH_MODE and __init__.py's
+# OAUTH_MODE_* (a test pins them in agreement). ha_auth = HA core is the
+# authorization server; legacy = this module's embedded authorization server.
+MODE_HA_AUTH = "ha_auth"
+MODE_LEGACY = "legacy"
+
 ACCESS_TOKEN_TTL = 60 * 60  # 1 hour
 REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60  # 30 days
 AUTH_CODE_TTL = 5 * 60  # 5 minutes
@@ -126,6 +156,14 @@ def _json_error(
     if restart_hint:
         body["error_description"] = RESTART_HINT
     return web.json_response(body, status=status, headers=headers)
+
+
+def _json_not_found() -> web.Response:
+    """404 for an OAuth view whose integration data is gone (the config entry
+    was unloaded but HA can't drop the bound view until a restart) or whose
+    route is disabled in the active mode. MCP clients fall through their
+    discovery chain on a 404, so this matches the not-registered behavior."""
+    return web.json_response({"error": "not_found"}, status=404)
 
 
 class _PendingCode(TypedDict):
@@ -266,6 +304,51 @@ def _build_base_url(request: web.Request, public_base_url: str | None = None) ->
     return f"{scheme}://{host}"
 
 
+def _active_oauth_mode(provider: object) -> str | None:
+    """Return the OAuth mode currently active for this integration.
+
+    Read live from hass.data so the SAME registered view instances serve
+    whichever mode is active now — e.g. a legacy-bound view after the operator
+    switched the add-on to ha_auth, which Home Assistant cannot rebind without a
+    restart. Returns ``MODE_HA_AUTH`` or ``MODE_LEGACY``, or ``None`` when no
+    mode is live — the integration data is gone (the config entry was unloaded)
+    or present without an ``oauth_mode`` key (reloaded with OAuth turned off) —
+    so a stale view can 404 like an unregistered route; HA can't drop the bound
+    views until a restart either way. A non-dict ``hass.data[DOMAIN]`` (only
+    happens with test doubles) defaults to ``MODE_LEGACY``, the pre-ha_auth
+    behavior.
+    """
+    hass = getattr(provider, "_hass", None)
+    domain_data = hass.data.get(DOMAIN) if hass is not None else None
+    if domain_data is None:
+        return None
+    if not isinstance(domain_data, dict):
+        return MODE_LEGACY
+    return domain_data.get("oauth_mode")
+
+
+def _active_provider(bound_provider: object) -> object:
+    """Return the provider whose base-URL policy is active right now.
+
+    After a live mode switch the still-bound view instances were constructed
+    with the PREVIOUS mode's provider (HA can't rebind views mid-session), and
+    the two modes build URLs differently: legacy pins the base URL to the
+    operator-configured public_base_url (Host-poisoning resistance) while
+    ha_auth derives it from the request host (the same install must work via
+    any hostname). Resolving ``hass.data[DOMAIN]["oauth"]`` at request time
+    applies whichever policy is live; falls back to the bound provider when the
+    domain data is absent (test doubles — the unloaded case already 404s in the
+    views before any URL is built).
+    """
+    hass = getattr(bound_provider, "_hass", None)
+    domain_data = hass.data.get(DOMAIN) if hass is not None else None
+    if isinstance(domain_data, dict):
+        active = domain_data.get("oauth")
+        if active is not None:
+            return active
+    return bound_provider
+
+
 class OAuthProvider:
     """Holds OAuth state and registers HA HTTP views.
 
@@ -334,42 +417,21 @@ class OAuthProvider:
     # -----------------------------------------------------------------
 
     def register_views(self) -> None:
-        """Register the OAuth endpoints with HA's HTTP layer.
+        """Register the legacy OAuth endpoints with HA's HTTP layer.
 
-        Besides the four core views, the metadata documents are also served
-        at the RFC 8414 / RFC 9728 / OIDC-discovery well-known locations —
-        see the WellKnown* view docstrings for the live-captured client
-        behavior (issue #1714) that makes those locations load-bearing.
+        Delegates the seven discovery-document views to the shared,
+        flag-guarded `register_metadata_views` (which binds them at most once
+        per HA session — see `_METADATA_VIEWS_REGISTERED_KEY`), then registers
+        ONLY the two root views (`AuthorizeView` + `TokenView`). ha_auth mode
+        registers just the seven metadata views (HA core owns `/authorize` +
+        `/token`, so it binds no root views); routing both modes through the
+        same registrar means a legacy<->ha_auth switch or a same-mode reload
+        never re-registers the seven and trips aiohttp's duplicate-view
+        ValueError. The two root views stay gated by the caller's route-owner /
+        fingerprint logic in __init__.py.
         """
-        views: list[HomeAssistantView] = [
-            ProtectedResourceMetadataView(self),
-            AuthorizationServerMetadataView(self),
-            AuthorizeView(self),
-            TokenView(self),
-            WellKnownProtectedResourceView(self),
-        ]
-        for url, name in (
-            (
-                f"/.well-known/oauth-authorization-server{OAUTH_BASE}",
-                "mcp_proxy_dev:oauth:wellknown-as-rfc8414",
-            ),
-            (
-                f"/.well-known/openid-configuration{OAUTH_BASE}",
-                "mcp_proxy_dev:oauth:wellknown-oidc-prefixed",
-            ),
-            (
-                f"{OAUTH_BASE}/.well-known/openid-configuration",
-                "mcp_proxy_dev:oauth:wellknown-oidc-suffixed",
-            ),
-            (
-                f"{OAUTH_BASE}/.well-known/oauth-authorization-server",
-                "mcp_proxy_dev:oauth:wellknown-as-suffixed",
-            ),
-        ):
-            views.append(
-                WellKnownAuthorizationServerMetadataView(self, url=url, name=name)
-            )
-        for view in views:
+        register_metadata_views(self._hass, self)
+        for view in (AuthorizeView(self), TokenView(self)):
             self._hass.http.register_view(view)
 
     # -----------------------------------------------------------------
@@ -519,13 +581,20 @@ class ProtectedResourceMetadataView(HomeAssistantView):
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
-        base = self._provider.base_url_for(request)
+        # The protected-resource document has the same shape in both OAuth
+        # modes; only 404 when no mode is live (entry unloaded / OAuth off) so a
+        # stale-bound view acts like an unregistered route. URLs are built via
+        # the ACTIVE mode's provider, not the instance this view was bound with,
+        # so a live mode switch also switches the base-URL policy (legacy:
+        # pinned; ha_auth: host-derived).
+        if _active_oauth_mode(self._provider) is None:
+            return _json_not_found()
+        provider = _active_provider(self._provider)
+        base = provider.base_url_for(request)
         return web.json_response(
             {
-                "resource": self._provider.resource_url(base),
-                "authorization_servers": [
-                    self._provider.authorization_server_url(base)
-                ],
+                "resource": provider.resource_url(base),
+                "authorization_servers": [provider.authorization_server_url(base)],
                 "bearer_methods_supported": ["header"],
                 "resource_documentation": (
                     "https://github.com/homeassistant-ai/ha-mcp"
@@ -546,8 +615,25 @@ class AuthorizationServerMetadataView(HomeAssistantView):
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
-        base = self._provider.base_url_for(request)
-        as_url = self._provider.authorization_server_url(base)
+        mode = _active_oauth_mode(self._provider)
+        if mode is None:
+            # No mode is live (entry unloaded / OAuth off) but HA can't drop
+            # this bound view until a restart — behave like an unregistered
+            # route.
+            return _json_not_found()
+        # Build URLs via the ACTIVE mode's provider (see _active_provider): a
+        # legacy-bound view serving the ha_auth document must use ha_auth's
+        # host-derived base URL, and vice versa the legacy pinned one.
+        provider = _active_provider(self._provider)
+        base = provider.base_url_for(request)
+        if mode == MODE_HA_AUTH:
+            # HA core is the authorization server: advertise its /auth/* endpoints
+            # + CIMD. Built in auth_native, imported lazily to avoid an import
+            # cycle (auth_native imports this module at load).
+            from .auth_native import authorization_server_document
+
+            return web.json_response(authorization_server_document(base))
+        as_url = provider.authorization_server_url(base)
         return web.json_response(
             {
                 "issuer": as_url,
@@ -644,6 +730,13 @@ class AuthorizeView(HomeAssistantView):
         )
 
     async def get(self, request: web.Request) -> web.Response:
+        if _active_oauth_mode(self._provider) != MODE_LEGACY:
+            # Serve ONLY when legacy is the live mode. Both ha_auth (HA core owns
+            # /authorize) and None (entry unloaded / OAuth off) mean this
+            # stale-bound root view must not serve: HA can't rebind or drop root
+            # views without a restart, so a legacy->ha_auth switch OR an unload
+            # leaves it bound. Refuse it.
+            return _text_error(404, "not found")
         params = request.query
         client_id = params.get("client_id", "")
         redirect_uri = params.get("redirect_uri", "")
@@ -695,6 +788,10 @@ class AuthorizeView(HomeAssistantView):
         return web.Response(text=html, content_type="text/html")
 
     async def post(self, request: web.Request) -> web.Response:
+        if _active_oauth_mode(self._provider) != MODE_LEGACY:
+            # Serve ONLY when legacy is live (see the GET defense above): ha_auth
+            # (HA core owns /authorize) and the unloaded/None case both 404.
+            return _text_error(404, "not found")
         data = await request.post()
         action = str(data.get("action", ""))
         client_id = str(data.get("client_id", ""))
@@ -789,6 +886,11 @@ class TokenView(HomeAssistantView):
         return form.get("client_id"), form.get("client_secret")
 
     async def post(self, request: web.Request) -> web.Response:
+        if _active_oauth_mode(self._provider) != MODE_LEGACY:
+            # Serve ONLY when legacy is live. Both ha_auth (HA core owns /token)
+            # and the unloaded/None case must not mint tokens from this
+            # stale-bound view (see AuthorizeView for the switch scenario).
+            return _json_not_found()
         form = dict(await request.post())
         client_id, client_secret = self._extract_client_creds(request, form)
         if not self._provider.authenticate_client(client_id, client_secret):
@@ -835,6 +937,75 @@ class TokenView(HomeAssistantView):
                 "refresh_token": self._provider.issue_refresh_token(),
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# Metadata-view registration (shared by legacy register_views + ha_auth)
+# ---------------------------------------------------------------------------
+
+
+def _metadata_views(provider: object) -> list[HomeAssistantView]:
+    """Build the seven discovery-document views bound to ``provider``.
+
+    The canonical protected-resource + authorization-server documents, the
+    path-scoped protected-resource document, and the four RFC 8414 / OIDC
+    well-known authorization-server locations (issue #1714). These serve the
+    same content in both OAuth modes (the AS view dispatches per-request); the
+    root `AuthorizeView` + `TokenView` are legacy-only and added by
+    `OAuthProvider.register_views`, never here.
+    """
+    views: list[HomeAssistantView] = [
+        ProtectedResourceMetadataView(provider),
+        AuthorizationServerMetadataView(provider),
+        WellKnownProtectedResourceView(provider),
+    ]
+    for url, name in (
+        (
+            f"/.well-known/oauth-authorization-server{OAUTH_BASE}",
+            "mcp_proxy_dev:oauth:wellknown-as-rfc8414",
+        ),
+        (
+            f"/.well-known/openid-configuration{OAUTH_BASE}",
+            "mcp_proxy_dev:oauth:wellknown-oidc-prefixed",
+        ),
+        (
+            f"{OAUTH_BASE}/.well-known/openid-configuration",
+            "mcp_proxy_dev:oauth:wellknown-oidc-suffixed",
+        ),
+        (
+            f"{OAUTH_BASE}/.well-known/oauth-authorization-server",
+            "mcp_proxy_dev:oauth:wellknown-as-suffixed",
+        ),
+    ):
+        views.append(
+            WellKnownAuthorizationServerMetadataView(provider, url=url, name=name)
+        )
+    return views
+
+
+def register_metadata_views(hass: HomeAssistant, provider: object) -> None:
+    """Register ONLY the seven discovery-document views (ha_auth mode).
+
+    ha_auth serves just these — Home Assistant core owns `/authorize` +
+    `/token`, so the add-on binds no root views and no HA restart is ever needed
+    to enable or disable the mode. ``provider`` is an
+    `auth_native.ResourceServer` (ha_auth) or an `OAuthProvider` (legacy, which
+    routes its seven views through here); the views read its `base_url_for`,
+    `resource_url`, `authorization_server_url`, `webhook_id`, and `_hass` (read
+    by `_active_oauth_mode` AND `_active_provider` for per-request mode/provider
+    dispatch).
+
+    Idempotent per HA session: the seven views bind at most once — a same-mode
+    reload or a legacy<->ha_auth switch reuses the already-bound views rather
+    than re-registering them (aiohttp raises ValueError on a duplicate view name
+    and HA can't drop a bound view until it restarts). The guard flag lives at a
+    top-level hass.data key so it survives async_unload_entry's pop(DOMAIN).
+    """
+    if hass.data.get(_METADATA_VIEWS_REGISTERED_KEY):
+        return
+    for view in _metadata_views(provider):
+        hass.http.register_view(view)
+    hass.data[_METADATA_VIEWS_REGISTERED_KEY] = True
 
 
 # ---------------------------------------------------------------------------

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -36,7 +36,7 @@ import secrets
 import time
 from html import escape
 from pathlib import Path
-from typing import TypedDict
+from typing import Protocol, TypedDict
 from urllib.parse import urlparse
 
 from aiohttp import web
@@ -72,8 +72,8 @@ DOMAIN = "mcp_proxy_dev"
 # re-registering them (which would raise and fail the reload).
 #
 # Suffixed with DOMAIN so each add-on flavor gets its OWN top-level flag: the
-# metadata-view URLs and names are domain-specific (mcp_proxy_dev vs mcp_proxy)
-# and therefore never collide across flavors, so one flavor's flag must not
+# metadata-view URLs and names embed the flavor's DOMAIN and therefore never
+# collide across flavors, so one flavor's flag must not
 # suppress the other flavor's (non-colliding) registration if both run ha_auth
 # once this dev code promotes to stable.
 _METADATA_VIEWS_REGISTERED_KEY = (
@@ -304,6 +304,26 @@ def _build_base_url(request: web.Request, public_base_url: str | None = None) ->
     return f"{scheme}://{host}"
 
 
+class MetadataProvider(Protocol):
+    """Interface the mode-aware discovery-document views need from a provider.
+
+    Satisfied structurally by both `OAuthProvider` (legacy) and
+    `auth_native.ResourceServer` (ha_auth). The views additionally read the
+    implementation's `_hass` via ``getattr`` (see `_active_oauth_mode` /
+    `_active_provider`), which a Protocol cannot express for a private
+    attribute — both implementations carry it.
+    """
+
+    @property
+    def webhook_id(self) -> str: ...
+
+    def resource_url(self, base_url: str) -> str: ...
+
+    def authorization_server_url(self, base_url: str) -> str: ...
+
+    def base_url_for(self, request: web.Request) -> str: ...
+
+
 def _active_oauth_mode(provider: object) -> str | None:
     """Return the OAuth mode currently active for this integration.
 
@@ -327,7 +347,7 @@ def _active_oauth_mode(provider: object) -> str | None:
     return domain_data.get("oauth_mode")
 
 
-def _active_provider(bound_provider: object) -> object:
+def _active_provider(bound_provider: MetadataProvider) -> MetadataProvider:
     """Return the provider whose base-URL policy is active right now.
 
     After a live mode switch the still-bound view instances were constructed
@@ -343,7 +363,7 @@ def _active_provider(bound_provider: object) -> object:
     hass = getattr(bound_provider, "_hass", None)
     domain_data = hass.data.get(DOMAIN) if hass is not None else None
     if isinstance(domain_data, dict):
-        active = domain_data.get("oauth")
+        active: MetadataProvider | None = domain_data.get("oauth")
         if active is not None:
             return active
     return bound_provider
@@ -577,7 +597,7 @@ class ProtectedResourceMetadataView(HomeAssistantView):
     url = f"{OAUTH_BASE}/protected-resource"
     name = "mcp_proxy_dev:oauth:protected-resource"
 
-    def __init__(self, provider: OAuthProvider) -> None:
+    def __init__(self, provider: MetadataProvider) -> None:
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
@@ -611,7 +631,7 @@ class AuthorizationServerMetadataView(HomeAssistantView):
     url = f"{OAUTH_BASE}/authorization-server"
     name = "mcp_proxy_dev:oauth:authorization-server"
 
-    def __init__(self, provider: OAuthProvider) -> None:
+    def __init__(self, provider: MetadataProvider) -> None:
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
@@ -672,7 +692,7 @@ class WellKnownProtectedResourceView(ProtectedResourceMetadataView):
 
     name = "mcp_proxy_dev:oauth:wellknown-protected-resource"
 
-    def __init__(self, provider: OAuthProvider) -> None:
+    def __init__(self, provider: MetadataProvider) -> None:
         super().__init__(provider)
         # Instance-level URL: the well-known path embeds this install's
         # webhook id, which is only known at runtime.
@@ -701,7 +721,7 @@ class WellKnownAuthorizationServerMetadataView(AuthorizationServerMetadataView):
       `code_challenge_methods_supported` they otherwise never see).
     """
 
-    def __init__(self, provider: OAuthProvider, url: str, name: str) -> None:
+    def __init__(self, provider: MetadataProvider, url: str, name: str) -> None:
         super().__init__(provider)
         self.url = url
         self.name = name
@@ -944,7 +964,7 @@ class TokenView(HomeAssistantView):
 # ---------------------------------------------------------------------------
 
 
-def _metadata_views(provider: object) -> list[HomeAssistantView]:
+def _metadata_views(provider: MetadataProvider) -> list[HomeAssistantView]:
     """Build the seven discovery-document views bound to ``provider``.
 
     The canonical protected-resource + authorization-server documents, the
@@ -983,7 +1003,7 @@ def _metadata_views(provider: object) -> list[HomeAssistantView]:
     return views
 
 
-def register_metadata_views(hass: HomeAssistant, provider: object) -> None:
+def register_metadata_views(hass: HomeAssistant, provider: MetadataProvider) -> None:
     """Register ONLY the seven discovery-document views (ha_auth mode).
 
     ha_auth serves just these — Home Assistant core owns `/authorize` +
@@ -1014,7 +1034,7 @@ def register_metadata_views(hass: HomeAssistant, provider: object) -> None:
 
 
 def build_unauthorized_response(
-    request: web.Request, provider: OAuthProvider
+    request: web.Request, provider: MetadataProvider
 ) -> web.Response:
     """Build the 401 + WWW-Authenticate response that MCP clients use to
     discover the OAuth endpoints.

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -53,6 +53,10 @@ def log_info(message: str) -> None:
     _log("INFO", message)
 
 
+def log_warning(message: str) -> None:
+    _log("WARNING", message, sys.stderr)
+
+
 def log_error(message: str) -> None:
     _log("ERROR", message, sys.stderr)
 
@@ -67,6 +71,16 @@ def log_error(message: str) -> None:
 MCP_ADDON_SLUG_SUFFIXES = ["_ha_mcp", "_ha_mcp_dev"]
 # Also try exact slugs for official repo installs
 MCP_ADDON_EXACT_SLUGS = ["ha_mcp", "ha_mcp_dev"]
+
+# OAuth mode values written into the proxy config's `oauth.mode`. Mirrored by
+# the integration (mcp_proxy_dev.OAUTH_MODE_* / auth_native.HA_AUTH_MODE).
+#   ha_auth — HA core is the authorization server; no add-on credentials, no
+#             signing key, no HA restart. Sign in with your Home Assistant login.
+#   legacy  — the previous embedded authorization server (client id/secret).
+# ha_auth is the default only for a FIRST-TIME OAuth enable; existing legacy
+# setups are auto-detected and kept on legacy so an upgrade never switches them.
+HA_AUTH_MODE = "ha_auth"
+LEGACY_MODE = "legacy"
 
 # ---------------------------------------------------------------------------
 # Mutual exclusion (dev vs stable webhook proxy)
@@ -606,6 +620,73 @@ def _resolve_oauth_creds(
     return final_id, final_secret
 
 
+def _resolve_oauth_mode(
+    configured_mode: str, configured_id: str, configured_secret: str, data_dir: Path
+) -> str:
+    """Decide which OAuth mode to activate, logging which rule fired.
+
+    Upgrade-safe precedence — an existing legacy OAuth user is NEVER switched
+    silently by an add-on update:
+      1. An explicit ``oauth_mode`` add-on option wins outright.
+      2. Otherwise, if legacy OAuth is already in use — the user set
+         ``oauth_client_id``/``oauth_client_secret``, OR a persisted legacy
+         creds file (``/data/oauth_creds.json``) exists from a prior run —
+         stay on ``legacy``.
+      3. Otherwise (a first-time enable with no legacy trace) default to
+         ``ha_auth``, the recommended mode.
+    Switching an existing setup is therefore an explicit user action
+    (set ``oauth_mode``), which also requires re-adding the MCP connector.
+    """
+    mode = (configured_mode or "").strip().lower()
+    if mode in (HA_AUTH_MODE, LEGACY_MODE):
+        log_info(f"OAuth mode: '{mode}' (set explicitly via the oauth_mode option)")
+        return mode
+    if mode:
+        # Supervisor validates the option against the schema enum, so an unknown
+        # value should be unreachable — but fall through to detection rather
+        # than crash if one ever gets here.
+        log_error(
+            f"Ignoring unrecognized oauth_mode '{configured_mode}' "
+            f"(valid: '{HA_AUTH_MODE}', '{LEGACY_MODE}'); auto-detecting instead."
+        )
+    creds_file = data_dir / "oauth_creds.json"
+    try:
+        creds_file_exists = creds_file.exists()
+    except OSError as e:
+        # Path.exists() re-raises stat errors other than "not there" (e.g.
+        # EACCES). A stat failure is no proof of a legacy install, so treat
+        # the file as absent and keep auto-detecting instead of crashing
+        # startup; the ha_auth-default warning below still tells a legacy
+        # user how to get back.
+        log_error(
+            f"Could not check {creds_file} ({type(e).__name__}): {e}; "
+            "treating it as absent for OAuth mode detection."
+        )
+        creds_file_exists = False
+    if configured_id.strip() or configured_secret.strip() or creds_file_exists:
+        log_info(
+            "OAuth mode: 'legacy' — existing legacy OAuth credentials detected "
+            "(a configured client id/secret or a persisted /data/oauth_creds.json). "
+            f"Staying on legacy mode; set oauth_mode: {HA_AUTH_MODE} to switch "
+            "(you must then re-add your MCP connector)."
+        )
+        return LEGACY_MODE
+    log_info(
+        f"OAuth mode: '{HA_AUTH_MODE}' (default for a first-time OAuth enable — "
+        "sign in with your Home Assistant account; leave the connector's OAuth "
+        "fields blank)."
+    )
+    # OAuth was already enabled but no legacy trace was found. Normally that
+    # IS a first-time enable — but if a legacy user's /data trace was lost,
+    # this default silently changes their flow, so say how to get back.
+    log_warning(
+        f"Defaulting to '{HA_AUTH_MODE}'. If you previously used the legacy "
+        "OAuth flow, your existing connector must be re-added — or set "
+        f"oauth_mode: {LEGACY_MODE} to keep the previous flow."
+    )
+    return HA_AUTH_MODE
+
+
 def _get_or_create_webhook_id(data_dir: Path) -> str:
     """Get or create a persistent webhook ID."""
     wh_file = data_dir / "webhook_id.txt"
@@ -1009,6 +1090,7 @@ def main() -> int:
     enable_oauth = False
     oauth_client_id = ""
     oauth_client_secret = ""
+    oauth_mode_option = ""
     regenerate_oauth_creds = False
     debug_logging = False
     config: dict = {}
@@ -1022,17 +1104,38 @@ def main() -> int:
             enable_oauth = bool(config.get("enable_oauth", False))
             oauth_client_id = config.get("oauth_client_id", "")
             oauth_client_secret = config.get("oauth_client_secret", "")
+            # Unset by default in config.yaml options (no default value), so an
+            # upgrader inherits nothing — the mode is resolved below.
+            oauth_mode_option = config.get("oauth_mode", "")
             regenerate_oauth_creds = bool(config.get("regenerate_oauth_creds", False))
             debug_logging = bool(config.get("debug_logging", False))
         except (OSError, json.JSONDecodeError) as e:
             log_error(f"Failed to read config ({type(e).__name__}): {e}")
 
-    # OAuth credential resolution: user-supplied values in the addon config
-    # win. Otherwise fall back to a persisted creds file in /data, and if
-    # that doesn't exist either, auto-generate. This makes the happy path
-    # "toggle on, restart, copy creds from log" without the user ever having
-    # to invent secret strings.
+    # OAuth mode + credential resolution. ha_auth (HA-native) needs no add-on
+    # credentials at all; legacy resolves/persists a client id + secret (user
+    # value wins, else a persisted /data file, else auto-generated) so the happy
+    # path is "toggle on, restart, copy creds from log".
+    oauth_mode = ""
     if enable_oauth:
+        oauth_mode = _resolve_oauth_mode(
+            oauth_mode_option, oauth_client_id, oauth_client_secret, data_dir
+        )
+    if enable_oauth and oauth_mode == HA_AUTH_MODE:
+        # HA core is the authorization server: no credential resolution,
+        # generation, or persistence; no regenerate handling. The regenerate
+        # toggle only applies to legacy creds. (The fail-closed stale-code
+        # restart probe below still runs in this mode — it closes the
+        # code-upgrade fail-open window without breaking the no-restart-to-
+        # toggle promise.)
+        if regenerate_oauth_creds:
+            log_info(
+                "Ignoring 'Regenerate OAuth Credentials on Next Start': it only "
+                "applies to legacy OAuth mode. In ha_auth mode you sign in with "
+                "your Home Assistant account; there are no add-on credentials to "
+                "regenerate."
+            )
+    elif enable_oauth:
         if regenerate_oauth_creds:
             _regenerate_oauth_creds(data_dir)
             # Force fresh generation: ignore any user-supplied values in this
@@ -1131,14 +1234,28 @@ def main() -> int:
     # turn on OAuth see no change to their config file.
     proxy_config: dict = {"target_url": target_url, "webhook_id": webhook_id}
     resolved_remote: str | None = None
-    if enable_oauth:
-        # Resolve the remote URL so the OAuth provider can pin metadata
-        # URLs to the operator-configured public URL instead of trusting
-        # attacker-supplied Host headers on a per-request basis.
+    if enable_oauth and oauth_mode == HA_AUTH_MODE:
+        # ha_auth is deliberately host-agnostic: the ResourceServer resolves the
+        # public base URL per-request so the discovery documents work on ANY
+        # hostname regardless of HA's external_url. Exactly ONE oauth-section
+        # shape is ever written — {"mode": "ha_auth"} with NO credential keys —
+        # so ha_auth and legacy can never both be active.
+        proxy_config["oauth"] = {"mode": HA_AUTH_MODE}
+        if remote_url and remote_url.strip():
+            log_info(
+                "Note: the configured External URL is ignored in ha_auth mode — "
+                "OAuth discovery is host-derived and works on any hostname."
+            )
+    elif enable_oauth:
+        # legacy: pin the public base URL so metadata/redirect URLs can't be
+        # poisoned via a forged Host header, and carry the resolved creds. The
+        # explicit "mode": "legacy" marker makes the section unambiguous (the
+        # integration also treats a creds-only section as legacy for back-compat).
         resolved_remote = _resolve_remote_url(remote_url)
         if resolved_remote:
             proxy_config["public_base_url"] = resolved_remote
         proxy_config["oauth"] = {
+            "mode": LEGACY_MODE,
             "client_id": oauth_client_id,
             "client_secret": oauth_client_secret,
         }
@@ -1296,6 +1413,15 @@ def main() -> int:
     # Kept in sync with `mcp_proxy_dev/repairs.py:RESTART_MARKER_FILE`.
     oauth_restart_marker = Path("/config/.mcp_proxy_dev_oauth_restart_required")
 
+    # The fail-closed stale-code probe runs in BOTH modes. It only fails when
+    # the OAuth metadata endpoint isn't served yet — i.e. HA is still running
+    # the OLD cached integration module (which has no ha_auth branch) after a
+    # code UPGRADE, which genuinely requires an HA restart for HA to import the
+    # new module. ha_auth needs no restart to TOGGLE once its code is loaded, so
+    # running the probe here does NOT break that promise; it closes the
+    # fail-open window where the old module could serve the webhook while the
+    # banner says "OAuth ENABLED". The restart marker / notification / Repair is
+    # a generic click-to-restart signal, appropriate in either mode.
     if enable_oauth and not _probe_oauth_active():
         log_error("")
         log_error("=" * 70)
@@ -1425,9 +1551,21 @@ def main() -> int:
         log_info("    Set 'remote_url' in addon config, or enable Nabu Casa")
     log_info("")
     log_info("  Copy the remote URL above into your MCP client.")
-    if enable_oauth:
+    if enable_oauth and oauth_mode == HA_AUTH_MODE:
         log_info("")
-        log_info("  OAuth (Beta) is ENABLED for this URL.")
+        log_info("  OAuth (Beta) is ENABLED — sign in with your Home Assistant login.")
+        log_info("    LEAVE the connector's OAuth fields BLANK (no Client ID or")
+        log_info("    Client Secret needed). You sign in with your Home Assistant")
+        log_info("    account when your MCP client connects.")
+        log_info("    Works with any hostname/URL, and no Home Assistant restart")
+        log_info("    is needed to enable or disable it.")
+        log_info("    Revoke access anytime from your Home Assistant profile's")
+        log_info("    sessions/tokens.")
+        log_info("    Note: if your MCP client's UI insists on a Client Secret,")
+        log_info("    any value works — Home Assistant ignores it.")
+    elif enable_oauth:
+        log_info("")
+        log_info("  OAuth (Beta) is ENABLED for this URL (legacy mode).")
         log_info(f"    OAuth Client ID:     {oauth_client_id}")
         log_info(f"    OAuth Client Secret: {oauth_client_secret}")
         log_info("    Paste both into the OAuth fields of your MCP client's")

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -630,8 +630,11 @@ def _resolve_oauth_mode(
       1. An explicit ``oauth_mode`` add-on option wins outright.
       2. Otherwise, if legacy OAuth is already in use — the user set
          ``oauth_client_id``/``oauth_client_secret``, OR a persisted legacy
-         creds file (``/data/oauth_creds.json``) exists from a prior run —
-         stay on ``legacy``.
+         creds file (``/data/oauth_creds.json``) exists from a prior run — OR
+         that creds-file check is INDETERMINATE (a stat error such as EACCES
+         stops us from knowing) — stay on ``legacy``. Flipping an existing
+         legacy user to ``ha_auth`` would break their connector, so an
+         unknown result preserves the previous flow.
       3. Otherwise (a first-time enable with no legacy trace) default to
          ``ha_auth``, the recommended mode.
     Switching an existing setup is therefore an explicit user action
@@ -654,15 +657,17 @@ def _resolve_oauth_mode(
         creds_file_exists = creds_file.exists()
     except OSError as e:
         # Path.exists() re-raises stat errors other than "not there" (e.g.
-        # EACCES). A stat failure is no proof of a legacy install, so treat
-        # the file as absent and keep auto-detecting instead of crashing
-        # startup; the ha_auth-default warning below still tells a legacy
-        # user how to get back.
+        # EACCES). A stat failure makes legacy detection INDETERMINATE — it is
+        # no proof the file is absent. Treating it as absent could flip an
+        # existing persisted-creds legacy user to ha_auth and break their
+        # connector, so preserve the previous flow: return legacy directly.
         log_error(
-            f"Could not check {creds_file} ({type(e).__name__}): {e}; "
-            "treating it as absent for OAuth mode detection."
+            f"Could not check {creds_file} ({type(e).__name__}): {e}; the "
+            "legacy-install check is indeterminate. Preserving the previous "
+            f"(legacy) OAuth flow; set oauth_mode: {HA_AUTH_MODE} explicitly "
+            "to switch (you must then re-add your MCP connector)."
         )
-        creds_file_exists = False
+        return LEGACY_MODE
     if configured_id.strip() or configured_secret.strip() or creds_file_exists:
         log_info(
             "OAuth mode: 'legacy' — existing legacy OAuth credentials detected "
@@ -1081,7 +1086,11 @@ def main() -> int:
     if _refuse_if_sibling_running():
         return 1
 
-    # Read config
+    # Read config. Supervisor always writes /data/options.json, so the outer
+    # existence check stays best-effort for the (unreachable) absent-file case.
+    # A present-but-unreadable/corrupt file, however, is FATAL (fail closed
+    # below): we can't tell whether the user enabled OAuth, and silently
+    # falling back to the unauthenticated defaults would betray that intent.
     config_file = Path("/data/options.json")
     data_dir = Path("/data")
     remote_url = ""
@@ -1110,7 +1119,31 @@ def main() -> int:
             regenerate_oauth_creds = bool(config.get("regenerate_oauth_creds", False))
             debug_logging = bool(config.get("debug_logging", False))
         except (OSError, json.JSONDecodeError) as e:
-            log_error(f"Failed to read config ({type(e).__name__}): {e}")
+            # Fail closed: the add-on config is present but unreadable/corrupt,
+            # so the user's intent is unknown — including whether OAuth should
+            # be enforced. Continuing would leave enable_oauth at its False
+            # default, silently serving an unauthenticated proxy (URL-secrecy
+            # only) to a user who turned OAuth ON. Refuse to start instead.
+            log_error("")
+            log_error("=" * 70)
+            log_error(
+                f"  Could not read the add-on configuration ({type(e).__name__}): {e}"
+            )
+            log_error("")
+            log_error("  The add-on options file could not be parsed, so your")
+            log_error("  configured intent is unknown — including whether OAuth")
+            log_error("  should be enforced. Starting now could serve the webhook")
+            log_error("  WITHOUT the authentication you asked for, so the add-on is")
+            log_error("  refusing to start.")
+            log_error("")
+            log_error("  Restart the add-on to recover: the Supervisor rewrites")
+            log_error("  this file from your saved configuration on every start,")
+            log_error("  so a restart normally heals a corrupted copy. If the")
+            log_error("  error persists across restarts, re-save the add-on's")
+            log_error("  Configuration tab and check the system's storage.")
+            log_error("=" * 70)
+            log_error("")
+            return 1
 
     # OAuth mode + credential resolution. ha_auth (HA-native) needs no add-on
     # credentials at all; legacy resolves/persists a client id + secret (user

--- a/homeassistant-addon-webhook-proxy-dev/translations/en.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/translations/en.yaml
@@ -20,48 +20,65 @@ configuration:
     description: |
       Adds OAuth 2.1 authentication to the webhook URL. The same URL keeps
       working but now requires a successful OAuth flow before serving MCP
-      requests.
+      requests. This is OFF by default and unchanged for anyone who leaves it
+      off — the webhook then works exactly as before with no auth check.
 
-      Easiest setup: turn this on, leave Client ID and Client Secret blank,
-      and restart the addon. The addon will generate strong values on first
-      start, persist them across restarts, and print them in the addon log
-      so you can copy them into your MCP client.
+      Two modes are available (see OAuth Mode below):
 
-      In Claude.ai: open the connector's Advanced settings and paste the
-      Client ID and Client Secret from the addon log into the OAuth fields
-      there. Claude.ai will then complete the OAuth handshake automatically
-      when adding the connector.
+      - ha_auth (recommended, the default for a first-time enable): you sign in
+        with your Home Assistant account. LEAVE the connector's OAuth fields
+        BLANK — no Client ID or Client Secret. Works with any hostname/URL and
+        needs NO Home Assistant restart to enable or disable.
+      - legacy: the previous flow, where the addon generates a Client ID +
+        Secret that you paste into the connector (see the OAuth Client ID /
+        Secret options). Enabling legacy requires a full Home Assistant restart
+        (a Repair with a restart button appears); disabling does not.
 
-      Enabling OAuth requires a full Home Assistant restart (Settings ->
-      System -> Restart) to take effect — restarting the add-on alone is NOT
-      enough, because Home Assistant only binds the OAuth authorize/token
-      endpoints cleanly at startup. After you enable this, a Repair
-      notification will appear with a button to restart Home Assistant.
-      Disabling OAuth does NOT require a restart. When this is off the webhook
-      URL works exactly as before with no auth check.
+      Upgrades are safe: if you already used the legacy flow (you set a Client
+      ID/Secret, or the addon stored one) the addon keeps you on legacy so your
+      existing connector keeps working. Switching modes is an explicit action
+      (set OAuth Mode) and requires deleting and re-adding your MCP connector.
+  oauth_mode:
+    name: OAuth Mode (Beta)
+    description: |
+      Which OAuth mode to use when Enable OAuth is on. Leave this UNSET unless
+      you want to switch — the addon picks the right default automatically.
+
+      - ha_auth: sign in with your Home Assistant account. Leave the connector's
+        OAuth fields blank; works with any hostname/URL; no Home Assistant
+        restart needed. This is the default for a first-time OAuth enable.
+      - legacy: the previous client-id/secret flow (deprecated), for setups that
+        still need it.
+
+      When unset, upgrades stay safe: if you already used legacy OAuth (a
+      configured or stored Client ID/Secret) the addon stays on legacy so
+      nothing breaks; otherwise it defaults to ha_auth. Changing this and
+      restarting switches modes — you must then delete and re-add your MCP
+      connector.
   oauth_client_id:
-    name: OAuth Client ID (auto-generated if blank)
+    name: OAuth Client ID (legacy mode; auto-generated if blank)
     description: |
-      Client ID that the MCP client (e.g. Claude.ai) must present at the
-      OAuth token endpoint. Leave blank to let the addon generate a value
-      on first start (recommended); the generated value is persisted in
-      /data/oauth_creds.json so it stays the same across restarts. If you
-      set a value here it must be at least 16 characters long.
+      Legacy OAuth mode only (ignored in ha_auth mode). Client ID that the MCP
+      client (e.g. Claude.ai) must present at the OAuth token endpoint. Leave
+      blank to let the addon generate a value on first start (recommended); the
+      generated value is persisted in /data/oauth_creds.json so it stays the
+      same across restarts. If you set a value here it must be at least 16
+      characters long.
   oauth_client_secret:
-    name: OAuth Client Secret (auto-generated if blank)
+    name: OAuth Client Secret (legacy mode; auto-generated if blank)
     description: |
-      Client Secret that the MCP client (e.g. Claude.ai) must present at
-      the OAuth token endpoint. Leave blank to let the addon generate a
-      strong random value on first start (recommended). Treat the value
-      like a password — anyone with it can complete the OAuth flow against
-      your MCP server.
+      Legacy OAuth mode only (ignored in ha_auth mode). Client Secret that the
+      MCP client (e.g. Claude.ai) must present at the OAuth token endpoint.
+      Leave blank to let the addon generate a strong random value on first
+      start (recommended). Treat the value like a password — anyone with it can
+      complete the OAuth flow against your MCP server.
   regenerate_oauth_creds:
-    name: Regenerate OAuth Credentials on Next Start
+    name: Regenerate OAuth Credentials on Next Start (legacy mode)
     description: |
-      One-shot action: when you turn this on and restart the addon, the
-      stored OAuth Client ID and Client Secret are wiped and fresh random
-      values are generated. The new values are printed in the addon log
-      and persisted across restarts.
+      Legacy OAuth mode only (ignored in ha_auth mode). One-shot action: when
+      you turn this on and restart the addon, the stored OAuth Client ID and
+      Client Secret are wiped and fresh random values are generated. The new
+      values are printed in the addon log and persisted across restarts.
 
       The addon attempts to flip this toggle back to off automatically
       after regenerating, so subsequent restarts don't keep regenerating.

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5340,8 +5340,13 @@ class TestStartHaAuthMode:
         out = capsys.readouterr().out
         assert "Home Assistant login" in out
         assert "BLANK" in out
+        # Pin the user-critical guidance lines, not just the headline: tokens
+        # are revoked from the HA profile, and a UI-required Client Secret can
+        # be any value (HA ignores it) — users act on these exact lines.
+        assert "Revoke access anytime from your Home Assistant profile's" in out
+        assert "any value works — Home Assistant ignores it." in out
 
-    def test_legacy_writes_mode_marker_and_creds(self, tmp_path):
+    def test_legacy_writes_mode_marker_and_creds(self, tmp_path, capsys):
         rc, written, mocks = self._run_main(
             tmp_path,
             {
@@ -5356,6 +5361,10 @@ class TestStartHaAuthMode:
         assert written["oauth"]["client_id"] == "client-1234567890ABCDEF"
         assert written["oauth"]["client_secret"] == "secret-much-secret"
         mocks["resolve_creds"].assert_called_once()
+        # Pin the copy-paste creds lines the legacy banner exists for.
+        out = capsys.readouterr().out
+        assert "OAuth Client ID:     client-1234567890ABCDEF" in out
+        assert "OAuth Client Secret: secret-much-secret" in out
 
     def test_ha_auth_stale_code_probe_fails_closed(self, tmp_path):
         """The fail-closed stale-code probe runs in ha_auth too (it closes the

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5387,20 +5387,25 @@ class TestResolveOAuthMode:
         still a legacy trace -> stay on legacy."""
         assert start._resolve_oauth_mode("", "", "sec", tmp_path) == "legacy"
 
-    def test_creds_file_stat_oserror_treated_absent(self, start, capsys):
+    def test_creds_file_stat_oserror_preserves_legacy(self, start, capsys):
         """start.py ~654: Path.exists() re-raises a stat error other than 'not
-        there' (e.g. EACCES). A stat failure is no proof of a legacy install, so
-        _resolve_oauth_mode must catch the OSError, log that it is treating the
-        file as absent, and keep auto-detecting (default ha_auth here) instead of
-        crashing startup."""
+        there' (e.g. EACCES). A stat failure makes legacy detection
+        INDETERMINATE — it is no proof the file is absent — and flipping an
+        existing persisted-creds legacy user to ha_auth would break their
+        connector. So _resolve_oauth_mode must catch the OSError, log that the
+        legacy-install check could not be completed, and preserve the previous
+        flow by returning 'legacy' instead of defaulting to ha_auth."""
         creds_file = MagicMock()
         creds_file.exists.side_effect = OSError("EACCES: permission denied")
         data_dir = MagicMock()
         data_dir.__truediv__.return_value = creds_file
-        # No configured id/secret and the creds-file stat fails -> ha_auth.
-        assert start._resolve_oauth_mode("", "", "", data_dir) == "ha_auth"
-        # log_error goes to stderr; the "treating it as absent" line must appear.
-        assert "treating it as absent" in capsys.readouterr().err
+        # No configured id/secret, but the creds-file stat fails -> preserve the
+        # previous (legacy) flow rather than silently switching to ha_auth.
+        assert start._resolve_oauth_mode("", "", "", data_dir) == "legacy"
+        # log_error goes to stderr; the indeterminate-preserve lines must appear.
+        err = capsys.readouterr().err
+        assert "indeterminate" in err
+        assert "Preserving the previous (legacy) OAuth flow" in err
 
 
 class TestStartHaAuthMode:
@@ -5603,6 +5608,52 @@ class TestStartHaAuthMode:
         assert written["oauth"] == {"mode": "ha_auth"}
         assert "public_base_url" not in written
         assert "public_base_url" not in written["oauth"]
+
+    def test_config_read_failure_refuses_to_start(self, tmp_path, capsys):
+        """FIX 1 (fail closed): if /data/options.json is present but
+        unreadable/corrupt, main() cannot tell whether the user enabled OAuth,
+        so it must refuse to start rather than fall back to the unauthenticated
+        defaults (enable_oauth=False). It logs a loud refusing-to-start block,
+        returns 1, and writes NO proxy config file.
+
+        Gated on _ha_auth_supported() like the rest of this class: the
+        fail-closed config read rides the dev flavor's start.py until it is
+        promoted to stable. Uses its own harness (not _run_main) because
+        _run_main reads the proxy config after main(), which is never written
+        on this early return."""
+        start = _import_start()
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        # Corrupt options.json: present but not valid JSON.
+        (data_dir / "options.json").write_text("{ this is not valid json ")
+        config_path = tmp_path / "proxy_config.json"
+
+        def path_factory(arg):
+            if arg == "/data/options.json":
+                return data_dir / "options.json"
+            if arg == "/data":
+                return data_dir
+            if arg == CURRENT["config_file"]:
+                return config_path
+            if arg == CURRENT["oauth_marker"]:
+                return tmp_path / "oauth_marker"
+            return Path(arg)
+
+        # Only the sibling-mutex probe runs before the config read; the mocks
+        # for webhook/config work are unnecessary because main() returns first.
+        with (
+            patch.object(start, "Path", side_effect=path_factory),
+            patch.object(start, "_supervisor_get", return_value={"addons": []}),
+        ):
+            rc = start.main()
+
+        assert rc == 1
+        # main() returned before any config work -> no proxy config written.
+        assert not config_path.exists()
+        # log_error goes to stderr; the loud refusing-to-start block must appear.
+        err = capsys.readouterr().err
+        assert "refusing to start" in err
+        assert "Could not read the add-on configuration" in err
 
 
 class TestStartOAuthOffConfigShape:

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -286,6 +286,61 @@ def _bind_repairs(mod, tmp_marker_dir):
     return repairs
 
 
+def _ha_auth_supported() -> bool:
+    """Feature-detect whether the CURRENT flavor ships ha_auth mode (its
+    `auth_native.py` module). The stable flavor skips the ha_auth tests until
+    the module is promoted — same lockstep-with-code approach as
+    `_wellknown_oauth_urls`."""
+    return os.path.exists(
+        os.path.join(PROXY_ADDON_DIR, CURRENT["component"], "auth_native.py")
+    )
+
+
+def _load_pkg_submodule(pkg_name, component_dir, sub):
+    """Load `<pkg_name>.<sub>` from `<component_dir>/<sub>.py` and register it in
+    sys.modules under that dotted name so relative imports resolve to it."""
+    name = f"{pkg_name}.{sub}"
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(component_dir, f"{sub}.py")
+    )
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _import_ha_auth_stack(tmp_secret_dir=None):
+    """Import the integration wired for ha_auth mode.
+
+    Loads __init__, oauth, and auth_native all as submodules of ONE package so
+    the relative imports resolve in BOTH directions to the same instances:
+    auth_native does `from .oauth import ...` at load, and the ha_auth AS view
+    does `from .auth_native import ...` at request time. (The legacy helpers load
+    oauth top-level, which can't satisfy the view's reverse relative import.)
+    Returns (init_mod, oauth_mod, auth_native_mod).
+    """
+    _install_runtime_stubs()
+    component_dir = os.path.join(PROXY_ADDON_DIR, CURRENT["component"])
+    pkg_name = f"mcp_proxy_init_{CURRENT['key']}"
+    for suffix in ("", ".oauth", ".auth_native", ".repairs"):
+        sys.modules.pop(f"{pkg_name}{suffix}", None)
+    # Create the package object first so submodules have a parent with __path__.
+    init_path = os.path.join(component_dir, "__init__.py")
+    init_spec = importlib.util.spec_from_file_location(
+        pkg_name, init_path, submodule_search_locations=[component_dir]
+    )
+    pkg = importlib.util.module_from_spec(init_spec)
+    sys.modules[pkg_name] = pkg
+    # oauth first (auth_native's `from .oauth` needs it bound), secret redirected.
+    oauth = _load_pkg_submodule(pkg_name, component_dir, "oauth")
+    if tmp_secret_dir is not None:
+        oauth.SECRET_FILE = Path(tmp_secret_dir) / ".mcp_proxy_oauth_secret"
+    auth_native = _load_pkg_submodule(pkg_name, component_dir, "auth_native")
+    # Execute the package __init__ last; its lazy imports resolve to the above.
+    init_spec.loader.exec_module(pkg)
+    return pkg, oauth, auth_native
+
+
 # ---------------------------------------------------------------------------
 # Structure tests
 # ---------------------------------------------------------------------------
@@ -4340,3 +4395,1077 @@ class TestUnauthorizedResponseShape:
         # Pinned base means evil.example is NOT in the metadata URL
         assert "evil.example" not in ww
         assert f"https://legit.example{CURRENT['oauth_base']}/protected-resource" in ww
+
+
+class TestHaAuthMode:
+    """The ha_auth OAuth mode: HA core is the authorization server and the
+    add-on is a pure resource server (serves the discovery documents + validates
+    bearers via hass.auth). Skips on flavors that don't ship auth_native yet."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_stable(self, _webhook_proxy_variant):
+        if not _ha_auth_supported():
+            pytest.skip("flavor does not ship ha_auth (auth_native) yet")
+
+    @pytest.fixture
+    def hass(self):
+        h = MagicMock()
+        h.data = {}
+        h.http = MagicMock()
+        h.http.register_view = MagicMock()
+
+        async def fake_executor(func, *args):
+            return func(*args)
+
+        h.async_add_executor_job = AsyncMock(side_effect=fake_executor)
+        return h
+
+    @staticmethod
+    def _ha_auth_config():
+        return {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+            "oauth": {"mode": "ha_auth"},
+        }
+
+    # ---- constants agree across the three modules ----
+
+    def test_mode_literals_agree(self, tmp_path):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        assert auth_native.HA_AUTH_MODE == "ha_auth"
+        assert auth_native.AUTH_V2 is True
+        assert oauth.MODE_HA_AUTH == auth_native.HA_AUTH_MODE
+        assert oauth.MODE_LEGACY == "legacy"
+        assert mod.OAUTH_MODE_HA_AUTH == auth_native.HA_AUTH_MODE
+        assert mod.OAUTH_MODE_LEGACY == "legacy"
+        # start.py mirrors the same two literals for the config it writes.
+        start = _import_start()
+        assert start.HA_AUTH_MODE == auth_native.HA_AUTH_MODE
+        assert start.LEGACY_MODE == "legacy"
+        # The DOMAIN key the discovery views read via _active_oauth_mode
+        # (oauth.DOMAIN) must equal the one the handler writes (mod.DOMAIN);
+        # a drift would make every view 404 (no live mode ever resolved).
+        assert oauth.DOMAIN == mod.DOMAIN
+
+    # ---- config.yaml + translations coverage for oauth_mode (dev-only) ----
+
+    def test_oauth_mode_schema_and_translation(self):
+        with open(f"{PROXY_ADDON_DIR}/config.yaml") as f:
+            config = yaml.safe_load(f)
+        assert config["schema"]["oauth_mode"] == "list(ha_auth|legacy)?"
+        # No default in options: (kept hidden + no inherited value on upgrade).
+        assert "oauth_mode" not in config["options"]
+        with open(f"{PROXY_ADDON_DIR}/translations/en.yaml") as f:
+            tr = yaml.safe_load(f)
+        entry = tr["configuration"]["oauth_mode"]
+        assert entry.get("name"), "oauth_mode needs a translation name"
+        assert entry.get("description"), "oauth_mode needs a translation description"
+        assert "Beta" in entry["name"]
+
+    # ---- setup registers exactly the 7 metadata views, no root views ----
+
+    async def test_setup_registers_seven_metadata_views_and_marks_mode(
+        self, hass, tmp_path
+    ):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        repairs = _bind_repairs(mod, tmp_path)
+        repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
+        with (
+            patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+            patch.object(repairs, "create_issue") as mock_create_issue,
+            patch.object(repairs, "_write_marker") as mock_write,
+            patch.object(repairs, "_delete_issue_only") as mock_delete,
+        ):
+            result = await mod.async_setup_entry(hass, MagicMock())
+
+        assert result is True
+        registered = {
+            call.args[0].url for call in hass.http.register_view.call_args_list
+        }
+        expected = {
+            f"{CURRENT['oauth_base']}/protected-resource",
+            f"{CURRENT['oauth_base']}/authorization-server",
+        } | _wellknown_oauth_urls(oauth, "mcp_test")
+        assert registered == expected
+        assert len(registered) == 7
+        # No root /authorize or /token views in ha_auth mode.
+        assert "/authorize" not in registered
+        assert "/token" not in registered
+        # hass.data carries the ResourceServer + the mode marker.
+        assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_HA_AUTH
+        assert isinstance(hass.data[mod.DOMAIN]["oauth"], auth_native.ResourceServer)
+        # No owner-key / fingerprint bookkeeping (those guard root views).
+        assert mod.OAUTH_ROUTE_OWNER_KEY not in hass.data
+        assert mod.OAUTH_ROUTE_KEY_FINGERPRINT not in hass.data
+        # Restart-Repair marker CLEARED, never created.
+        assert not repairs.RESTART_MARKER_FILE.exists()
+        mock_delete.assert_called_once_with(hass, mod.DOMAIN)
+        mock_create_issue.assert_not_called()
+        mock_write.assert_not_called()
+
+    async def test_setup_ignores_stray_public_base_url_host_derived(
+        self, hass, tmp_path
+    ):
+        """Fix 4 through async_setup_entry: a hand-edited ha_auth config that
+        ALSO carries a stray top-level `public_base_url` (the key legacy writes
+        and __init__ reads at line 507) must NOT pin the ResourceServer — ha_auth
+        is always host-derived. __init__ constructs the provider with
+        public_base_url=None regardless, so the served discovery base follows the
+        request Host, never the stray URL."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+            # Stray hand-edit: a legacy-style pinned URL left behind after a
+            # manual switch to ha_auth. The ambiguity guard only rejects
+            # client_id/client_secret keys, so this reaches the provider wiring.
+            "public_base_url": "https://stray-pinned.example",
+            "oauth": {"mode": "ha_auth"},
+        }
+        with (
+            patch.object(mod, "_read_config", return_value=config),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            result = await mod.async_setup_entry(hass, MagicMock())
+        assert result is True
+        rs = hass.data[mod.DOMAIN]["oauth"]
+        assert isinstance(rs, auth_native.ResourceServer)
+        # Wiring: the stray URL was dropped — the provider is host-derived.
+        assert rs._public_base_url is None
+        # Behavior: base_url_for follows the request Host, not the stray URL.
+        request = _make_view_request(headers={"Host": "host-abc.example"})
+        assert rs.base_url_for(request) == "https://host-abc.example"
+        # And the served authorization-server document reflects the request host.
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.AuthorizationServerMetadataView(rs).get(request)
+        doc = jr.call_args.args[0]
+        assert doc["issuer"] == f"https://host-abc.example{oauth.OAUTH_BASE}"
+        assert "stray-pinned.example" not in doc["issuer"]
+        assert "stray-pinned.example" not in doc["authorization_endpoint"]
+        # It genuinely served the ha_auth document (public client + CIMD).
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+
+    async def test_reload_does_not_reregister_views(self, hass, tmp_path):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        with (
+            patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+            first = hass.http.register_view.call_count
+            hass.http.register_view.reset_mock()
+            # A second setup (config-entry reload) must NOT re-register the views.
+            await mod.async_setup_entry(hass, MagicMock())
+        assert first == 7
+        assert hass.http.register_view.call_count == 0
+        # The register-once flag lives in oauth.py (a top-level hass.data key),
+        # not on the integration package.
+        assert hass.data[oauth._METADATA_VIEWS_REGISTERED_KEY] is True
+
+    async def test_register_once_flag_survives_unload(self, hass, tmp_path):
+        """The register-once flag lives at a TOP-LEVEL hass.data key so it
+        outlives async_unload_entry's pop(DOMAIN): HA can't drop the seven bound
+        views until it restarts, so a setup -> unload -> setup cycle must NOT
+        re-register them (which would trip aiohttp's duplicate-view ValueError)."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        session = MagicMock()
+        session.close = AsyncMock()
+        with (
+            patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
+            patch.object(mod, "async_register"),
+            patch.object(mod, "async_unregister"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=session),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+            assert hass.http.register_view.call_count == 7
+            flag_key = oauth._METADATA_VIEWS_REGISTERED_KEY
+            assert hass.data[flag_key] is True
+            await mod.async_unload_entry(hass, MagicMock())
+            # unload pops DOMAIN...
+            assert mod.DOMAIN not in hass.data
+            # ...but the top-level register-once flag survives it.
+            assert hass.data[flag_key] is True
+            hass.http.register_view.reset_mock()
+            # A fresh setup after the unload reuses the still-bound views.
+            await mod.async_setup_entry(hass, MagicMock())
+        assert hass.http.register_view.call_count == 0
+        assert hass.data[flag_key] is True
+
+    def _legacy_config(self):
+        return {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+            "oauth": {
+                "mode": "legacy",
+                "client_id": "client-1234567890ABCDEF",
+                "client_secret": "secret-much-secret",
+            },
+        }
+
+    async def test_ha_auth_then_legacy_does_not_reregister_metadata(
+        self, hass, tmp_path
+    ):
+        """A live ha_auth -> legacy switch reuses the already-bound seven
+        metadata views: legacy's register_views() routes them through the same
+        flag-guarded registrar, so the second setup registers ONLY the two root
+        views, never a duplicate of the seven."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        # Boot-time so legacy binds its root views cleanly (no restart Repair).
+        hass.is_running = False
+        with (
+            patch.object(
+                mod,
+                "_read_config",
+                side_effect=[self._ha_auth_config(), self._legacy_config()],
+            ),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())  # ha_auth: 7 metadata
+            assert hass.http.register_view.call_count == 7
+            hass.http.register_view.reset_mock()
+            await mod.async_setup_entry(hass, MagicMock())  # legacy: only 2 root
+        registered = {
+            call.args[0].url for call in hass.http.register_view.call_args_list
+        }
+        assert registered == {"/authorize", "/token"}
+        # None of the seven metadata views were registered a second time.
+        assert not (registered & _wellknown_oauth_urls(oauth, "mcp_test"))
+        assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_LEGACY
+
+    async def test_legacy_then_ha_auth_does_not_reregister_metadata(
+        self, hass, tmp_path
+    ):
+        """A live legacy -> ha_auth switch: legacy already bound the seven via
+        the shared registrar, so the ha_auth setup's register_metadata_views
+        no-ops and registers nothing new."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        hass.is_running = False
+        with (
+            patch.object(
+                mod,
+                "_read_config",
+                side_effect=[self._legacy_config(), self._ha_auth_config()],
+            ),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())  # legacy: 7 + 2 root
+            assert hass.http.register_view.call_count == 9
+            hass.http.register_view.reset_mock()
+            await mod.async_setup_entry(hass, MagicMock())  # ha_auth: reuse all
+        assert hass.http.register_view.call_count == 0
+        assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_HA_AUTH
+
+    async def test_unknown_mode_raises(self, hass, tmp_path):
+        mod = _import_mcp_proxy()
+        proxy_config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test_webhook_id_12345",
+            "oauth": {"mode": "bogus"},
+        }
+        session = MagicMock()
+        session.close = AsyncMock()
+        with (
+            patch.object(mod, "_read_config", return_value=proxy_config),
+            patch.object(mod, "async_register"),
+            patch.object(mod, "async_unregister") as mock_unreg,
+            patch.object(mod.aiohttp, "ClientSession", return_value=session),
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+        assert "Unknown OAuth mode" in str(exc_info.value)
+        mock_unreg.assert_called_once_with(hass, "mcp_test_webhook_id_12345")
+        session.close.assert_awaited_once()
+        assert mod.DOMAIN not in hass.data
+
+    async def test_ambiguous_ha_auth_with_creds_raises(self, hass, tmp_path):
+        """Hard mutual exclusion: mode ha_auth + legacy creds keys is ambiguous
+        and must be refused, not guessed."""
+        mod, _oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        proxy_config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test_webhook_id_12345",
+            "oauth": {
+                "mode": "ha_auth",
+                "client_id": "client-1234567890ABCDEF",
+                "client_secret": "secret-much-secret",
+            },
+        }
+        session = MagicMock()
+        session.close = AsyncMock()
+        with (
+            patch.object(mod, "_read_config", return_value=proxy_config),
+            patch.object(mod, "async_register"),
+            patch.object(mod, "async_unregister") as mock_unreg,
+            patch.object(mod.aiohttp, "ClientSession", return_value=session),
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+        assert "Ambiguous" in str(exc_info.value)
+        mock_unreg.assert_called_once_with(hass, "mcp_test_webhook_id_12345")
+        session.close.assert_awaited_once()
+        assert mod.DOMAIN not in hass.data
+        # The ResourceServer was never constructed and no view registered.
+        hass.http.register_view.assert_not_called()
+
+    async def test_creds_without_mode_takes_legacy_path(self, hass, tmp_path):
+        """Back-compat pin: a creds-shaped section without a mode key is legacy,
+        and the ha_auth module (auth_native) is NEVER imported for it."""
+        oauth = _import_oauth(tmp_secret_dir=tmp_path)
+        mod = _import_mcp_proxy(preload_oauth=oauth)
+        hass.is_running = False
+        auth_native_name = f"{mod.__name__}.auth_native"
+        sys.modules.pop(auth_native_name, None)
+        proxy_config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+            "oauth": {
+                "client_id": "client-1234567890ABCDEF",
+                "client_secret": "secret-much-secret",
+            },
+        }
+        with (
+            patch.object(mod, "_read_config", return_value=proxy_config),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+        assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_LEGACY
+        # Legacy constructed its embedded provider + claimed the root routes.
+        assert hass.data[mod.OAUTH_ROUTE_OWNER_KEY] == mod.DOMAIN
+        assert hasattr(hass.data[mod.DOMAIN]["oauth"], "validate_bearer")
+        # ha_auth's auth_native module must NOT be imported on the legacy path.
+        assert auth_native_name not in sys.modules
+
+    async def test_off_path_imports_neither_oauth_nor_auth_native(self, hass, tmp_path):
+        """The OAuth-off path must import neither oauth NOR auth_native (mirror
+        of the existing 'off path imports nothing' pin, extended to ha_auth)."""
+        mod = _import_mcp_proxy()
+        oauth_name = f"{mod.__name__}.oauth"
+        an_name = f"{mod.__name__}.auth_native"
+        sys.modules.pop(oauth_name, None)
+        sys.modules.pop(an_name, None)
+        proxy_config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+        }
+        with (
+            patch.object(mod, "_read_config", return_value=proxy_config),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+        assert oauth_name not in sys.modules
+        assert an_name not in sys.modules
+
+    # ---- documents ----
+
+    def _resource_server(self, tmp_path, mode="ha_auth"):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        hass.data = {mod.DOMAIN: {"oauth_mode": mode}}
+        rs = auth_native.ResourceServer(
+            hass, "mcp_webhook_id_aaaa", public_base_url="https://legit.example"
+        )
+        return oauth, rs
+
+    async def test_as_document_ha_auth_shape_canonical_and_wellknown(self, tmp_path):
+        oauth, rs = self._resource_server(tmp_path)
+        request = _make_view_request(headers={"Host": "ignored"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.AuthorizationServerMetadataView(rs).get(request)
+        doc = jr.call_args.args[0]
+        assert doc["issuer"] == f"https://legit.example{oauth.OAUTH_BASE}"
+        assert doc["authorization_endpoint"] == "https://legit.example/auth/authorize"
+        assert doc["token_endpoint"] == "https://legit.example/auth/token"
+        assert doc["response_types_supported"] == ["code"]
+        assert doc["grant_types_supported"] == ["authorization_code", "refresh_token"]
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+        assert doc["client_id_metadata_document_supported"] is True
+        assert "registration_endpoint" not in doc
+        # A well-known variant serves the SAME document.
+        wk = oauth.WellKnownAuthorizationServerMetadataView(
+            rs,
+            url=f"{oauth.OAUTH_BASE}/.well-known/oauth-authorization-server",
+            name="test:wk",
+        )
+        with patch.object(oauth.web, "json_response") as jr2:
+            await wk.get(request)
+        assert jr2.call_args.args[0] == doc
+
+    async def test_prm_document_ha_auth_matches_legacy_shape(self, tmp_path):
+        oauth, rs = self._resource_server(tmp_path)
+        request = _make_view_request(headers={"Host": "ignored"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.ProtectedResourceMetadataView(rs).get(request)
+        body = jr.call_args.args[0]
+        assert body["resource"] == (
+            "https://legit.example/api/webhook/mcp_webhook_id_aaaa"
+        )
+        assert body["authorization_servers"] == [
+            f"https://legit.example{oauth.OAUTH_BASE}"
+        ]
+        assert body["bearer_methods_supported"] == ["header"]
+        assert body["resource_documentation"] == (
+            "https://github.com/homeassistant-ai/ha-mcp"
+        )
+
+    # ---- runtime mutual-exclusion: root views 404 when ha_auth is active ----
+
+    async def test_authorize_and_token_views_404_when_ha_auth_active(self, tmp_path):
+        oauth = _import_oauth(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        hass.data = {oauth.DOMAIN: {"oauth_mode": oauth.MODE_HA_AUTH}}
+        # A legacy provider still bound from a prior legacy session.
+        provider = oauth.OAuthProvider(
+            hass=hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
+        av = oauth.AuthorizeView(provider)
+        good_query = {
+            "response_type": "code",
+            "client_id": "cid-1234567890ABCDEF",
+            "redirect_uri": "https://claude.ai/cb",
+            "code_challenge": "X" * 43,
+            "code_challenge_method": "S256",
+            "state": "s",
+        }
+        with patch.object(oauth.web, "Response") as rc:
+            await av.get(_make_view_request(query=good_query, method="GET"))
+        assert rc.call_args.kwargs.get("status") == 404
+        with patch.object(oauth.web, "Response") as rc2:
+            await av.post(
+                _make_view_request(method="POST", post_data={"action": "approve"})
+            )
+        assert rc2.call_args.kwargs.get("status") == 404
+        tv = oauth.TokenView(provider)
+        with patch.object(oauth.web, "json_response") as jr:
+            await tv.post(
+                _make_view_request(
+                    method="POST", post_data={"grant_type": "authorization_code"}
+                )
+            )
+        assert jr.call_args.kwargs.get("status") == 404
+
+    # ---- webhook gate: bearer validated via hass.auth ----
+
+    def _gate_hass(self, mod, auth_native, validate_return):
+        hass = MagicMock()
+        hass.auth.async_validate_access_token = MagicMock(return_value=validate_return)
+        rs = auth_native.ResourceServer(hass, "wh")
+        hass.data = {
+            mod.DOMAIN: {
+                "target_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "webhook_id": "mcp_test",
+                "session": MagicMock(),
+                "oauth": rs,
+                "oauth_mode": mod.OAUTH_MODE_HA_AUTH,
+            }
+        }
+        return hass
+
+    async def test_webhook_gate_valid_bearer_proxies(self, tmp_path):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = self._gate_hass(mod, auth_native, object())  # non-None -> authorized
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer good-token", "Host": "h"}
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        request.scheme = "https"
+        sentinel = mod.aiohttp.ClientError("stop here")
+        hass.data[mod.DOMAIN]["session"].request = MagicMock(side_effect=sentinel)
+        await mod._handle_webhook(hass, "mcp_test", request)
+        request.read.assert_awaited_once()  # gate passed -> upstream call reached
+        hass.auth.async_validate_access_token.assert_called_once_with("good-token")
+
+    async def test_webhook_gate_invalid_bearer_401(self, tmp_path):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = self._gate_hass(mod, auth_native, None)  # None -> unauthorized
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer bad", "Host": "example.nabu.casa"}
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        request.scheme = "https"
+        with patch.object(oauth.web, "Response") as response_ctor:
+            await mod._handle_webhook(hass, "mcp_test", request)
+        request.read.assert_not_awaited()
+        assert response_ctor.call_args.kwargs.get("status") == 401
+        ww = response_ctor.call_args.kwargs.get("headers", {}).get(
+            "WWW-Authenticate", ""
+        )
+        assert ww.startswith("Bearer realm=")
+        assert "resource_metadata=" in ww
+        hass.auth.async_validate_access_token.assert_called_once_with("bad")
+
+    async def test_webhook_gate_missing_bearer_401_validator_not_called(self, tmp_path):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = self._gate_hass(mod, auth_native, object())
+        request = MagicMock()
+        request.headers = {"Host": "example.nabu.casa"}  # no Authorization
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        request.scheme = "https"
+        with patch.object(oauth.web, "Response") as response_ctor:
+            await mod._handle_webhook(hass, "mcp_test", request)
+        request.read.assert_not_awaited()
+        assert response_ctor.call_args.kwargs.get("status") == 401
+        # Malformed/missing header rejected WITHOUT invoking the HA validator.
+        hass.auth.async_validate_access_token.assert_not_called()
+
+    async def test_validator_raises_gate_returns_401_not_500(self, tmp_path):
+        """A crafted token can make hass.auth.async_validate_access_token raise
+        (outside jwt.InvalidTokenError). ResourceServer.validate_request must
+        swallow it and return False, and the webhook gate must then emit the
+        normal 401 discovery challenge — never a 500 that leaks the exception."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = self._gate_hass(mod, auth_native, object())
+        hass.auth.async_validate_access_token = MagicMock(
+            side_effect=RuntimeError("crafted unsigned token")
+        )
+        rs = hass.data[mod.DOMAIN]["oauth"]
+        # Direct: the raise is contained and reported as unauthorized.
+        direct = MagicMock()
+        direct.headers = {"Authorization": "Bearer crafted"}
+        assert await rs.validate_request(direct) is False
+        # Gate: 401 challenge, not a 500, and the upstream is never reached.
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer crafted", "Host": "h.nabu.casa"}
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        request.scheme = "https"
+        with patch.object(oauth.web, "Response") as response_ctor:
+            await mod._handle_webhook(hass, "mcp_test", request)
+        request.read.assert_not_awaited()
+        assert response_ctor.call_args.kwargs.get("status") == 401
+        ww = response_ctor.call_args.kwargs.get("headers", {}).get(
+            "WWW-Authenticate", ""
+        )
+        assert ww.startswith("Bearer realm=")
+        assert "resource_metadata=" in ww
+
+    # ---- validate_request direct unit tests ----
+
+    def _resource_server_for_validate(self, tmp_path, validator):
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        hass.auth.async_validate_access_token = validator
+        return auth_native.ResourceServer(hass, "wh")
+
+    async def test_validate_request_empty_token_not_validated(self, tmp_path):
+        """A bare 'Bearer ' with an empty/whitespace token is rejected WITHOUT
+        calling the validator (no point hashing junk)."""
+        validator = MagicMock(return_value=object())
+        rs = self._resource_server_for_validate(tmp_path, validator)
+        req = MagicMock()
+        req.headers = {"Authorization": "Bearer    "}
+        assert await rs.validate_request(req) is False
+        validator.assert_not_called()
+
+    async def test_validate_request_wrong_scheme_rejected(self, tmp_path):
+        """A non-Bearer scheme (Basic) is rejected without touching the
+        validator."""
+        validator = MagicMock(return_value=object())
+        rs = self._resource_server_for_validate(tmp_path, validator)
+        req = MagicMock()
+        req.headers = {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+        assert await rs.validate_request(req) is False
+        validator.assert_not_called()
+
+    async def test_validate_request_mixed_case_bearer_accepted(self, tmp_path):
+        """The scheme match is case-insensitive: 'bEaReR' still routes the token
+        to the validator (a non-None RefreshToken -> authorized)."""
+        validator = MagicMock(return_value=object())
+        rs = self._resource_server_for_validate(tmp_path, validator)
+        req = MagicMock()
+        req.headers = {"Authorization": "bEaReR good-token"}
+        assert await rs.validate_request(req) is True
+        validator.assert_called_once_with("good-token")
+
+    async def test_validate_request_awaitable_result_branch(self, tmp_path):
+        """Defensive future-proofing: if a future HA turns async_validate_access_token
+        into a coroutine, validate_request awaits it before the None check."""
+        validator = AsyncMock(return_value=object())
+        rs = self._resource_server_for_validate(tmp_path, validator)
+        req = MagicMock()
+        req.headers = {"Authorization": "Bearer good-token"}
+        assert await rs.validate_request(req) is True
+        validator.assert_awaited_once_with("good-token")
+
+    # ---- unloaded (DOMAIN absent) -> every bound view 404s ----
+
+    async def test_unloaded_views_all_404(self, tmp_path):
+        """When the config entry was unloaded (hass.data lacks DOMAIN) but HA
+        can't drop the still-bound views until a restart, _active_oauth_mode
+        resolves None: both metadata views AND the three root view handlers must
+        404 like an unregistered route."""
+        _mod, oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        hass.data = {}  # DOMAIN absent -> unloaded
+        provider = oauth.OAuthProvider(
+            hass=hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
+        req = _make_view_request(headers={"Host": "h"})
+        for view in (
+            oauth.ProtectedResourceMetadataView(provider),
+            oauth.AuthorizationServerMetadataView(provider),
+        ):
+            with patch.object(oauth.web, "json_response") as jr:
+                await view.get(req)
+            assert jr.call_args.kwargs.get("status") == 404
+        av = oauth.AuthorizeView(provider)
+        with patch.object(oauth.web, "Response") as rc:
+            await av.get(_make_view_request(query={}, method="GET"))
+        assert rc.call_args.kwargs.get("status") == 404
+        with patch.object(oauth.web, "Response") as rc:
+            await av.post(
+                _make_view_request(method="POST", post_data={"action": "approve"})
+            )
+        assert rc.call_args.kwargs.get("status") == 404
+        tv = oauth.TokenView(provider)
+        with patch.object(oauth.web, "json_response") as jr:
+            await tv.post(
+                _make_view_request(
+                    method="POST", post_data={"grant_type": "authorization_code"}
+                )
+            )
+        assert jr.call_args.kwargs.get("status") == 404
+
+    # ---- the 401 challenge is the SAME builder + pointer in both modes ----
+
+    async def test_401_challenge_byte_identical_legacy_vs_ha_auth(self, tmp_path):
+        """Both modes emit the 401 through the one shared
+        build_unauthorized_response. Legacy pins its base to public_base_url and
+        ha_auth derives it from the host; for a request whose host equals the
+        pinned URL the two resolve to the same base, so the WWW-Authenticate
+        challenge (realm + resource_metadata pointer) is byte-identical."""
+        _mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        legacy = oauth.OAuthProvider(
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="mcp_webhook_id_aaaa",
+            signing_key=b"\x00" * 32,
+            public_base_url="https://myhost.example",
+        )
+        # ha_auth is host-derived (public_base_url None, per PR requirement).
+        ha = auth_native.ResourceServer(MagicMock(), "mcp_webhook_id_aaaa", None)
+        req = _make_view_request(headers={"Host": "myhost.example"}, scheme="https")
+        with patch.object(oauth.web, "Response") as rc:
+            oauth.build_unauthorized_response(req, legacy)
+        legacy_ww = rc.call_args.kwargs["headers"]["WWW-Authenticate"]
+        with patch.object(oauth.web, "Response") as rc:
+            oauth.build_unauthorized_response(req, ha)
+        ha_ww = rc.call_args.kwargs["headers"]["WWW-Authenticate"]
+        assert legacy_ww == ha_ww
+        assert legacy_ww == (
+            'Bearer realm="MCP Proxy", resource_metadata='
+            f'"https://myhost.example{oauth.OAUTH_BASE}/protected-resource"'
+        )
+
+    # ---- the ha_auth AS document is served identically at all 4 well-known URLs ----
+
+    async def test_ha_auth_as_doc_identity_across_all_wellknown_variants(
+        self, tmp_path
+    ):
+        """All four well-known authorization-server URLs must serve content
+        identical to the canonical ha_auth authorization_server_document (issue
+        #1714: claude.ai caches per-URL, so a stale/mismatched doc at any of
+        these poisons discovery)."""
+        oauth, rs = self._resource_server(tmp_path)  # oauth_mode ha_auth
+        request = _make_view_request(headers={"Host": "ignored"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.AuthorizationServerMetadataView(rs).get(request)
+        canonical = jr.call_args.args[0]
+        # It is genuinely the ha_auth document (public client + CIMD), not legacy.
+        assert canonical["token_endpoint_auth_methods_supported"] == ["none"]
+        assert canonical["client_id_metadata_document_supported"] is True
+        assert canonical["authorization_endpoint"] == (
+            "https://legit.example/auth/authorize"
+        )
+        base = oauth.OAUTH_BASE
+        variants = (
+            f"/.well-known/oauth-authorization-server{base}",
+            f"/.well-known/openid-configuration{base}",
+            f"{base}/.well-known/openid-configuration",
+            f"{base}/.well-known/oauth-authorization-server",
+        )
+        for url in variants:
+            view = oauth.WellKnownAuthorizationServerMetadataView(
+                rs, url=url, name=f"test:{url}"
+            )
+            with patch.object(oauth.web, "json_response") as jr2:
+                await view.get(request)
+            assert jr2.call_args.args[0] == canonical
+
+    # ---- live mode switch: served doc uses the ACTIVE provider's policy ----
+
+    async def test_live_switch_bound_legacy_view_serves_ha_auth_host_derived(
+        self, tmp_path
+    ):
+        """Regression guard for a no-restart legacy->ha_auth switch. The AS view
+        was bound with the LEGACY provider (pinned public_base_url), but
+        hass.data now marks ha_auth active with the ResourceServer as the live
+        provider. `_active_provider` resolves the live ha_auth provider from
+        hass.data at request time, so the served document is the ha_auth shape
+        with a HOST-DERIVED base — never the bound legacy provider's pinned URL.
+        Every other ha_auth test leaves hass.data[DOMAIN] without an 'oauth' key,
+        so this is the only test that exercises the dynamic-provider branch."""
+        _mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        shared_hass = MagicMock()
+        ha_rs = auth_native.ResourceServer(shared_hass, "wh", None)  # host-derived
+        # ha_auth is live; the ResourceServer is the active provider.
+        shared_hass.data = {
+            oauth.DOMAIN: {"oauth_mode": oauth.MODE_HA_AUTH, "oauth": ha_rs}
+        }
+        # The view is still bound with the PREVIOUS mode's (legacy) provider,
+        # which pins its base URL — HA can't rebind the view mid-session.
+        bound_legacy = oauth.OAuthProvider(
+            hass=shared_hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+            public_base_url="https://pinned-legacy.example",
+        )
+        request = _make_view_request(headers={"Host": "switch-host.example"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.AuthorizationServerMetadataView(bound_legacy).get(request)
+        doc = jr.call_args.args[0]
+        # ha_auth document shape (public client + CIMD), not legacy.
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+        assert doc["client_id_metadata_document_supported"] is True
+        # Host-derived base from the request, NOT the bound provider's pin.
+        assert doc["issuer"] == f"https://switch-host.example{oauth.OAUTH_BASE}"
+        assert doc["authorization_endpoint"] == (
+            "https://switch-host.example/auth/authorize"
+        )
+        assert "pinned-legacy.example" not in doc["issuer"]
+
+    async def test_live_switch_bound_ha_auth_view_serves_legacy_pinned(self, tmp_path):
+        """The mirror direction of the no-restart switch: the AS view was bound
+        with the HA_AUTH provider (host-derived), but hass.data now marks legacy
+        active with the pinned OAuthProvider as the live provider.
+        `_active_provider` resolves the live legacy provider, so the served
+        document is the legacy shape pinned to public_base_url — the request Host
+        is ignored (Host-poisoning resistance)."""
+        _mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        shared_hass = MagicMock()
+        pinned_legacy = oauth.OAuthProvider(
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+            public_base_url="https://pinned-legacy.example",
+        )
+        # legacy is live; the pinned OAuthProvider is the active provider.
+        shared_hass.data = {
+            oauth.DOMAIN: {"oauth_mode": oauth.MODE_LEGACY, "oauth": pinned_legacy}
+        }
+        # The view is still bound with the PREVIOUS mode's (ha_auth) provider.
+        bound_ha = auth_native.ResourceServer(shared_hass, "wh", None)
+        request = _make_view_request(headers={"Host": "other-host.example"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.AuthorizationServerMetadataView(bound_ha).get(request)
+        doc = jr.call_args.args[0]
+        # Legacy document shape (embedded AS, client_secret_* auth methods).
+        assert "client_secret_basic" in doc["token_endpoint_auth_methods_supported"]
+        assert "client_id_metadata_document_supported" not in doc
+        # Pinned base from public_base_url, NOT the request Host.
+        assert doc["issuer"] == f"https://pinned-legacy.example{oauth.OAUTH_BASE}"
+        assert doc["authorization_endpoint"] == (
+            "https://pinned-legacy.example/authorize"
+        )
+        assert "other-host.example" not in doc["issuer"]
+
+
+class TestResolveOAuthMode:
+    """start.py's upgrade-safe OAuth mode resolution. Skips on flavors that
+    don't ship ha_auth (their start.py has no _resolve_oauth_mode)."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_stable(self, _webhook_proxy_variant):
+        if not _ha_auth_supported():
+            pytest.skip("flavor does not ship ha_auth (_resolve_oauth_mode) yet")
+
+    @pytest.fixture
+    def start(self):
+        return _import_start()
+
+    def test_explicit_mode_wins(self, start, tmp_path):
+        assert start._resolve_oauth_mode("ha_auth", "", "", tmp_path) == "ha_auth"
+        assert start._resolve_oauth_mode("legacy", "", "", tmp_path) == "legacy"
+
+    def test_explicit_ha_auth_wins_even_with_legacy_creds_file(self, start, tmp_path):
+        (tmp_path / "oauth_creds.json").write_text(
+            json.dumps({"client_id": "x", "client_secret": "y"})
+        )
+        assert start._resolve_oauth_mode("ha_auth", "cid", "sec", tmp_path) == "ha_auth"
+
+    def test_unset_with_configured_creds_is_legacy(self, start, tmp_path):
+        assert (
+            start._resolve_oauth_mode("", "cid-1234567890ABCDEF", "sec", tmp_path)
+            == "legacy"
+        )
+
+    def test_unset_with_persisted_creds_file_is_legacy(self, start, tmp_path):
+        (tmp_path / "oauth_creds.json").write_text(
+            json.dumps({"client_id": "x", "client_secret": "y"})
+        )
+        assert start._resolve_oauth_mode("", "", "", tmp_path) == "legacy"
+
+    def test_unset_no_legacy_traces_defaults_ha_auth(self, start, tmp_path):
+        assert start._resolve_oauth_mode("", "", "", tmp_path) == "ha_auth"
+
+    def test_unknown_mode_falls_through_to_detection(self, start, tmp_path):
+        """Supervisor's enum validation normally blocks an unknown oauth_mode,
+        but if one reaches here it must fall through to auto-detection rather
+        than crash: no legacy trace -> ha_auth, a legacy trace -> legacy."""
+        assert start._resolve_oauth_mode("bogus", "", "", tmp_path) == "ha_auth"
+        assert (
+            start._resolve_oauth_mode("bogus", "cid-1234567890ABCDEF", "sec", tmp_path)
+            == "legacy"
+        )
+
+    def test_id_only_without_secret_or_file_is_legacy(self, start, tmp_path):
+        """A configured client id alone (no secret, no persisted creds file) is
+        still a legacy trace -> stay on legacy."""
+        assert (
+            start._resolve_oauth_mode("", "cid-1234567890ABCDEF", "", tmp_path)
+            == "legacy"
+        )
+
+    def test_secret_only_without_id_or_file_is_legacy(self, start, tmp_path):
+        """A configured client secret alone (no id, no persisted creds file) is
+        still a legacy trace -> stay on legacy."""
+        assert start._resolve_oauth_mode("", "", "sec", tmp_path) == "legacy"
+
+
+class TestStartHaAuthMode:
+    """start.py main(): ha_auth writes the mode-only oauth section and skips the
+    legacy credential machinery; legacy writes the mode + creds. Skips on
+    flavors without ha_auth."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_stable(self, _webhook_proxy_variant):
+        if not _ha_auth_supported():
+            pytest.skip("flavor does not ship ha_auth start.py support yet")
+
+    def _run_main(self, tmp_path, options, *, probe_active=True):
+        start = _import_start()
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "options.json").write_text(json.dumps(options))
+        config_path = tmp_path / "proxy_config.json"
+
+        def path_factory(arg):
+            if arg == "/data/options.json":
+                return data_dir / "options.json"
+            if arg == "/data":
+                return data_dir
+            if arg == CURRENT["config_file"]:
+                return config_path
+            if arg == CURRENT["oauth_marker"]:
+                return tmp_path / "oauth_marker"
+            return Path(arg)
+
+        resolve_creds = MagicMock(
+            wraps=lambda d, cid, sec: (cid or "hamcp-generated1234567890", sec or "sec")
+        )
+        with (
+            patch.object(start, "Path", side_effect=path_factory),
+            patch.object(start, "_supervisor_get", return_value={"addons": []}),
+            patch.object(start, "_ha_core_api", return_value={}),
+            patch.object(start, "_install_integration", return_value=(False, False)),
+            patch.object(start, "_ensure_config_entry", return_value=True),
+            patch.object(start, "_reload_config_entry"),
+            patch.object(start, "_resolve_oauth_creds", resolve_creds),
+            patch.object(start, "_probe_oauth_active", return_value=probe_active),
+            # Destructive fail-closed helpers: patched so the stale-code path is
+            # observable without tearing down / blocking on a real HA restart.
+            patch.object(start, "_remove_config_entry") as remove_entry,
+            patch.object(start, "_wait_for_ha_restart") as wait_restart,
+            patch.object(start, "_request_restart_repair") as request_repair,
+            patch.object(
+                start, "_install_shutdown_handlers", return_value={"reason": None}
+            ),
+            patch.object(start, "_health_check", return_value=True),
+            patch.object(start, "_shutdown_cleanup"),
+            patch.object(start.time, "sleep", side_effect=KeyboardInterrupt),
+        ):
+            rc = start.main()
+        written = json.loads(config_path.read_text())
+        mocks = {
+            "resolve_creds": resolve_creds,
+            "remove_entry": remove_entry,
+            "wait_restart": wait_restart,
+            "request_repair": request_repair,
+        }
+        return rc, written, mocks
+
+    def test_ha_auth_writes_mode_only_section_and_skips_creds(self, tmp_path, capsys):
+        rc, written, mocks = self._run_main(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": True,
+                # no oauth_mode, no creds, no /data/oauth_creds.json -> ha_auth
+            },
+        )
+        assert rc == 0
+        # Exactly the mode marker; no credential keys.
+        assert written["oauth"] == {"mode": "ha_auth"}
+        # The legacy credential machinery is never invoked in ha_auth mode.
+        mocks["resolve_creds"].assert_not_called()
+        # Probe active -> no fail-closed teardown.
+        mocks["remove_entry"].assert_not_called()
+        out = capsys.readouterr().out
+        assert "Home Assistant login" in out
+        assert "BLANK" in out
+
+    def test_legacy_writes_mode_marker_and_creds(self, tmp_path):
+        rc, written, mocks = self._run_main(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": True,
+                "oauth_client_id": "client-1234567890ABCDEF",
+                "oauth_client_secret": "secret-much-secret",
+            },
+        )
+        assert rc == 0
+        assert written["oauth"]["mode"] == "legacy"
+        assert written["oauth"]["client_id"] == "client-1234567890ABCDEF"
+        assert written["oauth"]["client_secret"] == "secret-much-secret"
+        mocks["resolve_creds"].assert_called_once()
+
+    def test_ha_auth_stale_code_probe_fails_closed(self, tmp_path):
+        """The fail-closed stale-code probe runs in ha_auth too (it closes the
+        code-upgrade fail-open window, not the no-restart-to-toggle promise).
+        When the OAuth metadata endpoint isn't served yet — old cached module
+        after an upgrade — the webhook is torn down and a click-to-restart
+        Repair is requested, even in ha_auth mode."""
+        rc, written, mocks = self._run_main(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": True,
+            },
+            probe_active=False,
+        )
+        assert rc == 0
+        # The ha_auth section is written BEFORE the probe, so it still lands.
+        assert written["oauth"] == {"mode": "ha_auth"}
+        # Fail-closed teardown fired: webhook removed, restart-Repair requested,
+        # and the HA-restart wait entered.
+        assert mocks["remove_entry"].called
+        assert mocks["request_repair"].called
+        mocks["wait_restart"].assert_called_once()
+        # The marker the integration's Repair flow watches was written.
+        assert (tmp_path / "oauth_marker").exists()
+
+    def test_ha_auth_with_remote_url_logs_ignored_notice_and_no_pin(
+        self, tmp_path, capsys
+    ):
+        """Fix 6: in ha_auth mode a configured External URL (remote_url) is
+        deliberately ignored — discovery is host-derived. main() logs the
+        info notice AND writes the mode-only oauth section with NO
+        public_base_url anywhere (reinforcing Fix 4: the External URL never
+        leaks into the ha_auth config)."""
+        rc, written, _mocks = self._run_main(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": True,
+                "remote_url": "https://example.nabu.casa",
+                # no oauth_mode, no creds, no /data/oauth_creds.json -> ha_auth
+            },
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "External URL is ignored in ha_auth mode" in out
+        # Mode-only section; the External URL did not leak into the config.
+        assert written["oauth"] == {"mode": "ha_auth"}
+        assert "public_base_url" not in written
+        assert "public_base_url" not in written["oauth"]
+
+
+class TestStartOAuthOffConfigShape:
+    """enable_oauth stays OFF by default and this PR must not change that: an
+    absent/false enable_oauth writes the byte-identical no-oauth config file
+    shape (no `oauth` section, no `public_base_url`). Runs on BOTH flavors."""
+
+    def _run_main_off(self, tmp_path, options):
+        start = _import_start()
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "options.json").write_text(json.dumps(options))
+        config_path = tmp_path / "proxy_config.json"
+
+        def path_factory(arg):
+            if arg == "/data/options.json":
+                return data_dir / "options.json"
+            if arg == "/data":
+                return data_dir
+            if arg == CURRENT["config_file"]:
+                return config_path
+            return Path(arg)
+
+        with (
+            patch.object(start, "Path", side_effect=path_factory),
+            patch.object(start, "_supervisor_get", return_value={"addons": []}),
+            patch.object(start, "_ha_core_api", return_value={}),
+            patch.object(start, "_install_integration", return_value=(False, False)),
+            patch.object(start, "_ensure_config_entry", return_value=True),
+            patch.object(start, "_reload_config_entry"),
+            patch.object(
+                start, "_install_shutdown_handlers", return_value={"reason": None}
+            ),
+            patch.object(start, "_health_check", return_value=True),
+            patch.object(start, "_shutdown_cleanup"),
+            patch.object(start.time, "sleep", side_effect=KeyboardInterrupt),
+        ):
+            rc = start.main()
+        return rc, json.loads(config_path.read_text())
+
+    def test_absent_enable_oauth_writes_no_oauth_section(self, tmp_path):
+        rc, written = self._run_main_off(
+            tmp_path,
+            {"mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa"},
+        )
+        assert rc == 0
+        # Byte-identical no-oauth shape: exactly the two legacy keys.
+        assert set(written.keys()) == {"target_url", "webhook_id"}
+        assert "oauth" not in written
+        assert "public_base_url" not in written
+
+    def test_false_enable_oauth_writes_no_oauth_section(self, tmp_path):
+        rc, written = self._run_main_off(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": False,
+            },
+        )
+        assert rc == 0
+        assert set(written.keys()) == {"target_url", "webhook_id"}
+        assert "oauth" not in written
+        assert "public_base_url" not in written

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -1972,6 +1972,19 @@ class TestOAuthProvider:
         assert provider.validate_access_token("") is False
         assert provider.validate_access_token("bare") is False
 
+    def test_non_ascii_bearer_rejected_not_raised(self, provider):
+        # C1 regression: a bearer whose pre-signature segment carries a
+        # non-ASCII char makes body.encode("ascii") raise UnicodeEncodeError.
+        # _validate_token must catch it and return False rather than let it
+        # escape the webhook gate (HA core's async_handle_webhook would swallow
+        # it into a 200 OK and never emit the 401 discovery challenge).
+        # The legacy hardening rides the dev flavor until promotion (stable still
+        # hmac's body.encode("ascii") outside the decode try), so skip on stable.
+        if not _ha_auth_supported():
+            pytest.skip("legacy non-ASCII hardening rides the dev flavor until promote")
+        assert provider.validate_access_token("é.AA") is False
+        assert provider.validate_access_token("\xff.AA") is False
+
     def test_token_with_tampered_payload_rejected(self, provider):
         token = provider.issue_access_token()
         body, sig = token.rsplit(".", 1)
@@ -2627,6 +2640,39 @@ class TestOAuthWebhookHandler:
         request.read.assert_not_awaited()
         response_ctor.assert_called_once()
         assert response_ctor.call_args.kwargs.get("status") == 401
+
+    async def test_non_ascii_bearer_gate_returns_401_not_swallowed(self, setup):
+        """C1 gate-level regression: a legacy-mode bearer whose pre-signature
+        segment has a non-ASCII char must yield the 401 discovery challenge, not
+        raise UnicodeEncodeError out of the gate — HA core's async_handle_webhook
+        would swallow that into a 200 OK and never challenge the client."""
+        mod, oauth = setup
+        # The C1 hardening rides the dev flavor until promotion (stable still
+        # hmac's body.encode("ascii") outside the decode try), so skip on stable.
+        if not _ha_auth_supported():
+            pytest.skip("legacy non-ASCII hardening rides the dev flavor until promote")
+        provider = oauth.OAuthProvider(
+            hass=MagicMock(),
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
+        hass = self._make_hass(mod, provider)
+        request = self._make_request("Bearer é.AA")
+        request.headers["Host"] = "example.nabu.casa"
+
+        with patch.object(oauth.web, "Response") as response_ctor:
+            await mod._handle_webhook(hass, "mcp_test", request)
+
+        request.read.assert_not_awaited()
+        response_ctor.assert_called_once()
+        assert response_ctor.call_args.kwargs.get("status") == 401
+        ww = response_ctor.call_args.kwargs.get("headers", {}).get(
+            "WWW-Authenticate", ""
+        )
+        assert ww.startswith("Bearer realm=")
+        assert "resource_metadata=" in ww
 
     async def test_passes_through_with_valid_bearer(self, setup):
         mod, oauth = setup
@@ -4505,6 +4551,36 @@ class TestHaAuthMode:
         mock_create_issue.assert_not_called()
         mock_write.assert_not_called()
 
+    async def test_ha_auth_init_failure_unregisters_and_raises(self, hass, tmp_path):
+        """ha_auth mirror of the legacy provider-init-failure teardown: if
+        register_metadata_views raises while enabling OAuth, the user opted into
+        auth, so refuse to start — raise ConfigEntryError, tear down the webhook
+        registered above (no unauthenticated endpoint left live), close the
+        session (no leak), and leave DOMAIN out of hass.data."""
+        mod, oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        session = MagicMock()
+        session.close = AsyncMock()
+        with (
+            patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
+            patch.object(mod, "async_register"),
+            patch.object(mod, "async_unregister") as mock_unreg,
+            patch.object(mod.aiohttp, "ClientSession", return_value=session),
+            # The integration lazy-imports register_metadata_views at call time
+            # (`from .oauth import register_metadata_views` inside
+            # async_setup_entry), so patching the oauth module attribute lands.
+            patch.object(
+                oauth, "register_metadata_views", side_effect=RuntimeError("boom")
+            ),
+            pytest.raises(_FakeConfigEntryError) as exc_info,
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+
+        assert "Failed to enable OAuth" in str(exc_info.value)
+        mock_unreg.assert_called_once_with(hass, "mcp_test")
+        session.close.assert_awaited_once()
+        assert mod.DOMAIN not in hass.data
+
     async def test_setup_ignores_stray_public_base_url_host_derived(
         self, hass, tmp_path
     ):
@@ -5048,6 +5124,59 @@ class TestHaAuthMode:
             )
         assert jr.call_args.kwargs.get("status") == 404
 
+    async def test_oauth_off_after_on_stale_views_all_404(self, tmp_path):
+        """OAuth toggled OFF after a prior ON: the entry reloaded and __init__
+        rewrote hass.data[DOMAIN] as {target_url, webhook_id, session} with NO
+        'oauth_mode' key, but HA can't drop the still-bound views until a
+        restart. _active_oauth_mode resolves domain_data.get('oauth_mode') ->
+        None, so every bound view must 404 — the distinct present-dict-without-
+        oauth_mode branch (test_unloaded_views_all_404 covers only the
+        DOMAIN-absent branch). Regression guard: someone re-adding a MODE_LEGACY
+        default on that .get()."""
+        _mod, oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        # Exact OAuth-off shape __init__ writes (target_url/webhook_id/session),
+        # a REAL dict with no "oauth_mode" -> _active_oauth_mode returns None.
+        hass.data = {
+            oauth.DOMAIN: {
+                "target_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "webhook_id": "wh",
+                "session": MagicMock(),
+            }
+        }
+        provider = oauth.OAuthProvider(
+            hass=hass,
+            client_id="cid-1234567890ABCDEF",
+            client_secret="sec",
+            webhook_id="wh",
+            signing_key=b"\x00" * 32,
+        )
+        req = _make_view_request(headers={"Host": "h"})
+        for view in (
+            oauth.ProtectedResourceMetadataView(provider),
+            oauth.AuthorizationServerMetadataView(provider),
+        ):
+            with patch.object(oauth.web, "json_response") as jr:
+                await view.get(req)
+            assert jr.call_args.kwargs.get("status") == 404
+        av = oauth.AuthorizeView(provider)
+        with patch.object(oauth.web, "Response") as rc:
+            await av.get(_make_view_request(query={}, method="GET"))
+        assert rc.call_args.kwargs.get("status") == 404
+        with patch.object(oauth.web, "Response") as rc:
+            await av.post(
+                _make_view_request(method="POST", post_data={"action": "approve"})
+            )
+        assert rc.call_args.kwargs.get("status") == 404
+        tv = oauth.TokenView(provider)
+        with patch.object(oauth.web, "json_response") as jr:
+            await tv.post(
+                _make_view_request(
+                    method="POST", post_data={"grant_type": "authorization_code"}
+                )
+            )
+        assert jr.call_args.kwargs.get("status") == 404
+
     # ---- the 401 challenge is the SAME builder + pointer in both modes ----
 
     async def test_401_challenge_byte_identical_legacy_vs_ha_auth(self, tmp_path):
@@ -5258,6 +5387,21 @@ class TestResolveOAuthMode:
         still a legacy trace -> stay on legacy."""
         assert start._resolve_oauth_mode("", "", "sec", tmp_path) == "legacy"
 
+    def test_creds_file_stat_oserror_treated_absent(self, start, capsys):
+        """start.py ~654: Path.exists() re-raises a stat error other than 'not
+        there' (e.g. EACCES). A stat failure is no proof of a legacy install, so
+        _resolve_oauth_mode must catch the OSError, log that it is treating the
+        file as absent, and keep auto-detecting (default ha_auth here) instead of
+        crashing startup."""
+        creds_file = MagicMock()
+        creds_file.exists.side_effect = OSError("EACCES: permission denied")
+        data_dir = MagicMock()
+        data_dir.__truediv__.return_value = creds_file
+        # No configured id/secret and the creds-file stat fails -> ha_auth.
+        assert start._resolve_oauth_mode("", "", "", data_dir) == "ha_auth"
+        # log_error goes to stderr; the "treating it as absent" line must appear.
+        assert "treating it as absent" in capsys.readouterr().err
+
 
 class TestStartHaAuthMode:
     """start.py main(): ha_auth writes the mode-only oauth section and skips the
@@ -5290,15 +5434,23 @@ class TestStartHaAuthMode:
         resolve_creds = MagicMock(
             wraps=lambda d, cid, sec: (cid or "hamcp-generated1234567890", sec or "sec")
         )
+        # A bool probe_active is a constant result; a list/tuple is a per-call
+        # sequence (side_effect) so a caller can model an initial probe failing
+        # and the re-probe succeeding after the HA restart.
+        probe_kwargs = (
+            {"side_effect": list(probe_active)}
+            if isinstance(probe_active, (list, tuple))
+            else {"return_value": probe_active}
+        )
         with (
             patch.object(start, "Path", side_effect=path_factory),
             patch.object(start, "_supervisor_get", return_value={"addons": []}),
-            patch.object(start, "_ha_core_api", return_value={}),
+            patch.object(start, "_ha_core_api", return_value={}) as ha_core_api,
             patch.object(start, "_install_integration", return_value=(False, False)),
             patch.object(start, "_ensure_config_entry", return_value=True),
             patch.object(start, "_reload_config_entry"),
             patch.object(start, "_resolve_oauth_creds", resolve_creds),
-            patch.object(start, "_probe_oauth_active", return_value=probe_active),
+            patch.object(start, "_probe_oauth_active", **probe_kwargs),
             # Destructive fail-closed helpers: patched so the stale-code path is
             # observable without tearing down / blocking on a real HA restart.
             patch.object(start, "_remove_config_entry") as remove_entry,
@@ -5318,6 +5470,7 @@ class TestStartHaAuthMode:
             "remove_entry": remove_entry,
             "wait_restart": wait_restart,
             "request_repair": request_repair,
+            "ha_core_api": ha_core_api,
         }
         return rc, written, mocks
 
@@ -5390,6 +5543,41 @@ class TestStartHaAuthMode:
         mocks["wait_restart"].assert_called_once()
         # The marker the integration's Repair flow watches was written.
         assert (tmp_path / "oauth_marker").exists()
+
+    def test_ha_auth_probe_recovers_after_restart(self, tmp_path, capsys):
+        """Auto-recovery branch (start.py ~1482): the initial stale-code probe
+        fails, so main() tears the entry down, writes the restart marker, and
+        waits for the HA restart; the re-probe then succeeds, so the stale
+        notification is dismissed, the marker is unlinked, and the webhook is
+        reported re-enabled — no manual intervention needed."""
+        rc, written, mocks = self._run_main(
+            tmp_path,
+            {
+                "mcp_server_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "enable_oauth": True,
+            },
+            probe_active=[False, True],  # initial probe fails, re-probe succeeds
+        )
+        assert rc == 0
+        # The ha_auth section is written BEFORE the probe, so it still lands.
+        assert written["oauth"] == {"mode": "ha_auth"}
+        # Initial probe failed -> fail-closed teardown ran and the restart was
+        # awaited.
+        assert mocks["remove_entry"].called
+        assert mocks["request_repair"].called
+        mocks["wait_restart"].assert_called_once()
+        # Re-probe succeeded -> the OAuth-stale notification was dismissed (the
+        # recovery branch's dismiss, not the several dismissed at startup).
+        dismiss_calls = [
+            c
+            for c in mocks["ha_core_api"].call_args_list
+            if c.args[:2] == ("POST", "/services/persistent_notification/dismiss")
+            and c.args[2].get("notification_id", "").endswith("oauth_stale")
+        ]
+        assert len(dismiss_calls) == 1
+        # ...the marker was unlinked, and the webhook reported re-enabled.
+        assert not (tmp_path / "oauth_marker").exists()
+        assert "webhook re-enabled" in capsys.readouterr().out
 
     def test_ha_auth_with_remote_url_logs_ignored_notice_and_no_pin(
         self, tmp_path, capsys


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1714. Adds a standardized OAuth mode (`ha_auth`) to the dev Webhook Proxy that delegates authorization to Home Assistant core instead of the add-on's hand-rolled embedded authorization server. HA core is the OAuth authorization server (`/auth/authorize` + `/auth/token`, PKCE, refresh) and the add-on is a pure resource server: it serves the RFC 8414/9728 discovery documents host-agnostically and validates bearer tokens via `hass.auth`. The AS document advertises Client ID Metadata Documents, so the connector's OAuth fields stay blank and the user signs in with their Home Assistant account. Also enables ChatGPT connectors (#1725).

Three mutually exclusive modes:
- **off** (default) — URL secrecy only, byte-identical to today.
- **ha_auth** — new default for first-time enables. Works on any hostname regardless of HA's `external_url` (discovery is derived from the request host). No HA restart to enable, disable, or switch.
- **legacy** — the existing client-id/secret embedded AS, unchanged, kept for host-mismatch setups (deprecated).

**Upgrade safety / potential breaking change (OAuth users):** no default is injected into upgraders' options; startup resolution keeps existing legacy users (explicit `oauth_mode` wins, else detected legacy credentials keep legacy, else first-time enables default to ha_auth) — an existing legacy user is never switched silently. Ambiguous configs fail loudly with teardown. Live mode switches are restart-free and safe: both modes share one flag-guarded metadata-view registrar and the bound views resolve the active mode/provider per request (host-derived under ha_auth, host-pinned under legacy); stale views 404 like unregistered routes, including the legacy `/authorize` + `/token`. The fail-closed stale-code probe now runs in both modes, and bearer validation fails closed to the 401 discovery challenge in both modes — review hardening also fixed a legacy token-parsing hole where a non-ASCII bearer escaped as an unhandled exception (an empty 200 via HA core's webhook wrapper) instead of the 401 challenge. `enable_oauth` stays OFF by default and the feature remains Beta.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Add-on suite green on both flavors: 504 passed, 56 skipped; 25 new tests (mode switches both directions, register-once across unload/reload, bearer header edge matrix including non-ASCII tokens, validator-exception fail-closed, unloaded and OAuth-off-after-on stale-view 404s, ha_auth setup-failure teardown, resolution precedence including stat errors, stale-code probe fail-closed and recovery, 401 parity, AS-document identity at all four well-known locations, live-switch base-URL policy both directions, cross-module literal agreement). The ha_auth flow was validated end-to-end against live claude.ai — browser sign-in via HA login, secret-less token exchange, authenticated MCP session — on a host HA's own metadata does not recognize. Stable flavor untouched; version bumped to 1.2.3.dev4 (config.yaml + manifest together).

## Checklist
- [x] I have updated documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)
