### PR TITLE
fix: show the browser landing page on the in-process server's MCP endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -651,11 +651,10 @@ fully validate a component change before merge.
   gates on it, so without a bump the old and new component are
   indistinguishable: a caller on the old version passes the gate and then hits
   raw "service not found" errors instead of an actionable "update" prompt.
-- **The component reaches users ahead of the server – keep it
-  backward-compatible with the released server.** HACS pushes a component
-  update immediately, while the server (add-on or PyPI/Docker) stays on the
-  prior stable until its next release, so a new component runs against the
-  *old* server in that window. Never remove or tighten an existing service
+- **Keep the component backward-compatible with the released server.** The
+  component (HACS) and the server (add-on / PyPI / Docker) follow the same
+  release cycle but are updated independently per install, so a new component
+  can run against an *older* server. Never remove or tighten an existing service
   schema (e.g. dropping a param from a strict `vol.Schema`) without a shim the
   prior server still satisfies; the version gate can't protect this direction
   (the old server is the caller). Remove the shim once the matching

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -313,7 +313,8 @@ OAUTH_BASE = "/api/ha_mcp_tools/oauth"
 ISSUE_PACKAGE_FAILED = "server_package_install_failed"
 ISSUE_START_FAILED = "server_start_failed"
 # Repair issue surfaced when the installed ha-mcp server requires a newer
-# custom component than the one running. HACS pushes the server package ahead
-# of a component update, so the running component can lag what the server
-# expects; this points the user at the HACS component update (non-blocking).
+# custom component than the one running. The server package updates
+# independently of the HACS component, so the running component can lag what
+# the server expects; this points the user at the HACS component update
+# (non-blocking).
 ISSUE_COMPONENT_OUTDATED = "component_outdated"

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -647,6 +647,21 @@ class EmbeddedServerManager:
         # same secret path as the MCP endpoint.
         register_settings_routes(server.mcp, server, secret_path=self._secret_path)
 
