### PR TITLE
ci(addon): install pytest-asyncio in the webhook-proxy sync workflows

### DIFF
--- a/.github/workflows/webhook-proxy-promote.yml
+++ b/.github/workflows/webhook-proxy-promote.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install ruff + pytest
-        run: pip install ruff pytest
+        run: pip install ruff pytest pytest-asyncio
 
       - name: Run the promote transform in place
         id: promote

--- a/.github/workflows/webhook-proxy-reset-dev.yml
+++ b/.github/workflows/webhook-proxy-reset-dev.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install ruff + pytest
-        run: pip install ruff pytest
+        run: pip install ruff pytest pytest-asyncio
 
       - name: Run the reset transform in place
         id: reset


### PR DESCRIPTION
## What does this PR do?

Fixes the `webhook-proxy-promote` and `webhook-proxy-reset-dev` workflows, whose drift-guard step aborts under pytest 9 with "ERROR: Unknown config option: asyncio_default_fixture_loop_scope" and exit code 4 ("no tests ran") because the bare `pip install ruff pytest` lacks pytest-asyncio, which provides the `asyncio_*` options in `tests/pytest.ini`. Observed on promote run 28684642222; the transform acceptance gate never executed. Adds `pytest-asyncio` to both installs.

Verified locally by running the exact promote path: `webhook_proxy_sync.py --direction promote --bump major` followed by the drift-guard suite with `WEBHOOK_PROXY_TREES_SYNCED=1` — 21 passed.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Workflow-file-only change; the drift-guard suite it gates was run locally (21 passed) via the exact commands the workflow executes.

## Checklist
- [x] I have updated documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)
