### PR TITLE
ci: route untrusted PR branch name through env in hotfix workflows

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -129,11 +129,16 @@ jobs:
 
     - name: Summary
       if: steps.semantic.outputs.released == 'true'
+      env:
+        # Route the untrusted PR branch name through env, not template
+        # interpolation, so shell metacharacters in the branch name cannot
+        # inject commands into this run: script.
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         echo "## 🚨 Hotfix Release" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** ${{ steps.semantic.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Branch:** ${{ github.event.pull_request.head.ref }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Branch:** $HEAD_REF" >> $GITHUB_STEP_SUMMARY
         echo "**PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
 
   # Build binaries and attach to release

--- a/.github/workflows/pr-validate-hotfix.yml
+++ b/.github/workflows/pr-validate-hotfix.yml
@@ -28,8 +28,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate hotfix is based on stable tag
+        env:
+          # Route the untrusted PR branch name through env, not template
+          # interpolation, so shell metacharacters in a fork branch name
+          # cannot inject commands into this run: script.
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "Validating hotfix branch: ${{ github.head_ref }}"
+          echo "Validating hotfix branch: $HEAD_REF"
 
           # Check if stable tag exists
           if ! git rev-parse stable &>/dev/null; then
@@ -82,7 +87,7 @@ jobs:
             echo ""
             echo "To fix this, rebase your hotfix onto the 'stable' tag:"
             echo ""
-            echo "  git checkout ${{ github.head_ref }}"
+            echo "  git checkout $HEAD_REF"
             echo "  git rebase --onto stable \$(git merge-base origin/master HEAD) HEAD"
             echo "  git push --force-with-lease"
             echo ""


### PR DESCRIPTION
## What does this PR do?

Fixes the expression/script injection reported in #1763. The attacker-controlled
PR head branch name (git permits shell metacharacters like `` ` ``, `$( )`, `;`,
`|`) was interpolated by the Actions template engine directly into `run:` scripts
in two hotfix workflows. This routes it through `env:` and references the shell
variable instead — matching the pattern already used in
`webhook-proxy-stable-guard.yml`.

- `pr-validate-hotfix.yml` (fork-reachable, plain `pull_request`): both
  `${{ github.head_ref }}` uses now go through `env: HEAD_REF`.
- `hotfix-release.yml`: same treatment for `${{ github.event.pull_request.head.ref }}`
  in the Summary step (gated behind `released == 'true'`, so latent, but the same
  unsafe pattern).

Impact today is bounded (`contents: read`, no secrets); the fix removes the
latent footgun should either workflow later gain write perms or secrets.

Closes #1763

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