+        # Parity with the CLI HTTP runner: answer a browser GET on the MCP path
+        # with the friendly landing page (405 + setup guidance) instead of a
+        # bare "Method Not Allowed" — both on the direct URL and through the
+        # ingress webhook. Guard only the import: the installed server version
+        # is user-controlled (channel choice, pip-spec override), so an older
+        # ha-mcp without this module must keep serving; the landing is simply
+        # absent there, as it is today.
+        try:
+            from ha_mcp.browser_landing import register_browser_landing
+        except ImportError:
+            # Older installed ha-mcp: no landing helper to register.
+            pass
+        else:
+            register_browser_landing(server.mcp, self._secret_path)
+
         # Own the uvicorn server instead of calling mcp.run_async(): cancelling
         # run_async's task does NOT release the listening socket in-process
         # (live-found: the next bring-up failed with EADDRINUSE and uvicorn's

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -402,10 +402,11 @@ async def _async_check_component_compat(
     """File/clear the component-outdated repair issue for the running server.
 
     The ha-mcp server declares the minimum custom-component version it needs
-    (``MIN_COMPONENT_VERSION``). HACS pushes a new server package ahead of a
-    component update, so the running component can lag what the server expects.
-    When it does, surface a WARNING repair issue pointing at the HACS component
-    update; clear it once the component is new enough.
+    (``MIN_COMPONENT_VERSION``). The server package updates independently of
+    the HACS component (this manager pip-installs new server builds), so the
+    running component can lag what the server expects. When it does, surface a
+    WARNING repair issue pointing at the HACS component update; clear it once
+    the component is new enough.
 
     Advisory only — it must never block or fail server startup, so an
     unexpected error is logged (visible, not silent) and swallowed rather than

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "0.14.0"
+    "version": "0.14.1"
 }

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -66,9 +66,12 @@ _STRIPPED_REQUEST_HEADERS = frozenset(
     }
 )
 
-# Content-Types an MCP response may carry; anything else is coerced to JSON to
-# prevent HTML injection / XSS through the proxy.
-_ALLOWED_CONTENT_TYPES = ("application/json", "text/event-stream")
+# Content-Types the forwarded response may carry as-is; anything else is coerced
+# to JSON to prevent HTML injection / XSS through the proxy. ``text/plain`` is
+# safe (a browser never executes it) and lets the server's friendly landing page
+# — a plain-text 405 shown when a browser GETs the endpoint — render as text
+# instead of a mislabeled JSON blob. ``text/html`` and friends stay coerced.
+_ALLOWED_CONTENT_TYPES = ("application/json", "text/event-stream", "text/plain")
 
 # Long timeout for streamed MCP responses (matches mcp_proxy).
 _CLIENT_TIMEOUT = aiohttp.ClientTimeout(total=300, sock_connect=10, sock_read=300)

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -34,8 +34,10 @@ from typing import TYPE_CHECKING, Any  # noqa: E402
 
 from fastmcp.exceptions import ToolError  # noqa: E402
 from pydantic import ValidationError as PydanticValidationError  # noqa: E402
-from starlette.requests import Request  # noqa: E402
-from starlette.responses import PlainTextResponse  # noqa: E402
+
+from ha_mcp.browser_landing import (  # noqa: E402
+    register_browser_landing as _register_landing_route,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -962,21 +964,20 @@ async def _run_http_with_graceful_shutdown(
     )
 
 
-_registered_landing_paths: set[str] = set()
-
-
 def register_browser_landing(
     mcp_instance: "FastMCP | _DeferredMCP",
     path: str,
     *,
     quiet_probe_log: bool = True,
 ) -> None:
-    """Register a GET handler that returns 405 with a helpful message.
+    """Register the friendly browser landing page and tidy the uvicorn access log.
 
-    Browsers and misconfigured clients that send GET instead of POST will see
-    a human-readable explanation instead of a bare "Method Not Allowed" error.
-    The 405 status and Allow header are set explicitly by this handler so
-    automated clients still get the correct HTTP semantics.
+    Delegates the GET landing route to the reusable core in
+    :mod:`ha_mcp.browser_landing` (also used by the in-process ``ha_mcp_tools``
+    server) and, when the route is newly registered, attaches
+    :class:`ProbeAccessLogFilter` to the uvicorn access logger. Browsers and
+    misconfigured clients that send GET instead of POST see a human-readable
+    explanation instead of a bare "Method Not Allowed" error.
 
     Args:
         mcp_instance: The FastMCP server to register the route on.
@@ -986,83 +987,13 @@ def register_browser_landing(
             access log (the handler logs an annotated replacement). Pass False
             for SSE, where a GET answers 200 and a 405 is a genuine fault.
     """
-    if path in _registered_landing_paths:
-        logger.warning(
-            "register_browser_landing: %r already registered, skipping", path
-        )
+    if not _register_landing_route(mcp_instance, path):
+        # Already registered for this path — don't double-attach the log filter.
         return
-    _registered_landing_paths.add(path)
-
-    _landing_message = (
-        "HA-MCP server is up and running!\n"
-        "\n"
-        "To connect, paste the full URL (including the /private_... key) into the\n"
-        "connector or MCP settings of your AI/LLM client. No username or password required.\n"
-        "Setup instructions: https://homeassistant-ai.github.io/ha-mcp/\n"
-        "\n"
-        "--- Seeing this page? Your URL is set up correctly ---\n"
-        "\n"
-        "If this page loads in your browser, the MCP server is reachable and the\n"
-        "URL is correct. If your AI client still cannot connect, the problem is\n"
-        "not on HA-MCP's side. Common causes:\n"
-        "\n"
-        "- Geo / country blocking in your reverse proxy / CDN (Cloudflare, NGINX,\n"
-        "  Traefik, Zoraxy, etc.). Most AI/LLM services connect from US-based\n"
-        "  cloud infrastructure, so if you block US IP addresses (or only allow\n"
-        "  your own country), that is why your client cannot connect. Allow your\n"
-        "  provider's IP ranges (or your client's egress IPs). For example,\n"
-        # Anthropic's documented outbound range; re-verify at
-        # https://platform.claude.com/docs/en/api/ip-addresses if it ever changes.
-        "  Claude.ai connects from Anthropic's network, 160.79.104.0/21.\n"
-        "- WAF, bot-blocking, or rate-limiting rules on the proxy that drop or\n"
-        "  challenge the request.\n"
-        "- The AI client's network can sometimes be spotty -- you may just need\n"
-        "  to try connecting again.\n"
-        "- The AI client itself refusing certain domains or proxy providers on\n"
-        "  its end. This is rare and outside your control; try a different\n"
-        "  hostname or proxy if you suspect it.\n"
-        "\n"
-        "Your proxy's access logs will show the blocked attempt -- look for the\n"
-        "request from your AI provider's IP (e.g. an Anthropic 160.79.x.x address).\n"
-        "\n"
-        "--- Cloudflare Users ---\n"
-        "\n"
-        'If your LLM cannot connect, Cloudflare\'s "Block AI training bots"\n'
-        "setting is the most common cause. To disable it:\n"
-        "\n"
-        "1. Log in to Cloudflare (https://dash.cloudflare.com)\n"
-        "2. In the left sidebar, click Domains, then click Overview\n"
-        "3. Click on the domain you use for connecting to Home Assistant\n"
-        '4. On the right side, find "Control AI Crawlers"\n'
-        '5. Under "Block AI training bots", open the dropdown\n'
-        '6. Select "do not block (allow crawlers)"\n'
-        "\n"
-        "Screenshot of the setting:\n"
-        "https://homeassistant-ai.github.io/ha-mcp/images/cloudflare-ai-crawlers-setting.jpg\n"
-    )
-
-    # Safe because FastMCP registers the MCP route with methods=["POST", "DELETE"]
-    # in stateless mode, so Starlette rejects GET requests before the MCP handler runs.
-    # Custom routes are registered at lowest precedence (after the MCP route).
-    @mcp_instance.custom_route(path, methods=["GET"])
-    async def _browser_landing(_: Request) -> PlainTextResponse:
-        # Any GET here is a non-MCP caller (browser, health check, proxy, or a
-        # connector's SSE-style pre-flight) hitting this POST-only Streamable HTTP
-        # endpoint, which answers 405 by design. Log one annotated line so the 405
-        # reads as expected; ProbeAccessLogFilter drops the raw uvicorn access line
-        # so there's no cryptic duplicate.
-        logger.info("GET %s -> 405 (NORMAL for most non-SSE connections)", path)
-        return PlainTextResponse(
-            _landing_message,
-            status_code=405,
-            # DELETE is included per the MCP Streamable HTTP spec (used for
-            # session termination), even though this deployment uses stateless mode.
-            headers={"Allow": "POST, DELETE"},
-        )
 
     # Tidy uvicorn's access log: always drop browser favicon 404s, and drop the
-    # raw by-design GET/HEAD-405 probe line on the MCP path (the handler above logs
-    # an annotated replacement). The 405 drop is skipped for SSE
+    # raw by-design GET/HEAD-405 probe line on the MCP path (the landing handler
+    # logs an annotated replacement). The 405 drop is skipped for SSE
     # (quiet_probe_log=False), where a GET answers 200 and a 405 is a real fault.
     # Attach to uvicorn.access directly — it has propagate=False, so a root-logger
     # filter would miss it.

--- a/src/ha_mcp/browser_landing.py
+++ b/src/ha_mcp/browser_landing.py
@@ -1,0 +1,124 @@
+"""Friendly browser landing page for the MCP endpoint (issue #777).
+
+A browser (or any GET client) that hits the POST-only Streamable HTTP MCP
+endpoint would otherwise see a bare "Method Not Allowed". This module registers
+a GET handler that answers ``405`` with a human-readable explanation plus the
+correct ``Allow`` header, so automated clients still get the right HTTP
+semantics.
+
+Extracted from :mod:`ha_mcp.__main__` so the in-process server (the
+``ha_mcp_tools`` custom-component worker thread) can register the same landing
+page. Importing ``ha_mcp.__main__`` runs process-global side effects at module
+load (``truststore.inject_into_ssl()``) that must never happen in-process, so
+the reusable core lives here — free of those side effects. ``__main__`` keeps a
+thin wrapper that additionally tidies the uvicorn access log.
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+logger = logging.getLogger(__name__)
+
+# The landing body. Plain text so no browser ever interprets it as markup, and
+# so it survives the ha_mcp_tools webhook proxy (which forwards text/plain but
+# coerces text/html to JSON as an XSS guard).
+LANDING_MESSAGE = (
+    "HA-MCP server is up and running!\n"
+    "\n"
+    "To connect, paste the full URL (including the /private_... key) into the\n"
+    "connector or MCP settings of your AI/LLM client. No username or password required.\n"
+    "Setup instructions: https://homeassistant-ai.github.io/ha-mcp/\n"
+    "\n"
+    "--- Seeing this page? Your URL is set up correctly ---\n"
+    "\n"
+    "If this page loads in your browser, the MCP server is reachable and the\n"
+    "URL is correct. If your AI client still cannot connect, the problem is\n"
+    "not on HA-MCP's side. Common causes:\n"
+    "\n"
+    "- Geo / country blocking in your reverse proxy / CDN (Cloudflare, NGINX,\n"
+    "  Traefik, Zoraxy, etc.). Most AI/LLM services connect from US-based\n"
+    "  cloud infrastructure, so if you block US IP addresses (or only allow\n"
+    "  your own country), that is why your client cannot connect. Allow your\n"
+    "  provider's IP ranges (or your client's egress IPs). For example,\n"
+    # Anthropic's documented outbound range; re-verify at
+    # https://platform.claude.com/docs/en/api/ip-addresses if it ever changes.
+    "  Claude.ai connects from Anthropic's network, 160.79.104.0/21.\n"
+    "- WAF, bot-blocking, or rate-limiting rules on the proxy that drop or\n"
+    "  challenge the request.\n"
+    "- The AI client's network can sometimes be spotty -- you may just need\n"
+    "  to try connecting again.\n"
+    "- The AI client itself refusing certain domains or proxy providers on\n"
+    "  its end. This is rare and outside your control; try a different\n"
+    "  hostname or proxy if you suspect it.\n"
+    "\n"
+    "Your proxy's access logs will show the blocked attempt -- look for the\n"
+    "request from your AI provider's IP (e.g. an Anthropic 160.79.x.x address).\n"
+    "\n"
+    "--- Cloudflare Users ---\n"
+    "\n"
+    'If your LLM cannot connect, Cloudflare\'s "Block AI training bots"\n'
+    "setting is the most common cause. To disable it:\n"
+    "\n"
+    "1. Log in to Cloudflare (https://dash.cloudflare.com)\n"
+    "2. In the left sidebar, click Domains, then click Overview\n"
+    "3. Click on the domain you use for connecting to Home Assistant\n"
+    '4. On the right side, find "Control AI Crawlers"\n'
+    '5. Under "Block AI training bots", open the dropdown\n'
+    '6. Select "do not block (allow crawlers)"\n'
+    "\n"
+    "Screenshot of the setting:\n"
+    "https://homeassistant-ai.github.io/ha-mcp/images/cloudflare-ai-crawlers-setting.jpg\n"
+)
+
+# Landing routes already registered, keyed PER MCP INSTANCE (weakly, so a
+# discarded server never leaks). The key must not be the path alone: the
+# in-process server builds a NEW FastMCP on every config-entry reload in the
+# SAME Python process while keeping the same secret path — a process-global
+# path set would skip the re-registration and silently drop the landing page
+# after the first reload. The CLI/add-on never sees this (their process exits).
+_registered_landing_paths: weakref.WeakKeyDictionary[Any, set[str]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def register_browser_landing(mcp_instance: Any, path: str) -> bool:
+    """Register a GET handler that returns 405 with the friendly landing message.
+
+    ``mcp_instance`` is a FastMCP-like object exposing ``custom_route`` (the real
+    server or ``__main__``'s deferred proxy). Returns True if the route was newly
+    registered, False if this instance already had one for ``path`` (idempotent
+    per instance + path).
+    """
+    paths = _registered_landing_paths.setdefault(mcp_instance, set())
+    if path in paths:
+        logger.warning(
+            "register_browser_landing: %r already registered, skipping", path
+        )
+        return False
+    paths.add(path)
+
+    # Safe because FastMCP registers the MCP route with methods=["POST", "DELETE"]
+    # in stateless mode, so Starlette rejects GET requests before the MCP handler
+    # runs. Custom routes are registered at lowest precedence (after the MCP route).
+    @mcp_instance.custom_route(path, methods=["GET"])
+    async def _browser_landing(_: Request) -> PlainTextResponse:
+        # Any GET here is a non-MCP caller (browser, health check, proxy, or a
+        # connector's SSE-style pre-flight) hitting this POST-only Streamable HTTP
+        # endpoint, which answers 405 by design. Log one annotated line so the 405
+        # reads as expected.
+        logger.info("GET %s -> 405 (NORMAL for most non-SSE connections)", path)
+        return PlainTextResponse(
+            LANDING_MESSAGE,
+            status_code=405,
+            # DELETE is included per the MCP Streamable HTTP spec (used for
+            # session termination), even though this deployment uses stateless mode.
+            headers={"Allow": "POST, DELETE"},
+        )
+
+    return True

--- a/src/ha_mcp/browser_landing.py
+++ b/src/ha_mcp/browser_landing.py
@@ -18,12 +18,25 @@ from __future__ import annotations
 
 import logging
 import weakref
-from typing import Any
+from typing import Any, Protocol
 
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
 logger = logging.getLogger(__name__)
+
+
+class CustomRouteServer(Protocol):
+    """Structural type for servers exposing FastMCP's ``custom_route`` decorator.
+
+    Matches the real FastMCP server and ``__main__``'s deferred proxy. Only the
+    ``(path, methods)`` call shape used here is pinned; the decorator's return
+    type is left to the implementation (fastmcp also takes optional ``name`` /
+    ``include_in_schema`` parameters this module never passes).
+    """
+
+    def custom_route(self, path: str, methods: list[str]) -> Any: ...
+
 
 # The landing body. Plain text so no browser ever interprets it as markup, and
 # so it survives the ha_mcp_tools webhook proxy (which forwards text/plain but
@@ -82,12 +95,12 @@ LANDING_MESSAGE = (
 # SAME Python process while keeping the same secret path — a process-global
 # path set would skip the re-registration and silently drop the landing page
 # after the first reload. The CLI/add-on never sees this (their process exits).
-_registered_landing_paths: weakref.WeakKeyDictionary[Any, set[str]] = (
+_registered_landing_paths: weakref.WeakKeyDictionary[CustomRouteServer, set[str]] = (
     weakref.WeakKeyDictionary()
 )
 
 
-def register_browser_landing(mcp_instance: Any, path: str) -> bool:
+def register_browser_landing(mcp_instance: CustomRouteServer, path: str) -> bool:
     """Register a GET handler that returns 405 with the friendly landing message.
 
     ``mcp_instance`` is a FastMCP-like object exposing ``custom_route`` (the real

--- a/src/ha_mcp/browser_landing.py
+++ b/src/ha_mcp/browser_landing.py
@@ -35,7 +35,8 @@ class CustomRouteServer(Protocol):
     ``include_in_schema`` parameters this module never passes).
     """
 
-    def custom_route(self, path: str, methods: list[str]) -> Any: ...
+    def custom_route(self, path: str, methods: list[str]) -> Any:
+        """Return a decorator that registers a handler for ``methods`` at ``path``."""
 
 
 # The landing body. Plain text so no browser ever interprets it as markup, and

--- a/tests/src/unit/test_browser_landing.py
+++ b/tests/src/unit/test_browser_landing.py
@@ -6,11 +6,8 @@ import httpx
 import pytest
 from fastmcp import FastMCP
 
-from ha_mcp.__main__ import (
-    ProbeAccessLogFilter,
-    _registered_landing_paths,
-    register_browser_landing,
-)
+from ha_mcp.__main__ import ProbeAccessLogFilter, register_browser_landing
+from ha_mcp.browser_landing import _registered_landing_paths
 
 
 @pytest.fixture(autouse=True)
@@ -176,6 +173,44 @@ def test_register_attaches_filter():
     register_browser_landing(server, "/mcp")
     access_logger = logging.getLogger("uvicorn.access")
     assert any(isinstance(f, ProbeAccessLogFilter) for f in access_logger.filters)
+
+
+@pytest.mark.asyncio
+async def test_same_path_registers_on_a_new_server_instance():
+    """An in-process config-entry reload builds a NEW FastMCP with the SAME
+    secret path, in the same Python process. The landing must register on the
+    new instance — dedup is per (instance, path), not a process-global path
+    set — or the page silently vanishes after the first reload."""
+    from ha_mcp import browser_landing
+
+    first = FastMCP("test")
+    assert browser_landing.register_browser_landing(first, "/private_x") is True
+
+    reloaded = FastMCP("test")
+    assert browser_landing.register_browser_landing(reloaded, "/private_x") is True
+
+    app = reloaded.http_app(path="/private_x", stateless_http=True)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/private_x")
+    assert resp.status_code == 405
+    assert "HA-MCP server is up and running" in resp.text
+
+
+def test_core_register_returns_bool_and_skips_log_filter():
+    """The reusable core registers once (True), no-ops on repeat (False), and
+    never touches uvicorn.access — attaching the probe filter is the __main__
+    wrapper's job. This lets the in-process server register the landing without
+    disturbing Home Assistant's logging."""
+    from ha_mcp import browser_landing
+
+    server = FastMCP("test")
+    access_logger = logging.getLogger("uvicorn.access")
+    before = list(access_logger.filters)
+    assert browser_landing.register_browser_landing(server, "/mcp") is True
+    assert browser_landing.register_browser_landing(server, "/mcp") is False
+    assert access_logger.filters == before
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -116,7 +116,12 @@ def _stub_ha_mcp_surface(monkeypatch, *, mcp, landing_mod=None) -> None:
     Wires a non-sentinel connection (so ``_serve`` passes its refuse-to-serve
     guard), a server whose ``.mcp`` is ``mcp``, no-op settings routes, and a stub
     uvicorn. Pass ``landing_mod`` to also stub ``ha_mcp.browser_landing``; omit it
-    to leave that submodule ABSENT — the older-server path ``_serve`` must tolerate.
+    to make that submodule ABSENT — the older-server path ``_serve`` must
+    tolerate. Absence is enforced by evicting the module from ``sys.modules``:
+    other unit files in the same worker import the REAL ``ha_mcp.browser_landing``
+    (via ``ha_mcp.__main__``), and a lingering real entry would satisfy the
+    ``from ha_mcp.browser_landing import ...`` in ``_serve`` even though the
+    parent ``ha_mcp`` is faked here.
     """
     settings = SimpleNamespace(
         homeassistant_url="http://127.0.0.1:8123", homeassistant_token="jwt"
@@ -149,6 +154,8 @@ def _stub_ha_mcp_surface(monkeypatch, *, mcp, landing_mod=None) -> None:
     if landing_mod is not None:
         ha_mcp_mod.browser_landing = landing_mod
         mods["ha_mcp.browser_landing"] = landing_mod
+    else:
+        monkeypatch.delitem(sys.modules, "ha_mcp.browser_landing", raising=False)
     for name, mod in mods.items():
         monkeypatch.setitem(sys.modules, name, mod)
 
@@ -1154,6 +1161,11 @@ class TestReadinessProbe:
         ha_mcp_mod.config = cfg
         ha_mcp_mod.server = server_mod
         ha_mcp_mod.settings_ui = ui_mod
+        # Evict any REAL ha_mcp.browser_landing left in sys.modules by other
+        # unit files in this worker (imported via ha_mcp.__main__); it would
+        # satisfy _serve's landing import and call custom_route on _FakeMcp,
+        # masking the OSError this test is about. Absent, _serve skips it.
+        monkeypatch.delitem(sys.modules, "ha_mcp.browser_landing", raising=False)
 
         try:
             mgr._thread_main("tok")

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -110,6 +110,49 @@ def _rt(rt_id="rt-1", user=None, client_name="", token_type=""):
     )
 
 
+def _stub_ha_mcp_surface(monkeypatch, *, mcp, landing_mod=None) -> None:
+    """Install a minimal in-memory ``ha_mcp`` package so ``_serve`` runs hermetically.
+
+    Wires a non-sentinel connection (so ``_serve`` passes its refuse-to-serve
+    guard), a server whose ``.mcp`` is ``mcp``, no-op settings routes, and a stub
+    uvicorn. Pass ``landing_mod`` to also stub ``ha_mcp.browser_landing``; omit it
+    to leave that submodule ABSENT — the older-server path ``_serve`` must tolerate.
+    """
+    settings = SimpleNamespace(
+        homeassistant_url="http://127.0.0.1:8123", homeassistant_token="jwt"
+    )
+    ha_mcp_mod = ModuleType("ha_mcp")
+    ha_mcp_mod.__path__ = []  # package semantics for submodule imports
+    cfg = ModuleType("ha_mcp.config")
+    cfg.reset_global_settings = lambda: None
+    cfg.set_embedded_connection = lambda u, t: None
+    cfg.OAUTH_MODE_URL = "__sentinel_url__"
+    cfg.OAUTH_MODE_TOKEN = "__sentinel_token__"
+    cfg.get_global_settings = lambda: settings
+    server_mod = ModuleType("ha_mcp.server")
+    server_mod.HomeAssistantSmartMCPServer = lambda: SimpleNamespace(mcp=mcp)
+    ui_mod = ModuleType("ha_mcp.settings_ui")
+    ui_mod.register_settings_routes = lambda *a, **k: None
+    uvicorn_mod = ModuleType("uvicorn")
+    uvicorn_mod.Config = lambda *a, **k: SimpleNamespace()
+    uvicorn_mod.Server = lambda config: SimpleNamespace(should_exit=False)
+    ha_mcp_mod.config = cfg
+    ha_mcp_mod.server = server_mod
+    ha_mcp_mod.settings_ui = ui_mod
+    mods = {
+        "ha_mcp": ha_mcp_mod,
+        "ha_mcp.config": cfg,
+        "ha_mcp.server": server_mod,
+        "ha_mcp.settings_ui": ui_mod,
+        "uvicorn": uvicorn_mod,
+    }
+    if landing_mod is not None:
+        ha_mcp_mod.browser_landing = landing_mod
+        mods["ha_mcp.browser_landing"] = landing_mod
+    for name, mod in mods.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
 # ---------------------------------------------------------------------------
 # Construction / option parsing
 # ---------------------------------------------------------------------------
@@ -1135,6 +1178,89 @@ class TestReadinessProbe:
         with pytest.raises(es.EmbeddedServerError, match="did not become reachable"):
             await mgr._async_wait_until_ready()
         stop.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _serve browser-landing registration
+# ---------------------------------------------------------------------------
+
+
+class TestServeBrowserLanding:
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self):
+        # _thread_main stages HA_MCP_CONFIG_DIR/HA_MCP_EMBEDDED into os.environ;
+        # snapshot + restore so the flags never leak into unrelated suites on
+        # this worker (as TestThreadEnvStaging documents).
+        keys = ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
+        saved = {k: os.environ.get(k) for k in keys}
+        for key in keys:
+            os.environ.pop(key, None)
+        yield
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_serve_registers_browser_landing(self, tmp_path, monkeypatch):
+        # Parity with the CLI HTTP runner (the reported bug): _serve must register
+        # the friendly browser landing on the MCP app so a browser GET — direct or
+        # forwarded by the ingress webhook — sees setup guidance, not a bare 405.
+        # Stop _serve right after by having http_app raise.
+        mgr, _hass, _entry = _manager(
+            tmp_path, options={OPT_SERVER_URL: "http://ha.local:8123"}
+        )
+
+        class _StopServe(Exception):
+            pass
+
+        class _FakeMcp:
+            def http_app(self, path, stateless_http):
+                raise _StopServe
+
+        fake_mcp = _FakeMcp()
+        landing_calls: list = []
+        landing_mod = ModuleType("ha_mcp.browser_landing")
+        landing_mod.register_browser_landing = lambda mcp, path: landing_calls.append(
+            (mcp, path)
+        )
+        _stub_ha_mcp_surface(monkeypatch, mcp=fake_mcp, landing_mod=landing_mod)
+
+        mgr._thread_main("tok")
+
+        # Registered on the real MCP app, at the server's secret path.
+        assert landing_calls == [(fake_mcp, "/private_secret")]
+        assert isinstance(mgr._thread_exc, _StopServe)
+
+    def test_serve_tolerates_missing_browser_landing_module(
+        self, tmp_path, monkeypatch
+    ):
+        # Backward-compat: an OLDER bundled ha-mcp (the component reaches users
+        # ahead of the server) has no browser_landing module. _serve must swallow
+        # the ImportError and keep serving — the landing is simply absent, as today.
+        mgr, _hass, _entry = _manager(
+            tmp_path, options={OPT_SERVER_URL: "http://ha.local:8123"}
+        )
+
+        class _StopServe(Exception):
+            pass
+
+        reached: list = []
+
+        class _FakeMcp:
+            def http_app(self, path, stateless_http):
+                reached.append(path)
+                raise _StopServe
+
+        # landing_mod omitted ⇒ ha_mcp.browser_landing is absent (import fails).
+        _stub_ha_mcp_surface(monkeypatch, mcp=_FakeMcp())
+
+        mgr._thread_main("tok")
+
+        # _serve got PAST the failed landing import to build the app (ImportError
+        # was swallowed, not propagated).
+        assert reached == ["/private_secret"]
+        assert isinstance(mgr._thread_exc, _StopServe)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -115,13 +115,15 @@ def _stub_ha_mcp_surface(monkeypatch, *, mcp, landing_mod=None) -> None:
 
     Wires a non-sentinel connection (so ``_serve`` passes its refuse-to-serve
     guard), a server whose ``.mcp`` is ``mcp``, no-op settings routes, and a stub
-    uvicorn. Pass ``landing_mod`` to also stub ``ha_mcp.browser_landing``; omit it
-    to make that submodule ABSENT — the older-server path ``_serve`` must
-    tolerate. Absence is enforced by evicting the module from ``sys.modules``:
-    other unit files in the same worker import the REAL ``ha_mcp.browser_landing``
-    (via ``ha_mcp.__main__``), and a lingering real entry would satisfy the
-    ``from ha_mcp.browser_landing import ...`` in ``_serve`` even though the
-    parent ``ha_mcp`` is faked here.
+    uvicorn. Pass ``landing_mod`` to stub ``ha_mcp.browser_landing``; omit it to
+    simulate an OLDER installed server without the landing helper — modeled as a
+    module missing the ``register_browser_landing`` attribute, so the from-import
+    in ``_serve`` raises the same ImportError class its guard catches. Injection
+    (a sys.modules hit) is the only hermetic way to force that failure: deleting
+    the entry is NOT enough, because the editable install (``uv sync``) adds a
+    meta-path finder that resolves ``ha_mcp.*`` by name and would re-import the
+    REAL module even though the parent ``ha_mcp`` is faked with an empty
+    ``__path__`` (live-found in CI).
     """
     settings = SimpleNamespace(
         homeassistant_url="http://127.0.0.1:8123", homeassistant_token="jwt"
@@ -151,11 +153,12 @@ def _stub_ha_mcp_surface(monkeypatch, *, mcp, landing_mod=None) -> None:
         "ha_mcp.settings_ui": ui_mod,
         "uvicorn": uvicorn_mod,
     }
-    if landing_mod is not None:
-        ha_mcp_mod.browser_landing = landing_mod
-        mods["ha_mcp.browser_landing"] = landing_mod
-    else:
-        monkeypatch.delitem(sys.modules, "ha_mcp.browser_landing", raising=False)
+    if landing_mod is None:
+        # Older-server stand-in: module present, helper attribute absent — the
+        # from-import raises ImportError, same class as a missing module.
+        landing_mod = ModuleType("ha_mcp.browser_landing")
+    ha_mcp_mod.browser_landing = landing_mod
+    mods["ha_mcp.browser_landing"] = landing_mod
     for name, mod in mods.items():
         monkeypatch.setitem(sys.modules, name, mod)
 
@@ -1161,11 +1164,17 @@ class TestReadinessProbe:
         ha_mcp_mod.config = cfg
         ha_mcp_mod.server = server_mod
         ha_mcp_mod.settings_ui = ui_mod
-        # Evict any REAL ha_mcp.browser_landing left in sys.modules by other
-        # unit files in this worker (imported via ha_mcp.__main__); it would
-        # satisfy _serve's landing import and call custom_route on _FakeMcp,
-        # masking the OSError this test is about. Absent, _serve skips it.
-        monkeypatch.delitem(sys.modules, "ha_mcp.browser_landing", raising=False)
+        # Inject an attributeless ha_mcp.browser_landing so _serve's landing
+        # import raises ImportError and is skipped (this test is about the
+        # OSError choreography). A sys.modules hit is the only hermetic way:
+        # without it, the editable install's meta-path finder resolves the
+        # REAL module by name and its register call would hit _FakeMcp
+        # (no custom_route), masking the OSError (live-found in CI).
+        monkeypatch.setitem(
+            sys.modules,
+            "ha_mcp.browser_landing",
+            ModuleType("ha_mcp.browser_landing"),
+        )
 
         try:
             mgr._thread_main("tok")

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -183,6 +183,25 @@ class TestForwardingHandler:
         resp = await mw._async_handle_webhook(hass, WEBHOOK_ID, make_request())
         assert resp.headers["Content-Type"] == "application/json"
 
+    async def test_text_plain_landing_content_type_preserved(self):
+        # The server's friendly landing page (a plain-text 405 shown to a browser
+        # that GETs the endpoint) must forward as text/plain, not be relabeled
+        # application/json — so it renders as readable text through the ingress URL.
+        # text/plain is XSS-safe; text/html (below) stays coerced.
+        upstream = FakeUpstream(
+            status=405,
+            headers={"Content-Type": "text/plain; charset=utf-8"},
+            body=b"HA-MCP server is up and running!",
+        )
+        session = FakeSession(upstream=upstream)
+        hass = _make_hass()
+        _store_cfg(hass, session=session)
+
+        resp = await mw._async_handle_webhook(hass, WEBHOOK_ID, make_request())
+        assert resp.status == 405
+        assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+        assert resp.body == b"HA-MCP server is up and running!"
+
     async def test_sse_branch_streams_chunks_with_anti_buffering_headers(self):
         chunks = [b"event: message\ndata: 1\n\n", b"data: 2\n\n"]
         upstream = FakeUpstream(


### PR DESCRIPTION
## What does this PR do?

The in-process server (ha_mcp_tools) returned a bare "Method Not Allowed" when a browser GETs its MCP endpoint — the direct `/private_...` URL or the ingress webhook URL. It now serves the same friendly landing page as the add-on.

- Extract the landing route from `ha_mcp.__main__` into a side-effect-free `ha_mcp.browser_landing` module — the worker thread must not import `__main__` (it patches SSL at import), which is why the landing was never wired up in-process.
- Register the landing in `embedded_server._serve` (import guarded so an older installed server without the module keeps working).
- Dedup the landing registration per MCP instance, not per path: an in-process entry reload builds a new FastMCP with the same secret path in the same Python process, and a global path set would silently drop the landing after the first reload.
- Forward `text/plain` through the ingress webhook unchanged so the landing renders as text; `text/html` stays coerced to JSON (XSS guard).
- Bump the component manifest to 0.14.1.

In `ha_auth` mode the webhook 401s a browser before forwarding, so there the landing only appears on the direct URL (expected). New unit tests cover all of the above.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
