### PR TITLE
feat: server update entity, auto-update notifications, and real HACS release notes (#1760)

### DIFF
--- a/.github/integration-mirror-workflows/release-on-tag.yml
+++ b/.github/integration-mirror-workflows/release-on-tag.yml
@@ -1,0 +1,50 @@
+name: Release on tag
+
+# Canonical copy: this file lives in the main repo (homeassistant-ai/ha-mcp)
+# at .github/integration-mirror-workflows/release-on-tag.yml and is synced
+# into the ha-mcp-integration mirror by sync-integration-mirror.yml. Do not
+# hand-edit it in the mirror -- edits are overwritten on the next sync.
+#
+# The monorepo sync pushes vX.Y.Z tags (deploy keys cannot call the GitHub
+# API to create a release directly, only push git refs -- including
+# annotated tags and, per this same sync workflow, this file). Since the
+# deploy key can't set a release body via the API either, the tag itself
+# carries the body: the sync workflow creates an ANNOTATED tag whose message
+# is the generated component release notes, and this job uses that message
+# verbatim as the release body. Tags predating this change (or any that
+# somehow end up lightweight/empty) fall back to the old generic stub so
+# behavior degrades gracefully instead of shipping a blank release.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # A shallow, ref-only checkout of a tag-push event is not
+          # guaranteed to bring down the full annotated tag object (only
+          # the commit it points to) -- fetch full history and tags so the
+          # tag message is actually present locally for the next step.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Extract tag message
+        run: |
+          git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > /tmp/notes.md
+          if ! grep -q '[^[:space:]]' /tmp/notes.md; then
+            echo "Component snapshot synced from homeassistant-ai/ha-mcp." > /tmp/notes.md
+          fi
+
+      - name: Create release for tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "$VER" -F /tmp/notes.md || echo "release exists"

--- a/.github/integration-mirror-workflows/release-on-tag.yml
+++ b/.github/integration-mirror-workflows/release-on-tag.yml
@@ -36,7 +36,16 @@ jobs:
 
       - name: Extract tag message
         run: |
-          git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > /tmp/notes.md
+          # A lightweight tag has no message of its own — %(contents) on one
+          # falls through to the pointed-to COMMIT's message, so an emptiness
+          # check cannot detect it (review finding). Check the tag object's
+          # actual type instead: only a real annotated tag ("tag" object)
+          # carries the generated release notes; anything else gets the stub.
+          if [ "$(git cat-file -t "refs/tags/$GITHUB_REF_NAME")" = "tag" ]; then
+            git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > /tmp/notes.md
+          else
+            : > /tmp/notes.md
+          fi
           if ! grep -q '[^[:space:]]' /tmp/notes.md; then
             echo "Component snapshot synced from homeassistant-ai/ha-mcp." > /tmp/notes.md
           fi
@@ -46,5 +55,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VER="${GITHUB_REF_NAME#v}"
+          # Check existence explicitly instead of `|| echo "release exists"`:
+          # that pattern treated EVERY create failure (auth, rate limit, bad
+          # notes file) as already-exists and reported green with no release
+          # published (review finding). Now only a genuine duplicate no-ops;
+          # a real create failure fails the job visibly.
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release exists"
+            exit 0
+          fi
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-            --title "$VER" -F /tmp/notes.md || echo "release exists"
+            --title "$VER" -F /tmp/notes.md

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -25,6 +25,7 @@ on:
       - "README.md"
       - ".github/integration-mirror-readme-prefix.md"
       - "scripts/build_mirror_readme.py"
+      - ".github/integration-mirror-workflows/**"
   workflow_run:
     workflows: ["SemVer Release"]
     types: [completed]
@@ -35,6 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The release-notes step needs the full stable-tag history
+          # (git tag -l 'v*') to find the previous and current server
+          # release, not just the default single-commit shallow checkout.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up mirror push key
         env:
@@ -62,6 +69,13 @@ jobs:
             --prefix .github/integration-mirror-readme-prefix.md \
             --readme README.md \
             --out /tmp/mirror/README.md
+          # Deploy keys can push workflow files (unlike a PAT, they aren't
+          # subject to the `workflow` scope restriction), and the mirror
+          # carries no hand-made changes, so its release-on-tag.yml is
+          # synced from here too rather than hand-edited in the mirror.
+          mkdir -p /tmp/mirror/.github/workflows
+          cp .github/integration-mirror-workflows/release-on-tag.yml \
+            /tmp/mirror/.github/workflows/release-on-tag.yml
 
       - name: Commit and push
         env:
@@ -80,11 +94,18 @@ jobs:
 
       - name: Tag mirror for stable release
         # Tags the mirror with the current component version after a successful
-        # SemVer Release (or a manual re-run). The mirror's own release-on-tag
-        # workflow turns this tag into a GitHub release (the monorepo
-        # GITHUB_TOKEN has no cross-repo API access; the deploy key can only
-        # push). Idempotent: an existing tag no-ops, so a release that did not
-        # change the component version simply re-confirms the current tag.
+        # SemVer Release (or a manual re-run). The tag is ANNOTATED and its
+        # message carries the release notes body: the deploy key can push git
+        # refs (including annotated tags) but has no cross-repo GitHub API
+        # access to set a release body directly, so the mirror's
+        # release-on-tag.yml (synced from
+        # .github/integration-mirror-workflows/release-on-tag.yml) reads the
+        # tag message and uses it as-is. `--cleanup=verbatim` is required:
+        # `git tag -a -F` defaults to `--cleanup=strip`, which silently drops
+        # any line starting with "#" -- including the markdown heading the
+        # notes script emits. Idempotent: an existing tag no-ops, so a
+        # release that did not change the component version simply
+        # re-confirms the current tag.
         if: >-
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'workflow_run' &&
@@ -93,10 +114,15 @@ jobs:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |
           VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
-          cd /tmp/mirror
-          if git ls-remote --tags origin "refs/tags/v${VER}" | grep -q .; then
+          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}" | grep -q .; then
             echo "mirror tag v${VER} exists"
             exit 0
           fi
-          git tag "v${VER}"
+          python3 scripts/build_mirror_release_notes.py \
+            --component-version "$VER" \
+            --out /tmp/mirror_notes.md
+          echo "--- release notes for v${VER} ---"
+          cat /tmp/mirror_notes.md
+          cd /tmp/mirror
+          git tag -a "v${VER}" -F /tmp/mirror_notes.md --cleanup=verbatim
           git push origin "v${VER}"

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -1771,6 +1771,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     (issue #1527). A missing ``entry_type`` means ``tools`` so pre-existing
     entries keep working across the component update with no migration.
     """
+    # Lazy import (matches the embedded chain's own convention in
+    # embedded_entry.py): keeps homeassistant.const's import surface out of
+    # every hermetic unit test that merely imports this package, not just the
+    # ones that actually call async_setup_entry.
+    from .install_source_check import async_schedule_install_source_check
+
+    # Runs for BOTH entry types: HACS delivers the component as a whole, not
+    # just the server entry, so a legacy-repo install needs detecting either way.
+    async_schedule_install_source_check(hass)
+
     if entry.data.get(CONF_ENTRY_TYPE) == ENTRY_TYPE_SERVER:
         from .embedded_entry import async_setup_server_entry
 

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -262,6 +262,12 @@ DATA_ACCESS_TOKEN = "access_token"
 # pre-release test channel) force an actual reinstall on the next start instead
 # of hitting the requirements manager's is-installed shortcut.
 DATA_LAST_PIP_SPEC = "last_pip_spec"
+# One-shot marker set by the update entity's Install button (issue #1760):
+# with auto-update off, EmbeddedServerManager._resolve_pip_spec pins the
+# channel to the CURRENTLY installed version, so a bare reload would just
+# reinstall the same build. This pins the next install to a specific version
+# regardless of auto_update; embedded_server clears it once that install lands.
+DATA_PENDING_INSTALL_VERSION = "pending_install_version"
 
 # hass.data[DOMAIN] sub-keys for the server runtime. Distinct from the tools
 # entry's sub-keys ("caller_token" / "allowed_paths") so both entry types can
@@ -273,6 +279,9 @@ DATA_BRINGUP_TASK = "bringup_task"
 # on a genuine options change — the background bring-up persists ids/token/pip
 # spec to entry.data, and those writes must not trigger a self-reload.
 DATA_LAST_OPTIONS = "last_options"
+# The ServerVersionCoordinator instance backing the `update` platform entity
+# (issue #1760) — stored so the platform's async_setup_entry can retrieve it.
+DATA_UPDATE_COORDINATOR = "update_coordinator"
 
 # Webhook auth modes (mirrors the webhook-proxy add-on's default posture).
 WEBHOOK_AUTH_NONE = "none"  # secret webhook URL is the shared secret (default)
@@ -309,6 +318,14 @@ SERVER_USER_NAME = "HA-MCP Server"
 # namespace (mirrors the webhook-proxy add-on's /api/mcp_proxy/oauth base).
 OAUTH_BASE = "/api/ha_mcp_tools/oauth"
 
+# HACS "add repository" deep link for the custom component. Shared learn_more_url
+# for every repair issue that ends with "install/reinstall the component via
+# HACS" (the component-outdated issue and the legacy-HACS-source issue below).
+HACS_COMPONENT_URL = (
+    "https://my.home-assistant.io/redirect/hacs_repository/"
+    "?owner=homeassistant-ai&repository=ha-mcp-integration&category=integration"
+)
+
 # Repair-issue ids surfaced when server bring-up fails.
 ISSUE_PACKAGE_FAILED = "server_package_install_failed"
 ISSUE_START_FAILED = "server_start_failed"
@@ -318,3 +335,11 @@ ISSUE_START_FAILED = "server_start_failed"
 # the server expects; this points the user at the HACS component update
 # (non-blocking).
 ISSUE_COMPONENT_OUTDATED = "component_outdated"
+# Repair issue surfaced when HACS is tracking the MAIN ha-mcp server repo for
+# this component (the pre-mirror install path — issue #1760). That install
+# keeps working (HACS downloads the repo snapshot at the release tag, which
+# contains the component), but HACS shows the SERVER's version numbers and
+# release notes, not the component's own; HACS has no repository-migration
+# mechanism, so this only self-resolves if the user re-adds the dedicated
+# mirror (homeassistant-ai/ha-mcp-integration).
+ISSUE_LEGACY_HACS_SOURCE = "legacy_hacs_source"

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -212,12 +212,31 @@ CHANNEL_STABLE = "stable"
 CHANNEL_DEV = "dev"
 DEFAULT_CHANNEL = CHANNEL_STABLE
 
-# Automatic server-version updates. Both channels are unpinned, so an entry
-# reload / HA restart already reinstalls the newest build; on top of that the
-# component polls PyPI on this interval and reloads the entry when a newer build
-# is published, so a long-running instance picks up releases without a restart.
-# An explicit pip-spec override disables the check, as does turning off the
-# ``auto_update`` option (OPT_AUTO_UPDATE).
+
+def dist_for_channel(channel: str) -> str:
+    """Map a release channel to its PyPI distribution name.
+
+    The channel <-> distribution correspondence is used by the version
+    coordinator, the auto-update notification, and the server manager's pip
+    resolution — one shared mapping so a future third channel cannot be added
+    to some sites and missed in others (review finding on #1760).
+    """
+    return DIST_NAME_DEV if channel == CHANNEL_DEV else DIST_NAME_STABLE
+
+
+def channel_for_dist(dist: str) -> str:
+    """Inverse of :func:`dist_for_channel`."""
+    return CHANNEL_DEV if dist == DIST_NAME_DEV else CHANNEL_STABLE
+
+
+# Interval of the ServerVersionCoordinator's PyPI poll (coordinator.py). The
+# poll itself ALWAYS runs — it feeds the `update` platform entity, which must
+# stay populated even when automatic updates are off (issue #1760). Whether a
+# newer build actually triggers a reload/reinstall is decided separately, per
+# refresh, in embedded_setup.async_maybe_auto_update (gated on OPT_AUTO_UPDATE
+# and on no pip-spec override). Only an explicit pip-spec override skips the
+# PyPI fetch — comparing PyPI-latest against an arbitrary pip spec is
+# meaningless.
 UPDATE_CHECK_INTERVAL = timedelta(hours=6)
 
 # PyPI JSON API for the latest published version of a distribution. ``{dist}``
@@ -227,11 +246,13 @@ PYPI_JSON_URL = "https://pypi.org/pypi/{dist}/json"
 # Options-flow keys (stored in entry.options).
 OPT_CHANNEL = "channel"
 # Automatic server-version updates toggle (default on). When on, the channel is
-# unpinned and auto-updates (force-install on reload/restart + the periodic
-# check). When off, the server stays on the version currently installed:
-# _resolve_pip_spec pins the channel's dist to that version and the periodic
-# check is skipped. Governs the ha-mcp server package only — component updates
-# still come through HACS. An explicit OPT_PIP_SPEC override wins over both.
+# unpinned and auto-updates (force-install on reload/restart + a reload when the
+# periodic check sees a newer build). When off, the server stays on the version
+# currently installed: _resolve_pip_spec pins the channel's dist to that version
+# — but the periodic PyPI check KEEPS running so the update entity still shows
+# newer builds; its Install button is the manual path (issue #1760). Governs the
+# ha-mcp server package only — component updates still come through HACS. An
+# explicit OPT_PIP_SPEC override wins over both and skips the check entirely.
 OPT_AUTO_UPDATE = "auto_update"
 DEFAULT_AUTO_UPDATE = True
 OPT_SERVER_PORT = "server_port"
@@ -266,7 +287,9 @@ DATA_LAST_PIP_SPEC = "last_pip_spec"
 # with auto-update off, EmbeddedServerManager._resolve_pip_spec pins the
 # channel to the CURRENTLY installed version, so a bare reload would just
 # reinstall the same build. This pins the next install to a specific version
-# regardless of auto_update; embedded_server clears it once that install lands.
+# regardless of auto_update; embedded_server clears it when it CONSUMES it
+# (before the install attempt) — one marker buys exactly one attempt, so a
+# failing pinned version can never re-pin later reloads (review finding).
 DATA_PENDING_INSTALL_VERSION = "pending_install_version"
 
 # hass.data[DOMAIN] sub-keys for the server runtime. Distinct from the tools
@@ -282,6 +305,14 @@ DATA_LAST_OPTIONS = "last_options"
 # The ServerVersionCoordinator instance backing the `update` platform entity
 # (issue #1760) — stored so the platform's async_setup_entry can retrieve it.
 DATA_UPDATE_COORDINATOR = "update_coordinator"
+# Set by async_maybe_auto_update right before it reloads the entry for an
+# automatic update ({"old": <version>}): the "server updated" notification must
+# only fire once the reloaded entry's bring-up actually installed and started
+# the new build — the reload call returns as soon as entry SETUP finishes,
+# while the pip install still runs in the background and can fail (review
+# finding on #1760). Bring-up pops it: notification on success, silent drop on
+# failure (the package/start repair issues cover that path).
+DATA_PENDING_UPDATE_NOTIFY = "pending_update_notify"
 
 # Webhook auth modes (mirrors the webhook-proxy add-on's default posture).
 WEBHOOK_AUTH_NONE = "none"  # secret webhook URL is the shared secret (default)

--- a/custom_components/ha_mcp_tools/coordinator.py
+++ b/custom_components/ha_mcp_tools/coordinator.py
@@ -1,0 +1,114 @@
+"""Poll the server package's installed vs. latest PyPI version (issue #1760).
+
+Backs the ``update`` platform entity (:mod:`update`) and the automatic-update
+decision (:func:`embedded_setup.async_maybe_auto_update`). Runs on
+:data:`UPDATE_CHECK_INTERVAL` regardless of the ``auto_update`` option — unlike
+the check this replaces, visibility must not depend on auto-update being on
+(issue #1760: with auto-update off, users previously got zero signal that a
+server update existed). Only the resulting *reload* is gated on ``auto_update``,
+in :mod:`embedded_setup`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    CHANNEL_DEV,
+    DEFAULT_CHANNEL,
+    DEFAULT_PIP_SPEC,
+    DIST_NAME_DEV,
+    DIST_NAME_STABLE,
+    DOMAIN,
+    OPT_CHANNEL,
+    OPT_PIP_SPEC,
+    PYPI_JSON_URL,
+    UPDATE_CHECK_INTERVAL,
+)
+from .embedded_server import _installed_dist_version
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# Per-request timeout for the PyPI version-check fetch - short so a slow or
+# wedged PyPI never ties up the coordinator; a miss just retries next interval
+# (moved here from the old embedded_setup.async_check_for_update).
+_PYPI_TIMEOUT_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class ServerVersionInfo:
+    """Installed vs. latest server-package version for one config entry."""
+
+    installed: str | None
+    latest: str | None
+    dist: str
+
+
+class ServerVersionCoordinator(DataUpdateCoordinator[ServerVersionInfo]):
+    """Poll the installed + PyPI-latest version of the in-process server package.
+
+    Deliberately NOT scoped to the ``auto_update`` option: the update entity
+    must stay populated and the periodic check must keep running even when the
+    user has automatic updates turned off - that visibility is the point of
+    issue #1760. ``embedded_entry`` schedules this coordinator's listener to
+    decide whether to actually reload.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Bind to the config entry and schedule on UPDATE_CHECK_INTERVAL."""
+        self._entry = entry
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN} server version",
+            update_interval=UPDATE_CHECK_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> ServerVersionInfo:
+        """Return the installed + latest version for the configured channel.
+
+        Never raises ``UpdateFailed`` for an expected PyPI transient - the
+        entity must stay available (showing the installed version) even when
+        PyPI is unreachable; :meth:`_async_fetch_latest`'s own narrow except
+        clause is the only one expected to fire in normal operation.
+        """
+        options = self._entry.options
+        channel = str(options.get(OPT_CHANNEL) or DEFAULT_CHANNEL)
+        dist = DIST_NAME_DEV if channel == CHANNEL_DEV else DIST_NAME_STABLE
+        installed = await self.hass.async_add_executor_job(
+            _installed_dist_version, dist
+        )
+
+        override = str(options.get(OPT_PIP_SPEC) or "").strip()
+        if override and override != DEFAULT_PIP_SPEC:
+            # An explicit pip-spec override (a version pin, a tarball URL)
+            # makes a PyPI-latest comparison meaningless - skip the fetch.
+            return ServerVersionInfo(installed=installed, latest=None, dist=dist)
+
+        latest = await self._async_fetch_latest(dist)
+        return ServerVersionInfo(installed=installed, latest=latest, dist=dist)
+
+    async def _async_fetch_latest(self, dist: str) -> str | None:
+        """Return the newest PyPI version for ``dist``, or None on any failure."""
+        try:
+            session = async_get_clientsession(self.hass)
+            async with asyncio.timeout(_PYPI_TIMEOUT_SECONDS):
+                async with session.get(PYPI_JSON_URL.format(dist=dist)) as resp:
+                    resp.raise_for_status()
+                    payload = await resp.json()
+            return str(payload["info"]["version"])
+        except (ClientError, TimeoutError, KeyError, ValueError) as err:
+            _LOGGER.debug("HA-MCP server version check failed for %s: %s", dist, err)
+            return None

--- a/custom_components/ha_mcp_tools/coordinator.py
+++ b/custom_components/ha_mcp_tools/coordinator.py
@@ -21,16 +21,14 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
-    CHANNEL_DEV,
     DEFAULT_CHANNEL,
     DEFAULT_PIP_SPEC,
-    DIST_NAME_DEV,
-    DIST_NAME_STABLE,
     DOMAIN,
     OPT_CHANNEL,
     OPT_PIP_SPEC,
     PYPI_JSON_URL,
     UPDATE_CHECK_INTERVAL,
+    dist_for_channel,
 )
 from .embedded_server import _installed_dist_version
 
