### PR TITLE
ci: fix release push race and hotfix mirror tagging

### DIFF
--- a/.github/workflows/_update-addon-config.yml
+++ b/.github/workflows/_update-addon-config.yml
@@ -92,6 +92,17 @@ jobs:
             echo "No changes to config.yaml, skipping commit"
           else
             git commit -m "chore(addon): ${{ inputs.commit_message_prefix }} $VERSION [skip ci]"
-            git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
-            echo "✓ Updated addon config.yaml to $VERSION"
+            # Master can advance between this job's checkout and its push
+            # (bot commits from other workflows); retry with a rebase instead
+            # of failing the publish. Mirrors the loop in sync-tool-docs.yml.
+            for attempt in 1 2 3 4 5; do
+              if git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master; then
+                echo "✓ Updated addon config.yaml to $VERSION (attempt ${attempt})"
+                exit 0
+              fi
+              echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
+              git pull --rebase origin master
+            done
+            echo "::error::Could not push addon config.yaml update after 5 attempts."
+            exit 1
           fi

--- a/.github/workflows/_update-addon-config.yml
+++ b/.github/workflows/_update-addon-config.yml
@@ -101,7 +101,12 @@ jobs:
                 exit 0
               fi
               echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
-              git pull --rebase origin master
+              # Abort a conflicted rebase so later attempts fail for the real reason.
+              git pull --rebase origin master || {
+                git rebase --abort 2>/dev/null || true
+                echo "::error::Rebase onto origin/master failed; aborting retries."
+                exit 1
+              }
             done
             echo "::error::Could not push addon config.yaml update after 5 attempts."
             exit 1

--- a/.github/workflows/addon-publish-dev.yml
+++ b/.github/workflows/addon-publish-dev.yml
@@ -25,6 +25,10 @@ permissions:
 concurrency:
   group: master-write
   cancel-in-progress: false
+  # queue: max keeps every queued run waiting FIFO. The default single-slot
+  # queue evicts the OLDER pending run when a new one queues, which could
+  # silently drop a queued release behind a bot push.
+  queue: max
 
 jobs:
   # Skip if commit is from semantic-release

--- a/.github/workflows/addon-publish-dev.yml
+++ b/.github/workflows/addon-publish-dev.yml
@@ -18,6 +18,14 @@ env:
 permissions:
   contents: read
 
+# Serialize with every other workflow that pushes to master (this one pushes
+# the dev add-on config bump via _update-addon-config.yml): a push landing
+# while a release workflow's semantic-release is mid-run aborts that release
+# un-retryably ("Upstream branch ... has changed").
+concurrency:
+  group: master-write
+  cancel-in-progress: false
+
 jobs:
   # Skip if commit is from semantic-release
   check-skip:

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -16,6 +16,10 @@ on:
 concurrency:
   group: master-write
   cancel-in-progress: false
+  # queue: max keeps every queued run waiting FIFO. The default single-slot
+  # queue evicts the OLDER pending run when a new one queues, which could
+  # silently drop a queued release behind a bot push.
+  queue: max
 
 env:
   PYTHON_VERSION: "3.13"
@@ -129,7 +133,12 @@ jobs:
             exit 0
           fi
           echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
-          git pull --rebase origin master
+          # Abort a conflicted rebase so later attempts fail for the real reason.
+          git pull --rebase origin master || {
+            git rebase --abort 2>/dev/null || true
+            echo "::error::Rebase onto origin/master failed; aborting retries."
+            exit 1
+          }
         done
         echo "::error::Could not push addon changelog sync after 5 attempts."
         exit 1

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -57,30 +57,23 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Validate hotfix is based on stable
+    - name: Require stable tag exists
       run: |
-        # Get the stable tag (moving tag that points to latest stable)
-        if ! git rev-parse stable &>/dev/null; then
-          echo "::error::No 'stable' tag found. Cannot validate hotfix base."
+        # Hotfix ORIGIN (branch based on the stable tag, not master) is validated
+        # PRE-merge in pr-validate-hotfix.yml, which checks out the unmerged
+        # branch head. Doing it here is impossible: post-merge HEAD is master's
+        # tip, and because master is never rewritten, `stable` is ALWAYS an
+        # ancestor of it — so `merge-base --is-ancestor stable HEAD` can never
+        # fail. The former ancestor check here was therefore dead code. The one
+        # thing still worth guarding is that `stable` exists at all: a hotfix
+        # must have been based on it, and the release below repoints it. (This
+        # missing-tag guard is not redundant with pr-validate-hotfix.yml, which
+        # only warns-and-skips when the tag is absent.)
+        if ! git rev-parse -q --verify refs/tags/stable >/dev/null; then
+          echo "::error::No 'stable' tag found — a hotfix must be based on the stable release."
           exit 1
         fi
