### PR TITLE
fix: relax the cryptography pin to an HA-compatible range (stable-channel install failure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "python-dotenv==1.2.2",
     "truststore==0.10.4",
     "websockets==16.0",
-    "cryptography==49.0.0",
+    "cryptography>=48.0.0,<50",
     "pydantic-monty==0.0.18",
     "tzdata>=2024.1",
     "packaging>=24.0",


### PR DESCRIPTION
## What does this PR do?

Hotfix: the released **ha-mcp 7.9.0 cannot be installed against current Home
Assistant** - its `cryptography==49.0.0` pin is unsatisfiable under HA
2026.7's package constraints (`cryptography 48.0.1`), so the in-process
server's stable channel fails at pip time on every fresh install/reinstall
(`uv: No solution found when resolving dependencies`). Live-hit today after
an HA Core update wiped site-packages and the entry re-installed its pin.

Relax to `cryptography>=48.0.0,<50` (same as master). `cryptography` is never
imported in `src/`; the pin only constrains dependency resolution.

Branch is based on the `stable` tag per the hotfix process; on merge,
`hotfix-release.yml` ships 7.9.1 and the release automation bumps the
component's stable-channel pin to match.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The identical range is already CI-proven on master (every lane green through
PR #1741, including the embedded lanes that runtime-install the package under
HA's constraints file). The failing case is reproduced verbatim in today's
live log: resolution conflict between the ==49.0.0 pin and HA's 48.0.1
constraint.

## Future improvements

None.

## Checklist
- [ ] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
