### PR TITLE
feat: align validator, traces, and update tools with HA 2026.7

### DIFF
--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -131,6 +131,16 @@ def _custom_tool_write(args: dict[str, Any]) -> str | None:
     return "sandbox code execution"
 
 
+def _updates_write(args: dict[str, Any]) -> str | None:
+    # ``action`` defaults to "list" at the schema layer, so a missing action
+    # executes as a read (the middleware sees RAW pre-validation arguments —
+    # an absent key here means the tool itself will run the list branch).
+    action = args.get("action")
+    if action in (None, "list", "get"):
+        return None
+    return f"action={action!r}"
+
+
 def _radio_write(args: dict[str, Any]) -> str | None:
     action = args.get("action")
     # Reads (allowed): per-node diagnostics, the integration/network summary,
@@ -199,6 +209,14 @@ READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
         "('network_status'), the active reachability probe ('ping'), a Zigbee "
         "cluster-attribute read ('cluster_read'), and the Thread dataset "
         "listing ('list_datasets')",
+    ),
+    # Update listing/details exist only here — ha_get_updates was merged
+    # into this tool (issue #1726), so hiding it would remove the read
+    # surface entirely.
+    "ha_manage_updates": ReadOnlyExemption(
+        _updates_write,
+        "listing pending updates (action='list', the default) and reading "
+        "update details/release notes (action='get')",
     ),
 }
 

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -695,7 +695,9 @@ def _check_triggers(
         platform = trigger.get("platform", trigger.get("trigger", ""))
 
         # 2026.7 renamed purpose-specific trigger keys — old keys no longer load.
-        renamed_trigger = _RENAMED_TRIGGER_KEYS.get(platform)
+        renamed_trigger = (
+            _RENAMED_TRIGGER_KEYS.get(platform) if isinstance(platform, str) else None
+        )
         if renamed_trigger:
             _emit(
                 warnings,

--- a/src/ha_mcp/tools/best_practice_checker.py
+++ b/src/ha_mcp/tools/best_practice_checker.py
@@ -162,6 +162,28 @@ _TARGET_FIELDS = ("entity_id", "device_id", "area_id", "floor_id", "label_id")
 # ``service:`` (legacy) and ``action:`` (modern, 2024+) for the same field.
 _SERVICE_KEYS = ("service", "action")
 
+# Purpose-specific trigger/condition keys renamed in HA 2026.7 — the old keys
+# no longer load (home-assistant/core#174463).
+_RENAMED_TRIGGER_KEYS = {
+    "battery.low": "battery.became_low",
+    "battery.not_low": "battery.no_longer_low",
+    "lawn_mower.docked": "lawn_mower.returned_to_dock",
+    "schedule.turned_on": "schedule.block_started",
+    "schedule.turned_off": "schedule.block_ended",
+    "timer.time_remaining": "timer.remaining_time_reached",
+    "update.update_became_available": "update.became_available",
+    "vacuum.docked": "vacuum.returned_to_dock",
+}
+_RENAMED_CONDITION_KEYS = {
+    "climate.target_temperature": "climate.is_target_temperature",
+    "climate.target_humidity": "climate.is_target_humidity",
+}
+# Trigger ``options.behavior`` values renamed in HA 2026.7: any→each,
+# last→all (home-assistant/core#173259). The old values still load but raise
+# an HA repair issue and face removal. Condition ``options.behavior`` keeps
+# ``any``/``all`` — conditions are never flagged.
+_DEPRECATED_TRIGGER_BEHAVIOR = {"any": "each", "last": "all"}
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -318,6 +340,23 @@ def _check_condition_templates(
             # Shorthand template condition
             _check_template_string(cond, warnings, skill_prefix, "condition")
         elif isinstance(cond, dict):
+            # 2026.7 renamed purpose-specific condition keys — old keys no
+            # longer load.
+            condition_key = cond.get("condition")
+            renamed_condition = (
+                _RENAMED_CONDITION_KEYS.get(condition_key)
+                if isinstance(condition_key, str)
+                else None
+            )
+            if renamed_condition:
+                _emit(
+                    warnings,
+                    f"Condition key `{condition_key}` was renamed to "
+                    f"`{renamed_condition}` in HA 2026.7 and the old key no "
+                    f"longer loads — use `condition: {renamed_condition}`.",
+                    skill_prefix,
+                    "automation-patterns.md#native-conditions",
+                )
             if cond.get("condition") == "template":
                 vt = cond.get("value_template", "")
                 if isinstance(vt, str):
@@ -655,12 +694,42 @@ def _check_triggers(
 
         platform = trigger.get("platform", trigger.get("trigger", ""))
 
+        # 2026.7 renamed purpose-specific trigger keys — old keys no longer load.
+        renamed_trigger = _RENAMED_TRIGGER_KEYS.get(platform)
+        if renamed_trigger:
+            _emit(
+                warnings,
+                f"Trigger key `{platform}` was renamed to `{renamed_trigger}` "
+                "in HA 2026.7 and the old key no longer loads — use "
+                f"`trigger: {renamed_trigger}`.",
+                skill_prefix,
+                "automation-patterns.md#trigger-types",
+            )
+
+        # 2026.7 renamed trigger `options.behavior` values (any→each, last→all).
+        options = trigger.get("options")
+        if isinstance(options, dict):
+            behavior = options.get("behavior")
+            if isinstance(behavior, str) and behavior in _DEPRECATED_TRIGGER_BEHAVIOR:
+                _emit(
+                    warnings,
+                    f"Trigger `options.behavior: {behavior}` was renamed to "
+                    f"`{_DEPRECATED_TRIGGER_BEHAVIOR[behavior]}` in HA 2026.7 — "
+                    "the old value still loads but raises a repair issue and "
+                    "will be removed. Valid trigger values: `each`, `first`, "
+                    "`all` (conditions keep `any`/`all`).",
+                    skill_prefix,
+                    "automation-patterns.md#trigger-types",
+                )
+
         # Device trigger → prefer entity_id-based triggers
         if platform == "device":
             _emit(
                 warnings,
-                "Trigger uses `device` platform with `device_id` — prefer "
-                "`state` or `event` trigger with `entity_id` when possible "
+                "Trigger uses `device` platform with `device_id` — prefer a "
+                "purpose-specific trigger (`<domain>.<name>` with a `target:` "
+                "of entities/areas/floors/labels, HA 2026.7+) or a `state`/"
+                "`event` trigger with `entity_id` when possible "
                 "(device_id breaks on re-add).",
                 skill_prefix,
                 "device-control.md#entity-id-vs-device-id",

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -440,6 +440,8 @@ class AutomationConfigTools:
             Field(
                 description="Complete automation configuration with required fields: 'alias', 'triggers', 'actions'. "
                 "Optional: 'description', 'conditions', 'mode', 'max', 'initial_state', 'variables'. "
+                "Purpose-specific triggers/conditions (HA 2026.7+ default: 'trigger': '<domain>.<name>' "
+                "with 'target'/'options') are valid config. "
                 "Mutually exclusive with python_transform.",
                 default=None,
             ),

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -712,6 +712,8 @@ def _populate_trigger_info(
             )
         if "entity_id" in trigger_vars:
             result["trigger"]["entity_id"] = trigger_vars["entity_id"]
+        if "error" in trigger_step:
+            result["trigger"]["error"] = trigger_step["error"]
 
     if "trigger" not in result and "trigger" in trace:
         result["trigger"] = {"description": trace["trigger"]}
@@ -731,6 +733,11 @@ def _populate_condition_results(
             }
             if "timestamp" in cond:
                 cond_result["timestamp"] = cond["timestamp"]
+            # HA 2026.7+ always records template errors on the failing step
+            # (core #172917) — dropping this field would hide the reason a
+            # condition evaluated to None.
+            if "error" in cond:
+                cond_result["error"] = cond["error"]
             condition_results.append(cond_result)
         result["condition_results"] = condition_results
 

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -661,118 +661,6 @@ class UpdateTools:
 
         return None, None
 
-    @tool(
-        name="ha_get_updates",
-        tags={"System"},
-        annotations={
-            "idempotentHint": True,
-            "openWorldHint": True,
-            "readOnlyHint": True,
-            "title": "Get Updates",
-        },
-    )
-    @log_tool_usage
-    async def ha_get_updates(
-        self,
-        entity_id: Annotated[
-            str | None,
-            Field(
-                description="Update entity ID to get details for (e.g., 'update.home_assistant_core_update'). "
-                "If omitted, lists all available updates.",
-                default=None,
-            ),
-        ] = None,
-        include_skipped: Annotated[
-            bool,
-            Field(
-                description="When listing all updates, include updates that have been skipped (default: False)",
-                default=False,
-            ),
-        ] = False,
-        include_release_notes: Annotated[
-            bool,
-            Field(
-                description="When getting a Core update entity, fetch multi-version release notes "
-                "and breaking changes for all versions between installed and latest (default: False). "
-                "Adds breaking_changes, multi_version_release_notes, and installed_integrations to the response.",
-                default=False,
-            ),
-        ] = False,
-    ) -> dict[str, Any]:
-        """
-        Get update information -- list all updates or get details for a specific one.
-
-        Without an entity_id: Lists all available updates across the system including
-        Home Assistant Core, add-ons, device firmware, HACS, and OS updates.
-
-        With an entity_id: Returns detailed information about a specific update including
-        version info, category, and release notes (if available).
-
-        With include_release_notes=True (Core updates only): Also fetches HA release
-        blog posts for every monthly version between installed and latest. Returns
-        structured breaking changes and installed integration domains for cross-referencing.
-
-        EXAMPLES:
-        - List all updates: ha_get_updates()
-        - List including skipped: ha_get_updates(include_skipped=True)
-        - Get specific update: ha_get_updates(entity_id="update.home_assistant_core_update")
-        - Pre-update analysis: ha_get_updates(entity_id="update.home_assistant_core_update", include_release_notes=True)
-
-        RETURNS (when listing):
-        - updates_available: Count of available updates
-        - updates: List of update entities with version info
-        - categories: Updates grouped by category (core, addons, devices, hacs, os)
-        - ha_mcp_update: This MCP server's own update status
-          {current, latest, update_available} — so you can flag a newer ha-mcp
-          release (from PyPI for pip/Docker, the Supervisor add-on store for the
-          add-on). Present on all install types; omitted only for the unknown
-          version and when HA_MCP_DISABLE_UPDATE_CHECK is set.
-
-        RETURNS (when getting specific update):
-        - Update details including installed/latest versions
-        - Release notes (fetched from WebSocket API or GitHub)
-        - Category and installation status
-
-        RETURNS (with include_release_notes=True, Core only):
-        - breaking_changes.entries[]: Each has integration, description, version
-        - multi_version_release_notes[]: Full text per version {version, content, source_url}
-        - installed_integrations: Your integration domains for cross-referencing
-        """
-        try:
-            if entity_id is None:
-                return await self._list_updates(bool(include_skipped))
-            else:
-                return await self._get_update_details(
-                    entity_id, bool(include_release_notes)
-                )
-
-        except ToolError:
-            raise
-        except Exception as e:
-            error_msg = str(e)
-            if entity_id and ("404" in error_msg or "not found" in error_msg.lower()):
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.ENTITY_NOT_FOUND,
-                        f"Update entity not found: {entity_id}",
-                        context={"entity_id": entity_id},
-                        suggestions=[
-                            "Use ha_get_updates() without entity_id to see all available updates"
-                        ],
-                    )
-                )
-            logger.error(f"Failed to get updates: {e}")
-            exception_to_structured_error(
-                e,
-                suggestions=[
-                    "Check Home Assistant connection",
-                    "Verify API access permissions",
-                ],
-            )
-            return (
-                None  # exception_to_structured_error always raises; explicit for CodeQL
-            )
-
     async def _resolve_update_targets(
         self,
         action: str,
@@ -780,16 +668,6 @@ class UpdateTools:
         categories: list[str] | str | None,
     ) -> list[str]:
         """Validate parameters and resolve the update entity_ids to act on."""
-        if action not in ("install", "skip", "clear_skipped"):
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"Invalid action '{action}'. "
-                    "Must be 'install', 'skip', or 'clear_skipped'.",
-                    context={"action": action},
-                )
-            )
-
         ids = [entity_ids] if isinstance(entity_ids, str) else list(entity_ids or [])
         cats = [categories] if isinstance(categories, str) else list(categories or [])
 
@@ -868,16 +746,20 @@ class UpdateTools:
         action: Annotated[
             str,
             Field(
-                description="'install' (apply pending updates), 'skip' (hide the "
-                "offered version), or 'clear_skipped' (re-offer a skipped version)."
+                description="'list' (all pending updates, default), 'get' "
+                "(details/release notes for one update), 'install' (apply "
+                "pending updates), 'skip' (hide the offered version), or "
+                "'clear_skipped' (re-offer a skipped version).",
+                default="list",
             ),
-        ],
+        ] = "list",
         entity_ids: Annotated[
             list[str] | str | None,
             JSON_STRING_COERCION,
             Field(
-                description="Update entity_id(s) to act on. Required for "
-                "skip/clear_skipped; for install, mutually exclusive with categories.",
+                description="Update entity_id(s) to act on. 'get' takes exactly "
+                "one; skip/clear_skipped require at least one; for install, "
+                "mutually exclusive with categories.",
                 default=None,
             ),
         ] = None,
