### PR TITLE
feat(addon-dev): log the ha_auth bearer rejection reason in the inbound debug log

### DIFF
--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,17 @@ history from before the fork.
 -->
 
 
+## v1.2.3.dev5 (2026-07-04)
+
+### Added
+
+- ha_auth debug observability: with debug logging enabled, a 401 on the webhook
+  now logs WHY the bearer was rejected — no usable bearer, token rejected by
+  Home Assistant's validator, or the validator raised — so provider-specific
+  login issues (issue #1714's OIDC leg) are diagnosable from the add-on log
+  alone. The token itself is never logged.
+
+
 ## v1.2.3.dev4 (2026-07-02)
 
 > **POTENTIAL BREAKING CHANGE (OAuth users).** This release changes the default

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "1.2.3.dev4"
+version: "1.2.3.dev5"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -715,16 +715,23 @@ async def _handle_webhook(
     # an invalid/missing bearer yields the SAME 401 discovery challenge.
     oauth_provider = data.get("oauth")
     if oauth_provider is not None:
+        # ha_auth carries a rejection reason so the debug log can distinguish
+        # "no usable bearer" from "hass.auth rejected/raised on the token" —
+        # the discrimination needed to debug provider-specific rejections
+        # (issue #1714's OIDC leg) from a user's add-on log. Never the token.
+        reject_reason = "no/invalid OAuth bearer"
         if data.get("oauth_mode") == OAUTH_MODE_HA_AUTH:
-            authorized = await oauth_provider.validate_request(request)
+            authorized, reject_reason = await oauth_provider.validate_request_detailed(
+                request
+            )
         else:
             authorized = oauth_provider.validate_bearer(request)
         if not authorized:
             if debug:
                 await _debug_log(
                     hass,
-                    "MCP Proxy [inbound]: -> 401 Unauthorized (no/invalid OAuth "
-                    "bearer; expected for the initial discovery probe)",
+                    f"MCP Proxy [inbound]: -> 401 Unauthorized ({reject_reason}; "
+                    "expected for the initial discovery probe)",
                 )
             from .oauth import build_unauthorized_response
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
@@ -123,6 +123,15 @@ class ResourceServer:
     async def validate_request(self, request: web.Request) -> bool:
         """Return True iff the request carries a Bearer token Home Assistant accepts.
 
+        Thin wrapper over `validate_request_detailed` — same contract, without
+        the rejection-reason string.
+        """
+        authorized, _ = await self.validate_request_detailed(request)
+        return authorized
+
+    async def validate_request_detailed(self, request: web.Request) -> tuple[bool, str]:
+        """Return ``(authorized, reason)`` for the request's Bearer token.
+
         A missing or malformed `Authorization` header is rejected WITHOUT
         touching the validator. Otherwise the token is handed to
         `hass.auth.async_validate_access_token`, which returns the backing
@@ -132,21 +141,30 @@ class ResourceServer:
         normal 401 challenge instead of a 500. That method is a synchronous
         `@callback` in HA core (`homeassistant/auth/__init__.py`); we still await
         defensively iff a future Home Assistant turns it into a coroutine.
+
+        The reason string is diagnostic telemetry for the add-on's inbound
+        debug log (never the token itself): it distinguishes a request that
+        carried no usable bearer from one whose bearer HA's validator rejected
+        outright vs. one where the validator raised — the discrimination needed
+        to debug provider-specific rejections (issue #1714's OIDC leg) from a
+        user's add-on log alone.
         """
         header = request.headers.get("Authorization", "")
         if not header.lower().startswith("bearer "):
-            return False
+            return False, "no bearer header"
         token = header[7:].strip()
         if not token:
-            return False
+            return False, "empty bearer token"
         try:
             result = self._hass.auth.async_validate_access_token(token)
             if inspect.isawaitable(result):
                 result = await result
-        except Exception:
+        except Exception as err:
             _LOGGER.debug(
                 "ha_auth: bearer validation raised; treating as unauthorized",
                 exc_info=True,
             )
-            return False
-        return result is not None
+            return False, f"validator raised {type(err).__name__}"
+        if result is None:
+            return False, "token rejected by hass.auth (returned None)"
+        return True, "valid"

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.3.dev4"
+  "version": "1.2.3.dev5"
 }

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5002,6 +5002,73 @@ class TestHaAuthMode:
         # Malformed/missing header rejected WITHOUT invoking the HA validator.
         hass.auth.async_validate_access_token.assert_not_called()
 
+    async def test_validate_request_detailed_reason_matrix(self, tmp_path):
+        """The diagnostic reason distinguishes every rejection class — no
+        usable bearer, empty token, hass.auth returned None, validator raised
+        — plus the accepted case, and never includes the token itself.
+        validate_request stays the bool-only wrapper over the same logic."""
+        _mod, _oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = MagicMock()
+        rs = auth_native.ResourceServer(hass, "wh")
+
+        def req(headers):
+            r = MagicMock()
+            r.headers = headers
+            return r
+
+        hass.auth.async_validate_access_token = MagicMock(return_value=None)
+        assert await rs.validate_request_detailed(req({})) == (
+            False,
+            "no bearer header",
+        )
+        assert await rs.validate_request_detailed(
+            req({"Authorization": "Basic abc"})
+        ) == (False, "no bearer header")
+        assert await rs.validate_request_detailed(
+            req({"Authorization": "Bearer   "})
+        ) == (False, "empty bearer token")
+        assert await rs.validate_request_detailed(
+            req({"Authorization": "Bearer sekret-tok"})
+        ) == (False, "token rejected by hass.auth (returned None)")
+        hass.auth.async_validate_access_token = MagicMock(
+            side_effect=ValueError("boom")
+        )
+        ok, reason = await rs.validate_request_detailed(
+            req({"Authorization": "Bearer sekret-tok"})
+        )
+        assert (ok, reason) == (False, "validator raised ValueError")
+        assert "sekret-tok" not in reason
+        hass.auth.async_validate_access_token = MagicMock(return_value=object())
+        assert await rs.validate_request_detailed(
+            req({"Authorization": "Bearer sekret-tok"})
+        ) == (True, "valid")
+        # Wrapper parity: same logic, bool-only contract.
+        assert (
+            await rs.validate_request(req({"Authorization": "Bearer sekret-tok"}))
+            is True
+        )
+
+    async def test_gate_debug_log_carries_rejection_reason(self, tmp_path):
+        """With debug logging on, the 401 line names WHY ha_auth rejected the
+        bearer (the issue #1714 OIDC-leg diagnosis aid) — never the token."""
+        mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        hass = self._gate_hass(mod, auth_native, None)  # validator -> None
+        hass.data[mod.DOMAIN]["debug_logging"] = True
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer sekret-tok", "Host": "h"}
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        request.scheme = "https"
+        with (
+            patch.object(mod, "_debug_log", new=AsyncMock()) as dbg,
+            patch.object(oauth.web, "Response") as response_ctor,
+        ):
+            await mod._handle_webhook(hass, "mcp_test", request)
+        assert response_ctor.call_args.kwargs.get("status") == 401
+        logged = " ".join(str(c.args[1]) for c in dbg.call_args_list)
+        assert "token rejected by hass.auth (returned None)" in logged
+        assert "sekret-tok" not in logged
+
     async def test_validator_raises_gate_returns_401_not_500(self, tmp_path):
         """A crafted token can make hass.auth.async_validate_access_token raise
         (outside jwt.InvalidTokenError). ResourceServer.validate_request must


### PR DESCRIPTION
## What does this PR do?

Diagnosis aid for the open OIDC leg of #1714: on NoSilver78's Authentik box, a bearer obtained via the hass-oidc-auth login is rejected by the ha_auth gate while a local-login bearer from the same connector validates — and his capture shows the token is HA-native, so the rejection reason is the missing piece. With debug logging enabled, the webhook's 401 line now names why the bearer was rejected: no usable bearer, empty token, token rejected by `hass.auth` (returned None), or the validator raised (with the exception type). The token itself is never logged.

Implementation: `ResourceServer.validate_request_detailed` returns `(authorized, reason)`; the webhook gate uses it in ha_auth mode and surfaces the reason in the debug log line. `validate_request` stays the bool-only wrapper, so the existing contract and its tests are unchanged. Dev flavor only; version 1.2.3.dev5 (config.yaml + manifest together).

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Add-on suite green on both flavors: 507 passed, 59 skipped (2 new dev-gated tests: the full reason matrix on `validate_request_detailed` including wrapper parity and no-token-leak, and a gate-level test pinning that the debug 401 line carries the reason and never the token).

## Checklist
- [x] I have updated documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)
