### PR TITLE
fix: surface WebSocket close to tool calls instead of hanging

### DIFF
--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -702,9 +702,15 @@ class HomeAssistantWebSocketClient:
             result_response = await asyncio.wait_for(
                 result_future, timeout=wait_timeout
             )
-        except TimeoutError:
+        except BaseException:
             self.cancel_pending_response(message_id)
             self.cancel_event_response(message_id)
+            # A connection drop fails BOTH futures via reset_connection;
+            # only result_future gets awaited on this path, so retrieve
+            # event_future's exception too or asyncio logs an ERROR-level
+            # "Future exception was never retrieved" when it is GC'd.
+            if event_future.done() and not event_future.cancelled():
+                event_future.exception()
             raise
 
         if not result_response.get("success"):

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -30,6 +30,15 @@ from .rest_client import (
 
 logger = logging.getLogger(__name__)
 
+# Matches the Supervisor's own Core-connection receive limit
+# (MAX_MESSAGE_SIZE_FROM_CORE in home-assistant/supervisor, see supervisor
+# issue #4392). On the add-on path frames above that limit die at the
+# Supervisor proxy anyway, so a larger client-side cap adds nothing there.
+# Registry list responses scale with entity count and arrive as ONE frame
+# (the HA WebSocket API has no pagination); a ~6.4k-entity instance
+# overflowed the previous 20MB cap (#1721).
+MAX_WS_MESSAGE_BYTES = 64 * 1024 * 1024
+
 
 class WebSocketConnectionState:
     """Encapsulates mutable state used by the WebSocket client."""
@@ -109,20 +118,43 @@ class WebSocketConnectionState:
         """Retrieve and remove an authentication message if present."""
         return self._auth_messages.pop(message_type, None)
 
-    def reset_connection(self) -> None:
-        """Reset connection-specific state while preserving handlers."""
+    def reset_connection(self, close_reason: str | None = None) -> None:
+        """Reset connection-specific state while preserving handlers.
+
+        Args:
+            close_reason: Human-readable description of why the connection
+                went away (e.g. a close code/reason pair), included in the
+                error surfaced to any request still awaiting a response.
+        """
         self.connected = False
         self.authenticated = False
         self._message_id = 0
 
+        # ``future.cancel()`` makes awaiters see ``asyncio.CancelledError``,
+        # a BaseException that skips every ``except Exception`` handler in
+        # the tool layer and reaches the MCP SDK, which treats it as a
+        # client-initiated cancellation, suppresses the response entirely,
+        # and leaves the MCP client hanging until its own timeout (#1721).
+        # ``set_exception`` with a normal exception propagates through
+        # ``except Exception`` as expected instead.
+        message = (
+            "WebSocket connection to Home Assistant closed while waiting for a response"
+        )
+        if close_reason:
+            message = f"{message} ({close_reason})"
+
         for future in self._pending_requests.values():
             if not future.done():
-                future.cancel()
+                # A fresh instance per future: sharing one exception object
+                # across multiple ``set_exception`` calls means the second
+                # raise attaches a traceback to an exception already
+                # associated with another future's stack.
+                future.set_exception(HomeAssistantConnectionError(message))
         self._pending_requests.clear()
 
         for future in self._event_responses.values():
             if not future.done():
-                future.cancel()
+                future.set_exception(HomeAssistantConnectionError(message))
         self._event_responses.clear()
 
         # Drop any subscription queues — readers wake on the close signal
@@ -144,9 +176,9 @@ class WebSocketConnectionState:
         """Mark the socket as authenticated and ready for commands."""
         self.authenticated = True
 
-    def mark_disconnected(self) -> None:
+    def mark_disconnected(self, close_reason: str | None = None) -> None:
         """Reset connection state when the socket is closed."""
-        self.reset_connection()
+        self.reset_connection(close_reason)
 
     @property
     def is_ready(self) -> bool:
@@ -293,9 +325,7 @@ class HomeAssistantWebSocketClient:
                 ping_timeout=10,
                 additional_headers={"Authorization": f"Bearer {self.token}"},
                 ssl=ssl_ctx,
-                # Increase max message size to 20MB for large responses
-                # (e.g., HACS repository list can be 2MB+)
-                max_size=20 * 1024 * 1024,
+                max_size=MAX_WS_MESSAGE_BYTES,
             )
             self._state.mark_connected()
 
@@ -390,6 +420,11 @@ class HomeAssistantWebSocketClient:
         """Background task to handle incoming WebSocket messages."""
         if not self.websocket:
             raise Exception("WebSocket not connected")
+        # None means a clean exit (the async-for loop simply ended); the
+        # except blocks below fill this in so pending futures — and the
+        # log — carry *why* the connection went away instead of a bare
+        # "WebSocket connection closed" that gave no lead on #1721.
+        close_reason: str | None = None
         try:
             async for message in self.websocket:
                 try:
@@ -400,12 +435,30 @@ class HomeAssistantWebSocketClient:
                     logger.error(f"Invalid JSON received: {e}")
                 except Exception as e:
                     logger.error(f"Error processing message: {e}")