@@ -893,6 +775,25 @@ class UpdateTools:
                 default=None,
             ),
         ] = None,
+        include_skipped: Annotated[
+            bool,
+            Field(
+                description="For list: include updates that have been skipped "
+                "(default: False).",
+                default=False,
+            ),
+        ] = False,
+        include_release_notes: Annotated[
+            bool,
+            Field(
+                description="For get on a Core update entity: fetch multi-version "
+                "release notes and breaking changes for all versions between "
+                "installed and latest (default: False). Adds breaking_changes, "
+                "multi_version_release_notes, and installed_integrations to the "
+                "response.",
+                default=False,
+            ),
+        ] = False,
         backup: Annotated[
             bool,
             Field(
@@ -902,16 +803,62 @@ class UpdateTools:
             ),
         ] = False,
     ) -> dict[str, Any]:
-        """Manage pending updates -- batch install, skip, or un-skip update entities.
+        """Manage Home Assistant updates -- list, read details, batch install, skip, or un-skip.
 
-        When NOT to use: reading update status or release notes -- use ha_get_updates.
+        Covers Core, OS, supervisor, apps (add-ons), device firmware, and HACS
+        update entities. In Read Only Mode the read actions ('list', 'get') stay
+        available; write actions are blocked.
 
-        Installs run asynchronously in Home Assistant and can take minutes: this
-        tool returns once the install calls are accepted, with per-entity results.
-        Poll ha_get_updates to watch in_progress until installed_version reaches
-        latest_version.
+        Installs run asynchronously in Home Assistant and can take minutes:
+        'install' returns once the service calls are accepted, with per-entity
+        results. Poll action='list' to watch in_progress until installed_version
+        reaches latest_version.
+
+        EXAMPLES:
+        - List all updates: ha_manage_updates()
+        - Pre-update analysis: ha_manage_updates(action="get", entity_ids=["update.home_assistant_core_update"], include_release_notes=True)
+        - Update everything pending in a category: ha_manage_updates(action="install", categories=["addons", "hacs"])
+
+        RETURNS (action='list'): updates_available, updates, categories, and
+        ha_mcp_update -- this MCP server's own update status {current, latest,
+        update_available}, so a newer ha-mcp release can be flagged.
+
+        RETURNS (action='get'): update details, release notes; with
+        include_release_notes=True on Core also breaking_changes.entries[],
+        multi_version_release_notes[], and installed_integrations.
         """
         try:
+            if action == "list":
+                return await self._list_updates(bool(include_skipped))
+
+            if action == "get":
+                ids = (
+                    [entity_ids]
+                    if isinstance(entity_ids, str)
+                    else list(entity_ids or [])
+                )
+                if len(ids) != 1:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            "'get' requires exactly one entity in entity_ids.",
+                            context={"entity_ids": ids},
+                        )
+                    )
+                return await self._get_update_details(
+                    ids[0], bool(include_release_notes)
+                )
+
+            if action not in ("install", "skip", "clear_skipped"):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Invalid action '{action}'. Must be 'list', 'get', "
+                        "'install', 'skip', or 'clear_skipped'.",
+                        context={"action": action},
+                    )
+                )
+
             targets = await self._resolve_update_targets(action, entity_ids, categories)
 
             results: list[dict[str, Any]] = []
@@ -928,7 +875,7 @@ class UpdateTools:
                         ErrorCode.ENTITY_NOT_FOUND,
                         f"Update entity not found: {eid}",
                         context={"entity_id": eid},
-                        suggestions=["Use ha_get_updates() to list update entities"],
+                        suggestions=["Use ha_manage_updates() to list update entities"],
                     )
                     for eid in targets
                     if eid not in known
@@ -967,19 +914,38 @@ class UpdateTools:
             elif action == "install" and succeeded:
                 response["note"] = (
                     "Installs run asynchronously in Home Assistant and can take "
-                    "minutes; poll ha_get_updates to track progress."
+                    "minutes; poll ha_manage_updates(action='list') to track "
+                    "progress."
                 )
             return response
 
         except ToolError:
             raise
         except Exception as e:
+            error_msg = str(e)
+            if (
+                action == "get"
+                and entity_ids
+                and ("404" in error_msg or "not found" in error_msg.lower())
+            ):
+                eid = entity_ids if isinstance(entity_ids, str) else entity_ids[0]
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        f"Update entity not found: {eid}",
+                        context={"entity_id": eid},
+                        suggestions=[
+                            "Use ha_manage_updates() without entity_ids to see "
+                            "all available updates"
+                        ],
+                    )
+                )
             logger.error(f"Failed to manage updates: {e}")
             exception_to_structured_error(
                 e,
                 suggestions=[
                     "Check Home Assistant connection",
-                    "Use ha_get_updates() to inspect available updates",
+                    "Use ha_manage_updates() to inspect available updates",
                 ],
             )
             return (

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -910,12 +910,15 @@ class UpdateTools:
                         )
                     )
 
+            failed = requested - succeeded
             response: dict[str, Any] = {
-                "success": True,
+                # Aggregate convention (matches ha_bulk-style tools): True only
+                # when nothing failed — zero requested counts as success.
+                "success": failed == 0,
                 "action": action,
                 "requested": requested,
                 "succeeded": succeeded,
-                "failed": requested - succeeded,
+                "failed": failed,
                 "results": results,
             }
             if not requested:

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -15,6 +15,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import (
+    HomeAssistantAuthError,
+    HomeAssistantConnectionError,
+)
 from ..errors import ErrorCode, create_error_response
 from .helpers import (
     exception_to_structured_error,
@@ -735,7 +739,7 @@ class UpdateTools:
         name="ha_manage_updates",
         tags={"System"},
         annotations={
-            "destructiveHint": False,
+            "destructiveHint": True,
             "openWorldHint": True,
             "title": "Manage Updates",
         },
@@ -891,6 +895,11 @@ class UpdateTools:
                     await self._client.call_service("update", action, data)
                     results.append({"success": True, "entity_id": eid})
                     succeeded += 1
+                except (HomeAssistantConnectionError, HomeAssistantAuthError):
+                    # Fatal transport/auth failure — the connection is gone,
+                    # so remaining items would fail identically. Propagate to
+                    # surface the root cause instead of N per-item errors.
+                    raise
                 except Exception as e:
                     # Batch item failure — collect, don't raise.
                     results.append(

--- a/src/ha_mcp/tools/tools_updates.py
+++ b/src/ha_mcp/tools/tools_updates.py
@@ -22,8 +22,15 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .util_helpers import JSON_STRING_COERCION
 
 logger = logging.getLogger(__name__)
+
+# Batch-install category split, mirroring the HA 2026.7 Updates page: the
+# "Update all" button never covers core/OS/supervisor — those are applied
+# individually, on purpose.
+_INSTALL_ALL_CATEGORIES = ("addons", "hacs", "devices", "other")
+_PROTECTED_UPDATE_CATEGORIES = ("core", "os", "supervisor")
 
 _GITHUB_CORE_RELEASE_URL = (
     "https://api.github.com/repos/home-assistant/core/releases/tags/{version}"
@@ -760,6 +767,219 @@ class UpdateTools:
                 suggestions=[
                     "Check Home Assistant connection",
                     "Verify API access permissions",
+                ],
+            )
+            return (
+                None  # exception_to_structured_error always raises; explicit for CodeQL
+            )
+
+    async def _resolve_update_targets(
+        self,
+        action: str,
+        entity_ids: list[str] | str | None,
+        categories: list[str] | str | None,
+    ) -> list[str]:
+        """Validate parameters and resolve the update entity_ids to act on."""
+        if action not in ("install", "skip", "clear_skipped"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Invalid action '{action}'. "
+                    "Must be 'install', 'skip', or 'clear_skipped'.",
+                    context={"action": action},
+                )
+            )
+
+        ids = [entity_ids] if isinstance(entity_ids, str) else list(entity_ids or [])
+        cats = [categories] if isinstance(categories, str) else list(categories or [])
+
+        if action != "install" and (not ids or cats):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"'{action}' requires entity_ids; categories is install-only.",
+                )
+            )
+        if action == "install" and bool(ids) == bool(cats):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "'install' requires exactly one of entity_ids or categories.",
+                )
+            )
+
+        invalid = [e for e in ids if not e.startswith("update.")]
+        if invalid:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "entity_ids must be 'update.' entities.",
+                    context={"invalid_entity_ids": invalid},
+                )
+            )
+
+        if not cats:
+            return list(dict.fromkeys(ids))
+
+        protected = sorted(set(cats) & set(_PROTECTED_UPDATE_CATEGORIES))
+        unknown = sorted(
+            set(cats) - set(_INSTALL_ALL_CATEGORIES) - set(_PROTECTED_UPDATE_CATEGORIES)
+        )
+        if protected or unknown:
+            problems = []
+            if protected:
+                problems.append(
+                    f"categories {protected} are excluded from batch install by "
+                    "design (mirrors the HA Updates page, which never bundles "
+                    "core/OS/supervisor into 'Update all') — target those "
+                    "individually via entity_ids"
+                )
+            if unknown:
+                problems.append(f"unknown categories {unknown}")
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "; ".join(problems),
+                    context={"allowed_categories": list(_INSTALL_ALL_CATEGORIES)},
+                )
+            )
+
+        listing = await self._list_updates(include_skipped=False)
+        listed_categories = listing.get("categories", {})
+        return [
+            update["entity_id"]
+            for cat in dict.fromkeys(cats)
+            for update in listed_categories.get(cat, [])
+            if update.get("can_install")
+        ]
+
+    @tool(
+        name="ha_manage_updates",
+        tags={"System"},
+        annotations={
+            "destructiveHint": False,
+            "openWorldHint": True,
+            "title": "Manage Updates",
+        },
+    )
+    @log_tool_usage
+    async def ha_manage_updates(
+        self,
+        action: Annotated[
+            str,
+            Field(
+                description="'install' (apply pending updates), 'skip' (hide the "
+                "offered version), or 'clear_skipped' (re-offer a skipped version)."
+            ),
+        ],
+        entity_ids: Annotated[
+            list[str] | str | None,
+            JSON_STRING_COERCION,
+            Field(
+                description="Update entity_id(s) to act on. Required for "
+                "skip/clear_skipped; for install, mutually exclusive with categories.",
+                default=None,
+            ),
+        ] = None,
+        categories: Annotated[
+            list[str] | str | None,
+            JSON_STRING_COERCION,
+            Field(
+                description="For install: apply every pending update in these "
+                "categories ('addons', 'hacs', 'devices', 'other'). Mirrors the "
+                "HA 2026.7 'Update all' button: core/os/supervisor are excluded "
+                "by design (target those individually via entity_ids) and "
+                "skipped updates are never included.",
+                default=None,
+            ),
+        ] = None,
+        backup: Annotated[
+            bool,
+            Field(
+                description="For install: create a backup before installing where "
+                "the update entity supports it (apps/add-ons). Default: False.",
+                default=False,
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Manage pending updates -- batch install, skip, or un-skip update entities.
+
+        When NOT to use: reading update status or release notes -- use ha_get_updates.
+
+        Installs run asynchronously in Home Assistant and can take minutes: this
+        tool returns once the install calls are accepted, with per-entity results.
+        Poll ha_get_updates to watch in_progress until installed_version reaches
+        latest_version.
+        """
+        try:
+            targets = await self._resolve_update_targets(action, entity_ids, categories)
+
+            results: list[dict[str, Any]] = []
+            requested = len(targets)
+
+            # Explicit-id mode: verify the entities exist up front. HA service
+            # calls targeting nonexistent entities no-op silently, which would
+            # otherwise read as success.
+            if entity_ids:
+                states = await self._client.get_states()
+                known = {s.get("entity_id") for s in states if isinstance(s, dict)}
+                results.extend(
+                    create_error_response(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        f"Update entity not found: {eid}",
+                        context={"entity_id": eid},
+                        suggestions=["Use ha_get_updates() to list update entities"],
+                    )
+                    for eid in targets
+                    if eid not in known
+                )
+                targets = [e for e in targets if e in known]
+
+            succeeded = 0
+            for eid in targets:
+                data: dict[str, Any] = {"entity_id": eid}
+                if action == "install" and backup:
+                    data["backup"] = True
+                try:
+                    await self._client.call_service("update", action, data)
+                    results.append({"success": True, "entity_id": eid})
+                    succeeded += 1
+                except Exception as e:
+                    # Batch item failure — collect, don't raise.
+                    results.append(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            str(e),
+                            context={"entity_id": eid},
+                        )
+                    )
+
+            response: dict[str, Any] = {
+                "success": True,
+                "action": action,
+                "requested": requested,
+                "succeeded": succeeded,
+                "failed": requested - succeeded,
+                "results": results,
+            }
+            if not requested:
+                response["note"] = "No matching pending updates to act on."
+            elif action == "install" and succeeded:
+                response["note"] = (
+                    "Installs run asynchronously in Home Assistant and can take "
+                    "minutes; poll ha_get_updates to track progress."
+                )
+            return response
+
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to manage updates: {e}")
+            exception_to_structured_error(
+                e,
+                suggestions=[
+                    "Check Home Assistant connection",
+                    "Use ha_get_updates() to inspect available updates",
                 ],
             )
             return (

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -3,7 +3,7 @@
 An operator can sit on an old build without ever knowing. This does a
 fail-silent check, holds the result in memory for the process, and surfaces a
 newer release via a startup log banner and the ``ha_get_overview`` /
-``ha_get_system_health`` / ``ha_get_updates`` tool fields.
+``ha_get_system_health`` / ``ha_manage_updates`` tool fields.
 
 The comparison reference depends on how ha-mcp is deployed, because the running
 version only means something against the matching source:
@@ -216,7 +216,7 @@ async def get_update_field() -> UpdateField | None:
     so it never blocks the event loop, and shapes the result for embedding under
     an ``ha_mcp_update`` key. Never raises — a hiccup yields None (the tool omits
     the field) and is logged at debug. Shared by every status tool that surfaces
-    the notice (``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates``)
+    the notice (``ha_get_overview`` / ``ha_get_system_health`` / ``ha_manage_updates``)
     so the shaping and event-loop offload live in one place.
     """
     try:

--- a/src/ha_mcp/utils/domain_handlers.py
+++ b/src/ha_mcp/utils/domain_handlers.py
@@ -176,7 +176,16 @@ DOMAIN_HANDLERS = {
         "valid_actions": [],
         "parameters": [],
         "quick_actions": [],
-        "state_attributes": ["state", "latitude", "longitude"],
+        # in_zones (all containing zones, smallest first) and tracking_type
+        # ("connection"/"location") were added in HA 2026.7; latitude/longitude
+        # may be absent when a person/tracker is located by a presence scanner.
+        "state_attributes": [
+            "state",
+            "latitude",
+            "longitude",
+            "in_zones",
+            "tracking_type",
+        ],
         "read_only": True,
         "provides_location": True,
     },

--- a/tests/src/e2e/workflows/system/test_self_update_notice.py
+++ b/tests/src/e2e/workflows/system/test_self_update_notice.py
@@ -2,7 +2,7 @@
 
 The standalone channels (pip / Docker / stdio) have no Supervisor-driven
 auto-update, so the server surfaces a newer-release notice via
-``ha_get_overview`` / ``ha_get_system_health`` / ``ha_get_updates``. These tests
+``ha_get_overview`` / ``ha_get_system_health`` / ``ha_manage_updates``. These tests
 exercise the real MCP client -> server -> tool -> ``update_check`` path against a
 live HA and assert the field actually reaches the response.
 
@@ -60,7 +60,7 @@ class TestSelfUpdateNoticeSurfacedInTools:
         [
             ("ha_get_overview", {}),
             ("ha_get_system_health", {}),
-            ("ha_get_updates", {}),
+            ("ha_manage_updates", {}),
         ],
     )
     async def test_update_available_surfaced(

--- a/tests/src/e2e/workflows/system/test_self_update_notice_inaddon.py
+++ b/tests/src/e2e/workflows/system/test_self_update_notice_inaddon.py
@@ -25,7 +25,7 @@ pytestmark = [pytest.mark.inaddon_only, pytest.mark.system]
 
 
 @pytest.mark.parametrize(
-    "tool", ["ha_get_overview", "ha_get_system_health", "ha_get_updates"]
+    "tool", ["ha_get_overview", "ha_get_system_health", "ha_manage_updates"]
 )
 async def test_dev_addon_surfaces_update_field_from_supervisor(
     mcp_client, tool: str

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -581,3 +581,89 @@ class TestUpdatesGetNegativeInputs:
             assert "suggestion" in data["error"], (
                 "Error response should include a suggestion"
             )
+
+
+@pytest.mark.updates
+class TestManageUpdates:
+    """E2E tests for ha_manage_updates (batch install / skip / clear_skipped)."""
+
+    async def test_invalid_action_rejected(self, mcp_client):
+        """An unknown action must fail validation."""
+        async with MCPAssertions(mcp_client) as mcp:
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {"action": "uninstall", "entity_ids": ["update.some_update"]},
+                expected_error="Invalid action",
+            )
+
+    async def test_install_requires_exactly_one_scope(self, mcp_client):
+        """install must reject entity_ids+categories together, and neither."""
+        async with MCPAssertions(mcp_client) as mcp:
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {"action": "install"},
+                expected_error="exactly one",
+            )
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {
+                    "action": "install",
+                    "entity_ids": ["update.some_update"],
+                    "categories": ["addons"],
+                },
+                expected_error="exactly one",
+            )
+
+    async def test_skip_requires_entity_ids(self, mcp_client):
+        """skip/clear_skipped act on explicit entities only."""
+        async with MCPAssertions(mcp_client) as mcp:
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {"action": "skip"},
+                expected_error="requires entity_ids",
+            )
+
+    async def test_non_update_entity_rejected(self, mcp_client):
+        """entity_ids outside the update domain must fail validation."""
+        async with MCPAssertions(mcp_client) as mcp:
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {"action": "install", "entity_ids": ["light.kitchen"]},
+                expected_error="update.",
+            )
+
+    async def test_protected_categories_rejected(self, mcp_client):
+        """core/os/supervisor are never batch-installed (mirrors HA Update all)."""
+        async with MCPAssertions(mcp_client) as mcp:
+            await mcp.call_tool_failure(
+                "ha_manage_updates",
+                {"action": "install", "categories": ["core"]},
+                expected_error="excluded from batch install",
+            )
+
+    async def test_install_all_with_no_pending_updates(self, mcp_client):
+        """Category install with nothing pending succeeds with zero targets."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_manage_updates",
+                {"action": "install", "categories": ["addons", "hacs"]},
+            )
+            assert result["action"] == "install"
+            assert result["requested"] == result["succeeded"] + result["failed"]
+            assert isinstance(result["results"], list)
+            if result["requested"] == 0:
+                assert "note" in result
+
+    async def test_skip_nonexistent_entity_reports_item_failure(self, mcp_client):
+        """A failing entity is reported per-item, not as a tool-level error."""
+        async with MCPAssertions(mcp_client) as mcp:
+            result = await mcp.call_tool_success(
+                "ha_manage_updates",
+                {
+                    "action": "skip",
+                    "entity_ids": ["update.nonexistent_entity_xyz"],
+                },
+            )
+            assert result["requested"] == 1
+            assert result["failed"] == 1
+            assert result["results"][0]["success"] is False

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -2,7 +2,7 @@
 End-to-End tests for Home Assistant Update Management tools.
 
 This test suite validates the update management tools including:
-- ha_get_updates: List all updates or get details for a specific update (consolidated tool)
+- ha_manage_updates: List, get details, install, skip, or un-skip updates (consolidated tool)
 - ha_get_overview: Get system version and info (includes entity overview)
 
 Tests are designed for Docker Home Assistant test environment.
@@ -28,15 +28,15 @@ class TestUpdateManagement:
         """
         Test: Basic listing of available updates.
 
-        Validates that ha_get_updates returns the expected structure
+        Validates that ha_manage_updates returns the expected structure
         even when no updates are available (test environment typically up-to-date).
         """
         logger.info("Testing basic update listing...")
 
         async with MCPAssertions(mcp_client) as mcp:
-            # Call ha_get_updates
+            # Call ha_manage_updates
             result = await mcp.call_tool_success(
-                "ha_get_updates",
+                "ha_manage_updates",
                 {"include_skipped": False},
             )
 
@@ -113,13 +113,13 @@ class TestUpdateManagement:
         async with MCPAssertions(mcp_client) as mcp:
             # Call with include_skipped=True
             result_with_skipped = await mcp.call_tool_success(
-                "ha_get_updates",
+                "ha_manage_updates",
                 {"include_skipped": True},
             )
 
             # Call without skipped (default)
             result_without_skipped = await mcp.call_tool_success(
-                "ha_get_updates",
+                "ha_manage_updates",
                 {"include_skipped": False},
             )
 
