### PR TITLE
ci: gate the mirror version tag on the release job, not the whole run

### DIFF
--- a/.github/workflows/_update-addon-config.yml
+++ b/.github/workflows/_update-addon-config.yml
@@ -2,6 +2,12 @@ name: Update Add-on Config Version
 
 # Reusable workflow to update addon config.yaml after Docker images are published.
 # Called from semver-release.yml, hotfix-release.yml, and addon-publish-dev.yml.
+# Also manually dispatchable: when a release run's addon leg fails AFTER the
+# images were published out-of-band (addon-publish.yml's own dispatch), this is
+# the recovery path for the config.yaml version bump — the calling release run
+# cannot be re-run with fixed workflow code (reruns pin the original commit's
+# workflows). ONLY dispatch with a version whose ghcr images actually exist:
+# config.yaml's version selects the image tag HAOS installs.
 on:
   workflow_call:
     inputs:
@@ -26,6 +32,22 @@ on:
         required: false
       RELEASE_TOKEN:
         required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to set in config.yaml (without v prefix). The ghcr addon images for this version MUST already exist.'
+        required: true
+        type: string
+      config_path:
+        description: 'Path to config.yaml to update'
+        required: false
+        type: string
+        default: 'homeassistant-addon/config.yaml'
+      commit_message_prefix:
+        description: 'Prefix for commit message'
+        required: false
+        type: string
+        default: 'publish version'
 
 jobs:
   update-addon-config:

--- a/.github/workflows/addon-publish.yml
+++ b/.github/workflows/addon-publish.yml
@@ -88,10 +88,12 @@ jobs:
         cache-from: type=gha,scope=${{ matrix.arch }}
         # ignore-error: cache export is best-effort. Without it, an Actions
         # cache-service failure fails the whole image publish — observed live
-        # on v7.12.2: "error writing layer blob: failed to reserve cache"
-        # (abandoned upload reservations from a failed attempt block
-        # re-reserving the same blob keys, so retries self-perpetuate the
-        # failure). A lost cache write only costs the next build a warm start.
+        # on v7.12.2: five attempts all died on "error writing layer blob:
+        # failed to reserve cache" (the repeats appear to be abandoned upload
+        # reservations from the failed attempts blocking re-reservation of the
+        # same blob keys; the cache-service internals are not documented).
+        # Whatever the mechanism, a cache write must never fail the publish —
+        # a lost export only costs the next build a warm start.
         cache-to: type=gha,mode=max,scope=${{ matrix.arch }},ignore-error=true
         build-args: |
           BUILD_VERSION=${{ steps.version.outputs.version }}

--- a/.github/workflows/addon-publish.yml
+++ b/.github/workflows/addon-publish.yml
@@ -86,7 +86,13 @@ jobs:
           io.hass.type=addon
           io.hass.arch=${{ matrix.arch }}
         cache-from: type=gha,scope=${{ matrix.arch }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+        # ignore-error: cache export is best-effort. Without it, an Actions
+        # cache-service failure fails the whole image publish — observed live
+        # on v7.12.2: "error writing layer blob: failed to reserve cache"
+        # (abandoned upload reservations from a failed attempt block
+        # re-reserving the same blob keys, so retries self-perpetuate the
+        # failure). A lost cache write only costs the next build a warm start.
+        cache-to: type=gha,mode=max,scope=${{ matrix.arch }},ignore-error=true
         build-args: |
           BUILD_VERSION=${{ steps.version.outputs.version }}
           BUILD_ARCH=${{ matrix.arch }}

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -26,6 +26,9 @@ env:
 
 jobs:
   semantic-release:
+    # This display name is load-bearing: sync-integration-mirror.yml's gate
+    # matches the triggering run's jobs by this exact name to decide whether a
+    # release happened. Rename it together with that gate's matcher.
     name: Semantic Release
     # Only run for merged hotfix PRs
     if: |

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -122,6 +122,9 @@ jobs:
   semantic-release:
     needs: [check-changes, validate-docker]
     if: needs.check-changes.outputs.has_changes == 'true'
+    # This display name is load-bearing: sync-integration-mirror.yml's gate
+    # matches the triggering run's jobs by this exact name to decide whether a
+    # release happened. Rename it together with that gate's matcher.
     name: Semantic Release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -56,13 +56,13 @@ jobs:
   # this sync never fired, and HACS was left without the component 1.0.3 tag
   # even though semantic-release had pushed the version and tag perfectly.
   # The mirror tag depends only on the "Semantic Release" job (the name both
-  # semver-release.yml and hotfix-release.yml use), so gate on that job's
-  # conclusion instead. workflow_run fires for EVERY completed run of the
-  # listed workflows — including the all-skipped Hotfix Release that every
-  # non-hotfix PR merge produces (the release job is `if`-guarded); those
-  # conclude "success" via GitHub's skipped-jobs quirk and used to run this
-  # sync pointlessly, but the job-level check now skips them too. Push and
-  # manual dispatch (where workflow_run is absent) always proceed.
+  # semver-release.yml and hotfix-release.yml use — commented as load-bearing
+  # there), so gate on that job's conclusion instead. workflow_run fires for
+  # EVERY completed run of the listed workflows; the all-skipped Hotfix
+  # Release runs that every non-hotfix PR merge produces conclude "skipped",
+  # which never satisfied the old success gate either — the job-level check
+  # keeps excluding them (a skipped Semantic Release job is not a release).
+  # Push and manual dispatch (where workflow_run is absent) always proceed.
   gate:
     runs-on: ubuntu-latest
     permissions:
@@ -80,16 +80,33 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          conclusion=$(gh api \
+          # Fail OPEN on an API error and on a missing job: the snapshot and
+          # tag steps are idempotent, so a spurious proceed is harmless, while
+          # a suppressed one strands HACS on the old component tag (the bug
+          # this gate exists to fix). An absent "Semantic Release" job means
+          # the job-name coupling with the release workflows broke (e.g. a
+          # rename) — degrade to tagging rather than silently never tagging.
+          if ! conclusion=$(gh api \
             "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" \
-            --jq '[.jobs[] | select(.name == "Semantic Release") | .conclusion] | first')
-          echo "Semantic Release job conclusion: ${conclusion:-<job absent>}"
-          if [ "$conclusion" = "success" ]; then
+            --jq '[.jobs[] | select(.name == "Semantic Release") | .conclusion] | first // empty'); then
+            echo "::warning::Could not query the triggering run's jobs; failing open."
             echo "proceed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No successful release in the triggering run - skipping the mirror sync."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "Semantic Release job conclusion: ${conclusion:-<job absent>}"
+          case "$conclusion" in
+            success)
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            "")
+              echo "::warning::No 'Semantic Release' job in the triggering run - the job-name coupling with the release workflows may be broken; failing open."
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "No successful release in the triggering run - skipping the mirror sync."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
   sync:
     needs: gate
