### PR TITLE
Fix nested helper flow options

### DIFF
--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -130,7 +130,7 @@ def _handle_menu_step(
 
 
 def iter_schema_fields(data_schema: Any) -> Iterator[dict[str, Any]]:
-    """Yield submitted fields from a flow schema, including nested sections."""
+    """Yield leaf field definitions from a flow schema, descending into sections."""
     if not isinstance(data_schema, list):
         return
     for field in data_schema:
@@ -143,10 +143,41 @@ def iter_schema_fields(data_schema: Any) -> Iterator[dict[str, Any]]:
         yield field
 
 
+def _section_path(path_prefix: str, name: Any) -> str:
+    """Return the dotted config path for a named or anonymous section."""
+    if not isinstance(name, str):
+        return path_prefix
+    return f"{path_prefix}.{name}" if path_prefix else name
+
+
+def _record_ignored_section_keys(
+    ignored_config_keys: set[str] | None,
+    remaining_config: dict[str, Any],
+    section_path: str,
+) -> None:
+    """Record undeclared keys remaining inside an explicit section dict."""
+    if ignored_config_keys is None:
+        return
+    ignored_config_keys.update(
+        f"{section_path}.{key}" if section_path else key
+        for key in remaining_config
+        if key not in _MENU_SELECTION_KEYS
+    )
+
+
 def _consume_form_schema(
-    data_schema: list[Any], remaining_config: dict[str, Any]
+    data_schema: list[Any],
+    remaining_config: dict[str, Any],
+    ignored_config_keys: set[str] | None = None,
+    path_prefix: str = "",
 ) -> dict[str, Any]:
-    """Consume matching config values and shape nested flow sections."""
+    """Consume matching config values and shape nested flow sections.
+
+    Mutates ``remaining_config`` by removing every consumed key. Flat child
+    values override the same value inside an explicitly supplied section dict.
+    Unknown keys inside explicit section dicts are added to
+    ``ignored_config_keys`` with their dotted section path.
+    """
     form_data: dict[str, Any] = {}
     missing = object()
 
@@ -157,6 +188,7 @@ def _consume_form_schema(
         name = field.get("name")
         nested_schema = field.get("schema")
         if isinstance(nested_schema, list):
+            section_path = _section_path(path_prefix, name)
             explicit_section = (
                 remaining_config.pop(name, missing)
                 if isinstance(name, str)
@@ -171,10 +203,28 @@ def _consume_form_schema(
 
             nested_data: dict[str, Any] = {}
             if isinstance(explicit_section, dict):
+                explicit_remaining = dict(explicit_section)
                 nested_data.update(
-                    _consume_form_schema(nested_schema, dict(explicit_section))
+                    _consume_form_schema(
+                        nested_schema,
+                        explicit_remaining,
+                        ignored_config_keys,
+                        section_path,
+                    )
                 )
-            nested_data.update(_consume_form_schema(nested_schema, remaining_config))
+                _record_ignored_section_keys(
+                    ignored_config_keys,
+                    explicit_remaining,
+                    section_path,
+                )
+            nested_data.update(
+                _consume_form_schema(
+                    nested_schema,
+                    remaining_config,
+                    ignored_config_keys,
+                    section_path,
+                )
+            )
 
             if nested_data:
                 if isinstance(name, str):
@@ -197,6 +247,7 @@ def _extract_schema_field_names(data_schema: Any) -> set[str] | None:
     """Extract the set of field names declared by a step's data_schema.
 
     HA returns data_schema as a list of {name, selector, required, ...} dicts.
+    Nested leaf names are included; section-container names are omitted.
     Returns ``None`` when the schema is absent or not a list (signalling
     the caller to fall back to legacy submit-all behaviour). Returns a
     (possibly empty) set when the schema is present and parseable.
@@ -215,13 +266,15 @@ def _handle_form_step(
     flow_id: str,
     current_step: dict[str, Any],
     remaining_config: dict[str, Any],
+    ignored_config_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Validate a form step and return form data to submit.
 
     When the step's ``data_schema`` is provided, pops ONLY the keys declared
     in that schema from ``remaining_config`` (mutating it) so any unconsumed
     keys remain available for subsequent steps. Menu selection keys are never
-    submitted.
+    submitted. Fields declared inside a section are grouped under the section
+    key; callers may provide them flat or inside an explicit section dict.
 
     When ``data_schema`` is absent (HA didn't tell us field names), falls
     back to legacy behaviour: submit all non-menu keys and clear them. This
@@ -256,7 +309,9 @@ def _handle_form_step(
                 continue
             form_data[key] = remaining_config.pop(key)
     else:
-        form_data = _consume_form_schema(data_schema, remaining_config)
+        form_data = _consume_form_schema(
+            data_schema, remaining_config, ignored_config_keys
+        )
 
     return form_data
 
@@ -572,7 +627,8 @@ async def _handle_flow_steps(
             for unstructured HA 4xx responses so the caller can react.
 
     Returns:
-        ``{"success": True, "entry": result}`` on success.
+        ``{"success": True, "entry": result}`` on success, plus ``warnings``
+        when caller-supplied config keys were not declared by any flow step.
         Raises ToolError on any failure.
     """
     if submit_fn is None:
@@ -580,13 +636,25 @@ async def _handle_flow_steps(
     remaining_config = dict(config)
     current_step = initial_step
     last_menu_choice: str | None = None
+    ignored_config_keys: set[str] = set()
     max_steps = 10
 
     for step_num in range(max_steps):
         result_type = current_step.get("type")
 
         if result_type == _FlowType.CREATE_ENTRY:
-            return {"success": True, "entry": current_step}
+            ignored_config_keys.update(
+                key
+                for key in remaining_config
+                if key not in _MENU_SELECTION_KEYS
+            )
+            response: dict[str, Any] = {"success": True, "entry": current_step}
+            if ignored_config_keys:
+                response["warnings"] = [
+                    "Ignored config keys not declared by the Home Assistant flow "
+                    f"schema: {', '.join(sorted(ignored_config_keys))}"
+                ]
+            return response
 
         if result_type == _FlowType.ABORT:
             raise_tool_error(
@@ -619,7 +687,12 @@ async def _handle_flow_steps(
             # step's data_schema, leaving any other keys in remaining_config
             # for subsequent steps (HA can present multi-step forms, e.g.
             # statistics: user step then pick-characteristic step).
-            form_data = _handle_form_step(flow_id, current_step, remaining_config)
+            form_data = _handle_form_step(
+                flow_id,
+                current_step,
+                remaining_config,
+                ignored_config_keys,
+            )
             logger.debug(
                 f"Flow step {step_num}: form submit "
                 f"(step_id={current_step.get('step_id')}, keys={list(form_data.keys())})"
@@ -935,7 +1008,7 @@ async def update_flow_helper(
         raise
 
     entry = result["entry"].get("result", {})
-    return {
+    response = {
         "success": True,
         "entry_id": entry_id,
         "title": entry.get("title"),
@@ -943,6 +1016,9 @@ async def update_flow_helper(
         "message": f"{helper_type} helper updated successfully",
         "updated": True,
     }
+    if result.get("warnings"):
+        response["warnings"] = result["warnings"]
+    return response
 
 
 async def create_flow_helper(
@@ -988,10 +1064,13 @@ async def create_flow_helper(
         raise
 
     entry = result["entry"].get("result", {})
-    return {
+    response = {
         "success": True,
         "entry_id": entry.get("entry_id"),
         "title": entry.get("title"),
         "domain": helper_type,
         "message": f"{helper_type} helper created successfully",
     }
+    if result.get("warnings"):
+        response["warnings"] = result["warnings"]
+    return response

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -12,6 +12,7 @@ for the 15 helper types listed in FLOW_HELPER_TYPES.
 
 import asyncio
 import logging
+from collections.abc import Iterator
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -128,6 +129,70 @@ def _handle_menu_step(
     return str(menu_choice)
 
 
+def iter_schema_fields(data_schema: Any) -> Iterator[dict[str, Any]]:
+    """Yield submitted fields from a flow schema, including nested sections."""
+    if not isinstance(data_schema, list):
+        return
+    for field in data_schema:
+        if not isinstance(field, dict):
+            continue
+        nested_schema = field.get("schema")
+        if isinstance(nested_schema, list):
+            yield from iter_schema_fields(nested_schema)
+            continue
+        yield field
+
+
+def _consume_form_schema(
+    data_schema: list[Any], remaining_config: dict[str, Any]
+) -> dict[str, Any]:
+    """Consume matching config values and shape nested flow sections."""
+    form_data: dict[str, Any] = {}
+    missing = object()
+
+    for field in data_schema:
+        if not isinstance(field, dict):
+            continue
+
+        name = field.get("name")
+        nested_schema = field.get("schema")
+        if isinstance(nested_schema, list):
+            explicit_section = (
+                remaining_config.pop(name, missing)
+                if isinstance(name, str)
+                else missing
+            )
+            if explicit_section is not missing and not isinstance(
+                explicit_section, dict
+            ):
+                if isinstance(name, str):
+                    form_data[name] = explicit_section
+                continue
+
+            nested_data: dict[str, Any] = {}
+            if isinstance(explicit_section, dict):
+                nested_data.update(
+                    _consume_form_schema(nested_schema, dict(explicit_section))
+                )
+            nested_data.update(_consume_form_schema(nested_schema, remaining_config))
+
+            if nested_data:
+                if isinstance(name, str):
+                    form_data[name] = nested_data
+                else:
+                    form_data.update(nested_data)
+            continue
+
+        if (
+            isinstance(name, str)
+            and name not in _MENU_SELECTION_KEYS
+            and name in remaining_config
+        ):
+            form_data[name] = remaining_config.pop(name)
+
+    return form_data
+
+
 def _extract_schema_field_names(data_schema: Any) -> set[str] | None:
     """Extract the set of field names declared by a step's data_schema.
 
@@ -139,11 +204,10 @@ def _extract_schema_field_names(data_schema: Any) -> set[str] | None:
     if not isinstance(data_schema, list):
         return None
     names: set[str] = set()
-    for field in data_schema:
-        if isinstance(field, dict):
-            name = field.get("name")
-            if isinstance(name, str):
-                names.add(name)
+    for field in iter_schema_fields(data_schema):
+        name = field.get("name")
+        if isinstance(name, str):
+            names.add(name)
     return names
 
 
@@ -180,10 +244,10 @@ def _handle_form_step(
             )
         )
 
-    schema_fields = _extract_schema_field_names(current_step.get("data_schema"))
+    data_schema = current_step.get("data_schema")
 
     form_data: dict[str, Any] = {}
-    if schema_fields is None:
+    if not isinstance(data_schema, list):
         # Legacy fallback: no schema info — dump every non-menu key and
         # consume them all so a follow-up step (rare without schema) won't
         # re-submit the same data.
@@ -192,11 +256,7 @@ def _handle_form_step(
                 continue
             form_data[key] = remaining_config.pop(key)
     else:
-        for key in list(remaining_config.keys()):
-            if key in _MENU_SELECTION_KEYS:
-                continue
-            if key in schema_fields:
-                form_data[key] = remaining_config.pop(key)
+        form_data = _consume_form_schema(data_schema, remaining_config)
 
     return form_data
 

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -644,9 +644,7 @@ async def _handle_flow_steps(
 
         if result_type == _FlowType.CREATE_ENTRY:
             ignored_config_keys.update(
-                key
-                for key in remaining_config
-                if key not in _MENU_SELECTION_KEYS
+                key for key in remaining_config if key not in _MENU_SELECTION_KEYS
             )
             response: dict[str, Any] = {"success": True, "entry": current_step}
             if ignored_config_keys:

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1968,6 +1968,7 @@ async def _handle_flow_helper(
     entry_id = flow_result.get("entry_id")
     title = flow_result.get("title")
     warnings = list(pre_warnings)
+    warnings.extend(flow_result.get("warnings", []))
     entities, wait_warnings = await _wait_for_flow_entities(
         client, entry_id, action, wait
     )

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -113,8 +113,8 @@ def options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
     ``default``). A field can carry both ``suggested_value`` and
     ``default`` at once — e.g. a group helper's ``hide_members`` stored as
     ``True`` over a schema default of ``False`` — and the stored value
-    must win (issue #1575). Fields with a missing or ``None`` value are
-    skipped.
+    must win (issue #1575). Nested section fields are flattened into the
+    returned top-level map. Fields with a missing or ``None`` value are skipped.
     """
     out: dict[str, Any] = {}
     # Defensive: HA should always return a list of dict fields, but guard

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -20,7 +20,7 @@ from ..client.rest_client import (
 )
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
-from .config_entry_flow import FLOW_HELPER_TYPES
+from .config_entry_flow import FLOW_HELPER_TYPES, iter_schema_fields
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -123,9 +123,7 @@ def options_from_form_flow(flow: dict[str, Any]) -> dict[str, Any]:
     data_schema = flow.get("data_schema")
     if not isinstance(data_schema, list):
         return out
-    for field in data_schema:
-        if not isinstance(field, dict):
-            continue
+    for field in iter_schema_fields(data_schema):
         name = field.get("name")
         if name is None:
             continue

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -109,6 +109,52 @@ class TestConfigEntryFlow:
             {"target": entry_id, "confirm": True},
         )
 
+    async def test_update_template_sensor_availability(self, mcp_client):
+        """Persist and read a template field nested under advanced options."""
+        config = {
+            "next_step_id": "sensor",
+            "name": "test_template_availability_e2e",
+            "state": "{{ 1 }}",
+        }
+        entry_id = await _create_config_entry_helper(
+            mcp_client, "template", config, "template sensor with availability"
+        )
+        availability = "{{ has_value('sensor.demo_temperature') }}"
+
+        try:
+            update_result = await mcp_client.call_tool(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "template",
+                    "helper_id": entry_id,
+                    "action": "update",
+                    "config": {
+                        "state": "{{ 1 }}",
+                        "availability": availability,
+                    },
+                },
+            )
+            assert_mcp_success(update_result, "Update template sensor availability")
+
+            integration_result = await mcp_client.call_tool(
+                "ha_get_integration",
+                {"entry_id": entry_id, "include_options": True},
+            )
+            integration_data = assert_mcp_success(
+                integration_result, "Read template sensor availability"
+            )
+            options = (integration_data.get("entry") or {}).get("options") or {}
+            assert options.get("availability") == availability, (
+                "Nested availability option was not persisted or read back; "
+                f"got {options!r}"
+            )
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
+
     async def test_create_template_binary_sensor(self, mcp_client):
         """Create a template binary sensor helper end-to-end."""
         config = {

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -131,10 +131,17 @@ class TestConfigEntryFlow:
                     "config": {
                         "state": "{{ 1 }}",
                         "availability": availability,
+                        "availabilty": "{{ false }}",
                     },
                 },
             )
-            assert_mcp_success(update_result, "Update template sensor availability")
+            update_data = assert_mcp_success(
+                update_result, "Update template sensor availability"
+            )
+            assert update_data.get("warnings") == [
+                "Ignored config keys not declared by the Home Assistant flow "
+                "schema: availabilty"
+            ]
 
             integration_result = await mcp_client.call_tool(
                 "ha_get_integration",

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -35,6 +35,24 @@ class TestExtractSchemaFieldNames:
         ]
         assert _extract_schema_field_names(schema) == {"name", "entity_id"}
 
+    def test_extracts_names_from_expandable_sections(self) -> None:
+        schema = [
+            {"name": "state", "required": True, "selector": {"template": {}}},
+            {
+                "type": "expandable",
+                "name": "advanced_options",
+                "schema": [
+                    {
+                        "name": "availability",
+                        "required": False,
+                        "selector": {"template": {}},
+                    }
+                ],
+            },
+        ]
+
+        assert _extract_schema_field_names(schema) == {"state", "availability"}
+
     def test_handles_missing_or_malformed_schema(self) -> None:
         # Non-list inputs signal "schema not available" → None (legacy fallback).
         assert _extract_schema_field_names(None) is None
@@ -71,6 +89,64 @@ class TestHandleFormStepFiltering:
             "state_characteristic": "mean",
             "extra_key": "should_remain",
         }
+
+    def test_wraps_flat_expandable_fields_for_submission(self) -> None:
+        remaining = {
+            "state": "{{ 1 }}",
+            "availability": "{{ has_value('sensor.x') }}",
+        }
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {"name": "state", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability", "required": False}],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "state": "{{ 1 }}",
+            "advanced_options": {
+                "availability": "{{ has_value('sensor.x') }}",
+            },
+        }
+        assert remaining == {}
+
+    def test_accepts_explicit_expandable_section_dict(self) -> None:
+        remaining = {
+            "state": "{{ 1 }}",
+            "advanced_options": {
+                "availability": "{{ has_value('sensor.x') }}",
+            },
+        }
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {"name": "state", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability", "required": False}],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "state": "{{ 1 }}",
+            "advanced_options": {
+                "availability": "{{ has_value('sensor.x') }}",
+            },
+        }
+        assert remaining == {}
 
     def test_strips_menu_selection_keys(self) -> None:
         remaining = {"group_type": "light", "name": "x"}

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -148,6 +148,132 @@ class TestHandleFormStepFiltering:
         }
         assert remaining == {}
 
+    def test_omits_section_when_only_top_level_field_is_updated(self) -> None:
+        remaining = {"state": "{{ 2 }}"}
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {"name": "state", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability", "required": False}],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {"state": "{{ 2 }}"}
+        assert remaining == {}
+
+    def test_flat_section_field_overrides_explicit_section_value(self) -> None:
+        remaining = {
+            "availability": "{{ true }}",
+            "advanced_options": {"availability": "{{ false }}"},
+        }
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability", "required": False}],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "advanced_options": {"availability": "{{ true }}"},
+        }
+        assert remaining == {}
+
+    def test_wraps_depth_two_flat_field_for_submission(self) -> None:
+        remaining = {"delay": 30}
+        step = {
+            "type": "form",
+            "step_id": "nested",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [
+                        {
+                            "type": "expandable",
+                            "name": "timing",
+                            "schema": [{"name": "delay"}],
+                        }
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "advanced_options": {
+                "timing": {"delay": 30},
+            },
+        }
+        assert remaining == {}
+
+    def test_legacy_fallback_submits_all_non_menu_keys(self) -> None:
+        remaining = {
+            "name": "Legacy",
+            "unknown": "still submitted",
+            "next_step_id": "sensor",
+        }
+        step = {"type": "form", "step_id": "user", "data_schema": None}
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "name": "Legacy",
+            "unknown": "still submitted",
+        }
+        assert remaining == {"next_step_id": "sensor"}
+
+    def test_passes_through_non_dict_explicit_section_value(self) -> None:
+        remaining = {"advanced_options": "invalid"}
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability"}],
+                }
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {"advanced_options": "invalid"}
+        assert remaining == {}
+
+    def test_flattens_children_when_section_name_is_missing(self) -> None:
+        remaining = {"availability": "{{ true }}"}
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "schema": [{"name": "availability"}],
+                }
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {"availability": "{{ true }}"}
+        assert remaining == {}
+
     def test_strips_menu_selection_keys(self) -> None:
         remaining = {"group_type": "light", "name": "x"}
         step = {
@@ -239,8 +365,8 @@ class TestMultiStepFlow:
         assert second_call_args[0] == "flow-1"
         assert second_call_args[1] == {"state_characteristic": "mean"}
 
-    async def test_extra_unknown_keys_are_dropped(self) -> None:
-        """Keys never declared by any step are silently dropped (HA will ignore)."""
+    async def test_extra_unknown_keys_are_reported_as_warnings(self) -> None:
+        """Keys never declared by any step are omitted and reported."""
         final_entry = {
             "type": "create_entry",
             "result": {"entry_id": "e1", "title": "t", "domain": "min_max"},
@@ -264,7 +390,7 @@ class TestMultiStepFlow:
             "junk": "ignored",
         }
 
-        await _handle_flow_steps(
+        result = await _handle_flow_steps(
             client=None,
             flow_id="flow-2",
             initial_step=initial_step,
@@ -279,6 +405,45 @@ class TestMultiStepFlow:
             "entity_ids": ["sensor.a"],
             "type": "mean",
         }
+        assert result["warnings"] == [
+            "Ignored config keys not declared by the Home Assistant flow schema: junk"
+        ]
+
+    async def test_unknown_explicit_section_keys_are_reported_with_path(self) -> None:
+        final_entry = {
+            "type": "create_entry",
+            "result": {"entry_id": "e1", "title": "t", "domain": "template"},
+        }
+        submit_fn = AsyncMock(side_effect=[final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-3",
+            "step_id": "sensor",
+            "data_schema": [
+                {"name": "state"},
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability"}],
+                },
+            ],
+        }
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-3",
+            initial_step=initial_step,
+            config={
+                "state": "{{ 1 }}",
+                "advanced_options": {"availabilty": "{{ true }}"},
+            },
+            submit_fn=submit_fn,
+        )
+
+        assert result["warnings"] == [
+            "Ignored config keys not declared by the Home Assistant flow schema: "
+            "advanced_options.availabilty"
+        ]
 
 
 class TestSubmitStep:

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -153,6 +153,18 @@ class TestUniformResponseShape:
         """
         mock_client.start_config_flow = AsyncMock(
             return_value={
+                "type": "form",
+                "flow_id": "flow-1",
+                "step_id": "user",
+                "data_schema": [
+                    {"name": "name"},
+                    {"name": "entity_ids"},
+                    {"name": "type"},
+                ],
+            }
+        )
+        mock_client.submit_config_flow_step = AsyncMock(
+            return_value={
                 "type": "create_entry",
                 "flow_id": "flow-1",
                 "result": {

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1294,6 +1294,30 @@ class TestOptionsFromFormFlow:
             "availability": "{{ has_value('sensor.x') }}",
         }
 
+    def test_reads_values_from_depth_two_sections(self) -> None:
+        flow = {
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [
+                        {
+                            "type": "expandable",
+                            "name": "timing",
+                            "schema": [
+                                {
+                                    "name": "delay",
+                                    "description": {"suggested_value": 30},
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ]
+        }
+
+        assert options_from_form_flow(flow) == {"delay": 30}
+
     def test_suggested_value_wins_over_default(self) -> None:
         # Issue #1575: a field can carry the static schema default AND the
         # entry's current value at the same time. HA injects the persisted

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1267,6 +1267,33 @@ class TestOptionsFromFormFlow:
             "device_class": "temperature",
         }
 
+    def test_reads_values_from_expandable_sections(self) -> None:
+        flow = {
+            "data_schema": [
+                {
+                    "name": "state",
+                    "description": {"suggested_value": "{{ 1 }}"},
+                },
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [
+                        {
+                            "name": "availability",
+                            "description": {
+                                "suggested_value": "{{ has_value('sensor.x') }}"
+                            },
+                        }
+                    ],
+                },
+            ]
+        }
+
+        assert options_from_form_flow(flow) == {
+            "state": "{{ 1 }}",
+            "availability": "{{ has_value('sensor.x') }}",
+        }
+
     def test_suggested_value_wins_over_default(self) -> None:
         # Issue #1575: a field can carry the static schema default AND the
         # entry's current value at the same time. HA injects the persisted


### PR DESCRIPTION
## What does this PR do?

Home Assistant flow schemas can place fields inside expandable sections. `ha_config_set_helper` treated those child fields as top-level form values, so updates such as a template sensor's `availability` were either silently dropped or rejected by Home Assistant. The options reader also skipped nested values, making persisted advanced settings invisible.

This recursively handles nested schema sections, wraps flat MCP inputs in the section shape Home Assistant expects, and flattens nested values when reading options. It includes unit coverage for flat and explicitly nested inputs plus an end-to-end template availability update and readback.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