-
-        STABLE_COMMIT=$(git rev-parse stable)
-        HOTFIX_BASE=$(git merge-base $STABLE_COMMIT HEAD)
-
-        # The hotfix should be based on or after the stable tag
-        if git merge-base --is-ancestor $STABLE_COMMIT HEAD; then
-          echo "✓ Hotfix is based on stable tag"
-        else
-          # Check if stable is ancestor of hotfix base
-          if git merge-base --is-ancestor $HOTFIX_BASE $STABLE_COMMIT; then
-            echo "✓ Hotfix is based on a commit at or before stable"
-          else
-            echo "::error::Hotfix contains commits from master that are not in stable release"
-            echo "Hotfix must be branched from the 'stable' tag"
-            exit 1
-          fi
-        fi
+        echo "✓ stable tag present"
 
     - name: Run semantic-release
       id: semantic

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -7,6 +7,16 @@ on:
     types: [closed]
     branches: [master, main]
 
+# Serialize with every other workflow that pushes to master (sync-tool-docs,
+# addon-publish-dev, semver-release). semantic-release's internal push aborts
+# hard when origin/master moves mid-run ("Upstream branch ... has changed") and
+# that abort is not retryable from inside the action, so the only safe fix is
+# to keep master writers from overlapping. cancel-in-progress stays false: a
+# queued release must run, not be cancelled.
+concurrency:
+  group: master-write
+  cancel-in-progress: false
+
 env:
   PYTHON_VERSION: "3.13"
 
@@ -28,21 +38,20 @@ jobs:
       issues: write
 
     steps:
-    - name: Checkout merged hotfix on master
+    - name: Checkout master tip
       uses: actions/checkout@v7
       with:
-        # Check out the merge commit so the workspace matches master's history;
-        # then attach to a local master branch below. python-semantic-release
-        # matches the active branch against [tool.semantic_release].branch
-        # in pyproject.toml — a detached HEAD checkout (e.g., of head.sha)
-        # fails silently with "Detached HEAD state cannot match any release
-        # groups; no release will be made", which is what broke PR #1090.
-        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        # Check out master BY NAME, not the event's frozen merge_commit_sha:
+        # a named branch ref gives an attached local master branch, which
+        # python-semantic-release matches against [tool.semantic_release].branch
+        # (a detached HEAD checkout of a bare SHA "cannot match any release
+        # groups", which is what broke PR #1090). Using the live tip also folds
+        # in any [skip ci] bot commits that landed right after the merge and —
+        # unlike the pinned SHA — lets a re-run of a failed release recover
+        # instead of aborting forever on "Upstream branch ... has changed".
+        ref: master
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Attach to master branch locally
-      run: git checkout -B master HEAD
 
     - name: Validate hotfix is based on stable
       run: |
@@ -111,7 +120,19 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add homeassistant-addon/CHANGELOG.md
         git diff --staged --quiet || git commit -m "chore(addon): sync changelog for Home Assistant add-on [skip ci]"
-        git push origin HEAD:master
+        # Master can advance between checkout and this push (bot commits from
+        # other workflows); retry with a rebase instead of failing the release.
+        # Mirrors the loop in sync-tool-docs.yml.
+        for attempt in 1 2 3 4 5; do
+          if git push origin HEAD:master; then
+            echo "Synced addon changelog (attempt ${attempt})."
+            exit 0
+          fi
+          echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
+          git pull --rebase origin master
+        done
+        echo "::error::Could not push addon changelog sync after 5 attempts."
+        exit 1
 
     - name: Update stable git tag
       if: steps.semantic.outputs.released == 'true'

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -17,6 +17,16 @@ on:
 permissions:
   contents: read
 
+# Serialize with every other workflow that pushes to master (sync-tool-docs,
+# addon-publish-dev, hotfix-release). semantic-release's internal push aborts
+# hard when origin/master moves mid-run ("Upstream branch ... has changed") and
+# that abort is not retryable from inside the action, so the only safe fix is
+# to keep master writers from overlapping. cancel-in-progress stays false: a
+# queued release must run, not be cancelled.
+concurrency:
+  group: master-write
+  cancel-in-progress: false
+
 env:
   PYTHON_VERSION: "3.13"
 
