### PR TITLE
test(addon): gate the dev5 validator tests on the capability, not file existence

### DIFF
--- a/.github/workflows/webhook-proxy-promote.yml
+++ b/.github/workflows/webhook-proxy-promote.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install ruff + pytest
-        run: pip install ruff pytest pytest-asyncio
+        run: pip install ruff pytest pytest-asyncio pytest-timeout
 
       - name: Run the promote transform in place
         id: promote

--- a/.github/workflows/webhook-proxy-reset-dev.yml
+++ b/.github/workflows/webhook-proxy-reset-dev.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install ruff + pytest
-        run: pip install ruff pytest pytest-asyncio
+        run: pip install ruff pytest pytest-asyncio pytest-timeout
 
       - name: Run the reset transform in place
         id: reset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=1.1.0",
     "pytest-cov>=5.0.0",
+    "pytest-timeout>=2.3.0",
     "pytest-rerunfailures>=15.0",
     "pytest-xdist>=3.8.0",
     "requests>=2.25.0",

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5008,6 +5008,11 @@ class TestHaAuthMode:
         — plus the accepted case, and never includes the token itself.
         validate_request stays the bool-only wrapper over the same logic."""
         _mod, _oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        # Capability gate, not file-existence: stable ships auth_native since
+        # 2.0.0 but gains the detailed validator only at the next promote, so
+        # the coarse _ha_auth_supported() gate is not enough here.
+        if not hasattr(auth_native.ResourceServer, "validate_request_detailed"):
+            pytest.skip("flavor does not ship the detailed bearer validator yet")
         hass = MagicMock()
         rs = auth_native.ResourceServer(hass, "wh")
 
@@ -5052,6 +5057,10 @@ class TestHaAuthMode:
         """With debug logging on, the 401 line names WHY ha_auth rejected the
         bearer (the issue #1714 OIDC-leg diagnosis aid) — never the token."""
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        # Capability gate (see test_validate_request_detailed_reason_matrix):
+        # the gate's reason plumbing ships together with the detailed validator.
+        if not hasattr(auth_native.ResourceServer, "validate_request_detailed"):
+            pytest.skip("flavor does not ship the detailed bearer validator yet")
         hass = self._gate_hass(mod, auth_native, None)  # validator -> None
         hass.data[mod.DOMAIN]["debug_logging"] = True
         request = MagicMock()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -65,6 +65,16 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 
+# Per-test timeout (pytest-timeout). A stuck server-side await otherwise
+# stalls the run silently until the JOB timeout — observed as a 22-minute
+# hang in test_zone_search_discovery on the HAOS in-addon backend. 300s is
+# ~10x the slowest legitimate test (~30s deliberate-timeout tests) while
+# session fixtures stay well under it. The signal method interrupts only
+# the hung test and raises inside the running coroutine, so the failure
+# traceback names the exact stuck await.
+timeout = 300
+timeout_method = signal
+
 
 # Log capture
 log_cli = true

--- a/uv.lock
+++ b/uv.lock
@@ -493,6 +493,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "ruamel-yaml" },
@@ -528,6 +529,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-rerunfailures", specifier = ">=15.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
@@ -1223,6 +1225,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.990Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Two test-infrastructure fixes:

**1. Unbreaks the add-on suite on every open PR's merge ref.** The two tests added with the ha_auth debug-reason feature (#1740) were gated on "flavor ships `auth_native.py`" — when the 2.0.0 promote (#1739) merged, stable gained `auth_native.py` at the pre-dev5 API, so the tests started running on the `[stable]` variant and failing with `'ResourceServer' object has no attribute 'validate_request_detailed'` (first seen on #1736's pipeline; master itself does not run the add-on suite on push). They now skip on flavors whose `ResourceServer` lacks the detailed validator; the skip self-lifts when the next promote carries the API to stable.

**2. Bounds every test at 300 seconds (pytest-timeout).** A stuck server-side await previously stalled the run silently until the job timeout — observed today as a 22-minute hang in `test_zone_search_discovery` on the HAOS in-addon backend (job normally finishes in ~8 minutes). 300s is ~10x the slowest legitimate test (~30s deliberate-timeout tests). The signal method interrupts only the hung test and raises inside the running coroutine, so the failure traceback names the exact stuck await instead of requiring a manual cancel with no diagnostics. The webhook-proxy sync workflows' minimal pytest installs gain `pytest-timeout` so the new ini option stays parseable there (same pytest 9 unknown-option fatal class as #1738); `uv.lock` updated accordingly.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Add-on suite on current master: 564 passed, 2 skipped (the two gated tests skip on [stable], pass on [dev]; every other ha_auth test now runs on stable 2.0.0 and passes). The timeout mechanism was verified to fire: a deliberately hung async test fails cleanly with "Timeout (>2.0s) from pytest-timeout" under a 2s marker.

## Checklist
- [x] I have updated documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)