@@ -204,23 +204,23 @@ class TestUpdateManagement:
         """
         Test: Get update details with invalid entity ID.
 
-        Validates that ha_get_updates handles invalid entity IDs gracefully.
+        Validates that ha_manage_updates handles invalid entity IDs gracefully.
         """
         logger.info("Testing update details with invalid entity...")
 
         async with MCPAssertions(mcp_client) as mcp:
             # Test with non-existent entity
             await mcp.call_tool_failure(
-                "ha_get_updates",
-                {"entity_id": "update.nonexistent_entity_xyz"},
+                "ha_manage_updates",
+                {"action": "get", "entity_ids": ["update.nonexistent_entity_xyz"]},
                 expected_error="not found",
             )
             logger.info("Non-existent entity test passed")
 
             # Test with invalid format (not starting with "update.")
             await mcp.call_tool_failure(
-                "ha_get_updates",
-                {"entity_id": "light.invalid_entity"},
+                "ha_manage_updates",
+                {"action": "get", "entity_ids": ["light.invalid_entity"]},
                 expected_error="Invalid entity_id format",
             )
             logger.info("Invalid format test passed")
@@ -237,7 +237,7 @@ class TestUpdateManagement:
         async with MCPAssertions(mcp_client) as mcp:
             # First, list all update entities
             list_result = await mcp.call_tool_success(
-                "ha_get_updates",
+                "ha_manage_updates",
                 {"include_skipped": True},
             )
 