@@ -177,7 +187,19 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add homeassistant-addon/CHANGELOG.md
         git diff --staged --quiet || git commit -m "chore(addon): sync changelog for Home Assistant add-on [skip ci]"
-        git push
+        # Master can advance between checkout and this push (bot commits from
+        # other workflows); retry with a rebase instead of failing the release.
+        # Mirrors the loop in sync-tool-docs.yml.
+        for attempt in 1 2 3 4 5; do
+          if git push; then
+            echo "Synced addon changelog (attempt ${attempt})."
+            exit 0
+          fi
+          echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
+          git pull --rebase origin master
+        done
+        echo "::error::Could not push addon changelog sync after 5 attempts."
+        exit 1
 
 
     - name: Update stable git tag

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -26,6 +26,10 @@ permissions:
 concurrency:
   group: master-write
   cancel-in-progress: false
+  # queue: max keeps every queued run waiting FIFO. The default single-slot
+  # queue evicts the OLDER pending run when a new one queues, which could
+  # silently drop a queued release behind a bot push.
+  queue: max
 
 env:
   PYTHON_VERSION: "3.13"
@@ -196,7 +200,12 @@ jobs:
             exit 0
           fi
           echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
-          git pull --rebase origin master
+          # Abort a conflicted rebase so later attempts fail for the real reason.
+          git pull --rebase origin master || {
+            git rebase --abort 2>/dev/null || true
+            echo "::error::Rebase onto origin/master failed; aborting retries."
+            exit 1
+          }
         done
         echo "::error::Could not push addon changelog sync after 5 attempts."
         exit 1

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -27,7 +27,13 @@ on:
       - "scripts/build_mirror_readme.py"
       - ".github/integration-mirror-workflows/**"
   workflow_run:
-    workflows: ["SemVer Release"]
+    # Both stable-release paths must tag the mirror: a hotfix that bumps the
+    # component version otherwise leaves HACS users stuck on the old tag
+    # (the push-triggered snapshot copies code to the mirror's main but only
+    # this workflow_run leg creates the version tag). The tag step is
+    # idempotent (skips when the manifest version is already tagged), so a
+    # hotfix without a component change is a harmless no-op.
+    workflows: ["SemVer Release", "Hotfix Release"]
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -37,8 +37,27 @@ on:
     types: [completed]
   workflow_dispatch:
 
+# Serialize mirror syncs. A real hotfix that touches the component triggers
+# BOTH legs — the master push (paths) and the workflow_run — nearly at once,
+# and both clone the mirror and push to main; without serialization the second
+# push is a non-fast-forward rejection that fails the job before it can tag.
+# queue: max keeps a queued release-tag run from being evicted by a later push
+# run (requires cancel-in-progress: false).
+concurrency:
+  group: mirror-sync
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   sync:
+    # workflow_run fires for EVERY completed run of the listed workflows —
+    # including the SKIPPED Hotfix Release that every non-hotfix PR merge
+    # produces (the release job is `if`-guarded) and odd-week / no-change
+    # SemVer runs. Only proceed for a SUCCESSFUL release run; push and manual
+    # dispatch (where workflow_run is absent) always run.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/sync-tool-docs.yml
+++ b/.github/workflows/sync-tool-docs.yml
@@ -15,10 +15,17 @@ on:
 permissions:
   contents: read
 
-# Prevent overlapping runs if multiple tool PRs merge in quick succession
+# Shared group for every workflow that pushes to master (hotfix-release,
+# semver-release, addon-publish-dev): a doc-sync push landing while
+# semantic-release is mid-run aborts the release un-retryably ("Upstream
+# branch ... has changed"), so master writers must not overlap. This also
+# keeps sync runs from overlapping each other. cancel-in-progress must be
+# false — cancelling a queued RELEASE to run a doc sync would drop the
+# release; a dropped doc sync self-heals on the next merge or via
+# workflow_dispatch, so it queues instead.
 concurrency:
-  group: sync-tool-docs
-  cancel-in-progress: true
+  group: master-write
+  cancel-in-progress: false
 
 jobs:
   sync-tools-json:

--- a/.github/workflows/sync-tool-docs.yml
+++ b/.github/workflows/sync-tool-docs.yml
@@ -20,12 +20,14 @@ permissions:
 # semantic-release is mid-run aborts the release un-retryably ("Upstream
 # branch ... has changed"), so master writers must not overlap. This also
 # keeps sync runs from overlapping each other. cancel-in-progress must be