@@ -86,7 +84,7 @@ class ServerVersionCoordinator(DataUpdateCoordinator[ServerVersionInfo]):
         """
         options = self._entry.options
         channel = str(options.get(OPT_CHANNEL) or DEFAULT_CHANNEL)
-        dist = DIST_NAME_DEV if channel == CHANNEL_DEV else DIST_NAME_STABLE
+        dist = dist_for_channel(channel)
         installed = await self.hass.async_add_executor_job(
             _installed_dist_version, dist
         )

--- a/custom_components/ha_mcp_tools/embedded_entry.py
+++ b/custom_components/ha_mcp_tools/embedded_entry.py
@@ -76,20 +76,23 @@ async def async_setup_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     # entry.data, and those writes must not self-reload.
     domain_data[DATA_LAST_OPTIONS] = dict(entry.options)
 
+    # Server-version visibility + automatic updates (issue #1760): the
+    # coordinator polls PyPI on its own UPDATE_CHECK_INTERVAL regardless of the
+    # auto_update option, backing the `update` platform entity forwarded below.
+    # Its listener forwards every refresh to async_maybe_auto_update, which
+    # decides whether to actually reload. Created and stored BEFORE the
+    # bring-up task: bring-up's success path (_async_finish_update_cycle)
+    # refreshes this coordinator, so it must already be in hass.data whenever
+    # that task runs.
+    coordinator = ServerVersionCoordinator(hass, entry)
+    domain_data[DATA_UPDATE_COORDINATOR] = coordinator
+
     task = entry.async_create_background_task(
         hass, async_bring_up_server(hass, entry), f"{DOMAIN}_bring_up"
     )
     domain_data[DATA_BRINGUP_TASK] = task
 
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
-
-    # Server-version visibility + automatic updates (issue #1760): the
-    # coordinator polls PyPI on its own UPDATE_CHECK_INTERVAL regardless of the
-    # auto_update option, backing the `update` platform entity forwarded below.
-    # Its listener forwards every refresh to async_maybe_auto_update, which
-    # decides whether to actually reload.
-    coordinator = ServerVersionCoordinator(hass, entry)
-    domain_data[DATA_UPDATE_COORDINATOR] = coordinator
 
     @callback
     def _on_version_update() -> None:

--- a/custom_components/ha_mcp_tools/embedded_entry.py
+++ b/custom_components/ha_mcp_tools/embedded_entry.py
@@ -20,31 +20,30 @@ import secrets
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
-from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
 
 from .const import (
     DATA_BRINGUP_TASK,
     DATA_LAST_OPTIONS,
     DATA_SECRET_PATH,
+    DATA_UPDATE_COORDINATOR,
     DATA_WEBHOOK_ID,
     DOMAIN,
     OPT_REGENERATE_SECRETS,
     OPT_SECRET_PATH_OVERRIDE,
     OPT_WEBHOOK_ID_OVERRIDE,
-    UPDATE_CHECK_INTERVAL,
 )
 
-# NOTE: embedded_setup (and its embedded_server / mcp_webhook chain) is imported
-# lazily inside the entry lifecycle functions below, not at module top level. It
-# pulls in aiohttp and several homeassistant.* submodules (auth, requirements,
-# util.package, components.http/webhook) that the entry-point wiring here never
-# touches directly, so a top-level import would make importing this package
-# require that whole stack — breaking hermetic unit tests that stub only the
-# modules they use.
+# NOTE: embedded_setup / coordinator (and their embedded_server / mcp_webhook
+# chain) are imported lazily inside the entry lifecycle functions below, not at
+# module top level. They pull in aiohttp and several homeassistant.* submodules
+# (auth, requirements, util.package, components.http/webhook) that the
+# entry-point wiring here never touches directly, so a top-level import would
+# make importing this package require that whole stack — breaking hermetic unit
+# tests that stub only the modules they use.
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from homeassistant.config_entries import ConfigEntry
 
 
@@ -60,9 +59,8 @@ async def async_setup_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     """
     # Imported lazily (see the import note) so the aiohttp / auth / requirements
     # chain is pulled in only when an entry is actually set up.
-    from homeassistant.helpers.event import async_track_time_interval
-
-    from .embedded_setup import async_bring_up_server, async_check_for_update
+    from .coordinator import ServerVersionCoordinator
+    from .embedded_setup import async_bring_up_server, async_maybe_auto_update
     from .ui_panel import async_register_ui_panel
 
     _ensure_secrets(hass, entry)
@@ -85,29 +83,57 @@ async def async_setup_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
-    # Periodic channel auto-update: poll PyPI for a newer server build and reload
-    # the entry (which reinstalls + restarts) when one is published, so a
-    # long-running instance tracks its channel without a manual restart. The
-    # check self-skips for a pip-spec override and before the first install, so
-    # registering it here (independent of bring-up completing) is safe. Cleaned
-    # up on unload via the returned cancel callback.
-    async def _scheduled_update_check(now: datetime) -> None:
-        await async_check_for_update(hass, entry)
+    # Server-version visibility + automatic updates (issue #1760): the
+    # coordinator polls PyPI on its own UPDATE_CHECK_INTERVAL regardless of the
+    # auto_update option, backing the `update` platform entity forwarded below.
+    # Its listener forwards every refresh to async_maybe_auto_update, which
+    # decides whether to actually reload.
+    coordinator = ServerVersionCoordinator(hass, entry)
+    domain_data[DATA_UPDATE_COORDINATOR] = coordinator
 
-    entry.async_on_unload(
-        async_track_time_interval(hass, _scheduled_update_check, UPDATE_CHECK_INTERVAL)
+    @callback
+    def _on_version_update() -> None:
+        # A reload must never run synchronously from inside this listener
+        # callback: it would unload the UPDATE platform this very coordinator
+        # drives (forwarded below), tearing the coordinator down mid-callback.
+        #
+        # hass-owned, NOT entry.async_create_background_task: entry background
+        # tasks are cancelled by the very unload that async_maybe_auto_update's
+        # reload performs, so an entry-owned task would cancel itself mid-reload
+        # and leave the entry unloaded without ever setting back up (server down
+        # until restart). The interval-timer wiring this replaces ran its checks
+        # as plain hass jobs for the same reason.
+        hass.async_create_background_task(
+            async_maybe_auto_update(hass, entry, coordinator.data),
+            f"{DOMAIN}_server_auto_update",
+        )
+
+    entry.async_on_unload(coordinator.async_add_listener(_on_version_update))
+
+    # Background, not awaited: entry setup must not block on a PyPI round-trip
+    # (this is why async_config_entry_first_refresh is NOT used here). The
+    # coordinator reschedules itself on UPDATE_CHECK_INTERVAL after this first
+    # refresh completes.
+    entry.async_create_background_task(
+        hass, coordinator.async_refresh(), f"{DOMAIN}_server_version_refresh"
     )
+
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.UPDATE])
     return True
 
 
 async def async_unload_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Stop the server + ingress webhook (reload-safe; keeps the provisioned token).
 
-    Cancels the bring-up task first so a still-in-flight install/start is torn
-    down before the explicit teardown runs.
+    Unloads the UPDATE platform first so the coordinator's entity is torn down
+    before the coordinator itself is popped from hass.data, then cancels the
+    bring-up task so a still-in-flight install/start is torn down before the
+    explicit teardown runs.
     """
     from .embedded_setup import async_teardown_server  # lazy (see import note)
     from .ui_panel import async_unregister_ui_panel
+
+    await hass.config_entries.async_unload_platforms(entry, [Platform.UPDATE])
 
     domain_data = hass.data.get(DOMAIN, {})
     task = domain_data.pop(DATA_BRINGUP_TASK, None)
@@ -119,6 +145,7 @@ async def async_unload_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> 
     await async_teardown_server(hass)
     async_unregister_ui_panel(hass)
     domain_data.pop(DATA_LAST_OPTIONS, None)
+    domain_data.pop(DATA_UPDATE_COORDINATOR, None)
     return True
 
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -54,6 +54,7 @@ from .const import (
     CHANNEL_DEV,
     DATA_ACCESS_TOKEN,
     DATA_LAST_PIP_SPEC,
+    DATA_PENDING_INSTALL_VERSION,
     DATA_REFRESH_TOKEN_ID,
     DATA_SECRET_PATH,
     DATA_SERVER_USER_ID,
@@ -336,6 +337,11 @@ class EmbeddedServerManager:
         pinned reinstall a no-op (breaking a dev→stable downgrade) and the reported
         version ambiguous.
 
+        A one-shot pending-install marker (:data:`DATA_PENDING_INSTALL_VERSION`,
+        set by the update entity's Install button — issue #1760) overrides both
+        the unpinned-channel and auto-update-off pinning above for this single
+        install, regardless of the ``auto_update`` option.
+
         Never imports ``ha_mcp`` in this (main) process — that happens only inside
         the worker thread.
         """
@@ -344,19 +350,27 @@ class EmbeddedServerManager:
             _installed_ha_mcp_version
         )
 
-        # Re-pin an auto-update-off channel to its TARGET distribution's
-        # installed version, read off-loop (the __init__ value was the bare
-        # dist to avoid a blocking read on the event loop). Reading the target
-        # dist specifically — not whichever dist happens to be present — keeps a
-        # cross-channel switch correct: the previous channel's dist is still
-        # installed at this point (removal happens below), so a whichever-present
-        # read would pin the new dist to a version that does not exist for it and
-        # fail the install. Nothing of the target channel installed yet => None
-        # => stays unpinned and installs the newest once.
-        if not self._pip_spec_override and not self._auto_update:
-            target_dist = (
-                DEV_PIP_SPEC if self._channel == CHANNEL_DEV else DIST_NAME_STABLE
-            )
+        pending_version = str(
+            self._entry.data.get(DATA_PENDING_INSTALL_VERSION) or ""
+        ).strip()
+        target_dist = DEV_PIP_SPEC if self._channel == CHANNEL_DEV else DIST_NAME_STABLE
+        if not self._pip_spec_override and pending_version:
+            # Pin to the requested version. Its own value differs from
+            # stored_spec below (that is the whole point of the marker), which
+            # already forces the force-install branch further down — no
+            # separate fast-path handling needed here.
+            self._pip_spec = f"{target_dist}=={pending_version}"
+        elif not self._pip_spec_override and not self._auto_update:
+            # Re-pin an auto-update-off channel to its TARGET distribution's
+            # installed version, read off-loop (the __init__ value was the bare
+            # dist to avoid a blocking read on the event loop). Reading the
+            # target dist specifically — not whichever dist happens to be
+            # present — keeps a cross-channel switch correct: the previous
+            # channel's dist is still installed at this point (removal happens
+            # below), so a whichever-present read would pin the new dist to a
+            # version that does not exist for it and fail the install. Nothing
+            # of the target channel installed yet => None => stays unpinned and
+            # installs the newest once.
             pin_version = await self._hass.async_add_executor_job(
                 _installed_dist_version, target_dist
             )
@@ -387,6 +401,7 @@ class EmbeddedServerManager:
         _LOGGER.info("HA-MCP in-process server package ready (version %s)", version)
         if stored_spec != self._pip_spec:
             self._store_installed_spec()
+        self._clear_pending_install_marker()
 
     async def _async_process_requirements_fast(self) -> None:
         """Fast path: let HA's requirements manager satisfy the override spec."""
@@ -459,6 +474,19 @@ class EmbeddedServerManager:
         new_data = {**self._entry.data, DATA_LAST_PIP_SPEC: self._pip_spec}
         if new_data != dict(self._entry.data):
             self._hass.config_entries.async_update_entry(self._entry, data=new_data)