@@ -270,10 +270,10 @@ class TestUpdateManagement:
 
             logger.info(f"Testing update details for: {entity_id}")
 
-            # Get details for this entity (consolidated ha_get_updates with entity_id)
+            # Get details for this entity (consolidated ha_manage_updates with entity_id)
             result = await mcp.call_tool_success(
-                "ha_get_updates",
-                {"entity_id": entity_id},
+                "ha_manage_updates",
+                {"action": "get", "entity_ids": [entity_id]},
             )
 
             # Verify response structure
@@ -319,8 +319,8 @@ class TestUpdateToolsEdgeCases:
 
         async with MCPAssertions(mcp_client) as mcp:
             # Make two calls
-            result1 = await mcp.call_tool_success("ha_get_updates", {})
-            result2 = await mcp.call_tool_success("ha_get_updates", {})
+            result1 = await mcp.call_tool_success("ha_manage_updates", {})
+            result2 = await mcp.call_tool_success("ha_manage_updates", {})
 
             # Both should have same structure
             assert result1.get("success") == result2.get("success")
@@ -385,7 +385,7 @@ class TestUpdateToolsEdgeCases:
 
         async with MCPAssertions(mcp_client) as mcp:
             result = await mcp.call_tool_success(
-                "ha_get_updates", {"include_skipped": True}
+                "ha_manage_updates", {"include_skipped": True}
             )
 
             updates = result.get("updates", [])
