### PR TITLE
ci(security): pin third-party actions & verify release binaries

### DIFF
--- a/.github/workflows/_build-and-release.yml
+++ b/.github/workflows/_build-and-release.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/_update-addon-config.yml
+++ b/.github/workflows/_update-addon-config.yml
@@ -59,16 +59,23 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
+      # persist-credentials: false so the push token is not written into the
+      # workspace, where any later step could read it. The version-bump push
+      # below re-authenticates explicitly with the token instead. The public
+      # repo checkout reads fine with the default token. (#1762)
       - uses: actions/checkout@v7
         with:
           ref: master
           fetch-depth: 1
-          token: ${{ steps.token.outputs.value }}
+          persist-credentials: false
 
-      - name: Install yq
-        uses: mikefarah/yq@master
-
+      # NOTE: yq runs from the runner's preinstalled binary (ubuntu-latest ships
+      # yq 4.x). The previous `mikefarah/yq@master` step was a no-op that only
+      # pulled a mutable-ref third-party container into this credentialed job, so
+      # it was removed rather than pinned. (#1762)
       - name: Update config.yaml with release version
+        env:
+          PUSH_TOKEN: ${{ steps.token.outputs.value }}
         run: |
           VERSION="${{ inputs.version }}"
           echo "Updating addon config.yaml to version $VERSION (using token: ${{ steps.token.outputs.source }})"
@@ -85,6 +92,6 @@ jobs:
             echo "No changes to config.yaml, skipping commit"
           else
             git commit -m "chore(addon): ${{ inputs.commit_message_prefix }} $VERSION [skip ci]"
-            git push
+            git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
             echo "✓ Updated addon config.yaml to $VERSION"
           fi

--- a/.github/workflows/addon-publish-dev.yml
+++ b/.github/workflows/addon-publish-dev.yml
@@ -82,17 +82,17 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: .
         file: ./homeassistant-addon-dev/Dockerfile

