### PR TITLE
fix: bump bundled skills to v12 + enable Renovate git-submodules manager (closes #1729)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,10 @@
     "dockerfile",
     "git-submodules"
   ],
+  "git-submodules": {
+    "description": "The git-submodules manager ships enabled=false by default; enabledManagers only filters the manager list and does not flip that default, so both are required (#1729)",
+    "enabled": true
+  },
   "ignorePaths": [],
   "customManagers": [
     {


### PR DESCRIPTION
## What does this PR do?

Fixes #1729 at both levels: catches the bundled skills up to current upstream, and fixes the Renovate misconfiguration that let them fall behind in the first place.

**1. Bump `skills-vendor` submodule** from `cf2b714c` (skill version 5) to `441d0770` (skill version 12), the current head of [homeassistant-ai/skills](https://github.com/homeassistant-ai/skills) `main` — 17 commits behind. Picks up:

- `references/appdaemon.md` (new)
- `references/scenes.md` (new: `scene.create`, `scene.apply`)
- Automation-patterns additions (variables, stopping sequences, capturing responses, parallel actions)
- Helper-selection additions (probabilistic inference)
- Dashboard additions (strategies, badges)
- Additional anti-patterns in `SKILL.md`

**2. Actually enable the Renovate `git-submodules` manager.** #1383 added it to `enabledManagers`, but `enabledManagers` is only a filter over which managers run — it does not override a manager's own default config. `git-submodules` is the one manager in our list that ships `enabled: false` by default ([manager docs](https://docs.renovatebot.com/modules/manager/git-submodules/) show the required `"git-submodules": {"enabled": true}` opt-in). So every weekly run since 2026-05-20 matched `.gitmodules`, hit the `if (!enabled) return []` guard in Renovate's `getManagerPackageFiles`, and silently extracted nothing — which is why the Dependency Dashboard (#1237) lists only `dockerfile` and `regex` and no submodule bump PR was ever opened. This PR sets `git-submodules.enabled: true` so future skills-vendor updates are proposed automatically every Tuesday run.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No Python changes — the skill loader resolves files dynamically from `src/ha_mcp/resources/skills-vendor/skills/`, so no code or manifest updates are needed. Verified the new tree contains `appdaemon.md` and `scenes.md` and `SKILL.md` frontmatter reads `version: 12`. The Renovate root cause was verified against the Renovate 43.249.2 source (manager `defaultConfig.enabled: false`; `enabledManagers` filter semantics; the `getManagerPackageFiles` enabled guard) and against the 2026-06-30 run's manager stats, which list only `dockerfile` and `regex`. The config fix takes effect on the next scheduled Tuesday run and can be confirmed there (git-submodules appearing in the Dependency Dashboard's detected dependencies).

## Checklist
- [x] I have updated documentation if needed