+
+    def _clear_pending_install_marker(self) -> None:
+        """Clear the update entity's one-shot pending-install marker.
+
+        Called unconditionally after every successful install (not just a
+        pending-version one) so a marker left over from an interrupted attempt
+        can never linger and silently re-pin a later, unrelated install.
+        """
+        if DATA_PENDING_INSTALL_VERSION not in self._entry.data:
+            return
+        new_data = dict(self._entry.data)
+        new_data.pop(DATA_PENDING_INSTALL_VERSION, None)
+        self._hass.config_entries.async_update_entry(self._entry, data=new_data)
 
     # -- token provisioning ------------------------------------------------
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -64,7 +64,6 @@ from .const import (
     DEFAULT_LOOPBACK_URL,
     DEFAULT_PIP_SPEC,
     DEFAULT_SERVER_PORT,
-    DEV_PIP_SPEC,
     DIST_NAME_DEV,
     DIST_NAME_STABLE,
     DOMAIN,
@@ -77,6 +76,7 @@ from .const import (
     SERVER_CONFIG_SUBDIR,
     SERVER_TOKEN_CLIENT_NAME,
     SERVER_USER_NAME,
+    dist_for_channel,
 )
 
 if TYPE_CHECKING:
@@ -147,9 +147,11 @@ class EmbeddedServerManager:
         self._pip_spec_override: str = (
             raw_pip_spec if raw_pip_spec and raw_pip_spec != DEFAULT_PIP_SPEC else ""
         )
-        # Auto-update toggle (default on). Off pins a non-override channel to the
-        # currently-installed version and disables the periodic check. Read
-        # before _resolve_pip_spec, which consults it.
+        # Auto-update toggle (default on). Off pins a non-override channel to
+        # the currently-installed version; the periodic PyPI check keeps
+        # running either way (it feeds the update entity — issue #1760), only
+        # the automatic reload is gated on this. Read before
+        # _resolve_pip_spec, which consults it.
         self._auto_update: bool = bool(
             options.get(OPT_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
         )
@@ -293,7 +295,7 @@ class EmbeddedServerManager:
         """
         if self._pip_spec_override:
             return self._pip_spec_override
-        dist = DEV_PIP_SPEC if self._channel == CHANNEL_DEV else DIST_NAME_STABLE
+        dist = dist_for_channel(self._channel)
         if not self._auto_update and installed_version is not None:
             return f"{dist}=={installed_version}"
         return dist
@@ -353,13 +355,21 @@ class EmbeddedServerManager:
         pending_version = str(
             self._entry.data.get(DATA_PENDING_INSTALL_VERSION) or ""
         ).strip()
-        target_dist = DEV_PIP_SPEC if self._channel == CHANNEL_DEV else DIST_NAME_STABLE
+        target_dist = dist_for_channel(self._channel)
         if not self._pip_spec_override and pending_version:
             # Pin to the requested version. Its own value differs from
             # stored_spec below (that is the whole point of the marker), which
             # already forces the force-install branch further down — no
             # separate fast-path handling needed here.
+            #
+            # Consumed HERE, before the install attempt: one-shot means one
+            # ATTEMPT, not "until it succeeds". If it were cleared only on
+            # success, a marker for a failing version would re-pin every later
+            # reload — including the periodic auto-update ones — to that same
+            # broken version, looping the failure forever while auto-update
+            # looks on (review finding).
             self._pip_spec = f"{target_dist}=={pending_version}"
+            self._clear_pending_install_marker()
         elif not self._pip_spec_override and not self._auto_update:
             # Re-pin an auto-update-off channel to its TARGET distribution's
             # installed version, read off-loop (the __init__ value was the bare
@@ -401,7 +411,6 @@ class EmbeddedServerManager:
         _LOGGER.info("HA-MCP in-process server package ready (version %s)", version)
         if stored_spec != self._pip_spec:
             self._store_installed_spec()
-        self._clear_pending_install_marker()
 
     async def _async_process_requirements_fast(self) -> None:
         """Fast path: let HA's requirements manager satisfy the override spec."""
@@ -478,9 +487,10 @@ class EmbeddedServerManager:
     def _clear_pending_install_marker(self) -> None:
         """Clear the update entity's one-shot pending-install marker.
 
-        Called unconditionally after every successful install (not just a
-        pending-version one) so a marker left over from an interrupted attempt
-        can never linger and silently re-pin a later, unrelated install.
+        Called at CONSUME time in :meth:`_async_ensure_package`, before the
+        install attempt runs: the marker buys exactly one attempt. Clearing
+        only on success would let a marker for a failing version re-pin every
+        later reload to that broken version (review finding).
         """
         if DATA_PENDING_INSTALL_VERSION not in self._entry.data:
             return

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -19,66 +19,51 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from aiohttp import ClientError
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_integration
 
 from .const import (
     BIND_HOST_ALL,
     CHANNEL_DEV,
+    CHANNEL_STABLE,
+    DATA_BRINGUP_TASK,
     DATA_MANAGER,
     DATA_SECRET_PATH,
     DATA_WEBHOOK_ID,
     DEFAULT_AUTO_UPDATE,
     DEFAULT_BIND_HOST,
-    DEFAULT_CHANNEL,
     DEFAULT_PIP_SPEC,
     DEFAULT_SERVER_PORT,
     DIST_NAME_DEV,
-    DIST_NAME_STABLE,
     DOMAIN,
+    HACS_COMPONENT_URL,
     ISSUE_COMPONENT_OUTDATED,
     ISSUE_PACKAGE_FAILED,
     ISSUE_START_FAILED,
     OPT_AUTO_UPDATE,
     OPT_BIND_HOST,
-    OPT_CHANNEL,
     OPT_ENABLE_WEBHOOK,
     OPT_EXTERNAL_URL,
     OPT_PIP_SPEC,
     OPT_SERVER_PORT,
     OPT_WEBHOOK_AUTH,
-    PYPI_JSON_URL,
     WEBHOOK_AUTH_NONE,
 )
-from .embedded_server import (
-    EmbeddedServerError,
-    EmbeddedServerManager,
-    _installed_dist_version,
-)
+from .embedded_server import EmbeddedServerError, EmbeddedServerManager
 from .mcp_webhook import async_register_webhook, async_unregister_webhook
-
-# Per-request timeout for the PyPI auto-update poll — short so a slow or wedged
-# PyPI never ties up the periodic check; a miss just retries next interval.
-_PYPI_TIMEOUT_SECONDS = 30
-
-# HACS "add repository" deep link for the custom component, surfaced as the
-# component-outdated repair issue's Learn More link so the fix is one click away.
-_HACS_COMPONENT_URL = (
-    "https://my.home-assistant.io/redirect/hacs_repository/"
-    "?owner=homeassistant-ai&repository=ha-mcp-integration&category=integration"
-)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
+    from .coordinator import ServerVersionInfo
+
 _LOGGER = logging.getLogger(__name__)
 
 _NOTIFICATION_ID = "ha_mcp_tools_server_connect"
+_UPDATE_NOTIFICATION_ID = "ha_mcp_tools_server_updated"
 _ISSUE_IDS = (ISSUE_PACKAGE_FAILED, ISSUE_START_FAILED)
 
 
@@ -316,19 +301,26 @@ def _clear_issues(hass: HomeAssistant) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def async_check_for_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the entry when the channel's PyPI dist has a newer build.
+async def async_maybe_auto_update(
+    hass: HomeAssistant, entry: ConfigEntry, info: ServerVersionInfo
+) -> None:
+    """Reload the entry when ``info`` shows a newer build AND auto-update is on.
 
-    Registered on a periodic interval by the entry setup (:mod:`embedded_entry`).
-    Both channels are unpinned, so reloading reinstalls the newest build and
-    restarts the server — the actual upgrade happens on the reload path, not
-    here. Skips entirely when a pip-spec override is set (the user pinned a
-    specific build and opted out of auto-update).
+    Called from the :class:`~.coordinator.ServerVersionCoordinator` listener
+    registered by :mod:`embedded_entry` on every refresh (every
+    ``UPDATE_CHECK_INTERVAL``, plus once shortly after setup). The coordinator
+    itself always fetches (see its docstring) so the `update` platform entity
+    stays populated regardless of this option; only the reload decided here is
+    gated on it.
 
-    Best-effort: an expected transient — a PyPI fetch error, a timeout, or an
-    unexpected payload shape — is logged at debug and swallowed (the next
-    interval retries). Genuine bugs propagate per the repo's no-silent-failure
-    convention.
+    Skips entirely when: auto-update is off, a pip-spec override is set,
+    either version is unknown (``info`` may still be ``None`` — the
+    coordinator's ``data`` type before its first successful refresh), or a
+    bring-up is still in flight (below).
+
+    Best-effort: an incomparable version string (AwesomeVersionException) is
+    logged at debug and skipped; the next refresh retries. Genuine bugs
+    propagate per the repo's no-silent-failure convention.
     """
     if not bool(entry.options.get(OPT_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)):
         # Auto-update turned off: stay on the currently-installed version.
@@ -338,43 +330,71 @@ async def async_check_for_update(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if override and override != DEFAULT_PIP_SPEC:
         return
 
-    channel = str(entry.options.get(OPT_CHANNEL) or DEFAULT_CHANNEL)
-    dist = DIST_NAME_DEV if channel == CHANNEL_DEV else DIST_NAME_STABLE
-
-    try:
-        session = async_get_clientsession(hass)
-        async with asyncio.timeout(_PYPI_TIMEOUT_SECONDS):
-            async with session.get(PYPI_JSON_URL.format(dist=dist)) as resp:
-                resp.raise_for_status()
-                payload = await resp.json()
-        latest = payload["info"]["version"]
-    except (ClientError, TimeoutError, KeyError, ValueError) as err:
-        _LOGGER.debug("HA-MCP auto-update check skipped for %s: %s", dist, err)
+    if info is None or info.installed is None or info.latest is None:
+        # Nothing to compare (not installed yet, or the PyPI fetch failed /
+        # was skipped) - the bring-up path installs the newest build itself.
         return
 
-    installed = await hass.async_add_executor_job(_installed_dist_version, dist)
-    if installed is None:
-        # Not installed yet (the first bring-up may still be running) — nothing
-        # to compare; the bring-up path installs the newest build itself.
+    bringup_task = hass.data.get(DOMAIN, {}).get(DATA_BRINGUP_TASK)
+    if bringup_task is not None and not bringup_task.done():
+        # The coordinator's first refresh runs shortly after setup, while the
+        # background bring-up (embedded_entry.async_setup_server_entry) may
+        # still be installing the package for the first time. Reloading here
+        # would cancel that in-flight install (async_unload_server_entry
+        # cancels the bring-up task on unload) and can loop: the reload's own
+        # bring-up starts a fresh install that the NEXT refresh could again
+        # interrupt.
         return
 
     try:
-        newer = AwesomeVersion(latest) > AwesomeVersion(installed)
+        newer = AwesomeVersion(info.latest) > AwesomeVersion(info.installed)
     except AwesomeVersionException as err:
         # Incomparable version strategies (e.g. a non-semver build string) — the
         # only expected failure here. Real bugs (TypeError, etc.) propagate.
         _LOGGER.debug("HA-MCP auto-update version compare failed: %s", err)
         return
 
-    if newer:
-        _LOGGER.info(
-            "HA-MCP server update available on the %s channel (%s -> %s); "
-            "reloading the entry to install it.",
-            channel,
-            installed,
-            latest,
-        )
-        await hass.config_entries.async_reload(entry.entry_id)
+    if not newer:
+        return
+
+    channel = CHANNEL_DEV if info.dist == DIST_NAME_DEV else CHANNEL_STABLE
+    _LOGGER.info(
+        "HA-MCP server update available on the %s channel (%s -> %s); "
+        "reloading the entry to install it.",
+        channel,
+        info.installed,
+        info.latest,
+    )
+    await hass.config_entries.async_reload(entry.entry_id)
+    _create_update_notification(hass, channel, info.installed, info.latest)
+
+
+def _create_update_notification(
+    hass: HomeAssistant, channel: str, old_version: str, new_version: str
+) -> None:
+    """Notify that an automatic server update just installed.
+
+    SECURITY: same posture as ``_surface_connect_urls`` - persistent
+    notifications are visible to every authenticated Home Assistant user, so
+    this carries no secrets or connect URLs, only version numbers and a public
+    GitHub link.
+    """
+    release_url = (
+        "https://github.com/homeassistant-ai/ha-mcp/commits/master"
+        if channel == CHANNEL_DEV
+        else f"https://github.com/homeassistant-ai/ha-mcp/releases/tag/v{new_version}"
+    )
+    message = (
+        f"The HA-MCP server was automatically updated from {old_version} to "
+        f"{new_version} on the {channel} channel.\n\n"
+        f"[Release notes]({release_url})"
+    )
+    persistent_notification.async_create(
+        hass,
+        message,
+        title="HA-MCP Server updated",
+        notification_id=_UPDATE_NOTIFICATION_ID,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -453,7 +473,7 @@ async def _async_check_component_compat(
             severity=ir.IssueSeverity.WARNING,
             translation_key=ISSUE_COMPONENT_OUTDATED,
             translation_placeholders={"required": required, "installed": own},
-            learn_more_url=_HACS_COMPONENT_URL,
+            learn_more_url=HACS_COMPONENT_URL,
         )
     else:
         ir.async_delete_issue(hass, DOMAIN, ISSUE_COMPONENT_OUTDATED)

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -28,16 +28,16 @@ from homeassistant.loader import async_get_integration
 from .const import (
     BIND_HOST_ALL,
     CHANNEL_DEV,
-    CHANNEL_STABLE,
     DATA_BRINGUP_TASK,
     DATA_MANAGER,
+    DATA_PENDING_UPDATE_NOTIFY,
     DATA_SECRET_PATH,
+    DATA_UPDATE_COORDINATOR,
     DATA_WEBHOOK_ID,
     DEFAULT_AUTO_UPDATE,
     DEFAULT_BIND_HOST,
     DEFAULT_PIP_SPEC,
     DEFAULT_SERVER_PORT,
-    DIST_NAME_DEV,
     DOMAIN,
     HACS_COMPONENT_URL,
     ISSUE_COMPONENT_OUTDATED,
@@ -51,6 +51,7 @@ from .const import (
     OPT_SERVER_PORT,
     OPT_WEBHOOK_AUTH,
     WEBHOOK_AUTH_NONE,
+    channel_for_dist,
 )
 from .embedded_server import EmbeddedServerError, EmbeddedServerManager
 from .mcp_webhook import async_register_webhook, async_unregister_webhook
@@ -107,9 +108,12 @@ async def async_bring_up_server(hass: HomeAssistant, entry: ConfigEntry) -> None
                 "(direct port + sidebar panel)"
             )
         _surface_connect_urls(hass, entry, auth_mode, webhook_enabled=webhook_enabled)
+        await _async_finish_update_cycle(hass)
     except asyncio.CancelledError:
         # Unloaded mid-bring-up: undo whatever partial state exists, then let the
-        # cancellation propagate so the task ends cancelled.
+        # cancellation propagate so the task ends cancelled. The pending
+        # update-notification marker (if any) deliberately survives — it
+        # belongs to a bring-up that has not run yet, not to this one.
         await async_teardown_server(hass)
         raise
     except EmbeddedServerError as err:
@@ -120,11 +124,15 @@ async def async_bring_up_server(hass: HomeAssistant, entry: ConfigEntry) -> None
         with suppress(Exception):
             await async_teardown_server(hass)
         _create_issue(hass, err.kind, str(err))
+        # The install did not land: never fire the "updated" notification for
+        # it — the repair issue above is the user-facing signal.
+        _drop_pending_update_notify(hass)
     except Exception as err:
         _LOGGER.exception("HA-MCP in-process server: bring-up failed")
         with suppress(Exception):
             await async_teardown_server(hass)
         _create_issue(hass, "start", str(err))
+        _drop_pending_update_notify(hass)
 
 
 async def async_teardown_server(hass: HomeAssistant) -> None:
@@ -302,7 +310,7 @@ def _clear_issues(hass: HomeAssistant) -> None:
 
 
 async def async_maybe_auto_update(
-    hass: HomeAssistant, entry: ConfigEntry, info: ServerVersionInfo
+    hass: HomeAssistant, entry: ConfigEntry, info: ServerVersionInfo | None
 ) -> None:
     """Reload the entry when ``info`` shows a newer build AND auto-update is on.
 
@@ -357,7 +365,7 @@ async def async_maybe_auto_update(
     if not newer:
         return
 
-    channel = CHANNEL_DEV if info.dist == DIST_NAME_DEV else CHANNEL_STABLE
+    channel = channel_for_dist(info.dist)
     _LOGGER.info(
         "HA-MCP server update available on the %s channel (%s -> %s); "
         "reloading the entry to install it.",
@@ -365,19 +373,82 @@ async def async_maybe_auto_update(
         info.installed,
         info.latest,
     )
-    await hass.config_entries.async_reload(entry.entry_id)
-    _create_update_notification(hass, channel, info.installed, info.latest)
+    # The "updated" notification must wait for the reloaded entry's bring-up to
+    # actually install and start the new build — async_reload returns when
+    # entry SETUP finishes, while the pip install still runs in the background
+    # and can fail (review finding). Leave a marker for bring-up to pop:
+    # notification on success (_async_finish_update_cycle), silent drop on
+    # failure (the package/start repair issues cover that path).
+    hass.data.setdefault(DOMAIN, {})[DATA_PENDING_UPDATE_NOTIFY] = {
+        "old": info.installed
+    }
+    try:
+        await hass.config_entries.async_reload(entry.entry_id)
+    except Exception:
+        # A raising reload leaves no repair issue behind (those are filed by
+        # bring-up, which never ran), so this ERROR log is the only signal —
+        # it must not be swallowed or left at debug (review finding). The next
+        # coordinator refresh retries the whole cycle.
+        _drop_pending_update_notify(hass)
+        _LOGGER.exception(
+            "HA-MCP auto-update reload failed (%s -> %s on the %s channel)",
+            info.installed,
+            info.latest,
+            channel,
+        )
+
+
+def _drop_pending_update_notify(hass: HomeAssistant) -> None:
+    """Drop the deferred update-notification marker without notifying."""
+    hass.data.get(DOMAIN, {}).pop(DATA_PENDING_UPDATE_NOTIFY, None)
+
+
+async def _async_finish_update_cycle(hass: HomeAssistant) -> None:
+    """Refresh the version entity and fire the deferred update notification.
+
+    Runs at the end of a fully successful bring-up. Both halves belong exactly
+    here (review findings): the freshly installed version is only knowable once
+    the install landed — without a refresh the `update` entity keeps showing a
+    stale "update available" for up to UPDATE_CHECK_INTERVAL after a successful
+    install — and the notification deferred by async_maybe_auto_update must
+    only fire for an install that actually happened. Advisory: a failure here
+    must never fail the (already running) server, so it is logged visibly and
+    swallowed. No reload loop: the refresh's listener re-enters
+    async_maybe_auto_update, which no-ops on the still-running bring-up task.
+    """
+    domain_data = hass.data.get(DOMAIN, {})
+    coordinator = domain_data.get(DATA_UPDATE_COORDINATOR)
+    try:
+        if coordinator is not None:
+            await coordinator.async_refresh()
+    except Exception:
+        _LOGGER.warning("HA-MCP: post-install version refresh failed", exc_info=True)
+    marker = domain_data.pop(DATA_PENDING_UPDATE_NOTIFY, None)
+    if marker is None or coordinator is None or coordinator.data is None:
+        return
+    installed = coordinator.data.installed
+    old = marker.get("old")
+    if installed is None or installed == old:
+        # The reload ran but the installed version did not actually move (the
+        # install can legitimately resolve to the same build) — an "updated
+        # to" notification would be false.
+        return
+    _create_update_notification(
+        hass, channel_for_dist(coordinator.data.dist), old, installed
+    )
 
 
 def _create_update_notification(
     hass: HomeAssistant, channel: str, old_version: str, new_version: str
 ) -> None:
-    """Notify that an automatic server update just installed.
+    """Notify that an automatic server update installed and the server is up.
 
-    SECURITY: same posture as ``_surface_connect_urls`` - persistent
-    notifications are visible to every authenticated Home Assistant user, so
-    this carries no secrets or connect URLs, only version numbers and a public
-    GitHub link.
+    Only called from :func:`_async_finish_update_cycle` after a successful
+    bring-up, so the versions are the confirmed before/after pair, never a
+    prediction. SECURITY: same posture as ``_surface_connect_urls`` -
+    persistent notifications are visible to every authenticated Home Assistant
+    user, so this carries no secrets or connect URLs, only version numbers and
+    a public GitHub link.
     """
     release_url = (
         "https://github.com/homeassistant-ai/ha-mcp/commits/master"

--- a/custom_components/ha_mcp_tools/install_source_check.py
+++ b/custom_components/ha_mcp_tools/install_source_check.py
@@ -1,0 +1,110 @@
+"""Detect a legacy (main-repo) HACS install source and warn (issue #1760).
+
+Before the dedicated HACS mirror (``homeassistant-ai/ha-mcp-integration``)
+existed, the README told users to add the MAIN ``ha-mcp`` server repository as
+a HACS custom repository. Those installs still work — HACS downloads the repo
+snapshot at the release tag, which contains this component — but HACS shows
+the SERVER's version numbers (``7.x``) and the server/add-on release notes in
+the update dialog, as if the component were the server itself. HACS has no
+repository-migration mechanism, so this population stays confused forever
+unless the component itself detects the legacy source and points them at the
+mirror. The legacy install keeps working either way — this only files an
+advisory repair issue, never blocks anything.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, callback
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN, HACS_COMPONENT_URL, ISSUE_LEGACY_HACS_SOURCE
+
+if TYPE_CHECKING:
+    from homeassistant.core import Event, HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# The main server repo's full_name, as HACS's repository registry keys it —
+# the legacy (pre-mirror) install path this module detects.
+_LEGACY_REPO_FULL_NAME = "homeassistant-ai/ha-mcp"
+
+# Guards the schedule below so multiple config entries (tools + server) on the
+# same HA run only ever schedule the check once.
+_DATA_SCHEDULED = "install_source_check_scheduled"
+
+
+def async_schedule_install_source_check(hass: HomeAssistant) -> None:
+    """Schedule the legacy-HACS-source check to run once per Home Assistant run.
+
+    Deferred to (or past) Home Assistant startup rather than run at
+    component-setup time: HACS is a separate integration that may set up AFTER
+    this one on a fresh boot, so checking here directly would race it and could
+    misread a legitimate HACS-managed install as "no HACS" before HACS has
+    populated ``hass.data["hacs"]``. ``EVENT_HOMEASSISTANT_STARTED`` only fires
+    once every integration's config entries have finished setup, which is the
+    guarantee this check needs. When hass has already reached that point (a
+    config entry added or reloaded after startup), the event has already fired
+    and never will again this run, so the check runs immediately instead.
+
+    Guarded by a once-flag in ``hass.data[DOMAIN]``: both entry types call this
+    on setup, and this must run at most once per HA run.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get(_DATA_SCHEDULED):
+        return
+    domain_data[_DATA_SCHEDULED] = True
+
+    if hass.state == CoreState.running:
+        hass.async_create_task(
+            _async_check_install_source(hass), f"{DOMAIN}_install_source_check"
+        )
+        return
+
+    @callback
+    def _on_started(_event: Event) -> None:
+        hass.async_create_task(
+            _async_check_install_source(hass), f"{DOMAIN}_install_source_check"
+        )
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _on_started)
+
+
+async def _async_check_install_source(hass: HomeAssistant) -> None:
+    """File/clear the legacy-HACS-source repair issue.
+
+    Wraps the entire HACS interaction in a broad except: HACS is a third-party
+    integration whose internals this reaches into directly (no public API
+    exists for "what repository is this component tracking"), so any shape
+    change there must degrade to a warning log rather than break Home
+    Assistant. Advisory only — a failure changes nothing in the issue registry.
+    """
+    try:
+        hacs = hass.data.get("hacs")
+        installed = False
+        if hacs is not None:
+            repo = hacs.repositories.get_by_full_name(_LEGACY_REPO_FULL_NAME)
+            installed = repo is not None and bool(repo.data.installed)
+    except Exception:
+        _LOGGER.warning(
+            "HA-MCP: could not determine the HACS install source", exc_info=True
+        )
+        return
+
+    if installed:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            ISSUE_LEGACY_HACS_SOURCE,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_LEGACY_HACS_SOURCE,
+            learn_more_url=HACS_COMPONENT_URL,
+        )
+    else:
+        # Not installed via the legacy repo (including: no HACS at all, e.g. a
+        # manual install) — clear any issue filed before the user migrated.
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_LEGACY_HACS_SOURCE)

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "0.15.0"
+    "version": "1.0.0"
 }

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "0.14.1"
+    "version": "0.15.0"
 }

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -73,6 +73,10 @@
         "component_outdated": {
             "title": "Update the HA-MCP Custom Component via HACS",
             "description": "The installed ha-mcp server requires HA-MCP Custom Component {required} or newer, but you have {installed}. Update the component via HACS and restart Home Assistant. The server keeps running in the meantime, but some newer features may not work until the component is updated."
+        },
+        "legacy_hacs_source": {
+            "title": "Component installed from the legacy repository",
+            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (0.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
         }
     },
     "selector": {
@@ -86,6 +90,13 @@
             "options": {
                 "none": "Secret webhook URL (default)",
                 "ha_auth": "Sign in with Home Assistant (OAuth)"
+            }
+        }
+    },
+    "entity": {
+        "update": {
+            "server_update": {
+                "name": "Update"
             }
         }
     }

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -76,7 +76,7 @@
         },
         "legacy_hacs_source": {
             "title": "Component installed from the legacy repository",
-            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (0.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
+            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (1.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
         }
     },
     "selector": {

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -73,6 +73,10 @@
         "component_outdated": {
             "title": "Update the HA-MCP Custom Component via HACS",
             "description": "The installed ha-mcp server requires HA-MCP Custom Component {required} or newer, but you have {installed}. Update the component via HACS and restart Home Assistant. The server keeps running in the meantime, but some newer features may not work until the component is updated."
+        },
+        "legacy_hacs_source": {
+            "title": "Component installed from the legacy repository",
+            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (0.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
         }
     },
     "selector": {
@@ -86,6 +90,13 @@
             "options": {
                 "none": "Secret webhook URL (default)",
                 "ha_auth": "Sign in with Home Assistant (OAuth)"
+            }
+        }
+    },
+    "entity": {
+        "update": {
+            "server_update": {
+                "name": "Update"
             }
         }
     }

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -76,7 +76,7 @@
         },
         "legacy_hacs_source": {
             "title": "Component installed from the legacy repository",
-            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (0.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
+            "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (1.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."
         }
     },
     "selector": {

--- a/custom_components/ha_mcp_tools/update.py
+++ b/custom_components/ha_mcp_tools/update.py
@@ -1,0 +1,182 @@
+"""Update platform for the in-process server package (issue #1760).
+
+Exposes one ``update`` entity per "server" config entry for the ha-mcp server
+package it runs in-process, backed by :class:`~.coordinator.ServerVersionCoordinator`.
+The entity stays populated whether or not automatic updates are on - see the
+coordinator's docstring for why.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from awesomeversion import AwesomeVersion, AwesomeVersionException
+from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DATA_PENDING_INSTALL_VERSION,
+    DATA_UPDATE_COORDINATOR,
+    DEFAULT_AUTO_UPDATE,
+    DIST_NAME_DEV,
+    DOMAIN,
+    OPT_AUTO_UPDATE,
+)
+from .coordinator import ServerVersionCoordinator
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+# GitHub releases API for the release-notes surface (stable channel only - the
+# dev channel has no tagged releases, see release_url / supported_features).
+_RELEASES_URL = (
+    "https://api.github.com/repos/homeassistant-ai/ha-mcp/releases?per_page=30"
+)
+_RELEASE_NOTES_TIMEOUT_SECONDS = 15
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Add the single server-package update entity for this config entry."""
+    coordinator: ServerVersionCoordinator = hass.data[DOMAIN][DATA_UPDATE_COORDINATOR]
+    async_add_entities([ServerUpdateEntity(coordinator, entry)])
+
+
+class ServerUpdateEntity(CoordinatorEntity[ServerVersionCoordinator], UpdateEntity):
+    """Update entity for the ha-mcp server package the "server" entry runs."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "server_update"
+
+    def __init__(
+        self, coordinator: ServerVersionCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Bind to the coordinator and the owning config entry."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_server_update"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Group under one device per config entry; sw_version = installed."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name="HA-MCP Server",
+            manufacturer="homeassistant-ai",
+            model="ha-mcp (in-process server)",
+            sw_version=self.installed_version,
+            configuration_url="https://github.com/homeassistant-ai/ha-mcp",
+        )
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the installed server-package version, or None if unknown."""
+        data = self.coordinator.data
+        return data.installed if data is not None else None
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the newest PyPI version, or None if unknown/unresolvable."""
+        data = self.coordinator.data
+        return data.latest if data is not None else None
+
+    @property
+    def auto_update(self) -> bool:
+        """Reflect the entry's automatic-update option."""
+        return bool(self._entry.options.get(OPT_AUTO_UPDATE, DEFAULT_AUTO_UPDATE))
+
+    @property
+    def release_url(self) -> str | None:
+        """Stable: the tagged GitHub release. Dev: the commit history (no tags)."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        if data.dist == DIST_NAME_DEV:
+            return "https://github.com/homeassistant-ai/ha-mcp/commits/master"
+        if data.latest is None:
+            return None
+        return f"https://github.com/homeassistant-ai/ha-mcp/releases/tag/v{data.latest}"
+
+    @property
+    def supported_features(self) -> UpdateEntityFeature:
+        """RELEASE_NOTES only on the stable channel — dev builds have no tags."""
+        features = UpdateEntityFeature.INSTALL
+        data = self.coordinator.data
+        if data is not None and data.dist != DIST_NAME_DEV:
+            features |= UpdateEntityFeature.RELEASE_NOTES
+        return features
+
+    async def async_release_notes(self) -> str | None:
+        """Concatenate GitHub release bodies between installed and latest.
+
+        Advisory-only (same reasoning as embedded_setup's
+        _async_check_component_compat): a GitHub fetch failure, rate limit, or
+        unexpected payload shape must degrade to None - the UI then falls back
+        to :attr:`release_url` - rather than break the update dialog.
+        """
+        data = self.coordinator.data
+        if data is None or data.installed is None or data.latest is None:
+            return None
+
+        try:
+            installed = AwesomeVersion(data.installed)
+            latest = AwesomeVersion(data.latest)
+            session = async_get_clientsession(self.hass)
+            async with asyncio.timeout(_RELEASE_NOTES_TIMEOUT_SECONDS):
+                async with session.get(_RELEASES_URL) as resp:
+                    resp.raise_for_status()
+                    releases = await resp.json()
+
+            notes: list[tuple[AwesomeVersion, str]] = []
+            for release in releases:
+                tag = str(release.get("tag_name") or "").removeprefix("v")
+                try:
+                    version = AwesomeVersion(tag)
+                except AwesomeVersionException:
+                    continue
+                if installed < version <= latest:
+                    notes.append((version, str(release.get("body") or "")))
+        except Exception as err:
+            _LOGGER.debug("HA-MCP release-notes fetch failed: %s", err)
+            return None
+
+        if not notes:
+            return None
+        notes.sort(key=lambda item: item[0], reverse=True)
+        return "\n\n---\n\n".join(body for _, body in notes)
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Reinstall pinned to ``version`` (or the latest known build).
+
+        With auto-update off, ``_resolve_pip_spec`` pins the install to the
+        currently-installed version, so a bare reload would just reinstall the
+        same build. The one-shot pending-install marker overrides that pin for
+        this single reload; embedded_server clears it once the install lands.
+        """
+        target = version or self.latest_version
+        if target is None:
+            raise HomeAssistantError("No target version available to install.")
+        # Broad except is intentional here (unlike this repo's usual narrow
+        # convention): async_install feeds Home Assistant's update UI, which
+        # expects a HomeAssistantError for ANY failure rather than an opaque
+        # traceback in the install dialog.
+        try:
+            new_data = {**self._entry.data, DATA_PENDING_INSTALL_VERSION: target}
+            self.hass.config_entries.async_update_entry(self._entry, data=new_data)
+            await self.hass.config_entries.async_reload(self._entry.entry_id)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Could not install the HA-MCP server update: {err}"
+            ) from err