--- a/.github/workflows/addon-publish.yml
+++ b/.github/workflows/addon-publish.yml
@@ -49,10 +49,10 @@ jobs:
         ref: ${{ inputs.version && format('v{0}', inputs.version) || github.sha }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
         echo "Add-on version: $VERSION"
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: .
         file: ./homeassistant-addon/Dockerfile

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,12 +43,12 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       with:
         cache-binary: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 
@@ -134,12 +134,12 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       with:
         cache-binary: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 

--- a/.github/workflows/haos-e2e-embedded-tests.yml
+++ b/.github/workflows/haos-e2e-embedded-tests.yml
@@ -218,7 +218,7 @@ jobs:
       # in conftest.py) — never on the cached base.
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/haos-e2e-inaddon-tests.yml
+++ b/.github/workflows/haos-e2e-inaddon-tests.yml
@@ -224,7 +224,7 @@ jobs:
       # gets cached.
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -222,7 +222,7 @@ jobs:
           key: ${{ steps.key.outputs.cache-key }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Run semantic-release
       id: semantic
-      uses: python-semantic-release/python-semantic-release@v10.6.1
+      uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         verbosity: "2"

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -77,7 +77,7 @@ jobs:
         exit 1
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -356,12 +356,12 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       with:
         cache-binary: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 
@@ -453,12 +453,12 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       with:
         cache-binary: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 
@@ -525,12 +525,12 @@ jobs:
         submodules: true
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       with:
         cache-binary: true
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -76,7 +76,7 @@ jobs:
           submodules: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Temporarily set package name and version for dev build
         run: |
@@ -96,7 +96,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
           skip-existing: true
@@ -114,17 +114,17 @@ jobs:
           submodules: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image (dev tags)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -138,13 +138,13 @@ jobs:
           submodules: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Build distribution
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
           skip-existing: true
@@ -171,10 +171,10 @@ jobs:
           submodules: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
           tags: |
@@ -193,7 +193,7 @@ jobs:
             type=raw,value=stable
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -233,9 +233,25 @@ jobs:
 
       - name: Install MCP Publisher CLI
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}
+        env:
+          # Pinned instead of `releases/latest` so an upstream re-point can't
+          # inject an unverified binary into this id-token: write job. Bump both
+          # values together on a mcp-publisher update; the sha256 is for the
+          # linux/amd64 artifact (ubuntu-latest runner). Upstream ships a
+          # checksums.txt, but fetching it from the same release is no trust
+          # anchor, so the hash is pinned here. Renovate/Dependabot can't track
+          # a bare curl, so this is a manual pin with a benign failure mode:
+          # last job, PyPI/Docker already published, workflow_dispatch re-runnable.
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
         run: |
           set -euo pipefail
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${os}_${arch}.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       - name: Render server manifest for publish
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,7 +43,7 @@ jobs:
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.18
+        uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
         with:
           configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -94,10 +94,10 @@ jobs:
           submodules: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build addon image (no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./homeassistant-addon/Dockerfile
@@ -138,7 +138,7 @@ jobs:
 
     - name: Python Semantic Release
       id: semantic
-      uses: python-semantic-release/python-semantic-release@v10.6.1
+      uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10.6.1
       with:
         # Use GitHub App token with bypass permissions
         github_token: ${{ steps.app-token.outputs.token || secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration
 
@@ -33,4 +33,4 @@ jobs:
       # owns. Mirrors scripts/codeql_quality_gate.py's PATHS_IGNORE convention.
       - name: Remove vendored test fixtures
         run: rm -rf tests/initial_test_state
-      - uses: home-assistant/actions/hassfest@master
+      - uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c # master


### PR DESCRIPTION
## What does this PR do?

Hardens the CI supply chain for the release/publish path (closes #1762).
Third-party code in credentialed jobs was pinned to mutable refs (branches,
movable tags, `releases/latest`); an upstream compromise of any one would run in
the privileged publish path without ever opening a PR here.

**Structural fixes (the two sharp credentialed instances):**

- **`_update-addon-config.yml`** mints a branch-protection-bypass push token. I
  removed the `mikefarah/yq@master` step: it is a Docker container action that
  installs nothing on the runner, so the next step's `yq -i` already runs from
  the runner's preinstalled yq (ubuntu-latest ships 4.x). Deleting it removes
  third-party mutable-ref code from the token-holding job entirely, which is
  better than pinning it. I also set `persist-credentials: false` on the
  checkout so the push token is not left in the workspace for a later step to
  read, and gave the version bump its own explicit tokenized push. The job
  previously ended in a bare `git push` that relied on the persisted credential,
  so flipping the flag alone would have broken the release in all three callers
  (`semver-release`, `hotfix-release`, `addon-publish-dev`); the explicit push
  keeps them working.

- **`release-publish.yml`** fetched the `mcp-publisher` binary with
  `curl .../releases/latest/... | tar xz` (no version pin, no checksum) and then
  ran it under `id-token: write`. I pinned it to `v1.7.9`, download to a file,
  `sha256sum -c` (fail closed), then extract. The sha256 is pinned in-repo.
  Upstream does ship a `checksums.txt` that covers this artifact, but fetching it
  from the same release is not a trust anchor against an upstream compromise, so
  the hash lives here. I verified the pinned value by downloading the v1.7.9
  `linux_amd64` artifact and computing `sha256sum`; it matches both my
  computation and upstream's `checksums.txt`.

**SHA-pin sweep:** every third-party action is now pinned to a full 40-char
commit SHA with a trailing `# <ref>` comment (`astral-sh/setup-uv`, `docker/*`,
`python-semantic-release`, `hacs/action`, `home-assistant/actions/hassfest`,
`renovatebot/github-action`, `dependabot/fetch-metadata`,
`pypa/gh-action-pypi-publish`). Dependabot's `github-actions` manager maintains
these going forward; Renovate's `github-actions` manager is not enabled in this
repo, so `helpers:pinGitHubActionDigests` would be a no-op and would only
duplicate Dependabot's PRs.

`pypa/gh-action-pypi-publish` is pinned to the current `release/v1` head like the
rest for a consistent posture. The tradeoff: a PyPA emergency fix lags behind the
Dependabot bump instead of arriving instantly.

First-party `actions/*` and `github/*` are intentionally left on version tags,
since they are GitHub-owned and out of the third-party upstream-compromise threat
this addresses.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

This is a workflows-only change, so the runtime test and lint boxes above do not
apply (`pytest` and `ruff` do not exercise `.github/workflows`). Validation done:
all 18 changed workflow files parse as YAML; every pinned SHA was resolved from
`gh api repos/<action>/commits/<ref>` and spot-re-verified; the credential flow
was traced across all three `_update-addon-config.yml` callers. `actionlint` runs
in CI.

## Checklist
- [x] I have updated documentation if needed
