### PR TITLE
fix(internal): split mypy-webhook-proxy lefthook job to avoid module collision

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,13 +26,15 @@ pre-commit:
           - name: mypy
             glob: "**/*.py"
             run: uv run mypy src/ homeassistant-addon/ scripts/
+          # Separate jobs, not one: both flavors' start.py resolve to the
+          # same mypy module name, so checking them together fails with
+          # "Duplicate module named start".
           - name: mypy-webhook-proxy
             glob: "**/*.py"
-            # Two separate invocations, not one with both paths: mypy infers
-            # each file's module name from its basename, and both flavors'
-            # start.py collide ("Duplicate module named start") when checked
-            # together in one run.
-            run: uv run mypy homeassistant-addon-webhook-proxy/start.py && uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
+            run: uv run mypy homeassistant-addon-webhook-proxy/start.py
+          - name: mypy-webhook-proxy-dev
+            glob: "**/*.py"
+            run: uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
           - name: unit-tests
             glob:
               - "**/*.py"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,7 +28,11 @@ pre-commit:
             run: uv run mypy src/ homeassistant-addon/ scripts/
           - name: mypy-webhook-proxy
             glob: "**/*.py"
-            run: uv run mypy homeassistant-addon-webhook-proxy/start.py homeassistant-addon-webhook-proxy-dev/start.py
+            # Two separate invocations, not one with both paths: mypy infers
+            # each file's module name from its basename, and both flavors'
+            # start.py collide ("Duplicate module named start") when checked
+            # together in one run.
+            run: uv run mypy homeassistant-addon-webhook-proxy/start.py && uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
           - name: unit-tests
             glob:
               - "**/*.py"


### PR DESCRIPTION
## What does this PR do?

Fixes the `mypy-webhook-proxy` pre-commit job (`lefthook.yml`), which currently fails for every contributor: `homeassistant-addon-webhook-proxy/start.py` and `homeassistant-addon-webhook-proxy-dev/start.py` both resolve to module name `start` with no package markers, so checking them together in a single `mypy` invocation fails with `Duplicate module named "start"`. Introduced when the `-dev` flavor's `start.py` was added in #1719 without updating this job. Splits it into two separate `mypy` invocations (one per file), which avoids ever building one type-check graph containing both same-named modules.

Found while working on an unrelated PR that got blocked by this at commit time.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified both `mypy` invocations pass cleanly when run separately (they previously failed when run together).

## Checklist
- [x] I have updated documentation if needed