-        except websockets.exceptions.ConnectionClosed:
-            logger.info("WebSocket connection closed")
+        except websockets.exceptions.ConnectionClosed as e:
+            # Prefer the frame we received (the peer closed on us); fall
+            # back to the frame we sent (we failed the connection
+            # ourselves, e.g. an over-max_size frame produces a sent
+            # Close(1009, ...) with no frame received at all).
+            close = e.rcvd if e.rcvd is not None else e.sent
+            if close is not None:
+                verb = "received" if e.rcvd is not None else "sent"
+                close_reason = f"{verb} close code {close.code}"
+                if close.reason:
+                    close_reason = f"{close_reason} ({close.reason})"
+            else:
+                close_reason = "connection dropped without a close frame"
+
+            log_message = f"WebSocket connection closed ({close_reason})"
+            if close is None or close.code not in (1000, 1001):
+                logger.warning(log_message)
+            else:
+                logger.info(log_message)
         except Exception as e:
+            close_reason = str(e)
             logger.error(f"WebSocket message handler error: {e}")
         finally:
-            self._state.mark_disconnected()
+            self._state.mark_disconnected(close_reason)
 
     async def _process_message(self, data: dict[str, Any]) -> None:
         """Process incoming WebSocket message."""

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -12,6 +12,11 @@ from ._base import _SearchBase
 
 logger = logging.getLogger(__name__)
 
+# Bounds the per-frame response size of config/entity_registry/get_entries
+# (extended entries, ~1KB typical each) so alias enrichment can't produce an
+# over-cap WebSocket frame on large instances (#1721).
+_GET_ENTRIES_CHUNK_SIZE = 500
+
 
 class EntitySearchMixin(_SearchBase):
     """``smart_entity_search`` and ``get_entities_by_area`` plus helpers."""
@@ -148,36 +153,67 @@ class EntitySearchMixin(_SearchBase):
         """Batch-fetch full registry entries for aliases.
 
         ``config/entity_registry/list`` deliberately omits ``aliases``;
-        ``get_entries`` includes them. One extra round-trip enriches the
-        survivor set without N+1 fan-out.
+        ``get_entries`` includes them. Survivors are split into
+        ``_GET_ENTRIES_CHUNK_SIZE``-sized chunks fetched concurrently: a
+        bounded number of round-trips (len(ids) / 500), not N+1 fan-out, and
+        each response frame stays bounded regardless of instance size.
+        Enrichment is best-effort per chunk — one chunk failing does not
+        drop aliases fetched by the others.
         """
         aliases_map: dict[str, list[str]] = {}
         if not survivor_ids:
             return aliases_map
-        try:
-            entries_resp = await self.client.send_websocket_message(
-                {
-                    "type": "config/entity_registry/get_entries",
-                    "entity_ids": survivor_ids,
-                }
-            )
-            if isinstance(entries_resp, dict) and entries_resp.get("success"):
-                for eid, entry in (entries_resp.get("result", {}) or {}).items():
-                    if isinstance(entry, dict):
-                        aliases_map[eid] = entry.get("aliases", []) or []
-            else:
+
+        chunks: list[list[str]] = [
+            survivor_ids[i : i + _GET_ENTRIES_CHUNK_SIZE]
+            for i in range(0, len(survivor_ids), _GET_ENTRIES_CHUNK_SIZE)
+        ]
+        responses: list[Any] = await asyncio.gather(
+            *(
+                self.client.send_websocket_message(
+                    {
+                        "type": "config/entity_registry/get_entries",
+                        "entity_ids": chunk,
+                    }
+                )
+                for chunk in chunks
+            ),
+            return_exceptions=True,
+        )
+
+        for chunk, entries_resp in zip(chunks, responses, strict=True):
+            # Same convention as _fetch_search_entities: a captured
+            # CancelledError means the surrounding task is being torn
+            # down — propagate it instead of degrading to a warning.
+            if isinstance(entries_resp, asyncio.CancelledError):
+                raise entries_resp
+            if isinstance(entries_resp, BaseException):
                 logger.warning(
-                    "alias_enrichment_failed: get_entries returned non-success "
-                    "for %d entities (resp=%r)",
-                    len(survivor_ids),
+                    "alias_enrichment_failed: get_entries chunk of %d entities "
+                    "raised (err=%r)",
+                    len(chunk),
                     entries_resp,
                 )
-        except (KeyError, TypeError, AttributeError) as alias_err:
-            logger.warning(
-                "alias_enrichment_failed: malformed payload for %d entities (err=%r)",
-                len(survivor_ids),
-                alias_err,
-            )
+                continue
+            try:
+                if isinstance(entries_resp, dict) and entries_resp.get("success"):
+                    for eid, entry in (entries_resp.get("result", {}) or {}).items():
+                        if isinstance(entry, dict):
+                            aliases_map[eid] = entry.get("aliases", []) or []
+                else:
+                    logger.warning(
+                        "alias_enrichment_failed: get_entries returned non-success "
+                        "for a chunk of %d entities (resp=%r)",
+                        len(chunk),
+                        entries_resp,
+                    )
+            except (KeyError, TypeError, AttributeError) as alias_err:
+                logger.warning(
+                    "alias_enrichment_failed: malformed payload for a chunk of "
+                    "%d entities (err=%r)",
+                    len(chunk),
+                    alias_err,
+                )
         return aliases_map
 
     async def _fetch_search_entities(

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -149,20 +149,26 @@ class EntitySearchMixin(_SearchBase):
 
     async def _fetch_entity_aliases(
         self, survivor_ids: list[str]
-    ) -> dict[str, list[str]]:
+    ) -> tuple[dict[str, list[str]], list[str]]:
         """Batch-fetch full registry entries for aliases.
 
         ``config/entity_registry/list`` deliberately omits ``aliases``;
         ``get_entries`` includes them. Survivors are split into
         ``_GET_ENTRIES_CHUNK_SIZE``-sized chunks fetched concurrently: a
-        bounded number of round-trips (len(ids) / 500), not N+1 fan-out, and
+        bounded number of round-trips (one per chunk), not N+1 fan-out, and
         each response frame stays bounded regardless of instance size.
         Enrichment is best-effort per chunk — one chunk failing does not
-        drop aliases fetched by the others.
+        drop aliases fetched by the others; failures are reported in the
+        returned warnings so the caller can tell "no aliases exist" apart
+        from "the alias fetch failed".
+
+        Returns:
+            ``(aliases_map, warnings)`` — warnings has one entry when any
+            chunk failed, empty otherwise.
         """
         aliases_map: dict[str, list[str]] = {}
         if not survivor_ids:
-            return aliases_map
+            return aliases_map, []
 
         chunks: list[list[str]] = [
             survivor_ids[i : i + _GET_ENTRIES_CHUNK_SIZE]
@@ -181,6 +187,7 @@ class EntitySearchMixin(_SearchBase):
             return_exceptions=True,
         )
 
+        failed_chunks = 0
         for chunk, entries_resp in zip(chunks, responses, strict=True):
             # Same convention as _fetch_search_entities: a captured
             # CancelledError means the surrounding task is being torn
@@ -188,6 +195,7 @@ class EntitySearchMixin(_SearchBase):
             if isinstance(entries_resp, asyncio.CancelledError):
                 raise entries_resp
             if isinstance(entries_resp, BaseException):
+                failed_chunks += 1
                 logger.warning(
                     "alias_enrichment_failed: get_entries chunk of %d entities "
                     "raised (err=%r)",
@@ -201,6 +209,7 @@ class EntitySearchMixin(_SearchBase):
                         if isinstance(entry, dict):
                             aliases_map[eid] = entry.get("aliases", []) or []
                 else:
+                    failed_chunks += 1
                     logger.warning(
                         "alias_enrichment_failed: get_entries returned non-success "
                         "for a chunk of %d entities (resp=%r)",
@@ -208,13 +217,21 @@ class EntitySearchMixin(_SearchBase):
                         entries_resp,
                     )
             except (KeyError, TypeError, AttributeError) as alias_err:
+                failed_chunks += 1
                 logger.warning(
                     "alias_enrichment_failed: malformed payload for a chunk of "
                     "%d entities (err=%r)",
                     len(chunk),
                     alias_err,
                 )
-        return aliases_map
+        warnings: list[str] = []
+        if failed_chunks:
+            warnings.append(
+                f"Alias enrichment incomplete: {failed_chunks} of {len(chunks)} "
+                "entity-registry lookups failed; alias-based matches may be "
+                "missing from these results."
+            )
+        return aliases_map, warnings
 
     async def _fetch_search_entities(
         self, domain_filter: str | None, include_hidden: bool
@@ -259,7 +276,8 @@ class EntitySearchMixin(_SearchBase):
         survivor_ids, survivor_states = self._filter_hidden_entities(
             entities, registry_slim, include_hidden, visibility_hidden
         )
-        aliases_map = await self._fetch_entity_aliases(survivor_ids)
+        aliases_map, alias_warnings = await self._fetch_entity_aliases(survivor_ids)
+        visibility_warnings = [*visibility_warnings, *alias_warnings]
 
         # Enrich with aliases + hidden_by for the fuzzy layer. Shallow copy +
         # private-prefixed keys so downstream consumers that round-trip these

--- a/tests/src/unit/test_alias_fetch_chunking.py
+++ b/tests/src/unit/test_alias_fetch_chunking.py
@@ -1,0 +1,154 @@
+"""Unit tests for chunked alias fetching (#1721).
+
+``_fetch_entity_aliases`` used to send a single ``config/entity_registry/
+get_entries`` WebSocket call with every survivor entity_id. ``get_entries``
+returns the full ``extended_dict`` per entry (a superset of the list
+projection, including aliases), so that one response frame scaled with the
+whole instance — on a large (~6.4k-entity) instance it could exceed the
+WebSocket message cap and kill the connection. These tests pin the chunked
+replacement: bounded per-frame size, concurrent fetch, and per-chunk
+best-effort failure handling.
+"""
+
+import logging
+import math
+from unittest.mock import patch
+
+import pytest
+
+from ha_mcp.tools.smart_search import SmartSearchTools
+from ha_mcp.tools.smart_search._entities import _GET_ENTRIES_CHUNK_SIZE
+
+
+def _make_tools(client):
+    """Create SmartSearchTools with mocked global settings."""
+    with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+        mock_settings.return_value.fuzzy_threshold = 60
+        return SmartSearchTools(client=client)
+
+
+class RecordingClient:
+    """Mock client recording each ``get_entries`` call, returning synthetic aliases.
+
+    ``fail_on_call`` (1-indexed) makes that call raise instead of returning;
+    ``fail_response_on_call`` makes that call return a non-success payload.
+    Both are optional and mutually exclusive per test.
+    """
+
+    def __init__(
+        self,
+        fail_on_call: int | None = None,
+        fail_response_on_call: int | None = None,
+    ) -> None:
+        self.calls: list[dict] = []
+        self.fail_on_call = fail_on_call
+        self.fail_response_on_call = fail_response_on_call
+
+    async def send_websocket_message(self, message: dict) -> dict:
+        self.calls.append(message)
+        call_number = len(self.calls)
+        if self.fail_on_call == call_number:
+            raise RuntimeError(f"simulated failure on call {call_number}")
+        if self.fail_response_on_call == call_number:
+            return {"success": False, "error": "simulated failure"}
+        entity_ids = message["entity_ids"]
+        return {
+            "success": True,
+            "result": {eid: {"aliases": [f"alias-{eid}"]} for eid in entity_ids},
+        }
+
+
+def _entity_ids(count: int) -> list[str]:
+    return [f"light.entity_{i}" for i in range(count)]
+
+
+class TestAliasFetchChunking:
+    @pytest.mark.asyncio
+    async def test_large_survivor_set_is_chunked(self):
+        """2501 ids split into 6 bounded chunks; every id is fetched exactly once."""
+        client = RecordingClient()
+        tools = _make_tools(client)
+        survivor_ids = _entity_ids(2501)
+
+        aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+
+        expected_calls = math.ceil(len(survivor_ids) / _GET_ENTRIES_CHUNK_SIZE)
+        assert len(client.calls) == expected_calls == 6
+
+        requested_ids: list[str] = []
+        for call in client.calls:
+            assert len(call["entity_ids"]) <= _GET_ENTRIES_CHUNK_SIZE
+            requested_ids.extend(call["entity_ids"])
+        assert sorted(requested_ids) == sorted(survivor_ids)
+
+        assert len(aliases_map) == len(survivor_ids)
+        for eid in survivor_ids:
+            assert aliases_map[eid] == [f"alias-{eid}"]
+
+    @pytest.mark.asyncio
+    async def test_below_chunk_size_issues_single_call(self):
+        """A small survivor set (below the chunk size) issues exactly one call."""
+        client = RecordingClient()
+        tools = _make_tools(client)
+        survivor_ids = _entity_ids(3)
+
+        aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+
+        assert len(client.calls) == 1
+        assert client.calls[0]["entity_ids"] == survivor_ids
+        assert len(aliases_map) == 3
+
+    @pytest.mark.asyncio
+    async def test_one_failing_chunk_does_not_fail_whole_fetch(self, caplog):
+        """One chunk raising still returns the other chunks' aliases, plus a warning."""
+        client = RecordingClient(fail_on_call=2)
+        tools = _make_tools(client)
+        # Two chunks: chunk 1 (ids 0..499) succeeds, chunk 2 (id 500) raises.
+        survivor_ids = _entity_ids(_GET_ENTRIES_CHUNK_SIZE + 1)
+
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.smart_search._entities"
+        ):
+            aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+
+        assert len(client.calls) == 2
+        # First chunk's aliases survive the second chunk's failure.
+        first_chunk_id = survivor_ids[0]
+        assert aliases_map[first_chunk_id] == [f"alias-{first_chunk_id}"]
+        # The failed chunk's id has no alias entry.
+        failed_id = survivor_ids[-1]
+        assert failed_id not in aliases_map
+
+        assert "alias_enrichment_failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_one_non_success_chunk_does_not_fail_whole_fetch(self, caplog):
+        """A non-success response for one chunk is also tolerated, with a warning."""
+        client = RecordingClient(fail_response_on_call=1)
+        tools = _make_tools(client)
+        survivor_ids = _entity_ids(_GET_ENTRIES_CHUNK_SIZE + 1)
+
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.smart_search._entities"
+        ):
+            aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+
+        assert len(client.calls) == 2
+        # The failed first chunk contributed no aliases...
+        first_chunk_id = survivor_ids[0]
+        assert first_chunk_id not in aliases_map
+        # ...but the successful second chunk still did.
+        second_chunk_id = survivor_ids[-1]
+        assert aliases_map[second_chunk_id] == [f"alias-{second_chunk_id}"]
+
+        assert "alias_enrichment_failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_empty_survivor_ids_returns_empty_and_makes_no_calls(self):
+        client = RecordingClient()
+        tools = _make_tools(client)
+
+        aliases_map = await tools._fetch_entity_aliases([])
+
+        assert aliases_map == {}
+        assert client.calls == []