-# false — cancelling a queued RELEASE to run a doc sync would drop the
-# release; a dropped doc sync self-heals on the next merge or via
-# workflow_dispatch, so it queues instead.
+# false: a running release must never be cancelled by a doc sync.
 concurrency:
   group: master-write
   cancel-in-progress: false
+  # queue: max keeps every queued run waiting FIFO. The default single-slot
+  # queue evicts the OLDER pending run when a new one queues, which could
+  # silently drop a queued release behind a bot push.
+  queue: max
 
 jobs:
   sync-tools-json:
@@ -69,18 +71,26 @@ jobs:
         git commit -m "chore(internal): sync tool docs after merge [skip ci]"
         # master can advance between this job's checkout and its push whenever
         # any unrelated PR merges in the same window, which rejects a bare push
-        # as a non-fast-forward (the concurrency group only serialises sync runs
-        # against each other, not against ordinary merges). Rebase onto the
-        # latest master and retry before giving up. cancel-in-progress guarantees
-        # no competing sync run, so the only thing to rebase over is unrelated
-        # commits that do not touch the generated files — never a conflict.
+        # as a non-fast-forward (the master-write concurrency group only
+        # serialises the workflows in the group, not ordinary merges). Rebase
+        # onto the latest master and retry before giving up. The group
+        # guarantees no competing sync run, so the only thing to rebase over
+        # is unrelated commits that do not touch the generated files — never
+        # a conflict.
         for attempt in 1 2 3 4 5; do
           if git push; then
             echo "Synced tool docs (attempt ${attempt})."
             exit 0
           fi
           echo "Push rejected on attempt ${attempt}; rebasing onto origin/master and retrying."
-          git pull --rebase origin master
+          # A conflicted/failed rebase leaves rebase-in-progress state and the
+          # remaining attempts would fail for a misleading reason — abort and
+          # surface the real error instead.
+          git pull --rebase origin master || {
+            git rebase --abort 2>/dev/null || true
+            echo "::error::Rebase onto origin/master failed; aborting retries."
+            exit 1
+          }
         done
         echo "::error::Could not push tool-doc sync after 5 attempts."
         exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,9 +219,6 @@ dev = [
 # Semantic versioning configuration
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-version_variables = [
-    "src/ha_mcp/__init__.py:__version__",
-]
 build_command = """
 pip install uv && uv lock
 git add uv.lock


### PR DESCRIPTION
## What does this PR do?

Fixes the release-pipeline failures uncovered by the PR #1780 hotfix release:

- **Serialize master writers and retry release pushes.** The Hotfix Release run for #1780 aborted inside python-semantic-release with `Upstream branch 'origin/master' has changed!` — `sync-tool-docs.yml` pushed its doc-sync commit mid-release, and the action's freshness check is not retryable. All four workflows that push to master (`hotfix-release`, `semver-release`, `sync-tool-docs`, `addon-publish-dev` via `_update-addon-config`) now share a `master-write` concurrency group (`cancel-in-progress: false`), and the plain changelog/config pushes get sync-tool-docs' rebase-and-retry loop as defense in depth. `hotfix-release` also checks out `master` by name instead of the event's frozen `merge_commit_sha`: still an attached branch (the #1090 constraint), but re-runs can now recover, and the manual attach step is gone. Documented tradeoff: GitHub queues only one pending run per group, so a hotfix merge that also touches tool files can cancel one queued bot run — both bot workflows are `workflow_dispatch`-recoverable and self-heal on the next merge.
- **Tag the integration mirror on hotfix releases.** `sync-integration-mirror.yml` only tagged the HACS mirror after "SemVer Release", so a hotfix bumping the component version left HACS users pinned to the old tag (bit component 1.0.1). The tag step is idempotent, so hotfixes without a component change are a no-op.
- **Drop the dead `version_variables` entry** from the semantic-release config: `__init__.py` assigns `__version__ = get_version()` (runtime metadata lookup), so the pattern has matched nothing (`num_matches=0` in release logs); `version_toml` is the single bump source.

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Workflow-only change (plus one dead config entry): all edited YAML parses clean; the retry loop mirrors the proven one in `sync-tool-docs.yml`; the release path itself is only exercisable by a real release run.

## Checklist
- [x] I have updated documentation if needed