--- a/custom_components/ha_mcp_tools/update.py
+++ b/custom_components/ha_mcp_tools/update.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientError
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.exceptions import HomeAssistantError
@@ -20,6 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    DATA_BRINGUP_TASK,
     DATA_PENDING_INSTALL_VERSION,
     DATA_UPDATE_COORDINATOR,
     DEFAULT_AUTO_UPDATE,
@@ -28,6 +30,7 @@ from .const import (
     OPT_AUTO_UPDATE,
 )
 from .coordinator import ServerVersionCoordinator
+from .embedded_server import _installed_dist_version
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -146,8 +149,17 @@ class ServerUpdateEntity(CoordinatorEntity[ServerVersionCoordinator], UpdateEnti
                     continue
                 if installed < version <= latest:
                     notes.append((version, str(release.get("body") or "")))
-        except Exception as err:
+        except (ClientError, TimeoutError) as err:
+            # Expected transients (GitHub unreachable, rate-limited, slow) —
+            # quiet; the dialog falls back to release_url.
             _LOGGER.debug("HA-MCP release-notes fetch failed: %s", err)
+            return None
+        except Exception:
+            # An unexpected payload shape (TypeError/AttributeError in the
+            # parse loop) is a bug or a GitHub API change — logged visibly per
+            # the repo's convention (review finding), still degrading to the
+            # release_url fallback rather than breaking the update dialog.
+            _LOGGER.warning("HA-MCP release-notes fetch failed", exc_info=True)
             return None
 
         if not notes:
@@ -163,20 +175,48 @@ class ServerUpdateEntity(CoordinatorEntity[ServerVersionCoordinator], UpdateEnti
         With auto-update off, ``_resolve_pip_spec`` pins the install to the
         currently-installed version, so a bare reload would just reinstall the
         same build. The one-shot pending-install marker overrides that pin for
-        this single reload; embedded_server clears it once the install lands.
+        this single reload; embedded_server clears it when it consumes it (one
+        marker buys one attempt). The reload only completes entry SETUP — the
+        pip install runs in the reloaded entry's background bring-up — so this
+        waits for that bring-up and verifies the requested version actually
+        landed; returning at reload time would report success for an install
+        that can still fail (review finding).
         """
+        data = self.coordinator.data
         target = version or self.latest_version
         if target is None:
             raise HomeAssistantError("No target version available to install.")
         # Broad except is intentional here (unlike this repo's usual narrow
         # convention): async_install feeds Home Assistant's update UI, which
         # expects a HomeAssistantError for ANY failure rather than an opaque
-        # traceback in the install dialog.
+        # traceback in the install dialog. Logged with traceback first so a
+        # genuine bug still reaches the log (review finding).
         try:
             new_data = {**self._entry.data, DATA_PENDING_INSTALL_VERSION: target}
             self.hass.config_entries.async_update_entry(self._entry, data=new_data)
             await self.hass.config_entries.async_reload(self._entry.entry_id)
+            # The reloaded entry's bring-up task does the actual install; it
+            # contains its own failures (files repair issues instead of
+            # raising), so awaiting it tells us the attempt is over, not that
+            # it worked — the version read below is the success check.
+            bringup = self.hass.data.get(DOMAIN, {}).get(DATA_BRINGUP_TASK)
+            if bringup is not None:
+                await bringup
+            installed: str | None = None
+            if data is not None:
+                installed = await self.hass.async_add_executor_job(
+                    _installed_dist_version, data.dist
+                )
         except Exception as err:
+            _LOGGER.exception("HA-MCP server update install failed")
             raise HomeAssistantError(
                 f"Could not install the HA-MCP server update: {err}"
             ) from err
+        # Outside the broad except: these raises must reach the UI as-is, not
+        # get re-wrapped into the generic message.
+        if data is not None and installed != target:
+            raise HomeAssistantError(
+                f"The HA-MCP server update to {target} did not complete "
+                f"(installed: {installed or 'none'}). See Settings > Repairs "
+                "for the failure details."
+            )

--- a/docs/in-process-server.md
+++ b/docs/in-process-server.md
@@ -119,7 +119,7 @@ Configure there just reports that.)
 | Option | Default | What it does |
 |--------|---------|--------------|
 | **Release channel** | `stable` | `stable` installs the latest stable release; `dev` installs the latest development build. Both channels update automatically (a reload or restart, plus a periodic check, install the newest build of the selected channel). See [Release channels](#release-channels). |
-| **Automatic server updates** | on | When on, the selected channel's newest release is installed automatically (on reload/restart and via a periodic check). When off, the server stays on the version currently installed until you turn this back on. Governs the ha-mcp **server package** only — component updates still come through HACS. A package override below overrides this. |
+| **Automatic server updates** | on | When on, the selected channel's newest release is installed automatically (on reload/restart and via a periodic check). When off, the server stays on the version currently installed — new releases are still offered on the server's update entity, and its **Install** button installs one without turning automatic updates back on. Governs the ha-mcp **server package** only — component updates still come through HACS. A package override below overrides this. |
 | **Server port** | `9584` | Local TCP port the server listens on. `9584` avoids the add-on's `9583` so an existing add-on install does not conflict. |
 | **Network access** | `0.0.0.0` | The default matches the add-on: the port is reachable on your LAN with the secret path as the credential. `127.0.0.1` restricts direct access to the Home Assistant machine (the webhook and panel work either way). |
 | **Webhook authentication** | `none` | `none`: the secret webhook URL is the credential. `ha_auth`: clients sign in with your Home Assistant account. See [Security](#security). |
@@ -146,13 +146,24 @@ unpinned: an entry reload or a Home Assistant restart always reinstalls the
 newest build of the selected channel, and on top of that the component checks
 PyPI for a newer build every 6 hours and reloads the entry automatically when
 one is published — so a long-running instance picks up releases without a
-restart. Turn **Automatic server updates** off to freeze the server on the
-version currently installed: the periodic check stops and reloads/restarts keep
-that exact version until you turn it back on (this governs the server package
+restart. Each automatic update also raises a notification naming the old and
+new version, with a link to the release notes. Turn **Automatic server
+updates** off to freeze the server on the version currently installed:
+reloads/restarts keep that exact version until you turn it back on or install
+a newer build yourself from the update entity (this governs the server package
 only — component updates still arrive through HACS). Setting the **ha-mcp
 package (advanced)** field overrides the channel entirely (pin a version, or
 install from a URL for pre-release testing) and also disables automatic updates
 until you clear it.
+
+The server's version is always visible on its **update entity**, under
+**Settings → Devices & Services → HA-MCP Custom Component → HA-MCP Server**
+(and under **Settings → System → Updates** whenever an update is available).
+The entity shows the installed and latest version of the selected channel and
+links the release notes — the 6-hour PyPI check keeps it populated even with
+automatic updates off, where its **Install** button installs the offered
+version on your schedule. The server (`7.x`) and the component (`1.x`) are
+versioned independently: this entity and HACS each own one of the two numbers.
 
 Switching channels reinstalls the server from the other channel on the next
 reload. `ha-mcp` and `ha-mcp-dev` share the same import package, so the previous
@@ -163,6 +174,16 @@ one you have (HACS can deliver a server build before you update the component),
 a repair issue titled **Update the HA-MCP Custom Component via HACS** appears
 under **Settings → Repairs** with a link to the HACS update. The server keeps
 running; update the component via HACS to clear it.
+
+If the component was installed from the legacy location — the main `ha-mcp`
+server repository added directly as a HACS custom repository, before the
+dedicated [`ha-mcp-integration`](https://github.com/homeassistant-ai/ha-mcp-integration)
+mirror existed — a repair issue titled **Component installed from the legacy
+repository** appears. Such an install keeps working, but HACS displays the
+server's `7.x` version numbers and the server's release notes for the
+component. Follow the issue's link to add the mirror in HACS and reinstall the
+component from it (your settings and config entries are kept), then restart
+Home Assistant; the issue clears itself afterwards.
 
 ### Local-only mode
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "HA-MCP Custom Component",
-  "homeassistant": "2024.1.0",
+  "homeassistant": "2024.11.0",
   "render_readme": true
 }

--- a/scripts/build_mirror_release_notes.py
+++ b/scripts/build_mirror_release_notes.py
@@ -1,0 +1,174 @@
+"""Generate release notes for a homeassistant-ai/ha-mcp-integration mirror tag.
+
+The mirror's release-on-tag workflow turns each pushed tag into a GitHub
+release, but the deploy key that pushes the tag cannot call the GitHub API
+to set a rich release body -- so the body has to travel inside the annotated
+tag message itself. This script produces that message: a summary of what
+changed in the HACS custom component (custom_components/ha_mcp_tools/) since
+the previous stable server release, so HACS shows real release notes instead
+of a generic stub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Main repo's stable release tags look like v7.10.0; dev tags append
+# ".devN" (e.g. v7.10.0.dev778) and the floating "stable" tag isn't a
+# vX.Y.Z tag at all -- both must be excluded from stable-tag selection.
+_STABLE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+# Commit subjects that touch custom_components/ha_mcp_tools/ only
+# incidentally, via merge/publish mechanics -- not real component changes,
+# so they'd just be noise in release notes.
+_NOISE_SUBJECT_PREFIXES = ("chore(addon): publish dev addon version",)
+
+_CHANGELOG_URL = "https://github.com/homeassistant-ai/ha-mcp/releases"
+
+_COMPONENT_PATH = "custom_components/ha_mcp_tools/"
+
+
+def _stable_version_key(tag: str) -> tuple[int, int, int]:
+    """Numeric sort key for a stable tag, e.g. 'v7.10.0' -> (7, 10, 0)."""
+    match = _STABLE_TAG_RE.match(tag)
+    assert match, f"not a stable tag: {tag}"
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def select_stable_tags(tags: list[str]) -> tuple[str | None, str]:
+    """Pick the two newest stable server release tags as (prev, curr).
+
+    Filters to tags matching vX.Y.Z (excludes dev tags like
+    'v7.10.0.dev778' and the floating 'stable' tag) and sorts numerically --
+    a lexical sort would put 'v7.10.0' before 'v7.9.0'. Returns (None, curr)
+    when only one stable tag exists (the first-ever stable release).
+    """
+    stable = sorted(
+        (tag for tag in tags if _STABLE_TAG_RE.match(tag)), key=_stable_version_key
+    )
+    if not stable:
+        raise ValueError("no stable tags (vX.Y.Z) found")
+    if len(stable) == 1:
+        return None, stable[0]
+    return stable[-2], stable[-1]
+
+
+def _filter_noise_subjects(subjects: list[str]) -> list[str]:
+    """Drop commit subjects that are automation noise, not component changes."""
+    return [s for s in subjects if not s.startswith(_NOISE_SUBJECT_PREFIXES)]
+
+
+def format_release_notes(
+    component_version: str,
+    prev_tag: str | None,
+    curr_tag: str,
+    subjects: list[str],
+) -> str:
+    """Render the mirror tag's annotated-tag message as markdown.
+
+    `subjects` are commit subject lines touching custom_components/ha_mcp_tools/
+    in the range (prev_tag, curr_tag] of the main repo. `curr_tag` names the
+    server release this notes body was generated from; `component_version` is
+    the mirror's own tag version (the two numbering schemes are unrelated).
+    """
+    subjects = _filter_noise_subjects(subjects)
+    lines = [f"## ha-mcp-tools {component_version}", ""]
+
+    if prev_tag is None:
+        lines.append("Initial component release.")
+    else:
+        lines.append(f"Synced from ha-mcp {curr_tag}.")
+    lines.append("")
+
+    if subjects:
+        since = prev_tag if prev_tag is not None else "this component's introduction"
+        lines.append(f"Component changes since {since}:")
+        lines.extend(f"- {subject}" for subject in subjects)
+    else:
+        lines.append(
+            "Component snapshot resync -- no changes to "
+            f"{_COMPONENT_PATH} in this server release."
+        )
+
+    lines.append("")
+    lines.append(f"Full server changelog: {_CHANGELOG_URL}")
+    return "\n".join(lines) + "\n"
+
+
+def _run_git(args: list[str], repo_dir: Path) -> str:
+    """Run a git command in repo_dir, returning stripped stdout.
+
+    Raises RuntimeError with git's stderr so callers surface an actionable
+    message instead of a bare CalledProcessError traceback.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def discover_stable_tags(repo_dir: Path) -> tuple[str | None, str]:
+    """Find the two newest stable server release tags in repo_dir."""
+    output = _run_git(["tag", "-l", "v*"], repo_dir)
+    tags = output.splitlines() if output else []
+    return select_stable_tags(tags)
+
+
+def collect_component_subjects(
+    prev_tag: str | None, curr_tag: str, repo_dir: Path
+) -> list[str]:
+    """Commit subjects touching custom_components/ha_mcp_tools/ in (prev_tag, curr_tag]."""
+    range_arg = curr_tag if prev_tag is None else f"{prev_tag}..{curr_tag}"
+    output = _run_git(
+        ["log", "--format=%s", range_arg, "--", _COMPONENT_PATH], repo_dir
+    )
+    return output.splitlines() if output else []
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--component-version",
+        required=True,
+        help="Version from custom_components/ha_mcp_tools/manifest.json",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Destination path for the generated release notes",
+    )
+    parser.add_argument(
+        "--repo-dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Main repository checkout (defaults to cwd)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        prev_tag, curr_tag = discover_stable_tags(args.repo_dir)
+        subjects = collect_component_subjects(prev_tag, curr_tag, args.repo_dir)
+    except (RuntimeError, ValueError) as e:
+        print(f"build_mirror_release_notes: {e}", file=sys.stderr)
+        return 1
+
+    notes = format_release_notes(args.component_version, prev_tag, curr_tag, subjects)
+    args.out.write_text(notes, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/src/unit/_embedded_stubs.py
+++ b/tests/src/unit/_embedded_stubs.py
@@ -22,6 +22,7 @@ chunks without a real event loop.
 
 from __future__ import annotations
 
+import enum
 import sys
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -113,6 +114,135 @@ class AwesomeVersionException(Exception):
 
 GROUP_ID_ADMIN = "system-admin"
 TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN = "long_lived_access_token"
+
+
+class HomeAssistantError(Exception):
+    """Stand-in for ``homeassistant.exceptions.HomeAssistantError``."""
+
+
+class Platform(enum.StrEnum):
+    """Stand-in for ``homeassistant.const.Platform`` (only UPDATE is needed)."""
+
+    UPDATE = "update"
+
+
+class CoreState(enum.StrEnum):
+    """Stand-in for ``homeassistant.core.CoreState`` (issue #1760 install-source
+    check gates on ``hass.state == CoreState.running``)."""
+
+    not_running = "NOT_RUNNING"
+    starting = "STARTING"
+    running = "RUNNING"
+    stopping = "STOPPING"
+    final_write = "FINAL_WRITE"
+    stopped = "STOPPED"
+
+
+EVENT_HOMEASSISTANT_STARTED = "homeassistant_started"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator / update-entity fakes (issue #1760)
+# ---------------------------------------------------------------------------
+
+
+class UpdateFailed(Exception):
+    """Stand-in for ``homeassistant.helpers.update_coordinator.UpdateFailed``."""
+
+
+class DataUpdateCoordinator[CoordinatorDataT]:
+    """Minimal stand-in for HA's ``DataUpdateCoordinator``.
+
+    Implements just enough for the coordinator/entry unit tests: ``async_refresh``
+    calls ``_async_update_data``, stores the result in ``.data``, and notifies
+    listeners — mirroring real HA's broad "swallow, log, don't raise" handling of
+    a failed update. Does not implement the internal scheduling/debounce
+    machinery (``_schedule_refresh``, auth-failure handling); the tests exercise
+    this component's own scheduling decisions, not HA's coordinator internals.
+    """
+
+    def __init__(
+        self,
+        hass: Any,
+        logger: Any,
+        *,
+        name: str,
+        update_interval: Any = None,
+        config_entry: Any = None,
+    ) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.config_entry = config_entry
+        self.data: Any = None
+        self.last_update_success = True
+        self.last_exception: BaseException | None = None
+        self._listeners: dict[Any, tuple[Any, Any]] = {}
+
+    async def _async_update_data(self) -> Any:
+        raise NotImplementedError
+
+    async def async_refresh(self) -> None:
+        try:
+            self.data = await self._async_update_data()
+        except Exception as err:  # matches real HA's broad catch-and-log
+            self.last_exception = err
+            self.last_update_success = False
+            self.logger.exception("Error fetching %s data", self.name)
+        else:
+            self.last_update_success = True
+        self.async_update_listeners()
+
+    async def async_config_entry_first_refresh(self) -> None:
+        await self.async_refresh()
+
+    def async_add_listener(self, update_callback: Any, context: Any = None) -> Any:
+        def remove_listener() -> None:
+            self._listeners.pop(remove_listener, None)
+
+        self._listeners[remove_listener] = (update_callback, context)
+        return remove_listener
+
+    def async_update_listeners(self) -> None:
+        for update_callback, _ctx in list(self._listeners.values()):
+            update_callback()
+
+
+class CoordinatorEntity[CoordinatorDataT]:
+    """Minimal stand-in for HA's ``CoordinatorEntity``."""
+
+    def __init__(self, coordinator: Any, context: Any = None) -> None:
+        self.coordinator = coordinator
+        self.hass = getattr(coordinator, "hass", None)
+
+    @property
+    def available(self) -> bool:
+        return bool(getattr(self.coordinator, "last_update_success", True))
+
+    async def async_added_to_hass(self) -> None:
+        return None
+
+    def async_on_remove(self, func: Any) -> None:
+        return None
+
+
+class UpdateEntityFeature(enum.IntFlag):
+    """Stand-in for ``homeassistant.components.update.UpdateEntityFeature``."""
+
+    INSTALL = 1
+    SPECIFIC_VERSION = 2
+    PROGRESS = 4
+    BACKUP = 8
+    RELEASE_NOTES = 16
+
+
+class UpdateEntity:
+    """Minimal stand-in for ``homeassistant.components.update.UpdateEntity``."""
+
+    _attr_has_entity_name = False
+    _attr_translation_key: str | None = None
+    _attr_unique_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +365,13 @@ def install() -> None:
     ):
         sys.modules.setdefault(generic, MagicMock())
 
+    # `callback` must be a real identity decorator, not a bare MagicMock's
+    # auto-generated (still-callable, but behavior-less) child attribute:
+    # embedded_entry decorates a real closure with it and needs that exact
+    # function back. Safe to set unconditionally — the only other module that
+    # configures this (test_config_flow.py) uses the same identity function.
+    sys.modules["homeassistant.core"].callback = lambda func: func
+
     # Specific-shape modules the embedded chain imports. Not stubbed by any
     # other unit-test module, so a direct assignment is safe.
     setmod("homeassistant.auth", const=None, models=None)
@@ -348,6 +485,31 @@ def install() -> None:
             name="async_setup_component", return_value=True
         ),
     )