--- a/tests/src/unit/test_alias_fetch_chunking.py
+++ b/tests/src/unit/test_alias_fetch_chunking.py
@@ -10,6 +10,7 @@ replacement: bounded per-frame size, concurrent fetch, and per-chunk
 best-effort failure handling.
 """
 
+import asyncio
 import logging
 import math
 from unittest.mock import patch
@@ -39,18 +40,28 @@ class RecordingClient:
         self,
         fail_on_call: int | None = None,
         fail_response_on_call: int | None = None,
+        cancel_on_call: int | None = None,
+        malformed_on_call: int | None = None,
     ) -> None:
         self.calls: list[dict] = []
         self.fail_on_call = fail_on_call
         self.fail_response_on_call = fail_response_on_call
+        self.cancel_on_call = cancel_on_call
+        self.malformed_on_call = malformed_on_call
 
     async def send_websocket_message(self, message: dict) -> dict:
         self.calls.append(message)
         call_number = len(self.calls)
         if self.fail_on_call == call_number:
             raise RuntimeError(f"simulated failure on call {call_number}")
+        if self.cancel_on_call == call_number:
+            raise asyncio.CancelledError
         if self.fail_response_on_call == call_number:
             return {"success": False, "error": "simulated failure"}
+        if self.malformed_on_call == call_number:
+            # success=True but result is a list, not the expected dict --
+            # .items() raises AttributeError in the merge loop.
+            return {"success": True, "result": ["not-a-dict"]}
         entity_ids = message["entity_ids"]
         return {
             "success": True,
@@ -70,8 +81,9 @@ class TestAliasFetchChunking:
         tools = _make_tools(client)
         survivor_ids = _entity_ids(2501)
 
-        aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+        aliases_map, warnings = await tools._fetch_entity_aliases(survivor_ids)
 
+        assert warnings == []
         expected_calls = math.ceil(len(survivor_ids) / _GET_ENTRIES_CHUNK_SIZE)
         assert len(client.calls) == expected_calls == 6
 
@@ -92,8 +104,9 @@ class TestAliasFetchChunking:
         tools = _make_tools(client)
         survivor_ids = _entity_ids(3)
 
-        aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+        aliases_map, warnings = await tools._fetch_entity_aliases(survivor_ids)
 
+        assert warnings == []
         assert len(client.calls) == 1
         assert client.calls[0]["entity_ids"] == survivor_ids
         assert len(aliases_map) == 3
@@ -109,8 +122,9 @@ class TestAliasFetchChunking:
         with caplog.at_level(
             logging.WARNING, logger="ha_mcp.tools.smart_search._entities"
         ):
-            aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+            aliases_map, warnings = await tools._fetch_entity_aliases(survivor_ids)
 
+        assert any("Alias enrichment incomplete" in w for w in warnings)
         assert len(client.calls) == 2
         # First chunk's aliases survive the second chunk's failure.
         first_chunk_id = survivor_ids[0]
@@ -131,8 +145,9 @@ class TestAliasFetchChunking:
         with caplog.at_level(
             logging.WARNING, logger="ha_mcp.tools.smart_search._entities"
         ):
-            aliases_map = await tools._fetch_entity_aliases(survivor_ids)
+            aliases_map, warnings = await tools._fetch_entity_aliases(survivor_ids)
 
+        assert any("Alias enrichment incomplete" in w for w in warnings)
         assert len(client.calls) == 2
         # The failed first chunk contributed no aliases...
         first_chunk_id = survivor_ids[0]
@@ -144,11 +159,44 @@ class TestAliasFetchChunking:
         assert "alias_enrichment_failed" in caplog.text
 
     @pytest.mark.asyncio
+    async def test_cancelled_chunk_propagates(self):
+        """A cancelled sub-fetch must abort enrichment, not degrade to a warning.
+
+        Swallowing a captured CancelledError as best-effort would reintroduce
+        the #1721 failure class on the new concurrent path.
+        """
+        client = RecordingClient(cancel_on_call=2)
+        tools = _make_tools(client)
+        survivor_ids = _entity_ids(_GET_ENTRIES_CHUNK_SIZE + 1)
+
+        with pytest.raises(asyncio.CancelledError):
+            await tools._fetch_entity_aliases(survivor_ids)
+
+    @pytest.mark.asyncio
+    async def test_malformed_success_payload_tolerated(self, caplog):
+        """success=True with a non-dict result warns and keeps other chunks."""
+        client = RecordingClient(malformed_on_call=1)
+        tools = _make_tools(client)
+        survivor_ids = _entity_ids(_GET_ENTRIES_CHUNK_SIZE + 1)
+
+        with caplog.at_level(
+            logging.WARNING, logger="ha_mcp.tools.smart_search._entities"
+        ):
+            aliases_map, warnings = await tools._fetch_entity_aliases(survivor_ids)
+
+        assert any("Alias enrichment incomplete" in w for w in warnings)
+        assert survivor_ids[0] not in aliases_map
+        second_chunk_id = survivor_ids[-1]
+        assert aliases_map[second_chunk_id] == [f"alias-{second_chunk_id}"]
+        assert "alias_enrichment_failed" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_empty_survivor_ids_returns_empty_and_makes_no_calls(self):
         client = RecordingClient()
         tools = _make_tools(client)
 
-        aliases_map = await tools._fetch_entity_aliases([])
+        aliases_map, warnings = await tools._fetch_entity_aliases([])
 
         assert aliases_map == {}
+        assert warnings == []
         assert client.calls == []

--- a/tests/src/unit/test_ws_close_pending_requests_1721.py
+++ b/tests/src/unit/test_ws_close_pending_requests_1721.py
@@ -20,6 +20,8 @@ import logging
 
 import pytest
 import websockets
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.frames import Close
 
 from ha_mcp.client.rest_client import HomeAssistantConnectionError
 from ha_mcp.client.websocket_client import (
@@ -99,11 +101,14 @@ async def test_close_code_and_reason_surface_in_log_and_error(caplog):
             with pytest.raises(HomeAssistantConnectionError) as excinfo:
                 await client.send_command("config/entity_registry/list")
         assert "1009" in str(excinfo.value)
-        messages = [record.getMessage() for record in caplog.records]
+        # Abnormal closes must stay visible at WARNING -- the #1721 pain was
+        # a close that logged nothing actionable at default log levels.
         assert any(
-            "1009" in message and "frame exceeds limit" in message
-            for message in messages
-        ), f"close code/reason not logged; got: {messages}"
+            record.levelno == logging.WARNING
+            and "1009" in record.getMessage()
+            and "frame exceeds limit" in record.getMessage()
+            for record in caplog.records
+        ), f"close code/reason not logged at WARNING; got: {caplog.records}"
         await client.disconnect()
     finally:
         server.close()
@@ -151,3 +156,169 @@ def test_max_ws_message_bytes_matches_supervisor_ceiling():
     WebSocket API); a ~6.4k-entity instance overflowed the previous 20MB cap.
     """
     assert MAX_WS_MESSAGE_BYTES == 64 * 1024 * 1024