@@ -424,22 +424,22 @@ class TestUpdateToolsEdgeCases:
 
 @pytest.mark.updates
 class TestIncludeReleaseNotes:
-    """Test suite for ha_get_updates include_release_notes parameter."""
+    """Test suite for ha_manage_updates include_release_notes parameter."""
 
     async def test_include_release_notes_response_structure(self, mcp_client):
         """
-        Test: ha_get_updates with include_release_notes returns expected structure.
+        Test: ha_manage_updates with include_release_notes returns expected structure.
 
         The Docker test environment may not have a Core update entity.
         When present, validates the full response structure including
         breaking_changes and installed_integrations fields.
         """
-        logger.info("Testing ha_get_updates with include_release_notes...")
+        logger.info("Testing ha_manage_updates with include_release_notes...")
 
         # First find the Core update entity
         result = await safe_call_tool(
             mcp_client,
-            "ha_get_updates",
+            "ha_manage_updates",
             {"include_skipped": True},
         )
 
@@ -461,8 +461,12 @@ class TestIncludeReleaseNotes:
         # Get details with include_release_notes
         detail_result = await safe_call_tool(
             mcp_client,
-            "ha_get_updates",
-            {"entity_id": core_entity_id, "include_release_notes": True},
+            "ha_manage_updates",
+            {
+                "action": "get",
+                "entity_ids": [core_entity_id],
+                "include_release_notes": True,
+            },
         )
 
         assert detail_result.get("success") is True, (
@@ -522,7 +526,7 @@ async def test_update_tools_discovery(mcp_client):
 
     # Check that update tools are registered
     expected_tools = [
-        "ha_get_updates",  # Handles list, get-by-entity_id, and release notes modes
+        "ha_manage_updates",  # Handles list, get, release notes, and write modes
         "ha_get_overview",  # System info and version
     ]
 
@@ -533,9 +537,9 @@ async def test_update_tools_discovery(mcp_client):
         )
         logger.info(f"Found tool: {tool_name}")
 
-    # ha_check_update_notes should NOT be registered (consolidated into ha_get_updates)
+    # ha_check_update_notes should NOT be registered (consolidated into ha_manage_updates)
     assert "ha_check_update_notes" not in tool_names, (
-        "ha_check_update_notes should be consolidated into ha_get_updates"
+        "ha_check_update_notes should be consolidated into ha_manage_updates"
     )
 
     logger.info("Update tools discovery test passed")
@@ -544,17 +548,17 @@ async def test_update_tools_discovery(mcp_client):
 @pytest.mark.updates
 class TestUpdatesGetNegativeInputs:
     """
-    A2 negative-input tests for ha_get_updates' single-entity detail mode.
+    A2 negative-input tests for ha_manage_updates' single-entity detail mode.
 
     Covers the nonexistent-entity_id failure path. Existing tests in this
     file exercise listing, release-notes inclusion, and edge cases on real
-    update entities, but do not call ha_get_updates with an entity_id that
+    update entities, but do not call ha_manage_updates with an entity_id that
     has no matching update.
 
     Methodology: source-verified against tools_updates.py. _get_update_details
     fetches the entity state via REST; a 404 from /api/states/<entity_id>
     raises HomeAssistantAPIError("API error: 404 - Entity not found.").
-    The except-Exception branch in ha_get_updates matches "404" / "not found"
+    The except-Exception branch in ha_manage_updates matches "404" / "not found"
     in the error message and raises ErrorCode.ENTITY_NOT_FOUND. Live-probed
     against a real HA instance: GET /api/states/update.<nonexistent> returns
     HTTP 404 with body {"message": "Entity not found."}.
@@ -562,16 +566,16 @@ class TestUpdatesGetNegativeInputs:
 
     async def test_get_updates_nonexistent_entity_id(self, mcp_client):
         """
-        Test: ha_get_updates(entity_id="update.<nonexistent>") returns a
+        Test: ha_manage_updates(entity_id="update.<nonexistent>") returns a
         structured error with code ENTITY_NOT_FOUND, not success=True.
 
         Source path: REST 404 → HomeAssistantAPIError → except-Exception
-        in ha_get_updates → ENTITY_NOT_FOUND.
+        in ha_manage_updates → ENTITY_NOT_FOUND.
         """
         async with MCPAssertions(mcp_client) as mcp:
             data = await mcp.call_tool_failure(
-                "ha_get_updates",
-                {"entity_id": "update.nonexistent_a2_e2e_xyz_404"},
+                "ha_manage_updates",
+                {"action": "get", "entity_ids": ["update.nonexistent_a2_e2e_xyz_404"]},
                 expected_error="not found",
             )
 

--- a/tests/src/e2e/workflows/updates/test_updates.py
+++ b/tests/src/e2e/workflows/updates/test_updates.py
@@ -659,15 +659,17 @@ class TestManageUpdates:
                 assert "note" in result
 
     async def test_skip_nonexistent_entity_reports_item_failure(self, mcp_client):
-        """A failing entity is reported per-item, not as a tool-level error."""
-        async with MCPAssertions(mcp_client) as mcp:
-            result = await mcp.call_tool_success(
-                "ha_manage_updates",
-                {
-                    "action": "skip",
-                    "entity_ids": ["update.nonexistent_entity_xyz"],
-                },
-            )
-            assert result["requested"] == 1
-            assert result["failed"] == 1
-            assert result["results"][0]["success"] is False
+        """A failing entity is reported per-item, not as a tool-level error,
+        and the aggregate success flag reflects the failure."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_manage_updates",
+            {
+                "action": "skip",
+                "entity_ids": ["update.nonexistent_entity_xyz"],
+            },
+        )
+        assert result["success"] is False
+        assert result["requested"] == 1
+        assert result["failed"] == 1
+        assert result["results"][0]["success"] is False

--- a/tests/src/unit/test_best_practice_checker.py
+++ b/tests/src/unit/test_best_practice_checker.py
@@ -2304,3 +2304,127 @@ class TestPluralKeyTolerance:
         }
         warnings = check_automation_config(config)
         assert _has_warning_containing(warnings, "motion", "mode: restart")