+    setmod("homeassistant.exceptions", HomeAssistantError=HomeAssistantError)
+    setmod(
+        "homeassistant.const",
+        Platform=Platform,
+        EVENT_HOMEASSISTANT_STARTED=EVENT_HOMEASSISTANT_STARTED,
+    )
+    # CoreState alongside the earlier `callback` fix: a bare MagicMock's
+    # auto-generated attribute would not be a stable, comparable enum, and the
+    # install-source-check gates on `hass.state == CoreState.running` (#1760).
+    sys.modules["homeassistant.core"].CoreState = CoreState
+    # Update-entity chain (issue #1760): coordinator.py / update.py.
+    setmod(
+        "homeassistant.helpers.update_coordinator",
+        DataUpdateCoordinator=DataUpdateCoordinator,
+        CoordinatorEntity=CoordinatorEntity,
+        UpdateFailed=UpdateFailed,
+    )
+    setmod(
+        "homeassistant.components.update",
+        UpdateEntity=UpdateEntity,
+        UpdateEntityFeature=UpdateEntityFeature,
+    )
+    # DeviceInfo is a TypedDict at runtime (a plain dict constructor) — a bare
+    # dict is a behavior-identical stand-in.
+    setmod("homeassistant.helpers.device_registry", DeviceInfo=dict)
 
     aiohttp_mod = _make_fake_aiohttp()
     sys.modules["aiohttp"] = aiohttp_mod

--- a/tests/src/unit/test_build_mirror_release_notes.py
+++ b/tests/src/unit/test_build_mirror_release_notes.py
@@ -1,0 +1,95 @@
+"""Unit tests for scripts/build_mirror_release_notes.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts" / "build_mirror_release_notes.py"
+)
+_spec = importlib.util.spec_from_file_location("build_mirror_release_notes", _SCRIPT)
+assert _spec and _spec.loader
+build = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build)
+
+CHANGELOG_URL = "https://github.com/homeassistant-ai/ha-mcp/releases"
+
+
+def test_format_release_notes_lists_subjects_as_bullets() -> None:
+    notes = build.format_release_notes(
+        "0.15.0",
+        "v7.9.0",
+        "v7.10.0",
+        ["feat: add foo tool (#100)", "fix: bar crash (#101)"],
+    )
+    assert "0.15.0" in notes
+    assert "- feat: add foo tool (#100)" in notes
+    assert "- fix: bar crash (#101)" in notes
+    assert "Component changes since v7.9.0:" in notes
+    assert CHANGELOG_URL in notes
+
+
+def test_format_release_notes_version_appears_in_lead() -> None:
+    notes = build.format_release_notes("0.15.0", "v7.9.0", "v7.10.0", [])
+    assert notes.startswith("## ha-mcp-tools 0.15.0")
+
+
+def test_format_release_notes_empty_subjects_is_honest_not_blank() -> None:
+    notes = build.format_release_notes("0.15.0", "v7.9.0", "v7.10.0", [])
+    assert not any(line.startswith("- ") for line in notes.splitlines())
+    assert "no changes to" in notes
+    assert "custom_components/ha_mcp_tools/" in notes
+    assert CHANGELOG_URL in notes
+
+
+def test_format_release_notes_prev_none_is_initial_release() -> None:
+    notes = build.format_release_notes(
+        "0.1.0", None, "v7.1.0", ["feat: first cut of the component"]
+    )
+    assert "Initial component release." in notes
+    assert "- feat: first cut of the component" in notes
+    # No prior tag to name -- must not print "since None".
+    assert "since None" not in notes
+
+
+def test_format_release_notes_filters_noise_subjects() -> None:
+    notes = build.format_release_notes(
+        "0.15.0",
+        "v7.9.0",
+        "v7.10.0",
+        [
+            "feat: real component change",
+            "chore(addon): publish dev addon version 7.10.0.dev481 [skip ci]",
+        ],
+    )
+    assert "- feat: real component change" in notes
+    assert "publish dev addon version" not in notes
+
+
+def test_select_stable_tags_filters_dev_and_stable_pointer() -> None:
+    tags = ["v7.9.0", "v7.9.0.dev759", "v7.10.0.dev772", "v7.10.0", "stable"]
+    prev, curr = build.select_stable_tags(tags)
+    assert prev == "v7.9.0"
+    assert curr == "v7.10.0"
+
+
+def test_select_stable_tags_sorts_numerically_not_lexically() -> None:
+    # Lexical sort would put "v7.10.0" before "v7.9.0".
+    tags = ["v7.10.0", "v7.9.0", "v7.2.0"]
+    prev, curr = build.select_stable_tags(tags)
+    assert prev == "v7.9.0"
+    assert curr == "v7.10.0"
+
+
+def test_select_stable_tags_single_tag_returns_none_prev() -> None:
+    prev, curr = build.select_stable_tags(["v7.1.0"])
+    assert prev is None
+    assert curr == "v7.1.0"
+
+
+def test_select_stable_tags_raises_on_no_stable_tags() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        build.select_stable_tags(["v7.1.0.dev1", "stable"])

--- a/tests/src/unit/test_coordinator.py
+++ b/tests/src/unit/test_coordinator.py
@@ -120,6 +120,26 @@ class TestUpdateData:
         assert session.get_urls == [coord.PYPI_JSON_URL.format(dist=DIST_NAME_DEV)]
         assert info.dist == DIST_NAME_DEV
 
+    async def test_options_re_read_on_every_refresh(self, monkeypatch):
+        # entry.options is read fresh inside _async_update_data on every call
+        # (not cached at __init__/construction time) - a channel switch made
+        # between two refreshes must be picked up by the very next one.
+        hass = _make_hass()
+        entry = _make_entry()
+        session = _FakeSession(
+            _FakeResp({"info": {"version": "7.10.0"}}),
+        )
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.9.0")
+        coordinator = coord.ServerVersionCoordinator(hass, entry)
+
+        first = await coordinator._async_update_data()
+        entry.options[OPT_CHANNEL] = CHANNEL_DEV
+        second = await coordinator._async_update_data()
+
+        assert first.dist == DIST_NAME_STABLE
+        assert second.dist == DIST_NAME_DEV
+
     async def test_not_installed_yet_still_fetches_latest(self, monkeypatch):
         # Visibility must not depend on the package being installed yet - the
         # entity should show "latest available" even before the first install.

--- a/tests/src/unit/test_coordinator.py
+++ b/tests/src/unit/test_coordinator.py
@@ -1,0 +1,186 @@
+"""Unit tests for :class:`ServerVersionCoordinator` (issue #1760).
+
+Covers channel/dist selection, the PyPI-latest fetch (moved here from the old
+``embedded_setup.async_check_for_update``), and the pip-spec-override skip.
+Home Assistant / aiohttp are stubbed via ``_embedded_stubs``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ._embedded_stubs import install
+
+install()
+
+import custom_components.ha_mcp_tools.coordinator as coord  # noqa: E402
+from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    CHANNEL_DEV,
+    DEFAULT_PIP_SPEC,
+    DIST_NAME_DEV,
+    DIST_NAME_STABLE,
+    OPT_CHANNEL,
+    OPT_PIP_SPEC,
+    UPDATE_CHECK_INTERVAL,
+)
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock(name="hass")
+
+    async def _executor(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=_executor)
+    return hass
+
+
+def _make_entry(*, options=None) -> MagicMock:
+    entry = MagicMock(name="entry")
+    entry.options = {} if options is None else dict(options)
+    entry.data = {}
+    entry.entry_id = "entry-1"
+    return entry
+
+
+class _FakeResp:
+    """aiohttp response stand-in: an async context manager with json/raise."""
+
+    def __init__(self, payload, *, raise_exc=None):
+        self._payload = payload
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """aiohttp ClientSession stand-in recording the URLs fetched."""
+
+    def __init__(self, resp):
+        self._resp = resp
+        self.get_urls: list[str] = []
+
+    def get(self, url):
+        self.get_urls.append(url)
+        return self._resp
+
+
+def _patch_session(monkeypatch, session):
+    monkeypatch.setattr(
+        coord, "async_get_clientsession", MagicMock(return_value=session)
+    )
+
+
+class TestConstruction:
+    def test_schedules_on_update_check_interval(self):
+        hass = _make_hass()
+        entry = _make_entry()
+        coordinator = coord.ServerVersionCoordinator(hass, entry)
+        assert coordinator.update_interval == UPDATE_CHECK_INTERVAL
+        assert coordinator.config_entry is entry
+
+
+class TestUpdateData:
+    async def test_stable_channel_fetches_stable_dist(self, monkeypatch):
+        hass = _make_hass()
+        entry = _make_entry()
+        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.9.0")
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        assert session.get_urls == [coord.PYPI_JSON_URL.format(dist=DIST_NAME_STABLE)]
+        assert info == coord.ServerVersionInfo(
+            installed="7.9.0", latest="7.10.0", dist=DIST_NAME_STABLE
+        )
+
+    async def test_dev_channel_fetches_dev_dist(self, monkeypatch):
+        hass = _make_hass()
+        entry = _make_entry(options={OPT_CHANNEL: CHANNEL_DEV})
+        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0.dev1"}}))
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.9.0.dev1")
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        assert session.get_urls == [coord.PYPI_JSON_URL.format(dist=DIST_NAME_DEV)]
+        assert info.dist == DIST_NAME_DEV
+
+    async def test_not_installed_yet_still_fetches_latest(self, monkeypatch):
+        # Visibility must not depend on the package being installed yet - the
+        # entity should show "latest available" even before the first install.
+        hass = _make_hass()
+        entry = _make_entry()
+        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: None)
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        assert info.installed is None
+        assert info.latest == "7.10.0"
+
+    async def test_override_skips_pypi_fetch(self, monkeypatch):
+        # An explicit pip-spec override makes a PyPI-latest comparison
+        # meaningless - no fetch at all, latest stays None.
+        hass = _make_hass()
+        entry = _make_entry(options={OPT_PIP_SPEC: "ha-mcp==7.8.0"})
+        get_session = MagicMock()
+        monkeypatch.setattr(coord, "async_get_clientsession", get_session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.8.0")
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        get_session.assert_not_called()
+        assert info == coord.ServerVersionInfo(
+            installed="7.8.0", latest=None, dist=DIST_NAME_STABLE
+        )
+
+    async def test_default_pip_spec_value_is_not_an_override(self, monkeypatch):
+        # The default pip-spec ("ha-mcp") stored verbatim still means "no
+        # override" - the fetch must run, not skip.
+        hass = _make_hass()
+        entry = _make_entry(options={OPT_PIP_SPEC: DEFAULT_PIP_SPEC})
+        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.9.0")
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        assert info.latest == "7.10.0"
+
+    @pytest.mark.parametrize(
+        "raise_exc",
+        [
+            coord.ClientError("boom"),
+            TimeoutError(),
+            KeyError("info"),
+            ValueError("bad json"),
+        ],
+    )
+    async def test_pypi_fetch_failure_returns_latest_none(self, monkeypatch, raise_exc):
+        hass = _make_hass()
+        entry = _make_entry()
+        resp = _FakeResp(None, raise_exc=raise_exc)
+        session = _FakeSession(resp)
+        _patch_session(monkeypatch, session)
+        monkeypatch.setattr(coord, "_installed_dist_version", lambda dist: "7.9.0")
+
+        info = await coord.ServerVersionCoordinator(hass, entry)._async_update_data()
+
+        assert info.installed == "7.9.0"
+        assert info.latest is None

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -20,7 +20,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", MagicMock())
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()

--- a/tests/src/unit/test_embedded_entry.py
+++ b/tests/src/unit/test_embedded_entry.py
@@ -1,20 +1,23 @@
-"""Unit tests for the server entry-point wiring (issue #1715 auto-update).
+"""Unit tests for the server entry-point wiring (issue #1760: update entity).
 
-Focuses on the periodic channel auto-update interval that
-``async_setup_server_entry`` registers: it must be scheduled on
-``UPDATE_CHECK_INTERVAL``, cleaned up on unload, and forward to
-``async_check_for_update``.
+Focuses on what ``async_setup_server_entry`` / ``async_unload_server_entry``
+wire up around the :class:`~.coordinator.ServerVersionCoordinator`: creating
+it with the right interval, registering its auto-update listener (as a
+background task, never a synchronous reload from inside the listener),
+kicking off an initial (non-blocking) refresh, and forwarding/unloading the
+``update`` platform.
 
 Home Assistant / aiohttp are stubbed via ``_embedded_stubs`` (imported first so
 the fakes are installed before the component module binds them). The lazily
-imported ``embedded_setup`` / ``ui_panel`` collaborators are replaced with fake
-modules so the entry-point wiring is exercised in isolation.
+imported ``embedded_setup`` / ``ui_panel`` / ``coordinator`` collaborators are
+replaced with fakes so the entry-point wiring is exercised in isolation.
 """
 
 from __future__ import annotations
 
+import asyncio
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -26,7 +29,9 @@ install()
 import custom_components.ha_mcp_tools.embedded_entry as eentry  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_SECRET_PATH,
+    DATA_UPDATE_COORDINATOR,
     DATA_WEBHOOK_ID,
+    DOMAIN,
     UPDATE_CHECK_INTERVAL,
 )
 
@@ -34,6 +39,21 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
 def _make_hass() -> MagicMock:
     hass = MagicMock(name="hass")
     hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    background_tasks: list[asyncio.Task] = []
+
+    def _create_bg_task(coro, name, eager_start=True):
+        # Mirrors HomeAssistant.async_create_background_task: schedule the
+        # coroutine so it actually runs (a bare MagicMock would leak it as a
+        # "was never awaited" warning and the drain helper would never see it).
+        task = asyncio.ensure_future(coro)
+        background_tasks.append(task)
+        return task
+
+    hass.async_create_background_task = MagicMock(side_effect=_create_bg_task)
+    hass.background_tasks = background_tasks
     return hass
 
 
@@ -44,29 +64,91 @@ def _make_entry() -> MagicMock:
     entry.entry_id = "entry-1"
     entry.async_on_unload = MagicMock()
     entry.add_update_listener = MagicMock(return_value=MagicMock(name="listener"))
-    # Non-coroutine so the (unused) bring-up arg never warns "never awaited".
-    entry.async_create_background_task = MagicMock()
+
+    background_tasks: list[asyncio.Task] = []
+
+    def _create_bg_task(hass, coro, name):
+        # Real ConfigEntry.async_create_background_task schedules the
+        # coroutine immediately; a bare MagicMock would instead leak it (an
+        # "was never awaited" warning) since nothing would ever run it. The
+        # fake bring-up coroutine below is a plain MagicMock return value (not
+        # a real coroutine), so it is left alone — same as before.
+        if asyncio.iscoroutine(coro):
+            task = asyncio.ensure_future(coro)
+            background_tasks.append(task)
+            return task
+        return MagicMock(name=f"bg_task:{name}")
+
+    entry.async_create_background_task = MagicMock(side_effect=_create_bg_task)
+    entry.background_tasks = background_tasks
     return entry
+
+
+async def _drain_background_tasks(hass, entry) -> None:
+    """Run every background task scheduled so far, including ones a still-
+    draining task schedules itself (the auto-update listener schedules its own
+    hass-owned background task from inside the entry-owned initial-refresh
+    task — hence draining BOTH pools)."""
+    seen: set[asyncio.Task] = set()
+    while True:
+        pending = [
+            t
+            for t in (*entry.background_tasks, *hass.background_tasks)
+            if t not in seen
+        ]
+        if not pending:
+            break
+        seen.update(pending)
+        await asyncio.gather(*pending)
+
+
+class _FakeCoordinator:
+    """Real (non-Mock) fake so ``isinstance``/listener wiring behave for real."""
+
+    def __init__(self, hass, entry) -> None:
+        self.hass = hass
+        self.entry = entry
+        self.data = None
+        self.update_interval = UPDATE_CHECK_INTERVAL
+        self._listeners: list = []
+
+    def async_add_listener(self, update_callback):
+        self._listeners.append(update_callback)
+
+        def _unsub() -> None:
+            self._listeners.remove(update_callback)
+
+        return _unsub
+
+    async def async_refresh(self) -> None:
+        self.data = SimpleNamespace(installed="1.0.0", latest="1.1.0", dist="ha-mcp")
+        for listener in list(self._listeners):
+            listener()
 
 
 @pytest.fixture
 def fake_collaborators(monkeypatch):
-    """Inject fake ``embedded_setup`` / ``ui_panel`` modules.
+    """Inject fake ``embedded_setup`` / ``ui_panel`` / ``coordinator`` modules.
 
     ``async_setup_server_entry`` imports ``async_bring_up_server`` /
-    ``async_check_for_update`` from ``embedded_setup`` and
-    ``async_register_ui_panel`` from ``ui_panel`` at call time; the fakes keep
-    the full HA chain out of this test and expose the check as an AsyncMock the
-    scheduled callback can be asserted against.
+    ``async_maybe_auto_update`` from ``embedded_setup``,
+    ``async_register_ui_panel`` from ``ui_panel``, and ``ServerVersionCoordinator``
+    from ``coordinator`` at call time; the fakes keep the full HA chain out of
+    this test.
     """
     fake_setup = ModuleType("custom_components.ha_mcp_tools.embedded_setup")
     fake_setup.async_bring_up_server = MagicMock(
         name="async_bring_up_server", return_value=MagicMock(name="bringup_task_arg")
     )
-    fake_setup.async_check_for_update = AsyncMock(name="async_check_for_update")
+    fake_setup.async_maybe_auto_update = AsyncMock(name="async_maybe_auto_update")
+    fake_setup.async_teardown_server = AsyncMock(name="async_teardown_server")
 
     fake_panel = ModuleType("custom_components.ha_mcp_tools.ui_panel")
     fake_panel.async_register_ui_panel = AsyncMock(name="async_register_ui_panel")
+    fake_panel.async_unregister_ui_panel = MagicMock(name="async_unregister_ui_panel")
+
+    fake_coord_mod = ModuleType("custom_components.ha_mcp_tools.coordinator")
+    fake_coord_mod.ServerVersionCoordinator = _FakeCoordinator
 
     monkeypatch.setitem(
         sys.modules, "custom_components.ha_mcp_tools.embedded_setup", fake_setup
@@ -74,55 +156,140 @@ def fake_collaborators(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "custom_components.ha_mcp_tools.ui_panel", fake_panel
     )
-    return fake_setup
-
-
-async def test_setup_registers_periodic_update_check(monkeypatch, fake_collaborators):
-    hass = _make_hass()
-    entry = _make_entry()
-    track = MagicMock(
-        name="async_track_time_interval", return_value=MagicMock(name="cancel_interval")
+    monkeypatch.setitem(
+        sys.modules, "custom_components.ha_mcp_tools.coordinator", fake_coord_mod
     )
-    monkeypatch.setattr(
-        sys.modules["homeassistant.helpers.event"],
-        "async_track_time_interval",
-        track,
+    return SimpleNamespace(
+        setup=fake_setup, panel=fake_panel, coordinator_cls=_FakeCoordinator
     )
 
-    result = await eentry.async_setup_server_entry(hass, entry)
-    assert result is True
 
-    # Registered on the auto-update interval...
-    track.assert_called_once()
-    args = track.call_args.args
-    assert args[0] is hass
-    assert args[2] == UPDATE_CHECK_INTERVAL
-    # ...and its cancel callback handed to async_on_unload for cleanup.
-    cancel = track.return_value
-    unload_args = [c.args[0] for c in entry.async_on_unload.call_args_list]
-    assert cancel in unload_args
+class TestSetup:
+    async def test_creates_coordinator_with_update_interval(self, fake_collaborators):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        result = await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        assert result is True
+        coordinator = hass.data[DOMAIN][DATA_UPDATE_COORDINATOR]
+        assert isinstance(coordinator, fake_collaborators.coordinator_cls)
+        assert coordinator.update_interval == UPDATE_CHECK_INTERVAL
+
+    async def test_registers_listener_cleaned_up_on_unload(self, fake_collaborators):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        coordinator = hass.data[DOMAIN][DATA_UPDATE_COORDINATOR]
+        assert coordinator._listeners  # the auto-update listener was registered
+        # ...and its unsub handed to async_on_unload for cleanup.
+        unload_args = [c.args[0] for c in entry.async_on_unload.call_args_list]
+        assert any(callable(arg) for arg in unload_args)
+
+    async def test_initial_refresh_runs_as_background_task(self, fake_collaborators):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        coordinator = hass.data[DOMAIN][DATA_UPDATE_COORDINATOR]
+        # The fake coordinator's async_refresh sets .data - proves it actually
+        # ran (not just constructed) via the background-task path, not an
+        # awaited call inline in async_setup_server_entry.
+        assert coordinator.data is not None
+        assert coordinator.data.installed == "1.0.0"
+
+    async def test_listener_schedules_auto_update_as_background_task(
+        self, fake_collaborators
+    ):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        fake_collaborators.setup.async_maybe_auto_update.assert_awaited_once()
+        args = fake_collaborators.setup.async_maybe_auto_update.await_args.args
+        assert args[0] is hass
+        assert args[1] is entry
+        assert args[2].installed == "1.0.0"
+        assert args[2].latest == "1.1.0"
+
+    async def test_auto_update_task_is_hass_owned_not_entry_owned(
+        self, fake_collaborators
+    ):
+        # Regression: entry background tasks are cancelled by the very unload
+        # that async_maybe_auto_update's reload performs, so an entry-owned
+        # task would cancel itself mid-reload and leave the entry unloaded
+        # (server down until restart). The auto-update task must be hass-owned.
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        hass_task_names = [
+            c.args[1] for c in hass.async_create_background_task.call_args_list
+        ]
+        assert f"{DOMAIN}_server_auto_update" in hass_task_names
+        entry_task_names = [
+            c.args[2] for c in entry.async_create_background_task.call_args_list
+        ]
+        assert f"{DOMAIN}_server_auto_update" not in entry_task_names
+
+    async def test_forwards_update_platform(self, fake_collaborators):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
+            entry, [eentry.Platform.UPDATE]
+        )
 
 
-async def test_scheduled_callback_forwards_to_update_check(
-    monkeypatch, fake_collaborators
-):
-    hass = _make_hass()
-    entry = _make_entry()
-    captured: dict = {}
+class TestUnload:
+    async def test_unloads_update_platform_and_pops_coordinator(
+        self, fake_collaborators
+    ):
+        hass = _make_hass()
+        entry = _make_entry()
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
 
-    def _track(h, action, interval):
-        captured["action"] = action
-        return MagicMock(name="cancel_interval")
+        result = await eentry.async_unload_server_entry(hass, entry)
 
-    monkeypatch.setattr(
-        sys.modules["homeassistant.helpers.event"],
-        "async_track_time_interval",
-        _track,
-    )
+        assert result is True
+        hass.config_entries.async_unload_platforms.assert_awaited_once_with(
+            entry, [eentry.Platform.UPDATE]
+        )
+        assert DATA_UPDATE_COORDINATOR not in hass.data.get(DOMAIN, {})
 
-    await eentry.async_setup_server_entry(hass, entry)
+    async def test_platform_unload_happens_before_teardown(self, fake_collaborators):
+        # Ordering matters (see the design note in async_unload_server_entry):
+        # the platform (and the entity it drives) must be gone before the
+        # server/webhook teardown and the bring-up-task cancellation run.
+        hass = _make_hass()
+        entry = _make_entry()
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
 
-    # The registered callback (called by HA with the fire time) forwards to
-    # async_check_for_update(hass, entry).
-    await captured["action"](None)
-    fake_collaborators.async_check_for_update.assert_awaited_once_with(hass, entry)
+        calls: list[str] = []
+        hass.config_entries.async_unload_platforms.side_effect = lambda *a, **k: (
+            calls.append("unload_platforms") or True
+        )
+
+        async def _teardown(*_a, **_k):
+            calls.append("teardown_server")
+
+        fake_collaborators.setup.async_teardown_server.side_effect = _teardown
+
+        await eentry.async_unload_server_entry(hass, entry)
+
+        assert calls == ["unload_platforms", "teardown_server"]

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -687,7 +687,12 @@ class TestPendingInstallMarker:
 
         assert DATA_PENDING_INSTALL_VERSION not in entry.data
 
-    async def test_marker_not_cleared_when_install_fails(self, tmp_path, monkeypatch):
+    async def test_marker_cleared_even_when_install_fails(self, tmp_path, monkeypatch):
+        # Review finding: the marker is consumed BEFORE the install attempt
+        # (one-shot means one ATTEMPT, not "until it succeeds"). Clearing only
+        # on success would let a marker for a failing version re-pin every
+        # later reload - including the periodic auto-update ones - to that
+        # same broken version, looping the failure forever.
         mgr, _hass, entry = _manager(
             tmp_path,
             data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.9.0"},
@@ -699,7 +704,7 @@ class TestPendingInstallMarker:
         with pytest.raises(es.EmbeddedServerError):
             await mgr._async_ensure_package()
 
-        assert entry.data[DATA_PENDING_INSTALL_VERSION] == "7.9.0"
+        assert DATA_PENDING_INSTALL_VERSION not in entry.data
 
 
 class TestDistHelpers:

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -32,6 +32,7 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
     CHANNEL_STABLE,
     DATA_ACCESS_TOKEN,
     DATA_LAST_PIP_SPEC,
+    DATA_PENDING_INSTALL_VERSION,
     DATA_REFRESH_TOKEN_ID,
     DATA_SECRET_PATH,
     DATA_SERVER_USER_ID,
@@ -597,6 +598,108 @@ class TestEnsurePackage:
 
         await mgr._async_ensure_package()
         uninstall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pending-install marker (issue #1760): the update entity's Install button
+# ---------------------------------------------------------------------------
+
+
+class TestPendingInstallMarker:
+    async def test_pinned_to_pending_version_regardless_of_auto_update(
+        self, tmp_path, monkeypatch
+    ):
+        # auto_update ON (default): the pending marker still forces a PINNED
+        # install, not the unpinned, auto-updating channel spec.
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.8.0"},
+        )
+        install_pkg = MagicMock(return_value=True)
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.8.0")
+        monkeypatch.setattr(es, "_dist_installed", lambda name: False)
+        monkeypatch.setattr(es, "_uninstall_distribution", MagicMock())
+
+        await mgr._async_ensure_package()
+
+        assert mgr._pip_spec == f"{DIST_NAME_STABLE}==7.8.0"
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == f"{DIST_NAME_STABLE}==7.8.0"
+
+    async def test_pinned_to_pending_version_overrides_auto_update_off_repin(
+        self, tmp_path, monkeypatch
+    ):
+        # auto_update OFF would normally re-pin to the CURRENTLY installed
+        # version (the whole reason the marker exists — see async_install's
+        # docstring: a bare reload would otherwise be a no-op). The pending
+        # marker must win over that re-pin.
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_AUTO_UPDATE: False},
+            data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.9.0"},
+        )
+        install_pkg = MagicMock(return_value=True)
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        # Currently-installed version differs from the requested pending one -
+        # proves the marker, not the auto-update-off re-pin, decided the spec.
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.8.0")
+        monkeypatch.setattr(es, "_installed_dist_version", lambda dist: "7.8.0")
+        monkeypatch.setattr(es, "_dist_installed", lambda name: False)
+        monkeypatch.setattr(es, "_uninstall_distribution", MagicMock())
+
+        await mgr._async_ensure_package()
+
+        assert mgr._pip_spec == f"{DIST_NAME_STABLE}==7.9.0"
+
+    async def test_explicit_override_wins_over_pending_marker(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_PIP_SPEC: "ha-mcp==7.5.0"},
+            data={
+                DATA_SECRET_PATH: "/p",
+                DATA_PENDING_INSTALL_VERSION: "7.9.0",
+                DATA_LAST_PIP_SPEC: "ha-mcp==7.5.0",
+            },
+        )
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.5.0")
+
+        await mgr._async_ensure_package()
+
+        assert mgr._pip_spec == "ha-mcp==7.5.0"
+
+    async def test_marker_cleared_after_successful_install(self, tmp_path, monkeypatch):
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.9.0"},
+        )
+        monkeypatch.setattr(es, "install_package", MagicMock(return_value=True))
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.9.0")
+        monkeypatch.setattr(es, "_dist_installed", lambda name: False)
+        monkeypatch.setattr(es, "_uninstall_distribution", MagicMock())
+
+        await mgr._async_ensure_package()
+
+        assert DATA_PENDING_INSTALL_VERSION not in entry.data
+
+    async def test_marker_not_cleared_when_install_fails(self, tmp_path, monkeypatch):
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.9.0"},
+        )
+        monkeypatch.setattr(es, "install_package", MagicMock(return_value=False))
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: None)
+
+        with pytest.raises(es.EmbeddedServerError):
+            await mgr._async_ensure_package()
+
+        assert entry.data[DATA_PENDING_INSTALL_VERSION] == "7.9.0"
 
 
 class TestDistHelpers:

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -34,7 +34,9 @@ _REAL_SURFACE_CONNECT_URLS = esetup._surface_connect_urls
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_BRINGUP_TASK,
     DATA_MANAGER,
+    DATA_PENDING_UPDATE_NOTIFY,
     DATA_SECRET_PATH,
+    DATA_UPDATE_COORDINATOR,
     DATA_WEBHOOK_ID,
     DEFAULT_PIP_SPEC,
     DIST_NAME_DEV,
@@ -216,6 +218,34 @@ class TestBringUp:
 
         fake_manager.async_stop.assert_awaited_once()  # partial state torn down
         esetup.ir.async_create_issue.assert_not_called()  # cancellation isn't a fault
+
+    async def test_package_failure_drops_pending_update_marker(self, fake_manager):
+        # The install did not land: the deferred "updated" notification must
+        # never fire for it - the repair issue is the user-facing signal.
+        hass = _make_hass()
+        hass.data[DOMAIN] = {DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0"}}
+        entry = _make_entry()
+        fake_manager.async_start.side_effect = esetup.EmbeddedServerError(
+            "pip failed", kind="package"
+        )
+
+        await esetup.async_bring_up_server(hass, entry)
+
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data[DOMAIN]
+
+    async def test_cancelled_bringup_keeps_pending_update_marker(self, fake_manager):
+        # Deliberately NOT dropped on cancellation: this bring-up never ran (the
+        # entry was unloaded before it started), so the marker belongs to
+        # whichever bring-up runs next, not to this cancelled attempt.
+        hass = _make_hass()
+        hass.data[DOMAIN] = {DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0"}}
+        entry = _make_entry()
+        fake_manager.async_start.side_effect = asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await esetup.async_bring_up_server(hass, entry)
+
+        assert hass.data[DOMAIN][DATA_PENDING_UPDATE_NOTIFY] == {"old": "7.9.0"}
 
 
 class TestTeardown:
@@ -526,7 +556,10 @@ class TestMaybeAutoUpdate:
         installed="7.9.0", latest="7.10.0", dist=DIST_NAME_STABLE
     )
 
-    async def test_newer_version_reloads_and_notifies(self, monkeypatch):
+    async def test_newer_version_reloads_and_sets_pending_marker(self, monkeypatch):
+        # The notification no longer fires here - it's deferred to
+        # _async_finish_update_cycle, which only runs after the reloaded
+        # entry's bring-up actually confirms the install landed.
         hass = _make_async_hass()
         entry = _make_entry()
         notif = MagicMock()
@@ -535,13 +568,30 @@ class TestMaybeAutoUpdate:
         await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
 
         hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
-        notif.assert_called_once()
-        message = notif.call_args.kwargs.get("message") or notif.call_args.args[1]
-        assert "7.9.0" in message
-        assert "7.10.0" in message
-        assert notif.call_args.kwargs.get("notification_id") == (
-            esetup._UPDATE_NOTIFICATION_ID
-        )
+        assert hass.data[DOMAIN][DATA_PENDING_UPDATE_NOTIFY] == {"old": "7.9.0"}
+        notif.assert_not_called()
+
+    async def test_info_none_does_not_reload_or_set_marker(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry()
+
+        await esetup.async_maybe_auto_update(hass, entry, None)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data.get(DOMAIN, {})
+
+    async def test_reload_failure_drops_marker_and_logs(self, monkeypatch, caplog):
+        import logging
+
+        hass = _make_async_hass()
+        hass.config_entries.async_reload = AsyncMock(side_effect=RuntimeError("boom"))
+        entry = _make_entry()
+
+        with caplog.at_level(logging.ERROR):
+            await esetup.async_maybe_auto_update(hass, entry, self._NEWER)  # no raise
+
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data.get(DOMAIN, {})
+        assert "reload failed" in caplog.text
 
     async def test_equal_version_does_not_reload(self, monkeypatch):
         hass = _make_async_hass()
@@ -639,20 +689,133 @@ class TestMaybeAutoUpdate:
 
         hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
 
-    async def test_dev_channel_notification_links_commit_history(self, monkeypatch):
+
+# ---------------------------------------------------------------------------
+# _async_finish_update_cycle (post-bring-up refresh + deferred notification)
+# ---------------------------------------------------------------------------
+
+
+class TestFinishUpdateCycle:
+    def _fake_coordinator(self, *, data, refresh_side_effect=None):
+        coordinator = MagicMock(name="coordinator")
+        coordinator.data = data
+
+        async def _refresh():
+            if refresh_side_effect is not None:
+                raise refresh_side_effect
+            return None
+
+        coordinator.async_refresh = AsyncMock(side_effect=_refresh)
+        return coordinator
+
+    async def test_marker_and_newer_install_fires_notification(self, monkeypatch):
         hass = _make_async_hass()
-        entry = _make_entry()
+        hass.data[DOMAIN] = {
+            DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0"},
+            DATA_UPDATE_COORDINATOR: self._fake_coordinator(
+                data=ServerVersionInfo(
+                    installed="7.10.0", latest="7.10.0", dist=DIST_NAME_STABLE
+                )
+            ),
+        }
         notif = MagicMock()
         monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
-        info = ServerVersionInfo(
-            installed="7.9.0.dev1", latest="7.10.0.dev1", dist=DIST_NAME_DEV
+
+        await esetup._async_finish_update_cycle(hass)
+
+        hass.data[DOMAIN][DATA_UPDATE_COORDINATOR].async_refresh.assert_awaited_once()
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data[DOMAIN]
+        notif.assert_called_once()
+        message = notif.call_args.kwargs.get("message") or notif.call_args.args[1]
+        assert "7.9.0" in message
+        assert "7.10.0" in message
+        assert "releases/tag/v7.10.0" in message
+        assert notif.call_args.kwargs.get("notification_id") == (
+            esetup._UPDATE_NOTIFICATION_ID
         )
 
-        await esetup.async_maybe_auto_update(hass, entry, info)
+    async def test_dev_channel_notification_links_commit_history(self, monkeypatch):
+        hass = _make_async_hass()
+        hass.data[DOMAIN] = {
+            DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0.dev1"},
+            DATA_UPDATE_COORDINATOR: self._fake_coordinator(
+                data=ServerVersionInfo(
+                    installed="7.10.0.dev1", latest="7.10.0.dev1", dist=DIST_NAME_DEV
+                )
+            ),
+        }
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
+
+        await esetup._async_finish_update_cycle(hass)
 
         message = notif.call_args.kwargs.get("message") or notif.call_args.args[1]
         assert "github.com/homeassistant-ai/ha-mcp/commits/master" in message
         assert "releases/tag" not in message
+
+    async def test_no_marker_refreshes_but_does_not_notify(self, monkeypatch):
+        hass = _make_async_hass()
+        coordinator = self._fake_coordinator(
+            data=ServerVersionInfo(
+                installed="7.10.0", latest="7.10.0", dist=DIST_NAME_STABLE
+            )
+        )
+        hass.data[DOMAIN] = {DATA_UPDATE_COORDINATOR: coordinator}
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
+
+        await esetup._async_finish_update_cycle(hass)
+
+        coordinator.async_refresh.assert_awaited_once()
+        notif.assert_not_called()
+
+    async def test_installed_unchanged_consumes_marker_no_notify(self, monkeypatch):
+        # A reload can legitimately resolve to the same build (e.g. already
+        # the newest) - an "updated to" notification would be false.
+        hass = _make_async_hass()
+        hass.data[DOMAIN] = {
+            DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0"},
+            DATA_UPDATE_COORDINATOR: self._fake_coordinator(
+                data=ServerVersionInfo(
+                    installed="7.9.0", latest="7.9.0", dist=DIST_NAME_STABLE
+                )
+            ),
+        }
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
+
+        await esetup._async_finish_update_cycle(hass)
+
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data[DOMAIN]
+        notif.assert_not_called()
+
+    async def test_missing_coordinator_consumes_marker_no_crash(self, monkeypatch):
+        hass = _make_async_hass()
+        hass.data[DOMAIN] = {DATA_PENDING_UPDATE_NOTIFY: {"old": "7.9.0"}}
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
+
+        await esetup._async_finish_update_cycle(hass)  # must not raise
+
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data[DOMAIN]
+        notif.assert_not_called()
+
+    async def test_refresh_failure_is_swallowed_and_logged(self, monkeypatch, caplog):
+        import logging
+
+        hass = _make_async_hass()
+        coordinator = self._fake_coordinator(
+            data=ServerVersionInfo(
+                installed="7.9.0", latest="7.9.0", dist=DIST_NAME_STABLE
+            ),
+            refresh_side_effect=RuntimeError("boom"),
+        )
+        hass.data[DOMAIN] = {DATA_UPDATE_COORDINATOR: coordinator}
+
+        with caplog.at_level(logging.WARNING):
+            await esetup._async_finish_update_cycle(hass)  # must not raise
+
+        assert "version refresh failed" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -32,7 +32,7 @@ import custom_components.ha_mcp_tools.embedded_setup as esetup  # noqa: E402
 _REAL_SURFACE_CONNECT_URLS = esetup._surface_connect_urls
 
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
-    CHANNEL_DEV,
+    DATA_BRINGUP_TASK,
     DATA_MANAGER,
     DATA_SECRET_PATH,
     DATA_WEBHOOK_ID,
@@ -44,11 +44,11 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
     ISSUE_PACKAGE_FAILED,
     ISSUE_START_FAILED,
     OPT_AUTO_UPDATE,
-    OPT_CHANNEL,
     OPT_PIP_SPEC,
     OPT_WEBHOOK_AUTH,
     WEBHOOK_AUTH_HA,
 )
+from custom_components.ha_mcp_tools.coordinator import ServerVersionInfo  # noqa: E402
 
 
 def _make_hass() -> MagicMock:
@@ -500,7 +500,7 @@ class TestBuildConnectUrls:
 
 
 # ---------------------------------------------------------------------------
-# Periodic channel auto-update check
+# Automatic-update decision (given a ServerVersionInfo from the coordinator)
 # ---------------------------------------------------------------------------
 
 
@@ -511,147 +511,148 @@ def _make_async_hass() -> MagicMock:
     return hass
 
 
-class _FakeResp:
-    """aiohttp response stand-in: an async context manager with json/raise."""
+class _FakeTask:
+    """Stand-in for the bring-up ``asyncio.Task`` — only ``.done()`` is read."""
 
-    def __init__(self, payload, *, raise_exc=None):
-        self._payload = payload
-        self._raise_exc = raise_exc
+    def __init__(self, *, done: bool) -> None:
+        self._done = done
 
-    def raise_for_status(self):
-        if self._raise_exc is not None:
-            raise self._raise_exc
-
-    async def json(self):
-        return self._payload
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc):
-        return False
+    def done(self) -> bool:
+        return self._done
 
 
-class _FakeSession:
-    """aiohttp ClientSession stand-in recording the URLs fetched."""
+class TestMaybeAutoUpdate:
+    _NEWER = ServerVersionInfo(
+        installed="7.9.0", latest="7.10.0", dist=DIST_NAME_STABLE
+    )
 
-    def __init__(self, resp):
-        self._resp = resp
-        self.get_urls: list[str] = []
-
-    def get(self, url):
-        self.get_urls.append(url)
-        return self._resp
-
-
-class TestAutoUpdateCheck:
-    def _patch_session(self, monkeypatch, session):
-        monkeypatch.setattr(
-            esetup, "async_get_clientsession", MagicMock(return_value=session)
-        )
-
-    async def test_newer_version_reloads_entry(self, monkeypatch):
+    async def test_newer_version_reloads_and_notifies(self, monkeypatch):
         hass = _make_async_hass()
         entry = _make_entry()
-        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
-        self._patch_session(monkeypatch, session)
-        monkeypatch.setattr(esetup, "_installed_dist_version", lambda dist: "7.9.0")
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
 
-        await esetup.async_check_for_update(hass, entry)
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
 
-        # Stable channel fetched, and the newer build triggers a reload.
-        assert session.get_urls == [esetup.PYPI_JSON_URL.format(dist=DIST_NAME_STABLE)]
         hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+        notif.assert_called_once()
+        message = notif.call_args.kwargs.get("message") or notif.call_args.args[1]
+        assert "7.9.0" in message
+        assert "7.10.0" in message
+        assert notif.call_args.kwargs.get("notification_id") == (
+            esetup._UPDATE_NOTIFICATION_ID
+        )
 
     async def test_equal_version_does_not_reload(self, monkeypatch):
         hass = _make_async_hass()
         entry = _make_entry()
-        session = _FakeSession(_FakeResp({"info": {"version": "7.9.0"}}))
-        self._patch_session(monkeypatch, session)
-        monkeypatch.setattr(esetup, "_installed_dist_version", lambda dist: "7.9.0")
-
-        await esetup.async_check_for_update(hass, entry)
-
-        hass.config_entries.async_reload.assert_not_awaited()
-
-    async def test_dev_channel_fetches_dev_dist(self, monkeypatch):
-        hass = _make_async_hass()
-        entry = _make_entry(options={OPT_CHANNEL: CHANNEL_DEV})
-        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0.dev1"}}))
-        self._patch_session(monkeypatch, session)
-        monkeypatch.setattr(
-            esetup, "_installed_dist_version", lambda dist: "7.9.0.dev1"
+        info = ServerVersionInfo(
+            installed="7.9.0", latest="7.9.0", dist=DIST_NAME_STABLE
         )
 
-        await esetup.async_check_for_update(hass, entry)
-
-        assert session.get_urls == [esetup.PYPI_JSON_URL.format(dist=DIST_NAME_DEV)]
-
-    async def test_network_error_is_swallowed(self, monkeypatch):
-        # A PyPI fetch failure must not raise and must not reload — the next
-        # interval retries.
-        hass = _make_async_hass()
-        entry = _make_entry()
-        resp = _FakeResp(None, raise_exc=esetup.ClientError("boom"))
-        session = _FakeSession(resp)
-        self._patch_session(monkeypatch, session)
-        installed = MagicMock(return_value="7.9.0")
-        monkeypatch.setattr(esetup, "_installed_dist_version", installed)
-
-        await esetup.async_check_for_update(hass, entry)
+        await esetup.async_maybe_auto_update(hass, entry, info)
 
         hass.config_entries.async_reload.assert_not_awaited()
-        installed.assert_not_called()  # bailed before reading the installed version
 
-    async def test_override_skips_pypi_entirely(self, monkeypatch):
-        # An explicit pip-spec override opts out of auto-update: no PyPI call.
-        hass = _make_async_hass()
-        entry = _make_entry(options={OPT_PIP_SPEC: "ha-mcp==7.8.0"})
-        get_session = MagicMock()
-        monkeypatch.setattr(esetup, "async_get_clientsession", get_session)
-
-        await esetup.async_check_for_update(hass, entry)
-
-        get_session.assert_not_called()
-        hass.config_entries.async_reload.assert_not_awaited()
-
-    async def test_auto_update_off_skips_pypi_entirely(self, monkeypatch):
-        # Auto-update toggled off: no PyPI call, no reload (stay on installed).
+    async def test_auto_update_off_does_not_reload(self, monkeypatch):
         hass = _make_async_hass()
         entry = _make_entry(options={OPT_AUTO_UPDATE: False})
-        get_session = MagicMock()
-        monkeypatch.setattr(esetup, "async_get_clientsession", get_session)
 
-        await esetup.async_check_for_update(hass, entry)
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
 
-        get_session.assert_not_called()
+        hass.config_entries.async_reload.assert_not_awaited()
+
+    async def test_override_does_not_reload(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry(options={OPT_PIP_SPEC: "ha-mcp==7.8.0"})
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
         hass.config_entries.async_reload.assert_not_awaited()
 
     async def test_default_pip_spec_value_is_not_an_override(self, monkeypatch):
         # The default pip-spec ("ha-mcp") stored verbatim still means "no
-        # override" — the check must run, not skip.
+        # override" - the reload must run, not skip.
         hass = _make_async_hass()
         entry = _make_entry(options={OPT_PIP_SPEC: DEFAULT_PIP_SPEC})
-        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
-        self._patch_session(monkeypatch, session)
-        monkeypatch.setattr(esetup, "_installed_dist_version", lambda dist: "7.9.0")
 
-        await esetup.async_check_for_update(hass, entry)
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
 
         hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
 
-    async def test_not_installed_yet_does_not_reload(self, monkeypatch):
-        # Before the first install completes there is no version to compare;
-        # the check must not reload (the bring-up installs the newest itself).
+    async def test_unknown_installed_version_does_not_reload(self, monkeypatch):
         hass = _make_async_hass()
         entry = _make_entry()
-        session = _FakeSession(_FakeResp({"info": {"version": "7.10.0"}}))
-        self._patch_session(monkeypatch, session)
-        monkeypatch.setattr(esetup, "_installed_dist_version", lambda dist: None)
+        info = ServerVersionInfo(installed=None, latest="7.10.0", dist=DIST_NAME_STABLE)
 
-        await esetup.async_check_for_update(hass, entry)
+        await esetup.async_maybe_auto_update(hass, entry, info)
 
         hass.config_entries.async_reload.assert_not_awaited()
+
+    async def test_unknown_latest_version_does_not_reload(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry()
+        info = ServerVersionInfo(installed="7.9.0", latest=None, dist=DIST_NAME_STABLE)
+
+        await esetup.async_maybe_auto_update(hass, entry, info)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+
+    async def test_version_compare_failure_does_not_reload(self, monkeypatch):
+        # Incomparable version strategies (AwesomeVersionException) must not
+        # raise or reload; the next refresh retries.
+        hass = _make_async_hass()
+        entry = _make_entry()
+        info = ServerVersionInfo(
+            installed="not-a-version",
+            latest="also-not-a-version",
+            dist=DIST_NAME_STABLE,
+        )
+        monkeypatch.setattr(
+            esetup,
+            "AwesomeVersion",
+            MagicMock(side_effect=esetup.AwesomeVersionException("bad version")),
+        )
+
+        await esetup.async_maybe_auto_update(hass, entry, info)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+
+    async def test_bringup_in_flight_does_not_reload(self, monkeypatch):
+        # The coordinator's first refresh can land while the background
+        # bring-up (first pip install) is still running — reloading here would
+        # cancel it mid-install.
+        hass = _make_async_hass()
+        hass.data[DOMAIN] = {DATA_BRINGUP_TASK: _FakeTask(done=False)}
+        entry = _make_entry()
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+
+    async def test_bringup_done_allows_reload(self, monkeypatch):
+        hass = _make_async_hass()
+        hass.data[DOMAIN] = {DATA_BRINGUP_TASK: _FakeTask(done=True)}
+        entry = _make_entry()
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+    async def test_dev_channel_notification_links_commit_history(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry()
+        notif = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_create", notif)
+        info = ServerVersionInfo(
+            installed="7.9.0.dev1", latest="7.10.0.dev1", dist=DIST_NAME_DEV
+        )
+
+        await esetup.async_maybe_auto_update(hass, entry, info)
+
+        message = notif.call_args.kwargs.get("message") or notif.call_args.args[1]
+        assert "github.com/homeassistant-ai/ha-mcp/commits/master" in message
+        assert "releases/tag" not in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_ha_mcp_server_entry.py
+++ b/tests/src/unit/test_ha_mcp_server_entry.py
@@ -52,6 +52,8 @@ def _make_hass() -> MagicMock:
 
     hass.config_entries.async_update_entry = MagicMock(side_effect=_update_entry)
     hass.config_entries.async_reload = AsyncMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
     return hass
 
 
@@ -60,7 +62,18 @@ def _make_entry(*, options=None, data=None) -> MagicMock:
     entry.entry_id = "entry-1"
     entry.options = {} if options is None else dict(options)
     entry.data = {} if data is None else dict(data)
-    entry.async_create_background_task = MagicMock(return_value="BRINGUP_TASK")
+
+    def _create_background_task(hass, coro, name):
+        # issue #1760: async_setup_server_entry now ALSO schedules the
+        # coordinator's initial version refresh as a real coroutine here (a
+        # second call, alongside the bring-up). This suite doesn't exercise
+        # coordinator behavior, so just close it to avoid an unawaited-
+        # coroutine warning rather than actually running it.
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return "BRINGUP_TASK"
+
+    entry.async_create_background_task = MagicMock(side_effect=_create_background_task)
     entry.add_update_listener = MagicMock(return_value="UNSUB")
     entry.async_on_unload = MagicMock()
     return entry
@@ -164,15 +177,20 @@ class TestSetupEntry:
         domain_data = hass.data[DOMAIN]
         # Options snapshot taken so data writes don't self-reload.
         assert domain_data[DATA_LAST_OPTIONS] == {"server_port": 9584}
-        # Bring-up scheduled as a config-entry background task and stored.
-        entry.async_create_background_task.assert_called_once()
+        # Bring-up AND the coordinator's initial version refresh are both
+        # scheduled as config-entry background tasks (issue #1760).
+        assert entry.async_create_background_task.call_count == 2
         assert domain_data[DATA_BRINGUP_TASK] == "BRINGUP_TASK"
-        # Reload-on-options-change listener AND the periodic auto-update interval
-        # are both registered under async_on_unload for cleanup.
+        # Reload-on-options-change listener AND the coordinator's auto-update
+        # listener are both registered under async_on_unload for cleanup.
         entry.add_update_listener.assert_called_once_with(pkg._async_options_updated)
         unload_args = [c.args[0] for c in entry.async_on_unload.call_args_list]
         assert "UNSUB" in unload_args  # options-change listener unsub
-        assert len(unload_args) == 2  # + the auto-update interval cancel callback
+        assert len(unload_args) == 2  # + the coordinator listener unsub
+        # The update platform entity is forwarded (issue #1760).
+        hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
+            entry, [pkg.Platform.UPDATE]
+        )
 
 
 class TestUnloadEntry:

--- a/tests/src/unit/test_install_source_check.py
+++ b/tests/src/unit/test_install_source_check.py
@@ -1,0 +1,185 @@
+"""Unit tests for the legacy-HACS-source detection (issue #1760).
+
+Before the dedicated HACS mirror existed, the README told users to add the
+main ha-mcp server repository as a HACS custom repository. Those installs
+still work but HACS shows the server's version numbers and release notes for
+this component. ``install_source_check`` detects that and files an advisory
+repair issue pointing at the mirror.
+
+Home Assistant / aiohttp are stubbed via ``_embedded_stubs``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ._embedded_stubs import install
+
+install()
+
+import custom_components.ha_mcp_tools.install_source_check as isc  # noqa: E402
+from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    DOMAIN,
+    HACS_COMPONENT_URL,
+    ISSUE_LEGACY_HACS_SOURCE,
+)
+
+
+def _make_hass(*, running: bool = True) -> MagicMock:
+    hass = MagicMock(name="hass")
+    hass.data = {}
+    hass.state = isc.CoreState.running if running else isc.CoreState.starting
+
+    def _create_task(coro, name):
+        # These tests assert scheduling decisions, not the scheduled check's
+        # own behavior (covered by TestCheckInstallSource) - close the real
+        # coroutine rather than run it, so it is never left un-awaited.
+        if asyncio.iscoroutine(coro):
+            coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_create_task)
+    return hass
+
+
+def _hacs_with_repo(*, installed: bool) -> MagicMock:
+    hacs = MagicMock(name="hacs")
+    repo = SimpleNamespace(data=SimpleNamespace(installed=installed))
+    hacs.repositories.get_by_full_name = MagicMock(return_value=repo)
+    return hacs
+
+
+def _hacs_without_repo() -> MagicMock:
+    hacs = MagicMock(name="hacs")
+    hacs.repositories.get_by_full_name = MagicMock(return_value=None)
+    return hacs
+
+
+class TestCheckInstallSource:
+    async def test_no_hacs_deletes_stale_issue(self, monkeypatch):
+        hass = _make_hass()
+        create = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(isc.ir, "async_create_issue", create)
+        monkeypatch.setattr(isc.ir, "async_delete_issue", delete)
+
+        await isc._async_check_install_source(hass)
+
+        create.assert_not_called()
+        delete.assert_called_once_with(hass, DOMAIN, ISSUE_LEGACY_HACS_SOURCE)
+
+    async def test_hacs_present_repo_not_found_deletes_issue(self, monkeypatch):
+        hass = _make_hass()
+        hass.data["hacs"] = _hacs_without_repo()
+        create = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(isc.ir, "async_create_issue", create)
+        monkeypatch.setattr(isc.ir, "async_delete_issue", delete)
+
+        await isc._async_check_install_source(hass)
+
+        create.assert_not_called()
+        delete.assert_called_once_with(hass, DOMAIN, ISSUE_LEGACY_HACS_SOURCE)
+
+    async def test_repo_present_but_not_installed_deletes_issue(self, monkeypatch):
+        hass = _make_hass()
+        hass.data["hacs"] = _hacs_with_repo(installed=False)
+        create = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(isc.ir, "async_create_issue", create)
+        monkeypatch.setattr(isc.ir, "async_delete_issue", delete)
+
+        await isc._async_check_install_source(hass)
+
+        create.assert_not_called()
+        delete.assert_called_once_with(hass, DOMAIN, ISSUE_LEGACY_HACS_SOURCE)
+
+    async def test_repo_installed_creates_warning_issue(self, monkeypatch):
+        hass = _make_hass()
+        hass.data["hacs"] = _hacs_with_repo(installed=True)
+        create = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(isc.ir, "async_create_issue", create)
+        monkeypatch.setattr(isc.ir, "async_delete_issue", delete)
+
+        await isc._async_check_install_source(hass)
+
+        delete.assert_not_called()
+        create.assert_called_once()
+        args = create.call_args.args
+        kwargs = create.call_args.kwargs
+        assert args[:3] == (hass, DOMAIN, ISSUE_LEGACY_HACS_SOURCE)
+        assert kwargs["is_fixable"] is False
+        assert kwargs["severity"] == isc.ir.IssueSeverity.WARNING
+        assert kwargs["translation_key"] == ISSUE_LEGACY_HACS_SOURCE
+        assert kwargs["learn_more_url"] == HACS_COMPONENT_URL
+
+    async def test_hacs_lookup_error_logs_and_leaves_registry_untouched(
+        self, monkeypatch, caplog
+    ):
+        import logging
+
+        hass = _make_hass()
+        broken_hacs = MagicMock(name="hacs")
+        broken_hacs.repositories.get_by_full_name = MagicMock(
+            side_effect=AttributeError("HACS internals changed")
+        )
+        hass.data["hacs"] = broken_hacs
+        create = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(isc.ir, "async_create_issue", create)
+        monkeypatch.setattr(isc.ir, "async_delete_issue", delete)
+
+        with caplog.at_level(logging.WARNING):
+            await isc._async_check_install_source(hass)  # must not raise
+
+        create.assert_not_called()
+        delete.assert_not_called()
+        assert "could not determine the HACS install source" in caplog.text
+
+
+class TestScheduling:
+    def test_already_running_schedules_immediately(self):
+        hass = _make_hass(running=True)
+
+        isc.async_schedule_install_source_check(hass)
+
+        hass.async_create_task.assert_called_once()
+        hass.bus.async_listen_once.assert_not_called()
+
+    def test_not_yet_started_registers_one_shot_listener(self):
+        hass = _make_hass(running=False)
+
+        isc.async_schedule_install_source_check(hass)
+
+        hass.async_create_task.assert_not_called()
+        hass.bus.async_listen_once.assert_called_once()
+        assert hass.bus.async_listen_once.call_args.args[0] == (
+            isc.EVENT_HOMEASSISTANT_STARTED
+        )
+
+    def test_listener_fires_check_when_started_event_arrives(self):
+        hass = _make_hass(running=False)
+
+        isc.async_schedule_install_source_check(hass)
+        listener = hass.bus.async_listen_once.call_args.args[1]
+        listener(MagicMock(name="event"))
+
+        hass.async_create_task.assert_called_once()
+
+    def test_second_call_schedules_only_once(self):
+        hass = _make_hass(running=True)
+
+        isc.async_schedule_install_source_check(hass)
+        isc.async_schedule_install_source_check(hass)
+
+        hass.async_create_task.assert_called_once()
+
+    def test_second_call_before_started_does_not_register_second_listener(self):
+        hass = _make_hass(running=False)
+
+        isc.async_schedule_install_source_check(hass)
+        isc.async_schedule_install_source_check(hass)
+
+        hass.bus.async_listen_once.assert_called_once()

--- a/tests/src/unit/test_update.py
+++ b/tests/src/unit/test_update.py
@@ -18,9 +18,11 @@ install()
 
 import custom_components.ha_mcp_tools.update as upd  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    DATA_BRINGUP_TASK,
     DATA_PENDING_INSTALL_VERSION,
     DIST_NAME_DEV,
     DIST_NAME_STABLE,
+    DOMAIN,
     OPT_AUTO_UPDATE,
 )
 
@@ -48,6 +50,20 @@ def _make_entity(coordinator=None, entry=None) -> upd.ServerUpdateEntity:
     coordinator = coordinator or _make_coordinator(_info())
     entry = entry or _make_entry()
     return upd.ServerUpdateEntity(coordinator, entry)
+
+
+def _make_install_hass(*, bringup=None, installed_version=None) -> MagicMock:
+    """A hass wired for async_install's post-reload flow: awaits the bring-up
+    task (if any) then reads the installed version via the executor."""
+    hass = MagicMock(name="hass")
+    hass.config_entries.async_reload = AsyncMock()
+    hass.data = {DOMAIN: {DATA_BRINGUP_TASK: bringup}}
+
+    async def _executor(_func, *_args):
+        return installed_version
+
+    hass.async_add_executor_job = AsyncMock(side_effect=_executor)
+    return hass
 
 
 class TestProperties:
@@ -128,6 +144,14 @@ class TestProperties:
         assert entity.supported_features & upd.UpdateEntityFeature.INSTALL
         assert not (entity.supported_features & upd.UpdateEntityFeature.RELEASE_NOTES)
 
+    def test_release_url_none_when_coordinator_data_absent(self):
+        entity = _make_entity(coordinator=_make_coordinator(None))
+        assert entity.release_url is None
+
+    def test_supported_features_install_only_when_coordinator_data_absent(self):
+        entity = _make_entity(coordinator=_make_coordinator(None))
+        assert entity.supported_features == upd.UpdateEntityFeature.INSTALL
+
 
 class _FakeResp:
     def __init__(self, payload, *, raise_exc=None):
@@ -197,6 +221,26 @@ class TestReleaseNotes:
 
         assert await entity.async_release_notes() is None
 
+    async def test_malformed_payload_returns_none_and_logs_warning(
+        self, monkeypatch, caplog
+    ):
+        import logging
+
+        # A list of bare strings instead of release dicts - .get() on a str
+        # raises AttributeError, an unexpected-shape bug/API-change, not a
+        # transient - must hit the broad except and log at WARNING.
+        session = _FakeSession(_FakeResp(["not", "a", "release", "dict"]))
+        monkeypatch.setattr(
+            upd, "async_get_clientsession", MagicMock(return_value=session)
+        )
+        entity = _make_entity(coordinator=_make_coordinator(_info()))
+
+        with caplog.at_level(logging.WARNING):
+            notes = await entity.async_release_notes()
+
+        assert notes is None
+        assert "release-notes fetch failed" in caplog.text
+
     async def test_no_qualifying_releases_returns_none(self, monkeypatch):
         session = _FakeSession(_FakeResp([{"tag_name": "v1.0.0", "body": "x"}]))
         monkeypatch.setattr(
@@ -212,9 +256,8 @@ class TestReleaseNotes:
 class TestAsyncInstall:
     async def test_writes_pending_marker_and_reloads(self):
         entry = _make_entry(data={"existing": "kept"})
-        hass = MagicMock(name="hass")
-        hass.config_entries.async_reload = AsyncMock()
-        coordinator = _make_coordinator(_info(latest="1.2.0"))
+        hass = _make_install_hass(installed_version="1.2.0")
+        coordinator = _make_coordinator(_info(dist=DIST_NAME_STABLE, latest="1.2.0"))
         entity = _make_entity(coordinator=coordinator, entry=entry)
         entity.hass = hass
 
@@ -227,9 +270,8 @@ class TestAsyncInstall:
 
     async def test_no_version_falls_back_to_latest(self):
         entry = _make_entry()
-        hass = MagicMock(name="hass")
-        hass.config_entries.async_reload = AsyncMock()
-        coordinator = _make_coordinator(_info(latest="1.3.0"))
+        hass = _make_install_hass(installed_version="1.3.0")
+        coordinator = _make_coordinator(_info(dist=DIST_NAME_STABLE, latest="1.3.0"))
         entity = _make_entity(coordinator=coordinator, entry=entry)
         entity.hass = hass
 
@@ -258,3 +300,33 @@ class TestAsyncInstall:
 
         with pytest.raises(upd.HomeAssistantError):
             await entity.async_install("1.2.0", backup=False)
+
+    async def test_version_mismatch_after_install_raises_naming_target(self):
+        # The reload only completes entry SETUP; the executor read below is the
+        # actual success check (review finding) - a version that landed
+        # different from the target must surface as a failure naming it.
+        entry = _make_entry()
+        hass = _make_install_hass(installed_version="1.1.0")  # target was 1.2.0
+        coordinator = _make_coordinator(_info(dist=DIST_NAME_STABLE, latest="1.2.0"))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        with pytest.raises(upd.HomeAssistantError, match=r"1\.2\.0"):
+            await entity.async_install("1.2.0", backup=False)
+
+    async def test_async_update_entry_raising_wrapped_and_logged(self, caplog):
+        import logging
+
+        entry = _make_entry()
+        hass = _make_install_hass(installed_version="1.2.0")
+        hass.config_entries.async_update_entry = MagicMock(
+            side_effect=RuntimeError("entry store boom")
+        )
+        coordinator = _make_coordinator(_info(dist=DIST_NAME_STABLE, latest="1.2.0"))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        with caplog.at_level(logging.ERROR), pytest.raises(upd.HomeAssistantError):
+            await entity.async_install("1.2.0", backup=False)
+
+        assert "install failed" in caplog.text

--- a/tests/src/unit/test_update.py
+++ b/tests/src/unit/test_update.py
@@ -1,0 +1,260 @@
+"""Unit tests for the ``update`` platform (issue #1760).
+
+Covers the entity's properties (installed/latest/auto_update/release_url per
+channel, supported_features per channel) and ``async_install``'s pending-marker
+write + reload. Home Assistant / aiohttp are stubbed via ``_embedded_stubs``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ._embedded_stubs import install
+
+install()
+
+import custom_components.ha_mcp_tools.update as upd  # noqa: E402
+from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    DATA_PENDING_INSTALL_VERSION,
+    DIST_NAME_DEV,
+    DIST_NAME_STABLE,
+    OPT_AUTO_UPDATE,
+)
+
+
+def _info(*, installed="1.0.0", latest="1.1.0", dist=DIST_NAME_STABLE):
+    return SimpleNamespace(installed=installed, latest=latest, dist=dist)
+
+
+def _make_coordinator(data=None) -> MagicMock:
+    coordinator = MagicMock(name="coordinator")
+    coordinator.data = data
+    coordinator.hass = MagicMock(name="hass")
+    return coordinator
+
+
+def _make_entry(*, options=None, data=None) -> MagicMock:
+    entry = MagicMock(name="entry")
+    entry.entry_id = "entry-1"
+    entry.options = {} if options is None else dict(options)
+    entry.data = {} if data is None else dict(data)
+    return entry
+
+
+def _make_entity(coordinator=None, entry=None) -> upd.ServerUpdateEntity:
+    coordinator = coordinator or _make_coordinator(_info())
+    entry = entry or _make_entry()
+    return upd.ServerUpdateEntity(coordinator, entry)
+
+
+class TestProperties:
+    def test_unique_id_and_entity_name(self):
+        entity = _make_entity(entry=_make_entry())
+        assert entity._attr_unique_id == "entry-1_server_update"
+        assert entity._attr_has_entity_name is True
+        assert entity._attr_translation_key == "server_update"
+
+    def test_installed_and_latest_version(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(installed="1.0.0", latest="1.2.0"))
+        )
+        assert entity.installed_version == "1.0.0"
+        assert entity.latest_version == "1.2.0"
+
+    def test_versions_none_when_coordinator_data_absent(self):
+        entity = _make_entity(coordinator=_make_coordinator(None))
+        assert entity.installed_version is None
+        assert entity.latest_version is None
+
+    def test_device_info_sw_version_is_installed_version(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(installed="1.0.0")),
+            entry=_make_entry(),
+        )
+        info = entity.device_info
+        assert info["sw_version"] == "1.0.0"
+        assert info["identifiers"] == {("ha_mcp_tools", "entry-1")}
+        assert info["name"] == "HA-MCP Server"
+
+    @pytest.mark.parametrize(
+        "option_value, default_used, expected",
+        [
+            (True, False, True),
+            (False, False, False),
+            (None, True, True),
+        ],
+    )
+    def test_auto_update_reflects_entry_option(
+        self, option_value, default_used, expected
+    ):
+        options = {} if default_used else {OPT_AUTO_UPDATE: option_value}
+        entity = _make_entity(entry=_make_entry(options=options))
+        assert entity.auto_update is expected
+
+    def test_release_url_stable_channel(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(latest="1.2.0", dist=DIST_NAME_STABLE))
+        )
+        assert entity.release_url == (
+            "https://github.com/homeassistant-ai/ha-mcp/releases/tag/v1.2.0"
+        )
+
+    def test_release_url_stable_channel_none_when_latest_unknown(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(latest=None, dist=DIST_NAME_STABLE))
+        )
+        assert entity.release_url is None
+
+    def test_release_url_dev_channel_is_commit_history(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(latest=None, dist=DIST_NAME_DEV))
+        )
+        assert entity.release_url == (
+            "https://github.com/homeassistant-ai/ha-mcp/commits/master"
+        )
+
+    def test_supported_features_stable_includes_release_notes(self):
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(dist=DIST_NAME_STABLE))
+        )
+        assert entity.supported_features & upd.UpdateEntityFeature.INSTALL
+        assert entity.supported_features & upd.UpdateEntityFeature.RELEASE_NOTES
+
+    def test_supported_features_dev_excludes_release_notes(self):
+        entity = _make_entity(coordinator=_make_coordinator(_info(dist=DIST_NAME_DEV)))
+        assert entity.supported_features & upd.UpdateEntityFeature.INSTALL
+        assert not (entity.supported_features & upd.UpdateEntityFeature.RELEASE_NOTES)
+
+
+class _FakeResp:
+    def __init__(self, payload, *, raise_exc=None):
+        self._payload = payload
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def get(self, _url):
+        return self._resp
+
+
+class TestReleaseNotes:
+    async def test_concatenates_bodies_between_installed_and_latest(self, monkeypatch):
+        releases = [
+            {"tag_name": "v1.3.0", "body": "too new"},
+            {"tag_name": "v1.2.0", "body": "second"},
+            {"tag_name": "v1.1.0", "body": "first"},
+            {"tag_name": "v1.0.0", "body": "already installed"},
+        ]
+        session = _FakeSession(_FakeResp(releases))
+        monkeypatch.setattr(
+            upd, "async_get_clientsession", MagicMock(return_value=session)
+        )
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(installed="1.0.0", latest="1.2.0"))
+        )
+
+        notes = await entity.async_release_notes()
+
+        assert notes is not None
+        assert "second" in notes
+        assert "first" in notes
+        assert "too new" not in notes
+        assert "already installed" not in notes
+        # Newest first.
+        assert notes.index("second") < notes.index("first")
+
+    async def test_no_coordinator_data_returns_none(self):
+        entity = _make_entity(coordinator=_make_coordinator(None))
+        assert await entity.async_release_notes() is None
+
+    async def test_fetch_failure_returns_none(self, monkeypatch):
+        # async_release_notes is advisory-only and catches broadly (any
+        # network/parsing error), so any exception type demonstrates the gate.
+        session = _FakeSession(_FakeResp(None, raise_exc=RuntimeError("boom")))
+        monkeypatch.setattr(
+            upd, "async_get_clientsession", MagicMock(return_value=session)
+        )
+        entity = _make_entity(coordinator=_make_coordinator(_info()))
+
+        assert await entity.async_release_notes() is None
+
+    async def test_no_qualifying_releases_returns_none(self, monkeypatch):
+        session = _FakeSession(_FakeResp([{"tag_name": "v1.0.0", "body": "x"}]))
+        monkeypatch.setattr(
+            upd, "async_get_clientsession", MagicMock(return_value=session)
+        )
+        entity = _make_entity(
+            coordinator=_make_coordinator(_info(installed="1.0.0", latest="1.0.0"))
+        )
+
+        assert await entity.async_release_notes() is None
+
+
+class TestAsyncInstall:
+    async def test_writes_pending_marker_and_reloads(self):
+        entry = _make_entry(data={"existing": "kept"})
+        hass = MagicMock(name="hass")
+        hass.config_entries.async_reload = AsyncMock()
+        coordinator = _make_coordinator(_info(latest="1.2.0"))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        await entity.async_install("1.2.0", backup=False)
+
+        updated_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert updated_data[DATA_PENDING_INSTALL_VERSION] == "1.2.0"
+        assert updated_data["existing"] == "kept"  # existing entry.data preserved
+        hass.config_entries.async_reload.assert_awaited_once_with("entry-1")
+
+    async def test_no_version_falls_back_to_latest(self):
+        entry = _make_entry()
+        hass = MagicMock(name="hass")
+        hass.config_entries.async_reload = AsyncMock()
+        coordinator = _make_coordinator(_info(latest="1.3.0"))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        await entity.async_install(None, backup=False)
+
+        updated_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert updated_data[DATA_PENDING_INSTALL_VERSION] == "1.3.0"
+
+    async def test_no_target_version_raises_home_assistant_error(self):
+        entry = _make_entry()
+        hass = MagicMock(name="hass")
+        coordinator = _make_coordinator(_info(latest=None))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        with pytest.raises(upd.HomeAssistantError):
+            await entity.async_install(None, backup=False)
+
+    async def test_reload_failure_wrapped_in_home_assistant_error(self):
+        entry = _make_entry()
+        hass = MagicMock(name="hass")
+        hass.config_entries.async_reload = AsyncMock(side_effect=RuntimeError("boom"))
+        coordinator = _make_coordinator(_info(latest="1.2.0"))
+        entity = _make_entity(coordinator=coordinator, entry=entry)
+        entity.hass = hass
+
+        with pytest.raises(upd.HomeAssistantError):
+            await entity.async_install("1.2.0", backup=False)

--- a/tests/src/unit/test_yaml_dashboards.py
+++ b/tests/src/unit/test_yaml_dashboards.py
@@ -16,7 +16,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", MagicMock())
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()

--- a/tests/src/unit/test_yaml_edit_untouched_content.py
+++ b/tests/src/unit/test_yaml_edit_untouched_content.py
@@ -30,7 +30,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", MagicMock())
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()

--- a/tests/src/unit/test_yaml_roundtrip.py
+++ b/tests/src/unit/test_yaml_roundtrip.py
@@ -15,7 +15,11 @@ sys.modules["homeassistant"] = homeassistant
 sys.modules["homeassistant.components"] = homeassistant.components
 sys.modules["homeassistant.config"] = homeassistant.config
 sys.modules["homeassistant.config_entries"] = homeassistant.config_entries
-sys.modules["homeassistant.core"] = homeassistant.core
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", homeassistant.core)
 sys.modules["homeassistant.helpers"] = homeassistant.helpers
 sys.modules["homeassistant.helpers.config_validation"] = (
     homeassistant.helpers.config_validation

--- a/tests/src/unit/test_yaml_rt_singleton.py
+++ b/tests/src/unit/test_yaml_rt_singleton.py
@@ -16,7 +16,11 @@ sys.modules["homeassistant"] = homeassistant
 sys.modules["homeassistant.components"] = homeassistant.components
 sys.modules["homeassistant.config"] = homeassistant.config
 sys.modules["homeassistant.config_entries"] = homeassistant.config_entries
-sys.modules["homeassistant.core"] = homeassistant.core
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", homeassistant.core)
 sys.modules["homeassistant.helpers"] = homeassistant.helpers
 sys.modules["homeassistant.helpers.config_validation"] = (
     homeassistant.helpers.config_validation

--- a/tests/src/unit/test_yaml_themes.py
+++ b/tests/src/unit/test_yaml_themes.py
@@ -12,7 +12,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", MagicMock())
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()

--- a/tests/src/unit/test_yaml_whole_file_replace.py
+++ b/tests/src/unit/test_yaml_whole_file_replace.py
@@ -21,7 +21,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.persistent_notification"] = MagicMock()
 sys.modules["homeassistant.config"] = MagicMock()
 sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
+# setdefault (not =): other test modules stub homeassistant.core with a real
+# `callback` identity function (production code decorates real closures with
+# it - a clobbered auto-mock attribute would silently replace them). This
+# file doesn't care what's already there, only that something importable is.
+sys.modules.setdefault("homeassistant.core", MagicMock())
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes #1760 while keeping the component and server independently versioned (no lockstep).

**Server updates were invisible.** The embedded server self-updates from PyPI with only an INFO log line, and with automatic updates off the PyPI poll never ran at all:

- New `update` platform entity per server entry, backed by a `ServerVersionCoordinator` that polls installed vs PyPI-latest on the existing 6h interval regardless of the auto-update option — only the reload stays gated on it, now also guarded against firing while the bring-up is still installing. The entity shows installed/latest version, reflects the auto-update option, links release notes (GitHub release bodies on the stable channel, commit history on dev), and reports the server version as the device's `sw_version`.
- Manual **Install** works with automatic updates off: a one-shot pending-install marker pins the next install to the requested version (overriding the auto-update-off re-pin); the server manager clears it after a successful install.
- A persistent notification (no secrets) is created when an automatic update installs, naming old/new version, channel, and the release-notes link.

**Legacy HACS installs show server versions/notes as if the component were the server.** Installs added before the mirror existed still track the main repo, so HACS shows `7.x` versions and the server changelog:

- After HA start (avoiding the HACS setup race), the component checks HACS's registry for the main repo and files a WARNING repair issue pointing at the `ha-mcp-integration` mirror via the one-click deep link. The legacy path keeps working; the issue self-clears after migration.

**Mirror releases carried stub release notes** ("Component snapshot synced from…"):

- The sync workflow now generates component-specific release notes — commit subjects touching `custom_components/ha_mcp_tools/` between the last two stable server releases (`scripts/build_mirror_release_notes.py`) — and delivers them as the annotated tag message, using `--cleanup=verbatim` because `git tag -F`'s default strip mode silently deletes `#`-prefixed markdown headings.
- The mirror's release-on-tag workflow now lives canonically in this repo (`.github/integration-mirror-workflows/`), is synced over like the rest of the mirror (deploy keys may push workflow files), and uses the tag message as the release body, falling back to the old stub for lightweight tags.

Also:

- `hacs.json` HA floor 2024.1.0 → 2024.11.0 (`DataUpdateCoordinator(config_entry=...)` exists since HA 2024.11).
- Component version → **1.0.0** (owner decision: the component has shipped the full in-process server since the installation overhaul). No `MIN_COMPONENT_VERSION` change — no new server-side service dependency, and the component stays compatible with the released server.
- `docs/in-process-server.md` documents the new surfaces and fixes the now-stale "the periodic check stops" claim.
- Test-infra fix: 7 pre-existing unit-test modules unconditionally overwrote `sys.modules["homeassistant.core"]`, clobbering shared stubs depending on collection order (`setdefault` now).

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Local: hermetic unit tier green with a failure set byte-identical to the master baseline (+63 new tests); `ruff check` + `ruff format` clean on all changed files; CodeQL local scan clean. E2E runs in CI. The component path needs the usual live dev-server smoke test after merge (update entity behavior against real HA, HACS detection against a real HACS instance).

## Checklist
- [x] I have updated documentation if needed