+
+
+async def test_connect_wires_max_size_into_websockets(monkeypatch):
+    """MAX_WS_MESSAGE_BYTES must actually reach websockets.connect."""
+    captured: dict = {}
+
+    async def fake_connect(url, **kwargs):
+        captured.update(kwargs)
+        raise OSError("abort after capture")
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+    client = HomeAssistantWebSocketClient(
+        "http://127.0.0.1:1", "test-token", verify_ssl=False
+    )
+    assert await client.connect() is False
+    assert captured["max_size"] == MAX_WS_MESSAGE_BYTES
+
+
+class _ClosingFakeWebSocket:
+    """Async-iterable stub whose iteration raises a given exception.
+
+    Lets tests drive ``_message_handler`` through close paths a real
+    loopback server cannot produce on demand -- most importantly the
+    self-initiated close (``rcvd=None, sent=Close(1009)``), which is the
+    literal #1721 trigger (the client fails the connection on an
+    over-``max_size`` frame).
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __aiter__(self) -> "_ClosingFakeWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        raise self._exc
+
+    async def close(self) -> None:
+        return None
+
+
+async def _run_handler_with(
+    exc: BaseException,
+) -> tuple[HomeAssistantWebSocketClient, "asyncio.Future[dict]"]:
+    """Drive _message_handler against a stub socket that dies with ``exc``."""
+    client = HomeAssistantWebSocketClient(
+        "http://127.0.0.1:1", "test-token", verify_ssl=False
+    )
+    client.websocket = _ClosingFakeWebSocket(exc)  # type: ignore[assignment]
+    future = client._state.register_pending_request(1)
+    await client._message_handler()
+    return client, future
+
+
+async def test_sent_close_1009_reaches_future_and_logs_warning(caplog):
+    """Self-initiated close (over-max_size frame) surfaces 'sent close code 1009'."""
+    caplog.set_level(logging.INFO, logger="ha_mcp.client.websocket_client")
+    exc = ConnectionClosedError(
+        rcvd=None,
+        sent=Close(1009, "frame exceeds limit of 67108864 bytes"),
+    )
+    _, future = await _run_handler_with(exc)
+
+    with pytest.raises(HomeAssistantConnectionError, match="sent close code 1009"):
+        future.result()
+    assert any(
+        record.levelno == logging.WARNING
+        and "sent close code 1009" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+async def test_clean_close_logs_info(caplog):
+    """A normal close (1000) stays at INFO -- no alarm for routine teardown."""
+    caplog.set_level(logging.INFO, logger="ha_mcp.client.websocket_client")
+    exc = ConnectionClosedOK(
+        rcvd=Close(1000, ""),
+        sent=Close(1000, ""),
+        rcvd_then_sent=True,
+    )
+    _, future = await _run_handler_with(exc)
+
+    # Consume the future's exception: even a clean close fails pending
+    # requests (and an unretrieved exception would pollute caplog with
+    # asyncio's own ERROR record).
+    assert isinstance(future.exception(), HomeAssistantConnectionError)
+    close_records = [
+        record
+        for record in caplog.records
+        if record.name == "ha_mcp.client.websocket_client"
+        and "received close code 1000" in record.getMessage()
+    ]
+    assert close_records, f"clean close not logged; got: {caplog.records}"
+    assert all(record.levelno == logging.INFO for record in close_records)
+
+
+async def test_abrupt_drop_without_close_frame_logs_warning(caplog):
+    """Transport loss with no close frame still warns and fails the future."""
+    caplog.set_level(logging.INFO, logger="ha_mcp.client.websocket_client")
+    exc = ConnectionClosedError(rcvd=None, sent=None)
+    _, future = await _run_handler_with(exc)
+
+    with pytest.raises(
+        HomeAssistantConnectionError, match="dropped without a close frame"
+    ):
+        future.result()
+    assert any(
+        record.levelno == logging.WARNING
+        and "dropped without a close frame" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+async def test_handler_generic_exception_fails_future_with_reason():
+    """A non-ConnectionClosed handler error still fails futures with its text."""
+    _, future = await _run_handler_with(RuntimeError("boom"))
+
+    with pytest.raises(HomeAssistantConnectionError, match="boom"):
+        future.result()
+
+
+async def test_command_with_event_drop_retrieves_event_future_exception():
+    """A drop during the result phase must not leak event_future's exception.
+
+    reset_connection fails BOTH futures registered by send_command_with_event;
+    only result_future is awaited on that path, so the client must retrieve
+    event_future's exception itself or asyncio logs an ERROR-level "Future
+    exception was never retrieved" when the future is garbage-collected.
+    ``_log_traceback`` is asyncio's retrieved-flag: True after set_exception,
+    flipped False only by result()/exception() — asserting it False proves the
+    production code consumed the exception (GC-log-based detection is not
+    deterministic because the raised exception's traceback keeps the future
+    alive).
+    """
+
+    async def close_on_command(connection, msg):
+        await connection.close(code=1011, reason="backend went away")
+
+    server = await websockets.serve(_fake_ha_server(close_on_command), "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        client = await _connect_client(port)
+        captured: list[asyncio.Future] = []
+        original = client.register_event_response
+
+        def capturing(message_id: int) -> asyncio.Future:
+            future = original(message_id)
+            captured.append(future)
+            return future
+
+        client.register_event_response = capturing  # type: ignore[method-assign]
+        async with asyncio.timeout(5):
+            with pytest.raises(HomeAssistantConnectionError):
+                await client.send_command_with_event("system_health/info")
+
+        (event_future,) = captured
+        assert event_future.done() and not event_future.cancelled()
+        assert event_future._log_traceback is False, (
+            "event_future's exception was never retrieved -- asyncio would "
+            "log 'Future exception was never retrieved' at GC"
+        )
+        assert isinstance(event_future.exception(), HomeAssistantConnectionError)
+        await client.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/src/unit/test_ws_close_pending_requests_1721.py
+++ b/tests/src/unit/test_ws_close_pending_requests_1721.py
@@ -1,0 +1,150 @@
+"""Regression tests for issue #1721 — WebSocket close while a request is pending.
+
+When the WebSocket to Home Assistant dies while ``send_command`` awaits a
+response, the pending future must fail with ``HomeAssistantConnectionError``,
+NOT ``asyncio.CancelledError``. A cancellation is a ``BaseException``: it
+escapes every ``except Exception`` handler in the tool layer and reaches the
+MCP SDK, which interprets it as a client-initiated request cancellation,
+suppresses the response entirely, and leaves the MCP client hanging until its
+own timeout (4 minutes in Claude clients).
+
+The close code/reason must also be logged and carried in the raised error:
+the #1721 investigation stalled for days because the log showed only a bare
+"WebSocket connection closed" with no hint that (for example) a frame had
+exceeded ``max_size`` (close code 1009).
+"""
+
+import asyncio
+import json
+import logging
+
+import pytest
+import websockets
+
+from ha_mcp.client.rest_client import HomeAssistantConnectionError
+from ha_mcp.client.websocket_client import (
+    MAX_WS_MESSAGE_BYTES,
+    HomeAssistantWebSocketClient,
+    WebSocketConnectionState,
+)
+
+HA_VERSION = "2026.7.0"
+
+
+def _fake_ha_server(on_command):
+    """Return a handler speaking the HA auth handshake, then delegating."""
+
+    async def handler(connection):
+        await connection.send(
+            json.dumps({"type": "auth_required", "ha_version": HA_VERSION})
+        )
+        async for raw in connection:
+            msg = json.loads(raw)
+            if msg.get("type") == "auth":
+                await connection.send(
+                    json.dumps({"type": "auth_ok", "ha_version": HA_VERSION})
+                )
+            else:
+                await on_command(connection, msg)
+
+    return handler
+
+
+async def _connect_client(port: int) -> HomeAssistantWebSocketClient:
+    client = HomeAssistantWebSocketClient(
+        f"http://127.0.0.1:{port}", "test-token", verify_ssl=False
+    )
+    assert await client.connect() is True
+    return client
+
+
+async def test_send_command_fails_fast_when_connection_closes():
+    """A close mid-request must raise a normal exception, not a cancellation.
+
+    Pre-#1721-fix behaviour: ``reset_connection`` cancelled the pending
+    future, ``send_command`` re-raised ``CancelledError``, and the MCP
+    request was silently dropped.
+    """
+
+    async def close_on_command(connection, msg):
+        await connection.close(code=1011, reason="backend went away")
+
+    server = await websockets.serve(_fake_ha_server(close_on_command), "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        client = await _connect_client(port)
+        # Bounded wait: the broken behaviour was an escaping CancelledError;
+        # 5s is generous for a local socket close (default timeout is 30s).
+        async with asyncio.timeout(5):
+            with pytest.raises(HomeAssistantConnectionError):
+                await client.send_command("config/entity_registry/list")
+        await client.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_close_code_and_reason_surface_in_log_and_error(caplog):
+    """The close code/reason must reach both the log and the raised error."""
+
+    async def close_1009(connection, msg):
+        await connection.close(code=1009, reason="frame exceeds limit")
+
+    server = await websockets.serve(_fake_ha_server(close_1009), "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    caplog.set_level(logging.INFO, logger="ha_mcp.client.websocket_client")
+    try:
+        client = await _connect_client(port)
+        async with asyncio.timeout(5):
+            with pytest.raises(HomeAssistantConnectionError) as excinfo:
+                await client.send_command("config/entity_registry/list")
+        assert "1009" in str(excinfo.value)
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "1009" in message and "frame exceeds limit" in message
+            for message in messages
+        ), f"close code/reason not logged; got: {messages}"
+        await client.disconnect()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_reset_connection_fails_pending_futures_with_exception():
+    """State-level contract: pending futures get an exception, not a cancel."""
+    state = WebSocketConnectionState()
+    request_future = state.register_pending_request(1)
+    event_future = state.register_event_response(2)
+
+    state.mark_disconnected("received close code 1009 (frame exceeds limit)")
+
+    assert not request_future.cancelled()
+    with pytest.raises(HomeAssistantConnectionError, match="1009"):
+        await request_future
+    assert not event_future.cancelled()
+    with pytest.raises(HomeAssistantConnectionError):
+        await event_future
+
+
+async def test_reset_connection_without_reason_still_raises_connection_error():
+    """Explicit disconnects (no close frame details) must fail futures too."""
+    state = WebSocketConnectionState()
+    request_future = state.register_pending_request(1)
+
+    state.mark_disconnected()
+
+    assert not request_future.cancelled()
+    with pytest.raises(HomeAssistantConnectionError):
+        await request_future
+
+
+def test_max_ws_message_bytes_matches_supervisor_ceiling():
+    """The cap must stay at the Supervisor's Core-connection limit (64MB).
+
+    On the add-on path frames above ``MAX_MESSAGE_SIZE_FROM_CORE`` die at the
+    Supervisor proxy anyway, so a smaller client cap only re-introduces the
+    #1721 failure mode ahead of the platform limit. Registry list responses
+    scale with entity count and arrive as ONE frame (no pagination in the HA
+    WebSocket API); a ~6.4k-entity instance overflowed the previous 20MB cap.
+    """
+    assert MAX_WS_MESSAGE_BYTES == 64 * 1024 * 1024

--- a/tests/src/unit/test_ws_close_pending_requests_1721.py
+++ b/tests/src/unit/test_ws_close_pending_requests_1721.py
@@ -118,12 +118,15 @@ async def test_reset_connection_fails_pending_futures_with_exception():
 
     state.mark_disconnected("received close code 1009 (frame exceeds limit)")
 
+    # reset_connection sets the exception synchronously, so the futures are
+    # already done: result() re-raises the stored exception directly, which is
+    # the state contract under test (no event loop round-trip needed).
     assert not request_future.cancelled()
     with pytest.raises(HomeAssistantConnectionError, match="1009"):
-        await request_future
+        request_future.result()
     assert not event_future.cancelled()
     with pytest.raises(HomeAssistantConnectionError):
-        await event_future
+        event_future.result()
 
 
 async def test_reset_connection_without_reason_still_raises_connection_error():
@@ -135,7 +138,7 @@ async def test_reset_connection_without_reason_still_raises_connection_error():
 
     assert not request_future.cancelled()
     with pytest.raises(HomeAssistantConnectionError):
-        await request_future
+        request_future.result()
 
 
 def test_max_ws_message_bytes_matches_supervisor_ceiling():


### PR DESCRIPTION
## What does this PR do?

Fixes the silent-hang failure mode behind #1721. When the internal WebSocket to Home Assistant closed while a tool call was awaiting a response, the pending future was **cancelled**; the resulting `CancelledError` (a `BaseException`) skipped every `except Exception` handler in the tool layer and reached the MCP SDK, which treated it as a client-initiated cancellation and suppressed the response entirely (`Request N cancelled - duplicate response suppressed`). The MCP client then hung until its own timeout (4 minutes in Claude clients) while the log showed only a bare `WebSocket connection closed`.

Four changes:

1. **Fail fast instead of hanging** — `reset_connection()` now fails pending request/event futures with `HomeAssistantConnectionError` (carrying the close code/reason) instead of cancelling them. Tools raise a structured error in under a second instead of leaving the client waiting.
2. **Surface the close code** — the `ConnectionClosed` handler now logs the close code and reason (e.g. `sent close code 1009 (frame exceeds limit of 67108864 bytes)`) and threads them into the raised error; abnormal closes log at WARNING. Close-time companion to #1495's connect-time fix — #1721 stalled for days because the log carried no reason.
3. **Raise the message cap 20MB → 64MB** — `config/entity_registry/list` / `config/device_registry/list` responses arrive as ONE frame that scales with entity count (the HA WebSocket API has no pagination for them; Core pre-serializes the whole registry). The previous 20MB cap — itself raised from 1MB in #410 for the same failure signature — overflows on large instances (#1721's reporter has ~6.4k entities). 64MB matches the Supervisor's own Core-connection receive limit (`MAX_MESSAGE_SIZE_FROM_CORE`, supervisor#4392), which is the hard ceiling on the add-on path anyway.
4. **Chunk `get_entries`** — deep_search alias enrichment previously sent ALL survivor entity_ids in one `config/entity_registry/get_entries` command; its extended-dict response is a second frame that scales with instance size. Now chunked at 500 ids per call, fetched concurrently, merged best-effort per chunk.

Scope note: the cap applies only to the internal ha-mcp ↔ HA Core WebSocket. Tool responses returned to MCP clients are unchanged (search returns top-N results, `ha_get_device` returns one device), so nothing here increases what an LLM client receives.

Root cause was verified end-to-end without a live HA instance, using a fake WebSocket server that speaks the real HA auth handshake: a >20MB single-frame registry response makes the `websockets` client fail the connection with close code 1009 (`frame exceeds limit of 20971520 bytes`); the pending future is cancelled and `send_command` raises `CancelledError` — reproducing the exact #1721 signature (`WebSocket connection closed` and `Request N cancelled` at the same instant, client hangs to timeout). With this PR, the same frame is delivered normally under the 64MB cap, and a frame exceeding the new cap produces an immediate structured error naming the close code instead of a hang. The new regression tests encode both halves (fake-server integration tests plus state-level contract tests for `reset_connection`).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit suite, ruff, ruff format, mypy, and ast-grep run locally; full E2E, HAOS E2E, and CodeQL suites are green in CI on this PR.

## Checklist
- [x] I have updated documentation if needed

