### PR TITLE
fix: stop the auto-updated in-process server crashing under an older custom component

### DIFF
--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -243,6 +243,22 @@ UPDATE_CHECK_INTERVAL = timedelta(hours=6)
 # is DIST_NAME_STABLE or DIST_NAME_DEV depending on the selected channel.
 PYPI_JSON_URL = "https://pypi.org/pypi/{dist}/json"
 
+# The component manifest as it existed at a server release's git tag. Its
+# ``version`` is the component version that SHIPPED with that server build, so
+# a value newer than the running component means the release changed the
+# component too — the pre-install auto-update gate in embedded_setup holds the
+# server update until HACS delivers the component (issues #1783/#1785).
+# Tag-timing caveat: stable ``vX.Y.Z`` tags exist before the PyPI publish
+# (semantic-release pushes the tag first), but a dev ``vX.Y.Z.devN`` tag is
+# only created when its draft GitHub release is published — AFTER the binary
+# builds, minutes after PyPI already has the version. During that dev window
+# this URL 404s and the gate deliberately fails open (the registry's
+# skip-on-failure is the backstop on that channel).
+COMPONENT_MANIFEST_AT_TAG_URL = (
+    "https://raw.githubusercontent.com/homeassistant-ai/ha-mcp/"
+    "v{version}/custom_components/ha_mcp_tools/manifest.json"
+)
+
 # Options-flow keys (stored in entry.options).
 OPT_CHANNEL = "channel"
 # Automatic server-version updates toggle (default on). When on, the channel is
@@ -366,6 +382,14 @@ ISSUE_START_FAILED = "server_start_failed"
 # the server expects; this points the user at the HACS component update
 # (non-blocking).
 ISSUE_COMPONENT_OUTDATED = "component_outdated"
+# Repair issue surfaced while an automatic server update is HELD because the
+# newer server release also shipped a newer custom component than the one
+# running (issues #1783/#1785): installing that server under the old component
+# is the combination that broke starts. Held is loud (this issue + a warning
+# log every check) and escapable — applying the HACS component update (which
+# takes an HA restart) unblocks the next check, and the update entity's
+# Install button bypasses the hold entirely.
+ISSUE_UPDATE_HELD = "server_update_held"
 # Repair issue surfaced when HACS is tracking the MAIN ha-mcp server repo for
 # this component (the pre-mirror install path — issue #1760). That install
 # keeps working (HACS downloads the repo snapshot at the release tag, which

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -19,15 +19,18 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from aiohttp import ClientError
 from awesomeversion import AwesomeVersion, AwesomeVersionException
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_integration
 
 from .const import (
     BIND_HOST_ALL,
     CHANNEL_DEV,
+    COMPONENT_MANIFEST_AT_TAG_URL,
     DATA_BRINGUP_TASK,
     DATA_MANAGER,
     DATA_PENDING_UPDATE_NOTIFY,
@@ -43,6 +46,7 @@ from .const import (
     ISSUE_COMPONENT_OUTDATED,
     ISSUE_PACKAGE_FAILED,
     ISSUE_START_FAILED,
+    ISSUE_UPDATE_HELD,
     OPT_AUTO_UPDATE,
     OPT_BIND_HOST,
     OPT_ENABLE_WEBHOOK,
@@ -65,7 +69,15 @@ _LOGGER = logging.getLogger(__name__)
 
 _NOTIFICATION_ID = "ha_mcp_tools_server_connect"
 _UPDATE_NOTIFICATION_ID = "ha_mcp_tools_server_updated"
-_ISSUE_IDS = (ISSUE_PACKAGE_FAILED, ISSUE_START_FAILED)
+# ISSUE_UPDATE_HELD is cleared at bring-up start too: any reload that reaches
+# bring-up either bypassed the hold deliberately (the update entity's Install
+# button) or made it moot; if the hold still applies, the coordinator refresh
+# that follows setup re-files it within moments.
+_ISSUE_IDS = (ISSUE_PACKAGE_FAILED, ISSUE_START_FAILED, ISSUE_UPDATE_HELD)
+
+# Per-request timeout for the component-manifest fetch behind the auto-update
+# gate — mirrors the coordinator's PyPI fetch budget; a miss fails open.
+_MANIFEST_FETCH_TIMEOUT_SECONDS = 30
 
 
 async def async_bring_up_server(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -326,6 +338,16 @@ async def async_maybe_auto_update(
     coordinator's ``data`` type before its first successful refresh), or a
     bring-up is still in flight (below).
 
+    A pending update is additionally gated on component compatibility
+    (issues #1783/#1785): when the candidate release also shipped a newer
+    custom component than the one running, the reload is HELD — loudly (a
+    repair issue plus a warning log every check) and escapably (applying the
+    HACS component update — which takes an HA restart, as the issue text
+    says — unblocks the next check; the update entity's Install button never
+    passes through here, so manual installs — like pip-spec overrides above —
+    bypass the hold entirely). Every failure inside the gate fails OPEN so a
+    GitHub hiccup can never wedge updates.
+
     Best-effort: an incomparable version string (AwesomeVersionException) is
     logged at debug and skipped; the next refresh retries. Genuine bugs
     propagate per the repo's no-silent-failure convention.
@@ -363,7 +385,39 @@ async def async_maybe_auto_update(
         return
 
     if not newer:
+        # Up to date: a hold that was pending is resolved (the component
+        # update landed and the unblocked reload installed the server).
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_UPDATE_HELD)
         return
+
+    held = await _async_update_held_by_component(hass, info)
+    if held is not None:
+        shipped, running = held
+        _LOGGER.warning(
+            "HA-MCP server %s is available, but that release also updated the "
+            "custom component (%s; running %s); holding the automatic server "
+            "update until the component is updated via HACS. Press Install on "
+            "the HA-MCP server update entity to install anyway.",
+            info.latest,
+            shipped,
+            running,
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            ISSUE_UPDATE_HELD,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_UPDATE_HELD,
+            translation_placeholders={
+                "latest": str(info.latest),
+                "shipped": shipped,
+                "running": running,
+            },
+            learn_more_url=HACS_COMPONENT_URL,
+        )
+        return
+    ir.async_delete_issue(hass, DOMAIN, ISSUE_UPDATE_HELD)
 
     channel = channel_for_dist(info.dist)
     _LOGGER.info(
@@ -401,6 +455,79 @@ async def async_maybe_auto_update(
 def _drop_pending_update_notify(hass: HomeAssistant) -> None:
     """Drop the deferred update-notification marker without notifying."""
     hass.data.get(DOMAIN, {}).pop(DATA_PENDING_UPDATE_NOTIFY, None)
+
+
+async def _async_update_held_by_component(
+    hass: HomeAssistant, info: ServerVersionInfo
+) -> tuple[str, str] | None:
+    """Return ``(shipped, running)`` when the pending update must be held.
+
+    The #1783/#1785 breakage: a server release whose repo state also bumped the
+    custom component auto-installed under the OLD component before HACS had
+    even surfaced the component update. The component version in the manifest
+    at the candidate release's git tag is what shipped with that server build —
+    newer than the running component means the release changed the component
+    too, so the automatic server install waits for the component.
+
+    Fails OPEN (returns None → install proceeds, the pre-gate behavior) on
+    every expected failure: manifest unreachable, component version unreadable,
+    incomparable versions. Blocking updates indefinitely on a transient would
+    be worse than the crash this guards against — and the crash itself is now
+    also survivable server-side (the tools registry skips a failing module).
+    """
+    shipped = await _async_fetch_shipped_component_version(hass, str(info.latest))
+    if shipped is None:
+        return None
+
+    try:
+        integration = await async_get_integration(hass, DOMAIN)
+        running = str(integration.version)
+    except Exception:
+        # Same wide loader surface as _async_check_component_compat: advisory
+        # gate, logged visibly rather than swallowed silently.
+        _LOGGER.warning(
+            "Could not read the HA-MCP component version for the auto-update "
+            "gate; proceeding with the update",
+            exc_info=True,
+        )
+        return None
+
+    try:
+        if AwesomeVersion(running) < AwesomeVersion(shipped):
+            return shipped, running
+    except AwesomeVersionException as err:
+        # Incomparable version strategies only; real bugs propagate.
+        _LOGGER.debug("HA-MCP auto-update gate version compare failed: %s", err)
+    return None
+
+
+async def _async_fetch_shipped_component_version(
+    hass: HomeAssistant, server_version: str
+) -> str | None:
+    """Return the component version shipped at server release ``vX.Y.Z``.
+
+    Reads the component manifest as committed at the release's git tag (raw
+    GitHub URL). Stable tags exist before the PyPI publish; a dev tag only
+    appears after its binary builds finish, so a fresh dev version can 404
+    here for some minutes — see COMPONENT_MANIFEST_AT_TAG_URL. Returns None
+    on any failure; the caller treats that as "nothing to hold on"
+    (fail-open).
+    """
+    url = COMPONENT_MANIFEST_AT_TAG_URL.format(version=server_version)
+    try:
+        session = async_get_clientsession(hass)
+        async with asyncio.timeout(_MANIFEST_FETCH_TIMEOUT_SECONDS):
+            async with session.get(url) as resp:
+                resp.raise_for_status()
+                # content_type=None: raw.githubusercontent.com serves
+                # text/plain, which aiohttp's default json() rejects.
+                payload = await resp.json(content_type=None)
+        return str(payload["version"])
+    except (ClientError, TimeoutError, KeyError, TypeError, ValueError) as err:
+        _LOGGER.debug(
+            "HA-MCP shipped-component manifest fetch failed for %s: %s", url, err
+        )
+        return None
 
 
 async def _async_finish_update_cycle(hass: HomeAssistant) -> None:

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.0.1"
+    "version": "1.0.2"
 }

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -74,6 +74,10 @@
             "title": "Update the HA-MCP Custom Component via HACS",
             "description": "The installed ha-mcp server requires HA-MCP Custom Component {required} or newer, but you have {installed}. Update the component via HACS and restart Home Assistant. The server keeps running in the meantime, but some newer features may not work until the component is updated."
         },
+        "server_update_held": {
+            "title": "HA-MCP server update waiting for a component update",
+            "description": "ha-mcp server {latest} is available, but that release also updated the HA-MCP Custom Component (to {shipped}; you are running {running}). To avoid starting a server version the running component has never been tested with, the automatic server update is on hold until the component is updated.\n\nUpdate the component via HACS (open the HA-MCP Custom Component entry and use 'Update information' if no update is shown yet), then restart Home Assistant - the server update installs automatically afterwards. To install the server update anyway, press Install on the HA-MCP server update entity."
+        },
         "legacy_hacs_source": {
             "title": "Component installed from the legacy repository",
             "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (1.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -74,6 +74,10 @@
             "title": "Update the HA-MCP Custom Component via HACS",
             "description": "The installed ha-mcp server requires HA-MCP Custom Component {required} or newer, but you have {installed}. Update the component via HACS and restart Home Assistant. The server keeps running in the meantime, but some newer features may not work until the component is updated."
         },
+        "server_update_held": {
+            "title": "HA-MCP server update waiting for a component update",
+            "description": "ha-mcp server {latest} is available, but that release also updated the HA-MCP Custom Component (to {shipped}; you are running {running}). To avoid starting a server version the running component has never been tested with, the automatic server update is on hold until the component is updated.\n\nUpdate the component via HACS (open the HA-MCP Custom Component entry and use 'Update information' if no update is shown yet), then restart Home Assistant - the server update installs automatically afterwards. To install the server update anyway, press Install on the HA-MCP server update entity."
+        },
         "legacy_hacs_source": {
             "title": "Component installed from the legacy repository",
             "description": "HACS is tracking the main ha-mcp server repository for this component, so HACS shows the server's version numbers (7.x) and the server's release notes here instead of the component's own (1.x). Updates keep working, but stay mislabeled this way. To fix: remove this repository from HACS (your integration settings and config entries are kept), add homeassistant-ai/ha-mcp-integration as a custom repository, reinstall the component from it, and restart Home Assistant."

--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -143,7 +143,8 @@ class ToolsRegistry:
         When ``func_name`` is given, uses it directly (explicit mode); otherwise scans
         the module for an attribute matching the ``register_*_tools`` convention.
         Returns True if registered, False if no register function was found.
-        Re-raises on import or registration failure (fail-fast).
+        Re-raises on import or registration failure; ``register_all_tools``
+        contains that failure to the one module (see its docstring).
         """
         import importlib
 
@@ -169,8 +170,8 @@ class ToolsRegistry:
                 logger.warning(f"Module {module_name} has no register_*_tools function")
                 return False
 
-        except Exception as e:
-            logger.error(f"Failed to register tools from {module_name}: {e}")
+        except Exception:
+            logger.exception(f"Failed to register tools from {module_name}")
             raise
 
     def register_all_tools(self) -> None:
@@ -178,6 +179,14 @@ class ToolsRegistry:
 
         Tool modules are imported and registered only when this method is called,
         which happens after the MCP server is ready to accept connections.
+
+        A module that fails to import or register is SKIPPED (logged loudly),
+        not fatal: the in-process server auto-updates the ha-mcp package inside
+        a running Home Assistant, and a mixed old/new module generation — or a
+        module needing a newer custom component — previously took the whole
+        server down over one module (issues #1783/#1785). Only a TOTAL failure
+        (zero modules registered) still raises: a tool-less server "running"
+        would hide a genuinely broken install.
         """
         if self._modules_registered:
             logger.debug("Tools already registered, skipping")
@@ -189,23 +198,52 @@ class ToolsRegistry:
             "device_tools": self.device_tools,
         }
 
+        # tools_*.py modules by convention, then the explicit modules (those
+        # not following the convention) — each only if discovery included it
+        # (respects filtering).
+        worklist: list[tuple[str, str | None]] = [
+            (name, None)
+            for name in self._discovered_modules
+            if name not in EXPLICIT_MODULES
+        ]
+        worklist += [
+            (name, func_name)
+            for name, func_name in EXPLICIT_MODULES.items()
+            if name in self._discovered_modules
+        ]
+
         registered_count = 0
+        failed: list[tuple[str, Exception]] = []
+        for module_name, func_name in worklist:
+            try:
+                if self._import_and_register_module(module_name, kwargs, func_name):
+                    registered_count += 1
+            except Exception as e:
+                failed.append((module_name, e))
 
-        # Import and register tools_*.py modules
-        for module_name in self._discovered_modules:
-            # Skip explicit modules - handled separately
-            if module_name in EXPLICIT_MODULES:
-                continue
-            if self._import_and_register_module(module_name, kwargs):
-                registered_count += 1
-
-        # Register explicit modules (those not following tools_*.py convention)
-        # Only register if they were included in discovered modules (respects filtering)
-        for module_name, func_name in EXPLICIT_MODULES.items():
-            if module_name not in self._discovered_modules:
-                continue
-            if self._import_and_register_module(module_name, kwargs, func_name):
-                registered_count += 1
+        self._raise_or_log_registration_failures(failed, registered_count)
 
         self._modules_registered = True
         logger.info(f"Auto-discovery registered tools from {registered_count} modules")
+
+    @staticmethod
+    def _raise_or_log_registration_failures(
+        failed: list[tuple[str, Exception]], registered_count: int
+    ) -> None:
+        """Raise on a total registration failure, log a summary on a partial one."""
+        if not failed:
+            return
+        if registered_count == 0:
+            raise RuntimeError(
+                "No tool module could be registered "
+                f"({', '.join(name for name, _ in failed)} all failed); "
+                "the installed ha-mcp package is broken."
+            ) from failed[0][1]
+        logger.error(
+            "Skipped %d tool module(s) that failed to register: %s. The "
+            "server is running without their tools. If this happened right "
+            "after a package update, restart Home Assistant so every "
+            "module loads from the same package version.",
+            len(failed),
+            ", ".join(name for name, _ in failed),
+        )

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -67,11 +67,15 @@ def is_dev_mode_enabled() -> bool:
 
     Reads through :func:`config.get_global_settings` so the same
     env-var / override-file / default precedence path applies as
-    every other runtime-editable Settings field.
+    every other runtime-editable Settings field. ``getattr`` with a
+    False default, not attribute access: during an in-process package
+    update the cached settings singleton can predate this field
+    (issues #1783/#1785), and that stale read must mean "dev mode
+    off", never AttributeError.
     """
     from ..config import get_global_settings
 
-    return bool(get_global_settings().enable_dev_mode)
+    return bool(getattr(get_global_settings(), "enable_dev_mode", False))
 
 
 def _spawn_background(coro: Any) -> None:

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -45,6 +45,7 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
     ISSUE_COMPONENT_OUTDATED,
     ISSUE_PACKAGE_FAILED,
     ISSUE_START_FAILED,
+    ISSUE_UPDATE_HELD,
     OPT_AUTO_UPDATE,
     OPT_PIP_SPEC,
     OPT_WEBHOOK_AUTH,
@@ -130,16 +131,23 @@ class TestBringUp:
         esetup.ir.async_create_issue.assert_not_called()
 
     async def test_success_clears_stale_repair_issues(self, fake_manager):
-        # Review gap: a successful bring-up must clear BOTH repair-issue ids
+        # Review gap: a successful bring-up must clear EVERY repair-issue id
         # left by a previous failed attempt, or a fixed install keeps showing
-        # a stale repair forever.
+        # a stale repair forever. The update-held issue clears here too: a
+        # reload that reached bring-up either bypassed the hold deliberately
+        # (Install button) or made it moot, and the post-setup coordinator
+        # refresh re-files it if it still applies.
         hass = _make_hass()
         entry = _make_entry()
 
         await esetup.async_bring_up_server(hass, entry)
 
         cleared = {c.args[2] for c in esetup.ir.async_delete_issue.call_args_list}
-        assert cleared == {esetup.ISSUE_PACKAGE_FAILED, esetup.ISSUE_START_FAILED}
+        assert cleared == {
+            esetup.ISSUE_PACKAGE_FAILED,
+            esetup.ISSUE_START_FAILED,
+            esetup.ISSUE_UPDATE_HELD,
+        }
 
     async def test_local_only_skips_webhook_registration(self, fake_manager, caplog):
         # Owner request: enable_webhook=False must never register the webhook
@@ -556,6 +564,18 @@ class TestMaybeAutoUpdate:
         installed="7.9.0", latest="7.10.0", dist=DIST_NAME_STABLE
     )
 
+    @pytest.fixture(autouse=True)
+    def _no_component_gate(self, monkeypatch):
+        """Neutralize the component-compatibility gate (fetch "fails" → the
+        gate fails open) so these tests keep exercising only the original
+        auto-update decision. The gate itself is covered by
+        :class:`TestAutoUpdateComponentGate`."""
+        monkeypatch.setattr(
+            esetup,
+            "_async_fetch_shipped_component_version",
+            AsyncMock(return_value=None),
+        )
+
     async def test_newer_version_reloads_and_sets_pending_marker(self, monkeypatch):
         # The notification no longer fires here - it's deferred to
         # _async_finish_update_cycle, which only runs after the reloaded
@@ -688,6 +708,275 @@ class TestMaybeAutoUpdate:
         await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
 
         hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Component-compatibility gate on the automatic server update (#1783/#1785)
+# ---------------------------------------------------------------------------
+
+
+class TestAutoUpdateComponentGate:
+    """The pre-install gate: a server release that also shipped a newer custom
+    component must not auto-install under the older running component (that is
+    the #1783/#1785 breakage). Held is loud (repair issue + warning log) and
+    escapable (HACS component update unblocks it automatically; the update
+    entity's Install button bypasses this path entirely). Every failure inside
+    the gate fails OPEN — the pre-gate behavior — so a GitHub hiccup can never
+    wedge auto-updates.
+    """
+
+    _NEWER = ServerVersionInfo(
+        installed="7.12.0", latest="7.12.1", dist=DIST_NAME_STABLE
+    )
+
+    def _stub_gate(self, monkeypatch, *, shipped, running="1.0.2"):
+        monkeypatch.setattr(
+            esetup,
+            "_async_fetch_shipped_component_version",
+            AsyncMock(return_value=shipped),
+        )
+        monkeypatch.setattr(
+            esetup,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version=running)),
+        )
+
+    async def test_newer_shipped_component_holds_update(self, monkeypatch, caplog):
+        import logging
+
+        hass = _make_async_hass()
+        entry = _make_entry()
+        self._stub_gate(monkeypatch, shipped="1.0.9", running="1.0.2")
+
+        with caplog.at_level(logging.WARNING):
+            await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+        assert DATA_PENDING_UPDATE_NOTIFY not in hass.data.get(DOMAIN, {})
+        esetup.ir.async_create_issue.assert_called_once()
+        args = esetup.ir.async_create_issue.call_args.args
+        kwargs = esetup.ir.async_create_issue.call_args.kwargs
+        assert ISSUE_UPDATE_HELD in args
+        assert kwargs["translation_placeholders"] == {
+            "latest": "7.12.1",
+            "shipped": "1.0.9",
+            "running": "1.0.2",
+        }
+        assert kwargs["severity"] == esetup.ir.IssueSeverity.WARNING
+        assert "HACS" in caplog.text
+
+    async def test_same_shipped_component_proceeds_and_clears_issue(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry()
+        self._stub_gate(monkeypatch, shipped="1.0.2", running="1.0.2")
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+        assert (hass, DOMAIN, ISSUE_UPDATE_HELD) in [
+            c.args for c in esetup.ir.async_delete_issue.call_args_list
+        ]
+
+    async def test_manifest_fetch_failure_fails_open(self, monkeypatch):
+        # GitHub unreachable / tag layout changed → behave exactly as before
+        # the gate existed: install the update. Held-forever is the failure
+        # mode this trades away deliberately.
+        hass = _make_async_hass()
+        entry = _make_entry()
+        self._stub_gate(monkeypatch, shipped=None)
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+        esetup.ir.async_create_issue.assert_not_called()
+
+    async def test_component_version_read_failure_fails_open(self, monkeypatch):
+        hass = _make_async_hass()
+        entry = _make_entry()
+        monkeypatch.setattr(
+            esetup,
+            "_async_fetch_shipped_component_version",
+            AsyncMock(return_value="1.0.9"),
+        )
+        monkeypatch.setattr(
+            esetup,
+            "async_get_integration",
+            AsyncMock(side_effect=RuntimeError("loader boom")),
+        )
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+        esetup.ir.async_create_issue.assert_not_called()
+
+    async def test_incomparable_component_versions_fail_open(self, monkeypatch):
+        from awesomeversion import AwesomeVersion as RealAwesomeVersion
+
+        hass = _make_async_hass()
+        entry = _make_entry()
+        self._stub_gate(monkeypatch, shipped="weird", running="strange")
+
+        def picky(value):
+            if value in ("weird", "strange"):
+                raise esetup.AwesomeVersionException("bad version")
+            return RealAwesomeVersion(value)
+
+        monkeypatch.setattr(esetup, "AwesomeVersion", picky)
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+        esetup.ir.async_create_issue.assert_not_called()
+
+    async def test_up_to_date_clears_held_issue(self, monkeypatch):
+        # The hold self-resolves: once the component update lands (installed
+        # catches up via the then-unblocked reload) the stale issue must not
+        # linger.
+        hass = _make_async_hass()
+        entry = _make_entry()
+        self._stub_gate(monkeypatch, shipped="1.0.2", running="1.0.2")
+        info = ServerVersionInfo(
+            installed="7.12.1", latest="7.12.1", dist=DIST_NAME_STABLE
+        )
+
+        await esetup.async_maybe_auto_update(hass, entry, info)
+
+        hass.config_entries.async_reload.assert_not_awaited()
+        assert (hass, DOMAIN, ISSUE_UPDATE_HELD) in [
+            c.args for c in esetup.ir.async_delete_issue.call_args_list
+        ]
+
+    async def test_gate_not_consulted_for_pip_spec_override(self, monkeypatch):
+        # PR-tarball / pinned-version testing must stay unaffected: the
+        # override path returns before the gate ever runs.
+        hass = _make_async_hass()
+        entry = _make_entry(options={OPT_PIP_SPEC: "ha-mcp==7.8.0"})
+        fetch = AsyncMock(return_value="1.0.9")
+        monkeypatch.setattr(esetup, "_async_fetch_shipped_component_version", fetch)
+
+        await esetup.async_maybe_auto_update(hass, entry, self._NEWER)
+
+        fetch.assert_not_awaited()
+        hass.config_entries.async_reload.assert_not_awaited()
+
+
+class TestFetchShippedComponentVersion:
+    """The raw-manifest fetch behind the gate: resolves the component version
+    that shipped at the candidate server release's git tag."""
+
+    class _FakeResp:
+        """Mimics aiohttp's content-type guard for a raw.githubusercontent.com
+        response: the body is served as text/plain, so ``json()`` raises
+        ContentTypeError unless the caller passes ``content_type=None`` —
+        pinning the exact call production must make (review finding: without
+        this, dropping ``content_type=None`` in production would silently turn
+        every fetch into a fail-open and disarm the gate with all tests green).
+        """
+
+        def __init__(self, payload, *, raise_err=None):
+            self._payload = payload
+            self._raise_err = raise_err
+
+        def raise_for_status(self):
+            if self._raise_err is not None:
+                raise self._raise_err
+
+        async def json(self, content_type="application/json"):
+            if content_type is not None:
+                from aiohttp import ContentTypeError
+
+                raise ContentTypeError(
+                    None,
+                    (),
+                    message="Attempt to decode JSON with unexpected mimetype: "
+                    "text/plain; charset=utf-8",
+                )
+            if isinstance(self._payload, Exception):
+                raise self._payload
+            return self._payload
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, resp):
+            self._resp = resp
+            self.requested_urls = []
+
+        def get(self, url):
+            self.requested_urls.append(url)
+            return self._resp
+
+    def _install_session(self, monkeypatch, resp):
+        session = self._FakeSession(resp)
+        monkeypatch.setattr(
+            esetup, "async_get_clientsession", MagicMock(return_value=session)
+        )
+        return session
+
+    async def test_returns_version_from_release_tag_manifest(self, monkeypatch):
+        hass = _make_hass()
+        session = self._install_session(
+            monkeypatch, self._FakeResp({"version": "1.0.2"})
+        )
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result == "1.0.2"
+        assert len(session.requested_urls) == 1
+        assert "/v7.12.1/" in session.requested_urls[0]
+        assert session.requested_urls[0].endswith("manifest.json")
+
+    async def test_http_error_returns_none(self, monkeypatch):
+        from aiohttp import ClientError
+
+        hass = _make_hass()
+        self._install_session(
+            monkeypatch, self._FakeResp({}, raise_err=ClientError("404"))
+        )
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result is None
+
+    async def test_missing_version_key_returns_none(self, monkeypatch):
+        hass = _make_hass()
+        self._install_session(monkeypatch, self._FakeResp({"domain": "ha_mcp_tools"}))
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result is None
+
+    async def test_invalid_json_returns_none(self, monkeypatch):
+        hass = _make_hass()
+        self._install_session(monkeypatch, self._FakeResp(ValueError("not json")))
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result is None
+
+    async def test_timeout_returns_none(self, monkeypatch):
+        # GitHub latency is the most common failure in the field; the
+        # TimeoutError limb of the except tuple must fail open like the rest.
+        hass = _make_hass()
+        self._install_session(monkeypatch, self._FakeResp({}, raise_err=TimeoutError()))
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result is None
+
+    async def test_non_mapping_payload_returns_none(self, monkeypatch):
+        # A JSON body that parses but is not an object ("null", a list) makes
+        # payload["version"] raise TypeError — the tuple's TypeError limb.
+        hass = _make_hass()
+        self._install_session(monkeypatch, self._FakeResp(None))
+
+        result = await esetup._async_fetch_shipped_component_version(hass, "7.12.1")
+
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_tools_registry.py
+++ b/tests/src/unit/test_tools_registry.py
@@ -1,0 +1,199 @@
+"""Unit tests for ToolsRegistry registration resilience (issues #1783/#1785).
+
+A single tool module whose import or register function fails must not take the
+whole server down: the in-process server auto-updates the ha-mcp package inside
+a running Home Assistant, and a mixed old/new module set (or a module that
+genuinely needs a newer custom component) previously crashed the entire server
+via the registry's fail-fast re-raise. The registry now skips the failing
+module, logs it loudly, and keeps every other module's tools available — but a
+TOTAL failure (zero modules registered) still raises, because a tool-less
+server silently "running" would be worse than a visible start failure.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ha_mcp.tools.registry import ToolsRegistry
+
+
+def _make_registry(module_names: list[str]) -> ToolsRegistry:
+    server = SimpleNamespace(
+        client=MagicMock(name="client"),
+        mcp=MagicMock(name="mcp"),
+        smart_tools=MagicMock(name="smart_tools"),
+        device_tools=MagicMock(name="device_tools"),
+    )
+    registry = ToolsRegistry(server)
+    registry._discovered_modules = list(module_names)
+    return registry
+
+
+def _fake_module(name: str, registered: list[str], *, fail: bool = False) -> Any:
+    """A stand-in tools module exposing one register_*_tools function."""
+
+    def register(mcp: Any, client: Any, **kwargs: Any) -> None:
+        if fail:
+            # The live failure shape from issues #1783/#1785: new module code
+            # reading a field an older cached Settings instance does not have.
+            raise AttributeError("'Settings' object has no attribute 'enable_dev_mode'")
+        registered.append(name)
+
+    module = SimpleNamespace()
+    setattr(module, f"register_{name}_tools", register)
+    return module
+
+
+@pytest.fixture
+def fake_import(monkeypatch):
+    """Route the registry's relative tool-module imports to fake modules.
+
+    Returns the dict to populate: ``fake_import["tools_x"] = module``. Names
+    not in the dict fall through to the real importer.
+    """
+    modules: dict[str, Any] = {}
+    real_import_module = importlib.import_module
+
+    def fake(name: str, package: str | None = None) -> Any:
+        key = name.lstrip(".")
+        if key in modules:
+            return modules[key]
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake)
+    return modules
+
+
+class TestRegisterAllToolsResilience:
+    def test_failing_module_is_skipped_and_others_register(self, fake_import, caplog):
+        registered: list[str] = []
+        fake_import["tools_ok_one"] = _fake_module("tools_ok_one", registered)
+        fake_import["tools_boom"] = _fake_module("tools_boom", registered, fail=True)
+        fake_import["tools_ok_two"] = _fake_module("tools_ok_two", registered)
+        registry = _make_registry(["tools_ok_one", "tools_boom", "tools_ok_two"])
+
+        with caplog.at_level(logging.ERROR):
+            registry.register_all_tools()  # must not raise
+
+        assert registered == ["tools_ok_one", "tools_ok_two"]
+
+    def test_skip_summary_names_modules_count_and_restart_hint(
+        self, fake_import, caplog
+    ):
+        # The summary is the only user-facing signal that tools are missing:
+        # it must carry the correct count, name EVERY skipped module, and
+        # point at the recovery action (restart HA to load a consistent
+        # package generation).
+        registered: list[str] = []
+        fake_import["tools_ok"] = _fake_module("tools_ok", registered)
+        fake_import["tools_boom_one"] = _fake_module(
+            "tools_boom_one", registered, fail=True
+        )
+        fake_import["tools_boom_two"] = _fake_module(
+            "tools_boom_two", registered, fail=True
+        )
+        registry = _make_registry(["tools_ok", "tools_boom_one", "tools_boom_two"])
+
+        with caplog.at_level(logging.ERROR):
+            registry.register_all_tools()
+
+        assert "Skipped 2 tool module(s)" in caplog.text
+        assert "tools_boom_one, tools_boom_two" in caplog.text
+        assert "restart Home Assistant" in caplog.text
+
+    def test_explicit_module_registers_via_its_declared_func_name(self, fake_import):
+        # EXPLICIT_MODULES entries ("backup") must register exactly once,
+        # through their DECLARED function — not the register_*_tools scan. The
+        # decoy sorts before the declared name, so if func_name threading were
+        # dropped the convention scan would pick the decoy and this fails.
+        registered: list[str] = []
+        backup = SimpleNamespace()
+
+        def register_backup_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+            registered.append("backup")
+
+        def register_aaa_decoy_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+            registered.append("DECOY")
+
+        backup.register_backup_tools = register_backup_tools
+        backup.register_aaa_decoy_tools = register_aaa_decoy_tools
+        fake_import["backup"] = backup
+        fake_import["tools_ok"] = _fake_module("tools_ok", registered)
+        registry = _make_registry(["tools_ok", "backup"])
+
+        registry.register_all_tools()
+
+        assert registered == ["tools_ok", "backup"]
+
+    def test_explicit_module_failure_is_skipped(self, fake_import, caplog):
+        # An EXPLICIT_MODULES entry failing goes through the same containment
+        # as convention modules: skipped, named in the summary, others intact.
+        registered: list[str] = []
+        backup = SimpleNamespace()
+
+        def register_backup_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+            raise RuntimeError("backup registration broke")
+
+        backup.register_backup_tools = register_backup_tools
+        fake_import["backup"] = backup
+        fake_import["tools_ok"] = _fake_module("tools_ok", registered)
+        registry = _make_registry(["tools_ok", "backup"])
+
+        with caplog.at_level(logging.ERROR):
+            registry.register_all_tools()  # must not raise
+
+        assert registered == ["tools_ok"]
+        assert "backup" in caplog.text
+
+    def test_import_failure_is_also_skipped(self, fake_import, monkeypatch, caplog):
+        # A module that cannot even be imported (e.g. it references code that
+        # only exists in a newer package generation) is skipped the same way
+        # as a failing register function.
+        registered: list[str] = []
+        fake_import["tools_ok"] = _fake_module("tools_ok", registered)
+        registry = _make_registry(["tools_ok", "tools_missing"])
+
+        def raising_import(name: str, package: str | None = None) -> Any:
+            key = name.lstrip(".")
+            if key == "tools_missing":
+                raise ImportError("No module named 'tools_missing'")
+            return fake_import[key]
+
+        # Re-route on top of the fixture: tools_missing raises at import time.
+        monkeypatch.setattr(importlib, "import_module", raising_import)
+
+        with caplog.at_level(logging.ERROR):
+            registry.register_all_tools()
+
+        assert registered == ["tools_ok"]
+        assert "tools_missing" in caplog.text
+
+    def test_all_modules_failing_raises(self, fake_import):
+        # Zero registered tools = the install is broken outright; the start
+        # must fail visibly (repair issue path), not "succeed" tool-less.
+        registered: list[str] = []
+        fake_import["tools_boom"] = _fake_module("tools_boom", registered, fail=True)
+        registry = _make_registry(["tools_boom"])
+
+        with pytest.raises(RuntimeError, match="tools_boom"):
+            registry.register_all_tools()
+
+
+class TestDevModeSettingsFallback:
+    def test_is_dev_mode_enabled_defaults_off_without_field(self, monkeypatch):
+        # During an in-process package update an older Settings instance
+        # (built before the field existed) can still be the cached singleton;
+        # the read must degrade to "dev mode off", never AttributeError
+        # (the exact crash in issues #1783/#1785).
+        import ha_mcp.config as config
+        from ha_mcp.tools.tools_dev import is_dev_mode_enabled
+
+        monkeypatch.setattr(config, "get_global_settings", SimpleNamespace)
+
+        assert is_dev_mode_enabled() is False


### PR DESCRIPTION
## What does this PR do?

Hotfix for the #1783/#1785 outage: the in-process server auto-updated to ha-mcp 7.12.0 before HACS surfaced the matching component release, and the old component (1.0.0, predates the sys.modules purge) mixed cached 7.11.x modules with the new on-disk `tools_dev` module — one `AttributeError` took the whole server down.

- **Server**: the tools registry now skips a tool module that fails to import or register (loud error log + restart-HA hint) instead of crashing the server; a total failure (zero modules registered) still raises. `is_dev_mode_enabled()` reads via `getattr` so a stale Settings singleton degrades to "dev mode off". This half ships to every existing install through the same PyPI auto-update channel that caused the outage, so old components are protected against future server releases too.
- **Component (1.0.2)**: before auto-installing a newer server build, fetch the component manifest at the candidate release's git tag; if that release also bumped the component version, hold the automatic server update until HACS delivers the component. The hold files a repair issue and logs a warning on every check, fails open on any fetch failure (an unreachable GitHub can never block updates), and does not touch manual installs (update entity Install button) or pip-spec overrides — PR-tarball testing keeps hot-swapping without an HA restart.

For currently-broken installs: a plain Home Assistant restart heals the crash — a fresh process imports a consistent module set, and component 1.0.0 + server 7.12.0 are compatible when cleanly imported.

Closes #1783
Closes #1785

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7FvJAi5hk5vy7FvtdcZZe