### PR TITLE
fix: keep HTTP servers reachable under fastmcp 3.4.3 Host/Origin guard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,21 +52,21 @@ other machines on the LAN. To restrict to the local machine, set
 
 fastmcp ships a Host/Origin guard — a DNS-rebinding defense that only accepts
 loopback `Host` headers and same-origin/loopback `Origin`s. ha-mcp defaults it
-off (`FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=false`) on every HTTP entrypoint
-(`ha-mcp-web`, `ha-mcp-sse`, `ha-mcp-oauth`, the add-on, and the in-process
-component server). The supported deployment model — reverse proxies, tunnels
-(Cloudflare, Nabu Casa), and direct LAN access — presents `Host` headers ha-mcp
-cannot enumerate, and the guard would otherwise reject them with `421`/`403`
-(including the plain browser landing page, a no-`Origin` navigation that still
-trips the `Host` check).
+off (`FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=false`) across its Streamable-HTTP
+entry points (`ha-mcp-web`, `ha-mcp-oauth`, the add-on, and the in-process
+component server). The supported
+deployment model — reverse proxies, tunnels (Cloudflare, Nabu Casa), and direct
+LAN access — presents `Host` headers ha-mcp cannot enumerate, and the guard
+would otherwise reject them with `421`/`403` (including the plain browser landing
+page, a no-`Origin` navigation that still trips the `Host` check).
 
 This does not change the boundary defined above. URL-path secrecy (standard
 mode) and the OAuth / Home Assistant session gates (OAuth and in-process modes)
 remain the authentication boundary, and the local network is already the trusted
 zone — so the DNS-rebinding class this guard addresses is out of scope
 regardless. A DNS-rebinding attacker's browser still cannot reach the secret MCP
-path (only the non-sensitive landing page and the public OAuth discovery
-documents), and the genuinely unauthenticated loopback settings sidecar enforces
+path — only the public OAuth discovery documents at fixed well-known paths (the
+landing page shares the secret path) — and the loopback settings sidecar enforces
 its own Host/Origin allow-list independent of this setting.
 
 Operators who front ha-mcp differently can re-enable the guard by setting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,31 @@ By default the HTTP entrypoints bind to `0.0.0.0` so they are reachable from
 other machines on the LAN. To restrict to the local machine, set
 `MCP_HOST=127.0.0.1` (or use `-p 127.0.0.1:8086:8086` at the Docker layer).
 
+### Host/Origin validation (DNS-rebinding guard) is off by default
+
+fastmcp ships a Host/Origin guard — a DNS-rebinding defense that only accepts
+loopback `Host` headers and same-origin/loopback `Origin`s. ha-mcp defaults it
+off (`FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=false`) on every HTTP entrypoint
+(`ha-mcp-web`, `ha-mcp-sse`, `ha-mcp-oauth`, the add-on, and the in-process
+component server). The supported deployment model — reverse proxies, tunnels
+(Cloudflare, Nabu Casa), and direct LAN access — presents `Host` headers ha-mcp
+cannot enumerate, and the guard would otherwise reject them with `421`/`403`
+(including the plain browser landing page, a no-`Origin` navigation that still
+trips the `Host` check).
+
+This does not change the boundary defined above. URL-path secrecy (standard
+mode) and the OAuth / Home Assistant session gates (OAuth and in-process modes)
+remain the authentication boundary, and the local network is already the trusted
+zone — so the DNS-rebinding class this guard addresses is out of scope
+regardless. A DNS-rebinding attacker's browser still cannot reach the secret MCP
+path (only the non-sensitive landing page and the public OAuth discovery
+documents), and the genuinely unauthenticated loopback settings sidecar enforces
+its own Host/Origin allow-list independent of this setting.
+
+Operators who front ha-mcp differently can re-enable the guard by setting
+`FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=true` and pinning
+`FASTMCP_HTTP_ALLOWED_HOSTS` / `FASTMCP_HTTP_ALLOWED_ORIGINS`.
+
 ### Standard mode is single-tenant
 
 The secret-URL model (`ha-mcp-web`, `ha-mcp-sse`) assumes a single operator.
@@ -168,6 +193,9 @@ the proxy returns 503 whenever the server is not running.
   trusted and untrusted code. Problems with `python_transform` behavior are
   bugs, not security vulnerabilities.
 - LAN-peer access to standard-mode HTTP endpoints: the local network is the
+  trusted zone (see [Threat Model](#threat-model) above).
+- DNS rebinding against the HTTP entrypoints: fastmcp's Host/Origin guard is off
+  by default; URL-path secrecy is the boundary and the local network is the
   trusted zone (see [Threat Model](#threat-model) above).
 - OAuth token containing an encoded LLAT: this is the Bearer token design
   (see [Threat Model](#threat-model) above).

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -606,18 +606,19 @@ class EmbeddedServerManager:
 
         # fastmcp >= 3.4.3 ships an on-by-default Host/Origin (DNS-rebinding)
         # guard that would 421 this in-process server's direct LAN listener
-        # (bind 0.0.0.0:9584) and its browser landing page, both reached on
-        # arbitrary hosts. Default it off to match the CLI / add-on entry
-        # points. Guarded import: a bundled ha-mcp old enough to lack the
-        # helper also predates the guard, so there is nothing to disable.
+        # (bind 0.0.0.0:9584 by default), reached on arbitrary hosts. Default it
+        # off to match the CLI / add-on entry points. Guard only the import: a
+        # bundled ha-mcp old enough to lack the helper also predates the guard,
+        # so there is nothing to disable.
         try:
             from ha_mcp.transport_security import (
                 ensure_host_origin_guard_default_off,
             )
-
-            ensure_host_origin_guard_default_off()
         except ImportError:
+            # Older bundled ha-mcp: no helper, and no guard to disable either.
             pass
+        else:
+            ensure_host_origin_guard_default_off()
 
         app = server.mcp.http_app(path=self._secret_path, stateless_http=True)
         config = uvicorn.Config(

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -604,6 +604,21 @@ class EmbeddedServerManager:
         # uvicorn.Config defaults + _lifespan_manager), pinned by ha-mcp.
         import uvicorn
 
+        # fastmcp >= 3.4.3 ships an on-by-default Host/Origin (DNS-rebinding)
+        # guard that would 421 this in-process server's direct LAN listener
+        # (bind 0.0.0.0:9584) and its browser landing page, both reached on
+        # arbitrary hosts. Default it off to match the CLI / add-on entry
+        # points. Guarded import: a bundled ha-mcp old enough to lack the
+        # helper also predates the guard, so there is nothing to disable.
+        try:
+            from ha_mcp.transport_security import (
+                ensure_host_origin_guard_default_off,
+            )
+
+            ensure_host_origin_guard_default_off()
+        except ImportError:
+            pass
+
         app = server.mcp.http_app(path=self._secret_path, stateless_http=True)
         config = uvicorn.Config(
             app,

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "0.13.0"
+    "version": "0.13.1"
 }

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -783,6 +783,14 @@ def main() -> int:
         StatelessSessionLogFilter()
     )
 
+    # The addon is reached via HA ingress, a direct port, and operator-chosen
+    # reverse proxies / tunnels on arbitrary hosts; default fastmcp's
+    # DNS-rebinding guard off so it does not 421 them (or the browser landing
+    # page). See ha_mcp.transport_security for the rationale.
+    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
+
+    ensure_host_origin_guard_default_off()
+
     # The addon normally binds to 0.0.0.0 so HA Supervisor ingress can
     # reach it inside the container; MCP_HOST override is provided for
     # parity with the standard CLI entry points (see issue #1434).

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -783,13 +783,10 @@ def main() -> int:
         StatelessSessionLogFilter()
     )
 
-    # The addon is reached via HA ingress, a direct port, and operator-chosen
-    # reverse proxies / tunnels on arbitrary hosts; default fastmcp's
-    # DNS-rebinding guard off so it does not 421 them (or the browser landing
-    # page). See ha_mcp.transport_security for the rationale.
-    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
-
-    ensure_host_origin_guard_default_off()
+    # fastmcp's DNS-rebinding guard is defaulted off in ha_mcp's _create_server
+    # (reached above via _get_server() / the `mcp` proxy, before the app is
+    # built), so the addon -- ingress, direct port, and reverse proxies / tunnels
+    # on arbitrary hosts -- is covered. See ha_mcp.transport_security.
 
     # The addon normally binds to 0.0.0.0 so HA Supervisor ingress can
     # reach it inside the container; MCP_HOST override is provided for

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -318,6 +318,15 @@ def _create_server() -> "HomeAssistantSmartMCPServer":
     """Create server instance (deferred to avoid import during smoke test)."""
     from pydantic import ValidationError
 
+    # Every deferred-``mcp`` entry point funnels through here before its
+    # Streamable-HTTP app is built -- ha-mcp-web, the add-on, and the
+    # ``fastmcp run fastmcp-http.json`` container path -- so default fastmcp's
+    # DNS-rebinding guard off once, here, for all of them. Direct-construction
+    # paths (_run_oauth_server, the in-process component server) call it themselves.
+    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
+
+    ensure_host_origin_guard_default_off()
+
     try:
         from ha_mcp.server import HomeAssistantSmartMCPServer
 
@@ -823,8 +832,6 @@ def _maybe_spawn_settings_sidecar() -> None:
 
 def main_dev() -> None:
     """Run server with DEBUG logging enabled (for ha-mcp-dev package)."""
-    import os
-
     os.environ["LOG_LEVEL"] = "DEBUG"
     main()
 
@@ -1093,13 +1100,9 @@ def _run_http_server(transport: str, default_port: int = 8086) -> None:
         default_port: Default port to use if MCP_PORT env var is not set.
     """
     from ha_mcp.settings_ui import register_settings_routes
-    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
 
-    # ha-mcp is reached through operator-chosen proxies / LAN IPs whose Host
-    # headers we cannot enumerate; default fastmcp's DNS-rebinding guard off so
-    # it does not 421 them (or the browser landing page). See transport_security.
-    ensure_host_origin_guard_default_off()
-
+    # The DNS-rebinding guard is defaulted off in _create_server (reached here via
+    # _get_mcp below, before the app is built) -- see transport_security.
     host, port, path = _get_http_runtime(default_port)
     _warn_if_default_path_exposed(host, port, path)
     # SSE transport answers GET with 200 (the event stream), so a GET->405 there

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1093,6 +1093,12 @@ def _run_http_server(transport: str, default_port: int = 8086) -> None:
         default_port: Default port to use if MCP_PORT env var is not set.
     """
     from ha_mcp.settings_ui import register_settings_routes
+    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
+
+    # ha-mcp is reached through operator-chosen proxies / LAN IPs whose Host
+    # headers we cannot enumerate; default fastmcp's DNS-rebinding guard off so
+    # it does not 421 them (or the browser landing page). See transport_security.
+    ensure_host_origin_guard_default_off()
 
     host, port, path = _get_http_runtime(default_port)
     _warn_if_default_path_exposed(host, port, path)
@@ -1224,6 +1230,12 @@ async def _run_oauth_server(
     """
     from ha_mcp.auth import HomeAssistantOAuthProvider
     from ha_mcp.server import HomeAssistantSmartMCPServer
+    from ha_mcp.transport_security import ensure_host_origin_guard_default_off
+
+    # Browser OAuth clients (Claude.ai / ChatGPT) reach the discovery endpoints
+    # cross-origin, and users front this server with proxies/tunnels on arbitrary
+    # hosts; default fastmcp's DNS-rebinding guard off so it does not 403/421 them.
+    ensure_host_origin_guard_default_off()
 
     # Create OAuth provider
     auth_provider = HomeAssistantOAuthProvider(

--- a/src/ha_mcp/transport_security.py
+++ b/src/ha_mcp/transport_security.py
@@ -1,0 +1,74 @@
+"""Transport-security defaults for ha-mcp's Streamable-HTTP servers.
+
+fastmcp >= 3.4.3 ships ``HostOriginGuardMiddleware`` (a DNS-rebinding guard) that
+is **on by default**. Inserted at the front of the ASGI stack, it rejects any
+request whose ``Host`` header is not loopback / an explicitly-allowed host with
+``421 Misdirected Request``, and any browser ``Origin`` that is not same-origin /
+loopback / explicitly allowed with ``403 Forbidden`` -- before the request
+reaches any route.
+
+That default is wrong for ha-mcp. We are *designed* to be reached through
+operator-chosen reverse proxies and tunnels (Cloudflare Tunnel, nginx, Traefik,
+Nabu Casa Remote UI) and via direct LAN IPs, whose ``Host`` values we cannot
+enumerate. Leaving the guard on would ``421`` the majority of real deployments --
+including the plain browser landing page, which is a no-``Origin`` navigation
+that still trips the ``Host`` check.
+
+Our security boundary is the high-entropy secret path (and, in OAuth mode, the
+per-user token), not the ``Host`` header. The genuinely unauthenticated loopback
+surface -- the settings sidecar -- already enforces its *own* Host/Origin
+allow-list (see ``stdio_settings_sidecar``). So defaulting fastmcp's guard off on
+the main server restores exactly the pre-3.4.3 behaviour without giving up the
+protection that matters.
+
+Operators who front ha-mcp differently can re-enable the guard (and pin their
+own allow-lists) via ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=true`` plus
+``FASTMCP_HTTP_ALLOWED_HOSTS`` / ``FASTMCP_HTTP_ALLOWED_ORIGINS``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+#: fastmcp's env var for the Host/Origin (DNS-rebinding) guard. Present as a
+#: field on fastmcp's Settings only from 3.4.3 onward.
+HOST_ORIGIN_PROTECTION_ENV = "FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"
+
+#: fastmcp Settings attribute backing the env var above.
+_HOST_ORIGIN_PROTECTION_ATTR = "http_host_origin_protection"
+
+
+def ensure_host_origin_guard_default_off() -> None:
+    """Default fastmcp's Host/Origin guard off for ha-mcp HTTP servers.
+
+    Idempotent. Call once before building/serving any Streamable-HTTP app
+    (``mcp.http_app()`` / ``mcp.run(transport="http"|"sse")`` /
+    ``mcp.run_async(...)``) -- ``http_app`` reads
+    ``fastmcp.settings.http_host_origin_protection`` at build time, so mutating
+    that singleton beforehand deterministically neutralises the guard.
+
+    No-op when:
+    - the operator has set ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`` explicitly
+      (either direction -- their choice wins), or
+    - the running fastmcp predates the guard (the setting field is absent).
+    """
+    if HOST_ORIGIN_PROTECTION_ENV in os.environ:
+        # Respect an explicit operator choice in either direction.
+        return
+
+    # Belt: honoured by any fresh ``Settings()`` read and by child processes.
+    os.environ[HOST_ORIGIN_PROTECTION_ENV] = "false"
+
+    # Suspenders (load-bearing): fastmcp's ``http_app`` reads the already-built
+    # module-global settings singleton, so mutate it directly.
+    try:
+        import fastmcp
+
+        settings = getattr(fastmcp, "settings", None)
+        if settings is not None and hasattr(settings, _HOST_ORIGIN_PROTECTION_ATTR):
+            setattr(settings, _HOST_ORIGIN_PROTECTION_ATTR, False)
+    except Exception:  # pragma: no cover - defensive: never block startup
+        logger.debug("Could not default fastmcp Host/Origin guard off", exc_info=True)

--- a/src/ha_mcp/transport_security.py
+++ b/src/ha_mcp/transport_security.py
@@ -1,11 +1,11 @@
 """Transport-security defaults for ha-mcp's Streamable-HTTP servers.
 
 fastmcp >= 3.4.3 ships ``HostOriginGuardMiddleware`` (a DNS-rebinding guard) that
-is **on by default**. Inserted at the front of the ASGI stack, it rejects any
-request whose ``Host`` header is not loopback / an explicitly-allowed host with
-``421 Misdirected Request``, and any browser ``Origin`` that is not same-origin /
-loopback / explicitly allowed with ``403 Forbidden`` -- before the request
-reaches any route.
+is **on by default**. Inserted at the front of the Streamable-HTTP ASGI stack, it
+rejects any request whose ``Host`` header is not loopback / an explicitly-allowed
+host with ``421 Misdirected Request``, and any browser ``Origin`` that is not
+same-origin / loopback / explicitly allowed with ``403 Forbidden`` -- before the
+request reaches any route.
 
 That default is wrong for ha-mcp. We are *designed* to be reached through
 operator-chosen reverse proxies and tunnels (Cloudflare Tunnel, nginx, Traefik,
@@ -15,11 +15,10 @@ including the plain browser landing page, which is a no-``Origin`` navigation
 that still trips the ``Host`` check.
 
 Our security boundary is the high-entropy secret path (and, in OAuth mode, the
-per-user token), not the ``Host`` header. The genuinely unauthenticated loopback
-surface -- the settings sidecar -- already enforces its *own* Host/Origin
-allow-list (see ``stdio_settings_sidecar``). So defaulting fastmcp's guard off on
-the main server restores exactly the pre-3.4.3 behaviour without giving up the
-protection that matters.
+per-user token), not the ``Host`` header. The loopback settings sidecar enforces
+its *own* Host/Origin allow-list (see ``stdio_settings_sidecar``), independent of
+this setting. So defaulting fastmcp's guard off on the main server restores
+exactly the pre-3.4.3 behaviour without giving up the protection that matters.
 
 Operators who front ha-mcp differently can re-enable the guard (and pin their
 own allow-lists) via ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=true`` plus
@@ -42,33 +41,50 @@ _HOST_ORIGIN_PROTECTION_ATTR = "http_host_origin_protection"
 
 
 def ensure_host_origin_guard_default_off() -> None:
-    """Default fastmcp's Host/Origin guard off for ha-mcp HTTP servers.
+    """Default fastmcp's Host/Origin guard off for ha-mcp's Streamable-HTTP servers.
 
-    Idempotent. Call once before building/serving any Streamable-HTTP app
-    (``mcp.http_app()`` / ``mcp.run(transport="http"|"sse")`` /
-    ``mcp.run_async(...)``) -- ``http_app`` reads
+    Idempotent and safe to call from every server-creation path. Call before the
+    Streamable-HTTP app is built (``mcp.http_app()`` / ``mcp.run(transport="http")``
+    / ``mcp.run_async(...)``): ``http_app`` reads
     ``fastmcp.settings.http_host_origin_protection`` at build time, so mutating
     that singleton beforehand deterministically neutralises the guard.
 
-    No-op when:
-    - the operator has set ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`` explicitly
-      (either direction -- their choice wins), or
-    - the running fastmcp predates the guard (the setting field is absent).
+    Does nothing when the running fastmcp predates the guard (the setting field is
+    absent, i.e. < 3.4.3) or when the operator set the env var explicitly (their
+    choice wins). A failed mutation is logged at WARNING and left retryable -- it
+    is not recorded as done -- so a later reload re-attempts it.
     """
-    if HOST_ORIGIN_PROTECTION_ENV in os.environ:
-        # Respect an explicit operator choice in either direction.
-        return
-
-    # Belt: honoured by any fresh ``Settings()`` read and by child processes.
-    os.environ[HOST_ORIGIN_PROTECTION_ENV] = "false"
-
-    # Suspenders (load-bearing): fastmcp's ``http_app`` reads the already-built
-    # module-global settings singleton, so mutate it directly.
     try:
         import fastmcp
+    except Exception:  # pragma: no cover - fastmcp is a hard dependency
+        return
 
-        settings = getattr(fastmcp, "settings", None)
-        if settings is not None and hasattr(settings, _HOST_ORIGIN_PROTECTION_ATTR):
-            setattr(settings, _HOST_ORIGIN_PROTECTION_ATTR, False)
-    except Exception:  # pragma: no cover - defensive: never block startup
-        logger.debug("Could not default fastmcp Host/Origin guard off", exc_info=True)
+    settings = getattr(fastmcp, "settings", None)
+    if settings is None or not hasattr(settings, _HOST_ORIGIN_PROTECTION_ATTR):
+        # fastmcp < 3.4.3: no guard exists, nothing to disable.
+        return
+
+    if getattr(settings, _HOST_ORIGIN_PROTECTION_ATTR) is False:
+        # Already off -- a prior call, or the operator's own default. Idempotent.
+        return
+
+    if HOST_ORIGIN_PROTECTION_ENV in os.environ:
+        # Operator explicitly opted in (guard on); honour their choice.
+        return
+
+    try:
+        setattr(settings, _HOST_ORIGIN_PROTECTION_ATTR, False)
+    except Exception:
+        logger.warning(
+            "Could not disable fastmcp's Host/Origin (DNS-rebinding) guard; MCP "
+            "reached through a reverse proxy, tunnel, or LAN IP -- and the browser "
+            "landing page -- may fail with 421/403. Set %s=false, or pin "
+            "FASTMCP_HTTP_ALLOWED_HOSTS / FASTMCP_HTTP_ALLOWED_ORIGINS.",
+            HOST_ORIGIN_PROTECTION_ENV,
+            exc_info=True,
+        )
+        return
+
+    # Belt: honoured by any fresh ``Settings()`` read and by child processes. Set
+    # only after a confirmed mutation so a failed attempt stays retryable.
+    os.environ.setdefault(HOST_ORIGIN_PROTECTION_ENV, "false")

--- a/tests/src/unit/conftest.py
+++ b/tests/src/unit/conftest.py
@@ -90,3 +90,33 @@ def _clear_update_check_memo():
         # ha_mcp not importable in this test run; nothing to clear.
         pass
     yield
+
+
+@pytest.fixture(autouse=True)
+def _restore_fastmcp_host_origin_guard():
+    """Restore fastmcp's Host/Origin guard env var + setting after each test.
+
+    ``transport_security.ensure_host_origin_guard_default_off`` runs for real in
+    server-creation paths some unit tests exercise (e.g. via ``_create_server``)
+    and writes ``os.environ`` and the fastmcp settings singleton directly, which
+    ``monkeypatch`` cannot revert. Snapshot and restore both so those mutations do
+    not leak across tests once fastmcp exposes the guard (>= 3.4.3).
+    """
+    env_key = "FASTMCP_HTTP_HOST_ORIGIN_PROTECTION"
+    attr = "http_host_origin_protection"
+    prev_env = os.environ.get(env_key)
+    try:
+        import fastmcp
+
+        settings = getattr(fastmcp, "settings", None)
+    except ImportError:
+        settings = None
+    has_attr = settings is not None and hasattr(settings, attr)
+    prev_setting = getattr(settings, attr) if has_attr else None
+    yield
+    if prev_env is None:
+        os.environ.pop(env_key, None)
+    else:
+        os.environ[env_key] = prev_env
+    if has_attr:
+        setattr(settings, attr, prev_setting)

--- a/tests/src/unit/test_oauth_metadata_http.py
+++ b/tests/src/unit/test_oauth_metadata_http.py
@@ -53,6 +53,20 @@ def oauth_app(tmp_path, monkeypatch):
     test hermetic — mirrors the ``isolate_data_dir`` fixture in ``test_oauth.py``.
     """
     monkeypatch.setattr("ha_mcp.auth.provider.get_data_dir", lambda: tmp_path)
+
+    # Assemble the app the way production serves it: ha-mcp defaults fastmcp's
+    # Host/Origin (DNS-rebinding) guard off (see ha_mcp.transport_security),
+    # because it is reached through operator-chosen proxies on arbitrary hosts.
+    # Without this, fastmcp >= 3.4.3's on-by-default guard 403s the cross-origin
+    # discovery preflight (and 421s a non-loopback Host) before the request
+    # reaches our metadata route. raising=False keeps this a no-op on fastmcp
+    # < 3.4.3, where the setting field does not exist.
+    import fastmcp
+
+    monkeypatch.setenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", "false")
+    if hasattr(fastmcp.settings, "http_host_origin_protection"):
+        monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", False)
+
     server = FastMCP("test")
     server.auth = HomeAssistantOAuthProvider(base_url=BASE_URL)
     return server.http_app(path="/mcp", stateless_http=True)

--- a/tests/src/unit/test_oauth_metadata_http.py
+++ b/tests/src/unit/test_oauth_metadata_http.py
@@ -59,8 +59,8 @@ def oauth_app(tmp_path, monkeypatch):
     # because it is reached through operator-chosen proxies on arbitrary hosts.
     # Without this, fastmcp >= 3.4.3's on-by-default guard 403s the cross-origin
     # discovery preflight (and 421s a non-loopback Host) before the request
-    # reaches our metadata route. raising=False keeps this a no-op on fastmcp
-    # < 3.4.3, where the setting field does not exist.
+    # reaches our metadata route. The ``hasattr`` check keeps this a no-op on
+    # fastmcp < 3.4.3, where the setting field does not exist.
     import fastmcp
 
     monkeypatch.setenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION", "false")

--- a/tests/src/unit/test_transport_security.py
+++ b/tests/src/unit/test_transport_security.py
@@ -1,0 +1,121 @@
+"""Tests for ``ha_mcp.transport_security`` (fastmcp Host/Origin guard default).
+
+fastmcp >= 3.4.3 ships an on-by-default DNS-rebinding guard that rejects
+non-loopback ``Host`` headers (421) and cross-origin ``Origin`` headers (403)
+before routing. ha-mcp is reached through operator-chosen proxies/tunnels and
+LAN IPs on arbitrary hosts, so it defaults that guard off. These tests pin the
+helper's contract and -- on fastmcp versions that actually have the guard --
+prove it is the disable that lets a cross-origin discovery preflight through.
+"""
+
+import os
+
+import fastmcp
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from ha_mcp.transport_security import (
+    HOST_ORIGIN_PROTECTION_ENV,
+    ensure_host_origin_guard_default_off,
+)
+
+# The guard (and its backing setting) exist only on fastmcp >= 3.4.3. Tests that
+# assert on the setting / real middleware behaviour are skipped on older fastmcp,
+# where the helper is a documented no-op.
+_HAS_GUARD = hasattr(fastmcp.settings, "http_host_origin_protection")
+_requires_guard = pytest.mark.skipif(
+    not _HAS_GUARD,
+    reason="fastmcp < 3.4.3 has no Host/Origin (DNS-rebinding) guard to disable",
+)
+
+_CROSS_ORIGIN_PREFLIGHT = {
+    "Origin": "https://claude.ai",
+    "Access-Control-Request-Method": "GET",
+}
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_guard_state():
+    """Undo the helper's direct process-global mutations after each test.
+
+    ``ensure_host_origin_guard_default_off`` writes ``os.environ`` and the
+    fastmcp settings singleton directly (by design), so restore both here to
+    keep the module hermetic and avoid leaking into other test modules.
+    """
+    original_env = os.environ.get(HOST_ORIGIN_PROTECTION_ENV)
+    original_setting = (
+        fastmcp.settings.http_host_origin_protection if _HAS_GUARD else None
+    )
+    yield
+    if original_env is None:
+        os.environ.pop(HOST_ORIGIN_PROTECTION_ENV, None)
+    else:
+        os.environ[HOST_ORIGIN_PROTECTION_ENV] = original_env
+    if _HAS_GUARD:
+        fastmcp.settings.http_host_origin_protection = original_setting
+
+
+def test_defaults_env_off_when_unset(monkeypatch):
+    """With the env var unset, the helper defaults it to 'false'."""
+    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+    ensure_host_origin_guard_default_off()
+    assert os.environ[HOST_ORIGIN_PROTECTION_ENV] == "false"
+
+
+def test_respects_explicit_env_value(monkeypatch):
+    """An explicit operator value is never overwritten (either direction)."""
+    monkeypatch.setenv(HOST_ORIGIN_PROTECTION_ENV, "true")
+    ensure_host_origin_guard_default_off()
+    assert os.environ[HOST_ORIGIN_PROTECTION_ENV] == "true"
+
+
+@_requires_guard
+def test_sets_setting_off_when_env_unset(monkeypatch):
+    """The load-bearing effect: the fastmcp settings singleton flips to False."""
+    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    ensure_host_origin_guard_default_off()
+    assert fastmcp.settings.http_host_origin_protection is False
+
+
+@_requires_guard
+def test_explicit_opt_in_is_preserved(monkeypatch):
+    """An operator who re-enabled the guard keeps it on."""
+    monkeypatch.setenv(HOST_ORIGIN_PROTECTION_ENV, "true")
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    ensure_host_origin_guard_default_off()
+    assert fastmcp.settings.http_host_origin_protection is True
+
+
+@_requires_guard
+@pytest.mark.asyncio
+async def test_guard_blocks_cross_origin_preflight_when_forced_on(monkeypatch):
+    """Non-vacuous guard: forced ON, a cross-origin preflight is 403ed.
+
+    Proves the guard is real and active, so the ``allows`` test below (and the
+    metadata preflight tests) are not passing vacuously.
+    """
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    app = FastMCP("t").http_app(path="/mcp", stateless_http=True)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.options("/mcp", headers=_CROSS_ORIGIN_PREFLIGHT)
+    assert resp.status_code == 403
+
+
+@_requires_guard
+@pytest.mark.asyncio
+async def test_helper_allows_cross_origin_preflight(monkeypatch):
+    """After the helper runs, the same preflight is no longer guard-blocked."""
+    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    ensure_host_origin_guard_default_off()
+    app = FastMCP("t").http_app(path="/mcp", stateless_http=True)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.options("/mcp", headers=_CROSS_ORIGIN_PREFLIGHT)
+    # 403 == Origin blocked, 421 == Host blocked; neither may come from the guard.
+    assert resp.status_code not in (403, 421)

--- a/tests/src/unit/test_transport_security.py
+++ b/tests/src/unit/test_transport_security.py
@@ -5,7 +5,11 @@ non-loopback ``Host`` headers (421) and cross-origin ``Origin`` headers (403)
 before routing. ha-mcp is reached through operator-chosen proxies/tunnels and
 LAN IPs on arbitrary hosts, so it defaults that guard off. These tests pin the
 helper's contract and -- on fastmcp versions that actually have the guard --
-prove it is the disable that lets a cross-origin discovery preflight through.
+prove both that the guard is real (Host and Origin paths) and that the default
+neutralises it, plus that ``_create_server`` wires the call in.
+
+Global-state cleanup (env var + settings singleton) is handled by the autouse
+``_restore_fastmcp_host_origin_guard`` fixture in ``conftest.py``.
 """
 
 import os
@@ -20,10 +24,8 @@ from ha_mcp.transport_security import (
     ensure_host_origin_guard_default_off,
 )
 
-# The guard (and its backing setting) exist only on fastmcp >= 3.4.3. Tests that
-# assert on the setting / real middleware behaviour are skipped on older fastmcp,
-# where the helper is a documented no-op.
-_HAS_GUARD = hasattr(fastmcp.settings, "http_host_origin_protection")
+_ATTR = "http_host_origin_protection"
+_HAS_GUARD = hasattr(fastmcp.settings, _ATTR)
 _requires_guard = pytest.mark.skipif(
     not _HAS_GUARD,
     reason="fastmcp < 3.4.3 has no Host/Origin (DNS-rebinding) guard to disable",
@@ -33,34 +35,15 @@ _CROSS_ORIGIN_PREFLIGHT = {
     "Origin": "https://claude.ai",
     "Access-Control-Request-Method": "GET",
 }
+_NON_LOOPBACK_HOST = {"Host": "mcp.example.com"}
 
 
-@pytest.fixture(autouse=True)
-def _restore_global_guard_state():
-    """Undo the helper's direct process-global mutations after each test.
-
-    ``ensure_host_origin_guard_default_off`` writes ``os.environ`` and the
-    fastmcp settings singleton directly (by design), so restore both here to
-    keep the module hermetic and avoid leaking into other test modules.
-    """
-    original_env = os.environ.get(HOST_ORIGIN_PROTECTION_ENV)
-    original_setting = (
-        fastmcp.settings.http_host_origin_protection if _HAS_GUARD else None
-    )
-    yield
-    if original_env is None:
-        os.environ.pop(HOST_ORIGIN_PROTECTION_ENV, None)
-    else:
-        os.environ[HOST_ORIGIN_PROTECTION_ENV] = original_env
-    if _HAS_GUARD:
-        fastmcp.settings.http_host_origin_protection = original_setting
+# --- helper contract ---------------------------------------------------------
 
 
-def test_defaults_env_off_when_unset(monkeypatch):
-    """With the env var unset, the helper defaults it to 'false'."""
-    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+def test_noop_never_raises():
+    """On any fastmcp version, calling the helper is safe (no exception)."""
     ensure_host_origin_guard_default_off()
-    assert os.environ[HOST_ORIGIN_PROTECTION_ENV] == "false"
 
 
 def test_respects_explicit_env_value(monkeypatch):
@@ -71,33 +54,47 @@ def test_respects_explicit_env_value(monkeypatch):
 
 
 @_requires_guard
-def test_sets_setting_off_when_env_unset(monkeypatch):
-    """The load-bearing effect: the fastmcp settings singleton flips to False."""
+def test_sets_setting_off_and_env_when_unset(monkeypatch):
+    """The load-bearing effect: the settings singleton flips off + env is set."""
     monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
-    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    monkeypatch.setattr(fastmcp.settings, _ATTR, True)
     ensure_host_origin_guard_default_off()
-    assert fastmcp.settings.http_host_origin_protection is False
+    assert getattr(fastmcp.settings, _ATTR) is False
+    assert os.environ[HOST_ORIGIN_PROTECTION_ENV] == "false"
 
 
 @_requires_guard
 def test_explicit_opt_in_is_preserved(monkeypatch):
-    """An operator who re-enabled the guard keeps it on."""
+    """An operator who re-enabled the guard (env=true) keeps it on."""
     monkeypatch.setenv(HOST_ORIGIN_PROTECTION_ENV, "true")
-    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
+    monkeypatch.setattr(fastmcp.settings, _ATTR, True)
     ensure_host_origin_guard_default_off()
-    assert fastmcp.settings.http_host_origin_protection is True
+    assert getattr(fastmcp.settings, _ATTR) is True
+
+
+@_requires_guard
+def test_idempotent_when_already_off(monkeypatch):
+    """Already-off is a no-op and does not write the env var (retry-safe path)."""
+    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+    monkeypatch.setattr(fastmcp.settings, _ATTR, False)
+    ensure_host_origin_guard_default_off()
+    assert getattr(fastmcp.settings, _ATTR) is False
+    assert HOST_ORIGIN_PROTECTION_ENV not in os.environ
+
+
+# --- end-to-end against the real middleware (guard-bearing fastmcp only) ------
+
+
+def _build_app():
+    return FastMCP("t").http_app(path="/mcp", stateless_http=True)
 
 
 @_requires_guard
 @pytest.mark.asyncio
 async def test_guard_blocks_cross_origin_preflight_when_forced_on(monkeypatch):
-    """Non-vacuous guard: forced ON, a cross-origin preflight is 403ed.
-
-    Proves the guard is real and active, so the ``allows`` test below (and the
-    metadata preflight tests) are not passing vacuously.
-    """
-    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
-    app = FastMCP("t").http_app(path="/mcp", stateless_http=True)
+    """Non-vacuous: forced ON, a cross-origin Origin preflight is 403ed."""
+    monkeypatch.setattr(fastmcp.settings, _ATTR, True)
+    app = _build_app()
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -107,15 +104,50 @@ async def test_guard_blocks_cross_origin_preflight_when_forced_on(monkeypatch):
 
 @_requires_guard
 @pytest.mark.asyncio
-async def test_helper_allows_cross_origin_preflight(monkeypatch):
-    """After the helper runs, the same preflight is no longer guard-blocked."""
-    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
-    monkeypatch.setattr(fastmcp.settings, "http_host_origin_protection", True)
-    ensure_host_origin_guard_default_off()
-    app = FastMCP("t").http_app(path="/mcp", stateless_http=True)
+async def test_guard_blocks_non_loopback_host_when_forced_on(monkeypatch):
+    """Non-vacuous: forced ON, a non-loopback Host is 421ed (landing-page case)."""
+    monkeypatch.setattr(fastmcp.settings, _ATTR, True)
+    app = _build_app()
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
-        resp = await client.options("/mcp", headers=_CROSS_ORIGIN_PREFLIGHT)
-    # 403 == Origin blocked, 421 == Host blocked; neither may come from the guard.
-    assert resp.status_code not in (403, 421)
+        resp = await client.get("/mcp", headers=_NON_LOOPBACK_HOST)
+    assert resp.status_code == 421
+
+
+@_requires_guard
+@pytest.mark.asyncio
+async def test_helper_allows_cross_origin_and_non_loopback(monkeypatch):
+    """After the helper runs, neither the Origin (403) nor Host (421) guard fires."""
+    monkeypatch.delenv(HOST_ORIGIN_PROTECTION_ENV, raising=False)
+    monkeypatch.setattr(fastmcp.settings, _ATTR, True)
+    ensure_host_origin_guard_default_off()
+    app = _build_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        preflight = await client.options("/mcp", headers=_CROSS_ORIGIN_PREFLIGHT)
+        host_req = await client.get("/mcp", headers=_NON_LOOPBACK_HOST)
+    assert preflight.status_code not in (403, 421)
+    assert host_req.status_code != 421
+
+
+# --- wiring: the deferred-mcp chokepoint calls the helper --------------------
+
+
+def test_create_server_disables_guard(monkeypatch):
+    """_create_server -- the chokepoint for ha-mcp-web/sse, the add-on, and the
+    ``fastmcp run fastmcp-http.json`` container path -- calls the guard-disable
+    before building the server."""
+    import ha_mcp.__main__ as main_module
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        "ha_mcp.transport_security.ensure_host_origin_guard_default_off",
+        lambda: calls.append(1),
+    )
+    monkeypatch.setattr(
+        "ha_mcp.server.HomeAssistantSmartMCPServer", lambda *a, **kw: object()
+    )
+    main_module._create_server()
+    assert calls == [1]


### PR DESCRIPTION
## What does this PR do?

fastmcp 3.4.3 adds an on-by-default DNS-rebinding guard (`HostOriginGuardMiddleware`) that only accepts loopback `Host` headers and same-origin/loopback `Origin`s, rejecting everything else with **421** (Host) or **403** (Origin) before the request reaches any route.

ha-mcp is reached through operator-chosen reverse proxies and tunnels (Cloudflare, Nabu Casa, nginx) and direct LAN IPs — on hosts we can't enumerate — so the guard would 421 the majority of HTTP/OAuth deployments and their browser landing page (a no-`Origin` navigation that still trips the Host check).

This defaults the guard **off** via a shared `transport_security` helper keyed on `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION`, so operators can re-enable it (and pin `FASTMCP_HTTP_ALLOWED_HOSTS` / `FASTMCP_HTTP_ALLOWED_ORIGINS`). The helper mutates `fastmcp.settings.http_host_origin_protection`, which `http_app` reads at build time; it is retry-safe, warns on a failed mutation, and is a **no-op on fastmcp < 3.4.3** (the setting field doesn't exist), so this is safe to merge **ahead of** the fastmcp 3.4.3 bump (#1753).

The call is wired at the points every HTTP-serving path passes through before its app is built:

| Call site | Covers |
|---|---|
| `_create_server` (the deferred-`mcp` chokepoint) | `ha-mcp-web`, the add-on, and the `fastmcp run fastmcp-http.json` container path |
| `_run_oauth_server` | `ha-mcp-oauth` |
| `embedded_server.py` (guarded import) | the in-process custom-component server (direct `:9584` listener) |

stdio paths are untouched (no guard there); SSE has no such guard either (the helper is a harmless no-op for it).

`SECURITY.md` documents the posture (new threat-model subsection + an out-of-scope bullet): defaulting the guard off is consistent with the existing model, which already treats the local network as the trusted zone and puts LAN-peer / DNS-rebinding access out of scope. The authentication boundary (secret path / OAuth token / HA session) is unchanged, and the loopback settings sidecar keeps its own independent Host/Origin allow-list.

## Type of change
- [x] 🐛 Bug fix
- [x] 📚 Documentation

## Testing
- [x] All automated tests pass (`uv run pytest`) — via CI
- [x] Code follows style guidelines (`uv run ruff check` / `ruff format` — clean)

`test_transport_security.py` proves the helper's contract (env-respecting, idempotent, retry-safe), that `_create_server` wires the call in, and — on guard-bearing fastmcp — that the guard really 421s a non-loopback `Host` / 403s a cross-origin `Origin` and that the default neutralises both. Those guard-specific assertions skip on fastmcp < 3.4.3, so they gain teeth automatically once #1753 lands. `test_oauth_metadata_http.py`'s fixture now assembles the app the way production serves it (guard defaulted off), restoring its CORS-preflight assertions. An autouse `conftest.py` fixture restores the guard env var + setting after each test so the real helper can't leak global state.

## Checklist
- [x] I have updated documentation if needed (`SECURITY.md`)
- [x] Custom-component `manifest.json` version bumped (0.13.0 → 0.13.1)