+
+
+# ---------------------------------------------------------------------------
+# HA 2026.7 renamed purpose-specific keys + trigger behavior values
+# ---------------------------------------------------------------------------
+
+
+class TestRenamedPurposeSpecificKeys:
+    """2026.7 renamed trigger/condition keys and options.behavior values."""
+
+    def test_renamed_trigger_key_warns(self):
+        config = {
+            "triggers": [
+                {"trigger": "vacuum.docked", "target": {"entity_id": "vacuum.robo"}}
+            ],
+            "actions": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(
+            warnings, "vacuum.docked", "vacuum.returned_to_dock", "2026.7"
+        )
+
+    def test_all_renamed_trigger_keys_warn(self):
+        from ha_mcp.tools.best_practice_checker import _RENAMED_TRIGGER_KEYS
+
+        for old, new in _RENAMED_TRIGGER_KEYS.items():
+            config = {"triggers": [{"trigger": old}], "actions": []}
+            warnings = check_automation_config(config)
+            assert _has_warning_containing(warnings, f"`{old}`", f"`{new}`"), old
+
+    def test_new_trigger_key_clean(self):
+        config = {
+            "triggers": [
+                {
+                    "trigger": "vacuum.returned_to_dock",
+                    "target": {"entity_id": "vacuum.robo"},
+                }
+            ],
+            "actions": [],
+        }
+        assert check_automation_config(config) == []
+
+    def test_renamed_condition_key_warns(self):
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "climate.x"}],
+            "conditions": [
+                {
+                    "condition": "climate.target_temperature",
+                    "target": {"entity_id": "climate.x"},
+                }
+            ],
+            "actions": [],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(
+            warnings, "climate.target_temperature", "climate.is_target_temperature"
+        )
+
+    def test_new_condition_key_clean(self):
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "climate.x"}],
+            "conditions": [
+                {
+                    "condition": "climate.is_target_temperature",
+                    "target": {"entity_id": "climate.x"},
+                }
+            ],
+            "actions": [],
+        }
+        assert check_automation_config(config) == []
+
+    def test_renamed_condition_key_in_action_tree_warns(self):
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "light.x"}],
+            "actions": [{"if": [{"condition": "climate.target_humidity"}], "then": []}],
+        }
+        warnings = check_automation_config(config)
+        assert _has_warning_containing(warnings, "climate.is_target_humidity")
+
+    def test_deprecated_trigger_behavior_warns(self):
+        for old, new in (("any", "each"), ("last", "all")):
+            config = {
+                "triggers": [
+                    {
+                        "trigger": "motion.detected",
+                        "target": {"area_id": "living_room"},
+                        "options": {"behavior": old},
+                    }
+                ],
+                "actions": [],
+            }
+            warnings = check_automation_config(config)
+            assert _has_warning_containing(
+                warnings, f"behavior: {old}", f"`{new}`", "2026.7"
+            ), old
+
+    def test_current_trigger_behavior_clean(self):
+        for value in ("each", "first", "all"):
+            config = {
+                "triggers": [
+                    {
+                        "trigger": "motion.detected",
+                        "target": {"area_id": "living_room"},
+                        "options": {"behavior": value},
+                    }
+                ],
+                "actions": [],
+            }
+            assert check_automation_config(config) == [], value
+
+    def test_condition_behavior_any_not_flagged(self):
+        # Conditions keep any/all — only trigger options.behavior was renamed.
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "light.x"}],
+            "conditions": [
+                {
+                    "condition": "battery.is_low",
+                    "target": {"label_id": "critical_devices"},
+                    "options": {"behavior": "any"},
+                }
+            ],
+            "actions": [],
+        }
+        assert check_automation_config(config) == []

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -508,6 +508,7 @@ _EXEMPT_TOOL_MODULES = {
     "ha_manage_pipeline": "tools_voice_assistant.py",
     "ha_manage_custom_tool": "tools_code.py",
     "ha_manage_radio": "tools_radio.py",
+    "ha_manage_updates": "tools_updates.py",
 }
 
 # INDEPENDENT, hardcoded manifests of the argument names each exempt
@@ -535,6 +536,7 @@ _EXEMPT_INSPECTED_ARGS = {
     "ha_manage_pipeline": {"action"},
     "ha_manage_custom_tool": {"list_saved", "code", "run_saved"},
     "ha_manage_radio": {"action"},
+    "ha_manage_updates": {"action"},
 }
 
 # The subset of the addon manifest that ``_addon_write`` iterates as
@@ -645,6 +647,16 @@ _EXEMPT_GATED_OR_READ_ARGS = {
         "entity_id",
         "params",
         "confirm",
+    },
+    "ha_manage_updates": {
+        # Targets/scope for the write actions (install/skip/clear_skipped),
+        # all blocked by the inspected ``action`` dispatch before use.
+        "entity_ids",
+        "categories",
+        "backup",
+        # Read-path modifiers of the allowed list/get actions.
+        "include_skipped",
+        "include_release_notes",
     },
 }
 

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -201,6 +201,27 @@ class TestExemptionRules:
     @pytest.mark.parametrize(
         ("args", "allowed"),
         [
+            # action defaults to "list" at the schema layer, so an absent
+            # action key executes the list branch — a read.
+            ({}, True),
+            ({"action": "list"}, True),
+            ({"action": "list", "include_skipped": True}, True),
+            ({"action": "get", "entity_ids": ["update.core"]}, True),
+            ({"action": "install", "categories": ["addons"]}, False),
+            ({"action": "install", "entity_ids": ["update.x"]}, False),
+            ({"action": "skip", "entity_ids": ["update.x"]}, False),
+            ({"action": "clear_skipped", "entity_ids": ["update.x"]}, False),
+            # Unknown actions fail closed.
+            ({"action": "uninstall"}, False),
+        ],
+    )
+    def test_manage_updates(self, args, allowed):
+        rule = READ_ONLY_EXEMPT_TOOLS["ha_manage_updates"].blocked_write
+        assert (rule(args) is None) is allowed
+
+    @pytest.mark.parametrize(
+        ("args", "allowed"),
+        [
             ({"radio": "matter", "action": "diagnostics", "device_id": "d1"}, True),
             ({"radio": "zwave", "action": "network_status"}, True),
             ({"radio": "matter", "action": "ping", "device_id": "d1"}, True),
@@ -465,6 +486,7 @@ class TestExemptTableContract:
             "ha_manage_pipeline",
             "ha_manage_custom_tool",
             "ha_manage_radio",
+            "ha_manage_updates",
         }
 
     def test_every_exemption_describes_whats_allowed(self):

--- a/tests/src/unit/test_tools_traces_detail.py
+++ b/tests/src/unit/test_tools_traces_detail.py
@@ -445,3 +445,49 @@ class TestFormatDetailedTrace:
         assert "1" in paths
         assert "0/repeat/sequence/0" in paths
         assert "sequence/0" in paths
+
+    def test_condition_step_error_surfaced(self):
+        """HA 2026.7 always records template errors on the failing step —
+        the condition formatter must not drop them."""
+        trace = {
+            "state": "stopped",
+            "trace": {
+                "condition/0": [
+                    {
+                        "path": "condition/0",
+                        "result": {"result": None},
+                        "error": "TemplateError: 'x' is undefined",
+                    }
+                ]
+            },
+        }
+        result = _format_detailed_trace("automation.x", "1", trace)
+        assert (
+            result["condition_results"][0]["error"] == "TemplateError: 'x' is undefined"
+        )
+
+    def test_trigger_step_error_surfaced(self):
+        trace = {
+            "state": "stopped",
+            "trace": {
+                "trigger/0": [
+                    {
+                        "path": "trigger/0",
+                        "changed_variables": {"trigger": {"platform": "template"}},
+                        "error": "TemplateError: bad template",
+                    }
+                ]
+            },
+        }
+        result = _format_detailed_trace("automation.x", "1", trace)
+        assert result["trigger"]["error"] == "TemplateError: bad template"
+
+    def test_condition_step_without_error_has_no_error_key(self):
+        trace = {
+            "state": "stopped",
+            "trace": {
+                "condition/0": [{"path": "condition/0", "result": {"result": True}}]
+            },
+        }
+        result = _format_detailed_trace("automation.x", "1", trace)
+        assert "error" not in result["condition_results"][0]

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -461,7 +461,7 @@ class TestManageUpdatesDispatch:
         assert result["success"] is False
         failures = [r for r in result["results"] if not r.get("success")]
         assert len(failures) == 1
-        assert failures[0]["error"]["context"]["entity_id"] == "update.missing"
+        assert failures[0]["entity_id"] == "update.missing"
 
     @pytest.mark.asyncio
     async def test_connection_error_propagates_out_of_batch(self, monkeypatch):

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -458,6 +458,7 @@ class TestManageUpdatesDispatch:
             1,
             1,
         )
