### PR TITLE
fix(internal): isolate 3 beta-gate tests from real ~/.ha-mcp config

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,13 +26,15 @@ pre-commit:
           - name: mypy
             glob: "**/*.py"
             run: uv run mypy src/ homeassistant-addon/ scripts/
+          # Separate jobs, not one: both flavors' start.py resolve to the
+          # same mypy module name, so checking them together fails with
+          # "Duplicate module named start".
           - name: mypy-webhook-proxy
             glob: "**/*.py"
-            # Two separate invocations, not one with both paths: mypy infers
-            # each file's module name from its basename, and both flavors'
-            # start.py collide ("Duplicate module named start") when checked
-            # together in one run.
-            run: uv run mypy homeassistant-addon-webhook-proxy/start.py && uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
+            run: uv run mypy homeassistant-addon-webhook-proxy/start.py
+          - name: mypy-webhook-proxy-dev
+            glob: "**/*.py"
+            run: uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
           - name: unit-tests
             glob:
               - "**/*.py"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,7 +28,11 @@ pre-commit:
             run: uv run mypy src/ homeassistant-addon/ scripts/
           - name: mypy-webhook-proxy
             glob: "**/*.py"
-            run: uv run mypy homeassistant-addon-webhook-proxy/start.py homeassistant-addon-webhook-proxy-dev/start.py
+            # Two separate invocations, not one with both paths: mypy infers
+            # each file's module name from its basename, and both flavors'
+            # start.py collide ("Duplicate module named start") when checked
+            # together in one run.
+            run: uv run mypy homeassistant-addon-webhook-proxy/start.py && uv run mypy homeassistant-addon-webhook-proxy-dev/start.py
           - name: unit-tests
             glob:
               - "**/*.py"

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -311,7 +311,9 @@ def test_master_on_allows_beta_subflag_file_overrides(
     assert s.enable_filesystem_tools is False
 
 
-def test_master_env_var_off_overrides_subflag_env_var(monkeypatch) -> None:
+def test_master_env_var_off_overrides_subflag_env_var(
+    isolated_data_dir, monkeypatch
+) -> None:
     """ENABLE_YAML_CONFIG_EDITING=true alone is not enough — without
     ENABLE_BETA_FEATURES=true the master gate forces yaml false."""
     monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3215,12 +3215,16 @@ class TestBetaMasterGateInSave:
 
     @pytest.mark.asyncio
     async def test_save_features_rejects_beta_subflag_when_master_off(
-        self, monkeypatch
+        self, monkeypatch, tmp_path
     ):
         """POST {enable_yaml_config_editing: true} while master is off → 409."""
         from ha_mcp.config import FEATURE_FLAG_FIELDS, _reset_global_settings
         from ha_mcp.settings_ui import build_settings_handlers
+        from ha_mcp.utils.data_paths import get_data_dir
 
+        get_data_dir.cache_clear()
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        get_data_dir.cache_clear()
         for _fname, ename, _ftype in FEATURE_FLAG_FIELDS:
             monkeypatch.delenv(ename, raising=False)
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -3220,11 +3220,8 @@ class TestBetaMasterGateInSave:
         """POST {enable_yaml_config_editing: true} while master is off → 409."""
         from ha_mcp.config import FEATURE_FLAG_FIELDS, _reset_global_settings
         from ha_mcp.settings_ui import build_settings_handlers
-        from ha_mcp.utils.data_paths import get_data_dir
 
-        get_data_dir.cache_clear()
         monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
-        get_data_dir.cache_clear()
         for _fname, ename, _ftype in FEATURE_FLAG_FIELDS:
             monkeypatch.delenv(ename, raising=False)
         monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -17,7 +17,7 @@ from ha_mcp.tools.tools_filesystem import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_settings_singleton():
+def _reset_settings_singleton(tmp_path, monkeypatch):
     """Reset the cached ``Settings`` between tests.
 
     ``is_filesystem_tools_enabled()`` reads through
@@ -26,10 +26,20 @@ def _reset_settings_singleton():
     via ``patch.dict(os.environ, ...)`` need the cache invalidated
     or every test after the first sees a stale value frozen at
     import time.
+
+    Also isolates ``get_data_dir`` to a tmp dir: ``get_global_settings()``
+    reads a real ``feature_flags.json`` under the resolved data dir (e.g.
+    ``~/.ha-mcp`` on a dev machine), so without this a locally-toggled beta
+    flag silently overrides what these tests expect to see.
     """
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    get_data_dir.cache_clear()
+    monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
     _reset_global_settings()
     yield
     _reset_global_settings()
+    get_data_dir.cache_clear()
 
 
 class TestFeatureFlag:


### PR DESCRIPTION
## What does this PR do?

Fixes 3 unit tests that read the real `~/.ha-mcp/feature_flags.json` instead of an isolated tmp dir, so a locally-toggled beta flag (e.g. from a dev `ha-mcp-web` run) silently flips their expected result and breaks `pytest`/pre-commit for anyone with that file present:

- `test_config.py::test_master_env_var_off_overrides_subflag_env_var`
- `test_tools_filesystem.py::TestFeatureFlag::test_master_off_forces_sub_flag_off`
- `test_settings_ui.py::TestBetaMasterGateInSave::test_save_features_rejects_beta_subflag_when_master_off`

Each was the one test in its file/class missing the `HA_MCP_CONFIG_DIR` tmp-dir isolation its sibling tests already have (`isolated_data_dir` fixture in `test_config.py`, `tmp_path`+`monkeypatch` in `test_settings_ui.py`). Mirrors the existing pattern in each file rather than introducing a new one; also hardened `test_tools_filesystem.py`'s autouse fixture so every test in that file is isolated going forward, not just the one that happened to fail.

Found while investigating why a C901 refactor PR's pre-commit hook failed on unrelated tests.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified all 3 tests (and their full parent files, 248 tests total) pass with the real `~/.ha-mcp/feature_flags.json` deliberately left polluted (`enable_beta_features: true` on disk) -- confirming true isolation, not just accidental passing.

## Checklist
- [x] I have updated documentation if needed