@@ -167,10 +184,14 @@ jobs:
         # notes script emits. Idempotent: an existing tag no-ops, so a
         # release that did not change the component version simply
         # re-confirms the current tag.
-        if: >-
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'workflow_run' &&
-           github.event.workflow_run.conclusion == 'success')
+        #
+        # No run-conclusion check here: the gate job already decided whether a
+        # release happened (checking workflow_run.conclusion again would
+        # re-introduce the suppressed-tag bug the gate fixes — an unrelated
+        # failed leg fails the RUN even when Semantic Release succeeded). The
+        # only event that reaches this job and must not tag is the push-leg
+        # code snapshot.
+        if: github.event_name != 'push'
         env:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -49,15 +49,51 @@ concurrency:
   queue: max
 
 jobs:
+  # Decide from the TRIGGERING RUN'S JOBS whether a release actually happened.
+  # Gating on the run's overall conclusion (the old `if`) skipped the mirror
+  # tag whenever any UNRELATED leg failed — observed live on v7.12.2: the
+  # addon amd64 image build's cache flake failed the whole Hotfix Release run,
+  # this sync never fired, and HACS was left without the component 1.0.3 tag
+  # even though semantic-release had pushed the version and tag perfectly.
+  # The mirror tag depends only on the "Semantic Release" job (the name both
+  # semver-release.yml and hotfix-release.yml use), so gate on that job's
+  # conclusion instead. workflow_run fires for EVERY completed run of the
+  # listed workflows — including the all-skipped Hotfix Release that every
+  # non-hotfix PR merge produces (the release job is `if`-guarded); those
+  # conclude "success" via GitHub's skipped-jobs quirk and used to run this
+  # sync pointlessly, but the job-level check now skips them too. Push and
+  # manual dispatch (where workflow_run is absent) always proceed.
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+    steps:
+      - name: Gate on the Semantic Release job, not the whole run
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" != "workflow_run" ]; then
+            echo "Push/dispatch trigger - proceeding."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          conclusion=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name == "Semantic Release") | .conclusion] | first')
+          echo "Semantic Release job conclusion: ${conclusion:-<job absent>}"
+          if [ "$conclusion" = "success" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No successful release in the triggering run - skipping the mirror sync."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   sync:
-    # workflow_run fires for EVERY completed run of the listed workflows —
-    # including the SKIPPED Hotfix Release that every non-hotfix PR merge
-    # produces (the release job is `if`-guarded) and odd-week / no-change
-    # SemVer runs. Only proceed for a SUCCESSFUL release run; push and manual
-    # dispatch (where workflow_run is absent) always run.
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What does this PR do?

Fixes the HACS component tag going missing when a release run fails on an unrelated leg: `sync-integration-mirror.yml`'s `workflow_run` gate required the whole Hotfix/SemVer Release run to conclude success, so the v7.12.2 addon image cache flake suppressed the mirror's component 1.0.3 tag even though semantic-release had pushed the version and tag cleanly. A new `gate` job queries the triggering run's jobs and proceeds when the **Semantic Release job** succeeded (the name both release workflows use); push and manual-dispatch triggers proceed unconditionally as before, and all-skipped release runs (every non-hotfix PR merge) now skip the pointless sync instead of running it.

Verifiable on the next hotfix merge: even if the addon leg fails again, the mirror should receive the new component tag automatically.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed