### PR TITLE
feat: dev mode tools, embedded server update fixes, and version diagnosability

### DIFF
--- a/.github/workflows/addon-publish-dev.yml
+++ b/.github/workflows/addon-publish-dev.yml
@@ -46,13 +46,21 @@ jobs:
       short_sha: ${{ steps.version.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: the dev version number is the commit count.
+          fetch-depth: 0
 
       - name: Generate dev version
         id: version
         run: |
           BASE_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          DEV_VERSION="${BASE_VERSION}.dev${{ github.run_number }}"
+          # dev N = commit count on master: the same commit produces the SAME
+          # number in every workflow (PyPI/Docker in publish-dev, the dev
+          # add-on here), so all surfaces report one dev version. run_number
+          # was per-workflow, which is how the add-on drifted ~300 builds
+          # behind the PyPI counter and made version reports incomparable.
+          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count HEAD)"
 
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT

--- a/.github/workflows/addon-publish-dev.yml
+++ b/.github/workflows/addon-publish-dev.yml
@@ -60,7 +60,10 @@ jobs:
           # add-on here), so all surfaces report one dev version. run_number
           # was per-workflow, which is how the add-on drifted ~300 builds
           # behind the PyPI counter and made version reports incomparable.
-          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count HEAD)"
+          # Count origin/master (not HEAD): a workflow_dispatch on an older
+          # ref would otherwise mint a LOWER number that collides with an
+          # existing dev release and clobbers it.
+          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count origin/master)"
 
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -60,7 +60,10 @@ jobs:
           # add-on here), so all surfaces report one dev version. run_number
           # was per-workflow, which is how the add-on drifted ~300 builds
           # behind the PyPI counter and made version reports incomparable.
-          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count HEAD)"
+          # Count origin/master (not HEAD): a workflow_dispatch on an older
+          # ref would otherwise mint a LOWER number that collides with an
+          # existing dev release and clobbers it.
+          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count origin/master)"
 
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -45,6 +45,9 @@ jobs:
       short_sha: ${{ steps.version.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: the dev version number is the commit count.
+          fetch-depth: 0
 
       - name: Generate dev version
         id: version
@@ -52,7 +55,12 @@ jobs:
           # Get base version from pyproject.toml
           BASE_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          DEV_VERSION="${BASE_VERSION}.dev${{ github.run_number }}"
+          # dev N = commit count on master: the same commit produces the SAME
+          # number in every workflow (PyPI/Docker in publish-dev, the dev
+          # add-on here), so all surfaces report one dev version. run_number
+          # was per-workflow, which is how the add-on drifted ~300 builds
+          # behind the PyPI counter and made version reports incomparable.
+          DEV_VERSION="${BASE_VERSION}.dev$(git rev-list --count HEAD)"
 
           echo "dev_version=$DEV_VERSION" >> $GITHUB_OUTPUT
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,6 +470,7 @@ src/ha_mcp/
 
 **Namespace prefixes**: An optional `<namespace>_` prefix between `ha_` and the verb is allowed for grouped tool families that share a domain. The full shape becomes `ha_<namespace>_<verb>_<noun>`:
 - `ha_config_<verb>_<noun>` — config-management tools (`ha_config_set_helper`, `ha_config_set_automation`, `ha_config_remove_automation`, `ha_config_delete_dashboard`)
+- `ha_dev_<verb>_<noun>` — developer-mode tools (`ha_dev_manage_server`, `ha_dev_manage_settings`); registered only when the `enable_dev_mode` setting is on (Developer section at the bottom of the web settings UI's Server Settings tab)
 
 **Accepted exceptions**: A small set of tools name a single, distinct operation where forcing a `<verb>_<noun>` shape would read worse than the natural name. These are accepted as-is and should not be flagged:
 - `ha_restart`, `ha_reload_core`, `ha_eval_template`

--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -252,10 +252,12 @@ class HaMcpServerOptionsFlow(OptionsFlow):
                 ),
                 vol.Optional(
                     OPT_PIP_SPEC,
-                    # ``or DEFAULT_PIP_SPEC`` so a stored-empty spec (the normalized
-                    # "no override" state) re-displays the default (the unpinned
-                    # stable distribution) as a hint.
-                    default=opts.get(OPT_PIP_SPEC) or DEFAULT_PIP_SPEC,
+                    # Pre-fill only a genuinely saved override. The normalized
+                    # "no override" state renders an EMPTY field — pre-filling
+                    # DEFAULT_PIP_SPEC as a hint made a field whose help text
+                    # says "leave blank" always look populated, and showed the
+                    # STABLE dist name even on the dev channel.
+                    default=opts.get(OPT_PIP_SPEC, ""),
                 ): str,
                 vol.Optional(
                     OPT_SERVER_URL,

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -169,6 +169,10 @@ class EmbeddedServerManager:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_event: asyncio.Event | None = None
         self._thread_exc: BaseException | None = None
+        # A worker that refused to die within the stop-join timeout (e.g.
+        # wedged in a slow cold import). Tracked so the next start can skip
+        # the module purge while it might still be importing.
+        self._orphaned_thread: threading.Thread | None = None
         # ha_mcp.__version__ as imported by the CURRENT worker thread (stashed
         # by _serve). Compared against the installed distribution after start
         # to detect a stale-code worker (see _purge_ha_mcp_modules).
@@ -211,7 +215,24 @@ class EmbeddedServerManager:
         # observed live: options saves reinstalled the package, the web UI
         # footer showed the new on-disk version, yet the serving worker kept
         # reporting the version it was first imported with).
-        _purge_ha_mcp_modules()
+        #
+        # SKIPPED while an orphaned worker may still be importing: ripping
+        # entries out of sys.modules under a live importer corrupts its
+        # import in progress (seen on QEMU-slow HAOS, where a cold import
+        # can outlive both the readiness timeout and the stop-join budget).
+        # The post-start staleness check below surfaces the consequence
+        # (old code possibly serving) instead.
+        orphan = self._orphaned_thread
+        if orphan is not None and not orphan.is_alive():
+            self._orphaned_thread = orphan = None
+        if orphan is None:
+            _purge_ha_mcp_modules()
+        else:
+            _LOGGER.warning(
+                "Skipping the ha_mcp module purge: a previous worker thread "
+                "is still shutting down. The new worker may serve the "
+                "previously imported code until Home Assistant restarts."
+            )
 
         self._thread_exc = None
         self._thread = threading.Thread(
@@ -273,6 +294,11 @@ class EmbeddedServerManager:
                 "leaving it to terminate with the process.",
                 _STOP_JOIN_TIMEOUT_SECONDS,
             )
+            # Remember the zombie: the next start must not purge modules
+            # while this thread may still be importing them. The worker
+            # holds its own loop/stop-event as locals, so clearing the
+            # published references below cannot crash it.
+            self._orphaned_thread = thread
         self._thread = None
         self._loop = None
         self._stop_event = None
@@ -616,10 +642,17 @@ class EmbeddedServerManager:
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        # The event is created HERE and handed to _serve as a local — the
+        # worker must never re-read it from self mid-flight: async_stop
+        # clears the published references after a join timeout, and a
+        # wedged-in-import worker reading them back would crash (live-found
+        # on QEMU-slow HAOS). Publishing to self is one-way, for
+        # async_stop's signaling only.
+        stop_event = asyncio.Event()
         self._loop = loop
-        self._stop_event = asyncio.Event()
+        self._stop_event = stop_event
         try:
-            loop.run_until_complete(self._serve(access_token))
+            loop.run_until_complete(self._serve(access_token, stop_event))
         except Exception as err:
             self._thread_exc = err
             _LOGGER.exception("HA-MCP in-process server thread crashed")
@@ -643,7 +676,7 @@ class EmbeddedServerManager:
                     )
             loop.close()
 
-    async def _serve(self, access_token: str) -> None:
+    async def _serve(self, access_token: str, stop_event: asyncio.Event) -> None:
         """Build the ha-mcp server and run it until a stop is signaled.
 
         Mirrors the CLI HTTP runner in ``ha_mcp.__main__`` without importing it
@@ -778,8 +811,7 @@ class EmbeddedServerManager:
         )
         uv_server = uvicorn.Server(config)
 
-        assert self._stop_event is not None
-        stop_task = asyncio.create_task(self._stop_event.wait())
+        stop_task = asyncio.create_task(stop_event.wait())
         async with server.mcp._lifespan_manager():
             serve_task = asyncio.create_task(uv_server.serve())
             done, _pending = await asyncio.wait(
@@ -866,13 +898,12 @@ def _purge_ha_mcp_modules() -> None:
     purged = [
         name for name in sys.modules if name == "ha_mcp" or name.startswith("ha_mcp.")
     ]
+    if not purged:
+        return
     for name in purged:
         sys.modules.pop(name, None)
     importlib.invalidate_caches()
-    if purged:
-        _LOGGER.debug(
-            "Purged %d cached ha_mcp module(s) before worker start", len(purged)
-        )
+    _LOGGER.debug("Purged %d cached ha_mcp module(s) before worker start", len(purged))
 
 
 def _installed_ha_mcp_version() -> str | None:

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -646,12 +646,9 @@ class EmbeddedServerManager:
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        # The event is created HERE and handed to _serve as a local — the
-        # worker must never re-read it from self mid-flight: async_stop
-        # clears the published references after a join timeout, and a
-        # wedged-in-import worker reading them back would crash (live-found
-        # on QEMU-slow HAOS). Publishing to self is one-way, for
-        # async_stop's signaling only.
+        # Created here and handed to _serve as a LOCAL; publishing to self
+        # is one-way, for async_stop's signaling only — see async_stop's
+        # zombie-thread comment for why the worker must never re-read it.
         stop_event = asyncio.Event()
         self._loop = loop
         self._stop_event = stop_event

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -90,8 +90,12 @@ _LOGGER = logging.getLogger(__name__)
 _ACCESS_TOKEN_TTL = timedelta(days=3650)
 
 # Readiness probe: how long to wait for the server thread to accept a loopback
-# TCP connection before declaring the start failed.
-_READY_TIMEOUT_SECONDS = 30.0
+# TCP connection before declaring the start failed. Generous on purpose: a
+# cold import of the fastmcp tree takes 1-3s on real hardware but has been
+# observed to exceed 30s on QEMU-emulated HAOS (the e2e lane), and a single
+# readiness timeout fails the bring-up outright — there is no retry. Real
+# deployments only pay this budget on the failure path.
+_READY_TIMEOUT_SECONDS = 90.0
 _READY_POLL_INTERVAL_SECONDS = 0.5
 
 # How long to wait for the worker thread to exit on stop before giving up and
@@ -895,8 +899,12 @@ def _purge_ha_mcp_modules() -> None:
     shared with the rest of Home Assistant), so a dependency-version change
     still needs an HA core restart.
     """
+    # Snapshot the keys: sys.modules can be mutated by concurrent imports on
+    # other threads mid-iteration (HA core is heavily threaded).
     purged = [
-        name for name in sys.modules if name == "ha_mcp" or name.startswith("ha_mcp.")
+        name
+        for name in list(sys.modules)
+        if name == "ha_mcp" or name.startswith("ha_mcp.")
     ]
     if not purged:
         return

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -169,6 +169,10 @@ class EmbeddedServerManager:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_event: asyncio.Event | None = None
         self._thread_exc: BaseException | None = None
+        # ha_mcp.__version__ as imported by the CURRENT worker thread (stashed
+        # by _serve). Compared against the installed distribution after start
+        # to detect a stale-code worker (see _purge_ha_mcp_modules).
+        self._running_version: str | None = None
 
     @property
     def port(self) -> int:
@@ -199,6 +203,16 @@ class EmbeddedServerManager:
         access_token = await self._async_provision_token()
         await self._hass.async_add_executor_job(self._prepare_config_dir)
 
+        # Drop cached ha_mcp modules so the worker imports the code that is on
+        # disk NOW. Without this, a reload after a pip install keeps serving
+        # the OLD code forever: all workers are threads of the one HA core
+        # process, and Python resolves ``import ha_mcp`` from sys.modules —
+        # installs only took effect after a full HA core restart (issue
+        # observed live: options saves reinstalled the package, the web UI
+        # footer showed the new on-disk version, yet the serving worker kept
+        # reporting the version it was first imported with).
+        _purge_ha_mcp_modules()
+
         self._thread_exc = None
         self._thread = threading.Thread(
             target=self._thread_main,
@@ -209,6 +223,25 @@ class EmbeddedServerManager:
         self._thread.start()
 
         await self._async_wait_until_ready()
+
+        # Belt-and-braces staleness check: the worker stashed the
+        # ha_mcp.__version__ it actually imported; if that disagrees with the
+        # installed distribution the purge did not fully take (e.g. a stray
+        # import of ha_mcp outside the worker re-cached old modules) and only
+        # an HA core restart applies the update — say so instead of serving
+        # old code silently.
+        if self._running_version:
+            installed = await self._hass.async_add_executor_job(
+                _installed_ha_mcp_version
+            )
+            if installed and installed != self._running_version:
+                _LOGGER.warning(
+                    "HA-MCP in-process server is running version %s but "
+                    "version %s is installed; restart Home Assistant to "
+                    "finish applying the update.",
+                    self._running_version,
+                    installed,
+                )
 
     async def async_stop(self) -> None:
         """Signal the worker thread to shut down and join it (bounded).
@@ -244,6 +277,7 @@ class EmbeddedServerManager:
         self._loop = None
         self._stop_event = None
         self._thread_exc = None
+        self._running_version = None
 
     async def async_revoke_credentials(self) -> None:
         """Revoke the provisioned refresh token and remove the server's user.
@@ -621,6 +655,11 @@ class EmbeddedServerManager:
         # of os.environ is the whole point of the in-process channel.
         import ha_mcp.config as _hamcp_config
 
+        # Record which code generation this worker actually imported — the
+        # post-start staleness check in async_start compares it against the
+        # installed distribution.
+        self._running_version = getattr(sys.modules.get("ha_mcp"), "__version__", None)
+
         # Drop any settings singleton cached by a PREVIOUS start in this same
         # Python process: an entry reload must re-read the override files
         # (feature flags, advanced settings) exactly like an add-on restart
@@ -810,6 +849,30 @@ class EmbeddedServerManager:
         with suppress(OSError, TimeoutError):
             await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
         return True
+
+
+def _purge_ha_mcp_modules() -> None:
+    """Drop every cached ``ha_mcp`` module so the next import loads fresh code.
+
+    The in-process server runs as a thread of the HA core Python process, and
+    Python resolves imports from the process-wide ``sys.modules`` cache — so
+    after a pip install the next worker would silently reuse the OLD code
+    unless the cache is purged first. Safe here because ``ha_mcp`` is pure
+    Python and is only ever imported inside the (currently stopped) worker
+    thread; third-party dependencies are deliberately NOT purged (they are
+    shared with the rest of Home Assistant), so a dependency-version change
+    still needs an HA core restart.
+    """
+    purged = [
+        name for name in sys.modules if name == "ha_mcp" or name.startswith("ha_mcp.")
+    ]
+    for name in purged:
+        sys.modules.pop(name, None)
+    importlib.invalidate_caches()
+    if purged:
+        _LOGGER.debug(
+            "Purged %d cached ha_mcp module(s) before worker start", len(purged)
+        )
 
 
 def _installed_ha_mcp_version() -> str | None:

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -30,6 +30,10 @@ The flag is intentionally absent from the add-on Configuration page.
 `update_source` makes PR testing a one-call operation on an in-process
 server install: point the pip spec at the PR tarball, wait for the reinstall,
 reconnect, and verify with `info`. No extra repos or add-on rebuilds needed.
+Server-code updates apply on the entry reload itself (component >= 1.0.1
+purges the module cache per worker start); a change that needs *newer
+third-party dependencies* still wants a Home Assistant core restart, since
+shared libraries already loaded by the HA process are not reloaded.
 
 ### `ha_dev_manage_settings`
 

--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -41,7 +41,7 @@ shared libraries already loaded by the HA process are not reloaded.
 | ------ | ------------- |
 | `list` | Returns the full server-settings matrix (the same fields as the web UI's Server Settings tab) with each value's origin: `env` (pinned, read-only), `file` (override file), `addon` (Supervisor-managed), or `default`. |
 | `set` | Validates and persists one setting through the same override layer the web UI uses. Env-pinned settings are refused; beta sub-flags still require the beta master to be on. |
-| `reset` | Removes one setting's override-file entry, returning it to its env/default value. |
+| `reset` | Removes one setting's override-file entry, returning it to its default. Refused for env-pinned and add-on-managed settings, like `set`. |
 
 Changes persist immediately but — like the web UI — most settings only take
 effect after a restart (`ha_dev_manage_server` `restart`).

--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -1,0 +1,46 @@
+# Developer Mode
+
+Developer mode registers two hidden MCP tools intended for people developing
+or testing ha-mcp itself. It is **off by default**, and while it is off the
+tools are never registered — MCP clients cannot see or call them.
+
+> **Warning**: with developer mode on, any connected MCP client (i.e. any AI
+> agent using this server) can change server settings and replace the running
+> server version. Enable it only on instances used for development/testing.
+
+## Enabling
+
+The toggle lives at the **very bottom of the web settings UI**: Server
+Settings tab → **Developer** section (below the beta features). Flip the
+switch, confirm the warning, and restart the server for the tools to
+register. Alternatively set the `HAMCP_ENABLE_DEV_MODE=true` env var.
+
+The flag is intentionally absent from the add-on Configuration page.
+
+## Tools
+
+### `ha_dev_manage_server`
+
+| Action | What it does |
+| ------ | ------------- |
+| `info` | Reports server version, deployment mode (embedded / add-on / standalone), Python version, data dir, HA version, and — when the [in-process server](in-process-server.md) entry exists — its current channel and pip spec. |
+| `update_source` | Points the in-process (custom component) server at a release `channel` (`stable` / `dev`) or an explicit `pip_spec` — a version pin or a GitHub tarball URL such as `https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/<PR>/head.tar.gz` — then reinstalls and restarts it via the component's own options flow. |
+| `restart` | Restarts this server: config-entry reload in embedded mode, Supervisor self-restart in add-on mode. Standalone processes must be restarted externally. |
+
+`update_source` makes PR testing a one-call operation on an in-process
+server install: point the pip spec at the PR tarball, wait for the reinstall,
+reconnect, and verify with `info`. No extra repos or add-on rebuilds needed.
+
+### `ha_dev_manage_settings`
+
+| Action | What it does |
+| ------ | ------------- |
+| `list` | Returns the full server-settings matrix (the same fields as the web UI's Server Settings tab) with each value's origin: `env` (pinned, read-only), `file` (override file), `addon` (Supervisor-managed), or `default`. |
+| `set` | Validates and persists one setting through the same override layer the web UI uses. Env-pinned settings are refused; beta sub-flags still require the beta master to be on. |
+| `reset` | Removes one setting's override-file entry, returning it to its env/default value. |
+
+Changes persist immediately but — like the web UI — most settings only take
+effect after a restart (`ha_dev_manage_server` `restart`).
+
+Backup settings and per-tool enable/disable state are separate surfaces
+(Backups tab / Tools tab) and are not covered by this tool.

--- a/docs/in-process-server.md
+++ b/docs/in-process-server.md
@@ -146,7 +146,11 @@ unpinned: an entry reload or a Home Assistant restart always reinstalls the
 newest build of the selected channel, and on top of that the component checks
 PyPI for a newer build every 6 hours and reloads the entry automatically when
 one is published — so a long-running instance picks up releases without a
-restart. Each automatic update also raises a notification naming the old and
+restart. The reload applies the new server code immediately (component >=
+1.0.1 reloads the module cache per worker start); only updates that require
+newer *third-party dependencies* still need a Home Assistant core restart.
+The web settings UI's **Restart HA-MCP Server** button performs the same
+entry reload. Each automatic update also raises a notification naming the old and
 new version, with a link to the release notes. Turn **Automatic server
 updates** off to freeze the server on the version currently installed:
 reloads/restarts keep that exact version until you turn it back on or install

--- a/src/ha_mcp/_version.py
+++ b/src/ha_mcp/_version.py
@@ -30,6 +30,18 @@ def get_version() -> str:
     """
     if override := os.environ.get("HA_MCP_BUILD_VERSION"):
         return override
+    # Prefer the distribution that actually OWNS the installed ha_mcp package.
+    # Both channel dists (ha-mcp / ha-mcp-dev) can leave metadata behind — an
+    # interrupted channel switch, a best-effort uninstall that failed — and a
+    # fixed name order then reports the leftover dist's version instead of the
+    # one whose files are really installed.
+    try:
+        owners = importlib.metadata.packages_distributions().get("ha_mcp", [])
+        unique = sorted(set(owners))
+        if len(unique) == 1:
+            return importlib.metadata.version(unique[0])
+    except Exception as exc:
+        logger.debug("packages_distributions probe failed: %s", exc)
     for pkg_name in ("ha-mcp", "ha-mcp-dev"):
         try:
             return importlib.metadata.version(pkg_name)

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -256,6 +256,15 @@ class Settings(BaseSettings):
         "", alias="HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL"
     )
 
+    # Developer mode (issue #1775) — registers the hidden ha_dev_* tools
+    # (server update/restart, direct settings editing). Deliberately NOT a
+    # beta flag: it is a development aid, not a feature preview, and must
+    # not ride the beta master gate. The toggle renders in its own
+    # "Developer" section at the very bottom of the web UI's Server
+    # Settings tab; it is intentionally absent from the add-on config
+    # schemas so it stays out of the add-on Configuration page.
+    enable_dev_mode: bool = Field(False, alias="HAMCP_ENABLE_DEV_MODE")
+
     # Code Mode — sandboxed Python execution via pydantic-monty.
     # Provides an "escape hatch" tool (ha_manage_custom_tool) that lets LLMs write
     # custom one-off Python code when no existing tool covers the request.
@@ -556,6 +565,7 @@ AdvancedSection = Literal[
     "tools_surface",
     "sidecar",
     "beta_codemode",
+    "developer",
 ]
 
 
@@ -814,6 +824,12 @@ ADVANCED_SETTINGS_FIELDS: tuple[AdvancedField, ...] = (
         "beta_codemode",
         True,
     ),
+    # Developer mode (issue #1775). Lives in ADVANCED_SETTINGS_FIELDS —
+    # not FEATURE_FLAG_FIELDS — so it renders in its own "Developer"
+    # section at the very bottom of the Server Settings tab instead of
+    # among the feature toggles, and stays independent of the beta
+    # master gate.
+    AdvancedField("enable_dev_mode", "HAMCP_ENABLE_DEV_MODE", bool, "developer", True),
 )
 
 

--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -1518,8 +1518,24 @@ def build_settings_handlers(
             try:
                 found = await find_server_config_entry(server.client)
             except Exception as exc:
+                # A discovery FAILURE is not "entry not found" — masking a
+                # WS/connection hiccup as not-found steers users toward
+                # reinstalling a running component. Also: the restart JS
+                # treats any 5xx as "restart in flight" and starts its
+                # poll-reload cycle, so a restart that was never initiated
+                # must answer BELOW 500.
                 logger.warning("Embedded restart: entry discovery failed: %s", exc)
-                found = None
+                return JSONResponse(
+                    create_error_response(
+                        ErrorCode.CONNECTION_FAILED,
+                        "Could not reach Home Assistant to locate the "
+                        f"in-process server's config entry: {exc}",
+                        suggestions=[
+                            "Retry once Home Assistant is responsive",
+                        ],
+                    ),
+                    status_code=409,
+                )
             if found is None:
                 return JSONResponse(
                     create_error_response(
@@ -1531,7 +1547,9 @@ def build_settings_handlers(
                             "Devices & Services instead",
                         ],
                     ),
-                    status_code=500,
+                    # Below 500 on purpose: no restart was initiated, and the
+                    # restart JS interprets 5xx as restart-in-flight.
+                    status_code=409,
                 )
             entry_id, flow, _options = found
             await abort_options_flow_quietly(server.client, flow)
@@ -1666,7 +1684,10 @@ def build_settings_handlers(
         # either channel; standalone Docker / uvx falls back to the
         # installed package's metadata.
         try:
-            version = get_version()
+            # Executor: get_version's distribution-ownership scan reads
+            # metadata for every installed package — too heavy for the
+            # event loop on an endpoint the restart cycle polls.
+            version = await asyncio.to_thread(get_version)
         except Exception:  # pragma: no cover — defensive only
             logger.warning("get_version() raised; omitting version from info")
             version = None

--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -27,7 +27,7 @@ import httpx
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 
-from .._version import get_version, is_running_in_addon
+from .._version import get_version, is_embedded, is_running_in_addon
 from ..backup_manager import get_backup_manager
 from ..client.supervisor_client import make_supervisor_httpx_client
 from ..config import (
@@ -1502,6 +1502,44 @@ def build_settings_handlers(
         )
 
     async def _restart_addon(request: Request) -> JSONResponse:
+        # Embedded (in-process custom-component server): "restart" means
+        # reloading the ha_mcp_tools server config entry. Checked before the
+        # Supervisor path — the HA core container carries SUPERVISOR_TOKEN,
+        # but the Supervisor add-on API is not ours to call from here, and
+        # post-reload the new worker imports the freshly installed code
+        # (the manager purges the module cache per start).
+        if server is not None and is_embedded():
+            from ..tools.tools_dev import (
+                abort_options_flow_quietly,
+                find_server_config_entry,
+                schedule_deferred_entry_reload,
+            )
+
+            try:
+                found = await find_server_config_entry(server.client)
+            except Exception as exc:
+                logger.warning("Embedded restart: entry discovery failed: %s", exc)
+                found = None
+            if found is None:
+                return JSONResponse(
+                    create_error_response(
+                        ErrorCode.INTERNAL_ERROR,
+                        "Could not locate the in-process server's config "
+                        "entry to reload",
+                        suggestions=[
+                            "Reload the HA-MCP integration from Settings > "
+                            "Devices & Services instead",
+                        ],
+                    ),
+                    status_code=500,
+                )
+            entry_id, flow, _options = found
+            await abort_options_flow_quietly(server.client, flow)
+            schedule_deferred_entry_reload(server.client, entry_id)
+            return JSONResponse(
+                {"success": True, "message": "In-process server reload scheduled"}
+            )
+
         # The sidecar process (server is None) has no Supervisor context
         # and no live server settings — refuse cleanly. The HTTP modes
         # that do pass a server still go through the SUPERVISOR_TOKEN
@@ -1632,10 +1670,20 @@ def build_settings_handlers(
         except Exception:  # pragma: no cover — defensive only
             logger.warning("get_version() raised; omitting version from info")
             version = None
+        # ``deployment_mode`` reuses the bug-report detector so the UI and
+        # ha_report_issue can never disagree about where the server runs —
+        # the embedded (in-process custom component) server would otherwise
+        # read as plain "docker" here (/.dockerenv exists in the HA core
+        # container).
+        from ..tools.tools_bug_report import _detect_installation_method
+
         return JSONResponse(
             {
                 "is_addon": addon,
                 "is_sidecar": is_sidecar,
+                "deployment_mode": (
+                    "sidecar" if is_sidecar else _detect_installation_method()
+                ),
                 "instance_id": _PROCESS_INSTANCE_ID,
                 "started_at": _PROCESS_STARTED_AT,
                 "version": version,

--- a/src/ha_mcp/settings_ui/settings.html
+++ b/src/ha_mcp/settings_ui/settings.html
@@ -161,7 +161,7 @@
   <button class="tab" data-panel="entity-visibility" role="tab" id="tab-entity-visibility" aria-controls="panel-entity-visibility" aria-selected="false" tabindex="-1">Entity Visibility</button>
   <button class="tab" data-panel="accessibility" role="tab" id="tab-accessibility" aria-controls="panel-accessibility" aria-selected="false" tabindex="-1">Accessibility</button>
 </div>
-<div class="restart-notice" id="restartNotice">
+<div class="restart-notice" id="restartNotice" role="status" aria-live="polite">
   <span class="restart-notice-text" id="restartNoticeText">
     ⚠ Changes saved. Restart HA-MCP for them to take effect. On next
     startup, HA-MCP fully removes disabled tools from the MCP tool list.

--- a/src/ha_mcp/settings_ui/settings.html
+++ b/src/ha_mcp/settings_ui/settings.html
@@ -265,6 +265,12 @@
             title="Permanently disables the settings UI: stops this server AND writes ~/.ha-mcp/settings_ui_disabled so it does not respawn on future ha-mcp launches. Delete that file to re-enable."
     >Permanently disable settings server</button>
   </div>
+
+  <!-- Developer section sits at the ABSOLUTE bottom of the panel by
+       design (issue #1775): the dev-mode toggle registers hidden
+       ha_dev_* tools and should not be obvious to casual users. -->
+  <h2 class="adv-section-title beta-section-title">Developer</h2>
+  <div id="advDeveloper" class="adv-section"></div>
 </div>
 <div class="panel" id="panel-backups" role="tabpanel" aria-labelledby="tab-backups" tabindex="0">
   <div class="backup-state" id="backupState">Loading backup state…</div>

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -217,6 +217,22 @@ async function applyInfoChrome() {
           'Desktop. Restarting the App (add-on) alone does not refresh your ' +
           'client\'s cached tool list.';
       }
+    } else if (info.deployment_mode === 'embedded') {
+      // In-process (custom component) server: the restart endpoint reloads
+      // the server config entry, which reinstalls-if-newer and swaps the
+      // worker onto the freshly installed code.
+      const rbtn = document.getElementById('restartBtn');
+      rbtn.style.display = '';
+      rbtn.textContent = 'Restart HA-MCP Server';
+      if (noticeEl) {
+        noticeEl.textContent =
+          '⚠ Changes saved. Click "Restart HA-MCP Server" (reloads the ' +
+          'in-process server integration) for them to take effect. ' +
+          'Disabled tools will be fully removed from the MCP tool list on ' +
+          'next startup. Then refresh the tool list in your AI client — ' +
+          'e.g. refresh tool list on claude.ai, re-add or refresh the ' +
+          'connector in ChatGPT, or close and reopen Claude Desktop.';
+      }
     } else if (info.is_sidecar) {
       if (noticeEl) {
         noticeEl.textContent =
@@ -414,7 +430,7 @@ async function _runRestartReloadCycle(previousInstanceId) {
 async function restartAddon() {
   if (restartInProgress) return;
   const btn = document.getElementById('restartBtn');
-  if (!confirm('Restart the App (add-on) now? The page will reload automatically once the App (add-on) is back online.')) return;
+  if (!confirm('Restart HA-MCP now? The page will reload automatically once it is back online.')) return;
   restartInProgress = true;
   btn.disabled = true;
   btn.textContent = 'Restarting…';

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -2946,6 +2946,7 @@ const ADVANCED_FIELD_META = {
   code_mode_max_invocations: { label: "Code-mode max invocations",    help: "API/tool-call cap per sandbox run. Restart required." },
   code_mode_saved_tools_path:{ label: "Saved-tools path",              help: "JSON file where ha_manage_custom_tool persists saved tools across restarts. Restart required." },
   sidecar_pin_port:    { label: "Settings UI sidecar port",    help: "0 = a new free port each restart (default); set 1024–65535 to pin a fixed port so the settings URL stays stable across restarts. Falls back to a free port if the pinned one is busy. Restart required." },
+  enable_dev_mode:     { label: "Developer mode",               help: "⚠ DANGER: registers hidden developer tools (ha_dev_manage_server, ha_dev_manage_settings) that let AI agents change server settings and replace the running server version (e.g. install a PR build). For development and testing only. Restart required." },
 };
 
 // Fields that require an MCP-host restart to take effect when changed
@@ -2974,6 +2975,9 @@ const ADVANCED_RESTART_REQUIRED = new Set([
   // The sidecar binds its port once at spawn (run_main), so changing the
   // pin needs a restart to respawn the sidecar on the new port.
   "sidecar_pin_port",
+  // Dev-mode tools register at startup; toggling needs a restart to
+  // (un)register them.
+  "enable_dev_mode",
 ]);
 
 let _advancedFields = [];
@@ -3039,6 +3043,7 @@ async function loadAdvancedSettings() {
   renderAdvancedSection('advToolsSurface', bySection.tools_surface || []);
   renderAdvancedSection('advDiagnostics', bySection.diagnostics || []);
   renderAdvancedSection('advSidecar', bySection.sidecar || []);
+  renderAdvancedSection('advDeveloper', bySection.developer || []);
   applySidecarAvailability(data.is_stdio !== false);
   // Re-render feature flags so the code_mode sub-numerics show up
   // beneath enable_code_mode (race: loadFeatureFlags may have run
@@ -3138,6 +3143,19 @@ function renderAdvancedSection(containerId, fields) {
       const fname = input.dataset.advField;
       const f = _advancedFields.find(x => x.field === fname);
       if (!f) return;
+      // Dev mode arms tools that can rewrite server settings and swap
+      // the running server version — confirm before enabling, matching
+      // the stopSidecar / restart danger-action convention.
+      if (fname === 'enable_dev_mode' && input.checked && !confirm(
+        '⚠ Enable developer mode?\n\n'
+        + 'After the next restart, hidden developer tools are exposed to '
+        + 'connected AI agents. They can change server settings and '
+        + 'replace the running server version. Only enable this for '
+        + 'development and testing.'
+      )) {
+        input.checked = false;
+        return;
+      }
       let v;
       if (input.type === 'checkbox') v = input.checked;
       else if (input.type === 'number') v = (f.type === 'float') ? parseFloat(input.value) : parseInt(input.value, 10);

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -153,14 +153,22 @@ def _instance_identity() -> dict[str, Any]:
 
 
 def _format_version_value(diagnostic_info: dict[str, Any]) -> str:
-    """Render the version for report surfaces, flagging a stale worker."""
+    """Render the version for report surfaces, flagging a stale worker.
+
+    A failed installed-version probe must stay distinguishable from
+    "checked, versions match" — otherwise the exact stale-worker
+    condition this field exists to expose disappears whenever the probe
+    itself hiccups.
+    """
     running = diagnostic_info.get("ha_mcp_version", "Unknown")
+    installed = diagnostic_info.get("installed_version")
     if diagnostic_info.get("version_mismatch"):
-        installed = diagnostic_info.get("installed_version")
         return (
             f"{running} (running) — {installed} is installed; "
             "restart to finish applying the update"
         )
+    if installed is None:
+        return f"{running} (installed-on-disk version could not be verified)"
     return str(running)
 
 
@@ -527,7 +535,7 @@ def _build_formatted_report(
         "=== ha-mcp Bug Report Info ===",
         "",
         f"ha-mcp Version: {_format_version_value(diagnostic_info)}",
-        f"Custom Component: {diagnostic_info.get('component_version') or 'not installed'}",
+        f"Custom Component: {diagnostic_info.get('component_version') or 'not detected (not installed, or probe failed)'}",
         f"Installation Method: {diagnostic_info['installation_method']}",
         f"MCP Transport: {mcp_transport}",
         f"MCP Client: {_format_client_info_for_template(client_info)}",
@@ -1177,7 +1185,7 @@ ha_call_service(domain="light", service="turn_on", entity_id="light.example")
 ## 🔧 Environment
 
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
-- **Custom Component:** {diagnostic_info.get("component_version") or "not installed"}
+- **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
@@ -1342,7 +1350,7 @@ def _generate_agent_behavior_template(
 ## 📊 Environment
 
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
-- **Custom Component:** {diagnostic_info.get("component_version") or "not installed"}
+- **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -5,6 +5,7 @@ This module provides a tool to collect diagnostic information and guide users
 on how to create effective bug reports.
 """
 
+import asyncio
 import importlib
 import logging
 import os
@@ -133,7 +134,7 @@ def _detect_installed_version() -> str | None:
         importlib.invalidate_caches()
         return get_version()
     except Exception as e:
-        logger.debug("Installed-version probe failed: %s", e)
+        logger.info("Installed-version probe failed: %s", e)
         return None
 
 
@@ -598,7 +599,7 @@ class BugReportTools:
             version = payload.get("version") if isinstance(payload, dict) else None
             return str(version) if version else None
         except Exception as e:
-            logger.debug("Component version probe failed: %s", e)
+            logger.info("Component version probe failed: %s", e)
             return None
 
     @tool(
@@ -675,7 +676,7 @@ class BugReportTools:
         config_toggles = _get_config_toggles()
         mcp_transport = _detect_mcp_transport()
         client_info = _extract_client_info(ctx)
-        installed_version = _detect_installed_version()
+        installed_version = await asyncio.to_thread(_detect_installed_version)
         component_version = await self._detect_component_version()
 
         diagnostic_info: dict[str, Any] = {

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -5,11 +5,13 @@ This module provides a tool to collect diagnostic information and guide users
 on how to create effective bug reports.
 """
 
+import importlib
 import logging
 import os
 import platform
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import quote_plus
@@ -21,7 +23,7 @@ from pydantic import Field
 
 from ha_mcp import __version__
 
-from .._version import is_running_in_addon
+from .._version import get_version, is_embedded, is_running_in_addon
 from ..client.supervisor_client import make_supervisor_httpx_client
 from ..config import Settings, get_global_settings
 from ..utils.usage_logger import (
@@ -72,21 +74,28 @@ def _detect_installation_method() -> str:
     """
     Detect how ha-mcp was installed.
 
-    Returns one of: pyinstaller, addon, docker, git, pypi, unknown
+    Returns one of: pyinstaller, embedded, addon, docker, git, pypi, unknown
     """
     # 1. PyInstaller binary
     if getattr(sys, "frozen", False):
         return "pyinstaller"
 
-    # 2. Home Assistant Add-on (has supervisor token)
+    # 2. In-process server inside HA core (the ha_mcp_tools custom
+    #    component's "server" entry). Checked BEFORE the docker probe: the
+    #    HA core container carries /.dockerenv, so without this branch
+    #    embedded installs misreport as plain docker.
+    if is_embedded():
+        return "embedded"
+
+    # 3. Home Assistant Add-on (has supervisor token)
     if is_running_in_addon():
         return "addon"
 
-    # 3. Docker container (non-addon)
+    # 4. Docker container (non-addon)
     if Path("/.dockerenv").exists():
         return "docker"
 
-    # 4. Git clone - check for .git directory relative to package
+    # 5. Git clone - check for .git directory relative to package
     try:
         # Go up from tools_bug_report.py -> tools -> ha_mcp -> src -> project_root
         project_root = Path(__file__).parent.parent.parent.parent
@@ -97,7 +106,7 @@ def _detect_installation_method() -> str:
         # fall through to the next detection heuristic.
         pass
 
-    # 5. PyPI install - marker file exists in package
+    # 6. PyPI install - marker file exists in package
     try:
         marker_path = Path(__file__).parent.parent / "_pypi_marker"
         if marker_path.exists():
@@ -107,8 +116,52 @@ def _detect_installation_method() -> str:
         # fall through to the default "unknown" result.
         pass
 
-    # 6. Default - unknown
+    # 7. Default - unknown
     return "unknown"
+
+
+def _detect_installed_version() -> str | None:
+    """Return the ha-mcp version installed ON DISK right now.
+
+    ``__version__`` is frozen when the process first imports ha_mcp, so after
+    an in-place update the running process keeps reporting the old version
+    while the disk already carries the new one. Reporting both (plus
+    ``version_mismatch``) turns a "which server am I talking to" hunt into a
+    single tool call.
+    """
+    try:
+        importlib.invalidate_caches()
+        return get_version()
+    except Exception as e:
+        logger.debug("Installed-version probe failed: %s", e)
+        return None
+
+
+def _instance_identity() -> dict[str, Any]:
+    """Return process identity (id, start time, uptime).
+
+    Mirrors the ``/api/settings/info`` fields so a report and the web UI can
+    be matched to the same (or different) server process.
+    """
+    from ..settings_ui import _PROCESS_INSTANCE_ID, _PROCESS_STARTED_AT
+
+    return {
+        "instance_id": _PROCESS_INSTANCE_ID,
+        "started_at": _PROCESS_STARTED_AT,
+        "uptime_seconds": round(time.time() - _PROCESS_STARTED_AT, 1),
+    }
+
+
+def _format_version_value(diagnostic_info: dict[str, Any]) -> str:
+    """Render the version for report surfaces, flagging a stale worker."""
+    running = diagnostic_info.get("ha_mcp_version", "Unknown")
+    if diagnostic_info.get("version_mismatch"):
+        installed = diagnostic_info.get("installed_version")
+        return (
+            f"{running} (running) — {installed} is installed; "
+            "restart to finish applying the update"
+        )
+    return str(running)
 
 
 def _detect_platform() -> dict[str, str]:
@@ -473,7 +526,8 @@ def _build_formatted_report(
     report_lines = [
         "=== ha-mcp Bug Report Info ===",
         "",
-        f"ha-mcp Version: {diagnostic_info['ha_mcp_version']}",
+        f"ha-mcp Version: {_format_version_value(diagnostic_info)}",
+        f"Custom Component: {diagnostic_info.get('component_version') or 'not installed'}",
         f"Installation Method: {diagnostic_info['installation_method']}",
         f"MCP Transport: {mcp_transport}",
         f"MCP Client: {_format_client_info_for_template(client_info)}",
@@ -517,6 +571,27 @@ def _build_formatted_report(
 class BugReportTools:
     def __init__(self, client: Any) -> None:
         self._client = client
+
+    async def _detect_component_version(self) -> str | None:
+        """Read the ha_mcp_tools custom component's version, best-effort.
+
+        Uses the component's ``get_caller_token`` bootstrap service, whose
+        response carries the manifest version (the same field the filesystem
+        tools' version gate reads). Returns None when the component is not
+        installed or the call fails — the report path must never break on it.
+        """
+        try:
+            resp = await self._client.call_service(
+                "ha_mcp_tools", "get_caller_token", {}, return_response=True
+            )
+            payload = (
+                resp.get("service_response", resp) if isinstance(resp, dict) else {}
+            )
+            version = payload.get("version") if isinstance(payload, dict) else None
+            return str(version) if version else None
+        except Exception as e:
+            logger.debug("Component version probe failed: %s", e)
+            return None
 
     @tool(
         name="ha_report_issue",
@@ -592,9 +667,17 @@ class BugReportTools:
         config_toggles = _get_config_toggles()
         mcp_transport = _detect_mcp_transport()
         client_info = _extract_client_info(ctx)
+        installed_version = _detect_installed_version()
+        component_version = await self._detect_component_version()
 
         diagnostic_info: dict[str, Any] = {
             "ha_mcp_version": __version__,
+            "installed_version": installed_version,
+            "version_mismatch": bool(
+                installed_version and installed_version != __version__
+            ),
+            "component_version": component_version,
+            "instance": _instance_identity(),
             "installation_method": install_method,
             "platform": platform_info,
             "mcp_transport": mcp_transport,
@@ -1093,7 +1176,8 @@ ha_call_service(domain="light", service="turn_on", entity_id="light.example")
 
 ## 🔧 Environment
 
-- **ha-mcp Version:** {diagnostic_info.get("ha_mcp_version", "Unknown")}
+- **ha-mcp Version:** {_format_version_value(diagnostic_info)}
+- **Custom Component:** {diagnostic_info.get("component_version") or "not installed"}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
@@ -1257,7 +1341,8 @@ def _generate_agent_behavior_template(
 
 ## 📊 Environment
 
-- **ha-mcp Version:** {diagnostic_info.get("ha_mcp_version", "Unknown")}
+- **ha-mcp Version:** {_format_version_value(diagnostic_info)}
+- **Custom Component:** {diagnostic_info.get("component_version") or "not installed"}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -80,6 +80,90 @@ def _spawn_background(coro: Any) -> None:
     task.add_done_callback(_BACKGROUND_TASKS.discard)
 
 
+async def find_server_config_entry(
+    client: Any,
+) -> tuple[str, dict[str, Any], dict[str, Any]] | None:
+    """Find the ha_mcp_tools in-process "server" config entry.
+
+    Probes each ``ha_mcp_tools`` entry's options flow: the server entry's
+    flow is a form whose schema carries the ``pip_spec`` field; the tools
+    (services) entry's flow aborts immediately. Returns
+    ``(entry_id, open_flow, current_options)`` with the options flow left
+    OPEN (callers must submit or abort it), or ``None`` when no server
+    entry exists. ``current_options`` maps schema field names to their
+    defaults — i.e. the entry's current option values.
+
+    Module-level (not a DevTools method) so the settings UI's embedded
+    restart handler can share it.
+    """
+    response = await client.send_websocket_message(
+        {"type": "config_entries/get", "domain": COMPONENT_DOMAIN}
+    )
+    if not response.get("success"):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                f"config_entries/get failed: {response.get('error')}",
+                suggestions=["Check the Home Assistant WebSocket connection"],
+            )
+        )
+    result = response.get("result", [])
+    entries = result if isinstance(result, list) else []
+    for entry in entries:
+        entry_id = entry.get("entry_id")
+        if not entry_id:
+            continue
+        try:
+            flow = await client.start_options_flow(entry_id)
+        except Exception as exc:  # probe is best-effort per entry
+            logger.debug("Options-flow probe failed for %s: %s", entry_id, exc)
+            continue
+        schema = flow.get("data_schema") or []
+        fields: dict[str, Any] = {
+            str(item["name"]): item.get("default")
+            for item in schema
+            if isinstance(item, dict) and item.get("name")
+        }
+        if flow.get("type") == "form" and _OPT_PIP_SPEC in fields:
+            return str(entry_id), flow, fields
+        # Not the server entry — close the probe flow if one opened.
+        await abort_options_flow_quietly(client, flow)
+    return None
+
+
+async def abort_options_flow_quietly(client: Any, flow: dict[str, Any]) -> None:
+    """Abort an open options flow, ignoring failures."""
+    flow_id = flow.get("flow_id")
+    if not flow_id:
+        return
+    try:
+        await client.abort_options_flow(flow_id)
+    except Exception as exc:
+        logger.debug("Options-flow abort failed: %s", exc)
+
+
+def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
+    """Reload a config entry after the response-flush delay, fire-and-forget.
+
+    Self-restart path for the embedded server: the reload tears down the
+    very worker answering the current request, so it must not run until the
+    response has flushed. Failures can only be logged — there is no caller
+    left to answer.
+    """
+
+    async def _reload() -> None:
+        await asyncio.sleep(_SELF_ACTION_FLUSH_DELAY_S)
+        try:
+            await client._request(
+                "POST", f"/config/config_entries/entry/{entry_id}/reload"
+            )
+            logger.info("Deferred reload of entry %s requested", entry_id)
+        except Exception:
+            logger.exception("Deferred config-entry reload failed")
+
+    _spawn_background(_reload())
+
+
 class DevTools:
     """Developer-mode tools for server introspection, update, and settings."""
 
@@ -290,72 +374,6 @@ class DevTools:
 
     # ----- server-entry helpers -----
 
-    async def _list_component_entries(self) -> list[dict[str, Any]]:
-        """List the ha_mcp_tools config entries via the WebSocket API."""
-        response = await self._client.send_websocket_message(
-            {"type": "config_entries/get", "domain": COMPONENT_DOMAIN}
-        )
-        if not response.get("success"):
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"config_entries/get failed: {response.get('error')}",
-                    suggestions=["Check the Home Assistant WebSocket connection"],
-                )
-            )
-        result = response.get("result", [])
-        return result if isinstance(result, list) else []
-
-    async def _find_server_entry(
-        self,
-    ) -> tuple[str, dict[str, Any], dict[str, Any]] | None:
-        """Find the component's in-process "server" entry.
-
-        Probes each ``ha_mcp_tools`` entry's options flow: the server
-        entry's flow is a form whose schema carries the ``pip_spec``
-        field; the tools (services) entry's flow aborts immediately.
-        Returns ``(entry_id, open_flow, current_options)`` with the
-        options flow left OPEN (callers must submit or abort it), or
-        ``None`` when no server entry exists. ``current_options`` maps
-        schema field names to their defaults — i.e. the entry's
-        current option values.
-        """
-        for entry in await self._list_component_entries():
-            entry_id = entry.get("entry_id")
-            if not entry_id:
-                continue
-            try:
-                flow = await self._client.start_options_flow(entry_id)
-            except Exception as exc:  # probe is best-effort per entry
-                logger.debug("Options-flow probe failed for %s: %s", entry_id, exc)
-                continue
-            schema = flow.get("data_schema") or []
-            fields: dict[str, Any] = {
-                str(item["name"]): item.get("default")
-                for item in schema
-                if isinstance(item, dict) and item.get("name")
-            }
-            if flow.get("type") == "form" and _OPT_PIP_SPEC in fields:
-                return entry_id, flow, fields
-            # Not the server entry — close the probe flow if one opened.
-            flow_id = flow.get("flow_id")
-            if flow_id:
-                try:
-                    await self._client.abort_options_flow(flow_id)
-                except Exception as exc:
-                    logger.debug("Probe-flow abort failed: %s", exc)
-        return None
-
-    async def _abort_flow_quietly(self, flow: dict[str, Any]) -> None:
-        """Abort an open options flow, ignoring failures."""
-        flow_id = flow.get("flow_id")
-        if not flow_id:
-            return
-        try:
-            await self._client.abort_options_flow(flow_id)
-        except Exception as exc:
-            logger.debug("Options-flow abort failed: %s", exc)
-
     async def _delayed_submit_options(
         self, flow_id: str, user_input: dict[str, Any]
     ) -> None:
@@ -373,17 +391,6 @@ class DevTools:
             logger.info("Deferred options submit result: %s", result.get("type"))
         except Exception:
             logger.exception("Deferred options-flow submit failed")
-
-    async def _delayed_entry_reload(self, entry_id: str) -> None:
-        """Reload a config entry after the response-flush delay."""
-        await asyncio.sleep(_SELF_ACTION_FLUSH_DELAY_S)
-        try:
-            await self._client._request(
-                "POST", f"/config/config_entries/entry/{entry_id}/reload"
-            )
-            logger.info("Deferred reload of entry %s requested", entry_id)
-        except Exception:
-            logger.exception("Deferred config-entry reload failed")
 
     # ----- tools -----
 
@@ -731,12 +738,12 @@ class DevTools:
         except Exception as exc:
             warnings.append(f"Could not read HA version: {exc}")
         try:
-            found = await self._find_server_entry()
+            found = await find_server_config_entry(self._client)
             if found is None:
                 data["component_server_entry"] = None
             else:
                 entry_id, flow, options = found
-                await self._abort_flow_quietly(flow)
+                await abort_options_flow_quietly(self._client, flow)
                 data["component_server_entry"] = {
                     "entry_id": entry_id,
                     "channel": options.get(_OPT_CHANNEL),
@@ -778,7 +785,7 @@ class DevTools:
                 )
             )
 
-        found = await self._find_server_entry()
+        found = await find_server_config_entry(self._client)
         if found is None:
             raise_tool_error(
                 create_error_response(
@@ -859,7 +866,7 @@ class DevTools:
 
     async def _restart_server(self) -> dict[str, Any]:
         if is_embedded():
-            found = await self._find_server_entry()
+            found = await find_server_config_entry(self._client)
             if found is None:
                 raise_tool_error(
                     create_error_response(
@@ -870,8 +877,8 @@ class DevTools:
                     )
                 )
             entry_id, flow, _options = found
-            await self._abort_flow_quietly(flow)
-            _spawn_background(self._delayed_entry_reload(entry_id))
+            await abort_options_flow_quietly(self._client, flow)
+            schedule_deferred_entry_reload(self._client, entry_id)
             return {
                 "success": True,
                 "data": {

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -20,6 +20,7 @@ from fastmcp.tools import tool
 from pydantic import Field
 
 from .._version import get_version, is_dev_version, is_embedded, is_running_in_addon
+from ..client.rest_client import HomeAssistantAPIError
 from ..errors import ErrorCode, create_error_response
 from .helpers import (
     exception_to_structured_error,
@@ -115,7 +116,13 @@ async def find_server_config_entry(
             continue
         try:
             flow = await client.start_options_flow(entry_id)
-        except Exception as exc:  # probe is best-effort per entry
+        except HomeAssistantAPIError as exc:
+            # This entry's flow can't open (e.g. an entry type without an
+            # options flow) — skip it and keep probing. Connection/auth
+            # errors deliberately propagate: swallowing them here would
+            # make a broken connection indistinguishable from "no server
+            # entry exists" and steer the caller toward reinstalling a
+            # component that is already running.
             logger.debug("Options-flow probe failed for %s: %s", entry_id, exc)
             continue
         schema = flow.get("data_schema") or []
@@ -430,8 +437,9 @@ class DevTools:
         env/file/addon origins.
 
         Caveats: changed values persist to the server's override file
-        (or the add-on options via Supervisor) but only take effect
-        after a server restart (ha_dev_manage_server action="restart").
+        (or the add-on options via Supervisor) but most settings only
+        take effect after a server restart (ha_dev_manage_server
+        action="restart").
         Env-pinned settings are read-only until the env var is unset.
         This can flip security-sensitive flags; treat with the same
         care as editing the web UI.
@@ -686,9 +694,11 @@ class DevTools:
         as a PR tarball, and restarting the server so config or code
         changes take effect.
 
-        Caveats: update_source and restart interrupt this MCP
-        connection — in embedded/add-on mode the reply arrives just
-        before the server goes down, and reinstalls can take minutes.
+        Caveats: restart interrupts this MCP connection in embedded and
+        add-on deployments (the reply arrives just before the server
+        goes down); update_source only self-interrupts in embedded mode
+        — elsewhere it reloads the separate in-process server entry
+        without dropping this connection. Reinstalls can take minutes.
         update_source requires the ha_mcp_tools component's in-process
         server entry; restart supports embedded and add-on deployments
         only (standalone processes must be restarted externally).
@@ -750,9 +760,11 @@ class DevTools:
                     "channel": options.get(_OPT_CHANNEL),
                     "pip_spec": options.get(_OPT_PIP_SPEC),
                 }
-        except ToolError:
-            raise
         except Exception as exc:
+            # Best-effort probe: a failure here (including the ToolError the
+            # entry discovery raises on a config_entries/get failure) must
+            # degrade the info report to a warning, mirroring the HA-version
+            # probe above — not hard-fail the whole diagnostic.
             warnings.append(f"Could not inspect component server entry: {exc}")
         result: dict[str, Any] = {"success": True, "data": data}
         if warnings:

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -229,6 +229,7 @@ class DevTools:
                 context={"setting": fname, "value": raw},
             )
         )
+        return None  # unreachable; explicit for CodeQL
 
     @staticmethod
     async def _merge_file_override(changes: dict[str, Any]) -> None:
@@ -389,7 +390,7 @@ class DevTools:
     @tool(
         name="ha_dev_manage_settings",
         tags={"Developer"},
-        annotations={"title": "Manage Server Settings (dev)"},
+        annotations={"title": "Manage Server Settings (dev)", "destructiveHint": True},
     )
     @log_tool_usage
     async def ha_dev_manage_settings(
@@ -630,7 +631,7 @@ class DevTools:
     @tool(
         name="ha_dev_manage_server",
         tags={"Developer"},
-        annotations={"title": "Manage MCP Server (dev)"},
+        annotations={"title": "Manage MCP Server (dev)", "destructiveHint": True},
     )
     @log_tool_usage
     async def ha_dev_manage_server(

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -335,7 +335,8 @@ class DevTools:
         async with _get_override_file_lock():
             existing: dict[str, Any] = {}
             try:
-                existing_raw = path.read_text()
+                # Executor thread: file I/O must not block the event loop.
+                existing_raw = await asyncio.to_thread(path.read_text)
             except FileNotFoundError:
                 existing_raw = None
             except OSError as exc:
@@ -370,7 +371,7 @@ class DevTools:
                     existing.pop(key, None)
                 else:
                     existing[key] = val
-            _atomic_write_json(path, existing)
+            await asyncio.to_thread(_atomic_write_json, path, existing)
 
     # ----- server-entry helpers -----
 

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -454,7 +454,7 @@ class DevTools:
                 return {
                     "success": True,
                     "data": {
-                        "settings": self._settings_rows(),
+                        "settings": await asyncio.to_thread(self._settings_rows),
                         "is_addon": is_running_in_addon(),
                         "is_embedded": is_embedded(),
                         "note": (
@@ -500,7 +500,7 @@ class DevTools:
                 choices = None
             elif setting in advanced:
                 env_name, ftype, _section, registry_editable = advanced[setting]
-                overrides = _read_feature_flag_override_file()
+                overrides = await asyncio.to_thread(_read_feature_flag_override_file)
                 origin = self._advanced_origin(setting, env_name, overrides)
                 editable = registry_editable and origin != "env"
                 bounds = _ADVANCED_SETTINGS_BOUNDS.get(setting)
@@ -728,7 +728,7 @@ class DevTools:
     async def _server_info(self) -> dict[str, Any]:
         from ..utils.data_paths import get_data_dir
 
-        version = get_version()
+        version = await asyncio.to_thread(get_version)
         if is_embedded():
             mode = "embedded"
         elif is_running_in_addon():

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1,0 +1,933 @@
+"""
+Developer-mode tools for managing the ha-mcp server itself.
+
+These tools are hidden behind the ``enable_dev_mode`` setting (the
+"Developer" section at the bottom of the web settings UI's Server
+Settings tab, or the ``HAMCP_ENABLE_DEV_MODE`` env var). When the flag
+is off — the default — ``register_dev_tools`` registers nothing, so the
+tools do not exist for MCP clients at all.
+
+Feature Flag: Set HAMCP_ENABLE_DEV_MODE=true to enable these tools.
+"""
+
+import asyncio
+import logging
+import sys
+from typing import Annotated, Any, Literal
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import tool
+from pydantic import Field
+
+from .._version import get_version, is_dev_version, is_embedded, is_running_in_addon
+from ..errors import ErrorCode, create_error_response
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    register_tool_methods,
+)
+
+logger = logging.getLogger(__name__)
+
+# Feature flag - disabled by default; the toggle lives in the Developer
+# section of the web settings UI (Server Settings tab, bottom).
+FEATURE_FLAG = "HAMCP_ENABLE_DEV_MODE"
+
+# Domain of the ha_mcp_tools custom component. Its "server" config entry
+# runs the ha-mcp server in-process inside HA and exposes channel /
+# pip-spec options that ha_dev_manage_server drives.
+COMPONENT_DOMAIN = "ha_mcp_tools"
+
+# Options-flow field names of the component's server entry
+# (custom_components/ha_mcp_tools/const.py OPT_CHANNEL / OPT_PIP_SPEC).
+_OPT_CHANNEL = "channel"
+_OPT_PIP_SPEC = "pip_spec"
+_VALID_CHANNELS = ("stable", "dev")
+
+# Delay before a self-affecting action (embedded entry reload / options
+# submit) fires, so this tool's JSON response flushes to the MCP client
+# before the serving thread is torn down. Mirrors
+# settings_ui._SUPERVISOR_SELF_RESTART_FLUSH_DELAY_S, with more headroom
+# because the embedded response may traverse the HA ingress/webhook hop.
+_SELF_ACTION_FLUSH_DELAY_S = 1.0
+
+# Strong references to in-flight fire-and-forget tasks so the event
+# loop's weakref-only task table can't garbage-collect them mid-run.
+# Same pattern as settings_ui._BACKGROUND_RESTART_TASKS.
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
+# Sentinel marking a key for removal in _merge_file_override (reset action).
+_REMOVE = object()
+
+
+def is_dev_mode_enabled() -> bool:
+    """Check if developer mode is enabled.
+
+    Reads through :func:`config.get_global_settings` so the same
+    env-var / override-file / default precedence path applies as
+    every other runtime-editable Settings field.
+    """
+    from ..config import get_global_settings
+
+    return bool(get_global_settings().enable_dev_mode)
+
+
+def _spawn_background(coro: Any) -> None:
+    """Run ``coro`` as a strongly-referenced fire-and-forget task."""
+    task = asyncio.get_running_loop().create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+class DevTools:
+    """Developer-mode tools for server introspection, update, and settings."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    # ----- settings management helpers -----
+
+    @staticmethod
+    def _advanced_origin(fname: str, env_name: str, overrides: dict[str, Any]) -> str:
+        """Origin for an ADVANCED_SETTINGS_FIELDS entry.
+
+        Mirrors the settings UI's ``_origin_for_advanced_field``:
+        addon-synced fields report ``addon`` in add-on mode (writes
+        route through Supervisor); an explicitly-set env var wins
+        (``env``, locked); a value in the override file is ``file``;
+        otherwise ``default``.
+        """
+        import os
+
+        from ..config import ADDON_SYNCED_ADVANCED_FIELDS
+
+        if is_running_in_addon() and fname in ADDON_SYNCED_ADVANCED_FIELDS:
+            return "addon"
+        if os.environ.get(env_name) is not None:
+            return "env"
+        if fname in overrides:
+            return "file"
+        return "default"
+
+    def _settings_rows(self) -> list[dict[str, Any]]:
+        """Build the full settings matrix from both registries."""
+        from ..config import (
+            _ADVANCED_SETTINGS_BOUNDS,
+            _ADVANCED_SETTINGS_CHOICES,
+            _ADVANCED_SETTINGS_SENTINELS,
+            _FEATURE_FLAG_INT_BOUNDS,
+            ADVANCED_SETTINGS_FIELDS,
+            FEATURE_FLAG_FIELDS,
+            OAUTH_MODE_TOKEN,
+            _read_feature_flag_override_file,
+            get_feature_flag_origin,
+            get_global_settings,
+        )
+
+        settings = get_global_settings()
+        overrides = _read_feature_flag_override_file()
+        rows: list[dict[str, Any]] = []
+        bounds: tuple[float, float] | None
+        for fname, env_name, ftype in FEATURE_FLAG_FIELDS:
+            origin = get_feature_flag_origin(env_name)
+            row: dict[str, Any] = {
+                "setting": fname,
+                "env_var": env_name,
+                "value": getattr(settings, fname),
+                "type": ftype.__name__,
+                "registry": "features",
+                "origin": origin,
+                "editable": origin in ("addon", "file", "default"),
+            }
+            bounds = _FEATURE_FLAG_INT_BOUNDS.get(fname)
+            if bounds is not None:
+                row["min"], row["max"] = bounds
+            rows.append(row)
+        for (
+            fname,
+            env_name,
+            ftype,
+            section,
+            registry_editable,
+        ) in ADVANCED_SETTINGS_FIELDS:
+            origin = self._advanced_origin(fname, env_name, overrides)
+            value: Any = getattr(settings, fname, None)
+            # Never echo the real long-lived token; the OAuth-mode
+            # sentinel survives so deployment mode stays visible.
+            if fname == "homeassistant_token":
+                value = "*****" if value and value != OAUTH_MODE_TOKEN else value
+            row = {
+                "setting": fname,
+                "env_var": env_name,
+                "value": value,
+                "type": ftype.__name__,
+                "registry": "advanced",
+                "section": section,
+                "origin": origin,
+                "editable": registry_editable and origin != "env",
+            }
+            bounds = _ADVANCED_SETTINGS_BOUNDS.get(fname)
+            if bounds is not None:
+                row["min"], row["max"] = bounds
+                sentinel = _ADVANCED_SETTINGS_SENTINELS.get(fname)
+                if sentinel is not None:
+                    row["min"] = sentinel
+            choices = _ADVANCED_SETTINGS_CHOICES.get(fname)
+            if choices is not None:
+                row["choices"] = list(choices)
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    def _coerce_setting_value(fname: str, raw: Any, ftype: type) -> Any:
+        """Coerce/validate ``raw`` against the registry field type.
+
+        Accepts the natural JSON type plus common MCP-client
+        stringifications ("true"/"false" for bools, numeric strings
+        for int/float). Raises ``ToolError`` on mismatch.
+        """
+        if ftype is bool:
+            if isinstance(raw, bool):
+                return raw
+            if isinstance(raw, str) and raw.strip().lower() in ("true", "false"):
+                return raw.strip().lower() == "true"
+        elif ftype is int:
+            if isinstance(raw, bool):
+                pass  # bool is an int subclass; reject below
+            elif isinstance(raw, int):
+                return raw
+            elif isinstance(raw, str):
+                try:
+                    return int(raw.strip())
+                except ValueError:
+                    pass
+        elif ftype is float:
+            if isinstance(raw, bool):
+                pass
+            elif isinstance(raw, int | float):
+                return float(raw)
+            elif isinstance(raw, str):
+                try:
+                    return float(raw.strip())
+                except ValueError:
+                    pass
+        elif ftype is str:
+            if isinstance(raw, str):
+                if "\x00" in raw:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            f"{fname!r} value contains a null byte",
+                        )
+                    )
+                return raw
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                f"{fname!r} must be of type {ftype.__name__}, got {type(raw).__name__}",
+                context={"setting": fname, "value": raw},
+            )
+        )
+
+    @staticmethod
+    async def _merge_file_override(changes: dict[str, Any]) -> None:
+        """Read-merge-write ``changes`` into the shared override file.
+
+        Uses the settings UI's override-file lock and atomic-write
+        helper so a concurrent web-UI save can't interleave and
+        clobber this write (or vice versa). Refuses to overwrite an
+        unreadable or corrupt existing file — same data-loss guard as
+        the web UI save handlers.
+        """
+        import json
+
+        from ..config import _FEATURE_FLAG_OVERRIDE_FILENAME
+        from ..settings_ui import _atomic_write_json, _get_override_file_lock
+        from ..utils.data_paths import get_data_dir
+
+        path = get_data_dir() / _FEATURE_FLAG_OVERRIDE_FILENAME
+        async with _get_override_file_lock():
+            existing: dict[str, Any] = {}
+            try:
+                existing_raw = path.read_text()
+            except FileNotFoundError:
+                existing_raw = None
+            except OSError as exc:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.INTERNAL_ERROR,
+                        f"Could not read existing override file "
+                        f"({type(exc).__name__}: {exc}); refusing to "
+                        "overwrite to preserve prior settings.",
+                        suggestions=["Check filesystem permissions and retry"],
+                    )
+                )
+            if existing_raw is not None:
+                try:
+                    parsed = json.loads(existing_raw)
+                except json.JSONDecodeError as exc:
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.CONFIG_INVALID,
+                            f"Existing override file at {path} is not valid "
+                            f"JSON ({exc}); refusing to overwrite to preserve "
+                            "prior settings.",
+                            suggestions=[
+                                "Inspect or delete the file manually and retry"
+                            ],
+                        )
+                    )
+                if isinstance(parsed, dict):
+                    existing = parsed
+            for key, val in changes.items():
+                if val is _REMOVE:
+                    existing.pop(key, None)
+                else:
+                    existing[key] = val
+            _atomic_write_json(path, existing)
+
+    # ----- server-entry helpers -----
+
+    async def _list_component_entries(self) -> list[dict[str, Any]]:
+        """List the ha_mcp_tools config entries via the WebSocket API."""
+        response = await self._client.send_websocket_message(
+            {"type": "config_entries/get", "domain": COMPONENT_DOMAIN}
+        )
+        if not response.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"config_entries/get failed: {response.get('error')}",
+                    suggestions=["Check the Home Assistant WebSocket connection"],
+                )
+            )
+        result = response.get("result", [])
+        return result if isinstance(result, list) else []
+
+    async def _find_server_entry(
+        self,
+    ) -> tuple[str, dict[str, Any], dict[str, Any]] | None:
+        """Find the component's in-process "server" entry.
+
+        Probes each ``ha_mcp_tools`` entry's options flow: the server
+        entry's flow is a form whose schema carries the ``pip_spec``
+        field; the tools (services) entry's flow aborts immediately.
+        Returns ``(entry_id, open_flow, current_options)`` with the
+        options flow left OPEN (callers must submit or abort it), or
+        ``None`` when no server entry exists. ``current_options`` maps
+        schema field names to their defaults — i.e. the entry's
+        current option values.
+        """
+        for entry in await self._list_component_entries():
+            entry_id = entry.get("entry_id")
+            if not entry_id:
+                continue
+            try:
+                flow = await self._client.start_options_flow(entry_id)
+            except Exception as exc:  # probe is best-effort per entry
+                logger.debug("Options-flow probe failed for %s: %s", entry_id, exc)
+                continue
+            schema = flow.get("data_schema") or []
+            fields: dict[str, Any] = {
+                str(item["name"]): item.get("default")
+                for item in schema
+                if isinstance(item, dict) and item.get("name")
+            }
+            if flow.get("type") == "form" and _OPT_PIP_SPEC in fields:
+                return entry_id, flow, fields
+            # Not the server entry — close the probe flow if one opened.
+            flow_id = flow.get("flow_id")
+            if flow_id:
+                try:
+                    await self._client.abort_options_flow(flow_id)
+                except Exception as exc:
+                    logger.debug("Probe-flow abort failed: %s", exc)
+        return None
+
+    async def _abort_flow_quietly(self, flow: dict[str, Any]) -> None:
+        """Abort an open options flow, ignoring failures."""
+        flow_id = flow.get("flow_id")
+        if not flow_id:
+            return
+        try:
+            await self._client.abort_options_flow(flow_id)
+        except Exception as exc:
+            logger.debug("Options-flow abort failed: %s", exc)
+
+    async def _delayed_submit_options(
+        self, flow_id: str, user_input: dict[str, Any]
+    ) -> None:
+        """Submit an options flow after the response-flush delay.
+
+        Fire-and-forget path for embedded mode: applying the options
+        reloads the config entry, which tears down the very server
+        thread answering this tool call, so the submit must happen
+        after our JSON response has flushed. Failures can only be
+        logged — there is no caller left to answer.
+        """
+        await asyncio.sleep(_SELF_ACTION_FLUSH_DELAY_S)
+        try:
+            result = await self._client.submit_options_flow_step(flow_id, user_input)
+            logger.info("Deferred options submit result: %s", result.get("type"))
+        except Exception:
+            logger.exception("Deferred options-flow submit failed")
+
+    async def _delayed_entry_reload(self, entry_id: str) -> None:
+        """Reload a config entry after the response-flush delay."""
+        await asyncio.sleep(_SELF_ACTION_FLUSH_DELAY_S)
+        try:
+            await self._client._request(
+                "POST", f"/config/config_entries/entry/{entry_id}/reload"
+            )
+            logger.info("Deferred reload of entry %s requested", entry_id)
+        except Exception:
+            logger.exception("Deferred config-entry reload failed")
+
+    # ----- tools -----
+
+    @tool(
+        name="ha_dev_manage_settings",
+        tags={"Developer"},
+        annotations={"title": "Manage Server Settings (dev)"},
+    )
+    @log_tool_usage
+    async def ha_dev_manage_settings(
+        self,
+        action: Annotated[
+            Literal["list", "set", "reset"],
+            Field(
+                description="list all settings, set one value, or reset one override"
+            ),
+        ],
+        setting: Annotated[
+            str | None,
+            Field(default=None, description="Setting name (required for set/reset)"),
+        ] = None,
+        value: Annotated[
+            bool | int | float | str | None,
+            Field(default=None, description="New value (required for set)"),
+        ] = None,
+    ) -> dict[str, Any]:
+        """Manage ha-mcp server settings directly (developer mode).
+
+        When NOT to use: for HA entity/automation configuration use the
+        ha_config_* tools; for enabling/disabling individual MCP tools
+        use the web settings UI (Tools tab).
+
+        When to use: reading or changing the server's own settings (the
+        same matrix as the web UI's Server Settings tab) during
+        development/testing — feature flags, advanced fields, and their
+        env/file/addon origins.
+
+        Caveats: changed values persist to the server's override file
+        (or the add-on options via Supervisor) but only take effect
+        after a server restart (ha_dev_manage_server action="restart").
+        Env-pinned settings are read-only until the env var is unset.
+        This can flip security-sensitive flags; treat with the same
+        care as editing the web UI.
+
+        EXAMPLES:
+        ha_dev_manage_settings("list")
+        ha_dev_manage_settings("set", setting="log_level", value="DEBUG")
+        ha_dev_manage_settings("reset", setting="log_level")
+        """
+        try:
+            if action == "list":
+                return {
+                    "success": True,
+                    "data": {
+                        "settings": self._settings_rows(),
+                        "is_addon": is_running_in_addon(),
+                        "is_embedded": is_embedded(),
+                        "note": (
+                            "Most settings need a server restart to take "
+                            "effect (ha_dev_manage_server action='restart')."
+                        ),
+                    },
+                }
+
+            if not setting:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_MISSING_PARAMETER,
+                        f"'setting' is required for action={action!r}",
+                    )
+                )
+
+            from ..config import (
+                _ADVANCED_SETTINGS_BOUNDS,
+                _ADVANCED_SETTINGS_CHOICES,
+                _ADVANCED_SETTINGS_SENTINELS,
+                _FEATURE_FLAG_INT_BOUNDS,
+                ADVANCED_SETTINGS_FIELDS,
+                BETA_FEATURE_FIELDS,
+                FEATURE_FLAG_FIELDS,
+                _read_feature_flag_override_file,
+                _reset_global_settings,
+                get_feature_flag_origin,
+                get_global_settings,
+            )
+
+            features = {f: (e, t) for f, e, t in FEATURE_FLAG_FIELDS}
+            advanced = {f: (e, t, s, ed) for f, e, t, s, ed in ADVANCED_SETTINGS_FIELDS}
+            bounds: tuple[float, float] | None
+            sentinel: int | None
+            choices: tuple[str, ...] | None
+            if setting in features:
+                env_name, ftype = features[setting]
+                origin = get_feature_flag_origin(env_name)
+                editable = origin in ("addon", "file", "default")
+                bounds = _FEATURE_FLAG_INT_BOUNDS.get(setting)
+                sentinel = None
+                choices = None
+            elif setting in advanced:
+                env_name, ftype, _section, registry_editable = advanced[setting]
+                overrides = _read_feature_flag_override_file()
+                origin = self._advanced_origin(setting, env_name, overrides)
+                editable = registry_editable and origin != "env"
+                bounds = _ADVANCED_SETTINGS_BOUNDS.get(setting)
+                sentinel = _ADVANCED_SETTINGS_SENTINELS.get(setting)
+                choices = _ADVANCED_SETTINGS_CHOICES.get(setting)
+            else:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Unknown setting: {setting!r}",
+                        suggestions=[
+                            "Call ha_dev_manage_settings('list') for valid names"
+                        ],
+                    )
+                )
+
+            if action == "reset":
+                if origin == "env":
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            f"{setting!r} is pinned by the {env_name} env var; "
+                            "unset the env var instead.",
+                        )
+                    )
+                if origin == "addon":
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            f"{setting!r} is managed by the add-on "
+                            "configuration; change it there or via "
+                            "action='set'.",
+                        )
+                    )
+                had_override = origin == "file"
+                if had_override:
+                    await self._merge_file_override({setting: _REMOVE})
+                    _reset_global_settings()
+                return {
+                    "success": True,
+                    "data": {
+                        "setting": setting,
+                        "removed_override": had_override,
+                        "restart_required": had_override,
+                    },
+                }
+
+            # action == "set"
+            if value is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_MISSING_PARAMETER,
+                        "'value' is required for action='set'",
+                    )
+                )
+            if not editable:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{setting!r} is locked by {origin}. "
+                        + (
+                            f"Unset the {env_name} env var to edit it here."
+                            if origin == "env"
+                            else "It is display-only on this surface."
+                        ),
+                    )
+                )
+            coerced = self._coerce_setting_value(setting, value, ftype)
+            if (
+                bounds is not None
+                and coerced != sentinel
+                and not (bounds[0] <= coerced <= bounds[1])
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{setting!r} must be between {bounds[0]} and {bounds[1]}",
+                    )
+                )
+            if choices is not None and coerced not in choices:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{setting!r} must be one of {list(choices)}",
+                    )
+                )
+            # Master beta gate: enabling a beta sub-flag while the
+            # effective master is off would be silently forced back off
+            # at runtime — reject loudly instead (same rule as the web
+            # UI save handler).
+            if (
+                setting in BETA_FEATURE_FIELDS
+                and bool(coerced)
+                and not get_global_settings().enable_beta_features
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Cannot enable beta sub-flag {setting!r} while "
+                        "'enable_beta_features' is off.",
+                        suggestions=["Set enable_beta_features=true first, then retry"],
+                    )
+                )
+
+            if origin == "addon":
+                from ..settings_ui import _supervisor_merge_and_post_options
+
+                ok, err = await _supervisor_merge_and_post_options(
+                    get_global_settings().verify_ssl, {setting: coerced}
+                )
+                if not ok:
+                    message = err.message if err else "Supervisor update failed"
+                    raise_tool_error(
+                        create_error_response(
+                            ErrorCode.SERVICE_CALL_FAILED,
+                            f"Supervisor rejected the options update: {message}",
+                            suggestions=["Check the Supervisor and add-on logs"],
+                        )
+                    )
+                mode = "addon"
+            else:
+                await self._merge_file_override({setting: coerced})
+                _reset_global_settings()
+                mode = "file"
+            return {
+                "success": True,
+                "data": {
+                    "setting": setting,
+                    "value": coerced,
+                    "mode": mode,
+                    "restart_required": True,
+                },
+            }
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"action": action, "setting": setting},
+                suggestions=["Check server logs for details"],
+            )
+            return None  # unreachable; explicit for CodeQL
+
+    @tool(
+        name="ha_dev_manage_server",
+        tags={"Developer"},
+        annotations={"title": "Manage MCP Server (dev)"},
+    )
+    @log_tool_usage
+    async def ha_dev_manage_server(
+        self,
+        action: Annotated[
+            Literal["info", "update_source", "restart"],
+            Field(
+                description=(
+                    "info: deployment/version report; update_source: point the "
+                    "in-process server at a channel or pip spec and reinstall; "
+                    "restart: restart this server"
+                )
+            ),
+        ],
+        channel: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description="Release channel for update_source: 'stable' or 'dev'",
+            ),
+        ] = None,
+        pip_spec: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    "Explicit pip requirement for update_source — a version pin "
+                    "(ha-mcp==7.9.0) or a GitHub tarball URL such as "
+                    "https://github.com/homeassistant-ai/ha-mcp/archive/refs/"
+                    "pull/<PR>/head.tar.gz. Empty string clears the override."
+                ),
+            ),
+        ] = None,
+    ) -> dict[str, Any]:
+        """Manage the running ha-mcp server itself (developer mode).
+
+        When NOT to use: to restart Home Assistant use ha_restart; to
+        update HA add-ons or HACS packages use ha_manage_addon /
+        ha_manage_hacs.
+
+        When to use: development/testing workflows — inspecting how this
+        server is deployed, switching the in-process (custom component)
+        server to another release channel or an arbitrary pip spec such
+        as a PR tarball, and restarting the server so config or code
+        changes take effect.
+
+        Caveats: update_source and restart interrupt this MCP
+        connection — in embedded/add-on mode the reply arrives just
+        before the server goes down, and reinstalls can take minutes.
+        update_source requires the ha_mcp_tools component's in-process
+        server entry; restart supports embedded and add-on deployments
+        only (standalone processes must be restarted externally).
+
+        EXAMPLES:
+        ha_dev_manage_server("info")
+        ha_dev_manage_server("update_source", channel="dev")
+        ha_dev_manage_server("update_source", pip_spec="https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/1234/head.tar.gz")
+        ha_dev_manage_server("restart")
+        """
+        try:
+            if action == "info":
+                return await self._server_info()
+            if action == "update_source":
+                return await self._update_source(channel, pip_spec)
+            return await self._restart_server()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"action": action, "channel": channel, "pip_spec": pip_spec},
+                suggestions=["Check server and Home Assistant logs for details"],
+            )
+            return None  # unreachable; explicit for CodeQL
+
+    async def _server_info(self) -> dict[str, Any]:
+        from ..utils.data_paths import get_data_dir
+
+        version = get_version()
+        if is_embedded():
+            mode = "embedded"
+        elif is_running_in_addon():
+            mode = "addon"
+        else:
+            mode = "standalone"
+        data: dict[str, Any] = {
+            "server_version": version,
+            "is_dev_build": is_dev_version(version),
+            "deployment_mode": mode,
+            "python_version": sys.version.split()[0],
+            "data_dir": str(get_data_dir()),
+        }
+        warnings: list[str] = []
+        try:
+            ha_config = await self._client.get_config()
+            data["ha_version"] = ha_config.get("version")
+        except Exception as exc:
+            warnings.append(f"Could not read HA version: {exc}")
+        try:
+            found = await self._find_server_entry()
+            if found is None:
+                data["component_server_entry"] = None
+            else:
+                entry_id, flow, options = found
+                await self._abort_flow_quietly(flow)
+                data["component_server_entry"] = {
+                    "entry_id": entry_id,
+                    "channel": options.get(_OPT_CHANNEL),
+                    "pip_spec": options.get(_OPT_PIP_SPEC),
+                }
+        except ToolError:
+            raise
+        except Exception as exc:
+            warnings.append(f"Could not inspect component server entry: {exc}")
+        result: dict[str, Any] = {"success": True, "data": data}
+        if warnings:
+            result["warnings"] = warnings
+        return result
+
+    async def _update_source(
+        self, channel: str | None, pip_spec: str | None
+    ) -> dict[str, Any]:
+        if channel is None and pip_spec is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "update_source needs 'channel' and/or 'pip_spec'",
+                )
+            )
+        if channel is not None and channel not in _VALID_CHANNELS:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"channel must be one of {list(_VALID_CHANNELS)}",
+                )
+            )
+        if pip_spec is not None and (
+            len(pip_spec) > 500 or any(ord(c) < 32 for c in pip_spec)
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "pip_spec must be a single-line string under 500 chars",
+                )
+            )
+
+        found = await self._find_server_entry()
+        if found is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.COMPONENT_NOT_INSTALLED,
+                    "No ha_mcp_tools in-process server entry found. "
+                    "update_source drives that entry's channel/pip-spec "
+                    "options, so it needs the entry to exist.",
+                    suggestions=[
+                        "Install the ha_mcp_tools component and add its "
+                        + "'server' entry (Settings > Devices & Services)",
+                        "Setup guide: https://github.com/homeassistant-ai/"
+                        + "ha-mcp/blob/master/docs/in-process-server.md",
+                    ],
+                )
+            )
+        entry_id, flow, current = found
+        user_input: dict[str, Any] = {}
+        if channel is not None:
+            user_input[_OPT_CHANNEL] = channel
+        if pip_spec is not None:
+            user_input[_OPT_PIP_SPEC] = pip_spec
+        flow_id = flow.get("flow_id")
+        if not flow_id:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    "Options flow opened without a flow_id",
+                )
+            )
+
+        if is_embedded():
+            # Applying options reloads the entry that runs THIS server;
+            # defer the submit so this response reaches the client first.
+            _spawn_background(self._delayed_submit_options(flow_id, user_input))
+            return {
+                "success": True,
+                "data": {
+                    "scheduled": True,
+                    "entry_id": entry_id,
+                    "applying": user_input,
+                    "previous": {
+                        _OPT_CHANNEL: current.get(_OPT_CHANNEL),
+                        _OPT_PIP_SPEC: current.get(_OPT_PIP_SPEC),
+                    },
+                    "note": (
+                        "The in-process server will reinstall and restart "
+                        "now; this connection will drop. Reconnect in 1-5 "
+                        "minutes and verify with ha_dev_manage_server('info')."
+                    ),
+                },
+            }
+
+        result = await self._client.submit_options_flow_step(flow_id, user_input)
+        if result.get("type") != "create_entry":
+            errors = result.get("errors") or result.get("reason")
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.CONFIG_VALIDATION_FAILED,
+                    f"Options flow did not apply: {errors}",
+                    context={"flow_result_type": result.get("type")},
+                )
+            )
+        return {
+            "success": True,
+            "data": {
+                "entry_id": entry_id,
+                "applied": user_input,
+                "previous": {
+                    _OPT_CHANNEL: current.get(_OPT_CHANNEL),
+                    _OPT_PIP_SPEC: current.get(_OPT_PIP_SPEC),
+                },
+                "note": (
+                    "The component is reloading the in-process server with "
+                    "the new source; installs can take a few minutes."
+                ),
+            },
+        }
+
+    async def _restart_server(self) -> dict[str, Any]:
+        if is_embedded():
+            found = await self._find_server_entry()
+            if found is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.COMPONENT_NOT_INSTALLED,
+                        "Embedded mode detected but no in-process server "
+                        "entry was found to reload.",
+                        suggestions=["Reload the ha_mcp_tools integration in HA"],
+                    )
+                )
+            entry_id, flow, _options = found
+            await self._abort_flow_quietly(flow)
+            _spawn_background(self._delayed_entry_reload(entry_id))
+            return {
+                "success": True,
+                "data": {
+                    "scheduled": True,
+                    "mode": "embedded",
+                    "note": (
+                        "Config entry reload scheduled; this connection will "
+                        "drop. Reconnect in ~1 minute."
+                    ),
+                },
+            }
+        if is_running_in_addon():
+            from ..config import get_global_settings
+            from ..settings_ui import _schedule_supervisor_self_restart
+
+            _schedule_supervisor_self_restart(get_global_settings().verify_ssl)
+            return {
+                "success": True,
+                "data": {
+                    "scheduled": True,
+                    "mode": "addon",
+                    "note": (
+                        "Supervisor add-on self-restart scheduled; this "
+                        "connection will drop. Reconnect in ~1 minute."
+                    ),
+                },
+            }
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "restart is only available in embedded (custom component) "
+                "or add-on deployments; restart this standalone process "
+                "externally.",
+                suggestions=[
+                    "Docker: docker restart <container>",
+                    "Desktop MCP clients: relaunch the client to respawn "
+                    + "the stdio server",
+                ],
+            )
+        )
+        return None  # unreachable; explicit for CodeQL
+
+
+def register_dev_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register developer-mode tools.
+
+    Registers NOTHING unless developer mode is enabled — the tools are
+    invisible to MCP clients by default. Enable via the Developer
+    section of the web settings UI or HAMCP_ENABLE_DEV_MODE=true.
+    """
+    if not is_dev_mode_enabled():
+        logger.debug(f"Dev tools disabled (set {FEATURE_FLAG}=true to enable)")
+        return
+
+    logger.warning(
+        "Developer mode is ON: ha_dev_manage_server / ha_dev_manage_settings "
+        "are registered. These tools can change server settings and replace "
+        "the running server version."
+    )
+    register_tool_methods(mcp, DevTools(client))

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -42,6 +42,7 @@ from ._version import (
     get_supervisor_base_url,
     get_version,
     is_dev_version,
+    is_embedded,
     is_running_in_addon,
 )
 from .stdio_settings_sidecar import _TRUTHY  # shared HA_MCP_DISABLE_* truthy set
@@ -246,6 +247,14 @@ def _running_in_docker() -> bool:
 
 def update_command_hint(current: str) -> str:
     """Return a deployment- and channel-aware one-liner for how to upgrade."""
+    if is_embedded():
+        # In-process (custom component) server: the component's update
+        # entity / auto-update installs new builds; the entry reload (or
+        # the settings UI's Restart button) applies them.
+        return (
+            "Update via the HA-MCP Server update entity (Settings -> "
+            "Devices & Services -> HA-MCP), or reload the integration."
+        )
     if is_running_in_addon():
         # Add-on users update through the Supervisor UI, not pip/docker.
         return "Update from Settings -> Add-ons -> Home Assistant MCP Server."

--- a/tests/src/e2e/tools/test_dev_mode_tools.py
+++ b/tests/src/e2e/tools/test_dev_mode_tools.py
@@ -29,6 +29,19 @@ FEATURE_FLAG = "HAMCP_ENABLE_DEV_MODE"
 DEV_TOOL_NAMES = {"ha_dev_manage_server", "ha_dev_manage_settings"}
 
 
+def _reset_settings_state():
+    """Drop the cached Settings singleton + data-dir memo.
+
+    Both are read-once caches; every env mutation in this module must be
+    followed by this reset or the server under test sees stale values.
+    """
+    from ha_mcp.config import reset_global_settings
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    get_data_dir.cache_clear()
+    reset_global_settings()
+
+
 @pytest.fixture(scope="module")
 def dev_mode_enabled(ha_container_with_fresh_config, tmp_path_factory):
     """Enable dev mode + isolate the data dir for the test module.
@@ -37,17 +50,12 @@ def dev_mode_enabled(ha_container_with_fresh_config, tmp_path_factory):
     ``get_data_dir()``; pointing ``HA_MCP_CONFIG_DIR`` at a module tmp
     dir keeps those writes away from the developer's real data dir.
     """
-    from ha_mcp.utils.data_paths import get_data_dir
-
     old_flag = os.environ.get(FEATURE_FLAG)
     old_dir = os.environ.get("HA_MCP_CONFIG_DIR")
     data_dir = tmp_path_factory.mktemp("dev-mode-data")
     os.environ[FEATURE_FLAG] = "true"
     os.environ["HA_MCP_CONFIG_DIR"] = str(data_dir)
-    get_data_dir.cache_clear()
-    import ha_mcp.config
-
-    ha_mcp.config._settings = None
+    _reset_settings_state()
     logger.info("Dev mode feature flag enabled (data dir: %s)", data_dir)
     yield data_dir
     if old_flag is not None:
@@ -58,8 +66,7 @@ def dev_mode_enabled(ha_container_with_fresh_config, tmp_path_factory):
         os.environ["HA_MCP_CONFIG_DIR"] = old_dir
     else:
         os.environ.pop("HA_MCP_CONFIG_DIR", None)
-    get_data_dir.cache_clear()
-    ha_mcp.config._settings = None
+    _reset_settings_state()
 
 
 @pytest.fixture(scope="module")
@@ -92,9 +99,7 @@ class TestDevModeAvailability:
         """Verify the ha_dev_* tools are NOT registered when the flag is off."""
         original = os.environ.pop(FEATURE_FLAG, None)
         try:
-            import ha_mcp.config
-
-            ha_mcp.config._settings = None
+            _reset_settings_state()
 
             from fastmcp import Client
 
@@ -115,9 +120,7 @@ class TestDevModeAvailability:
         finally:
             if original:
                 os.environ[FEATURE_FLAG] = original
-            import ha_mcp.config
-
-            ha_mcp.config._settings = None
+            _reset_settings_state()
 
     async def test_dev_tools_registered_when_enabled(self, mcp_client_with_dev_mode):
         tool_names = {t.name for t in await mcp_client_with_dev_mode.list_tools()}

--- a/tests/src/e2e/tools/test_dev_mode_tools.py
+++ b/tests/src/e2e/tools/test_dev_mode_tools.py
@@ -1,0 +1,222 @@
+"""
+End-to-End tests for developer-mode tools (issue #1775).
+
+This test suite validates:
+- Feature flag behavior: ha_dev_* tools are NOT registered by default and
+  appear only when HAMCP_ENABLE_DEV_MODE is on
+- ha_dev_manage_settings list / set / reset against a real server
+- ha_dev_manage_server info and its validation / deployment-mode errors
+
+Feature Flag: Set HAMCP_ENABLE_DEV_MODE=true to enable.
+
+ha_dev_manage_server's update_source action is exercised only through its
+validation error paths here — submitting a real options flow would reinstall
+the in-process server that other tests in the session depend on.
+"""
+
+import json
+import logging
+import os
+
+import pytest
+
+from ..utilities.assertions import extract_error_message, safe_call_tool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+FEATURE_FLAG = "HAMCP_ENABLE_DEV_MODE"
+DEV_TOOL_NAMES = {"ha_dev_manage_server", "ha_dev_manage_settings"}
+
+
+@pytest.fixture(scope="module")
+def dev_mode_enabled(ha_container_with_fresh_config, tmp_path_factory):
+    """Enable dev mode + isolate the data dir for the test module.
+
+    The settings tool persists to ``feature_flags.json`` under
+    ``get_data_dir()``; pointing ``HA_MCP_CONFIG_DIR`` at a module tmp
+    dir keeps those writes away from the developer's real data dir.
+    """
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    old_flag = os.environ.get(FEATURE_FLAG)
+    old_dir = os.environ.get("HA_MCP_CONFIG_DIR")
+    data_dir = tmp_path_factory.mktemp("dev-mode-data")
+    os.environ[FEATURE_FLAG] = "true"
+    os.environ["HA_MCP_CONFIG_DIR"] = str(data_dir)
+    get_data_dir.cache_clear()
+    import ha_mcp.config
+
+    ha_mcp.config._settings = None
+    logger.info("Dev mode feature flag enabled (data dir: %s)", data_dir)
+    yield data_dir
+    if old_flag is not None:
+        os.environ[FEATURE_FLAG] = old_flag
+    else:
+        os.environ.pop(FEATURE_FLAG, None)
+    if old_dir is not None:
+        os.environ["HA_MCP_CONFIG_DIR"] = old_dir
+    else:
+        os.environ.pop("HA_MCP_CONFIG_DIR", None)
+    get_data_dir.cache_clear()
+    ha_mcp.config._settings = None
+
+
+@pytest.fixture(scope="module")
+async def _dev_mode_server(dev_mode_enabled, ha_container_with_fresh_config):
+    """Create a single MCP server with dev mode enabled for the module."""
+    from ha_mcp.client.rest_client import HomeAssistantClient
+    from ha_mcp.server import HomeAssistantSmartMCPServer
+    from tests.test_constants import TEST_TOKEN
+
+    base_url = ha_container_with_fresh_config["base_url"]
+    client = HomeAssistantClient(base_url=base_url, token=TEST_TOKEN)
+    server = HomeAssistantSmartMCPServer(client=client)
+    yield server
+
+
+@pytest.fixture
+async def mcp_client_with_dev_mode(_dev_mode_server):
+    """Create MCP client connected to the dev-mode-enabled server."""
+    from fastmcp import Client
+
+    mcp_client = Client(_dev_mode_server.mcp)
+    async with mcp_client:
+        yield mcp_client
+
+
+class TestDevModeAvailability:
+    """The tools must be invisible by default and present when enabled."""
+
+    async def test_dev_tools_hidden_by_default(self, ha_container_with_fresh_config):
+        """Verify the ha_dev_* tools are NOT registered when the flag is off."""
+        original = os.environ.pop(FEATURE_FLAG, None)
+        try:
+            import ha_mcp.config
+
+            ha_mcp.config._settings = None
+
+            from fastmcp import Client
+
+            from ha_mcp.server import HomeAssistantSmartMCPServer
+
+            server = HomeAssistantSmartMCPServer(
+                client=None,
+                server_name="test-dev-mode-disabled",
+            )
+            client = Client(server.mcp)
+            async with client:
+                tool_names = {t.name for t in await client.list_tools()}
+                present = DEV_TOOL_NAMES & tool_names
+                assert not present, (
+                    f"Dev tools should NOT be registered when {FEATURE_FLAG} "
+                    f"is off, but found: {present}"
+                )
+        finally:
+            if original:
+                os.environ[FEATURE_FLAG] = original
+            import ha_mcp.config
+
+            ha_mcp.config._settings = None
+
+    async def test_dev_tools_registered_when_enabled(self, mcp_client_with_dev_mode):
+        tool_names = {t.name for t in await mcp_client_with_dev_mode.list_tools()}
+        missing = DEV_TOOL_NAMES - tool_names
+        assert not missing, f"Dev tools missing with flag on: {missing}"
+
+
+class TestDevManageSettings:
+    async def test_list_returns_settings_matrix(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode, "ha_dev_manage_settings", {"action": "list"}
+        )
+        assert result.get("success") is True
+        rows = {r["setting"]: r for r in result["data"]["settings"]}
+        assert rows["enable_dev_mode"]["value"] is True
+        assert rows["enable_dev_mode"]["origin"] == "env"
+        assert "log_level" in rows
+
+    async def test_set_and_reset_roundtrip(
+        self, mcp_client_with_dev_mode, dev_mode_enabled
+    ):
+        data_dir = dev_mode_enabled
+        set_result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_settings",
+            {"action": "set", "setting": "fuzzy_threshold", "value": 61},
+        )
+        assert set_result.get("success") is True
+        assert set_result["data"]["restart_required"] is True
+        persisted = json.loads((data_dir / "feature_flags.json").read_text())
+        assert persisted["fuzzy_threshold"] == 61
+
+        list_result = await safe_call_tool(
+            mcp_client_with_dev_mode, "ha_dev_manage_settings", {"action": "list"}
+        )
+        rows = {r["setting"]: r for r in list_result["data"]["settings"]}
+        assert rows["fuzzy_threshold"]["value"] == 61
+        assert rows["fuzzy_threshold"]["origin"] == "file"
+
+        reset_result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_settings",
+            {"action": "reset", "setting": "fuzzy_threshold"},
+        )
+        assert reset_result["data"]["removed_override"] is True
+        persisted = json.loads((data_dir / "feature_flags.json").read_text())
+        assert "fuzzy_threshold" not in persisted
+
+    async def test_set_rejects_unknown_setting(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_settings",
+            {"action": "set", "setting": "not_a_setting", "value": 1},
+        )
+        assert result.get("success") is not True
+        assert "unknown setting" in extract_error_message(result).lower()
+
+    async def test_set_rejects_env_pinned_setting(self, mcp_client_with_dev_mode):
+        """enable_dev_mode itself is env-pinned in this fixture setup."""
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_settings",
+            {"action": "set", "setting": "enable_dev_mode", "value": False},
+        )
+        assert result.get("success") is not True
+        assert "locked by env" in extract_error_message(result).lower()
+
+
+class TestDevManageServer:
+    async def test_info_reports_deployment(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode, "ha_dev_manage_server", {"action": "info"}
+        )
+        assert result.get("success") is True
+        data = result["data"]
+        assert data["deployment_mode"] == "standalone"
+        assert isinstance(data["server_version"], str) and data["server_version"]
+        assert "component_server_entry" in data
+
+    async def test_update_source_requires_params(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_server",
+            {"action": "update_source"},
+        )
+        assert result.get("success") is not True
+        assert "channel" in extract_error_message(result).lower()
+
+    async def test_update_source_rejects_bad_channel(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode,
+            "ha_dev_manage_server",
+            {"action": "update_source", "channel": "nightly"},
+        )
+        assert result.get("success") is not True
+
+    async def test_restart_unavailable_standalone(self, mcp_client_with_dev_mode):
+        result = await safe_call_tool(
+            mcp_client_with_dev_mode, "ha_dev_manage_server", {"action": "restart"}
+        )
+        assert result.get("success") is not True
+        assert "standalone" in extract_error_message(result).lower()

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -78,6 +78,7 @@ def test_advanced_section_values_are_in_known_set() -> None:
         "tools_surface",
         "sidecar",
         "beta_codemode",
+        "developer",
     }
     seen = {row[3] for row in ADVANCED_SETTINGS_FIELDS}
     bad = seen - known

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -371,6 +371,19 @@ class TestServerOptionsFlow:
         )
         assert result["data"][const.OPT_PIP_SPEC] == ""
 
+    def test_pip_spec_field_empty_when_no_override(self):
+        # The "leave blank to follow the channel" field must actually BE
+        # blank when no override is stored — pre-filling the default dist
+        # name as a hint made it always look populated (and showed the
+        # STABLE dist name even on the dev channel). A saved override still
+        # pre-fills: see test_form_prefills_every_field_from_saved_options.
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        form = asyncio.run(flow.async_step_init(None))
+        marker = next(
+            m for m in form["data_schema"].schema if m.schema == const.OPT_PIP_SPEC
+        )
+        assert marker.default() == ""
+
     def test_no_enable_toggle_option_exists(self):
         # Regression guard for the single-instance pivot: the enable/disable
         # toggle was dropped (entry-exists = server runs).

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1693,3 +1693,43 @@ class TestPurgeSkippedWhileOrphanAlive:
 
         assert purges == [True]
         assert mgr._orphaned_thread is None  # bookkeeping cleared
+
+
+class TestServeRunningVersionCapture:
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self):
+        # _thread_main stages HA_MCP_CONFIG_DIR/HA_MCP_EMBEDDED into
+        # os.environ; snapshot + restore so the flags never leak into
+        # unrelated suites on this worker.
+        keys = ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
+        saved = {k: os.environ.get(k) for k in keys}
+        for key in keys:
+            os.environ.pop(key, None)
+        yield
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_serve_captures_imported_version(self, tmp_path, monkeypatch):
+        # The staleness feature hinges on this one line: the worker must
+        # stash the __version__ of the ha_mcp it ACTUALLY imported.
+        mgr, _hass, _entry = _manager(
+            tmp_path, options={OPT_SERVER_URL: "http://ha.local:8123"}
+        )
+
+        class _StopServe(Exception):
+            pass
+
+        class _FakeMcp:
+            def http_app(self, path, stateless_http):
+                raise _StopServe
+
+        _stub_ha_mcp_surface(monkeypatch, mcp=_FakeMcp())
+        sys.modules["ha_mcp"].__version__ = "9.8.7"
+
+        mgr._thread_main("tok")
+
+        assert mgr._running_version == "9.8.7"
+        assert isinstance(mgr._thread_exc, _StopServe)

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -849,7 +849,7 @@ class TestThreadEnvStaging:
         )
         captured = {}
 
-        async def _fake_serve(_token):
+        async def _fake_serve(_token, _stop_event):
             for key in (
                 "HOMEASSISTANT_URL",
                 "HOMEASSISTANT_TOKEN",
@@ -982,7 +982,7 @@ class TestThreadEnvStaging:
     def test_thread_crash_is_captured_not_raised(self, tmp_path, monkeypatch):
         mgr, _hass, _entry = _manager(tmp_path)
 
-        async def _boom(_token):
+        async def _boom(_token, _stop_event):
             raise RuntimeError("serve failed")
 
         monkeypatch.setattr(mgr, "_serve", _boom)
@@ -1481,11 +1481,14 @@ class TestLifecycle:
 
         assert len(loop.scheduled) == 1  # stop event scheduled threadsafe
         assert joins == [es._STOP_JOIN_TIMEOUT_SECONDS]  # bounded join
-        # Worker state fully cleared even for the orphaned thread.
+        # Worker state fully cleared even for the orphaned thread...
         assert mgr._thread is None
         assert mgr._loop is None
         assert mgr._stop_event is None
         assert mgr._thread_exc is None
+        # ...but the zombie itself is REMEMBERED so the next start skips
+        # the module purge while it may still be importing.
+        assert mgr._orphaned_thread is not None
 
     async def test_stop_survives_loop_closing_race(self, tmp_path):
         # The loop can close between is_closed() and call_soon_threadsafe
@@ -1632,3 +1635,61 @@ class TestRunningVersionStalenessWarning:
             mgr._thread.join(timeout=2)
 
         assert "restart Home Assistant" not in caplog.text
+
+
+class TestPurgeSkippedWhileOrphanAlive:
+    """A wedged old worker must block the module purge, not crash it.
+
+    Live-found on QEMU-slow HAOS: a cold import outlived both the
+    readiness timeout and the stop-join budget; purging sys.modules
+    under the still-importing zombie corrupted its import and the next
+    bring-up never came up.
+    """
+
+    def _start_kwargs(self, mgr, monkeypatch, purges):
+        monkeypatch.setattr(mgr, "_async_ensure_package", AsyncMock())
+        monkeypatch.setattr(
+            mgr, "_async_provision_token", AsyncMock(return_value="tok")
+        )
+        monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        monkeypatch.setattr(mgr, "_async_wait_until_ready", AsyncMock())
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: purges.append(True))
+
+    async def test_purge_skipped_when_orphan_still_alive(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges)
+
+        class _AliveThread:
+            def is_alive(self):
+                return True
+
+        mgr._orphaned_thread = _AliveThread()
+        with caplog.at_level("WARNING"):
+            await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == []
+        assert "Skipping the ha_mcp module purge" in caplog.text
+        assert mgr._orphaned_thread is not None  # still tracked
+
+    async def test_purge_resumes_once_orphan_died(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges)
+
+        class _DeadThread:
+            def is_alive(self):
+                return False
+
+        mgr._orphaned_thread = _DeadThread()
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == [True]
+        assert mgr._orphaned_thread is None  # bookkeeping cleared

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1422,6 +1422,7 @@ class TestLifecycle:
             "_async_wait_until_ready",
             AsyncMock(side_effect=lambda: calls.append("ready")),
         )
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: calls.append("purge"))
         # Replace the thread body so no real ha_mcp import happens.
         started = []
         monkeypatch.setattr(mgr, "_thread_main", lambda token: started.append(token))
@@ -1430,7 +1431,10 @@ class TestLifecycle:
         if mgr._thread is not None:
             mgr._thread.join(timeout=2)
 
-        assert calls == ["ensure", "token", "dir", "ready"]
+        # The module purge must land between the pip install (so the fresh
+        # code is on disk) and the thread spawn (so the worker's import
+        # resolves from disk, not the process-wide module cache).
+        assert calls == ["ensure", "token", "dir", "purge", "ready"]
         assert started == ["tok"]
 
     async def test_stop_without_start_is_noop(self, tmp_path):
@@ -1517,3 +1521,108 @@ class TestLifecycle:
         mgr, _hass, _entry = _manager(tmp_path)
         mgr._prepare_config_dir()
         assert os.path.isdir(mgr._config_dir)
+
+
+class TestPurgeHaMcpModules:
+    """The stale-worker fix: cached ha_mcp modules are dropped per start.
+
+    Regression guard for the live-found bug where an entry reload
+    reinstalled the package but the new worker silently reused the OLD
+    code from ``sys.modules`` — updates only took effect after a full HA
+    core restart.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _preserve_real_modules(self):
+        """Restore any genuinely imported ha_mcp modules after each test.
+
+        Other unit tests in the same pytest session import the real
+        ``ha_mcp``; purging it here without restoring would change module
+        identity for everything that runs afterwards.
+        """
+        saved = {
+            name: mod
+            for name, mod in sys.modules.items()
+            if name == "ha_mcp" or name.startswith("ha_mcp.")
+        }
+        yield
+        sys.modules.update(saved)
+
+    def test_purges_only_ha_mcp_modules(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "ha_mcp", ModuleType("ha_mcp"))
+        monkeypatch.setitem(sys.modules, "ha_mcp.config", ModuleType("ha_mcp.config"))
+        unrelated = ModuleType("ha_mcp_other")
+        monkeypatch.setitem(sys.modules, "ha_mcp_other", unrelated)
+
+        es._purge_ha_mcp_modules()
+
+        assert "ha_mcp" not in sys.modules
+        assert "ha_mcp.config" not in sys.modules
+        # Prefix match must not swallow lookalike top-level names.
+        assert sys.modules["ha_mcp_other"] is unrelated
+
+    def test_noop_when_nothing_cached(self):
+        for name in [
+            n for n in list(sys.modules) if n == "ha_mcp" or n.startswith("ha_mcp.")
+        ]:
+            sys.modules.pop(name)
+        es._purge_ha_mcp_modules()  # must not raise
+
+
+class TestRunningVersionStalenessWarning:
+    async def test_start_warns_when_running_version_stale(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(mgr, "_async_ensure_package", AsyncMock())
+        monkeypatch.setattr(
+            mgr, "_async_provision_token", AsyncMock(return_value="tok")
+        )
+        monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "9.9.9")
+
+        def _ready_with_stale_worker():
+            # Deterministic stand-in for the _serve stash: the worker
+            # imported an older generation than what pip just installed.
+            mgr._running_version = "1.1.1"
+
+        monkeypatch.setattr(
+            mgr,
+            "_async_wait_until_ready",
+            AsyncMock(side_effect=_ready_with_stale_worker),
+        )
+
+        with caplog.at_level("WARNING"):
+            await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert "running version 1.1.1" in caplog.text
+        assert "restart Home Assistant" in caplog.text
+
+    async def test_start_quiet_when_versions_match(self, tmp_path, monkeypatch, caplog):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(mgr, "_async_ensure_package", AsyncMock())
+        monkeypatch.setattr(
+            mgr, "_async_provision_token", AsyncMock(return_value="tok")
+        )
+        monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "1.1.1")
+
+        def _ready_with_current_worker():
+            mgr._running_version = "1.1.1"
+
+        monkeypatch.setattr(
+            mgr,
+            "_async_wait_until_ready",
+            AsyncMock(side_effect=_ready_with_current_worker),
+        )
+
+        with caplog.at_level("WARNING"):
+            await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert "restart Home Assistant" not in caplog.text

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1579,6 +1579,9 @@ class TestRunningVersionStalenessWarning:
             mgr, "_async_provision_token", AsyncMock(return_value="tok")
         )
         monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        # Stub the module purge: letting it run for real would drop every
+        # live ha_mcp module and poison later tests in this process.
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: None)
         monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
         monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "9.9.9")
 
@@ -1608,6 +1611,9 @@ class TestRunningVersionStalenessWarning:
             mgr, "_async_provision_token", AsyncMock(return_value="tok")
         )
         monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        # Stub the module purge: letting it run for real would drop every
+        # live ha_mcp module and poison later tests in this process.
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: None)
         monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
         monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "1.1.1")
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -4387,3 +4387,50 @@ class TestVisibilitySettingsTab:
         assert 'data-areas="garage"' in result.dom  # edit preserved
         assert 'data-role="alert"' in result.dom
         assert "another tab or session" in result.dom
+
+
+class TestEmbeddedRestartButton:
+    """Embedded deployments get a relabeled restart button (issue #1778)."""
+
+    def test_embedded_mode_shows_relabeled_restart_button(
+        self, settings_script: str
+    ) -> None:
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/info": {
+                "status": 200,
+                "json": {
+                    "instance_id": "baseline-id",
+                    "deployment_mode": "embedded",
+                    "is_addon": False,
+                    "is_sidecar": False,
+                    "version": "7.11.0",
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="""
+              await new Promise(r => setTimeout(r, 300));
+              const btn = document.getElementById('restartBtn');
+              document.body.setAttribute('data-btn-hidden',
+                String(btn.style.display === 'none'));
+              document.body.setAttribute('data-btn-label', btn.textContent);
+              document.body.setAttribute('data-notice-head',
+                document.getElementById('restartNoticeText')
+                  .textContent.trim().slice(0, 80));
+            """,
+        )
+        _assert_clean_init(result)
+        assert 'data-btn-hidden="false"' in result.dom, (
+            "restart button must be visible in embedded mode"
+        )
+        assert "Restart HA-MCP Server" in result.dom, (
+            "embedded mode must relabel the restart button"
+        )
+        m = re.search(r'data-notice-head="([^"]*)"', result.dom)
+        assert m and "Restart HA-MCP Server" in m.group(1), (
+            f"embedded restart-notice copy missing; got {m.group(1) if m else None}"
+        )

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -93,6 +93,9 @@ _TOP_LEVEL_ELEMENT_IDS = [
     "advOperations",
     "advToolsSurface",
     "advDiagnostics",
+    # Developer section (issue #1775) — bottom of panel-server; hosts the
+    # dev-mode toggle whose enable path is confirm()-gated.
+    "advDeveloper",
     # Beta features dedicated container — beta
     # master + sub-flags render here, NOT into featuresBody, so the
     # dangerous block sits at the bottom of panel-server.
@@ -2238,6 +2241,73 @@ class TestBetaBlockRendersAtBottom:
         assert result.broadcasts_of_type("restart-required"), (
             "no restart-required cross-tab broadcast"
         )
+
+    def test_dev_mode_toggle_enable_is_confirm_gated(
+        self, settings_script: str
+    ) -> None:
+        """Enabling the dev-mode toggle (issue #1775) must pass a
+        confirm() gate: declining reverts the checkbox and saves
+        nothing; accepting fires exactly one auto-save POST."""
+        adv_field = {
+            "field": "enable_dev_mode",
+            "env_var": "HAMCP_ENABLE_DEV_MODE",
+            "value": False,
+            "type": "bool",
+            "section": "developer",
+            "origin": "default",
+            "editable": True,
+        }
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/advanced": {
+                "status": 200,
+                "json": {"fields": [adv_field], "is_addon": False},
+                "responses": [
+                    {"status": 200, "json": {"fields": [adv_field], "is_addon": False}},
+                    {"status": 200, "json": {"applied": {"enable_dev_mode": True}}},
+                    {"status": 200, "json": {"fields": [adv_field], "is_addon": False}},
+                ],
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            invoke="""
+              await new Promise(r => setTimeout(r, 200));
+              const cb = document.querySelector(
+                '#advDeveloper input[data-adv-field="enable_dev_mode"]');
+              document.body.setAttribute('data-rendered', String(!!cb));
+              // Decline the warning: the toggle must revert and no save fires.
+              window.confirm = () => false;
+              cb.checked = true;
+              cb.dispatchEvent(new Event('change'));
+              await new Promise(r => setTimeout(r, 1200));
+              document.body.setAttribute('data-declined-state', String(cb.checked));
+              // Accept the warning: the save proceeds.
+              window.confirm = () => true;
+              cb.checked = true;
+              cb.dispatchEvent(new Event('change'));
+              await new Promise(r => setTimeout(r, 1500));
+            """,
+        )
+        _assert_clean_init(result)
+        assert 'data-rendered="true"' in result.dom, (
+            "enable_dev_mode row did not render into #advDeveloper"
+        )
+        assert 'data-declined-state="false"' in result.dom, (
+            "declining the confirm() must revert the dev-mode checkbox"
+        )
+        posts = [
+            f
+            for f in result.fetches
+            if "/api/settings/advanced" in f["url"] and f["method"] == "POST"
+        ]
+        assert len(posts) == 1, (
+            f"expected exactly one save POST (declined change must not "
+            f"save), got {len(posts)}: {result.fetches}"
+        )
+        assert json.loads(posts[0]["body"]).get("enable_dev_mode") is True
 
     def test_advanced_field_autosave_error_shows_error_toast(
         self, settings_script: str

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -1321,7 +1321,7 @@ class TestEmbeddedRestart:
         # The probe flow must not be left open.
         server.client.abort_options_flow.assert_awaited_once_with("f1")
 
-    def test_embedded_restart_500_when_entry_missing(self, monkeypatch):
+    def test_embedded_restart_409_when_entry_missing(self, monkeypatch):
         from unittest.mock import AsyncMock, MagicMock
 
         server = MagicMock()
@@ -1332,7 +1332,9 @@ class TestEmbeddedRestart:
         resp = self._post_restart(
             server, monkeypatch, lambda client, entry_id: scheduled.append(entry_id)
         )
-        assert resp.status_code == 500
+        # Below 500 on purpose: the restart JS treats 5xx as
+        # restart-in-flight and would start its poll-reload cycle.
+        assert resp.status_code == 409
         assert scheduled == []
 
 
@@ -1357,3 +1359,43 @@ class TestSettingsInfoDeploymentMode:
         resp = TestClient(app).get("/api/settings/info")
         assert resp.status_code == 200
         assert resp.json()["deployment_mode"] == "embedded"
+
+
+class TestEmbeddedRestartDiscoveryFailure:
+    def test_discovery_failure_is_not_masked_as_not_found(self, monkeypatch):
+        # A WS/connection failure during entry discovery must answer as a
+        # connection problem (and below 500 — no restart was initiated),
+        # not as "entry not found" with a reinstall-flavored suggestion.
+        from unittest.mock import AsyncMock, MagicMock
+
+        from starlette.routing import Route
+
+        from ha_mcp.tools import tools_dev
+
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        server = MagicMock()
+        server.client.send_websocket_message = AsyncMock(
+            side_effect=Exception("ws down")
+        )
+        scheduled: list = []
+        monkeypatch.setattr(
+            tools_dev,
+            "schedule_deferred_entry_reload",
+            lambda client, entry_id: scheduled.append(entry_id),
+        )
+        handlers = build_settings_handlers(server=server)
+        app = Starlette(
+            routes=[
+                Route(
+                    "/api/settings/restart",
+                    handlers["restart_addon"],
+                    methods=["POST"],
+                )
+            ]
+        )
+        resp = TestClient(app).post("/api/settings/restart")
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error"]["code"] == "CONNECTION_FAILED"
+        assert "not locate" not in body["error"]["message"]
+        assert scheduled == []

--- a/tests/src/unit/test_stdio_settings_sidecar.py
+++ b/tests/src/unit/test_stdio_settings_sidecar.py
@@ -1272,3 +1272,88 @@ class TestVisibilityHandlers:
     def test_put_rejects_invalid_payload(self, tmp_data_dir: Path) -> None:
         resp = self._client().put("/api/visibility/config", json={"version": "abc"})
         assert resp.status_code == 400
+
+
+class TestEmbeddedRestart:
+    """The restart endpoint reloads the server config entry in embedded mode."""
+
+    def _post_restart(self, server, monkeypatch, recorder):
+        from starlette.routing import Route
+
+        from ha_mcp.tools import tools_dev
+
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "schedule_deferred_entry_reload", recorder)
+        handlers = build_settings_handlers(server=server)
+        app = Starlette(
+            routes=[
+                Route(
+                    "/api/settings/restart",
+                    handlers["restart_addon"],
+                    methods=["POST"],
+                )
+            ]
+        )
+        return TestClient(app).post("/api/settings/restart")
+
+    def test_embedded_restart_schedules_entry_reload(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        server = MagicMock()
+        server.client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": [{"entry_id": "server-e"}]}
+        )
+        server.client.start_options_flow = AsyncMock(
+            return_value={
+                "type": "form",
+                "flow_id": "f1",
+                "data_schema": [{"name": "pip_spec", "default": ""}],
+            }
+        )
+        server.client.abort_options_flow = AsyncMock(return_value={})
+        scheduled: list[tuple] = []
+        resp = self._post_restart(
+            server, monkeypatch, lambda client, entry_id: scheduled.append(entry_id)
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert scheduled == ["server-e"]
+        # The probe flow must not be left open.
+        server.client.abort_options_flow.assert_awaited_once_with("f1")
+
+    def test_embedded_restart_500_when_entry_missing(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        server = MagicMock()
+        server.client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        scheduled: list[tuple] = []
+        resp = self._post_restart(
+            server, monkeypatch, lambda client, entry_id: scheduled.append(entry_id)
+        )
+        assert resp.status_code == 500
+        assert scheduled == []
+
+
+class TestSettingsInfoDeploymentMode:
+    def test_sidecar_mode_reported(self):
+        from starlette.routing import Route
+
+        handlers = build_settings_handlers(server=None, is_sidecar=True)
+        app = Starlette(routes=[Route("/api/settings/info", handlers["settings_info"])])
+        resp = TestClient(app).get("/api/settings/info")
+        assert resp.status_code == 200
+        assert resp.json()["deployment_mode"] == "sidecar"
+
+    def test_embedded_mode_reported(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from starlette.routing import Route
+
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        handlers = build_settings_handlers(server=MagicMock())
+        app = Starlette(routes=[Route("/api/settings/info", handlers["settings_info"])])
+        resp = TestClient(app).get("/api/settings/info")
+        assert resp.status_code == 200
+        assert resp.json()["deployment_mode"] == "embedded"

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -1561,3 +1561,70 @@ class TestBugReportNewIdentityFields:
         # hallucination bait we removed.
         for vendor in ("Claude, Gemini", "Gemini, GPT", "GPT, Llama"):
             assert vendor not in instructions
+
+
+class TestDeploymentAndVersionDiagnostics:
+    """Embedded detection + running-vs-installed reporting (issue #1778)."""
+
+    def test_embedded_detected_before_docker_and_addon(self, monkeypatch):
+        from ha_mcp.tools.tools_bug_report import _detect_installation_method
+
+        # The HA core container carries BOTH /.dockerenv and (on HAOS) a
+        # SUPERVISOR_TOKEN, so embedded must win outright.
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+        assert _detect_installation_method() == "embedded"
+
+    def test_format_version_value_flags_stale_worker(self):
+        from ha_mcp.tools.tools_bug_report import _format_version_value
+
+        rendered = _format_version_value(
+            {
+                "ha_mcp_version": "7.10.0.dev779",
+                "installed_version": "7.11.0",
+                "version_mismatch": True,
+            }
+        )
+        assert "7.10.0.dev779 (running)" in rendered
+        assert "7.11.0 is installed" in rendered
+
+    def test_format_version_value_plain_when_matched(self):
+        from ha_mcp.tools.tools_bug_report import _format_version_value
+
+        assert (
+            _format_version_value(
+                {"ha_mcp_version": "7.11.0", "version_mismatch": False}
+            )
+            == "7.11.0"
+        )
+
+    def test_instance_identity_shape(self):
+        from ha_mcp.tools.tools_bug_report import _instance_identity
+
+        identity = _instance_identity()
+        assert identity["instance_id"]
+        assert identity["started_at"] > 0
+        assert identity["uptime_seconds"] >= 0
+
+    async def test_component_version_probe_reads_service_response(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock(
+            return_value={"service_response": {"version": "1.0.1"}}
+        )
+        assert await BugReportTools(client)._detect_component_version() == "1.0.1"
+        client.call_service.assert_awaited_once_with(
+            "ha_mcp_tools", "get_caller_token", {}, return_response=True
+        )
+
+    async def test_component_version_probe_none_when_component_missing(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock(side_effect=Exception("service not found"))
+        assert await BugReportTools(client)._detect_component_version() is None

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -1593,7 +1593,11 @@ class TestDeploymentAndVersionDiagnostics:
 
         assert (
             _format_version_value(
-                {"ha_mcp_version": "7.11.0", "version_mismatch": False}
+                {
+                    "ha_mcp_version": "7.11.0",
+                    "installed_version": "7.11.0",
+                    "version_mismatch": False,
+                }
             )
             == "7.11.0"
         )
@@ -1628,3 +1632,42 @@ class TestDeploymentAndVersionDiagnostics:
         client = MagicMock()
         client.call_service = AsyncMock(side_effect=Exception("service not found"))
         assert await BugReportTools(client)._detect_component_version() is None
+
+
+class TestVersionRenderingHonesty:
+    """Probe failures must stay distinguishable from healthy results."""
+
+    def test_unverified_installed_version_is_visible(self):
+        from ha_mcp.tools.tools_bug_report import _format_version_value
+
+        rendered = _format_version_value(
+            {
+                "ha_mcp_version": "7.11.0",
+                "installed_version": None,
+                "version_mismatch": False,
+            }
+        )
+        assert "could not be verified" in rendered
+
+    async def test_report_carries_version_and_instance_fields(self):
+        # End-to-end composition: the tool's diagnostic_info must include
+        # the new fields even when every probe degrades.
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.get_config = AsyncMock(side_effect=Exception("down"))
+        client.call_service = AsyncMock(side_effect=Exception("down"))
+        result = await BugReportTools(client).ha_report_issue(tool_call_count=1)
+        info = result["diagnostic_info"]
+        assert "installed_version" in info
+        assert "version_mismatch" in info
+        assert info["component_version"] is None
+        assert info["instance"]["instance_id"]
+        # The rendered report keeps the probe failure visible instead of
+        # claiming the component is absent.
+        assert (
+            "not detected (not installed, or probe failed)"
+            in (result["formatted_report"])
+        )

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.config import _reset_global_settings, get_global_settings
+from ha_mcp.config import get_global_settings, reset_global_settings
 from ha_mcp.tools import tools_dev
 from ha_mcp.tools.tools_dev import (
     FEATURE_FLAG,
@@ -33,10 +33,10 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.delenv("HA_MCP_EMBEDDED", raising=False)
     monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
     get_data_dir.cache_clear()
-    _reset_global_settings()
+    reset_global_settings()
     yield
     get_data_dir.cache_clear()
-    _reset_global_settings()
+    reset_global_settings()
 
 
 def _override_file_path():
@@ -64,7 +64,7 @@ class TestRegistrationGating:
 
     def test_flag_enabled_via_env(self, monkeypatch):
         monkeypatch.setenv(FEATURE_FLAG, "true")
-        _reset_global_settings()
+        reset_global_settings()
         assert is_dev_mode_enabled() is True
 
     def test_register_noop_when_disabled(self):
@@ -74,7 +74,7 @@ class TestRegistrationGating:
 
     def test_register_adds_tools_when_enabled(self, monkeypatch):
         monkeypatch.setenv(FEATURE_FLAG, "true")
-        _reset_global_settings()
+        reset_global_settings()
         mcp = MagicMock()
         register_dev_tools(mcp, MagicMock())
         registered = {call.args[0].__name__ for call in mcp.add_tool.call_args_list}
@@ -83,7 +83,7 @@ class TestRegistrationGating:
     def test_flag_persisted_via_override_file(self):
         """The web-UI toggle path: value in feature_flags.json, no env var."""
         _override_file_path().write_text(json.dumps({"enable_dev_mode": True}))
-        _reset_global_settings()
+        reset_global_settings()
         assert is_dev_mode_enabled() is True
 
 
@@ -103,7 +103,7 @@ class TestManageSettings:
 
     async def test_list_masks_token(self, dev_tools, monkeypatch):
         monkeypatch.setenv("HOMEASSISTANT_TOKEN", "super-secret-token")
-        _reset_global_settings()
+        reset_global_settings()
         result = await dev_tools.ha_dev_manage_settings(action="list")
         rows = {r["setting"]: r for r in result["data"]["settings"]}
         assert rows["homeassistant_token"]["value"] == "*****"
@@ -129,7 +129,7 @@ class TestManageSettings:
 
     async def test_set_rejects_env_locked(self, dev_tools, monkeypatch):
         monkeypatch.setenv("LOG_LEVEL", "INFO")
-        _reset_global_settings()
+        reset_global_settings()
         with pytest.raises(ToolError, match="locked by env"):
             await dev_tools.ha_dev_manage_settings(
                 action="set", setting="log_level", value="DEBUG"
@@ -211,7 +211,7 @@ class TestManageSettings:
 
     async def test_reset_rejects_env_pinned(self, dev_tools, monkeypatch):
         monkeypatch.setenv("LOG_LEVEL", "INFO")
-        _reset_global_settings()
+        reset_global_settings()
         with pytest.raises(ToolError, match="env var"):
             await dev_tools.ha_dev_manage_settings(action="reset", setting="log_level")
 
@@ -350,7 +350,7 @@ class TestManageServer:
 
     async def test_restart_addon_schedules_supervisor_restart(self, monkeypatch):
         monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
-        _reset_global_settings()
+        reset_global_settings()
         with patch("ha_mcp.settings_ui._schedule_supervisor_self_restart") as sched:
             result = await DevTools(_mock_client()).ha_dev_manage_server(
                 action="restart"

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -358,3 +358,154 @@ class TestManageServer:
         sched.assert_called_once()
         assert result["data"]["mode"] == "addon"
         assert result["data"]["scheduled"] is True
+
+
+class TestMergeFileOverrideGuards:
+    """The settings-write path must refuse to clobber unreadable state."""
+
+    async def test_set_refuses_corrupt_override_file(self):
+        _override_file_path().write_text("not json {{{")
+        with pytest.raises(ToolError, match="not valid"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set", setting="log_level", value="DEBUG"
+            )
+        # The corrupt file is preserved for inspection, not overwritten.
+        assert _override_file_path().read_text() == "not json {{{"
+
+    async def test_set_refuses_unreadable_override_file(self):
+        _override_file_path().write_text("{}")
+        from pathlib import Path
+
+        with (
+            patch.object(Path, "read_text", side_effect=OSError("boom")),
+            pytest.raises(ToolError, match="refusing to overwrite"),
+        ):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set", setting="log_level", value="DEBUG"
+            )
+
+
+class TestManageSettingsAddonOrigin:
+    """Add-on-origin fields route through Supervisor, not the file."""
+
+    @pytest.fixture(autouse=True)
+    def _addon_mode(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+        reset_global_settings()
+
+    async def test_set_routes_via_supervisor(self, monkeypatch):
+        from ha_mcp import settings_ui
+
+        calls: list[dict] = []
+
+        async def _fake_merge(verify_ssl, changes):
+            calls.append(changes)
+            return True, None
+
+        monkeypatch.setattr(
+            settings_ui, "_supervisor_merge_and_post_options", _fake_merge
+        )
+        result = await DevTools(MagicMock()).ha_dev_manage_settings(
+            action="set", setting="enable_tool_search", value=True
+        )
+        assert result["data"]["mode"] == "addon"
+        assert calls == [{"enable_tool_search": True}]
+        # Nothing lands in the override file on the addon path.
+        assert not _override_file_path().exists()
+
+    async def test_set_surfaces_supervisor_rejection(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from ha_mcp import settings_ui
+
+        async def _fake_merge(verify_ssl, changes):
+            return False, SimpleNamespace(message="schema says no")
+
+        monkeypatch.setattr(
+            settings_ui, "_supervisor_merge_and_post_options", _fake_merge
+        )
+        with pytest.raises(ToolError, match="Supervisor rejected"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set", setting="enable_tool_search", value=True
+            )
+
+    async def test_reset_rejects_addon_managed(self):
+        with pytest.raises(ToolError, match="add-on"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="reset", setting="enable_tool_search"
+            )
+
+
+class TestManageSettingsValueEdgeCases:
+    async def test_set_rejects_null_byte_string(self):
+        with pytest.raises(ToolError, match="null byte"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set", setting="mcp_server_name", value="a\x00b"
+            )
+
+
+class TestServerEntryDiscoveryErrors:
+    """Probe failures must surface as what they are (issue #1780 review)."""
+
+    async def test_ws_failure_raises_tool_error(self):
+        client = _mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "ws down"}
+        )
+        with pytest.raises(ToolError, match="config_entries/get failed"):
+            await DevTools(client).ha_dev_manage_server(
+                action="update_source", channel="dev"
+            )
+
+    async def test_connection_error_propagates_not_masked(self):
+        # A dead connection must NOT read as "no server entry exists" —
+        # that told users to reinstall a component that was running.
+        from ha_mcp.client.rest_client import HomeAssistantConnectionError
+
+        client = _mock_client(entries=[{"entry_id": "server-e"}])
+        client.start_options_flow = AsyncMock(
+            side_effect=HomeAssistantConnectionError("conn refused")
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await DevTools(client).ha_dev_manage_server(
+                action="update_source", channel="dev"
+            )
+        assert "server entry" not in str(excinfo.value)
+
+    async def test_api_error_skips_entry_and_keeps_probing(self):
+        from ha_mcp.client.rest_client import HomeAssistantAPIError
+
+        client = _mock_client(
+            entries=[{"entry_id": "tools-e"}, {"entry_id": "server-e"}],
+            flows=[HomeAssistantAPIError("no options"), dict(_SERVER_FLOW)],
+        )
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        entry = result["data"]["component_server_entry"]
+        assert entry and entry["entry_id"] == "server-e"
+
+    async def test_restart_embedded_errors_without_entry(self, monkeypatch):
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        client = _mock_client(entries=[])
+        with pytest.raises(ToolError, match="server entry"):
+            await DevTools(client).ha_dev_manage_server(action="restart")
+
+
+class TestServerInfoDegradation:
+    """info is best-effort: probe failures become warnings, not failures."""
+
+    async def test_warns_when_ha_version_unavailable(self):
+        client = _mock_client()
+        client.get_config = AsyncMock(side_effect=Exception("api down"))
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        assert result["success"] is True
+        assert any("HA version" in w for w in result["warnings"])
+
+    async def test_warns_when_entry_probe_fails(self):
+        client = _mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "ws down"}
+        )
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        assert result["success"] is True
+        assert any("component server entry" in w for w in result["warnings"])
+        assert result["data"]["server_version"]

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -509,3 +509,18 @@ class TestServerInfoDegradation:
         assert result["success"] is True
         assert any("component server entry" in w for w in result["warnings"])
         assert result["data"]["server_version"]
+
+
+class TestConcurrentSettingsWrites:
+    async def test_concurrent_sets_serialize_under_the_lock(self):
+        # Two overlapping set calls must both land — the shared override-file
+        # lock serializes the read-merge-write so neither clobbers the other.
+        dev_tools = DevTools(MagicMock())
+        await asyncio.gather(
+            dev_tools.ha_dev_manage_settings(
+                action="set", setting="log_level", value="DEBUG"
+            ),
+            dev_tools.ha_dev_manage_settings(action="set", setting="debug", value=True),
+        )
+        persisted = json.loads(_override_file_path().read_text())
+        assert persisted == {"log_level": "DEBUG", "debug": True}

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -1,5 +1,6 @@
 """Unit tests for tools_dev (developer-mode tools, issue #1775)."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -46,8 +47,13 @@ def _override_file_path():
 
 async def _drain_background_tasks():
     """Await any fire-and-forget tasks the tool spawned."""
-    for task in list(tools_dev._BACKGROUND_TASKS):
-        await task
+    tasks = list(tools_dev._BACKGROUND_TASKS)
+    if not tasks:
+        return
+    done, pending = await asyncio.wait(tasks)
+    assert not pending
+    for task in done:
+        task.result()  # re-raise anything the background task threw
 
 
 class TestRegistrationGating:

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -1,0 +1,354 @@
+"""Unit tests for tools_dev (developer-mode tools, issue #1775)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.config import _reset_global_settings, get_global_settings
+from ha_mcp.tools import tools_dev
+from ha_mcp.tools.tools_dev import (
+    FEATURE_FLAG,
+    DevTools,
+    is_dev_mode_enabled,
+    register_dev_tools,
+)
+from ha_mcp.utils.data_paths import get_data_dir
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    """Isolate the data dir and the Settings singleton per test.
+
+    ``is_dev_mode_enabled()`` and the settings tool read through
+    ``get_global_settings()`` (cached) and persist to
+    ``feature_flags.json`` under ``get_data_dir()`` (memoized) — both
+    must be reset so tests can't see each other's state or the real
+    user data dir.
+    """
+    monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv(FEATURE_FLAG, raising=False)
+    monkeypatch.delenv("HA_MCP_EMBEDDED", raising=False)
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    get_data_dir.cache_clear()
+    _reset_global_settings()
+    yield
+    get_data_dir.cache_clear()
+    _reset_global_settings()
+
+
+def _override_file_path():
+    from ha_mcp.config import _FEATURE_FLAG_OVERRIDE_FILENAME
+
+    return get_data_dir() / _FEATURE_FLAG_OVERRIDE_FILENAME
+
+
+async def _drain_background_tasks():
+    """Await any fire-and-forget tasks the tool spawned."""
+    for task in list(tools_dev._BACKGROUND_TASKS):
+        await task
+
+
+class TestRegistrationGating:
+    """Dev tools must not exist at all unless the flag is on."""
+
+    def test_flag_disabled_by_default(self):
+        assert is_dev_mode_enabled() is False
+
+    def test_flag_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv(FEATURE_FLAG, "true")
+        _reset_global_settings()
+        assert is_dev_mode_enabled() is True
+
+    def test_register_noop_when_disabled(self):
+        mcp = MagicMock()
+        register_dev_tools(mcp, MagicMock())
+        mcp.add_tool.assert_not_called()
+
+    def test_register_adds_tools_when_enabled(self, monkeypatch):
+        monkeypatch.setenv(FEATURE_FLAG, "true")
+        _reset_global_settings()
+        mcp = MagicMock()
+        register_dev_tools(mcp, MagicMock())
+        registered = {call.args[0].__name__ for call in mcp.add_tool.call_args_list}
+        assert registered == {"ha_dev_manage_server", "ha_dev_manage_settings"}
+
+    def test_flag_persisted_via_override_file(self):
+        """The web-UI toggle path: value in feature_flags.json, no env var."""
+        _override_file_path().write_text(json.dumps({"enable_dev_mode": True}))
+        _reset_global_settings()
+        assert is_dev_mode_enabled() is True
+
+
+class TestManageSettings:
+    @pytest.fixture
+    def dev_tools(self):
+        return DevTools(MagicMock())
+
+    async def test_list_includes_dev_flag_row(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(action="list")
+        rows = {r["setting"]: r for r in result["data"]["settings"]}
+        row = rows["enable_dev_mode"]
+        assert row["registry"] == "advanced"
+        assert row["section"] == "developer"
+        assert row["value"] is False
+        assert rows["log_level"]["editable"] is True
+
+    async def test_list_masks_token(self, dev_tools, monkeypatch):
+        monkeypatch.setenv("HOMEASSISTANT_TOKEN", "super-secret-token")
+        _reset_global_settings()
+        result = await dev_tools.ha_dev_manage_settings(action="list")
+        rows = {r["setting"]: r for r in result["data"]["settings"]}
+        assert rows["homeassistant_token"]["value"] == "*****"
+        assert "super-secret-token" not in json.dumps(result)
+
+    async def test_set_writes_override_file(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set", setting="log_level", value="DEBUG"
+        )
+        assert result["data"]["restart_required"] is True
+        assert result["data"]["mode"] == "file"
+        persisted = json.loads(_override_file_path().read_text())
+        assert persisted == {"log_level": "DEBUG"}
+        assert get_global_settings().log_level == "DEBUG"
+
+    async def test_set_merges_with_existing_overrides(self, dev_tools):
+        _override_file_path().write_text(json.dumps({"debug": True}))
+        await dev_tools.ha_dev_manage_settings(
+            action="set", setting="log_level", value="ERROR"
+        )
+        persisted = json.loads(_override_file_path().read_text())
+        assert persisted == {"debug": True, "log_level": "ERROR"}
+
+    async def test_set_rejects_env_locked(self, dev_tools, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        _reset_global_settings()
+        with pytest.raises(ToolError, match="locked by env"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="log_level", value="DEBUG"
+            )
+
+    async def test_set_rejects_unknown_setting(self, dev_tools):
+        with pytest.raises(ToolError, match="Unknown setting"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="no_such_setting", value=1
+            )
+
+    async def test_set_rejects_display_only_field(self, dev_tools):
+        with pytest.raises(ToolError):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="homeassistant_url", value="http://x"
+            )
+
+    async def test_set_validates_bounds(self, dev_tools):
+        with pytest.raises(ToolError, match="between"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="fuzzy_threshold", value=500
+            )
+
+    async def test_set_validates_choices(self, dev_tools):
+        with pytest.raises(ToolError, match="one of"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="log_level", value="VERBOSE"
+            )
+
+    async def test_set_validates_type(self, dev_tools):
+        with pytest.raises(ToolError, match="must be of type"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="debug", value=3.14
+            )
+
+    async def test_set_coerces_bool_strings(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set", setting="debug", value="true"
+        )
+        persisted = json.loads(_override_file_path().read_text())
+        assert persisted == {"debug": True}
+
+    async def test_set_enforces_beta_master_gate(self, dev_tools):
+        with pytest.raises(ToolError, match="beta"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set", setting="enable_filesystem_tools", value=True
+            )
+        # Enabling the master first unblocks the sub-flag.
+        await dev_tools.ha_dev_manage_settings(
+            action="set", setting="enable_beta_features", value=True
+        )
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set", setting="enable_filesystem_tools", value=True
+        )
+        assert result["data"]["value"] is True
+
+    async def test_set_requires_setting_and_value(self, dev_tools):
+        with pytest.raises(ToolError, match="'setting' is required"):
+            await dev_tools.ha_dev_manage_settings(action="set")
+        with pytest.raises(ToolError, match="'value' is required"):
+            await dev_tools.ha_dev_manage_settings(action="set", setting="debug")
+
+    async def test_reset_removes_override(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set", setting="log_level", value="DEBUG"
+        )
+        result = await dev_tools.ha_dev_manage_settings(
+            action="reset", setting="log_level"
+        )
+        assert result["data"]["removed_override"] is True
+        assert "log_level" not in json.loads(_override_file_path().read_text())
+        assert get_global_settings().log_level == "INFO"
+
+    async def test_reset_without_override_is_noop(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="reset", setting="log_level"
+        )
+        assert result["data"]["removed_override"] is False
+
+    async def test_reset_rejects_env_pinned(self, dev_tools, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        _reset_global_settings()
+        with pytest.raises(ToolError, match="env var"):
+            await dev_tools.ha_dev_manage_settings(action="reset", setting="log_level")
+
+
+def _mock_client(entries=None, flows=None):
+    """Client mock with config-entry and options-flow surfaces."""
+    client = MagicMock()
+    client.get_config = AsyncMock(return_value={"version": "2025.1.0"})
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": entries or []}
+    )
+    client.start_options_flow = AsyncMock(side_effect=flows or [])
+    client.abort_options_flow = AsyncMock(return_value={})
+    client.submit_options_flow_step = AsyncMock(return_value={"type": "create_entry"})
+    client._request = AsyncMock(return_value={})
+    return client
+
+
+_SERVER_FLOW = {
+    "type": "form",
+    "flow_id": "flow-1",
+    "data_schema": [
+        {"name": "channel", "default": "stable"},
+        {"name": "pip_spec", "default": ""},
+    ],
+}
+
+
+class TestManageServer:
+    async def test_info_standalone_without_component(self):
+        client = _mock_client()
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        data = result["data"]
+        assert data["deployment_mode"] == "standalone"
+        assert data["ha_version"] == "2025.1.0"
+        assert data["component_server_entry"] is None
+        assert isinstance(data["server_version"], str)
+
+    async def test_info_detects_server_entry(self):
+        client = _mock_client(
+            entries=[{"entry_id": "tools-e"}, {"entry_id": "server-e"}],
+            flows=[{"type": "abort", "reason": "no_options"}, dict(_SERVER_FLOW)],
+        )
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        entry = result["data"]["component_server_entry"]
+        assert entry == {
+            "entry_id": "server-e",
+            "channel": "stable",
+            "pip_spec": "",
+        }
+        client.abort_options_flow.assert_awaited_with("flow-1")
+
+    async def test_update_source_requires_params(self):
+        with pytest.raises(ToolError, match="channel"):
+            await DevTools(_mock_client()).ha_dev_manage_server(action="update_source")
+
+    async def test_update_source_rejects_bad_channel(self):
+        with pytest.raises(ToolError, match="channel must be one of"):
+            await DevTools(_mock_client()).ha_dev_manage_server(
+                action="update_source", channel="nightly"
+            )
+
+    async def test_update_source_rejects_multiline_pip_spec(self):
+        with pytest.raises(ToolError, match="single-line"):
+            await DevTools(_mock_client()).ha_dev_manage_server(
+                action="update_source", pip_spec="a\nb"
+            )
+
+    async def test_update_source_errors_without_server_entry(self):
+        client = _mock_client(entries=[])
+        with pytest.raises(ToolError, match="server entry"):
+            await DevTools(client).ha_dev_manage_server(
+                action="update_source", channel="dev"
+            )
+
+    async def test_update_source_submits_options_flow(self):
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        client.submit_options_flow_step.assert_awaited_once_with(
+            "flow-1", {"channel": "dev"}
+        )
+        assert result["data"]["applied"] == {"channel": "dev"}
+        assert result["data"]["previous"]["channel"] == "stable"
+
+    async def test_update_source_surfaces_flow_rejection(self):
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        client.submit_options_flow_step = AsyncMock(
+            return_value={"type": "form", "errors": {"base": "invalid"}}
+        )
+        with pytest.raises(ToolError, match="did not apply"):
+            await DevTools(client).ha_dev_manage_server(
+                action="update_source", pip_spec="ha-mcp==0.0.0"
+            )
+
+    async def test_update_source_embedded_defers_submit(self, monkeypatch):
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source",
+            pip_spec="https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/1/head.tar.gz",
+        )
+        assert result["data"]["scheduled"] is True
+        client.submit_options_flow_step.assert_not_awaited()
+        await _drain_background_tasks()
+        client.submit_options_flow_step.assert_awaited_once()
+
+    async def test_restart_standalone_errors(self):
+        with pytest.raises(ToolError, match="standalone"):
+            await DevTools(_mock_client()).ha_dev_manage_server(action="restart")
+
+    async def test_restart_embedded_defers_entry_reload(self, monkeypatch):
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(action="restart")
+        assert result["data"] == {
+            "scheduled": True,
+            "mode": "embedded",
+            "note": result["data"]["note"],
+        }
+        await _drain_background_tasks()
+        client._request.assert_awaited_once_with(
+            "POST", "/config/config_entries/entry/server-e/reload"
+        )
+
+    async def test_restart_addon_schedules_supervisor_restart(self, monkeypatch):
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+        _reset_global_settings()
+        with patch("ha_mcp.settings_ui._schedule_supervisor_self_restart") as sched:
+            result = await DevTools(_mock_client()).ha_dev_manage_server(
+                action="restart"
+            )
+        sched.assert_called_once()
+        assert result["data"]["mode"] == "addon"
+        assert result["data"]["scheduled"] is True

--- a/tests/src/unit/test_update_check.py
+++ b/tests/src/unit/test_update_check.py
@@ -457,3 +457,15 @@ class TestUpdateCommandHint:
         hint = update_command_hint("7.9.0")
         assert "Add-ons" in hint
         assert "pip install" not in hint and "docker pull" not in hint
+
+
+class TestEmbeddedUpdateHint:
+    def test_embedded_hint_points_to_update_entity(self, monkeypatch):
+        # Embedded wins even though the HA core container also carries a
+        # SUPERVISOR_TOKEN — same precedence bug class as the install-method
+        # detector fixed in the same PR.
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+        hint = update_command_hint("7.11.0")
+        assert "update entity" in hint
+        assert "pip install" not in hint

--- a/tests/src/unit/test_version.py
+++ b/tests/src/unit/test_version.py
@@ -288,3 +288,47 @@ class TestLogStartupVersion:
         # add-on upgrade hint, not the dev-channel banner (suppressed in add-on)
         assert any("Settings -> Add-ons" in m for m in warnings), warnings
         assert not any("dev channel" in m for m in warnings), warnings
+
+
+class TestGetVersionDistOwnership:
+    """get_version prefers the distribution that owns the ha_mcp package.
+
+    Regression guard for the live-found ambiguity: both channel dists can
+    leave metadata behind (interrupted channel switch / failed best-effort
+    uninstall), and the old fixed name order then reported the leftover
+    dist's version instead of the installed one.
+    """
+
+    def test_prefers_owning_distribution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ha_mcp import _version
+
+        monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
+        monkeypatch.setattr(
+            _version.importlib.metadata,
+            "packages_distributions",
+            lambda: {"ha_mcp": ["ha-mcp-dev"]},
+        )
+        monkeypatch.setattr(
+            _version.importlib.metadata,
+            "version",
+            lambda dist: {"ha-mcp": "1.0.0", "ha-mcp-dev": "2.0.0.dev5"}[dist],
+        )
+        assert get_version() == "2.0.0.dev5"
+
+    def test_ambiguous_owners_fall_back_to_name_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ha_mcp import _version
+
+        monkeypatch.delenv("HA_MCP_BUILD_VERSION", raising=False)
+        monkeypatch.setattr(
+            _version.importlib.metadata,
+            "packages_distributions",
+            lambda: {"ha_mcp": ["ha-mcp", "ha-mcp-dev"]},
+        )
+        monkeypatch.setattr(
+            _version.importlib.metadata,
+            "version",
+            lambda dist: {"ha-mcp": "1.0.0", "ha-mcp-dev": "2.0.0.dev5"}[dist],
+        )
+        assert get_version() == "1.0.0"


### PR DESCRIPTION
## What does this PR do?

Closes #1775. Supersedes #1778 (same commits — the head branch was renamed to `hotfix/*` so the merge triggers an immediate hotfix release instead of waiting for the biweekly cut; #1778 carries the original review, with all threads resolved).


Started as the dev-mode feature; live-testing it on a real installation uncovered a serious embedded-server bug and a cluster of version/deployment diagnosability gaps, all fixed here (maintainer-approved bundle).

### 1. Developer mode (the #1775 feature)

**The toggle.** A new `enable_dev_mode` setting renders in a new "Developer" section at the very bottom of the web settings UI's Server Settings tab (below the beta block). Enabling it requires a `confirm()` warning dialog, and it persists through the standard feature-flags override layer (`HAMCP_ENABLE_DEV_MODE` env var wins). Deliberately absent from the add-on config schemas. Restart-required, like every registration-gating flag.

**The tools.** A new auto-discovered `tools_dev.py` module. When the flag is off (default), `register_dev_tools()` returns without registering anything — the `ha_dev_*` tools do not exist for MCP clients at all (no `FEATURE_GATED_TOOLS` stubs on purpose: stubs would advertise them). When on, the server logs a startup WARNING and registers:

- `ha_dev_manage_server` — `info` (versions, deployment mode, HA version, embedded entry channel/pip spec), `update_source` (points the in-process server entry at a channel or explicit pip spec — including GitHub PR tarball URLs — by driving the entry's existing options flow), `restart` (embedded: deferred entry reload; add-on: Supervisor self-restart).
- `ha_dev_manage_settings` — `list`/`set`/`reset` over the same settings matrix as the web UI, origin-aware (env-pinned refused, addon-origin via Supervisor merge, file overrides written atomically under the shared lock), beta master gate enforced, token masked.

### 2. Embedded server: updates never actually applied (live-found, component 1.0.1)

Reproduced on a real installation: an options save reinstalled the package — the web UI footer showed the new on-disk version — but the "new" worker thread silently reused the OLD code. All workers are threads of the one HA core Python process, and Python resolves imports from the process-wide `sys.modules` cache, so **installs only took effect after a full HA core restart**, while every version surface disagreed about what was running.

Fix: the manager now purges `ha_mcp*` from `sys.modules` between the pip install and the worker spawn (safe: ha-mcp is pure Python with a single, controlled import site — the worker thread). Shared third-party dependencies are deliberately not purged, so a dependency-version change still wants an HA core restart; a post-start check compares the worker's imported version against the installed distribution and warns loudly if they ever diverge again. Also fixed while in the options flow: the pip-spec override field no longer pre-fills the default dist name (a "leave blank" field that never looked blank, and showed the stable dist name on the dev channel).

### 3. Version & deployment diagnosability (how the bug stayed invisible)

- `ha_report_issue` now reports the **running** version (`__version__`, frozen at import) and the **installed** on-disk version separately, with an explicit `version_mismatch` flag rendered on every report surface, plus process identity (`instance_id`, `started_at`, uptime) matching `/api/settings/info`, and the custom component's version (via its `get_caller_token` bootstrap service).
- Installation-method detection gains an `embedded` branch checked before the `/.dockerenv` probe — in-process installs previously misreported as plain `docker` in the report tool, the web UI, and the update hint.
- `get_version()` now prefers the distribution that actually owns the imported `ha_mcp` package instead of a fixed name order, so leftover channel metadata (interrupted channel switch) can't misreport.
- The web settings UI reports `deployment_mode`, and in embedded mode shows a **Restart HA-MCP Server** button that reloads the server config entry (which, with the fix above, actually applies pending updates). `update_command_hint` points embedded users at the update entity instead of `pip install -U`.

### 4. Embedded bring-up: survive a wedged worker (HAOS e2e regression fix)

The purge fix exposed a startup crash cascade on QEMU-slow HAOS (caught by the HAOS embedded e2e leg, reproducible twice): a cold import outlived the 30s readiness timeout, the stop path's bounded join gave up on the still-importing thread and nulled the shared stop event, the zombie crashed on `_serve`'s assert, and the next bring-up purged `sys.modules` out from under the zombie's in-flight imports. Fixes: `_serve` receives its stop event as a local (nothing shared to trip on), a timed-out join remembers the orphaned thread, the next start skips the purge while that thread may still be importing (loud warning; the staleness check covers the consequence), and `invalidate_caches()` runs only when modules were actually purged. HAOS embedded is green with the fix.

### 5. Dev build-number sync

`publish-dev` and `addon-publish-dev` each minted versions from their own `github.run_number`, so the same commit shipped as `.dev779` on PyPI/Docker but `.dev481` on the dev add-on — long-standing confusion when comparing installs. Both now derive the number from the commit count (identical for the same commit everywhere; jumps both counters upward, so update detection is safe).

### Testing

- Unit: registration gating both ways, settings list/set/reset validation matrix, manage_server flows incl. deferred embedded paths; module-purge scoping/ordering regression guards + staleness warning; running/installed/mismatch and embedded-detection diagnostics; `get_version` ownership preference; embedded restart handler (schedule + 500-on-missing-entry) and `deployment_mode`; config-flow pip-spec prefill; jsdom tests for the confirm-gated dev toggle and the embedded restart button.
- E2E: new `test_dev_mode_tools.py` — tools hidden by default on a real server, present when enabled, settings roundtrip, info report, validation errors.
- Live on a real HA install (2026.7.1), full end-to-end: the stale-worker bug was reproduced twice under controlled conditions, then component 1.0.1 was deployed and the fix verified both directions (running version tracked channel flips on entry reload alone, fresh worker each time). The PR server build was then installed via pip-spec tarball with dev mode enabled: `ha_dev_manage_server` correctly reported the embedded deployment and its own entry's channel/pip spec, `ha_dev_manage_settings` returned the full origin-aware matrix, and `update_source` successfully replaced the running server with a newer PR commit in one call (deferred submit delivered the response before teardown; connection recovered without client changes). The new `ha_report_issue` fields (running vs installed version, mismatch flag, component version, embedded detection, instance identity) all verified live.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

(Bundled per maintainer instruction; the branch is `hotfix/*` and based on the `stable` tag lineage, so merging triggers `hotfix-release.yml` for an immediate release of the fixes.)

## Testing
- [x] I have tested these changes with a LLM agent — the dev tools were driven end-to-end by an AI agent over a live MCP connector (see Testing above)
- [x] All automated tests pass (`uv run pytest`) — unit suite green locally; full CI including all E2E and HAOS legs green on the final commit
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
