### PR TITLE
ci: write the mirror deploy key with a trailing newline

### DIFF
--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -29,7 +29,7 @@ jobs:
           DEPLOY_KEY: ${{ secrets.INTEGRATION_MIRROR_DEPLOY_KEY }}
         run: |
           mkdir -p ~/.ssh
-          printf -- "%s" "$DEPLOY_KEY" > ~/.ssh/mirror_key
+          printf -- "%s\n" "$DEPLOY_KEY" > ~/.ssh/mirror_key
           chmod 600 ~/.ssh/mirror_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 


### PR DESCRIPTION
## What does this PR do?

Fixes the first post-merge run of `sync-integration-mirror.yml` (run
28750315936): the deploy key was written with `printf '%s'` - no trailing
newline - and OpenSSH rejects such key files (`Load key: error in libcrypto`
then `Permission denied (publickey)`). One line: add the newline.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

CI-only one-liner; YAML validated. Proof is the next master push re-running
the sync (or a workflow_dispatch after merge).

## Future improvements

None.

## Checklist
- [ ] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