+        assert result["success"] is False
         failures = [r for r in result["results"] if not r.get("success")]
         assert len(failures) == 1
         assert failures[0]["error"]["context"]["entity_id"] == "update.missing"

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -383,3 +383,106 @@ class TestTryRawCdn:
         assert result is not None
         assert result["notes"] == "y" * 100
         assert client.get.await_count == 2
+
+
+class TestManageUpdatesDispatch:
+    """Write-action dispatch: category resolution, filtering, aggregation."""
+
+    @pytest.mark.asyncio
+    async def test_install_category_resolves_filters_and_dispatches(self, monkeypatch):
+        from ha_mcp import update_check
+        from ha_mcp.tools.tools_updates import UpdateTools
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        # Titles carry "Add-on" so _categorize_update buckets both as
+        # "addons"; addon_b is in_progress and must be filtered out.
+        states = [
+            {
+                "entity_id": "update.addon_a",
+                "state": "on",
+                "attributes": {"title": "Add-on A", "in_progress": False},
+            },
+            {
+                "entity_id": "update.addon_b",
+                "state": "on",
+                "attributes": {"title": "Add-on B", "in_progress": True},
+            },
+        ]
+        client = MagicMock()
+        client.get_states = AsyncMock(return_value=states)
+        client.call_service = AsyncMock(return_value={"success": True})
+
+        result = await UpdateTools(client).ha_manage_updates(
+            action="install", categories=["addons"], backup=True
+        )
+
+        client.call_service.assert_awaited_once_with(
+            "update", "install", {"entity_id": "update.addon_a", "backup": True}
+        )
+        assert (result["requested"], result["succeeded"], result["failed"]) == (
+            1,
+            1,
+            0,
+        )
+        assert result["results"][0]["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_skip_mixed_existing_and_missing_aggregates(self, monkeypatch):
+        from ha_mcp import update_check
+        from ha_mcp.tools.tools_updates import UpdateTools
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        client = MagicMock()
+        client.get_states = AsyncMock(
+            return_value=[
+                {"entity_id": "update.exists", "state": "on", "attributes": {}}
+            ]
+        )
+        client.call_service = AsyncMock(return_value={"success": True})
+
+        result = await UpdateTools(client).ha_manage_updates(
+            action="skip", entity_ids=["update.exists", "update.missing"]
+        )
+
+        # The existence precheck routes the missing entity to a per-item
+        # ENTITY_NOT_FOUND result; only the real one reaches call_service.
+        client.call_service.assert_awaited_once_with(
+            "update", "skip", {"entity_id": "update.exists"}
+        )
+        assert (result["requested"], result["succeeded"], result["failed"]) == (
+            2,
+            1,
+            1,
+        )
+        failures = [r for r in result["results"] if not r.get("success")]
+        assert len(failures) == 1
+        assert failures[0]["error"]["context"]["entity_id"] == "update.missing"
+
+    @pytest.mark.asyncio
+    async def test_connection_error_propagates_out_of_batch(self, monkeypatch):
+        from ha_mcp import update_check
+        from ha_mcp.client.rest_client import HomeAssistantConnectionError
+        from ha_mcp.tools.tools_updates import UpdateTools
+
+        monkeypatch.setattr(
+            update_check, "get_update_field", AsyncMock(return_value=None)
+        )
+        client = MagicMock()
+        client.get_states = AsyncMock(
+            return_value=[
+                {"entity_id": "update.exists", "state": "on", "attributes": {}}
+            ]
+        )
+        client.call_service = AsyncMock(
+            side_effect=HomeAssistantConnectionError("connection lost")
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            await UpdateTools(client).ha_manage_updates(
+                action="skip", entity_ids=["update.exists"]
+            )
+        assert "connection" in str(excinfo.value).lower()

--- a/tests/src/unit/test_tools_updates.py
+++ b/tests/src/unit/test_tools_updates.py
@@ -19,7 +19,7 @@ from ha_mcp.tools.tools_updates import (
 
 
 class TestListUpdatesHaMcpUpdate:
-    """ha_get_updates (list mode) surfaces the MCP server's own update status."""
+    """ha_manage_updates (list mode) surfaces the MCP server's own update status."""
 
     @pytest.mark.asyncio
     async def test_ha_mcp_update_present_when_available(self, monkeypatch):
@@ -39,7 +39,7 @@ class TestListUpdatesHaMcpUpdate:
         )
         client = MagicMock()
         client.get_states = AsyncMock(return_value=[])
-        result = await UpdateTools(client).ha_get_updates()
+        result = await UpdateTools(client).ha_manage_updates()
         assert result["ha_mcp_update"] == {
             "current": "7.8.0",
             "latest": "7.9.0",
@@ -56,7 +56,7 @@ class TestListUpdatesHaMcpUpdate:
         )
         client = MagicMock()
         client.get_states = AsyncMock(return_value=[])
-        result = await UpdateTools(client).ha_get_updates()
+        result = await UpdateTools(client).ha_manage_updates()
         assert "ha_mcp_update" not in result
 
 


### PR DESCRIPTION
## What does this PR do?

Aligns ha-mcp with the HA 2026.7 release (closes #1726). The 2026.7 audit found nothing that breaks ha-mcp; this PR covers the alignment and feature items:

- **Best-practice checker**: flags the ten purpose-specific trigger/condition keys renamed in 2026.7 (`battery.low` → `battery.became_low`, `vacuum.docked` → `vacuum.returned_to_dock`, etc. — the old keys no longer load), naming the new key inline; flags deprecated trigger `options.behavior` values `any`/`last` (renamed to `each`/`all` in 2026.7, repair-issue parity — conditions keep `any`/`all` and are never flagged); the device-trigger warning now names purpose-specific triggers with entity/area/floor/label targets as the preferred replacement.
- **`ha_config_set_automation`**: documents purpose-specific trigger/condition config (`trigger: <domain>.<name>` with `target`/`options`) as valid input.
- **Traces**: per-step `error` fields on condition and trigger steps are no longer dropped — HA 2026.7 always records template errors in traces (core #172917) and reports numeric-entity trigger errors (core #175093), and `_populate_condition_results` was silently discarding them.
- **Domain handlers**: `device_tracker` gains the 2026.7 `in_zones` and `tracking_type` attributes; coordinates may be absent under presence-scanner tracking.
- **`ha_manage_updates` (consolidates `ha_get_updates`)**: one tool for list (default), get (details/release notes incl. multi-version breaking changes), batch install by category mirroring the 2026.7 'Update all' UX (core/OS/supervisor excluded from category mode by design, skipped versions never included), skip, and clear_skipped. Explicit-id mode verifies entities exist first, since HA service calls silently no-op on unknown entities; per-item batch failure results. `ha_get_updates` is removed per the tool-consolidation policy — behavior carried over, references swept, docs tables regenerate on merge.
- **Read Only Mode**: `ha_manage_updates` is registered as a mixed read/write exemption — `list`/`get` remain available while the mode is on; write actions are blocked at call time and unknown actions fail closed.

Checked and intentionally unchanged: the new `infrared` entity platform registers no services (verified in core) and no radio-frequency component exists yet, so there is no domain-handler surface to add. Checker warnings reference the `automation-patterns.md#trigger-types` skill anchor, which resolves in both the current skills-vendor pin and the pending skills update (homeassistant-ai/skills#66, arriving via the Renovate submodule bump).

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
