### PR TITLE
fix: catch fastmcp 3.4.3's wrapped ValidationError in arg-validation middleware

### DIFF
--- a/src/ha_mcp/tools/validation_middleware.py
+++ b/src/ha_mcp/tools/validation_middleware.py
@@ -1,9 +1,11 @@
 """FastMCP middleware that converts Pydantic validation errors to structured ToolErrors.
 
 When a model passes the wrong type for a tool parameter (e.g. a JSON string where
-a dict is required), FastMCP raises a PydanticValidationError with a raw message
-like "Input should be a valid dictionary". This middleware intercepts those errors
-and converts them to ha-mcp's structured format with actionable guidance.
+a dict is required), FastMCP surfaces a validation error with a raw message like
+"Input should be a valid dictionary" -- a bare ``pydantic.ValidationError`` on
+older FastMCP, or a ``fastmcp.exceptions.ValidationError`` wrapping it (chained
+via ``from e``) on FastMCP >= 3.4.3. This middleware intercepts either shape and
+converts it to ha-mcp's structured format with actionable guidance.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware.middleware import CallNext, Middleware, MiddlewareContext
 from pydantic import ValidationError as PydanticValidationError
 
@@ -40,9 +43,20 @@ class ValidationErrorMiddleware(Middleware):
         self, context: MiddlewareContext, call_next: CallNext
     ) -> Any:
         try:
-            return await call_next(context)
-        except PydanticValidationError as exc:
-            errors = exc.errors(include_url=False)
+            result = await call_next(context)
+        except (PydanticValidationError, FastMCPValidationError) as exc:
+            # fastmcp >= 3.4.3 re-raises an argument-validation failure as
+            # ``fastmcp.exceptions.ValidationError`` wrapping the pydantic error
+            # (chained via ``from e``); older fastmcp raises the pydantic error
+            # directly. Recover the pydantic errors from whichever shape arrived,
+            # and let any other fastmcp ValidationError (e.g. a return-value
+            # failure with no pydantic cause) propagate unchanged.
+            pydantic_exc = (
+                exc if isinstance(exc, PydanticValidationError) else exc.__cause__
+            )
+            if not isinstance(pydantic_exc, PydanticValidationError):
+                raise
+            errors = pydantic_exc.errors(include_url=False)
             # Group by the real argument path. A union param like
             # `str | list[str]` emits one error per arm with loc (param, "str"),
             # (param, "list[str]"); without grouping the user saw `param.str` /
@@ -73,3 +87,4 @@ class ValidationErrorMiddleware(Middleware):
                     details=", ".join(dict.fromkeys(err["type"] for err in errors)),
                 )
             )
+        return result

--- a/tests/src/unit/test_validation_middleware.py
+++ b/tests/src/unit/test_validation_middleware.py
@@ -33,6 +33,39 @@ def _make_mcp() -> FastMCP:
 
 
 @pytest.mark.asyncio
+async def test_wrapped_fastmcp_validation_error_is_structured():
+    """fastmcp >= 3.4.3 wraps an arg-validation pydantic error in
+    ``fastmcp.exceptions.ValidationError`` (chained via ``from e``); the
+    middleware must recover the pydantic cause and still emit a structured
+    ToolError. Version-independent: the wrapped error is synthesised, so this
+    exercises the 3.4.3 code path even on older fastmcp.
+    """
+    from fastmcp.exceptions import ValidationError as FastMCPValidationError
+    from pydantic import BaseModel
+    from pydantic import ValidationError as PydanticValidationError
+
+    class _Args(BaseModel):
+        config: dict
+
+    with pytest.raises(PydanticValidationError) as pyd_info:
+        _Args(config="{}")  # str where a dict is required -> dict_type error
+
+    wrapped = FastMCPValidationError(str(pyd_info.value))
+    wrapped.__cause__ = pyd_info.value
+
+    async def _raise_wrapped(_context):
+        raise wrapped
+
+    middleware = ValidationErrorMiddleware()
+    with pytest.raises(ToolError) as exc_info:
+        await middleware.on_call_tool(None, _raise_wrapped)
+
+    msg = json.loads(str(exc_info.value))["error"]["message"]
+    assert "config" in msg
+    assert "JSON object" in msg
+
+
+@pytest.mark.asyncio
 async def test_string_for_dict_gives_actionable_message():
     """Passing a JSON string where a dict is expected raises a structured ToolError."""
     mcp = _make_mcp()


### PR DESCRIPTION
## What does this PR do?

Second fastmcp 3.4.3 compatibility fix (companion to #1756), needed before the fastmcp bump (#1753) can go green.

fastmcp 3.4.3 (`tools/function_tool.py`) now catches an argument-validation `pydantic.ValidationError` and **re-raises it as `fastmcp.exceptions.ValidationError`**, chained via `from e`. `ValidationErrorMiddleware` only caught `pydantic.ValidationError`, so under 3.4.3 the raw wrapped error propagates instead of ha-mcp's structured, actionable `ToolError` — breaking 3 tests in `test_validation_middleware.py` once fastmcp is bumped.

The middleware now catches both shapes and recovers the pydantic errors from the wrapper's `__cause__`. Any `fastmcp.exceptions.ValidationError` with no pydantic cause (e.g. a return-value failure) is re-raised unchanged. Cross-version safe: a bare `pydantic.ValidationError` on the pinned fastmcp 3.4.2 is still handled directly, so this is a no-op on current master and safe to merge ahead of #1753.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`) — via CI
- [x] Code follows style guidelines (`uv run ruff check` / `ruff format` — clean)

Adds a version-independent regression test that synthesises the wrapped `fastmcp.exceptions.ValidationError` (chained from a real pydantic error), so the 3.4.3 code path is exercised on the current 3.4.2 CI — not only once #1753 lands. The 3 existing end-to-end tests continue to cover the real path on both fastmcp versions.

## Checklist
- [x] I have updated documentation if needed (module docstring)
