### PR TITLE
feat: ha_search optimization + component-backed read API

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -55,6 +55,7 @@ from .const import (
     YAML_KEY_DEFAULT_POST_ACTION,
     YAML_KEY_POST_ACTIONS,
 )
+from .websocket_api import async_register_commands
 from .yaml_rt import apply_seq_indent, detect_seq_indent, make_yaml, yaml_dumps
 
 _LOGGER = logging.getLogger(__name__)
@@ -2480,6 +2481,12 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         schema=SERVICE_READ_LEGACY_BACKUP_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
+
+    # Register the in-process ha_mcp_tools/* WebSocket commands (info + search)
+    # the server calls behind a capability gate. Idempotent, and independent of
+    # the caller-token gate above — HA core authenticates the WS connection and
+    # @require_admin gates each command (see websocket_api.py).
+    async_register_commands(hass)
 
     _LOGGER.info("HA MCP Tools initialized with file management services")
     return True

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -18,6 +18,14 @@ from datetime import timedelta
 
 DOMAIN = "ha_mcp_tools"
 
+# Component version, kept in lockstep with ``manifest.json``'s ``version``.
+# ``ha_mcp_tools/info`` reports this so the server can display/debug the running
+# component build; ``TestManifestVersionParity`` pins the two together so a
+# manifest bump that forgets this constant (or vice-versa) fails in CI. The
+# capability negotiation — not this version — gates each WS command (see
+# ``websocket_api.CAPABILITIES``).
+COMPONENT_VERSION = "1.1.0"
+
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the
 # component update with no migration.

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.0.6"
+    "version": "1.1.0"
 }

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -23,6 +23,12 @@ Design notes that are load-bearing:
   items return identity/metadata only (their ``raw_config`` may carry resolved
   ``!secret`` plaintext). Body emission for YAML belongs to the future
   ``config_get`` command.
+* **Resolved secrets are scrubbed from the match corpus.** Because YAML bodies
+  (and flow-helper options) can hold ``!secret`` values resolved to plaintext,
+  a body leaf that exactly equals a ``secrets.yaml`` value is dropped before
+  scoring (:func:`_load_secret_values`) — otherwise a query equal to a suspected
+  secret would confirm it via ``match_in_config`` (a probe oracle). Blocked, not
+  merely unemitted.
 * **Event-loop hygiene.** Every join is a pure in-memory read over live
   registries — run synchronously, no executor, no persistent index (always
   fresh, zero cache-invalidation surface).
@@ -36,11 +42,13 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import Any
 
 import voluptuous as vol
+import yaml  # type: ignore[import-untyped]
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -111,7 +119,8 @@ CONFIG_SEARCH_TYPES = (
 )
 
 # Collection ("storage collection") helpers — entities in the state machine.
-# Matched on entity_id / friendly_name only; their body is not read in v1.
+# Matched on entity_id / friendly_name AND the live state-attribute body (an
+# input_select's ``options``, an input_number's ``min``/``max``/``step``, …).
 COLLECTION_HELPER_DOMAINS = frozenset(
     {
         "input_boolean",
@@ -284,6 +293,20 @@ def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
     diagnostics: dict[str, int] = {}
     partial_reasons: list[str] = []
 
+    # Resolved-!secret scrub set: config bodies (YAML-loaded automations/scripts/
+    # scenes reach this path, unlike the server's 404-ing per-id path) can carry
+    # a secret already resolved to plaintext, and matching inside it would make
+    # ha_search a probe oracle (query a suspected secret, confirm via
+    # match_in_config). Load the secrets.yaml values once per call, only when a
+    # config/helper surface is actually searched, so entity-only searches skip
+    # the file read entirely.
+    scrub_surfaces = (*CONFIG_SEARCH_TYPES, SEARCH_TYPE_HELPER)
+    secret_values = (
+        _load_secret_values(hass)
+        if any(st in search_types for st in scrub_surfaces)
+        else frozenset()
+    )
+
     # --- Entities ------------------------------------------------------------
     entities: list[dict[str, Any]] = []
     entity_total = 0
@@ -323,6 +346,7 @@ def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
                     include_config=include_config,
                     partial_reasons=partial_reasons,
                     diagnostics=diagnostics,
+                    secret_values=secret_values,
                 )
             )
     if SEARCH_TYPE_HELPER in search_types:
@@ -334,6 +358,7 @@ def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
                 match_all=match_all,
                 exact=exact,
                 include_config=include_config,
+                secret_values=secret_values,
             )
         )
 
@@ -380,6 +405,44 @@ def _sort_key(rec: dict[str, Any]) -> str:
     return str(rec.get("entity_id") or rec.get("id") or rec.get("name") or "")
 
 
+def _load_secret_values(hass: HomeAssistant) -> frozenset[str]:
+    """Load the string values from the instance's ``secrets.yaml``.
+
+    These scrub resolved ``!secret`` plaintext out of the config-body match
+    corpus: a YAML-loaded automation/script/scene body (or a flow-helper's
+    options) can carry a secret already resolved to its plaintext value, and
+    matching inside it would turn ``ha_search`` into a probe oracle — a query
+    equal to a suspected secret confirmed via ``match_in_config``. Any body leaf
+    that exactly equals one of these values is dropped before scoring.
+
+    Defensive by design: a missing or malformed ``secrets.yaml`` yields an empty
+    set (scrub degrades OFF, never raising). Only string values are collected —
+    a secret can be any YAML scalar, but a non-string can't be a plaintext-leak
+    leaf and is skipped. Computed once per ``_do_search`` call (see the caller),
+    never cached across calls, so an edited ``secrets.yaml`` applies on the next
+    search. ``secrets.yaml`` is a flat ``key: value`` mapping with no custom
+    tags, so the plain ``yaml.safe_load`` (not HA's ``!secret``/``!include``
+    loader) reads it correctly.
+    """
+    config = getattr(hass, "config", None)
+    path_fn = getattr(config, "path", None)
+    if not callable(path_fn):
+        return frozenset()
+    try:
+        path = path_fn("secrets.yaml")
+        if not path:
+            return frozenset()
+        with open(path, encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+    except (OSError, yaml.YAMLError):
+        return frozenset()
+    except Exception:  # pragma: no cover - defensive against loader edge cases
+        return frozenset()
+    if not isinstance(raw, dict):
+        return frozenset()
+    return frozenset(v for v in raw.values() if isinstance(v, str) and v)
+
+
 # --- Entity join + scoring ---------------------------------------------------
 def _search_entities(
     hass: HomeAssistant,
@@ -417,11 +480,92 @@ def _search_entities(
             if tier is None:
                 continue
             score = _apply_hidden_penalty(tier, rec["_hidden"])
-            match_type = "exact_match" if exact else "fuzzy"
+            match_type = _entity_match_type(
+                query_lower,
+                rec["entity_id"],
+                rec["friendly_name"],
+                rec["domain"],
+                rec["aliases"],
+                exact=exact,
+            )
         rec["score"] = score
         rec["match_type"] = match_type
         results.append(rec)
     return results
+
+
+def _entity_match_type(
+    query_lower: str,
+    entity_id: str,
+    friendly: str,
+    domain: str,
+    aliases: list[str],
+    *,
+    exact: bool,
+) -> str:
+    """Classify an entity hit into the server's match_type taxonomy.
+
+    The server labels matches two ways and the component must be
+    indistinguishable from it:
+
+    - **exact mode** — the server's ``_match_exact_search_entity`` stamps a flat
+      ``"exact_match"`` on every hit, so mirror that constant.
+    - **fuzzy mode** — the server's ``FuzzySearchEngine`` emits a richer set that
+      agents key on. ``"alias_match"`` wins when the hit is driven by an alias
+      token the id/name don't already carry (the engine's ``alias_hit`` tracking
+      — closes #1166); otherwise the ``_get_match_type`` tiers: ``exact_id`` /
+      ``exact_name`` / ``exact_domain`` / ``partial_id`` / ``partial_name``,
+      falling to ``fuzzy_match``.
+    """
+    if exact:
+        return "exact_match"
+    if _is_alias_driven(query_lower, entity_id, friendly, aliases):
+        return "alias_match"
+    return _get_match_type_tier(query_lower, entity_id, friendly, domain)
+
+
+def _is_alias_driven(
+    query_lower: str, entity_id: str, friendly: str, aliases: list[str]
+) -> bool:
+    """Whether a query token lands only on an alias, mirroring the engine's alias_hit.
+
+    Collects the alias tokens (and each alias's separator-stripped concat form)
+    that are NOT already present in the id/name token set; a query token in that
+    set means the friendly_name / id alone would not have surfaced this entity.
+    """
+    id_tail = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+    id_name_tokens = set(_tokenize(entity_id)) | set(_tokenize(str(friendly)))
+    id_name_tokens.add(_SPLIT_RE.sub("", id_tail.lower()))
+    id_name_tokens.add(_SPLIT_RE.sub("", str(friendly).lower()))
+    alias_only: set[str] = set()
+    for alias in aliases:
+        a_lower = str(alias).lower()
+        for tok in _tokenize(a_lower):
+            if tok not in id_name_tokens:
+                alias_only.add(tok)
+        a_concat = _SPLIT_RE.sub("", a_lower)
+        if a_concat and a_concat not in id_name_tokens:
+            alias_only.add(a_concat)
+    return bool(set(_tokenize(query_lower)) & alias_only)
+
+
+def _get_match_type_tier(
+    query_lower: str, entity_id: str, friendly: str, domain: str
+) -> str:
+    """The server's ``_get_match_type`` id/name/domain tiers (non-alias hits)."""
+    eid = entity_id.lower()
+    fname = str(friendly).lower()
+    if query_lower == eid:
+        return "exact_id"
+    if query_lower == fname:
+        return "exact_name"
+    if query_lower == domain.lower():
+        return "exact_domain"
+    if query_lower in eid:
+        return "partial_id"
+    if query_lower in fname:
+        return "partial_name"
+    return "fuzzy_match"
 
 
 def _entity_record(state: Any, view: _RegistryView) -> dict[str, Any]:
@@ -517,6 +661,7 @@ def _search_config_surface(
     include_config: bool,
     partial_reasons: list[str],
     diagnostics: dict[str, int],
+    secret_values: frozenset[str] = frozenset(),
 ) -> list[dict[str, Any]]:
     """Score one config domain's loaded entities (raw_config indexed, not emitted for YAML)."""
     component = hass.data.get(domain) if getattr(hass, "data", None) else None
@@ -541,7 +686,12 @@ def _search_config_surface(
             match_in_config = False
         else:
             scored = _config_score(
-                query_lower, entity_id, name, config_dict, exact=exact
+                query_lower,
+                entity_id,
+                name,
+                config_dict,
+                exact=exact,
+                secret_values=secret_values,
             )
             if scored is None:
                 continue
@@ -661,11 +811,19 @@ def _search_helpers(
     match_all: bool,
     exact: bool,
     include_config: bool,
+    secret_values: frozenset[str] = frozenset(),
 ) -> list[dict[str, Any]]:
     """Index collection helpers (states) + flow helpers (config-entry options)."""
     results: list[dict[str, Any]] = []
 
-    # Collection helpers: entities in the state machine, matched on name only.
+    # Collection helpers: entities in the state machine. Their searchable body is
+    # the live state attributes — an input_select's ``options``, an
+    # input_number's ``min``/``max``/``step``, etc. — so a query on an option
+    # value matches in-config the way the server's ``<type>/list`` body search
+    # does. (Residual delta vs the server: the ``<type>/list`` record's
+    # config-only leaves — e.g. ``initial`` — are not state attributes, so a
+    # match existing ONLY there is unreachable here; and the attribute set
+    # carries the CURRENT friendly_name, not the creation-time storage name.)
     for state in _iter_states(hass):
         entity_id = getattr(state, "entity_id", "") or ""
         domain = entity_id.split(".")[0] if "." in entity_id else ""
@@ -674,14 +832,23 @@ def _search_helpers(
         attrs = getattr(state, "attributes", None) or {}
         name = attrs.get("friendly_name", entity_id)
         object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+        body = dict(attrs) if isinstance(attrs, Mapping) else {}
         if match_all:
             score: int | None = 100
             match_in_name = False
+            match_in_config = False
         else:
-            score = _name_tier(query_lower, [entity_id, name], exact=exact)
-            if score is None:
+            scored = _config_score(
+                query_lower,
+                entity_id,
+                name,
+                body,
+                exact=exact,
+                secret_values=secret_values,
+            )
+            if scored is None:
                 continue
-            match_in_name = True
+            score, match_in_name, match_in_config = scored
         results.append(
             {
                 "entity_id": entity_id,
@@ -691,8 +858,8 @@ def _search_helpers(
                 "kind": "collection",
                 "score": score,
                 "match_in_name": match_in_name,
-                "match_in_config": False,
-                "config": None,
+                "match_in_config": match_in_config,
+                "config": body if include_config else None,
             }
         )
 
@@ -702,15 +869,28 @@ def _search_helpers(
         if domain not in FLOW_HELPER_DOMAINS:
             continue
         title = getattr(entry, "title", None) or ""
-        options = getattr(entry, "options", None)
-        options = dict(options) if isinstance(options, dict) else {}
+        # ``ConfigEntry.options`` is a ``MappingProxyType`` in live HA, not a
+        # ``dict``; the old ``isinstance(..., dict)`` guard silently dropped it to
+        # ``{}``, so a flow helper's body (a template's ``state``, a group's
+        # members, …) was never indexed and ``match_in_config`` could never fire.
+        # Accept any ``Mapping`` so the persisted options are searchable and
+        # emittable under ``include_config``.
+        raw_options = getattr(entry, "options", None)
+        options = dict(raw_options) if isinstance(raw_options, Mapping) else {}
         entry_id = getattr(entry, "entry_id", None)
         if match_all:
             score = 100
             match_in_name = False
             match_in_config = False
         else:
-            scored = _config_score(query_lower, title, title, options, exact=exact)
+            scored = _config_score(
+                query_lower,
+                title,
+                title,
+                options,
+                exact=exact,
+                secret_values=secret_values,
+            )
             if scored is None:
                 continue
             score, match_in_name, match_in_config = scored
@@ -816,14 +996,18 @@ def _config_score(
     config_dict: dict[str, Any] | None,
     *,
     exact: bool,
+    secret_values: frozenset[str] = frozenset(),
 ) -> tuple[int, bool, bool] | None:
     """Score a config surface: (total, match_in_name, match_in_config) or None.
 
     Exact mode is binary 100/0 with a threshold of 100 (server parity); fuzzy
-    mode floors at :data:`FUZZY_THRESHOLD`.
+    mode floors at :data:`FUZZY_THRESHOLD`. ``secret_values`` scrubs the body
+    match corpus (see :func:`_search_in_dict_exact`).
     """
     name_score = _name_tier(query_lower, [entity_id, name], exact=exact) or 0
-    config_score = _config_body_score(query_lower, config_dict, exact=exact)
+    config_score = _config_body_score(
+        query_lower, config_dict, exact=exact, secret_values=secret_values
+    )
     threshold = 100 if exact else FUZZY_THRESHOLD
     total = max(name_score, config_score)
     if total < threshold:
@@ -832,21 +1016,26 @@ def _config_score(
 
 
 def _config_body_score(
-    query_lower: str, config_dict: dict[str, Any] | None, *, exact: bool
+    query_lower: str,
+    config_dict: dict[str, Any] | None,
+    *,
+    exact: bool,
+    secret_values: frozenset[str] = frozenset(),
 ) -> int:
     """Match the query against a config body's keys/values.
 
     Exact => 100/0 substring (``_search_in_dict_exact`` parity). Fuzzy adds a
     token-vs-token ``calculate_ratio`` fallback (the server's tier-3 path).
+    ``secret_values`` scrubs resolved-``!secret`` leaves from the corpus.
     """
     if config_dict is None:
         return 0
-    if _search_in_dict_exact(config_dict, query_lower) >= 100:
+    if _search_in_dict_exact(config_dict, query_lower, secret_values) >= 100:
         return 100
     if exact:
         return 0
     leaves: list[str] = []
-    _collect_string_leaves(config_dict, leaves)
+    _collect_string_leaves(config_dict, leaves, secret_values)
     query_tokens = _tokenize(query_lower)
     if not query_tokens:
         return 0
@@ -858,41 +1047,68 @@ def _config_body_score(
     return best if best >= FUZZY_THRESHOLD else 0
 
 
-def _search_in_dict_exact(data: Any, query_lower: str) -> int:
+def _search_in_dict_exact(
+    data: Any, query_lower: str, secret_values: frozenset[str] = frozenset()
+) -> int:
     """Exact substring search in nested structures (100 or 0).
 
-    Mirrors ``smart_search._scoring.ScoringMixin._search_in_dict_exact``.
+    Mirrors ``smart_search._scoring.ScoringMixin._search_in_dict_exact``, plus a
+    secret scrub: a string leaf that exactly equals a known secret value never
+    contributes a match (see :func:`_load_secret_values`), so a query equal to a
+    resolved ``!secret`` cannot be confirmed via ``match_in_config``. Keys and
+    non-string scalars are never secrets, so they are matched as before.
     """
     if isinstance(data, dict):
         for key, value in data.items():
             if query_lower in str(key).lower():
                 return 100
-            if _search_in_dict_exact(value, query_lower) >= 100:
+            if _search_in_dict_exact(value, query_lower, secret_values) >= 100:
                 return 100
         return 0
     if isinstance(data, (list, tuple)):
         for item in data:
-            if _search_in_dict_exact(item, query_lower) >= 100:
+            if _search_in_dict_exact(item, query_lower, secret_values) >= 100:
                 return 100
         return 0
+    return _leaf_exact_score(data, query_lower, secret_values)
+
+
+def _leaf_exact_score(
+    data: Any, query_lower: str, secret_values: frozenset[str]
+) -> int:
+    """Exact substring score for a scalar leaf (100 or 0).
+
+    A string leaf that exactly equals a known secret value scores 0 — the scrub
+    that keeps a resolved ``!secret`` out of the match corpus.
+    """
     if isinstance(data, str):
+        if data in secret_values:
+            return 0
         return 100 if query_lower in data.lower() else 0
     if data is not None:
         return 100 if query_lower in str(data).lower() else 0
     return 0
 
 
-def _collect_string_leaves(data: Any, out: list[str]) -> None:
-    """Recursively collect string representations. Mirrors the server helper."""
+def _collect_string_leaves(
+    data: Any, out: list[str], secret_values: frozenset[str] = frozenset()
+) -> None:
+    """Recursively collect string representations. Mirrors the server helper.
+
+    A string leaf that exactly equals a known secret value is dropped so it
+    never reaches the fuzzy token corpus (the scrub in :func:`_search_in_dict_exact`
+    covers the exact path).
+    """
     if isinstance(data, dict):
         for key, value in data.items():
             out.append(str(key))
-            _collect_string_leaves(value, out)
+            _collect_string_leaves(value, out, secret_values)
     elif isinstance(data, (list, tuple)):
         for item in data:
-            _collect_string_leaves(item, out)
+            _collect_string_leaves(item, out, secret_values)
     elif isinstance(data, str):
-        out.append(data)
+        if data not in secret_values:
+            out.append(data)
     elif data is not None:
         out.append(str(data))
 

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -937,14 +937,30 @@ def _tokenize(text: str) -> list[str]:
     return [t for t in _SPLIT_RE.split(text.lower()) if t]
 
 
+def _sep_normalized(text: str) -> str:
+    """Collapse ``.``/``_``/``-``/whitespace runs to single spaces.
+
+    The server's fuzzy engine (BM25) tokenizes query and documents with the
+    same splitter, making ``input_boolean`` and ``input boolean`` equivalent
+    queries (pinned by the e2e underscore/space-equivalence test). Comparing
+    separator-normalized strings replicates that equivalence for the
+    component's tier scorer.
+    """
+    return " ".join(_tokenize(text))
+
+
 def _text_tier(query_lower: str, texts: Any, *, fuzzy: bool) -> int | None:
     """Entity tier: 100 (exact), 80 (substring), fuzzy ratio (>=threshold), or None.
 
     Mirrors the server's ``_match_exact_search_entity`` (100/80) over the entity
     id + friendly name, extended to the joined alias/area/floor/label/domain/
-    device texts. In fuzzy mode a whole-string ``calculate_ratio`` fallback
-    surfaces typos above :data:`FUZZY_THRESHOLD`.
+    device texts. In fuzzy mode comparisons run on BOTH the raw strings and
+    their separator-normalized forms (unified tokenization — ``_``/space
+    equivalence), with a whole-string ``calculate_ratio`` fallback surfacing
+    typos above :data:`FUZZY_THRESHOLD`. Exact mode stays raw-only for
+    byte-parity with the server's exact path.
     """
+    query_norm = _sep_normalized(query_lower) if fuzzy else ""
     best_substring: int | None = None
     best_ratio = 0
     for text in texts:
@@ -953,12 +969,17 @@ def _text_tier(query_lower: str, texts: Any, *, fuzzy: bool) -> int | None:
         text_lower = str(text).lower()
         if query_lower == text_lower:
             return 100
+        if fuzzy and query_norm and query_norm == _sep_normalized(text_lower):
+            return 100
         if query_lower in text_lower:
             best_substring = 80
         elif fuzzy:
-            ratio = _calc_ratio(query_lower, text_lower)
-            if ratio > best_ratio:
-                best_ratio = ratio
+            if query_norm and query_norm in _sep_normalized(text_lower):
+                best_substring = 80
+            else:
+                ratio = _calc_ratio(query_lower, text_lower)
+                if ratio > best_ratio:
+                    best_ratio = ratio
     if best_substring is not None:
         return best_substring
     if fuzzy and best_ratio >= FUZZY_THRESHOLD:
@@ -973,6 +994,7 @@ def _name_tier(query_lower: str, texts: Any, *, exact: bool) -> int | None:
     (``_score_deep_match``: ``name_exact = 100 if query in id/name else 0``),
     unlike entity matches which have the 80 substring tier.
     """
+    query_norm = "" if exact else _sep_normalized(query_lower)
     best_ratio = 0
     for text in texts:
         if not text:
@@ -981,6 +1003,8 @@ def _name_tier(query_lower: str, texts: Any, *, exact: bool) -> int | None:
         if query_lower in text_lower:
             return 100
         if not exact:
+            if query_norm and query_norm in _sep_normalized(text_lower):
+                return 100
             ratio = _calc_ratio(query_lower, text_lower)
             if ratio > best_ratio:
                 best_ratio = ratio

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2,22 +2,13 @@
 
 This module registers versioned ``ha_mcp_tools/*`` WebSocket commands that the
 ha-mcp server calls in-process (same HA core, no REST/WS round-trips) behind a
-capability gate. v1.1.0 ships five commands (four capabilities):
+capability gate. v1.1.0 ships four commands (three capabilities):
 
 * ``ha_mcp_tools/info`` — the handshake: ``schema_version`` + ``capabilities[]``
   + ``component_version`` + advisory ``limits``. One cached probe tells the
   server which commands are live (capability negotiation, NOT a version floor).
 * ``ha_mcp_tools/search`` — a unified in-process search over live registries and
   states, joined and scored, mirroring today's ``ha_search`` response envelope.
-* ``ha_mcp_tools/config_get`` — one-call fetch of a storage/editor-backed
-  automation/script body + current entity_id + friendly_name + entity category,
-  collapsing the server's id-resolve + config-fetch + registry-category
-  round-trips. Automation/script ONLY — scenes are excluded because a
-  ``HomeAssistantScene`` holds no raw storage body in memory (its
-  ``scene_config.states`` is runtime State objects, not the storage ``entities``
-  dict), so ``ha_config_get_scene`` stays on its legacy REST path. Storage-only:
-  a YAML-loaded item returns a structured not-found (its body is never emitted —
-  that belongs to the future file-based tool).
 * ``ha_mcp_tools/overview`` — the raw in-process reads the server's
   ``get_system_overview`` + ``ha_get_overview`` wrapper consume (states,
   services, entity/device/area registries, ``hass.config``, persistent
@@ -32,6 +23,13 @@ capability gate. v1.1.0 ships five commands (four capabilities):
   enumerated, so the server falls back to its legacy ``<type>/list`` path for an
   uncovered type (e.g. ``tag``, which has no state entity) instead of trusting an
   empty result.
+
+``ha_mcp_tools/config_get`` was withdrawn before release: it served an entity's
+``raw_config``, whose freshness lags the config file between a write and the next
+completed reload (no version marker distinguishes a fresh body from a stale one),
+so a get racing a reload returned a pre-edit body. ``ha_config_get_{automation,
+script}`` stay on the legacy REST path (which reads the fresh config file);
+scenes were already legacy-only. A file-reading redesign may return (issue #1813).
 
 Design notes that are load-bearing:
 
@@ -104,7 +102,6 @@ _LOGGER = logging.getLogger(__name__)
 WS_API_PREFIX = "ha_mcp_tools"
 WS_INFO = f"{WS_API_PREFIX}/info"
 WS_SEARCH = f"{WS_API_PREFIX}/search"
-WS_CONFIG_GET = f"{WS_API_PREFIX}/config_get"
 WS_OVERVIEW = f"{WS_API_PREFIX}/overview"
 WS_HELPERS_LIST = f"{WS_API_PREFIX}/helpers_list"
 
@@ -117,7 +114,7 @@ SCHEMA_VERSION = 1
 # each consumer on ``capability in caps.capabilities``. Never remove an entry
 # without a major bump. (``info`` is always present in 1.1.0, so it carries no
 # capability key of its own.)
-CAPABILITIES: list[str] = ["search", "config_get", "overview", "helpers_list"]
+CAPABILITIES: list[str] = ["search", "overview", "helpers_list"]
 
 # Advisory caps advertised in ``info.limits`` so no single WS frame balloons.
 MAX_RESULTS = 500
@@ -149,17 +146,6 @@ CONFIG_SEARCH_TYPES = (
     SEARCH_TYPE_AUTOMATION,
     SEARCH_TYPE_SCRIPT,
     SEARCH_TYPE_SCENE,
-)
-
-# Domains ``ha_mcp_tools/config_get`` will serve a storage body for. Scenes are
-# deliberately EXCLUDED (unlike search, which indexes all three): a
-# ``HomeAssistantScene`` keeps ``scene_config.states`` as runtime State objects,
-# not the storage ``entities`` dict, so there is no raw storage body in memory to
-# return — a component-served scene body would break shape parity and
-# ``config_hash`` stability, so ``ha_config_get_scene`` stays on its legacy path.
-CONFIG_GET_DOMAINS = (
-    SEARCH_TYPE_AUTOMATION,
-    SEARCH_TYPE_SCRIPT,
 )
 
 # Collection ("storage collection") helpers — entities in the state machine.
@@ -264,7 +250,6 @@ def _command_specs() -> list[tuple[dict[Any, Any], Any, Any]]:
     return [
         (_info_schema(), lambda hass, msg: _do_info(), None),
         (_search_schema(), _do_search, _search_prep),
-        (_config_get_schema(), _do_config_get, None),
         (_overview_schema(), _do_overview, None),
         (_helpers_list_schema(), _do_helpers_list, None),
     ]
@@ -308,14 +293,6 @@ def _search_schema() -> dict[Any, Any]:
             int, vol.Range(min=1, max=MAX_RESULTS)
         ),
         vol.Optional("offset", default=0): vol.All(int, vol.Range(min=0)),
-    }
-
-
-def _config_get_schema() -> dict[Any, Any]:
-    return {
-        vol.Required("type"): WS_CONFIG_GET,
-        vol.Required("domain"): vol.In(list(CONFIG_GET_DOMAINS)),
-        vol.Required("item_id"): str,
     }
 
 
@@ -1509,80 +1486,6 @@ def _reg_name(reg: Any) -> str | None:
     return str(name) if name else None
 
 
-# =============================================================================
-# ha_mcp_tools/config_get
-# =============================================================================
-def _do_config_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
-    """One-call fetch of a storage-backed automation/script config body.
-
-    Automation/script ONLY — the schema (:func:`_config_get_schema`) rejects any
-    other domain. Scenes are excluded on purpose: a ``HomeAssistantScene`` keeps
-    no raw storage body in memory (``scene_config.states`` is runtime State
-    objects, not the storage ``entities`` dict), so ``ha_config_get_scene`` stays
-    on its legacy REST path.
-
-    Storage-only (maintainer decision): a YAML-loaded item (id-less, same
-    ``_classify_source`` rule as search) returns a structured not-found and its
-    body is NEVER emitted — YAML-body retrieval belongs to a future file-based
-    tool. Collapses the server's id-resolve + config-fetch + registry-category
-    round-trips into one in-process call.
-    """
-    domain = params["domain"]
-    item_id = str(params["item_id"])
-
-    entity, name, storage_id, config_dict = _find_config_item(hass, domain, item_id)
-    if entity is None:
-        # Nothing resolves — a clean not-found (mirrors the REST 404).
-        return {"found": False, "domain": domain, "item_id": item_id, "source": None}
-
-    entity_id = getattr(entity, "entity_id", None)
-    if _classify_source(storage_id) != "storage":
-        # Resolved to a YAML item: structured not-found, body absent.
-        return {
-            "found": False,
-            "domain": domain,
-            "item_id": item_id,
-            "entity_id": entity_id,
-            "source": "yaml",
-        }
-
-    view = _resolve_registries(hass)
-    return {
-        "found": True,
-        "domain": domain,
-        "item_id": storage_id,
-        "entity_id": entity_id,
-        "friendly_name": _current_friendly_name(hass, entity_id, name),
-        "config": config_dict,
-        "source": "storage",
-        "category": _entity_category(view, entity_id, domain),
-    }
-
-
-def _find_config_item(
-    hass: HomeAssistant, domain: str, item_id: str
-) -> tuple[Any, str | None, str | None, dict[str, Any] | None]:
-    """Resolve (entity, name, storage_id, config_dict) for a config id, or Nones.
-
-    Matches ``item_id`` against the loaded entity's entity_id, its storage id
-    (unique_id / raw_config ``id``), or its object_id slug — the same identifiers
-    the server accepts for ``ha_config_get_*``.
-    """
-    component = hass.data.get(domain) if getattr(hass, "data", None) else None
-    entities = getattr(component, "entities", None)
-    if entities is None:
-        return None, None, None, None
-    for entity in entities:
-        entity_id = getattr(entity, "entity_id", None)
-        if not entity_id:
-            continue
-        name, storage_id, config_dict = _extract_config(domain, entity)
-        object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
-        if item_id in (entity_id, storage_id, object_id):
-            return entity, name, storage_id, config_dict
-    return None, None, None, None
-
-
 def _current_friendly_name(
     hass: HomeAssistant, entity_id: str | None, fallback: str | None
 ) -> str | None:
@@ -1601,16 +1504,6 @@ def _current_friendly_name(
     if fallback:
         return str(fallback)
     return entity_id
-
-
-def _entity_category(view: _RegistryView, entity_id: str | None, scope: str) -> Any:
-    """In-process equivalent of ``fetch_entity_category``: registry ``categories[scope]``."""
-    reg = _reg_entity(view, entity_id) if entity_id else None
-    categories = getattr(reg, "categories", None) if reg is not None else None
-    if isinstance(categories, Mapping):
-        cat = categories.get(scope)
-        return str(cat) if cat is not None else None
-    return None
 
 
 # =============================================================================

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -10,10 +10,14 @@ capability gate. v1.1.0 ships five commands (four capabilities):
 * ``ha_mcp_tools/search`` — a unified in-process search over live registries and
   states, joined and scored, mirroring today's ``ha_search`` response envelope.
 * ``ha_mcp_tools/config_get`` — one-call fetch of a storage/editor-backed
-  automation/script/scene body + current entity_id + friendly_name + entity
-  category, collapsing the server's id-resolve + config-fetch + registry-category
-  round-trips. Storage-only: a YAML-loaded item returns a structured not-found
-  (its body is never emitted — that belongs to the future file-based tool).
+  automation/script body + current entity_id + friendly_name + entity category,
+  collapsing the server's id-resolve + config-fetch + registry-category
+  round-trips. Automation/script ONLY — scenes are excluded because a
+  ``HomeAssistantScene`` holds no raw storage body in memory (its
+  ``scene_config.states`` is runtime State objects, not the storage ``entities``
+  dict), so ``ha_config_get_scene`` stays on its legacy REST path. Storage-only:
+  a YAML-loaded item returns a structured not-found (its body is never emitted —
+  that belongs to the future file-based tool).
 * ``ha_mcp_tools/overview`` — the raw in-process reads the server's
   ``get_system_overview`` + ``ha_get_overview`` wrapper consume (states,
   services, entity/device/area registries, ``hass.config``, persistent
@@ -142,6 +146,17 @@ CONFIG_SEARCH_TYPES = (
     SEARCH_TYPE_AUTOMATION,
     SEARCH_TYPE_SCRIPT,
     SEARCH_TYPE_SCENE,
+)
+
+# Domains ``ha_mcp_tools/config_get`` will serve a storage body for. Scenes are
+# deliberately EXCLUDED (unlike search, which indexes all three): a
+# ``HomeAssistantScene`` keeps ``scene_config.states`` as runtime State objects,
+# not the storage ``entities`` dict, so there is no raw storage body in memory to
+# return — a component-served scene body would break shape parity and
+# ``config_hash`` stability, so ``ha_config_get_scene`` stays on its legacy path.
+CONFIG_GET_DOMAINS = (
+    SEARCH_TYPE_AUTOMATION,
+    SEARCH_TYPE_SCRIPT,
 )
 
 # Collection ("storage collection") helpers — entities in the state machine.
@@ -275,7 +290,7 @@ def _search_schema() -> dict[Any, Any]:
 def _config_get_schema() -> dict[Any, Any]:
     return {
         vol.Required("type"): WS_CONFIG_GET,
-        vol.Required("domain"): vol.In(list(CONFIG_SEARCH_TYPES)),
+        vol.Required("domain"): vol.In(list(CONFIG_GET_DOMAINS)),
         vol.Required("item_id"): str,
     }
 
@@ -1357,7 +1372,13 @@ def _reg_name(reg: Any) -> str | None:
 # ha_mcp_tools/config_get
 # =============================================================================
 def _do_config_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
-    """One-call fetch of a storage-backed automation/script/scene config body.
+    """One-call fetch of a storage-backed automation/script config body.
+
+    Automation/script ONLY — the schema (:func:`_config_get_schema`) rejects any
+    other domain. Scenes are excluded on purpose: a ``HomeAssistantScene`` keeps
+    no raw storage body in memory (``scene_config.states`` is runtime State
+    objects, not the storage ``entities`` dict), so ``ha_config_get_scene`` stays
+    on its legacy REST path.
 
     Storage-only (maintainer decision): a YAML-loaded item (id-less, same
     ``_classify_source`` rule as search) returns a structured not-found and its

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2,13 +2,32 @@
 
 This module registers versioned ``ha_mcp_tools/*`` WebSocket commands that the
 ha-mcp server calls in-process (same HA core, no REST/WS round-trips) behind a
-capability gate. v1.1.0 ships two commands:
+capability gate. v1.1.0 ships five commands (four capabilities):
 
 * ``ha_mcp_tools/info`` — the handshake: ``schema_version`` + ``capabilities[]``
   + ``component_version`` + advisory ``limits``. One cached probe tells the
   server which commands are live (capability negotiation, NOT a version floor).
 * ``ha_mcp_tools/search`` — a unified in-process search over live registries and
   states, joined and scored, mirroring today's ``ha_search`` response envelope.
+* ``ha_mcp_tools/config_get`` — one-call fetch of a storage/editor-backed
+  automation/script/scene body + current entity_id + friendly_name + entity
+  category, collapsing the server's id-resolve + config-fetch + registry-category
+  round-trips. Storage-only: a YAML-loaded item returns a structured not-found
+  (its body is never emitted — that belongs to the future file-based tool).
+* ``ha_mcp_tools/overview`` — the raw in-process reads the server's
+  ``get_system_overview`` + ``ha_get_overview`` wrapper consume (states,
+  services, entity/device/area registries, ``hass.config``, persistent
+  notifications, repairs issues) in one call, so the server builds its existing
+  overview envelope with no extra HA round-trips.
+* ``ha_mcp_tools/helpers_list`` — collection helpers (live state-attribute
+  bodies) AND flow helpers (``ConfigEntry.options``/``title``/``entry_id`` —
+  never ``entry.data``), each with the CURRENT entity_id + display name from the
+  registry (renamed helpers show current values — issue #1794), closing the
+  documented "flow helpers cannot be listed" gap with no OptionsFlow dance. The
+  response's ``covered_types`` names which helper_type values were authoritatively
+  enumerated, so the server falls back to its legacy ``<type>/list`` path for an
+  uncovered type (e.g. ``tag``, which has no state entity) instead of trusting an
+  empty result.
 
 Design notes that are load-bearing:
 
@@ -33,9 +52,9 @@ Design notes that are load-bearing:
   registries — run synchronously, no executor, no persistent index (always
   fresh, zero cache-invalidation surface).
 
-Extension point — to add a command later (overview / config_get / helpers_list):
-write ``_do_<name>(hass, params)``, append its capability to :data:`CAPABILITIES`,
-and add one row to :func:`_command_specs`. ``info`` enumerates the rest.
+Extension point — to add another command later: write ``_do_<name>(hass,
+params)``, append its capability to :data:`CAPABILITIES`, and add one row to
+:func:`_command_specs`. ``info`` enumerates the rest.
 """
 
 from __future__ import annotations
@@ -64,6 +83,9 @@ from homeassistant.helpers import (
     floor_registry as fr,
 )
 from homeassistant.helpers import (
+    issue_registry as ir,
+)
+from homeassistant.helpers import (
     label_registry as lr,
 )
 
@@ -75,6 +97,9 @@ _LOGGER = logging.getLogger(__name__)
 WS_API_PREFIX = "ha_mcp_tools"
 WS_INFO = f"{WS_API_PREFIX}/info"
 WS_SEARCH = f"{WS_API_PREFIX}/search"
+WS_CONFIG_GET = f"{WS_API_PREFIX}/config_get"
+WS_OVERVIEW = f"{WS_API_PREFIX}/overview"
+WS_HELPERS_LIST = f"{WS_API_PREFIX}/helpers_list"
 
 # Wire-format generation of the request/response envelopes. Bumped only on an
 # *incompatible* shape change to an existing command; additive fields do not
@@ -83,8 +108,9 @@ SCHEMA_VERSION = 1
 
 # Which commands exist. Grows one entry per shipped command; the server gates
 # each consumer on ``capability in caps.capabilities``. Never remove an entry
-# without a major bump.
-CAPABILITIES: list[str] = ["search"]
+# without a major bump. (``info`` is always present in 1.1.0, so it carries no
+# capability key of its own.)
+CAPABILITIES: list[str] = ["search", "config_get", "overview", "helpers_list"]
 
 # Advisory caps advertised in ``info.limits`` so no single WS frame balloons.
 MAX_RESULTS = 500
@@ -160,6 +186,23 @@ FLOW_HELPER_DOMAINS = frozenset(
     }
 )
 
+# Collection helper domains enumerated by ``ha_mcp_tools/helpers_list``: the
+# collection helpers ``search`` indexes PLUS zone/person, which are state-machine
+# entities the server's ``ha_config_list_helpers`` also accepts. Kept SEPARATE
+# from :data:`COLLECTION_HELPER_DOMAINS` so search behaviour is unchanged — zones
+# and persons are not indexed as "helpers" by ``ha_mcp_tools/search``.
+#
+# ``tag`` is deliberately EXCLUDED: tags are a storage collection with no state
+# entity (the server reaches them via ``tag/list``, and its create/list paths
+# special-case ``tag`` precisely because it has no entity_id), so a from-states
+# scan can never enumerate them. Advertising it as covered would make an empty
+# result indistinguishable from "no tags exist" (a silent-wrong listing); it is
+# left OUT of ``covered_types`` so the server falls back to its legacy
+# ``tag/list`` path for that type. See :func:`_do_helpers_list`.
+HELPERS_LIST_COLLECTION_DOMAINS = COLLECTION_HELPER_DOMAINS | frozenset(
+    {"zone", "person"}
+)
+
 _SPLIT_RE = re.compile(r"[._\-\s]+")
 
 
@@ -187,6 +230,9 @@ def _command_specs() -> list[tuple[dict[Any, Any], Any]]:
     return [
         (_info_schema(), lambda hass, msg: _do_info()),
         (_search_schema(), _do_search),
+        (_config_get_schema(), _do_config_get),
+        (_overview_schema(), _do_overview),
+        (_helpers_list_schema(), _do_helpers_list),
     ]
 
 
@@ -223,6 +269,30 @@ def _search_schema() -> dict[Any, Any]:
             int, vol.Range(min=1, max=MAX_RESULTS)
         ),
         vol.Optional("offset", default=0): vol.All(int, vol.Range(min=0)),
+    }
+
+
+def _config_get_schema() -> dict[Any, Any]:
+    return {
+        vol.Required("type"): WS_CONFIG_GET,
+        vol.Required("domain"): vol.In(list(CONFIG_SEARCH_TYPES)),
+        vol.Required("item_id"): str,
+    }
+
+
+def _overview_schema() -> dict[Any, Any]:
+    return {
+        vol.Required("type"): WS_OVERVIEW,
+        vol.Optional("include_notifications", default=True): bool,
+        vol.Optional("include_repairs", default=True): bool,
+    }
+
+
+def _helpers_list_schema() -> dict[Any, Any]:
+    return {
+        vol.Required("type"): WS_HELPERS_LIST,
+        vol.Optional("helper_types"): [str],
+        vol.Optional("include_flow_helpers", default=True): bool,
     }
 
 
@@ -1231,3 +1301,544 @@ def _call_lookup(registry: Any, method: str, key: str) -> Any:
         return getter(key)
     except Exception:  # pragma: no cover - defensive
         return None
+
+
+def _call_no_arg(obj: Any, method: str) -> Any:
+    """Call a no-argument accessor (e.g. ``async_services``), guarded."""
+    if obj is None:
+        return None
+    fn = getattr(obj, method, None)
+    if not callable(fn):
+        return None
+    try:
+        return fn()
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _iso(value: Any) -> Any:
+    """Serialize a datetime-ish value to an ISO string; pass through otherwise.
+
+    HA registry/state timestamps are ``datetime`` objects. The WS layer can
+    encode them, but the REST shapes the overview consumer mirrors carry ISO
+    strings, so normalize here for a stable wire contract.
+    """
+    if value is None:
+        return None
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        try:
+            return iso()
+        except Exception:  # pragma: no cover - defensive
+            return None
+    return value if isinstance(value, (str, int, float, bool)) else str(value)
+
+
+def _enum_value(value: Any) -> Any:
+    """Unwrap a StrEnum-ish registry field (``entity_category``/``hidden_by``/…).
+
+    HA stores these as enums whose ``.value`` is the wire string; a plain string
+    (or None) passes through unchanged.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    return getattr(value, "value", str(value))
+
+
+def _reg_name(reg: Any) -> str | None:
+    """Current display name from a registry entry: user override, else original."""
+    if reg is None:
+        return None
+    name = getattr(reg, "name", None) or getattr(reg, "original_name", None)
+    return str(name) if name else None
+
+
+# =============================================================================
+# ha_mcp_tools/config_get
+# =============================================================================
+def _do_config_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+    """One-call fetch of a storage-backed automation/script/scene config body.
+
+    Storage-only (maintainer decision): a YAML-loaded item (id-less, same
+    ``_classify_source`` rule as search) returns a structured not-found and its
+    body is NEVER emitted — YAML-body retrieval belongs to a future file-based
+    tool. Collapses the server's id-resolve + config-fetch + registry-category
+    round-trips into one in-process call.
+    """
+    domain = params["domain"]
+    item_id = str(params["item_id"])
+
+    entity, name, storage_id, config_dict = _find_config_item(hass, domain, item_id)
+    if entity is None:
+        # Nothing resolves — a clean not-found (mirrors the REST 404).
+        return {"found": False, "domain": domain, "item_id": item_id, "source": None}
+
+    entity_id = getattr(entity, "entity_id", None)
+    if _classify_source(storage_id) != "storage":
+        # Resolved to a YAML item: structured not-found, body absent.
+        return {
+            "found": False,
+            "domain": domain,
+            "item_id": item_id,
+            "entity_id": entity_id,
+            "source": "yaml",
+        }
+
+    view = _resolve_registries(hass)
+    return {
+        "found": True,
+        "domain": domain,
+        "item_id": storage_id,
+        "entity_id": entity_id,
+        "friendly_name": _current_friendly_name(hass, entity_id, name),
+        "config": config_dict,
+        "source": "storage",
+        "category": _entity_category(view, entity_id, domain),
+    }
+
+
+def _find_config_item(
+    hass: HomeAssistant, domain: str, item_id: str
+) -> tuple[Any, str | None, str | None, dict[str, Any] | None]:
+    """Resolve (entity, name, storage_id, config_dict) for a config id, or Nones.
+
+    Matches ``item_id`` against the loaded entity's entity_id, its storage id
+    (unique_id / raw_config ``id``), or its object_id slug — the same identifiers
+    the server accepts for ``ha_config_get_*``.
+    """
+    component = hass.data.get(domain) if getattr(hass, "data", None) else None
+    entities = getattr(component, "entities", None)
+    if entities is None:
+        return None, None, None, None
+    for entity in entities:
+        entity_id = getattr(entity, "entity_id", None)
+        if not entity_id:
+            continue
+        name, storage_id, config_dict = _extract_config(domain, entity)
+        object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+        if item_id in (entity_id, storage_id, object_id):
+            return entity, name, storage_id, config_dict
+    return None, None, None, None
+
+
+def _current_friendly_name(
+    hass: HomeAssistant, entity_id: str | None, fallback: str | None
+) -> str | None:
+    """Current friendly_name from the state machine, falling back to the config name."""
+    if entity_id:
+        for state in _iter_states(hass):
+            if getattr(state, "entity_id", None) != entity_id:
+                continue
+            attrs = getattr(state, "attributes", None) or {}
+            friendly = (
+                attrs.get("friendly_name") if isinstance(attrs, Mapping) else None
+            )
+            if friendly:
+                return str(friendly)
+            break
+    if fallback:
+        return str(fallback)
+    return entity_id
+
+
+def _entity_category(view: _RegistryView, entity_id: str | None, scope: str) -> Any:
+    """In-process equivalent of ``fetch_entity_category``: registry ``categories[scope]``."""
+    reg = _reg_entity(view, entity_id) if entity_id else None
+    categories = getattr(reg, "categories", None) if reg is not None else None
+    if isinstance(categories, Mapping):
+        cat = categories.get(scope)
+        return str(cat) if cat is not None else None
+    return None
+
+
+# =============================================================================
+# ha_mcp_tools/helpers_list
+# =============================================================================
+def _do_helpers_list(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+    """List collection helpers (live state bodies) + flow helpers (config-entry options).
+
+    Flow-helper ``options`` come straight from ``ConfigEntry.options`` — no
+    OptionsFlow start/abort dance, and NEVER ``entry.data`` (integration
+    credentials). Every record carries the CURRENT entity_id + display name from
+    the entity registry so a renamed helper shows current values (issue #1794),
+    not the stale storage-collection name. No secret scrub: collection bodies are
+    live state attributes and flow options are storage-backed — neither is
+    YAML-derived, so no resolved ``!secret`` plaintext can appear.
+
+    ``covered_types`` names exactly the helper_type values this command can
+    enumerate (the state-machine collection domains + the flow domains, minus the
+    flow set when ``include_flow_helpers`` is false). It is the anti-silent-wrong
+    signal: for a requested helper_type NOT in ``covered_types`` (e.g. ``tag``,
+    which has no state entity), an empty ``helpers`` list means "cannot
+    enumerate", NOT "none exist" — the server must fall back to its legacy
+    ``<type>/list`` path rather than trust the emptiness.
+    """
+    requested = params.get("helper_types")
+    type_filter = frozenset(requested) if requested else None
+    include_flow = params.get("include_flow_helpers", True)
+
+    view = _resolve_registries(hass)
+    helpers = _collection_helpers_list(hass, view, type_filter)
+    covered = set(HELPERS_LIST_COLLECTION_DOMAINS)
+    if include_flow:
+        helpers.extend(_flow_helpers_list(hass, view, type_filter))
+        covered |= FLOW_HELPER_DOMAINS
+    return {
+        "helpers": helpers,
+        "count": len(helpers),
+        "covered_types": sorted(covered),
+    }
+
+
+def _collection_helpers_list(
+    hass: HomeAssistant, view: _RegistryView, type_filter: frozenset[str] | None
+) -> list[dict[str, Any]]:
+    """Collection helpers from the state machine (input_*, counter, timer, zone, …)."""
+    out: list[dict[str, Any]] = []
+    for state in _iter_states(hass):
+        entity_id = getattr(state, "entity_id", "") or ""
+        domain = entity_id.split(".")[0] if "." in entity_id else ""
+        if domain not in HELPERS_LIST_COLLECTION_DOMAINS:
+            continue
+        if type_filter is not None and domain not in type_filter:
+            continue
+        attrs = getattr(state, "attributes", None) or {}
+        body = dict(attrs) if isinstance(attrs, Mapping) else {}
+        object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+        reg = _reg_entity(view, entity_id)
+        # Current display name: state friendly_name reflects a registry rename;
+        # fall back to the registry name, then the object_id.
+        current = attrs.get("friendly_name") if isinstance(attrs, Mapping) else None
+        name = current or _reg_name(reg) or object_id
+        storage_id = getattr(reg, "unique_id", None) or object_id
+        out.append(
+            {
+                "helper_type": domain,
+                "kind": "collection",
+                "entity_id": entity_id,
+                "object_id": object_id,
+                "name": str(name),
+                "storage_id": storage_id,
+                "config": _plainify(body),
+            }
+        )
+    return out
+
+
+def _flow_helpers_list(
+    hass: HomeAssistant, view: _RegistryView, type_filter: frozenset[str] | None
+) -> list[dict[str, Any]]:
+    """Flow (config-entry-backed) helpers — options + title + entry_id, never data."""
+    out: list[dict[str, Any]] = []
+    entity_by_entry = _entities_by_config_entry(view)
+    for entry in _iter_config_entries(hass):
+        domain = getattr(entry, "domain", None)
+        if domain not in FLOW_HELPER_DOMAINS:
+            continue
+        if type_filter is not None and domain not in type_filter:
+            continue
+        entry_id = getattr(entry, "entry_id", None)
+        title = getattr(entry, "title", None) or ""
+        raw_options = getattr(entry, "options", None)
+        options = (
+            _plainify(dict(raw_options)) if isinstance(raw_options, Mapping) else {}
+        )
+        reg = entity_by_entry.get(entry_id)
+        entity_id = getattr(reg, "entity_id", None) if reg is not None else None
+        name = _reg_name(reg) or _current_friendly_name(hass, entity_id, title)
+        out.append(
+            {
+                "helper_type": domain,
+                "kind": "flow",
+                "entry_id": entry_id,
+                "entity_id": entity_id,
+                "name": str(name) if name else title,
+                "storage_id": entry_id,
+                # Data minimization: options only, never entry.data.
+                "options": options,
+            }
+        )
+    return out
+
+
+def _entities_by_config_entry(view: _RegistryView) -> dict[Any, Any]:
+    """Index the first registry entity bound to each config entry (flow helpers)."""
+    index: dict[Any, Any] = {}
+    for entry in _all_entity_entries(view):
+        config_entry_id = getattr(entry, "config_entry_id", None)
+        if config_entry_id and config_entry_id not in index:
+            index[config_entry_id] = entry
+    return index
+
+
+def _all_entity_entries(view: _RegistryView) -> list[Any]:
+    """All entity-registry entries (``registry.entities`` is a mapping in HA)."""
+    reg = view.entity
+    entities = getattr(reg, "entities", None) if reg is not None else None
+    if entities is None:
+        return []
+    try:
+        return list(entities.values())
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+# =============================================================================
+# ha_mcp_tools/overview
+# =============================================================================
+def _do_overview(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+    """Return the raw in-process reads the server's overview path consumes.
+
+    NOT the assembled overview envelope — the RAW slices the server's
+    ``get_system_overview`` + ``ha_get_overview`` wrapper fetch today (states,
+    services, entity/device/area registries, ``hass.config``, persistent
+    notifications, repairs issues). The server runs its existing overview logic
+    over these, so detail_level / domains / pagination stay server-side and no
+    logic is duplicated (or drifts) in the component. Registries are BARE lists
+    (not the ``{success, result}`` WS wrapper); the server adapts. Collapses the
+    ~8 round-trips to one in-process call.
+    """
+    include_notifications = params.get("include_notifications", True)
+    include_repairs = params.get("include_repairs", True)
+
+    view = _resolve_registries(hass)
+    result: dict[str, Any] = {
+        "states": _overview_states(hass),
+        "services": _overview_services(hass),
+        "entity_registry": _overview_entity_registry(view),
+        "device_registry": _overview_device_registry(view),
+        "area_registry": _overview_area_registry(view),
+        "config": _overview_config(hass),
+        "notifications": _overview_notifications(hass) if include_notifications else [],
+        "repairs": _overview_repairs(hass) if include_repairs else [],
+    }
+    return result
+
+
+def _overview_states(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """States in the ``client.get_states()`` shape the overview consumer reads."""
+    out: list[dict[str, Any]] = []
+    for state in _iter_states(hass):
+        entity_id = getattr(state, "entity_id", None)
+        if not entity_id:
+            continue
+        attrs = getattr(state, "attributes", None) or {}
+        out.append(
+            {
+                "entity_id": entity_id,
+                "state": getattr(state, "state", "unknown"),
+                "attributes": _plainify(dict(attrs))
+                if isinstance(attrs, Mapping)
+                else {},
+                "last_changed": _iso(getattr(state, "last_changed", None)),
+                "last_updated": _iso(getattr(state, "last_updated", None)),
+            }
+        )
+    return out
+
+
+def _overview_services(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Service catalog in the ``client.get_services()`` list shape.
+
+    The consumer's ``_build_service_stats`` reads only the per-domain service
+    *names*, so each service maps to an empty dict — keeps the frame small while
+    preserving the ``{domain, services: {name: {...}}}`` structure.
+    """
+    services = _call_no_arg(getattr(hass, "services", None), "async_services")
+    if not isinstance(services, Mapping):
+        return []
+    out: list[dict[str, Any]] = []
+    for domain, svcs in services.items():
+        names = list(svcs.keys()) if isinstance(svcs, Mapping) else []
+        out.append({"domain": domain, "services": {name: {} for name in names}})
+    return out
+
+
+def _overview_entity_registry(view: _RegistryView) -> list[dict[str, Any]]:
+    """Entity registry as a bare list, with the fields the overview + visibility
+    consumers read (area/device/labels/entity_category/hidden_by/options/…)."""
+    out: list[dict[str, Any]] = []
+    for entry in _all_entity_entries(view):
+        entity_id = getattr(entry, "entity_id", None)
+        if not entity_id:
+            continue
+        out.append(
+            {
+                "entity_id": entity_id,
+                "area_id": getattr(entry, "area_id", None),
+                "device_id": getattr(entry, "device_id", None),
+                "labels": sorted(
+                    str(x) for x in (getattr(entry, "labels", None) or [])
+                ),
+                "entity_category": _enum_value(getattr(entry, "entity_category", None)),
+                "hidden_by": _enum_value(getattr(entry, "hidden_by", None)),
+                "categories": _plainify(getattr(entry, "categories", None) or {}),
+                "options": _plainify(getattr(entry, "options", None) or {}),
+                "name": getattr(entry, "name", None),
+                "original_name": getattr(entry, "original_name", None),
+                "platform": getattr(entry, "platform", None),
+                "unique_id": getattr(entry, "unique_id", None),
+                "disabled_by": _enum_value(getattr(entry, "disabled_by", None)),
+            }
+        )
+    return out
+
+
+def _overview_device_registry(view: _RegistryView) -> list[dict[str, Any]]:
+    """Device registry as a bare list (id + area + labels + name/manufacturer/model)."""
+    out: list[dict[str, Any]] = []
+    reg = view.device
+    devices = getattr(reg, "devices", None) if reg is not None else None
+    values = _mapping_values(devices)
+    for dev in values:
+        dev_id = getattr(dev, "id", None)
+        if not dev_id:
+            continue
+        out.append(
+            {
+                "id": dev_id,
+                "area_id": getattr(dev, "area_id", None),
+                "labels": sorted(str(x) for x in (getattr(dev, "labels", None) or [])),
+                "name": getattr(dev, "name", None),
+                "name_by_user": getattr(dev, "name_by_user", None),
+                "manufacturer": getattr(dev, "manufacturer", None),
+                "model": getattr(dev, "model", None),
+            }
+        )
+    return out
+
+
+def _overview_area_registry(view: _RegistryView) -> list[dict[str, Any]]:
+    """Area registry as a bare list (area_id + name + floor_id)."""
+    out: list[dict[str, Any]] = []
+    for area in _all_area_entries(view):
+        area_id = getattr(area, "id", None) or getattr(area, "area_id", None)
+        if not area_id:
+            continue
+        out.append(
+            {
+                "area_id": area_id,
+                "name": getattr(area, "name", None),
+                "floor_id": getattr(area, "floor_id", None),
+            }
+        )
+    return out
+
+
+def _all_area_entries(view: _RegistryView) -> list[Any]:
+    """All area-registry entries via ``async_list_areas()`` or the ``areas`` mapping."""
+    reg = view.area
+    if reg is None:
+        return []
+    listed = _call_no_arg(reg, "async_list_areas")
+    if listed is not None:
+        try:
+            return list(listed)
+        except Exception:  # pragma: no cover - defensive
+            return []
+    return _mapping_values(getattr(reg, "areas", None))
+
+
+def _mapping_values(mapping: Any) -> list[Any]:
+    """``list(mapping.values())`` guarded against a non-mapping / drift."""
+    if mapping is None:
+        return []
+    try:
+        return list(mapping.values())
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _overview_config(hass: HomeAssistant) -> dict[str, Any]:
+    """The ``hass.config`` fields the wrapper's ``_fetch_system_info`` reads.
+
+    ``base_url`` is intentionally omitted — the server supplies it from its own
+    client; only HA-core config values are the component's to provide.
+    """
+    config = getattr(hass, "config", None)
+    raw = _call_no_arg(config, "as_dict")
+    if not isinstance(raw, Mapping):
+        return {}
+    keys = (
+        "version",
+        "location_name",
+        "time_zone",
+        "language",
+        "state",
+        "country",
+        "currency",
+        "unit_system",
+        "latitude",
+        "longitude",
+        "elevation",
+        "components",
+        "safe_mode",
+        "internal_url",
+        "external_url",
+        "allowlist_external_dirs",
+    )
+    return {k: _plainify(raw[k]) for k in keys if k in raw}
+
+
+def _overview_notifications(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Active persistent notifications (``persistent_notification/get`` shape)."""
+    store = getattr(hass, "data", None)
+    data = store.get("persistent_notification") if isinstance(store, Mapping) else None
+    return [
+        {
+            "notification_id": _field(note, "notification_id"),
+            "title": _field(note, "title"),
+            "message": _field(note, "message"),
+            "created_at": _iso(_field(note, "created_at")),
+        }
+        for note in _notification_values(data)
+    ]
+
+
+def _field(obj: Any, key: str) -> Any:
+    """Read ``key`` from a mapping (``.get``) or an object (``getattr``)."""
+    if isinstance(obj, Mapping):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _notification_values(data: Any) -> list[Any]:
+    """Notification records: ``{id: note}`` mapping values, or a bare list."""
+    if isinstance(data, Mapping):
+        return list(data.values())
+    if isinstance(data, list):
+        return list(data)
+    return []
+
+
+def _overview_repairs(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Raw issue-registry entries (the server filters/projects them itself).
+
+    ``ignored`` is derived from ``dismissed_version`` so the server's
+    ``filter_active_repairs`` (which keys off ``ignored``) works unchanged.
+    """
+    registry = _safe(ir.async_get, hass)
+    issues = getattr(registry, "issues", None) if registry is not None else None
+    out: list[dict[str, Any]] = []
+    for issue in _mapping_values(issues):
+        dismissed = getattr(issue, "dismissed_version", None)
+        out.append(
+            {
+                "issue_id": getattr(issue, "issue_id", None),
+                "domain": getattr(issue, "domain", None),
+                "severity": _enum_value(getattr(issue, "severity", None)),
+                "translation_key": getattr(issue, "translation_key", None),
+                "translation_placeholders": _plainify(
+                    getattr(issue, "translation_placeholders", None) or {}
+                ),
+                "ignored": dismissed is not None,
+                "dismissed_version": dismissed,
+                "is_fixable": getattr(issue, "is_fixable", None),
+                "breaks_in_ha_version": getattr(issue, "breaks_in_ha_version", None),
+                "created": _iso(getattr(issue, "created", None)),
+                "issue_domain": getattr(issue, "issue_domain", None),
+                "learn_more_url": getattr(issue, "learn_more_url", None),
+                "active": getattr(issue, "active", None),
+            }
+        )
+    return out

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -36,25 +36,28 @@ capability gate. v1.1.0 ships five commands (four capabilities):
 Design notes that are load-bearing:
 
 * **Capability negotiation, not version-lockstep.** ``CAPABILITIES`` grows one
-  entry per shipped command; the server asks "do you support ``search``?"
-  rather than "are you >= X". The manifest version is reported for display only.
+  entry per shipped command (except the always-present ``info`` handshake); the
+  server asks "do you support ``search``?" rather than "are you >= X". The
+  manifest version is reported for display only.
 * **Data minimization.** Flow-helper indexing reads ``ConfigEntry.options`` /
   ``title`` only — **never** ``ConfigEntry.data`` (integration credentials).
 * **YAML config bodies are never emitted.** automation/script/scene bodies are
   indexed for *matching*, but a matched item's ``config`` body is returned only
   when it is storage/editor-backed AND ``include_config`` is set. YAML-loaded
   items return identity/metadata only (their ``raw_config`` may carry resolved
-  ``!secret`` plaintext). Body emission for YAML belongs to the future
-  ``config_get`` command.
+  ``!secret`` plaintext). Body emission for YAML belongs to a future file-based
+  tool.
 * **Resolved secrets are scrubbed from the match corpus.** Because YAML bodies
   (and flow-helper options) can hold ``!secret`` values resolved to plaintext,
   a body leaf that exactly equals a ``secrets.yaml`` value is dropped before
   scoring (:func:`_load_secret_values`) — otherwise a query equal to a suspected
   secret would confirm it via ``match_in_config`` (a probe oracle). Blocked, not
   merely unemitted.
-* **Event-loop hygiene.** Every join is a pure in-memory read over live
-  registries — run synchronously, no executor, no persistent index (always
-  fresh, zero cache-invalidation surface).
+* **Event-loop hygiene.** Every registry/state join is a pure in-memory read
+  over live data — run synchronously, no persistent index (always fresh, zero
+  cache-invalidation surface). The one blocking read — ``secrets.yaml`` for the
+  match-corpus scrub — runs in the executor via the command wrapper's async
+  pre-step (:func:`_search_prep`), never on the event loop.
 
 Extension point — to add another command later: write ``_do_<name>(hass,
 params)``, append its capability to :data:`CAPABILITIES`, and add one row to
@@ -218,6 +221,15 @@ HELPERS_LIST_COLLECTION_DOMAINS = COLLECTION_HELPER_DOMAINS | frozenset(
     {"zone", "person"}
 )
 
+# Every ``EntityComponent`` self-registers here (core's
+# ``entity_component.DATA_INSTANCES``). Collection-helper domains (input_*,
+# counter, timer, schedule) do NOT set ``hass.data[DOMAIN]`` and their
+# ``StorageCollection`` is a setup-local (``helpers/collection.py`` writes
+# nothing to ``hass.data``), so this registry is how their component — and thus
+# each entity's storage ``_config`` body — is reached. See
+# :func:`_collection_storage_index`.
+ENTITY_COMPONENTS_KEY = "entity_components"
+
 _SPLIT_RE = re.compile(r"[._\-\s]+")
 
 
@@ -231,8 +243,8 @@ def async_register_commands(hass: HomeAssistant) -> None:
     so re-running on a config-entry reload is harmless. Called from the tools
     config-entry setup alongside the service registrations.
     """
-    for schema, do_fn in _command_specs():
-        websocket_api.async_register_command(hass, _build_handler(schema, do_fn))
+    for schema, do_fn, prep in _command_specs():
+        websocket_api.async_register_command(hass, _build_handler(schema, do_fn, prep))
     _LOGGER.debug(
         "Registered ha_mcp_tools WS commands: schema_version=%s capabilities=%s",
         SCHEMA_VERSION,
@@ -240,19 +252,30 @@ def async_register_commands(hass: HomeAssistant) -> None:
     )
 
 
-def _command_specs() -> list[tuple[dict[Any, Any], Any]]:
-    """The (schema, pure-handler) rows. Append one row to add a command."""
+def _command_specs() -> list[tuple[dict[Any, Any], Any, Any]]:
+    """The (schema, pure-handler, async-prep) rows. Append one row per command.
+
+    ``prep`` (or ``None``) is an ``async`` pre-step run before the pure handler;
+    it returns keyword args merged into the ``do_fn`` call. It is the seam for a
+    command that must touch the filesystem/network off the event loop —
+    :func:`_search_prep` loads ``secrets.yaml`` in the executor — keeping every
+    ``_do_*`` function a pure, synchronous in-memory read.
+    """
     return [
-        (_info_schema(), lambda hass, msg: _do_info()),
-        (_search_schema(), _do_search),
-        (_config_get_schema(), _do_config_get),
-        (_overview_schema(), _do_overview),
-        (_helpers_list_schema(), _do_helpers_list),
+        (_info_schema(), lambda hass, msg: _do_info(), None),
+        (_search_schema(), _do_search, _search_prep),
+        (_config_get_schema(), _do_config_get, None),
+        (_overview_schema(), _do_overview, None),
+        (_helpers_list_schema(), _do_helpers_list, None),
     ]
 
 
-def _build_handler(schema: dict[Any, Any], do_fn: Any) -> Any:
-    """Wrap a pure ``_do_*`` function as an admin-gated WS command handler."""
+def _build_handler(schema: dict[Any, Any], do_fn: Any, prep: Any = None) -> Any:
+    """Wrap a pure ``_do_*`` function as an admin-gated WS command handler.
+
+    An optional ``prep`` async pre-step runs first (off-loop I/O such as the
+    ``secrets.yaml`` read); the keyword args it returns are passed to ``do_fn``.
+    """
 
     @websocket_api.websocket_command(schema)
     @websocket_api.require_admin
@@ -260,7 +283,8 @@ def _build_handler(schema: dict[Any, Any], do_fn: Any) -> Any:
     async def _handler(
         hass: HomeAssistant, connection: Any, msg: dict[str, Any]
     ) -> None:
-        connection.send_result(msg["id"], do_fn(hass, msg))
+        extra = await prep(hass, msg) if prep is not None else {}
+        connection.send_result(msg["id"], do_fn(hass, msg, **extra))
 
     return _handler
 
@@ -356,11 +380,21 @@ def _safe(fn: Any, hass: HomeAssistant) -> Any:
         return None
 
 
-def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+def _do_search(
+    hass: HomeAssistant,
+    params: dict[str, Any],
+    *,
+    secret_values: frozenset[str] = frozenset(),
+) -> dict[str, Any]:
     """Unified in-process search. Pure over ``hass`` — the WS wrapper is thin.
 
     Joins live registries + states, scores per the server's tiers, paginates
     per surface, and returns the ``ha_search``-shaped envelope.
+
+    ``secret_values`` is the resolved-``!secret`` scrub set, loaded off the event
+    loop by :func:`_search_prep` and passed in (default empty — the loader is
+    skipped for an entity-only search, and direct callers/tests supply it
+    explicitly). It keeps this function a pure, synchronous in-memory read.
     """
     query_lower = (params.get("query") or "").strip().lower()
     match_all = not query_lower
@@ -378,19 +412,11 @@ def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
     diagnostics: dict[str, int] = {}
     partial_reasons: list[str] = []
 
-    # Resolved-!secret scrub set: config bodies (YAML-loaded automations/scripts/
-    # scenes reach this path, unlike the server's 404-ing per-id path) can carry
-    # a secret already resolved to plaintext, and matching inside it would make
-    # ha_search a probe oracle (query a suspected secret, confirm via
-    # match_in_config). Load the secrets.yaml values once per call, only when a
-    # config/helper surface is actually searched, so entity-only searches skip
-    # the file read entirely.
-    scrub_surfaces = (*CONFIG_SEARCH_TYPES, SEARCH_TYPE_HELPER)
-    secret_values = (
-        _load_secret_values(hass)
-        if any(st in search_types for st in scrub_surfaces)
-        else frozenset()
-    )
+    # ``secret_values`` (loaded off-loop by _search_prep) scrubs resolved-!secret
+    # plaintext from the config-body match corpus: a YAML-loaded automation/script/
+    # scene body (or a flow-helper's options) can carry a secret resolved to
+    # plaintext, and matching inside it would make ha_search a probe oracle (query
+    # a suspected secret, confirm via match_in_config). See _load_secret_values.
 
     # --- Entities ------------------------------------------------------------
     entities: list[dict[str, Any]] = []
@@ -490,6 +516,23 @@ def _sort_key(rec: dict[str, Any]) -> str:
     return str(rec.get("entity_id") or rec.get("id") or rec.get("name") or "")
 
 
+async def _search_prep(hass: HomeAssistant, msg: dict[str, Any]) -> dict[str, Any]:
+    """Async pre-step for ``search``: load the secret-scrub set off the loop.
+
+    The scrub only applies to config/helper surfaces, so an entity-only search
+    skips the ``secrets.yaml`` read entirely (perf gate). When a scrubbed surface
+    is requested, the blocking ``open()`` + ``yaml.safe_load`` runs in the
+    executor via :meth:`hass.async_add_executor_job` so the WS handler never
+    blocks the event loop. The loaded set is handed to :func:`_do_search`.
+    """
+    search_types = msg.get("search_types") or ALL_SEARCH_TYPES
+    scrub_surfaces = (*CONFIG_SEARCH_TYPES, SEARCH_TYPE_HELPER)
+    if not any(st in search_types for st in scrub_surfaces):
+        return {"secret_values": frozenset()}
+    values = await hass.async_add_executor_job(_load_secret_values, hass)
+    return {"secret_values": values}
+
+
 def _load_secret_values(hass: HomeAssistant) -> frozenset[str]:
     """Load the string values from the instance's ``secrets.yaml``.
 
@@ -500,10 +543,12 @@ def _load_secret_values(hass: HomeAssistant) -> frozenset[str]:
     equal to a suspected secret confirmed via ``match_in_config``. Any body leaf
     that exactly equals one of these values is dropped before scoring.
 
-    Defensive by design: a missing or malformed ``secrets.yaml`` yields an empty
-    set (scrub degrades OFF, never raising). Only string values are collected —
-    a secret can be any YAML scalar, but a non-string can't be a plaintext-leak
-    leaf and is skipped. Computed once per ``_do_search`` call (see the caller),
+    Defensive by design: an absent ``secrets.yaml`` (``FileNotFoundError`` — the
+    common case) yields an empty set silently; a present-but-unreadable or
+    malformed file logs one warning and also degrades to an empty set (the scrub
+    turns OFF but never raises). Only string values are collected — a secret can
+    be any YAML scalar, but a non-string can't be a plaintext-leak leaf and is
+    skipped. Loaded off the event loop by :func:`_search_prep` once per search,
     never cached across calls, so an edited ``secrets.yaml`` applies on the next
     search. ``secrets.yaml`` is a flat ``key: value`` mapping with no custom
     tags, so the plain ``yaml.safe_load`` (not HA's ``!secret``/``!include``
@@ -519,9 +564,18 @@ def _load_secret_values(hass: HomeAssistant) -> frozenset[str]:
             return frozenset()
         with open(path, encoding="utf-8") as handle:
             raw = yaml.safe_load(handle)
-    except (OSError, yaml.YAMLError):
+    except FileNotFoundError:
+        # Expected: many instances have no secrets.yaml — nothing to scrub.
         return frozenset()
-    except Exception:  # pragma: no cover - defensive against loader edge cases
+    except Exception:
+        # Present-but-unreadable / malformed / permission error: unexpected, so
+        # warn once (this runs once per search) to surface a broken scrub, then
+        # degrade OFF (empty set) rather than raising into the WS handler.
+        _LOGGER.warning(
+            "Could not read secrets.yaml for the search secret-scrub; "
+            "continuing without it",
+            exc_info=True,
+        )
         return frozenset()
     if not isinstance(raw, dict):
         return frozenset()
@@ -782,8 +836,16 @@ def _search_config_surface(
                 continue
             score, match_in_name, match_in_config = scored
 
+        # Scenes never emit a component-served body: a HomeAssistantScene holds no
+        # raw storage dict (its states are runtime State objects), so config stays
+        # None and config_dict is used only as the faithful match corpus.
         config_out: dict[str, Any] | None = None
-        if include_config and source == "storage" and config_dict is not None:
+        if (
+            domain != SEARCH_TYPE_SCENE
+            and include_config
+            and source == "storage"
+            and config_dict is not None
+        ):
             if _too_large(config_dict):
                 partial_reasons.append(f"{domain} {entity_id} body omitted (too large)")
             else:
@@ -814,7 +876,9 @@ def _extract_config(
 
     Uses defensive getattr because the exact accessor can drift across core
     versions: automation/script expose ``raw_config``; scenes expose
-    ``scene_config`` (name/icon/id/states) rather than ``raw_config``.
+    ``scene_config`` (name/icon/id/states) rather than ``raw_config``. For a
+    scene the returned ``config_dict`` is the faithful MATCH corpus only (see
+    :func:`_scene_match_corpus`), never an emittable body.
     """
     entity_id = getattr(entity, "entity_id", "") or ""
     name = getattr(entity, "name", None) or entity_id
@@ -822,7 +886,7 @@ def _extract_config(
 
     if domain == SEARCH_TYPE_SCENE:
         scene_config = getattr(entity, "scene_config", None)
-        config_dict = _scene_config_to_dict(scene_config)
+        config_dict = _scene_match_corpus(scene_config)
         item_id = unique_id
         if item_id is None and config_dict is not None:
             item_id = config_dict.get("id")
@@ -840,17 +904,41 @@ def _extract_config(
     return str(name), (str(item_id) if item_id is not None else None), config_dict
 
 
-def _scene_config_to_dict(scene_config: Any) -> dict[str, Any] | None:
-    """Coerce a ``HomeAssistantScene.scene_config`` object into a plain dict."""
+def _scene_match_corpus(scene_config: Any) -> dict[str, Any] | None:
+    """Faithful, minimal MATCH corpus for a scene — never an emittable body.
+
+    A ``HomeAssistantScene`` holds no raw storage dict: ``scene_config.states`` is
+    a ``{entity_id: State}`` map of RUNTIME ``State`` objects. Scoring/emitting
+    those (each stringifying to ``<state light.x=on; ...>``) was garbage and
+    diverged the component's scoring from any real body. Index only the faithful,
+    non-runtime facts instead: ``id`` / ``name`` / ``icon`` plus the entity-id
+    KEYS of ``states`` (so "which scenes touch ``light.x``" still matches) — no
+    State values, no timestamps or contexts. Used for MATCHING only; the scene
+    record never emits a ``config`` body (see :func:`_search_config_surface`).
+    """
     if scene_config is None:
         return None
-    if isinstance(scene_config, dict):
-        return dict(scene_config)
+    if isinstance(scene_config, Mapping):
+        src: Mapping[str, Any] = scene_config
+    else:
+        collected: dict[str, Any] = {}
+        for attr in ("id", "name", "icon", "states", "entities"):
+            val = getattr(scene_config, attr, None)
+            if val is not None:
+                collected[attr] = val
+        src = collected
     out: dict[str, Any] = {}
-    for attr in ("id", "name", "icon", "states", "entities"):
-        val = getattr(scene_config, attr, None)
+    for key in ("id", "name", "icon"):
+        val = src.get(key)
         if val is not None:
-            out[attr] = _plainify(val)
+            out[key] = str(val)
+    entity_ids: set[str] = set()
+    for key in ("states", "entities"):
+        mapping = src.get(key)
+        if isinstance(mapping, Mapping):
+            entity_ids.update(str(k) for k in mapping)
+    if entity_ids:
+        out["entities"] = sorted(entity_ids)
     return out or None
 
 
@@ -889,6 +977,56 @@ def _too_large(config_dict: dict[str, Any]) -> bool:
 
 
 # --- Helpers surface ---------------------------------------------------------
+def _collection_storage_index(
+    hass: HomeAssistant, domains: frozenset[str]
+) -> dict[str, tuple[dict[str, Any], str | None]]:
+    """Map collection-helper ``entity_id`` -> ``(storage body, storage id)``.
+
+    Collection helpers keep their full storage config on the ``CollectionEntity``
+    as ``_config`` — a schedule's weekday blocks, an input_datetime's
+    ``has_date``/``has_time``, an input_boolean's ``initial`` — fields the live
+    state attributes do NOT carry. The ``StorageCollection`` that loaded them is a
+    setup-local (``helpers/collection.py`` writes nothing to ``hass.data``), so
+    the reachable in-process source is the domain's ``EntityComponent``
+    (``hass.data['entity_components'][domain]``, or ``hass.data[domain]`` for the
+    automation/script/scene pattern) and each entity's ``_config``.
+
+    Domains that decompose config into ``_attr_*`` instead of keeping ``_config``
+    (input_number / input_text / input_select) have no entry here; the caller
+    falls back to the state-attributes body for them (and for any YAML-defined
+    helper whose entity is absent). All access is getattr-guarded against drift.
+    """
+    index: dict[str, tuple[dict[str, Any], str | None]] = {}
+    data = getattr(hass, "data", None)
+    if not isinstance(data, Mapping):
+        return index
+    instances = data.get(ENTITY_COMPONENTS_KEY)
+    for domain in domains:
+        component = (
+            instances.get(domain) if isinstance(instances, Mapping) else None
+        ) or data.get(domain)
+        entities = getattr(component, "entities", None)
+        if entities is None:
+            continue
+        try:
+            entity_list = list(entities)
+        except Exception:  # pragma: no cover - defensive
+            continue
+        for entity in entity_list:
+            entity_id = getattr(entity, "entity_id", None)
+            if not entity_id:
+                continue
+            raw = getattr(entity, "_config", None)
+            if not isinstance(raw, dict):
+                continue
+            storage_id = getattr(entity, "unique_id", None) or raw.get("id")
+            index[entity_id] = (
+                dict(raw),
+                str(storage_id) if storage_id is not None else None,
+            )
+    return index
+
+
 def _search_helpers(
     hass: HomeAssistant,
     query_lower: str,
@@ -901,14 +1039,13 @@ def _search_helpers(
     """Index collection helpers (states) + flow helpers (config-entry options)."""
     results: list[dict[str, Any]] = []
 
-    # Collection helpers: entities in the state machine. Their searchable body is
-    # the live state attributes — an input_select's ``options``, an
-    # input_number's ``min``/``max``/``step``, etc. — so a query on an option
-    # value matches in-config the way the server's ``<type>/list`` body search
-    # does. (Residual delta vs the server: the ``<type>/list`` record's
-    # config-only leaves — e.g. ``initial`` — are not state attributes, so a
-    # match existing ONLY there is unreachable here; and the attribute set
-    # carries the CURRENT friendly_name, not the creation-time storage name.)
+    # Collection helpers: entities in the state machine, matched on entity_id /
+    # friendly_name AND the searchable config body. That body is the entity's real
+    # storage ``_config`` (a schedule's weekday blocks, an input_select's
+    # ``options`` + ``initial``, …) when reachable, falling back to the live state
+    # attributes otherwise (see _collection_storage_index). The name still comes
+    # from the CURRENT friendly_name, not the creation-time storage name.
+    storage = _collection_storage_index(hass, COLLECTION_HELPER_DOMAINS)
     for state in _iter_states(hass):
         entity_id = getattr(state, "entity_id", "") or ""
         domain = entity_id.split(".")[0] if "." in entity_id else ""
@@ -917,7 +1054,11 @@ def _search_helpers(
         attrs = getattr(state, "attributes", None) or {}
         name = attrs.get("friendly_name", entity_id)
         object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
-        body = dict(attrs) if isinstance(attrs, Mapping) else {}
+        stored = storage.get(entity_id)
+        if stored is not None:
+            body = _plainify(stored[0])
+        else:
+            body = dict(attrs) if isinstance(attrs, Mapping) else {}
         if match_all:
             score: int | None = 100
             match_in_name = False
@@ -1482,9 +1623,10 @@ def _do_helpers_list(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, A
     OptionsFlow start/abort dance, and NEVER ``entry.data`` (integration
     credentials). Every record carries the CURRENT entity_id + display name from
     the entity registry so a renamed helper shows current values (issue #1794),
-    not the stale storage-collection name. No secret scrub: collection bodies are
-    live state attributes and flow options are storage-backed — neither is
-    YAML-derived, so no resolved ``!secret`` plaintext can appear.
+    not the stale storage-collection name. No secret scrub: collection bodies come
+    from the storage collection (or live state attributes) and flow options are
+    storage-backed — neither is YAML-derived, so no resolved ``!secret`` plaintext
+    can appear.
 
     ``covered_types`` names exactly the helper_type values this command can
     enumerate (the state-machine collection domains + the flow domains, minus the
@@ -1514,8 +1656,16 @@ def _do_helpers_list(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, A
 def _collection_helpers_list(
     hass: HomeAssistant, view: _RegistryView, type_filter: frozenset[str] | None
 ) -> list[dict[str, Any]]:
-    """Collection helpers from the state machine (input_*, counter, timer, zone, …)."""
+    """Collection helpers from the state machine (input_*, counter, timer, zone, …).
+
+    The record's ``config`` is the entity's real storage ``_config`` body when
+    reachable — so a schedule surfaces its weekday blocks, which the live state
+    attributes omit — falling back to the state attributes otherwise (see
+    :func:`_collection_storage_index`). ``name`` stays the CURRENT display name
+    (a rename updates the registry, not the storage body — issue #1794).
+    """
     out: list[dict[str, Any]] = []
+    storage = _collection_storage_index(hass, HELPERS_LIST_COLLECTION_DOMAINS)
     for state in _iter_states(hass):
         entity_id = getattr(state, "entity_id", "") or ""
         domain = entity_id.split(".")[0] if "." in entity_id else ""
@@ -1524,14 +1674,20 @@ def _collection_helpers_list(
         if type_filter is not None and domain not in type_filter:
             continue
         attrs = getattr(state, "attributes", None) or {}
-        body = dict(attrs) if isinstance(attrs, Mapping) else {}
         object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
         reg = _reg_entity(view, entity_id)
         # Current display name: state friendly_name reflects a registry rename;
         # fall back to the registry name, then the object_id.
         current = attrs.get("friendly_name") if isinstance(attrs, Mapping) else None
         name = current or _reg_name(reg) or object_id
-        storage_id = getattr(reg, "unique_id", None) or object_id
+        # Prefer the real storage body + id; the state attributes omit fields like
+        # a schedule's weekday blocks.
+        stored = storage.get(entity_id)
+        if stored is not None:
+            body, storage_id = stored
+        else:
+            body = dict(attrs) if isinstance(attrs, Mapping) else {}
+            storage_id = getattr(reg, "unique_id", None) or object_id
         out.append(
             {
                 "helper_type": domain,
@@ -1618,21 +1774,51 @@ def _do_overview(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
     logic is duplicated (or drifts) in the component. Registries are BARE lists
     (not the ``{success, result}`` WS wrapper); the server adapts. Collapses the
     ~8 round-trips to one in-process call.
+
+    ``slice_errors`` names any slice whose accessor RAISED (empty list when
+    clean). A missing/None registry degrades to an empty slice WITHOUT an entry —
+    that is "nothing here", not "failed". A genuine raise is caught per slice,
+    logged, and named here so the server can tell "empty" from "failed" and fall
+    back to its legacy REST read for just that slice instead of trusting the
+    empty value.
     """
     include_notifications = params.get("include_notifications", True)
     include_repairs = params.get("include_repairs", True)
 
     view = _resolve_registries(hass)
+    slice_errors: list[str] = []
+
+    def _slice(name: str, fn: Any, default: Any) -> Any:
+        try:
+            return fn()
+        except Exception:
+            _LOGGER.warning("overview slice %r degraded", name, exc_info=True)
+            slice_errors.append(name)
+            return default
+
     result: dict[str, Any] = {
-        "states": _overview_states(hass),
-        "services": _overview_services(hass),
-        "entity_registry": _overview_entity_registry(view),
-        "device_registry": _overview_device_registry(view),
-        "area_registry": _overview_area_registry(view),
-        "config": _overview_config(hass),
-        "notifications": _overview_notifications(hass) if include_notifications else [],
-        "repairs": _overview_repairs(hass) if include_repairs else [],
+        "states": _slice("states", lambda: _overview_states(hass), []),
+        "services": _slice("services", lambda: _overview_services(hass), []),
+        "entity_registry": _slice(
+            "entity_registry", lambda: _overview_entity_registry(view), []
+        ),
+        "device_registry": _slice(
+            "device_registry", lambda: _overview_device_registry(view), []
+        ),
+        "area_registry": _slice(
+            "area_registry", lambda: _overview_area_registry(view), []
+        ),
+        "config": _slice("config", lambda: _overview_config(hass), {}),
+        "notifications": _slice(
+            "notifications", lambda: _overview_notifications(hass), []
+        )
+        if include_notifications
+        else [],
+        "repairs": _slice("repairs", lambda: _overview_repairs(hass), [])
+        if include_repairs
+        else [],
     }
+    result["slice_errors"] = slice_errors
     return result
 
 

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1,0 +1,978 @@
+"""In-process WebSocket command surface for the ha_mcp_tools component.
+
+This module registers versioned ``ha_mcp_tools/*`` WebSocket commands that the
+ha-mcp server calls in-process (same HA core, no REST/WS round-trips) behind a
+capability gate. v1.1.0 ships two commands:
+
+* ``ha_mcp_tools/info`` — the handshake: ``schema_version`` + ``capabilities[]``
+  + ``component_version`` + advisory ``limits``. One cached probe tells the
+  server which commands are live (capability negotiation, NOT a version floor).
+* ``ha_mcp_tools/search`` — a unified in-process search over live registries and
+  states, joined and scored, mirroring today's ``ha_search`` response envelope.
+
+Design notes that are load-bearing:
+
+* **Capability negotiation, not version-lockstep.** ``CAPABILITIES`` grows one
+  entry per shipped command; the server asks "do you support ``search``?"
+  rather than "are you >= X". The manifest version is reported for display only.
+* **Data minimization.** Flow-helper indexing reads ``ConfigEntry.options`` /
+  ``title`` only — **never** ``ConfigEntry.data`` (integration credentials).
+* **YAML config bodies are never emitted.** automation/script/scene bodies are
+  indexed for *matching*, but a matched item's ``config`` body is returned only
+  when it is storage/editor-backed AND ``include_config`` is set. YAML-loaded
+  items return identity/metadata only (their ``raw_config`` may carry resolved
+  ``!secret`` plaintext). Body emission for YAML belongs to the future
+  ``config_get`` command.
+* **Event-loop hygiene.** Every join is a pure in-memory read over live
+  registries — run synchronously, no executor, no persistent index (always
+  fresh, zero cache-invalidation surface).
+
+Extension point — to add a command later (overview / config_get / helpers_list):
+write ``_do_<name>(hass, params)``, append its capability to :data:`CAPABILITIES`,
+and add one row to :func:`_command_specs`. ``info`` enumerates the rest.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    area_registry as ar,
+)
+from homeassistant.helpers import (
+    device_registry as dr,
+)
+from homeassistant.helpers import (
+    entity_registry as er,
+)
+from homeassistant.helpers import (
+    floor_registry as fr,
+)
+from homeassistant.helpers import (
+    label_registry as lr,
+)
+
+from .const import COMPONENT_VERSION
+
+_LOGGER = logging.getLogger(__name__)
+
+# --- Wire contract -----------------------------------------------------------
+WS_API_PREFIX = "ha_mcp_tools"
+WS_INFO = f"{WS_API_PREFIX}/info"
+WS_SEARCH = f"{WS_API_PREFIX}/search"
+
+# Wire-format generation of the request/response envelopes. Bumped only on an
+# *incompatible* shape change to an existing command; additive fields do not
+# bump it (the server checks ``schema_version >= N`` before using a new shape).
+SCHEMA_VERSION = 1
+
+# Which commands exist. Grows one entry per shipped command; the server gates
+# each consumer on ``capability in caps.capabilities``. Never remove an entry
+# without a major bump.
+CAPABILITIES: list[str] = ["search"]
+
+# Advisory caps advertised in ``info.limits`` so no single WS frame balloons.
+MAX_RESULTS = 500
+MAX_BODY_BYTES = 1_000_000
+LIMITS = {"max_results": MAX_RESULTS, "max_body_bytes": MAX_BODY_BYTES}
+
+DEFAULT_LIMIT = 10
+
+# Fuzzy floor + hidden penalty, mirrored from the server so the two scorers do
+# not drift (guarded by the golden parity test).
+FUZZY_THRESHOLD = 70
+HIDDEN_SCORE_PENALTY = 20
+
+# --- Search surfaces ---------------------------------------------------------
+SEARCH_TYPE_ENTITY = "entity"
+SEARCH_TYPE_AUTOMATION = "automation"
+SEARCH_TYPE_SCRIPT = "script"
+SEARCH_TYPE_SCENE = "scene"
+SEARCH_TYPE_HELPER = "helper"
+ALL_SEARCH_TYPES = [
+    SEARCH_TYPE_ENTITY,
+    SEARCH_TYPE_AUTOMATION,
+    SEARCH_TYPE_SCRIPT,
+    SEARCH_TYPE_SCENE,
+    SEARCH_TYPE_HELPER,
+]
+# raw_config surfaces reached via each domain's EntityComponent in hass.data.
+CONFIG_SEARCH_TYPES = (
+    SEARCH_TYPE_AUTOMATION,
+    SEARCH_TYPE_SCRIPT,
+    SEARCH_TYPE_SCENE,
+)
+
+# Collection ("storage collection") helpers — entities in the state machine.
+# Matched on entity_id / friendly_name only; their body is not read in v1.
+COLLECTION_HELPER_DOMAINS = frozenset(
+    {
+        "input_boolean",
+        "input_number",
+        "input_text",
+        "input_select",
+        "input_datetime",
+        "input_button",
+        "counter",
+        "timer",
+        "schedule",
+    }
+)
+# Flow (config-entry-backed) helpers. Indexed from ``entry.options`` / ``title``
+# directly — no OptionsFlow start/abort dance, and NEVER ``entry.data``.
+FLOW_HELPER_DOMAINS = frozenset(
+    {
+        "template",
+        "group",
+        "utility_meter",
+        "threshold",
+        "derivative",
+        "integration",
+        "min_max",
+        "statistics",
+        "trend",
+        "tod",
+        "random",
+        "switch_as_x",
+        "mold_indicator",
+        "history_stats",
+        "bayesian",
+        "filter",
+        "generic_thermostat",
+        "generic_hygrostat",
+        "combine",
+    }
+)
+
+_SPLIT_RE = re.compile(r"[._\-\s]+")
+
+
+# =============================================================================
+# Registration (thin @websocket_command wrappers over the pure `_do_*` funcs)
+# =============================================================================
+def async_register_commands(hass: HomeAssistant) -> None:
+    """Register the ``ha_mcp_tools/*`` WebSocket commands.
+
+    Idempotent: HA's ``async_register_command`` overwrites an existing handler,
+    so re-running on a config-entry reload is harmless. Called from the tools
+    config-entry setup alongside the service registrations.
+    """
+    for schema, do_fn in _command_specs():
+        websocket_api.async_register_command(hass, _build_handler(schema, do_fn))
+    _LOGGER.debug(
+        "Registered ha_mcp_tools WS commands: schema_version=%s capabilities=%s",
+        SCHEMA_VERSION,
+        CAPABILITIES,
+    )
+
+
+def _command_specs() -> list[tuple[dict[Any, Any], Any]]:
+    """The (schema, pure-handler) rows. Append one row to add a command."""
+    return [
+        (_info_schema(), lambda hass, msg: _do_info()),
+        (_search_schema(), _do_search),
+    ]
+
+
+def _build_handler(schema: dict[Any, Any], do_fn: Any) -> Any:
+    """Wrap a pure ``_do_*`` function as an admin-gated WS command handler."""
+
+    @websocket_api.websocket_command(schema)
+    @websocket_api.require_admin
+    @websocket_api.async_response
+    async def _handler(
+        hass: HomeAssistant, connection: Any, msg: dict[str, Any]
+    ) -> None:
+        connection.send_result(msg["id"], do_fn(hass, msg))
+
+    return _handler
+
+
+def _info_schema() -> dict[Any, Any]:
+    return {vol.Required("type"): WS_INFO}
+
+
+def _search_schema() -> dict[Any, Any]:
+    return {
+        vol.Required("type"): WS_SEARCH,
+        vol.Optional("query"): vol.Any(str, None),
+        vol.Optional("search_types"): [vol.In(ALL_SEARCH_TYPES)],
+        vol.Optional("domain_filter"): str,
+        vol.Optional("area_filter"): str,
+        vol.Optional("state_filter"): str,
+        vol.Optional("exact", default=True): bool,
+        vol.Optional("include_hidden", default=True): bool,
+        vol.Optional("include_config", default=False): bool,
+        vol.Optional("limit", default=DEFAULT_LIMIT): vol.All(
+            int, vol.Range(min=1, max=MAX_RESULTS)
+        ),
+        vol.Optional("offset", default=0): vol.All(int, vol.Range(min=0)),
+    }
+
+
+# =============================================================================
+# ha_mcp_tools/info
+# =============================================================================
+def _do_info() -> dict[str, Any]:
+    """Return the handshake payload (pure; no hass access)."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "component_version": COMPONENT_VERSION,
+        "capabilities": list(CAPABILITIES),
+        "limits": dict(LIMITS),
+    }
+
+
+# =============================================================================
+# ha_mcp_tools/search
+# =============================================================================
+@dataclass
+class _RegistryView:
+    """Bundle of the five HA registries (any may be ``None`` if unavailable)."""
+
+    entity: Any = None
+    area: Any = None
+    floor: Any = None
+    label: Any = None
+    device: Any = None
+
+
+def _resolve_registries(hass: HomeAssistant) -> _RegistryView:
+    """Snapshot the five registries. Test seam — monkeypatched in unit tests."""
+    return _RegistryView(
+        entity=_safe(er.async_get, hass),
+        area=_safe(ar.async_get, hass),
+        floor=_safe(fr.async_get, hass),
+        label=_safe(lr.async_get, hass),
+        device=_safe(dr.async_get, hass),
+    )
+
+
+def _safe(fn: Any, hass: HomeAssistant) -> Any:
+    try:
+        return fn(hass)
+    except Exception:  # pragma: no cover - defensive; core drift
+        return None
+
+
+def _do_search(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+    """Unified in-process search. Pure over ``hass`` — the WS wrapper is thin.
+
+    Joins live registries + states, scores per the server's tiers, paginates
+    per surface, and returns the ``ha_search``-shaped envelope.
+    """
+    query_lower = (params.get("query") or "").strip().lower()
+    match_all = not query_lower
+    exact = params.get("exact", True)
+    include_hidden = params.get("include_hidden", True)
+    include_config = params.get("include_config", False)
+    limit = params.get("limit", DEFAULT_LIMIT)
+    offset = params.get("offset", 0)
+    search_types = params.get("search_types") or ALL_SEARCH_TYPES
+    domain_filter = params.get("domain_filter")
+    area_filter = params.get("area_filter")
+    state_filter = params.get("state_filter")
+
+    view = _resolve_registries(hass)
+    diagnostics: dict[str, int] = {}
+    partial_reasons: list[str] = []
+
+    # --- Entities ------------------------------------------------------------
+    entities: list[dict[str, Any]] = []
+    entity_total = 0
+    entity_has_more = False
+    if SEARCH_TYPE_ENTITY in search_types:
+        scored_entities = _search_entities(
+            hass,
+            view,
+            query_lower,
+            match_all=match_all,
+            exact=exact,
+            include_hidden=include_hidden,
+            domain_filter=domain_filter,
+            area_filter=area_filter,
+            state_filter=state_filter,
+        )
+        scored_entities.sort(key=lambda r: (-r["score"], r["entity_id"]))
+        entity_total = len(scored_entities)
+        page = scored_entities[offset : offset + limit]
+        entity_has_more = offset + len(page) < entity_total
+        entities = [_project_entity(r) for r in page]
+
+    # --- Config surfaces (automations + scripts + scenes + helpers) ----------
+    # One combined pagination window, mirroring the server's config branch.
+    combined: list[tuple[str, dict[str, Any]]] = []
+    for domain in CONFIG_SEARCH_TYPES:
+        if domain in search_types:
+            combined.extend(
+                (domain, rec)
+                for rec in _search_config_surface(
+                    hass,
+                    view,
+                    domain,
+                    query_lower,
+                    match_all=match_all,
+                    exact=exact,
+                    include_config=include_config,
+                    partial_reasons=partial_reasons,
+                    diagnostics=diagnostics,
+                )
+            )
+    if SEARCH_TYPE_HELPER in search_types:
+        combined.extend(
+            ("helper", rec)
+            for rec in _search_helpers(
+                hass,
+                query_lower,
+                match_all=match_all,
+                exact=exact,
+                include_config=include_config,
+            )
+        )
+
+    combined.sort(key=lambda item: (-item[1]["score"], _sort_key(item[1])))
+    config_total = len(combined)
+    config_page = combined[offset : offset + limit]
+    config_has_more = offset + len(config_page) < config_total
+
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "automations": [],
+        "scripts": [],
+        "scenes": [],
+        "helpers": [],
+    }
+    bucket_of = {
+        SEARCH_TYPE_AUTOMATION: "automations",
+        SEARCH_TYPE_SCRIPT: "scripts",
+        SEARCH_TYPE_SCENE: "scenes",
+        "helper": "helpers",
+    }
+    for surface, rec in config_page:
+        buckets[bucket_of[surface]].append(rec)
+
+    result: dict[str, Any] = {
+        "entities": entities,
+        "entity_total_matches": entity_total,
+        "entity_has_more": entity_has_more,
+        "automations": buckets["automations"],
+        "scripts": buckets["scripts"],
+        "scenes": buckets["scenes"],
+        "helpers": buckets["helpers"],
+        "config_total_matches": config_total,
+        "config_has_more": config_has_more,
+        "partial": bool(partial_reasons),
+        "partial_reason": " ; ".join(partial_reasons) if partial_reasons else None,
+    }
+    if diagnostics:
+        result["diagnostics"] = diagnostics
+    return result
+
+
+def _sort_key(rec: dict[str, Any]) -> str:
+    """Stable tiebreak for combined config sorting."""
+    return str(rec.get("entity_id") or rec.get("id") or rec.get("name") or "")
+
+
+# --- Entity join + scoring ---------------------------------------------------
+def _search_entities(
+    hass: HomeAssistant,
+    view: _RegistryView,
+    query_lower: str,
+    *,
+    match_all: bool,
+    exact: bool,
+    include_hidden: bool,
+    domain_filter: str | None,
+    area_filter: str | None,
+    state_filter: str | None,
+) -> list[dict[str, Any]]:
+    """Score every state against the query over the joined registry view."""
+    results: list[dict[str, Any]] = []
+    area_filter_lower = area_filter.lower() if area_filter else None
+    for state in _iter_states(hass):
+        rec = _entity_record(state, view)
+        if domain_filter and rec["domain"] != domain_filter:
+            continue
+        if rec["_hidden"] and not include_hidden:
+            continue
+        if state_filter is not None and rec["state"] != state_filter:
+            continue
+        if area_filter_lower is not None and not _entity_matches_area(
+            rec, area_filter_lower
+        ):
+            continue
+
+        if match_all:
+            score: int | None = _apply_hidden_penalty(100, rec["_hidden"])
+            match_type = "match_all"
+        else:
+            tier = _text_tier(query_lower, rec["_match_texts"], fuzzy=not exact)
+            if tier is None:
+                continue
+            score = _apply_hidden_penalty(tier, rec["_hidden"])
+            match_type = "exact_match" if exact else "fuzzy"
+        rec["score"] = score
+        rec["match_type"] = match_type
+        results.append(rec)
+    return results
+
+
+def _entity_record(state: Any, view: _RegistryView) -> dict[str, Any]:
+    """Join a state with the entity/device/area/floor/label registries."""
+    entity_id = getattr(state, "entity_id", "") or ""
+    domain = entity_id.split(".")[0] if "." in entity_id else ""
+    attrs = getattr(state, "attributes", None) or {}
+    friendly = attrs.get("friendly_name", entity_id)
+
+    reg = _reg_entity(view, entity_id)
+    aliases = (
+        sorted(str(a) for a in (getattr(reg, "aliases", None) or [])) if reg else []
+    )
+    area_id = getattr(reg, "area_id", None) if reg else None
+    device_id = getattr(reg, "device_id", None) if reg else None
+    labels = set(getattr(reg, "labels", None) or []) if reg else set()
+    hidden = bool(getattr(reg, "hidden_by", None)) if reg else False
+
+    dev = _device(view, device_id) if device_id else None
+    dev_texts: list[str] = []
+    if dev is not None:
+        if area_id is None:
+            area_id = getattr(dev, "area_id", None)
+        labels |= set(getattr(dev, "labels", None) or [])
+        for attr in ("name_by_user", "name", "manufacturer", "model"):
+            val = getattr(dev, attr, None)
+            if val:
+                dev_texts.append(str(val))
+
+    area_name = _area_name(view, area_id)
+    floor_name = _floor_name_for_area(view, area_id)
+    label_names = _label_names(view, labels)
+
+    # Scored texts extend the server's id + friendly-name pair with the specific
+    # joined identifiers (alias / area / floor / label / device). The bare domain
+    # is deliberately excluded: matching it would score every entity of a domain
+    # at the exact tier (a "light" query flooding all lights), which the server
+    # does not do — domain is a filter dimension, not a scored text.
+    match_texts = [entity_id, friendly, *aliases, *label_names, *dev_texts]
+    if area_name:
+        match_texts.append(area_name)
+    if floor_name:
+        match_texts.append(floor_name)
+
+    return {
+        "entity_id": entity_id,
+        "friendly_name": friendly,
+        "domain": domain,
+        "state": getattr(state, "state", "unknown"),
+        "area": area_name,
+        "floor": floor_name,
+        "labels": label_names,
+        "aliases": aliases,
+        "_hidden": hidden,
+        "_area_id": area_id,
+        "_match_texts": match_texts,
+    }
+
+
+def _entity_matches_area(rec: dict[str, Any], area_filter_lower: str) -> bool:
+    area_id = rec.get("_area_id")
+    if area_id and str(area_id).lower() == area_filter_lower:
+        return True
+    area_name = rec.get("area")
+    return bool(area_name and str(area_name).lower() == area_filter_lower)
+
+
+def _project_entity(rec: dict[str, Any]) -> dict[str, Any]:
+    """Strip internal ``_``-prefixed keys for the wire response."""
+    return {
+        "entity_id": rec["entity_id"],
+        "friendly_name": rec["friendly_name"],
+        "domain": rec["domain"],
+        "state": rec["state"],
+        "area": rec["area"],
+        "floor": rec["floor"],
+        "labels": rec["labels"],
+        "aliases": rec["aliases"],
+        "score": rec["score"],
+        "match_type": rec["match_type"],
+    }
+
+
+# --- Config surfaces (automation/script/scene) -------------------------------
+def _search_config_surface(
+    hass: HomeAssistant,
+    view: _RegistryView,
+    domain: str,
+    query_lower: str,
+    *,
+    match_all: bool,
+    exact: bool,
+    include_config: bool,
+    partial_reasons: list[str],
+    diagnostics: dict[str, int],
+) -> list[dict[str, Any]]:
+    """Score one config domain's loaded entities (raw_config indexed, not emitted for YAML)."""
+    component = hass.data.get(domain) if getattr(hass, "data", None) else None
+    entities = getattr(component, "entities", None)
+    if entities is None:
+        diagnostics["config_components_inaccessible"] = (
+            diagnostics.get("config_components_inaccessible", 0) + 1
+        )
+        return []
+
+    results: list[dict[str, Any]] = []
+    for entity in entities:
+        entity_id = getattr(entity, "entity_id", None)
+        if not entity_id:
+            continue
+        name, item_id, config_dict = _extract_config(domain, entity)
+        source = _classify_source(item_id)
+
+        if match_all:
+            score: int | None = 100
+            match_in_name = False
+            match_in_config = False
+        else:
+            scored = _config_score(
+                query_lower, entity_id, name, config_dict, exact=exact
+            )
+            if scored is None:
+                continue
+            score, match_in_name, match_in_config = scored
+
+        emit_body = include_config and source == "storage" and config_dict is not None
+        config_out: dict[str, Any] | None = None
+        if emit_body:
+            if _too_large(config_dict):
+                partial_reasons.append(f"{domain} {entity_id} body omitted (too large)")
+            else:
+                config_out = config_dict
+
+        rec: dict[str, Any] = {
+            "id": item_id,
+            "entity_id": entity_id,
+            "source": source,
+            "score": score,
+            "match_in_name": match_in_name,
+            "match_in_config": match_in_config,
+            "config": config_out,
+        }
+        # Scenes carry a "name"; automations/scripts carry an "alias".
+        if domain == SEARCH_TYPE_SCENE:
+            rec["name"] = name
+        else:
+            rec["alias"] = name
+        results.append(rec)
+    return results
+
+
+def _extract_config(
+    domain: str, entity: Any
+) -> tuple[str, str | None, dict[str, Any] | None]:
+    """Return (display_name, item_id, config_dict) for a config entity.
+
+    Uses defensive getattr because the exact accessor can drift across core
+    versions: automation/script expose ``raw_config``; scenes expose
+    ``scene_config`` (name/icon/id/states) rather than ``raw_config``.
+    """
+    entity_id = getattr(entity, "entity_id", "") or ""
+    name = getattr(entity, "name", None) or entity_id
+    unique_id = getattr(entity, "unique_id", None)
+
+    if domain == SEARCH_TYPE_SCENE:
+        scene_config = getattr(entity, "scene_config", None)
+        config_dict = _scene_config_to_dict(scene_config)
+        item_id = unique_id
+        if item_id is None and config_dict is not None:
+            item_id = config_dict.get("id")
+        if config_dict is not None:
+            cfg_name = config_dict.get("name")
+            if cfg_name:
+                name = str(cfg_name)
+        return str(name), (str(item_id) if item_id is not None else None), config_dict
+
+    raw = getattr(entity, "raw_config", None)
+    config_dict = dict(raw) if isinstance(raw, dict) else None
+    item_id = unique_id
+    if item_id is None and config_dict is not None:
+        item_id = config_dict.get("id")
+    return str(name), (str(item_id) if item_id is not None else None), config_dict
+
+
+def _scene_config_to_dict(scene_config: Any) -> dict[str, Any] | None:
+    """Coerce a ``HomeAssistantScene.scene_config`` object into a plain dict."""
+    if scene_config is None:
+        return None
+    if isinstance(scene_config, dict):
+        return dict(scene_config)
+    out: dict[str, Any] = {}
+    for attr in ("id", "name", "icon", "states", "entities"):
+        val = getattr(scene_config, attr, None)
+        if val is not None:
+            out[attr] = _plainify(val)
+    return out or None
+
+
+def _plainify(value: Any) -> Any:
+    """Best-effort conversion of registry/state objects to plain JSON-able data."""
+    if isinstance(value, dict):
+        return {str(k): _plainify(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_plainify(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _classify_source(item_id: str | None) -> str:
+    """Classify an automation/script/scene as storage- or YAML-backed.
+
+    HA addresses editor-managed items by their ``id`` (the entity's
+    ``unique_id``); the config editor's ``/config/<domain>/config/<id>`` REST
+    path — and its edit link — key off exactly that id, and 404 for items with
+    no id. So an id-bearing item is treated as ``storage`` (body emittable under
+    ``include_config``); an id-less item is ``yaml`` and its body is never
+    emitted from search (its ``raw_config`` may carry resolved ``!secret``
+    plaintext). This is the conservative rule: the safe error is toward
+    withholding a body, not leaking one.
+    """
+    return "storage" if item_id else "yaml"
+
+
+def _too_large(config_dict: dict[str, Any]) -> bool:
+    """Rough guard so a huge body never balloons a single WS frame."""
+    try:
+        return len(repr(config_dict)) > MAX_BODY_BYTES
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+# --- Helpers surface ---------------------------------------------------------
+def _search_helpers(
+    hass: HomeAssistant,
+    query_lower: str,
+    *,
+    match_all: bool,
+    exact: bool,
+    include_config: bool,
+) -> list[dict[str, Any]]:
+    """Index collection helpers (states) + flow helpers (config-entry options)."""
+    results: list[dict[str, Any]] = []
+
+    # Collection helpers: entities in the state machine, matched on name only.
+    for state in _iter_states(hass):
+        entity_id = getattr(state, "entity_id", "") or ""
+        domain = entity_id.split(".")[0] if "." in entity_id else ""
+        if domain not in COLLECTION_HELPER_DOMAINS:
+            continue
+        attrs = getattr(state, "attributes", None) or {}
+        name = attrs.get("friendly_name", entity_id)
+        object_id = entity_id.split(".", 1)[1] if "." in entity_id else entity_id
+        if match_all:
+            score: int | None = 100
+            match_in_name = False
+        else:
+            score = _name_tier(query_lower, [entity_id, name], exact=exact)
+            if score is None:
+                continue
+            match_in_name = True
+        results.append(
+            {
+                "entity_id": entity_id,
+                "helper_type": domain,
+                "object_id": object_id,
+                "name": name,
+                "kind": "collection",
+                "score": score,
+                "match_in_name": match_in_name,
+                "match_in_config": False,
+                "config": None,
+            }
+        )
+
+    # Flow helpers: config entries — options + title ONLY, never data.
+    for entry in _iter_config_entries(hass):
+        domain = getattr(entry, "domain", None)
+        if domain not in FLOW_HELPER_DOMAINS:
+            continue
+        title = getattr(entry, "title", None) or ""
+        options = getattr(entry, "options", None)
+        options = dict(options) if isinstance(options, dict) else {}
+        entry_id = getattr(entry, "entry_id", None)
+        if match_all:
+            score = 100
+            match_in_name = False
+            match_in_config = False
+        else:
+            scored = _config_score(query_lower, title, title, options, exact=exact)
+            if scored is None:
+                continue
+            score, match_in_name, match_in_config = scored
+        results.append(
+            {
+                "entity_id": None,
+                "helper_type": domain,
+                "entry_id": entry_id,
+                "name": title,
+                "kind": "flow",
+                "score": score,
+                "match_in_name": match_in_name,
+                "match_in_config": match_in_config,
+                # Data minimization: options only, never entry.data.
+                "options": options if include_config else None,
+            }
+        )
+    return results
+
+
+# =============================================================================
+# Scoring — mirrors the server's tiers (guarded by the golden parity test)
+# =============================================================================
+def _apply_hidden_penalty(score: int, hidden: bool) -> int:
+    """Reduce ``score`` by :data:`HIDDEN_SCORE_PENALTY` for hidden entities.
+
+    Mirrors ``utils.fuzzy_search.apply_hidden_penalty`` so the two rankings
+    stay consistent.
+    """
+    s = int(score)
+    return max(0, s - HIDDEN_SCORE_PENALTY) if hidden else s
+
+
+def _calc_ratio(a: str, b: str) -> int:
+    """SequenceMatcher ratio (0-100). Mirrors ``fuzzy_search.calculate_ratio``."""
+    return int(SequenceMatcher(None, a, b, autojunk=False).ratio() * 100)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split on ``.``/``_``/``-``/whitespace, lowercase, drop empties.
+
+    Mirrors ``utils.fuzzy_search.tokenize``.
+    """
+    return [t for t in _SPLIT_RE.split(text.lower()) if t]
+
+
+def _text_tier(query_lower: str, texts: Any, *, fuzzy: bool) -> int | None:
+    """Entity tier: 100 (exact), 80 (substring), fuzzy ratio (>=threshold), or None.
+
+    Mirrors the server's ``_match_exact_search_entity`` (100/80) over the entity
+    id + friendly name, extended to the joined alias/area/floor/label/domain/
+    device texts. In fuzzy mode a whole-string ``calculate_ratio`` fallback
+    surfaces typos above :data:`FUZZY_THRESHOLD`.
+    """
+    best_substring: int | None = None
+    best_ratio = 0
+    for text in texts:
+        if not text:
+            continue
+        text_lower = str(text).lower()
+        if query_lower == text_lower:
+            return 100
+        if query_lower in text_lower:
+            best_substring = 80
+        elif fuzzy:
+            ratio = _calc_ratio(query_lower, text_lower)
+            if ratio > best_ratio:
+                best_ratio = ratio
+    if best_substring is not None:
+        return best_substring
+    if fuzzy and best_ratio >= FUZZY_THRESHOLD:
+        return best_ratio
+    return None
+
+
+def _name_tier(query_lower: str, texts: Any, *, exact: bool) -> int | None:
+    """Config-name tier: substring => 100 (not 80), else fuzzy ratio or None.
+
+    Config name matches are binary 100/0 in the server's exact path
+    (``_score_deep_match``: ``name_exact = 100 if query in id/name else 0``),
+    unlike entity matches which have the 80 substring tier.
+    """
+    best_ratio = 0
+    for text in texts:
+        if not text:
+            continue
+        text_lower = str(text).lower()
+        if query_lower in text_lower:
+            return 100
+        if not exact:
+            ratio = _calc_ratio(query_lower, text_lower)
+            if ratio > best_ratio:
+                best_ratio = ratio
+    if not exact and best_ratio >= FUZZY_THRESHOLD:
+        return best_ratio
+    return None
+
+
+def _config_score(
+    query_lower: str,
+    entity_id: str,
+    name: str,
+    config_dict: dict[str, Any] | None,
+    *,
+    exact: bool,
+) -> tuple[int, bool, bool] | None:
+    """Score a config surface: (total, match_in_name, match_in_config) or None.
+
+    Exact mode is binary 100/0 with a threshold of 100 (server parity); fuzzy
+    mode floors at :data:`FUZZY_THRESHOLD`.
+    """
+    name_score = _name_tier(query_lower, [entity_id, name], exact=exact) or 0
+    config_score = _config_body_score(query_lower, config_dict, exact=exact)
+    threshold = 100 if exact else FUZZY_THRESHOLD
+    total = max(name_score, config_score)
+    if total < threshold:
+        return None
+    return total, name_score >= threshold, config_score >= threshold
+
+
+def _config_body_score(
+    query_lower: str, config_dict: dict[str, Any] | None, *, exact: bool
+) -> int:
+    """Match the query against a config body's keys/values.
+
+    Exact => 100/0 substring (``_search_in_dict_exact`` parity). Fuzzy adds a
+    token-vs-token ``calculate_ratio`` fallback (the server's tier-3 path).
+    """
+    if config_dict is None:
+        return 0
+    if _search_in_dict_exact(config_dict, query_lower) >= 100:
+        return 100
+    if exact:
+        return 0
+    leaves: list[str] = []
+    _collect_string_leaves(config_dict, leaves)
+    query_tokens = _tokenize(query_lower)
+    if not query_tokens:
+        return 0
+    doc_tokens = {tok for leaf in leaves for tok in _tokenize(leaf)}
+    best = 0
+    for qt in query_tokens:
+        for dt in doc_tokens:
+            best = max(best, _calc_ratio(qt, dt))
+    return best if best >= FUZZY_THRESHOLD else 0
+
+
+def _search_in_dict_exact(data: Any, query_lower: str) -> int:
+    """Exact substring search in nested structures (100 or 0).
+
+    Mirrors ``smart_search._scoring.ScoringMixin._search_in_dict_exact``.
+    """
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if query_lower in str(key).lower():
+                return 100
+            if _search_in_dict_exact(value, query_lower) >= 100:
+                return 100
+        return 0
+    if isinstance(data, (list, tuple)):
+        for item in data:
+            if _search_in_dict_exact(item, query_lower) >= 100:
+                return 100
+        return 0
+    if isinstance(data, str):
+        return 100 if query_lower in data.lower() else 0
+    if data is not None:
+        return 100 if query_lower in str(data).lower() else 0
+    return 0
+
+
+def _collect_string_leaves(data: Any, out: list[str]) -> None:
+    """Recursively collect string representations. Mirrors the server helper."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            out.append(str(key))
+            _collect_string_leaves(value, out)
+    elif isinstance(data, (list, tuple)):
+        for item in data:
+            _collect_string_leaves(item, out)
+    elif isinstance(data, str):
+        out.append(data)
+    elif data is not None:
+        out.append(str(data))
+
+
+# =============================================================================
+# Registry accessors (all getattr-guarded against core drift)
+# =============================================================================
+def _iter_states(hass: HomeAssistant) -> list[Any]:
+    states = getattr(hass, "states", None)
+    getter = getattr(states, "async_all", None) if states is not None else None
+    if getter is None:
+        return []
+    try:
+        return list(getter())
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _iter_config_entries(hass: HomeAssistant) -> list[Any]:
+    config_entries = getattr(hass, "config_entries", None)
+    getter = (
+        getattr(config_entries, "async_entries", None)
+        if config_entries is not None
+        else None
+    )
+    if getter is None:
+        return []
+    try:
+        return list(getter())
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _reg_entity(view: _RegistryView, entity_id: str) -> Any:
+    return _call_lookup(view.entity, "async_get", entity_id)
+
+
+def _device(view: _RegistryView, device_id: str | None) -> Any:
+    if not device_id:
+        return None
+    return _call_lookup(view.device, "async_get", device_id)
+
+
+def _area_name(view: _RegistryView, area_id: str | None) -> str | None:
+    if not area_id:
+        return None
+    area = _call_lookup(view.area, "async_get_area", area_id)
+    name = getattr(area, "name", None) if area is not None else None
+    return str(name) if name else None
+
+
+def _floor_name_for_area(view: _RegistryView, area_id: str | None) -> str | None:
+    if not area_id:
+        return None
+    area = _call_lookup(view.area, "async_get_area", area_id)
+    floor_id = getattr(area, "floor_id", None) if area is not None else None
+    if not floor_id:
+        return None
+    floor = _call_lookup(view.floor, "async_get_floor", floor_id)
+    name = getattr(floor, "name", None) if floor is not None else None
+    return str(name) if name else None
+
+
+def _label_names(view: _RegistryView, label_ids: Any) -> list[str]:
+    names: list[str] = []
+    for label_id in sorted(label_ids or []):
+        label = _call_lookup(view.label, "async_get_label", label_id)
+        name = getattr(label, "name", None) if label is not None else None
+        names.append(str(name) if name else str(label_id))
+    return names
+
+
+def _call_lookup(registry: Any, method: str, key: str) -> Any:
+    if registry is None:
+        return None
+    getter = getattr(registry, method, None)
+    if getter is None:
+        return None
+    try:
+        return getter(key)
+    except Exception:  # pragma: no cover - defensive
+        return None

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -966,25 +966,41 @@ def _text_tier(query_lower: str, texts: Any, *, fuzzy: bool) -> int | None:
     for text in texts:
         if not text:
             continue
-        text_lower = str(text).lower()
-        if query_lower == text_lower:
+        tier, ratio = _tier_one_text(query_lower, query_norm, str(text).lower(), fuzzy)
+        if tier == 100:
             return 100
-        if fuzzy and query_norm and query_norm == _sep_normalized(text_lower):
-            return 100
-        if query_lower in text_lower:
+        if tier == 80:
             best_substring = 80
-        elif fuzzy:
-            if query_norm and query_norm in _sep_normalized(text_lower):
-                best_substring = 80
-            else:
-                ratio = _calc_ratio(query_lower, text_lower)
-                if ratio > best_ratio:
-                    best_ratio = ratio
+        elif ratio > best_ratio:
+            best_ratio = ratio
     if best_substring is not None:
         return best_substring
     if fuzzy and best_ratio >= FUZZY_THRESHOLD:
         return best_ratio
     return None
+
+
+def _tier_one_text(
+    query_lower: str, query_norm: str, text_lower: str, fuzzy: bool
+) -> tuple[int | None, int]:
+    """Score one candidate text: ``(tier, ratio)``.
+
+    Tier 100 = exact (raw, or separator-normalized in fuzzy mode); tier 80 =
+    substring (same two forms); otherwise ``ratio`` carries the fuzzy
+    whole-string fallback (0 when not in fuzzy mode).
+    """
+    if query_lower == text_lower:
+        return 100, 0
+    text_norm = _sep_normalized(text_lower) if fuzzy and query_norm else ""
+    if text_norm and query_norm == text_norm:
+        return 100, 0
+    if query_lower in text_lower:
+        return 80, 0
+    if text_norm and query_norm in text_norm:
+        return 80, 0
+    if fuzzy:
+        return None, _calc_ratio(query_lower, text_lower)
+    return None, 0
 
 
 def _name_tier(query_lower: str, texts: Any, *, exact: bool) -> int | None:

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -547,9 +547,8 @@ def _search_config_surface(
                 continue
             score, match_in_name, match_in_config = scored
 
-        emit_body = include_config and source == "storage" and config_dict is not None
         config_out: dict[str, Any] | None = None
-        if emit_body:
+        if include_config and source == "storage" and config_dict is not None:
             if _too_large(config_dict):
                 partial_reasons.append(f"{domain} {entity_id} body omitted (too large)")
             else:

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -86,7 +86,19 @@ class HomeAssistantCommandError(HomeAssistantError):
     ``_classify_exception``'s match dispatch; classification then falls
     through to ``_classify_by_message`` for pattern matching on the
     error message.
+
+    ``code`` carries HA's structured WebSocket error code (the ``code`` field
+    of the response ``error`` object — e.g. ``"unknown_command"``,
+    ``"invalid_format"``) when available, so routing decisions can key off the
+    stable code rather than pattern-matching the human-readable message. It
+    defaults to ``None`` for exceptions raised without a code (older raise
+    sites, string error payloads, or direct construction in tests), which
+    keeps the single-positional-argument constructor backward-compatible.
     """
+
+    def __init__(self, message: str, code: str | None = None):
+        super().__init__(message)
+        self.code = code
 
 
 class HomeAssistantCommandTimeout(HomeAssistantError):

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -40,6 +40,20 @@ logger = logging.getLogger(__name__)
 MAX_WS_MESSAGE_BYTES = 64 * 1024 * 1024
 
 
+def _extract_ws_error(error: Any) -> tuple[str, str | None]:
+    """Split an HA WebSocket ``error`` payload into ``(message, code)``.
+
+    HA replies to a failed command with ``{"error": {"code": ..., "message":
+    ...}}``. Dict payloads yield both fields; a bare string (or other shape)
+    yields ``str(error)`` as the message and ``None`` for the code. The code is
+    threaded onto ``HomeAssistantCommandError`` so callers route on the stable
+    ``code`` (e.g. ``unknown_command``) instead of the message text.
+    """
+    if isinstance(error, dict):
+        return error.get("message", str(error)), error.get("code")
+    return str(error), None
+
+
 class WebSocketConnectionState:
     """Encapsulates mutable state used by the WebSocket client."""
 
@@ -632,13 +646,10 @@ class HomeAssistantWebSocketClient:
             # Process standard Home Assistant WebSocket response
             if response.get("type") == "result":
                 if response.get("success") is False:
-                    error = response.get("error", {})
-                    error_msg = (
-                        error.get("message", str(error))
-                        if isinstance(error, dict)
-                        else str(error)
+                    error_msg, error_code = _extract_ws_error(response.get("error", {}))
+                    raise HomeAssistantCommandError(
+                        f"Command failed: {error_msg}", error_code
                     )
-                    raise HomeAssistantCommandError(f"Command failed: {error_msg}")
 
                 # Return success response according to HA WebSocket format
                 return {
@@ -715,13 +726,8 @@ class HomeAssistantWebSocketClient:
 
         if not result_response.get("success"):
             self.cancel_event_response(message_id)
-            error = result_response.get("error", {})
-            error_msg = (
-                error.get("message", str(error))
-                if isinstance(error, dict)
-                else str(error)
-            )
-            raise HomeAssistantCommandError(f"Command failed: {error_msg}")
+            error_msg, error_code = _extract_ws_error(result_response.get("error", {}))
+            raise HomeAssistantCommandError(f"Command failed: {error_msg}", error_code)
 
         try:
             event_response = await asyncio.wait_for(event_future, timeout=wait_timeout)
@@ -787,11 +793,10 @@ class HomeAssistantWebSocketClient:
         if response.get("type") == "result" and response.get("success"):
             return message_id
 
-        error = response.get("error", {})
-        error_msg = (
-            error.get("message", str(error)) if isinstance(error, dict) else str(error)
+        error_msg, error_code = _extract_ws_error(response.get("error", {}))
+        raise HomeAssistantCommandError(
+            f"subscribe_events failed: {error_msg}", error_code
         )
-        raise HomeAssistantCommandError(f"subscribe_events failed: {error_msg}")
 
     async def unsubscribe_events(self, subscription_id: int) -> None:
         """Release a subscription previously returned by ``subscribe_events``.
@@ -885,12 +890,9 @@ class HomeAssistantWebSocketClient:
             return message_id, queue
 
         self._state.unregister_subscription_queue(message_id)
-        error = response.get("error", {})
-        error_msg = (
-            error.get("message", str(error)) if isinstance(error, dict) else str(error)
-        )
+        error_msg, error_code = _extract_ws_error(response.get("error", {}))
         raise HomeAssistantCommandError(
-            f"subscribe_command({command_type!r}) failed: {error_msg}"
+            f"subscribe_command({command_type!r}) failed: {error_msg}", error_code
         )
 
     async def unsubscribe_command(

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -728,6 +728,22 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             "For routing guidance and the full allowlist, see "
             "ha_get_skill_guide."
         ),
+        "ha_search": (
+            "Search Home Assistant for entities (by name, domain, or area) AND "
+            "inside automation/script/scene/helper/dashboard configs, in one "
+            "call. Returns tagged buckets — `entities` plus per-config-type "
+            "lists — paginated per-surface and combined "
+            "(`has_more`/`next_offset`).\n\n"
+            "Config-body search is skipped when domain/area/state filters signal "
+            "entity-only intent; a warning names the skip — pass `search_types` "
+            "to force it.\n\n"
+            "`partial: True` means results are NOT exhaustive: a surface failed "
+            "or the config branch lost data. Empty buckets with `partial: True` "
+            'mean "search failed", not "no results" — see `partial_reason` '
+            "(also mirrored into `warnings`). Do not treat a partial response as "
+            "complete.\n\n"
+            "For parameters, schema, and examples, see ha_get_skill_guide."
+        ),
     }
 
     # Description overrides that REPLACE the original description for BM25.

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 import weakref
 from dataclasses import dataclass
 from typing import Any
@@ -50,6 +51,25 @@ INFO_COMMAND = "ha_mcp_tools/info"
 # ``HomeAssistantCommandError``) rather than matching the message text.
 UNKNOWN_COMMAND_CODE = "unknown_command"
 
+# The wire-format generation this server speaks. A probe advertising any other
+# ``schema_version`` is treated as no-caps (see ``get_component_caps``): the
+# routing gate can't trust command payloads shaped for a different generation.
+SUPPORTED_SCHEMA_VERSION = 1
+
+# Negative (None) caps entries expire after this many seconds of monotonic
+# time, so a component installed / upgraded mid-session is re-probed and
+# adopted instead of being pinned to "absent" for the whole process lifetime
+# (the cache key is the process-lifetime REST client — see ``_CAPS_CACHE``).
+# Positive entries never expire on this timer; they are dropped only by
+# ``invalidate_caps`` (a supposedly-supported command coming back
+# ``unknown_command``).
+_NEGATIVE_CACHE_TTL_S = 300.0
+
+
+def _monotonic() -> float:
+    """Monotonic clock read, isolated so tests can advance it deterministically."""
+    return time.monotonic()
+
 
 @dataclass(frozen=True)
 class ComponentCaps:
@@ -68,14 +88,20 @@ class ComponentCaps:
     limits: dict[str, Any]
 
 
-# Weak-keyed by client so the negotiated caps live for the client's lifetime
-# (the component version only changes on a HACS update + HA restart, which drops
-# the WS connection and yields a fresh pooled client → fresh probe) and
-# self-evict when the client is collected. ``None`` is a cached *negative*
-# ("probed, no usable WS surface"); absence means "not yet probed".
+# Weak-keyed by client so the negotiated caps self-evict when the client is
+# garbage-collected. The key is the process-lifetime REST client, NOT the WS
+# connection: an HA restart drops the socket but reuses the same pooled client,
+# so a positive entry persists for the whole process (dropped only by
+# ``invalidate_caps`` on an ``unknown_command``). A ``None`` value is a cached
+# *negative* ("probed, no usable WS surface"); absence means "not yet probed".
+# Negatives carry an expiry in ``_NEGATIVE_CACHE_TS`` so a component installed /
+# upgraded mid-session is eventually re-probed instead of pinned absent forever.
 _CAPS_CACHE: weakref.WeakKeyDictionary[Any, ComponentCaps | None] = (
     weakref.WeakKeyDictionary()
 )
+# Monotonic timestamp a negative entry was stored, keyed by the same client.
+# Only populated for ``None`` values; positive entries never appear here.
+_NEGATIVE_CACHE_TS: weakref.WeakKeyDictionary[Any, float] = weakref.WeakKeyDictionary()
 _CAPS_LOCKS: weakref.WeakKeyDictionary[Any, asyncio.Lock] = weakref.WeakKeyDictionary()
 
 
@@ -86,6 +112,34 @@ def _get_caps_lock(client: Any) -> asyncio.Lock:
         lock = asyncio.Lock()
         _CAPS_LOCKS[client] = lock
     return lock
+
+
+def _live_cache_entry(client: Any) -> tuple[bool, ComponentCaps | None]:
+    """Return ``(hit, caps)`` for a still-valid cache entry, else ``(False, None)``.
+
+    A positive entry is a hit for the process lifetime. A negative (``None``)
+    entry is a hit only within ``_NEGATIVE_CACHE_TTL_S`` of when it was stored
+    (monotonic clock); once that window lapses it reports a miss so the caller
+    re-probes and can adopt a component that appeared mid-session.
+    """
+    if client not in _CAPS_CACHE:
+        return False, None
+    cached = _CAPS_CACHE[client]
+    if cached is not None:
+        return True, cached
+    stored_at = _NEGATIVE_CACHE_TS.get(client)
+    if stored_at is not None and (_monotonic() - stored_at) < _NEGATIVE_CACHE_TTL_S:
+        return True, None
+    return False, None
+
+
+def _store_caps(client: Any, caps: ComponentCaps | None) -> None:
+    """Cache ``caps`` for ``client``, stamping a negative with the current clock."""
+    _CAPS_CACHE[client] = caps
+    if caps is None:
+        _NEGATIVE_CACHE_TS[client] = _monotonic()
+    else:
+        _NEGATIVE_CACHE_TS.pop(client, None)
 
 
 def _parse_caps(response: Any) -> ComponentCaps | None:
@@ -119,27 +173,37 @@ def _parse_caps(response: Any) -> ComponentCaps | None:
 async def get_component_caps(client: Any) -> ComponentCaps | None:
     """Return the cached (or freshly probed) capabilities of the component.
 
-    One ``ha_mcp_tools/info`` probe per client lifetime. ``None`` means "no
+    One ``ha_mcp_tools/info`` probe per client, cached. ``None`` means "no
     usable component WS surface" — the caller falls back to its legacy path.
 
     Cache-on-failure semantics follow the error taxonomy:
 
     - ``HomeAssistantCommandError`` (``info`` is ``unknown_command`` on an old
-      component, or the handler raised): cache ``None``. The negative is stable
-      until the connection is replaced, so we probe exactly once.
+      component, or the handler raised): cache ``None`` with an expiry. The
+      negative is re-probed after ``_NEGATIVE_CACHE_TTL_S`` so a component
+      installed / upgraded mid-session (the REST client — the cache key — is not
+      recreated on an HA restart) is eventually adopted instead of pinned absent.
     - ``HomeAssistantConnectionError`` / ``HomeAssistantCommandTimeout`` (WS
       down or slow): do **not** cache — re-probe on the next call once the
       connection recovers. The consuming tool's legacy path will surface the
       transport failure on its own.
     - No credentials on the client (a bare test double with no ``base_url`` /
       ``token``): nothing to probe; return ``None`` without caching.
+    - Any other unexpected exception: logged at debug, returns ``None`` without
+      caching (a transient runtime fault re-probes on the next call).
+
+    A probe whose ``schema_version`` is not ``SUPPORTED_SCHEMA_VERSION`` is
+    treated as no-caps (cached negative, logged once): the server can't trust
+    command payloads shaped for a different wire-format generation.
     """
-    if client in _CAPS_CACHE:
-        return _CAPS_CACHE[client]
+    hit, caps = _live_cache_entry(client)
+    if hit:
+        return caps
 
     async with _get_caps_lock(client):
-        if client in _CAPS_CACHE:
-            return _CAPS_CACHE[client]
+        hit, caps = _live_cache_entry(client)
+        if hit:
+            return caps
 
         base_url = getattr(client, "base_url", None)
         token = getattr(client, "token", None)
@@ -153,7 +217,7 @@ async def get_component_caps(client: Any) -> ComponentCaps | None:
         except HomeAssistantCommandError:
             # Old component (unknown_command) or an info handler bug: the
             # component can't serve WS commands. Cache the negative.
-            _CAPS_CACHE[client] = None
+            _store_caps(client, None)
             return None
         except (HomeAssistantConnectionError, HomeAssistantCommandTimeout):
             logger.debug(
@@ -165,7 +229,15 @@ async def get_component_caps(client: Any) -> ComponentCaps | None:
             return None
 
         caps = _parse_caps(response)
-        _CAPS_CACHE[client] = caps
+        if caps is not None and caps.schema_version != SUPPORTED_SCHEMA_VERSION:
+            logger.warning(
+                "ha_mcp_tools component schema_version %s unsupported "
+                "(server supports %s); routing no commands through the component",
+                caps.schema_version,
+                SUPPORTED_SCHEMA_VERSION,
+            )
+            caps = None
+        _store_caps(client, caps)
         return caps
 
 
@@ -192,3 +264,22 @@ def invalidate_caps(client: Any) -> None:
     stale positive doesn't keep routing to a dead command.
     """
     _CAPS_CACHE.pop(client, None)
+    _NEGATIVE_CACHE_TS.pop(client, None)
+
+
+async def send_component_config_get(
+    client: Any, domain: str, item_id: str
+) -> dict[str, Any]:
+    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
+
+    Returns the raw ``{success, result}`` envelope; the caller shapes
+    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
+    on a ``success:False`` reply (routed by the caller's error taxonomy).
+
+    Shared by the automation and script config-get consumers; both route their
+    single-item read through this one WS round-trip.
+    """
+    ws = await get_websocket_client(url=client.base_url, token=client.token)
+    return await ws.send_command(
+        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
+    )

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -1,0 +1,194 @@
+"""Capability gate for the ``ha_mcp_tools`` custom-component WebSocket API.
+
+The custom component (``custom_components/ha_mcp_tools/``, manifest 1.1.0+)
+registers in-process WebSocket commands under the ``ha_mcp_tools/`` namespace
+that let the server answer read queries (search, config-get, overview, ...)
+from HA's live registries in a single round-trip, instead of the multi-fetch
+REST/WS pipelines the server uses today.
+
+Because the component ships over HACS on its own release cadence, a given
+install may be at any version — old (no WS surface at all), new (full surface),
+or somewhere in between. This module negotiates that with a single cached
+``ha_mcp_tools/info`` probe per client:
+
+- ``info`` enumerates the ``capabilities`` the running component actually
+  registered. The server checks ``component_supports(caps, "<capability>")``
+  before routing a tool through the component, so a capability that a released
+  component hasn't shipped yet simply never gets used — no version lockstep.
+- If ``info`` itself is ``unknown_command``, the component predates the WS
+  surface entirely; caps are cached as ``None`` and every consumer falls back
+  to its legacy path.
+
+This mirrors the caller-token cache in ``tools_filesystem.py``: weak-keyed by
+client so multi-client / OAuth setups each negotiate independently and the
+entry self-evicts when a client is garbage-collected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+from ..client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+    HomeAssistantConnectionError,
+)
+from ..client.websocket_client import get_websocket_client
+
+logger = logging.getLogger(__name__)
+
+# The WS command every 1.1.0+ component registers; probing it does double duty
+# (existence check + capability enumeration — see module docstring).
+INFO_COMMAND = "ha_mcp_tools/info"
+
+# HA's structured error code for a command no handler is registered for. Routing
+# keys off this (via the ``code`` attribute threaded onto
+# ``HomeAssistantCommandError``) rather than matching the message text.
+UNKNOWN_COMMAND_CODE = "unknown_command"
+
+
+@dataclass(frozen=True)
+class ComponentCaps:
+    """Snapshot of what the running ``ha_mcp_tools`` component can serve.
+
+    ``capabilities`` is the routing gate — the set of ``ha_mcp_tools/*``
+    commands the component actually registered. ``schema_version`` guards the
+    wire-format generation of those commands (a consumer needing a reshaped
+    payload checks ``schema_version >= N``). ``component_version`` and
+    ``limits`` are advisory (display / body-size caps).
+    """
+
+    schema_version: int
+    component_version: str
+    capabilities: frozenset[str]
+    limits: dict[str, Any]
+
+
+# Weak-keyed by client so the negotiated caps live for the client's lifetime
+# (the component version only changes on a HACS update + HA restart, which drops
+# the WS connection and yields a fresh pooled client → fresh probe) and
+# self-evict when the client is collected. ``None`` is a cached *negative*
+# ("probed, no usable WS surface"); absence means "not yet probed".
+_CAPS_CACHE: weakref.WeakKeyDictionary[Any, ComponentCaps | None] = (
+    weakref.WeakKeyDictionary()
+)
+_CAPS_LOCKS: weakref.WeakKeyDictionary[Any, asyncio.Lock] = weakref.WeakKeyDictionary()
+
+
+def _get_caps_lock(client: Any) -> asyncio.Lock:
+    """Per-client lock so concurrent first-callers probe ``info`` exactly once."""
+    lock = _CAPS_LOCKS.get(client)
+    if lock is None:
+        lock = asyncio.Lock()
+        _CAPS_LOCKS[client] = lock
+    return lock
+
+
+def _parse_caps(response: Any) -> ComponentCaps | None:
+    """Map an ``ha_mcp_tools/info`` response into ``ComponentCaps``.
+
+    Returns ``None`` for a malformed payload — the command responded, so this
+    is still a stable negative worth caching, just not a usable capability set.
+    """
+    result = response.get("result") if isinstance(response, dict) else None
+    if not isinstance(result, dict):
+        return None
+    raw_caps = result.get("capabilities")
+    capabilities = (
+        frozenset(c for c in raw_caps if isinstance(c, str))
+        if isinstance(raw_caps, list)
+        else frozenset()
+    )
+    raw_limits = result.get("limits")
+    try:
+        schema_version = int(result.get("schema_version", 0) or 0)
+    except (TypeError, ValueError):
+        schema_version = 0
+    return ComponentCaps(
+        schema_version=schema_version,
+        component_version=str(result.get("component_version", "")),
+        capabilities=capabilities,
+        limits=raw_limits if isinstance(raw_limits, dict) else {},
+    )
+
+
+async def get_component_caps(client: Any) -> ComponentCaps | None:
+    """Return the cached (or freshly probed) capabilities of the component.
+
+    One ``ha_mcp_tools/info`` probe per client lifetime. ``None`` means "no
+    usable component WS surface" — the caller falls back to its legacy path.
+
+    Cache-on-failure semantics follow the error taxonomy:
+
+    - ``HomeAssistantCommandError`` (``info`` is ``unknown_command`` on an old
+      component, or the handler raised): cache ``None``. The negative is stable
+      until the connection is replaced, so we probe exactly once.
+    - ``HomeAssistantConnectionError`` / ``HomeAssistantCommandTimeout`` (WS
+      down or slow): do **not** cache — re-probe on the next call once the
+      connection recovers. The consuming tool's legacy path will surface the
+      transport failure on its own.
+    - No credentials on the client (a bare test double with no ``base_url`` /
+      ``token``): nothing to probe; return ``None`` without caching.
+    """
+    if client in _CAPS_CACHE:
+        return _CAPS_CACHE[client]
+
+    async with _get_caps_lock(client):
+        if client in _CAPS_CACHE:
+            return _CAPS_CACHE[client]
+
+        base_url = getattr(client, "base_url", None)
+        token = getattr(client, "token", None)
+        if not base_url or not token:
+            # Not a credentialed HA client — no WS connection to negotiate over.
+            return None
+
+        try:
+            ws = await get_websocket_client(url=base_url, token=token)
+            response = await ws.send_command(INFO_COMMAND)
+        except HomeAssistantCommandError:
+            # Old component (unknown_command) or an info handler bug: the
+            # component can't serve WS commands. Cache the negative.
+            _CAPS_CACHE[client] = None
+            return None
+        except (HomeAssistantConnectionError, HomeAssistantCommandTimeout):
+            logger.debug(
+                "%s probe skipped: WS unavailable", INFO_COMMAND, exc_info=True
+            )
+            return None
+        except Exception:
+            logger.debug("%s probe failed unexpectedly", INFO_COMMAND, exc_info=True)
+            return None
+
+        caps = _parse_caps(response)
+        _CAPS_CACHE[client] = caps
+        return caps
+
+
+def component_supports(caps: ComponentCaps | None, capability: str) -> bool:
+    """Return True when the component advertised ``capability``."""
+    return caps is not None and capability in caps.capabilities
+
+
+def is_unknown_command(exc: Exception) -> bool:
+    """Return True when ``exc`` is HA's ``unknown_command`` rejection.
+
+    Keys off the structured ``code`` threaded onto ``HomeAssistantCommandError``
+    (never the message text), so a downgraded component that drops a command
+    routes cleanly to the legacy fallback.
+    """
+    return getattr(exc, "code", None) == UNKNOWN_COMMAND_CODE
+
+
+def invalidate_caps(client: Any) -> None:
+    """Drop the cached caps so the next call re-probes ``ha_mcp_tools/info``.
+
+    Called when a command believed to be supported comes back
+    ``unknown_command`` (e.g. the component was downgraded mid-session), so the
+    stale positive doesn't keep routing to a dead command.
+    """
+    _CAPS_CACHE.pop(client, None)

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -265,21 +265,3 @@ def invalidate_caps(client: Any) -> None:
     """
     _CAPS_CACHE.pop(client, None)
     _NEGATIVE_CACHE_TS.pop(client, None)
-
-
-async def send_component_config_get(
-    client: Any, domain: str, item_id: str
-) -> dict[str, Any]:
-    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
-
-    Returns the raw ``{success, result}`` envelope; the caller shapes
-    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
-    on a ``success:False`` reply (routed by the caller's error taxonomy).
-
-    Shared by the automation and script config-get consumers; both route their
-    single-item read through this one WS round-trip.
-    """
-    ws = await get_websocket_client(url=client.base_url, token=client.token)
-    return await ws.send_command(
-        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
-    )

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -65,8 +65,13 @@ class DeepSearchMixin(SceneSearchMixin):
                 ha_search orchestrator when both search branches run; ``None``
                 means fetch here.
             prefetched_registry: Pre-fetched ``config/entity_registry/list``
-                response threaded to the scene registry walk; ``None`` means the
-                walk fetches it itself.
+                response threaded to the scene registry walk *and* the helper
+                name-staleness map. ``None`` means the scene walk fetches it
+                itself; the helper branch degrades to storage-name matching
+                (it never fetches the registry on its own — see
+                ``_deep_search_helpers``). The orchestrator only hands one down
+                when both the entity and config-body branches run, so direct
+                ``deep_search``/``ha_deep_search`` callers get ``None`` here.
 
         Returns:
             Dictionary with search results grouped by type
@@ -222,7 +227,11 @@ class DeepSearchMixin(SceneSearchMixin):
                     results["helpers"],
                     helper_failed,
                 ) = await self._deep_search_helpers(
-                    query_lower, exact_match, semaphore, include_config
+                    query_lower,
+                    exact_match,
+                    semaphore,
+                    include_config,
+                    prefetched_registry=prefetched_registry,
                 )
                 phase_done += 1
                 await safe_progress(
@@ -588,12 +597,56 @@ class DeepSearchMixin(SceneSearchMixin):
         ]
         return matches, skipped_count, failed_count, yaml_skipped_count, timeout_count
 
+    @staticmethod
+    def _build_helper_registry_map(
+        prefetched_registry: Any,
+        helper_types: set[str],
+    ) -> dict[str, tuple[str, str | None]]:
+        """Map each input_* helper's storage ``unique_id`` to current ``(entity_id, name)``.
+
+        Derived from the entity-registry snapshot the ha_search orchestrator
+        already fetched — never fetched here, so the helper branch adds no
+        request (see ``_deep_search_helpers``). A UI rename updates only the
+        entity registry, so this lets helper scoring match a helper's CURRENT
+        entity_id and name while the ``<type>/list`` storage record still
+        carries its creation-time slug/name (issue #1794). For a storage helper
+        the registry ``unique_id`` equals the ``<type>/list`` record ``id`` and
+        ``platform`` equals the helper domain (e.g. ``input_boolean``); the
+        current name is the registry ``name`` (user override) falling back to
+        ``original_name`` — left ``None`` when both are absent so the caller
+        keeps the storage name. Entries with no usable ``unique_id`` /
+        ``entity_id``, a non-input_* platform, or a non-dict shape are skipped.
+
+        Returns ``{}`` when no snapshot was handed down (direct ``deep_search``
+        callers) or the snapshot is a soft failure — the caller then degrades
+        to storage-name-only matching.
+        """
+        if not (
+            isinstance(prefetched_registry, dict) and prefetched_registry.get("success")
+        ):
+            return {}
+        out: dict[str, tuple[str, str | None]] = {}
+        for entry in prefetched_registry.get("result") or []:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("platform") not in helper_types:
+                continue
+            uid = entry.get("unique_id")
+            entity_id = entry.get("entity_id")
+            if not uid or not entity_id:
+                continue
+            current_name = entry.get("name") or entry.get("original_name")
+            out[uid] = (entity_id, current_name)
+        return out
+
     async def _search_helper_type(
         self,
         helper_type: str,
         query_lower: str,
         exact_match: bool,
         semaphore: asyncio.Semaphore,
+        *,
+        registry_by_uid: dict[str, tuple[str, str | None]] | None = None,
     ) -> tuple[list[dict[str, Any]], bool]:
         """Fetch one input_* helper type via WS list and return query matches.
 
@@ -605,7 +658,20 @@ class DeepSearchMixin(SceneSearchMixin):
         swallowed to an empty list: otherwise the caller cannot tell a real
         zero-match from a partial backend outage (helpers run on every
         default ``ha_search`` call).
+
+        ``registry_by_uid`` maps a helper's storage ``unique_id`` to its
+        CURRENT ``(entity_id, name)`` from the entity registry (built by
+        ``_deep_search_helpers`` from the orchestrator's registry snapshot). A
+        UI rename updates only the registry, so the ``<type>/list`` record
+        still carries the creation-time entity_id slug and name (issue #1794);
+        when the map has an entry we score and emit the current values so a
+        search for the renamed name/entity_id matches. The storage name is
+        still scored (and the storage body still searched below), so config
+        references and un-renamed helpers never regress. ``None`` (direct
+        ``deep_search`` callers with no snapshot) degrades to the storage
+        values — today's behaviour.
         """
+        registry_by_uid = registry_by_uid or {}
         async with semaphore:
             try:
                 resp = await self.client.send_websocket_message(
@@ -621,18 +687,32 @@ class DeepSearchMixin(SceneSearchMixin):
                 matches: list[dict[str, Any]] = []
                 for helper in resp.get("result", []):
                     helper_id = helper.get("id", "")
-                    entity_id = f"{helper_type}.{helper_id}"
-                    name = helper.get("name", helper_id)
+                    storage_name = helper.get("name", helper_id)
+                    # Prefer the registry's CURRENT entity_id + name after a UI
+                    # rename; fall back to the storage-derived values when this
+                    # helper isn't in the snapshot (or no snapshot was handed
+                    # down at all).
+                    reg_entity_id, reg_name = registry_by_uid.get(
+                        helper_id, (None, None)
+                    )
+                    entity_id = reg_entity_id or f"{helper_type}.{helper_id}"
+                    display_name = reg_name or storage_name
 
-                    name_match_score = self.fuzzy_searcher._calculate_entity_score(
-                        entity_id, name, helper_type, query_lower
+                    # Score the query against every name the helper answers to —
+                    # its current (registry) name and its storage name — so
+                    # neither the rename nor the pre-rename value can hide it.
+                    name_match_score = max(
+                        self.fuzzy_searcher._calculate_entity_score(
+                            entity_id, candidate, helper_type, query_lower
+                        )
+                        for candidate in {display_name, storage_name}
                     )
                     config_match_score = self._search_in_dict(
                         helper, query_lower, exact_match
                     )
                     total_score, threshold, match_in_name = self._score_deep_match(
                         entity_id,
-                        name,
+                        display_name,
                         name_match_score,
                         config_match_score,
                         query_lower,
@@ -644,7 +724,7 @@ class DeepSearchMixin(SceneSearchMixin):
                             {
                                 "entity_id": entity_id,
                                 "helper_type": helper_type,
-                                "name": name,
+                                "name": display_name,
                                 "score": total_score,
                                 "match_in_name": match_in_name,
                                 "match_in_config": config_match_score >= threshold,
@@ -662,6 +742,8 @@ class DeepSearchMixin(SceneSearchMixin):
         exact_match: bool,
         semaphore: asyncio.Semaphore,
         include_config: bool,
+        *,
+        prefetched_registry: Any = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Deep-search helpers: parallel input_* WS lists plus flow-based helpers.
 
@@ -678,6 +760,14 @@ class DeepSearchMixin(SceneSearchMixin):
         ``ha_search`` call, so silent failures here mean the caller cannot
         tell "no helpers match" from "helper backend partially down" —
         surfaced via ``partial: True``.
+
+        ``prefetched_registry`` is the orchestrator's already-fetched
+        ``config/entity_registry/list`` response, reused (never re-fetched
+        here — this path adds no request) to map each input_* helper's storage
+        ``unique_id`` to its CURRENT entity_id + name so a UI rename doesn't
+        hide the helper from a search for its new name (#1794). ``None`` on the
+        direct ``deep_search``/``ha_deep_search`` path yields an empty map and
+        storage-name-only matching.
         """
         helper_types = [
             "input_boolean",
@@ -688,11 +778,21 @@ class DeepSearchMixin(SceneSearchMixin):
             "input_button",
         ]
 
+        registry_by_uid = self._build_helper_registry_map(
+            prefetched_registry, set(helper_types)
+        )
+
         results: list[dict[str, Any]] = []
         failed_type_count = 0
         type_results = await asyncio.gather(
             *[
-                self._search_helper_type(ht, query_lower, exact_match, semaphore)
+                self._search_helper_type(
+                    ht,
+                    query_lower,
+                    exact_match,
+                    semaphore,
+                    registry_by_uid=registry_by_uid,
+                )
                 for ht in helper_types
             ],
             return_exceptions=True,

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -41,6 +41,9 @@ class DeepSearchMixin(SceneSearchMixin):
         exact_match: bool = True,
         config_time_budget: float | None = None,
         ctx: Context | None = None,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> dict[str, Any]:
         """
         Deep search across automation, script, scene, helper, and dashboard
@@ -58,6 +61,12 @@ class DeepSearchMixin(SceneSearchMixin):
             include_config: Include full config in results (default: False)
             concurrency_limit: Max concurrent API calls for config fetching
             exact_match: Use exact substring matching (default: True). Set False for fuzzy.
+            prefetched_states: Pre-fetched ``get_states()`` list shared by the
+                ha_search orchestrator when both search branches run; ``None``
+                means fetch here.
+            prefetched_registry: Pre-fetched ``config/entity_registry/list``
+                response threaded to the scene registry walk; ``None`` means the
+                walk fetches it itself.
 
         Returns:
             Dictionary with search results grouped by type
@@ -87,8 +96,14 @@ class DeepSearchMixin(SceneSearchMixin):
                 message="fetching entity states",
             )
 
-            # Fetch all entities once at the beginning to avoid repeated calls
-            all_entities = await self.client.get_states()
+            # Fetch all entities once at the beginning to avoid repeated calls.
+            # The ha_search orchestrator may hand us a snapshot it already fetched
+            # for the entity branch so the two branches share one /api/states.
+            all_entities = (
+                prefetched_states
+                if prefetched_states is not None
+                else await self.client.get_states()
+            )
             phase_done = 1
             await safe_progress(
                 ctx,
@@ -192,6 +207,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     query_lower,
                     exact_match,
                     config_time_budget=config_time_budget,
+                    prefetched_registry=prefetched_registry,
                 )
                 phase_done += 1
                 await safe_progress(

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -5,7 +5,10 @@ import logging
 from typing import Any
 
 from ...utils.fuzzy_search import calculate_partial_ratio
-from ...visibility.resolver import load_hidden_set
+from ...visibility.resolver import (
+    device_registry_needed_for_visibility,
+    load_hidden_set,
+)
 from ..helpers import exception_to_structured_error
 from ..util_helpers import merge_visibility_warnings
 from ._base import _SearchBase
@@ -29,6 +32,9 @@ class EntitySearchMixin(_SearchBase):
         include_attributes: bool = False,
         domain_filter: str | None = None,
         include_hidden: bool = True,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> dict[str, Any]:
         """
         Search entities with fuzzy matching and typo tolerance.
@@ -43,6 +49,11 @@ class EntitySearchMixin(_SearchBase):
                 set in the entity registry are still returned but receive
                 a score penalty so they sort below comparable visible
                 matches. Pass False to filter them out entirely.
+            prefetched_states: Pre-fetched ``get_states()`` list shared by the
+                ha_search orchestrator when both search branches run; ``None``
+                means fetch here.
+            prefetched_registry: Pre-fetched ``config/entity_registry/list``
+                response shared the same way; ``None`` means fetch here.
 
         Returns:
             Dictionary with search results and metadata
@@ -55,7 +66,10 @@ class EntitySearchMixin(_SearchBase):
                 domain_filter = domain_filter.strip().lower()
 
             entities, visibility_warnings = await self._fetch_search_entities(
-                domain_filter, include_hidden
+                domain_filter,
+                include_hidden,
+                prefetched_states=prefetched_states,
+                prefetched_registry=prefetched_registry,
             )
 
             # Perform fuzzy search - returns (paginated_results, total_count)
@@ -234,48 +248,101 @@ class EntitySearchMixin(_SearchBase):
         return aliases_map, warnings
 
     async def _fetch_search_entities(
-        self, domain_filter: str | None, include_hidden: bool
+        self,
+        domain_filter: str | None,
+        include_hidden: bool,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> tuple[list[dict[str, Any]], list[str]]:
         """Fetch + enrich the entity set fed into the fuzzy search layer.
 
         Fetches states + the slim entity-registry list in parallel (the slim
         view gives ``hidden_by`` and the ids needed for the alias batch fetch;
-        aliases live only in ``get_entries``), filters hidden entities, enriches
-        survivors with aliases + hidden_by, then applies the optional domain
-        filter.
+        aliases live only in ``get_entries``), filters hidden entities, applies
+        the optional domain filter, then enriches the survivors with aliases +
+        hidden_by. The domain filter runs *before* the alias fetch so the chunked
+        alias WS calls only cover entities that survive it. states/registry may be
+        pre-fetched and shared by the ha_search orchestrator (``None`` = fetch
+        here); the device registry is fetched only when a visibility area/label
+        dimension will consume it.
         """
-        results = await asyncio.gather(
-            self.client.get_states(),
-            self.client.send_websocket_message({"type": "config/entity_registry/list"}),
-            self.client.send_websocket_message({"type": "config/device_registry/list"}),
-            return_exceptions=True,
+        need_device = await device_registry_needed_for_visibility()
+        fetch_coros: list[Any] = []
+        fetch_slots: list[str] = []
+        if prefetched_states is None:
+            fetch_coros.append(self.client.get_states())
+            fetch_slots.append("states")
+        if prefetched_registry is None:
+            fetch_coros.append(
+                self.client.send_websocket_message(
+                    {"type": "config/entity_registry/list"}
+                )
+            )
+            fetch_slots.append("registry")
+        if need_device:
+            fetch_coros.append(
+                self.client.send_websocket_message(
+                    {"type": "config/device_registry/list"}
+                )
+            )
+            fetch_slots.append("device")
+        fetched = (
+            await asyncio.gather(*fetch_coros, return_exceptions=True)
+            if fetch_coros
+            else []
         )
+        slots = dict(zip(fetch_slots, fetched, strict=True))
+        states_result: Any = (
+            prefetched_states if prefetched_states is not None else slots.get("states")
+        )
+        registry_result: Any = (
+            prefetched_registry
+            if prefetched_registry is not None
+            else slots.get("registry")
+        )
+        device_result: Any = slots.get("device")
         # States-fetch failure is fatal — auth/connection errors must propagate
         # so the caller sees the real cause instead of a bogus "zero matches"
         # with success=True.
-        if isinstance(results[0], BaseException):
-            raise results[0]
+        if isinstance(states_result, BaseException):
+            raise states_result
         # CancelledError on the registry tasks must propagate too; gather captures
         # it like any other exception when return_exceptions=True.
-        if isinstance(results[1], asyncio.CancelledError):
-            raise results[1]
-        if isinstance(results[2], asyncio.CancelledError):
-            raise results[2]
-        entities = results[0]
+        if isinstance(registry_result, asyncio.CancelledError):
+            raise registry_result
+        if isinstance(device_result, asyncio.CancelledError):
+            raise device_result
+        entities = states_result
 
-        # Opt-in visibility filter. results[1] is the unprojected registry, so
-        # entity_category/hidden_by/area_id/labels are present (the slim map
-        # below drops them); results[2] is the device registry, which lets the
-        # area/label dimensions match a device-bound entity by its device's
-        # area/labels. Fails open; do NOT wrap in try/except or the failure mode
-        # inverts.
+        # Opt-in visibility filter. registry_result is the unprojected registry,
+        # so entity_category/hidden_by/area_id/labels are present (the slim map
+        # below drops them); device_result is the device registry (``None`` when
+        # no area/label dimension needs it), which lets the area/label dimensions
+        # match a device-bound entity by its device's area/labels. Fails open; do
+        # NOT wrap in try/except or the failure mode inverts.
         visibility_hidden, visibility_warnings = await load_hidden_set(
-            results[1], results[0], self.client, results[2]
+            registry_result, states_result, self.client, device_result
         )
-        registry_slim = self._build_registry_slim(results[1])
+        registry_slim = self._build_registry_slim(registry_result)
         survivor_ids, survivor_states = self._filter_hidden_entities(
             entities, registry_slim, include_hidden, visibility_hidden
         )
+
+        # Apply the domain filter before the alias fetch. The old order fetched
+        # aliases for every survivor and filtered at the very end; the final set
+        # and its order are identical (each survivor keeps its own aliases), so
+        # this only shrinks the alias WS fan-out.
+        if domain_filter:
+            domain_prefix = f"{domain_filter}."
+            kept = [
+                (eid, state)
+                for eid, state in zip(survivor_ids, survivor_states, strict=True)
+                if eid.startswith(domain_prefix)
+            ]
+            survivor_ids = [eid for eid, _ in kept]
+            survivor_states = [state for _, state in kept]
+
         aliases_map, alias_warnings = await self._fetch_entity_aliases(survivor_ids)
         visibility_warnings = [*visibility_warnings, *alias_warnings]
 
@@ -293,12 +360,6 @@ class EntitySearchMixin(_SearchBase):
                 }
             )
 
-        if domain_filter:
-            enriched = [
-                e
-                for e in enriched
-                if e.get("entity_id", "").startswith(f"{domain_filter}.")
-            ]
         return enriched, visibility_warnings
 
     @staticmethod

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -25,6 +25,7 @@ class SystemOverviewMixin(_SearchBase):
         domains_filter: list[str] | None = None,
         limit: int | None = None,
         offset: int = 0,
+        prefetched_slices: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
         Get AI-friendly system overview with intelligent categorization.
@@ -42,27 +43,50 @@ class SystemOverviewMixin(_SearchBase):
                 Defaults to None (no limit) for minimal, 200 for standard/full.
                 Domain counts and states_summary are always complete regardless.
             offset: Number of entities to skip for pagination (default: 0)
+            prefetched_slices: The five overview reads (``states``, ``services``,
+                ``area_registry``, ``entity_registry``, ``device_registry``)
+                already fetched by a caller — the ``ha_mcp_tools/overview``
+                component collapses them into one round-trip. When given, the
+                parallel gather is skipped and these are used verbatim (bare
+                ``states``/``services`` lists; the three registries in the
+                ``{success, result}`` envelope ``_extract_registry_list`` /
+                ``load_hidden_set`` unwrap). ``None`` (default) fetches them
+                itself, mirroring the ``prefetched_states``/``prefetched_registry``
+                threading used by the search paths.
 
         Returns:
             System overview optimized for AI understanding at requested detail level
         """
         try:
-            # Fetch all data in parallel. return_exceptions=True so a degraded
-            # registry/service fetch doesn't abort the whole overview.
-            results = await asyncio.gather(
-                self.client.get_states(),
-                self.client.get_services(),
-                self.client.send_websocket_message(
-                    {"type": "config/area_registry/list"}
-                ),
-                self.client.send_websocket_message(
-                    {"type": "config/entity_registry/list"}
-                ),
-                self.client.send_websocket_message(
-                    {"type": "config/device_registry/list"}
-                ),
-                return_exceptions=True,
-            )
+            if prefetched_slices is not None:
+                # Component raw-slice path: the reads were already returned in
+                # one WS round-trip, so use them instead of fetching. Downstream
+                # unwrapping is unchanged — states/services are bare lists and the
+                # registries carry the {success, result} envelope.
+                results: list[Any] = [
+                    prefetched_slices["states"],
+                    prefetched_slices["services"],
+                    prefetched_slices["area_registry"],
+                    prefetched_slices["entity_registry"],
+                    prefetched_slices["device_registry"],
+                ]
+            else:
+                # Fetch all data in parallel. return_exceptions=True so a degraded
+                # registry/service fetch doesn't abort the whole overview.
+                results = await asyncio.gather(
+                    self.client.get_states(),
+                    self.client.get_services(),
+                    self.client.send_websocket_message(
+                        {"type": "config/area_registry/list"}
+                    ),
+                    self.client.send_websocket_message(
+                        {"type": "config/entity_registry/list"}
+                    ),
+                    self.client.send_websocket_message(
+                        {"type": "config/device_registry/list"}
+                    ),
+                    return_exceptions=True,
+                )
 
             # Entities are mandatory — surface connection/auth errors immediately.
             # Use BaseException so a cancelled states fetch propagates instead of

--- a/src/ha_mcp/tools/smart_search/_scenes.py
+++ b/src/ha_mcp/tools/smart_search/_scenes.py
@@ -19,7 +19,10 @@ class SceneSearchMixin(ConfigFetchMixin):
     """Scene config search (scenes lack a list primitive; per-id fetch + registry walk)."""
 
     async def _walk_scene_registry(
-        self, configs: dict[str, dict[str, Any]]
+        self,
+        configs: dict[str, dict[str, Any]],
+        *,
+        prefetched_registry: Any = None,
     ) -> tuple[set[str], dict[str, str], bool]:
         """Walk the entity registry once for scene metadata (Phase 2.5).
 
@@ -60,12 +63,19 @@ class SceneSearchMixin(ConfigFetchMixin):
         # scene the registry knows about regardless of bulk-fetch coverage.
         slug_to_storage_id: dict[str, str] = {}
         try:
-            reg_resp = await asyncio.wait_for(
-                self.client.send_websocket_message(
-                    {"type": "config/entity_registry/list"}
-                ),
-                timeout=BULK_WEBSOCKET_TIMEOUT,
-            )
+            # The ha_search orchestrator may hand us the registry list it already
+            # fetched for the entity branch (one list instead of two). A
+            # pre-fetched non-success payload flows through the same else-branch
+            # below → registry_failed=True, matching a self-fetched soft failure.
+            if prefetched_registry is not None:
+                reg_resp = prefetched_registry
+            else:
+                reg_resp = await asyncio.wait_for(
+                    self.client.send_websocket_message(
+                        {"type": "config/entity_registry/list"}
+                    ),
+                    timeout=BULK_WEBSOCKET_TIMEOUT,
+                )
             if isinstance(reg_resp, dict) and reg_resp.get("success"):
                 for entry in reg_resp.get("result") or []:
                     self._index_scene_registry_entry(
@@ -200,6 +210,7 @@ class SceneSearchMixin(ConfigFetchMixin):
         exact_match: bool,
         *,
         config_time_budget: float | None = None,
+        prefetched_registry: Any = None,
     ) -> tuple[list[dict[str, Any]], int, int, int, bool, int]:
         """Deep-search scenes: 3-tier strategy plus registry-walk augmentation.
 
@@ -246,7 +257,9 @@ class SceneSearchMixin(ConfigFetchMixin):
             homeassistant_scene_uids,
             slug_to_storage_id,
             registry_failed,
-        ) = await self._walk_scene_registry(configs)
+        ) = await self._walk_scene_registry(
+            configs, prefetched_registry=prefetched_registry
+        )
 
         failed_count = 0
         skipped_count = 0

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -16,9 +16,9 @@ from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
     HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
-from ..client.websocket_client import get_websocket_client
 from ..errors import (
     ErrorCode,
     create_config_error,
@@ -44,6 +44,7 @@ from .component_api import (
     get_component_caps,
     invalidate_caps,
     is_unknown_command,
+    send_component_config_get,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -68,21 +69,6 @@ from .util_helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-async def _send_component_config_get(
-    client: Any, domain: str, item_id: str
-) -> dict[str, Any]:
-    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
-
-    Returns the raw ``{success, result}`` envelope; the caller shapes
-    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
-    on a ``success:False`` reply (routed by the caller's error taxonomy).
-    """
-    ws = await get_websocket_client(url=client.base_url, token=client.token)
-    return await ws.send_command(
-        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
-    )
 
 
 # Skill files attached to ha_config_set_automation responses when
@@ -476,7 +462,8 @@ class AutomationConfigTools:
 
         - ``unknown_command`` (component downgraded mid-session, stale caps):
           invalidate caps and return ``None`` for a silent legacy fallback.
-        - any other ``HomeAssistantCommandError`` (component handler bug):
+        - any other ``HomeAssistantCommandError`` (component handler bug) or a
+          ``HomeAssistantCommandTimeout`` (the component WS read timed out):
           serve the correct result from the legacy path, append a
           ``warnings[]`` entry, and ``log.warning``.
         - ``HomeAssistantConnectionError`` (WS down): not caught, so it
@@ -488,10 +475,10 @@ class AutomationConfigTools:
         ``_raise_automation_not_found``.
         """
         try:
-            raw = await _send_component_config_get(
+            raw = await send_component_config_get(
                 self._client, "automation", identifier
             )
-        except HomeAssistantCommandError as exc:
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             if is_unknown_command(exc):
                 invalidate_caps(self._client)
                 return None

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -15,8 +15,6 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
-    HomeAssistantCommandError,
-    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
 from ..errors import (
@@ -38,13 +36,6 @@ from .best_practice_checker import (
 )
 from .best_practice_checker import (
     check_automation_config as _check_best_practices,
-)
-from .component_api import (
-    component_supports,
-    get_component_caps,
-    invalidate_caps,
-    is_unknown_command,
-    send_component_config_get,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -397,18 +388,18 @@ class AutomationConfigTools:
                 ],
             )
 
-            # Prefer the custom component's in-process config_get when it
-            # advertises the capability: one WS round-trip returns the config
-            # body + current entity_id + category, replacing the legacy 3-4
-            # (id resolution + per-id config REST + fetch_entity_category WS).
-            # Falls back cleanly when the component is absent, downlevel, or
-            # errors — taxonomy lives in ``_get_automation_via_component``.
-            caps = await get_component_caps(self._client)
-            if component_supports(caps, "config_get"):
-                routed = await self._get_automation_via_component(identifier)
-                if routed is not None:
-                    return routed
-
+            # Automation gets ALWAYS take the legacy path — the component's
+            # in-process ``config_get`` was withdrawn. It served
+            # ``entity.raw_config``, which is only the storage body as of the
+            # last COMPLETED async reload, with no version marker to tell a
+            # fresh body from a stale one. A get racing a reload returned the
+            # pre-edit body and broke the get -> python_transform -> set
+            # round-trip (caught live by the automation python_transform e2e on
+            # the arm/HAOS runners). The legacy REST config endpoint reads the
+            # config FILE, which is fresh the instant a write lands, so it stays
+            # the sole path. Scenes were already legacy-only (no storage body in
+            # memory at all); automations join them here for freshness. A
+            # file-reading ``config_get`` may return later (issue #1813).
             return await self._legacy_get_automation(identifier)
         except ToolError:
             raise
@@ -427,11 +418,12 @@ class AutomationConfigTools:
     async def _legacy_get_automation(self, identifier: str) -> dict[str, Any]:
         """Assemble the automation-get response from the REST/WS pipeline.
 
-        The multi-fetch fallback: per-id config REST + state-lookup entity_id
-        resolution + ``fetch_entity_category`` WS call. Behaviourally
-        unchanged from the pre-component implementation — the component path
-        (``_get_automation_via_component``) reproduces this exact envelope
-        from a single WS call.
+        The multi-fetch path: per-id config REST + state-lookup entity_id
+        resolution + ``fetch_entity_category`` WS call. This is the ONLY
+        automation-get path — see ``ha_config_get_automation`` for why
+        automation gets never route through the component's ``config_get``
+        (its ``raw_config`` freshness lags the config file between a write and
+        the next completed reload).
         """
         normalized_config, config_hash = await self._get_automation_config_internal(
             identifier
@@ -444,67 +436,6 @@ class AutomationConfigTools:
             cat_id = await fetch_entity_category(self._client, entity_id, "automation")
             if cat_id:
                 normalized_config["category"] = cat_id
-
-        return {
-            "success": True,
-            "action": "get",
-            "automation_id": entity_id or identifier,
-            "config": normalized_config,
-            "config_hash": config_hash,
-        }
-
-    async def _get_automation_via_component(
-        self, identifier: str
-    ) -> dict[str, Any] | None:
-        """Serve ha_config_get_automation from the component; ``None`` ⇒ legacy.
-
-        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
-
-        - ``unknown_command`` (component downgraded mid-session, stale caps):
-          invalidate caps and return ``None`` for a silent legacy fallback.
-        - any other ``HomeAssistantCommandError`` (component handler bug) or a
-          ``HomeAssistantCommandTimeout`` (the component WS read timed out):
-          serve the correct result from the legacy path, append a
-          ``warnings[]`` entry, and ``log.warning``.
-        - ``HomeAssistantConnectionError`` (WS down): not caught, so it
-          propagates; the legacy path shares the socket and would fail alike.
-
-        A ``found:false`` result (the id resolves to nothing, or resolves to a
-        YAML-defined item the component won't serve) raises the same
-        ``RESOURCE_NOT_FOUND`` the legacy REST 404 path raises, via
-        ``_raise_automation_not_found``.
-        """
-        try:
-            raw = await send_component_config_get(
-                self._client, "automation", identifier
-            )
-        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
-            if is_unknown_command(exc):
-                invalidate_caps(self._client)
-                return None
-            legacy = await self._legacy_get_automation(identifier)
-            legacy.setdefault("warnings", []).append(
-                f"component config_get path failed ({exc}); served via legacy path"
-            )
-            logger.warning(
-                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
-            )
-            return legacy
-
-        result = raw.get("result") or {}
-        if not result.get("found"):
-            await self._raise_automation_not_found(identifier)  # raises ToolError
-        config = result.get("config")
-        if not isinstance(config, dict):
-            # Malformed success payload — defer to legacy rather than trust it.
-            return None
-
-        normalized_config = _normalize_config_for_roundtrip(config)
-        config_hash = compute_config_hash(normalized_config)
-        entity_id = result.get("entity_id")
-        category = result.get("category")
-        if category:
-            normalized_config["category"] = str(category)
 
         return {
             "success": True,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -15,8 +15,10 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
+    HomeAssistantCommandError,
     HomeAssistantConnectionError,
 )
+from ..client.websocket_client import get_websocket_client
 from ..errors import (
     ErrorCode,
     create_config_error,
@@ -36,6 +38,12 @@ from .best_practice_checker import (
 )
 from .best_practice_checker import (
     check_automation_config as _check_best_practices,
+)
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -60,6 +68,21 @@ from .util_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _send_component_config_get(
+    client: Any, domain: str, item_id: str
+) -> dict[str, Any]:
+    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
+
+    Returns the raw ``{success, result}`` envelope; the caller shapes
+    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
+    on a ``success:False`` reply (routed by the caller's error taxonomy).
+    """
+    ws = await get_websocket_client(url=client.base_url, token=client.token)
+    return await ws.send_command(
+        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
+    )
 
 
 # Skill files attached to ha_config_set_automation responses when
@@ -387,27 +410,20 @@ class AutomationConfigTools:
                     "Use ha_search(domain_filter='automation') to list automations",
                 ],
             )
-            normalized_config, config_hash = await self._get_automation_config_internal(
-                identifier
-            )
 
-            # Resolve entity_id and fetch category from entity registry
-            # (injected after hash so transient registry failures don't affect the hash)
-            entity_id = await self._resolve_automation_entity_id(identifier)
-            if entity_id:
-                cat_id = await fetch_entity_category(
-                    self._client, entity_id, "automation"
-                )
-                if cat_id:
-                    normalized_config["category"] = cat_id
+            # Prefer the custom component's in-process config_get when it
+            # advertises the capability: one WS round-trip returns the config
+            # body + current entity_id + category, replacing the legacy 3-4
+            # (id resolution + per-id config REST + fetch_entity_category WS).
+            # Falls back cleanly when the component is absent, downlevel, or
+            # errors — taxonomy lives in ``_get_automation_via_component``.
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "config_get"):
+                routed = await self._get_automation_via_component(identifier)
+                if routed is not None:
+                    return routed
 
-            return {
-                "success": True,
-                "action": "get",
-                "automation_id": entity_id or identifier,
-                "config": normalized_config,
-                "config_hash": config_hash,
-            }
+            return await self._legacy_get_automation(identifier)
         except ToolError:
             raise
         except Exception as e:
@@ -421,6 +437,95 @@ class AutomationConfigTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+
+    async def _legacy_get_automation(self, identifier: str) -> dict[str, Any]:
+        """Assemble the automation-get response from the REST/WS pipeline.
+
+        The multi-fetch fallback: per-id config REST + state-lookup entity_id
+        resolution + ``fetch_entity_category`` WS call. Behaviourally
+        unchanged from the pre-component implementation — the component path
+        (``_get_automation_via_component``) reproduces this exact envelope
+        from a single WS call.
+        """
+        normalized_config, config_hash = await self._get_automation_config_internal(
+            identifier
+        )
+
+        # Resolve entity_id and fetch category from entity registry
+        # (injected after hash so transient registry failures don't affect the hash)
+        entity_id = await self._resolve_automation_entity_id(identifier)
+        if entity_id:
+            cat_id = await fetch_entity_category(self._client, entity_id, "automation")
+            if cat_id:
+                normalized_config["category"] = cat_id
+
+        return {
+            "success": True,
+            "action": "get",
+            "automation_id": entity_id or identifier,
+            "config": normalized_config,
+            "config_hash": config_hash,
+        }
+
+    async def _get_automation_via_component(
+        self, identifier: str
+    ) -> dict[str, Any] | None:
+        """Serve ha_config_get_automation from the component; ``None`` ⇒ legacy.
+
+        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
+
+        - ``unknown_command`` (component downgraded mid-session, stale caps):
+          invalidate caps and return ``None`` for a silent legacy fallback.
+        - any other ``HomeAssistantCommandError`` (component handler bug):
+          serve the correct result from the legacy path, append a
+          ``warnings[]`` entry, and ``log.warning``.
+        - ``HomeAssistantConnectionError`` (WS down): not caught, so it
+          propagates; the legacy path shares the socket and would fail alike.
+
+        A ``found:false`` result (the id resolves to nothing, or resolves to a
+        YAML-defined item the component won't serve) raises the same
+        ``RESOURCE_NOT_FOUND`` the legacy REST 404 path raises, via
+        ``_raise_automation_not_found``.
+        """
+        try:
+            raw = await _send_component_config_get(
+                self._client, "automation", identifier
+            )
+        except HomeAssistantCommandError as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            legacy = await self._legacy_get_automation(identifier)
+            legacy.setdefault("warnings", []).append(
+                f"component config_get path failed ({exc}); served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
+            )
+            return legacy
+
+        result = raw.get("result") or {}
+        if not result.get("found"):
+            await self._raise_automation_not_found(identifier)  # raises ToolError
+        config = result.get("config")
+        if not isinstance(config, dict):
+            # Malformed success payload — defer to legacy rather than trust it.
+            return None
+
+        normalized_config = _normalize_config_for_roundtrip(config)
+        config_hash = compute_config_hash(normalized_config)
+        entity_id = result.get("entity_id")
+        category = result.get("category")
+        if category:
+            normalized_config["category"] = str(category)
+
+        return {
+            "success": True,
+            "action": "get",
+            "automation_id": entity_id or identifier,
+            "config": normalized_config,
+            "config_hash": config_hash,
+        }
 
     @tool(
         name="ha_config_set_automation",

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -10,17 +10,25 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable
-from typing import Annotated, Any, Literal, TypedDict
+from typing import Annotated, Any, Literal, NoReturn, TypedDict
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import AliasChoices, Field
 
-from ..client.rest_client import HomeAssistantAPIError
+from ..client.rest_client import HomeAssistantAPIError, HomeAssistantCommandError
+from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
+)
 from .config_entry_flow import (
     FLOW_HELPER_TYPES,
+    SUPPORTED_HELPERS,
     create_flow_helper,
     fetch_helper_flow_info,
     get_user_step_field_names,
@@ -3349,6 +3357,129 @@ def _validate_pre_dispatch_params(
 # ---------------------------------------------------------------------------
 
 
+def _shape_collection_helper_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Map one component collection-helper record onto the legacy list record.
+
+    The legacy ``{helper_type}/list`` record is the storage body itself
+    (``id`` = storage id, ``name`` = creation-time name, plus type-specific
+    keys). The component supplies that same body as ``config`` and, from the
+    entity registry, the current ``entity_id`` and display ``name``. Keep the
+    legacy keys with their legacy meanings (``id`` stays the storage id) and
+    layer the current ``entity_id`` + ``name`` on top — the additive form of
+    the #1794 stale-id fix that the legacy-path PR converges to.
+    """
+    config = rec.get("config")
+    out: dict[str, Any] = dict(config) if isinstance(config, dict) else {}
+    # The faithful component body already carries ``id``; fall back to the
+    # record-level ``object_id`` only when it doesn't, so the storage id the
+    # legacy record guarantees is never dropped.
+    if "id" not in out and rec.get("object_id") is not None:
+        out["id"] = rec["object_id"]
+    entity_id = rec.get("entity_id")
+    if entity_id is not None:
+        out["entity_id"] = entity_id
+    name = rec.get("name")
+    if name is not None:
+        out["name"] = name
+    return out
+
+
+def _shape_flow_helper_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Map one component flow-helper record onto a list record.
+
+    Flow helpers have no storage ``id`` and no ``{type}/list`` command; the
+    component sources them from the config entry. The record carries the
+    ``entry_id`` (config-entry id), the current ``entity_id`` + display
+    ``name``, the ``helper_type``, and the data-minimized ``options`` body
+    (``ConfigEntry.options`` only, never ``entry.data``). Mirrors the
+    collection shaper's current-fields layering.
+    """
+    out: dict[str, Any] = {"helper_type": rec.get("helper_type")}
+    entry_id = rec.get("entry_id")
+    if entry_id is not None:
+        out["entry_id"] = entry_id
+    entity_id = rec.get("entity_id")
+    if entity_id is not None:
+        out["entity_id"] = entity_id
+    name = rec.get("name")
+    if name is not None:
+        out["name"] = name
+    options = rec.get("options")
+    if isinstance(options, dict):
+        out["options"] = options
+    return out
+
+
+def _shape_component_helpers_response(
+    helper_type: str, result: dict[str, Any]
+) -> dict[str, Any]:
+    """Map an ``ha_mcp_tools/helpers_list`` result into the legacy envelope.
+
+    Emits the exact legacy top-level keys (``success``/``helper_type``/
+    ``count``/``helpers``/``message``). Records are shaped to the requested
+    universe: a flow ``helper_type`` yields flow records (``entry_id`` +
+    current ``entity_id``/``name`` + ``options``); a storage type yields the
+    storage-body records. A record of the other kind is dropped defensively.
+    ``count`` is the length of the emitted list, mirroring the legacy
+    ``count == len(helpers)`` guarantee.
+    """
+    raw = result.get("helpers")
+    records = raw if isinstance(raw, list) else []
+    want_flow = helper_type in FLOW_HELPER_TYPES
+    helpers: list[dict[str, Any]] = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        if (rec.get("kind") == "flow") != want_flow:
+            continue
+        helpers.append(
+            _shape_flow_helper_record(rec)
+            if want_flow
+            else _shape_collection_helper_record(rec)
+        )
+    return {
+        "success": True,
+        "helper_type": helper_type,
+        "count": len(helpers),
+        "helpers": helpers,
+        "message": f"Found {len(helpers)} {helper_type} helper(s)",
+    }
+
+
+def _component_covers(result: dict[str, Any], helper_type: str) -> bool:
+    """Whether a helpers_list response authoritatively enumerated ``helper_type``.
+
+    The component reports ``covered_types``: the helper types its response could
+    actually see. A type outside that list (e.g. ``tag`` — tags have no state
+    entity, so the component's from-states scan can't enumerate them) must NOT
+    be trusted as "none exist". A response with no ``covered_types`` at all (an
+    older component) is treated conservatively as covering nothing, so the
+    caller falls back rather than trusting a possibly-partial list.
+    """
+    covered = result.get("covered_types")
+    return isinstance(covered, list) and helper_type in covered
+
+
+def _raise_flow_requires_component(helper_type: str) -> NoReturn:
+    """Raise the structured error for a flow helper with no component path.
+
+    Flow-based helper types have no ``{type}/list`` WS command, so the legacy
+    listing path cannot enumerate them — only the ha_mcp_tools component's
+    ``helpers_list`` can. When the component is absent, downlevel, or its call
+    fails, this is a hard error: never a silent empty list, never a legacy
+    fallback (there is none for flow types).
+    """
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.COMPONENT_NOT_INSTALLED,
+            f"Listing '{helper_type}' (a flow-based helper) requires the "
+            "ha_mcp_tools custom component (>= 1.1.0); the built-in listing "
+            "path cannot enumerate flow helpers.",
+            context={"helper_type": helper_type},
+        )
+    )
+
+
 class HelperConfigTools:
     """Encapsulates helper configuration tools for ha_config_list_helpers and ha_config_set_helper."""
 
@@ -3381,15 +3512,23 @@ class HelperConfigTools:
                 "zone",
                 "person",
                 "tag",
-            ],
-            Field(description="Type of helper entity to list"),
+            ]
+            | SUPPORTED_HELPERS,
+            Field(
+                description=(
+                    "Helper type to list. Storage types are listed on all "
+                    "installs; flow-based types require the ha_mcp_tools "
+                    "custom component."
+                )
+            ),
         ],
     ) -> dict[str, Any]:
         """
         List all Home Assistant helpers of a specific type with their configurations.
 
         Returns complete configuration for all helpers of the specified type including:
-        - ID, name, icon
+        - ID (storage id), name, icon
+        - entity_id and current display name (where available)
         - Type-specific settings (min/max for input_number, options for input_select, etc.)
         - Area and label assignments
 
@@ -3417,10 +3556,36 @@ class HelperConfigTools:
         **NOTE:** This only returns storage-based helpers (created via UI/API), not YAML-defined helpers.
 
         Flow-based types (template / group / utility_meter / derivative / etc.)
-        cannot be listed via this tool — use ``ha_search`` for those.
+        require the ha_mcp_tools custom component (>= 1.1.0) and are served only
+        through it; storage types are listed on all installs. Requesting a flow
+        type without the component returns a COMPONENT_NOT_INSTALLED error.
 
         For detailed helper documentation, use ha_get_skill_guide.
         """
+        # Flow-based helper types have no ``{type}/list`` command, so only the
+        # component's ``helpers_list`` can enumerate them: they are served
+        # exclusively through the component path (never the legacy body, never a
+        # silent empty). Storage/collection types keep the legacy fallback.
+        is_flow = helper_type in FLOW_HELPER_TYPES
+
+        # Prefer the custom component's in-process listing when it advertises
+        # the capability: one WS round-trip that joins the entity registry, so
+        # each record carries the current entity_id + display name (the #1794
+        # stale-id fix, shipped additively) instead of only the storage id.
+        # Fall back cleanly for storage types when the component is absent,
+        # downlevel, or errors — the taxonomy lives in
+        # ``_list_helpers_via_component``. The legacy body below is untouched.
+        caps = await get_component_caps(self._client)
+        if component_supports(caps, "helpers_list"):
+            component_response = await self._list_helpers_via_component(
+                helper_type, is_flow=is_flow
+            )
+            if component_response is not None:
+                return component_response
+        if is_flow:
+            # No usable component path and the legacy body cannot serve flow
+            # helpers: hard error rather than an empty or misleading list.
+            _raise_flow_requires_component(helper_type)
         try:
             result = await self._client.send_websocket_message(
                 {"type": f"{helper_type}/list"}
@@ -3458,6 +3623,117 @@ class HelperConfigTools:
                 None  # exception_to_structured_error always raises; explicit for CodeQL
             )
         return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
+
+    async def _list_helpers_via_component(
+        self, helper_type: str, *, is_flow: bool
+    ) -> dict[str, Any] | None:
+        """Serve ha_config_list_helpers from the component; ``None`` ⇒ legacy.
+
+        Error taxonomy (component_api design § 4), with a flow-helper override
+        (a flow type has no legacy path, so any component failure is fatal):
+
+        - ``unknown_command`` (the cached positive caps went stale after a
+          component downgrade): invalidate the caps. For a storage type, return
+          ``None`` so the caller falls through to the byte-identical legacy
+          body, **silently**. For a flow type, raise the component-required
+          error.
+        - any other ``HomeAssistantCommandError`` (a component handler bug):
+          for a storage type, serve the correct result from the legacy WS list,
+          append a ``warnings[]`` entry, and ``log.warning``. For a flow type,
+          raise the component-required error — no legacy fallback exists.
+        - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
+          propagates; the legacy path depends on the same socket and would
+          fail identically.
+
+        On a successful response the type must also be in the component's
+        ``covered_types`` (see :func:`_component_covers`): a type the response
+        could not authoritatively enumerate (``tag``, or any type on an older
+        component with no ``covered_types``) is handled like a component miss —
+        storage falls back to legacy silently, flow raises.
+        """
+        try:
+            raw = await self._send_component_helpers_list(helper_type, is_flow=is_flow)
+        except HomeAssistantCommandError as exc:
+            unknown = is_unknown_command(exc)
+            if unknown:
+                invalidate_caps(self._client)
+            if is_flow:
+                logger.warning(
+                    "ha_mcp_tools/helpers_list failed for flow type %r: %r",
+                    helper_type,
+                    exc,
+                )
+                _raise_flow_requires_component(helper_type)
+            if unknown:
+                return None
+            legacy = await self._legacy_helper_list(helper_type)
+            legacy.setdefault("warnings", []).append(
+                f"component helpers_list path failed ({exc}); served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/helpers_list failed; fell back to legacy: %r", exc
+            )
+            return legacy
+        result = raw.get("result") or {}
+        if not _component_covers(result, helper_type):
+            # The component did not authoritatively enumerate this type (tag has
+            # no state entity for the from-states scan; or an older component
+            # sent no covered_types). Don't trust a partial/empty list: storage
+            # types fall back to the legacy path silently; a flow type (always
+            # covered when include_flow_helpers=True) raises the same
+            # component-required error rather than emptying out.
+            if is_flow:
+                _raise_flow_requires_component(helper_type)
+            return None
+        return _shape_component_helpers_response(helper_type, result)
+
+    async def _send_component_helpers_list(
+        self, helper_type: str, *, is_flow: bool
+    ) -> dict[str, Any]:
+        """Send one ``ha_mcp_tools/helpers_list`` command over the per-client WS.
+
+        Requests only the single ``helper_type`` and sets
+        ``include_flow_helpers`` to match its universe — ``True`` for a
+        flow-based type (so the component returns its config-entry-backed
+        record), ``False`` for a storage/collection type.
+        """
+        ws = await get_websocket_client(
+            url=self._client.base_url, token=self._client.token
+        )
+        return await ws.send_command(
+            "ha_mcp_tools/helpers_list",
+            helper_types=[helper_type],
+            include_flow_helpers=is_flow,
+        )
+
+    async def _legacy_helper_list(self, helper_type: str) -> dict[str, Any]:
+        """Legacy ``{helper_type}/list`` success envelope, for the § 4 #3 fallback.
+
+        A faithful copy of the tool's inline legacy success path, kept separate
+        (rather than extracted from that body) so the #1794 registry-join PR can
+        patch the inline body without a conflict here. The drift is bounded to
+        the rare component-error fallback and is flagged by the ``warnings[]``
+        entry the caller appends.
+        """
+        result = await self._client.send_websocket_message(
+            {"type": f"{helper_type}/list"}
+        )
+        if not result.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to list helpers: {result.get('error', 'Unknown error')}",
+                    context={"helper_type": helper_type},
+                )
+            )
+        items = result.get("result", [])
+        return {
+            "success": True,
+            "helper_type": helper_type,
+            "count": len(items),
+            "helpers": items,
+            "message": f"Found {len(items)} {helper_type} helper(s)",
+        }
 
     @tool(
         name="ha_config_set_helper",

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -16,7 +16,11 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import AliasChoices, Field
 
-from ..client.rest_client import HomeAssistantAPIError, HomeAssistantCommandError
+from ..client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
 from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
@@ -3363,18 +3367,24 @@ def _shape_collection_helper_record(rec: dict[str, Any]) -> dict[str, Any]:
     The legacy ``{helper_type}/list`` record is the storage body itself
     (``id`` = storage id, ``name`` = creation-time name, plus type-specific
     keys). The component supplies that same body as ``config`` and, from the
-    entity registry, the current ``entity_id`` and display ``name``. Keep the
-    legacy keys with their legacy meanings (``id`` stays the storage id) and
-    layer the current ``entity_id`` + ``name`` on top — the additive form of
-    the #1794 stale-id fix that the legacy-path PR converges to.
+    real storage collection + entity registry, the authoritative
+    ``storage_id`` plus the current ``entity_id`` and display ``name``. Keep the
+    legacy keys with their legacy meanings and layer the current ``entity_id`` +
+    ``name`` on top — the additive form of the #1794 stale-id fix that the
+    legacy-path PR converges to.
     """
     config = rec.get("config")
     out: dict[str, Any] = dict(config) if isinstance(config, dict) else {}
-    # The faithful component body already carries ``id``; fall back to the
-    # record-level ``object_id`` only when it doesn't, so the storage id the
-    # legacy record guarantees is never dropped.
-    if "id" not in out and rec.get("object_id") is not None:
-        out["id"] = rec["object_id"]
+    # Prefer the record-level ``storage_id`` (the component reads it from the
+    # real storage collection). Not every collection body carries its own
+    # ``id`` — person/zone are stored keyed by id rather than embedding it — so
+    # trusting the body's ``id`` drifts for those types. Fall back to
+    # ``object_id`` only when ``storage_id`` is absent (older component).
+    storage_id = rec.get("storage_id")
+    if storage_id is None:
+        storage_id = rec.get("object_id")
+    if storage_id is not None:
+        out["id"] = storage_id
     entity_id = rec.get("entity_id")
     if entity_id is not None:
         out["entity_id"] = entity_id
@@ -3637,7 +3647,8 @@ class HelperConfigTools:
           ``None`` so the caller falls through to the byte-identical legacy
           body, **silently**. For a flow type, raise the component-required
           error.
-        - any other ``HomeAssistantCommandError`` (a component handler bug):
+        - any other ``HomeAssistantCommandError`` (a component handler bug) or a
+          ``HomeAssistantCommandTimeout`` (the component WS list timed out):
           for a storage type, serve the correct result from the legacy WS list,
           append a ``warnings[]`` entry, and ``log.warning``. For a flow type,
           raise the component-required error — no legacy fallback exists.
@@ -3653,7 +3664,7 @@ class HelperConfigTools:
         """
         try:
             raw = await self._send_component_helpers_list(helper_type, is_flow=is_flow)
-        except HomeAssistantCommandError as exc:
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             unknown = is_unknown_command(exc)
             if unknown:
                 invalidate_caps(self._client)

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -18,10 +18,8 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
-    HomeAssistantCommandError,
     HomeAssistantConnectionError,
 )
-from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -31,12 +29,6 @@ from ..utils.python_sandbox import (
     safe_execute,
 )
 from .auto_backup import with_auto_backup
-from .component_api import (
-    component_supports,
-    get_component_caps,
-    invalidate_caps,
-    is_unknown_command,
-)
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -67,21 +59,6 @@ from .util_helpers import (
 _SCENE_SKILL_FILES: tuple[str, ...] = ("SKILL.md",)
 
 logger = logging.getLogger(__name__)
-
-
-async def _send_component_config_get(
-    client: Any, domain: str, item_id: str
-) -> dict[str, Any]:
-    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
-
-    Returns the raw ``{success, result}`` envelope; the caller shapes
-    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
-    on a ``success:False`` reply (routed by the caller's error taxonomy).
-    """
-    ws = await get_websocket_client(url=client.base_url, token=client.token)
-    return await ws.send_command(
-        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
-    )
 
 
 class ConfigSceneTools:
@@ -271,19 +248,16 @@ class ConfigSceneTools:
                 ],
                 context={"scene_id": scene_id},
             )
-            # Prefer the custom component's in-process config_get when it
-            # advertises the capability: one WS round-trip returns the config
-            # body + storage key + current entity_id + category, replacing the
-            # legacy 3-4 (id resolution WS + per-id config REST +
-            # ``_resolve_scene_entity_id`` WS + ``fetch_entity_category`` WS).
-            # Falls back cleanly when the component is absent, downlevel, or
-            # errors — taxonomy lives in ``_get_scene_via_component``.
-            caps = await get_component_caps(self._client)
-            if component_supports(caps, "config_get"):
-                routed = await self._get_scene_via_component(scene_id)
-                if routed is not None:
-                    return routed
-
+            # Scenes ALWAYS take the legacy path — deliberately no component
+            # routing here, unlike the automation/script gets. Scenes do not
+            # retain their raw storage body in memory: HomeAssistantScene's
+            # ``scene_config.states`` holds runtime State OBJECTS built at
+            # setup, not the storage ``entities`` dict, so a component-served
+            # body can neither match the REST body byte-for-byte nor produce
+            # a stable ``config_hash`` — and the get -> surgical-edit -> set
+            # round-trip depends on both (caught live by the scene lifecycle
+            # e2e suite). automation/script expose ``raw_config`` (the exact
+            # storage dict), which is why their gets DO route.
             return await self._legacy_get_scene(scene_id)
         except ToolError:
             raise
@@ -313,11 +287,12 @@ class ConfigSceneTools:
     async def _legacy_get_scene(self, scene_id: str) -> dict[str, Any]:
         """Assemble the scene-get response from the REST/WS pipeline.
 
-        The multi-fetch fallback: id-resolution WS + per-id config REST +
-        ``_resolve_scene_entity_id`` WS + ``fetch_entity_category`` WS.
-        Behaviourally unchanged from the pre-component implementation — the
-        component path (``_get_scene_via_component``) reproduces this exact
-        envelope from a single WS call.
+        The multi-fetch path: id-resolution WS + per-id config REST +
+        ``_resolve_scene_entity_id`` WS + ``fetch_entity_category`` WS. This is
+        the ONLY scene-get path — see ``ha_config_get_scene`` for why scenes
+        never route through the component's ``config_get`` (their in-memory
+        ``scene_config.states`` is runtime State objects, not the storage
+        ``entities`` dict).
         """
         # Issue #1168 R3 blockers 3 + 6: unwrap the rest-client envelope
         # so the response carries the scene body directly (no nested
@@ -344,68 +319,6 @@ class ConfigSceneTools:
         }
         if cat_id:
             response["category"] = cat_id
-        return response
-
-    async def _get_scene_via_component(self, scene_id: str) -> dict[str, Any] | None:
-        """Serve ha_config_get_scene from the component; ``None`` ⇒ legacy.
-
-        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
-        ``unknown_command`` → invalidate caps + silent legacy fallback; any
-        other ``HomeAssistantCommandError`` → legacy + ``warnings[]`` +
-        ``log.warning``; connection errors propagate.
-        """
-        try:
-            raw = await _send_component_config_get(self._client, "scene", scene_id)
-        except HomeAssistantCommandError as exc:
-            if is_unknown_command(exc):
-                invalidate_caps(self._client)
-                return None
-            legacy = await self._legacy_get_scene(scene_id)
-            legacy.setdefault("warnings", []).append(
-                f"component config_get path failed ({exc}); served via legacy path"
-            )
-            logger.warning(
-                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
-            )
-            return legacy
-
-        result = raw.get("result") or {}
-        if not result.get("found"):
-            # Scenes have no dedicated not-found raiser: the legacy path 404s
-            # at the REST editor and the tool's ``except Exception`` classifies
-            # it (entity_id in context → ENTITY_NOT_FOUND). Re-raise the same
-            # 404 so identical classification runs. ``resolve_scene_id`` returns
-            # the bare id for a missing scene, so the storage-key suffix appears
-            # iff the caller passed a ``scene.`` prefix — matching rest_client.
-            bare = scene_id.removeprefix("scene.")
-            msg = f"Scene not found: {scene_id}"
-            if bare != scene_id:
-                msg += f" (resolved storage key: {bare})"
-            raise HomeAssistantAPIError(msg, status_code=404)
-
-        config = result.get("config")
-        if not isinstance(config, dict):
-            # Malformed success payload — defer to legacy rather than trust it.
-            return None
-
-        config_hash_value = compute_config_hash(config)
-        # The component's item_id/id is the scene storage key (unique_id, or the
-        # body's ``id``). HA derives a scene entity_id from its name, so the
-        # storage key is NOT recoverable from entity_id — prefer the explicit key.
-        storage_key = result.get("item_id") or result.get("id")
-        if not storage_key:
-            storage_key = config.get("id") or scene_id.removeprefix("scene.")
-
-        response: dict[str, Any] = {
-            "success": True,
-            "action": "get",
-            "scene_id": storage_key,
-            "config": config,
-            "config_hash": config_hash_value,
-        }
-        category = result.get("category")
-        if category:
-            response["category"] = str(category)
         return response
 
     async def _get_scene_config_internal(

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -18,8 +18,10 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
+    HomeAssistantCommandError,
     HomeAssistantConnectionError,
 )
+from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -29,6 +31,12 @@ from ..utils.python_sandbox import (
     safe_execute,
 )
 from .auto_backup import with_auto_backup
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
+)
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -59,6 +67,21 @@ from .util_helpers import (
 _SCENE_SKILL_FILES: tuple[str, ...] = ("SKILL.md",)
 
 logger = logging.getLogger(__name__)
+
+
+async def _send_component_config_get(
+    client: Any, domain: str, item_id: str
+) -> dict[str, Any]:
+    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
+
+    Returns the raw ``{success, result}`` envelope; the caller shapes
+    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
+    on a ``success:False`` reply (routed by the caller's error taxonomy).
+    """
+    ws = await get_websocket_client(url=client.base_url, token=client.token)
+    return await ws.send_command(
+        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
+    )
 
 
 class ConfigSceneTools:
@@ -248,32 +271,20 @@ class ConfigSceneTools:
                 ],
                 context={"scene_id": scene_id},
             )
-            # Issue #1168 R3 blockers 3 + 6: unwrap the rest-client envelope
-            # so the response carries the scene body directly (no nested
-            # `success`/`scene_id`/`config` chain), and use the storage key
-            # consistently for `scene_id` regardless of whether the caller
-            # passed the entity_id slug or the storage key.
-            envelope = await self._client.get_scene_config(scene_id)
-            actual_config = envelope.get("config", envelope)
-            resolved_id = envelope.get("scene_id", scene_id)
-            config_hash_value = compute_config_hash(actual_config)
+            # Prefer the custom component's in-process config_get when it
+            # advertises the capability: one WS round-trip returns the config
+            # body + storage key + current entity_id + category, replacing the
+            # legacy 3-4 (id resolution WS + per-id config REST +
+            # ``_resolve_scene_entity_id`` WS + ``fetch_entity_category`` WS).
+            # Falls back cleanly when the component is absent, downlevel, or
+            # errors — taxonomy lives in ``_get_scene_via_component``.
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "config_get"):
+                routed = await self._get_scene_via_component(scene_id)
+                if routed is not None:
+                    return routed
 
-            # Resolve real entity_id via registry — see _resolve_scene_entity_id
-            # for the reasoning. Category fetch on the wrong entity_id is a
-            # silent no-op, masking real category assignments.
-            entity_id = await self._resolve_scene_entity_id(resolved_id)
-            cat_id = await fetch_entity_category(self._client, entity_id, "scene")
-
-            response: dict[str, Any] = {
-                "success": True,
-                "action": "get",
-                "scene_id": resolved_id,
-                "config": actual_config,
-                "config_hash": config_hash_value,
-            }
-            if cat_id:
-                response["category"] = cat_id
-            return response
+            return await self._legacy_get_scene(scene_id)
         except ToolError:
             raise
         except Exception as e:
@@ -298,6 +309,104 @@ class ConfigSceneTools:
             # explicit raise makes the function's exit unambiguous (no implicit
             # ``return None`` fall-through) and is never reached at runtime.
             raise
+
+    async def _legacy_get_scene(self, scene_id: str) -> dict[str, Any]:
+        """Assemble the scene-get response from the REST/WS pipeline.
+
+        The multi-fetch fallback: id-resolution WS + per-id config REST +
+        ``_resolve_scene_entity_id`` WS + ``fetch_entity_category`` WS.
+        Behaviourally unchanged from the pre-component implementation — the
+        component path (``_get_scene_via_component``) reproduces this exact
+        envelope from a single WS call.
+        """
+        # Issue #1168 R3 blockers 3 + 6: unwrap the rest-client envelope
+        # so the response carries the scene body directly (no nested
+        # `success`/`scene_id`/`config` chain), and use the storage key
+        # consistently for `scene_id` regardless of whether the caller
+        # passed the entity_id slug or the storage key.
+        envelope = await self._client.get_scene_config(scene_id)
+        actual_config = envelope.get("config", envelope)
+        resolved_id = envelope.get("scene_id", scene_id)
+        config_hash_value = compute_config_hash(actual_config)
+
+        # Resolve real entity_id via registry — see _resolve_scene_entity_id
+        # for the reasoning. Category fetch on the wrong entity_id is a
+        # silent no-op, masking real category assignments.
+        entity_id = await self._resolve_scene_entity_id(resolved_id)
+        cat_id = await fetch_entity_category(self._client, entity_id, "scene")
+
+        response: dict[str, Any] = {
+            "success": True,
+            "action": "get",
+            "scene_id": resolved_id,
+            "config": actual_config,
+            "config_hash": config_hash_value,
+        }
+        if cat_id:
+            response["category"] = cat_id
+        return response
+
+    async def _get_scene_via_component(self, scene_id: str) -> dict[str, Any] | None:
+        """Serve ha_config_get_scene from the component; ``None`` ⇒ legacy.
+
+        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
+        ``unknown_command`` → invalidate caps + silent legacy fallback; any
+        other ``HomeAssistantCommandError`` → legacy + ``warnings[]`` +
+        ``log.warning``; connection errors propagate.
+        """
+        try:
+            raw = await _send_component_config_get(self._client, "scene", scene_id)
+        except HomeAssistantCommandError as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            legacy = await self._legacy_get_scene(scene_id)
+            legacy.setdefault("warnings", []).append(
+                f"component config_get path failed ({exc}); served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
+            )
+            return legacy
+
+        result = raw.get("result") or {}
+        if not result.get("found"):
+            # Scenes have no dedicated not-found raiser: the legacy path 404s
+            # at the REST editor and the tool's ``except Exception`` classifies
+            # it (entity_id in context → ENTITY_NOT_FOUND). Re-raise the same
+            # 404 so identical classification runs. ``resolve_scene_id`` returns
+            # the bare id for a missing scene, so the storage-key suffix appears
+            # iff the caller passed a ``scene.`` prefix — matching rest_client.
+            bare = scene_id.removeprefix("scene.")
+            msg = f"Scene not found: {scene_id}"
+            if bare != scene_id:
+                msg += f" (resolved storage key: {bare})"
+            raise HomeAssistantAPIError(msg, status_code=404)
+
+        config = result.get("config")
+        if not isinstance(config, dict):
+            # Malformed success payload — defer to legacy rather than trust it.
+            return None
+
+        config_hash_value = compute_config_hash(config)
+        # The component's item_id/id is the scene storage key (unique_id, or the
+        # body's ``id``). HA derives a scene entity_id from its name, so the
+        # storage key is NOT recoverable from entity_id — prefer the explicit key.
+        storage_key = result.get("item_id") or result.get("id")
+        if not storage_key:
+            storage_key = config.get("id") or scene_id.removeprefix("scene.")
+
+        response: dict[str, Any] = {
+            "success": True,
+            "action": "get",
+            "scene_id": storage_key,
+            "config": config,
+            "config_hash": config_hash_value,
+        }
+        category = result.get("category")
+        if category:
+            response["category"] = str(category)
+        return response
 
     async def _get_scene_config_internal(
         self, scene_id: str

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -15,8 +15,10 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
+    HomeAssistantCommandError,
     HomeAssistantConnectionError,
 )
+from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -31,6 +33,12 @@ from .best_practice_checker import (
 )
 from .best_practice_checker import (
     check_script_config as _check_best_practices,
+)
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -54,6 +62,21 @@ from .util_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _send_component_config_get(
+    client: Any, domain: str, item_id: str
+) -> dict[str, Any]:
+    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
+
+    Returns the raw ``{success, result}`` envelope; the caller shapes
+    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
+    on a ``success:False`` reply (routed by the caller's error taxonomy).
+    """
+    ws = await get_websocket_client(url=client.base_url, token=client.token)
+    return await ws.send_command(
+        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
+    )
 
 
 # Scripts share the automation skill mapping — both use
@@ -155,41 +178,20 @@ class ConfigScriptTools:
                     "Use ha_search(domain_filter='script') to list scripts",
                 ],
             )
-            config_result = await self._fetch_script_config_envelope(script_id)
-            # Extract actual script config body and compute hash before category injection
-            actual_config = config_result.get("config", config_result)
-            config_hash_value = compute_config_hash(actual_config)
 
-            # Fetch category from entity registry (best-effort)
-            # (injected after hash so transient registry failures don't affect the hash)
-            entity_id = f"script.{script_id}"
-            cat_id = await fetch_entity_category(self._client, entity_id, "script")
-            if cat_id:
-                config_result["category"] = cat_id
+            # Prefer the custom component's in-process config_get when it
+            # advertises the capability: one WS round-trip returns the config
+            # body + storage key + category, replacing the legacy 3-4 (id
+            # resolution WS + per-id config REST + fetch_entity_category WS).
+            # Falls back cleanly when the component is absent, downlevel, or
+            # errors — taxonomy lives in ``_get_script_via_component``.
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "config_get"):
+                routed = await self._get_script_via_component(script_id)
+                if routed is not None:
+                    return routed
 
-            # Issue #1334: return the canonical storage key from the
-            # rest_client envelope so callers can thread the result into
-            # subsequent ha_config_*_script calls without re-resolving.
-            # Falls back to the input when the rest_client response omits
-            # the key — a contract violation that we surface via warning
-            # rather than mask silently.
-            canonical_id = config_result.get("script_id")
-            if canonical_id is None:
-                logger.warning(
-                    "get_script_config envelope missing 'script_id' for "
-                    "input %r; falling back to caller input. This indicates "
-                    "a rest_client contract violation.",
-                    script_id,
-                )
-                canonical_id = script_id
-
-            return {
-                "success": True,
-                "action": "get",
-                "script_id": canonical_id,
-                "config": config_result,
-                "config_hash": config_hash_value,
-            }
+            return await self._legacy_get_script(script_id)
         except ToolError:
             raise
         except Exception as e:
@@ -203,6 +205,113 @@ class ConfigScriptTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+
+    async def _legacy_get_script(self, script_id: str) -> dict[str, Any]:
+        """Assemble the script-get response from the REST/WS pipeline.
+
+        The multi-fetch fallback: id-resolution WS + per-id config REST +
+        ``fetch_entity_category`` WS call. Behaviourally unchanged from the
+        pre-component implementation — the component path
+        (``_get_script_via_component``) reproduces this exact envelope
+        (including the REST-wrapper ``config``) from a single WS call.
+        """
+        config_result = await self._fetch_script_config_envelope(script_id)
+        # Extract actual script config body and compute hash before category injection
+        actual_config = config_result.get("config", config_result)
+        config_hash_value = compute_config_hash(actual_config)
+
+        # Fetch category from entity registry (best-effort)
+        # (injected after hash so transient registry failures don't affect the hash)
+        entity_id = f"script.{script_id}"
+        cat_id = await fetch_entity_category(self._client, entity_id, "script")
+        if cat_id:
+            config_result["category"] = cat_id
+
+        # Issue #1334: return the canonical storage key from the
+        # rest_client envelope so callers can thread the result into
+        # subsequent ha_config_*_script calls without re-resolving.
+        # Falls back to the input when the rest_client response omits
+        # the key — a contract violation that we surface via warning
+        # rather than mask silently.
+        canonical_id = config_result.get("script_id")
+        if canonical_id is None:
+            logger.warning(
+                "get_script_config envelope missing 'script_id' for "
+                "input %r; falling back to caller input. This indicates "
+                "a rest_client contract violation.",
+                script_id,
+            )
+            canonical_id = script_id
+
+        return {
+            "success": True,
+            "action": "get",
+            "script_id": canonical_id,
+            "config": config_result,
+            "config_hash": config_hash_value,
+        }
+
+    async def _get_script_via_component(self, script_id: str) -> dict[str, Any] | None:
+        """Serve ha_config_get_script from the component; ``None`` ⇒ legacy.
+
+        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
+        ``unknown_command`` → invalidate caps + silent legacy fallback; any
+        other ``HomeAssistantCommandError`` → legacy + ``warnings[]`` +
+        ``log.warning``; connection errors propagate.
+
+        A ``found:false`` result (id resolves to nothing, or to a YAML-defined
+        item the component won't serve) raises the same ``RESOURCE_NOT_FOUND``
+        the legacy REST 404 path raises, via ``_raise_script_not_found``.
+        """
+        try:
+            raw = await _send_component_config_get(self._client, "script", script_id)
+        except HomeAssistantCommandError as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            legacy = await self._legacy_get_script(script_id)
+            legacy.setdefault("warnings", []).append(
+                f"component config_get path failed ({exc}); served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
+            )
+            return legacy
+
+        result = raw.get("result") or {}
+        if not result.get("found"):
+            await self._raise_script_not_found(script_id)  # raises ToolError
+        config = result.get("config")
+        if not isinstance(config, dict):
+            # Malformed success payload — defer to legacy rather than trust it.
+            return None
+
+        config_hash_value = compute_config_hash(config)
+        entity_id = result.get("entity_id")
+        # The component's item_id/id is the storage key (unique_id), which
+        # survives an entity_id rename — prefer it over deriving from entity_id.
+        storage_key = result.get("item_id") or result.get("id")
+        if not storage_key:
+            storage_key = entity_id.removeprefix("script.") if entity_id else script_id
+
+        # Rebuild the REST-wrapper shape the legacy path returns under ``config``
+        # ({success, script_id, config[, category]}) for byte-parity.
+        config_result: dict[str, Any] = {
+            "success": True,
+            "script_id": storage_key,
+            "config": config,
+        }
+        category = result.get("category")
+        if category:
+            config_result["category"] = str(category)
+
+        return {
+            "success": True,
+            "action": "get",
+            "script_id": storage_key,
+            "config": config_result,
+            "config_hash": config_hash_value,
+        }
 
     async def _list_script_entity_ids(self) -> list[str]:
         """Best-effort list of bare script IDs (up to 10) from the entity registry.

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -15,8 +15,6 @@ from pydantic import Field
 from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
-    HomeAssistantCommandError,
-    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
 from ..errors import ErrorCode, create_error_response
@@ -33,13 +31,6 @@ from .best_practice_checker import (
 )
 from .best_practice_checker import (
     check_script_config as _check_best_practices,
-)
-from .component_api import (
-    component_supports,
-    get_component_caps,
-    invalidate_caps,
-    is_unknown_command,
-    send_component_config_get,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -165,18 +156,18 @@ class ConfigScriptTools:
                 ],
             )
 
-            # Prefer the custom component's in-process config_get when it
-            # advertises the capability: one WS round-trip returns the config
-            # body + storage key + category, replacing the legacy 3-4 (id
-            # resolution WS + per-id config REST + fetch_entity_category WS).
-            # Falls back cleanly when the component is absent, downlevel, or
-            # errors — taxonomy lives in ``_get_script_via_component``.
-            caps = await get_component_caps(self._client)
-            if component_supports(caps, "config_get"):
-                routed = await self._get_script_via_component(script_id)
-                if routed is not None:
-                    return routed
-
+            # Script gets ALWAYS take the legacy path — the component's
+            # in-process ``config_get`` was withdrawn. It served
+            # ``entity.raw_config``, which is only the storage body as of the
+            # last COMPLETED async reload, with no version marker to tell a
+            # fresh body from a stale one. A get racing a reload returned the
+            # pre-edit body and broke the get -> python_transform -> set
+            # round-trip (caught live by the automation/script config e2e on the
+            # arm/HAOS runners). The legacy REST config endpoint reads the config
+            # FILE, which is fresh the instant a write lands, so it stays the
+            # sole path. Scenes were already legacy-only (no storage body in
+            # memory at all); scripts join them here for freshness. A
+            # file-reading ``config_get`` may return later (issue #1813).
             return await self._legacy_get_script(script_id)
         except ToolError:
             raise
@@ -195,11 +186,11 @@ class ConfigScriptTools:
     async def _legacy_get_script(self, script_id: str) -> dict[str, Any]:
         """Assemble the script-get response from the REST/WS pipeline.
 
-        The multi-fetch fallback: id-resolution WS + per-id config REST +
-        ``fetch_entity_category`` WS call. Behaviourally unchanged from the
-        pre-component implementation — the component path
-        (``_get_script_via_component``) reproduces this exact envelope
-        (including the REST-wrapper ``config``) from a single WS call.
+        The multi-fetch path: id-resolution WS + per-id config REST +
+        ``fetch_entity_category`` WS call. This is the ONLY script-get path —
+        see ``ha_config_get_script`` for why script gets never route through the
+        component's ``config_get`` (its ``raw_config`` freshness lags the config
+        file between a write and the next completed reload).
         """
         config_result = await self._fetch_script_config_envelope(script_id)
         # Extract actual script config body and compute hash before category injection
@@ -233,69 +224,6 @@ class ConfigScriptTools:
             "success": True,
             "action": "get",
             "script_id": canonical_id,
-            "config": config_result,
-            "config_hash": config_hash_value,
-        }
-
-    async def _get_script_via_component(self, script_id: str) -> dict[str, Any] | None:
-        """Serve ha_config_get_script from the component; ``None`` ⇒ legacy.
-
-        Error taxonomy mirrors ``tools_search._ha_search_via_component``:
-        ``unknown_command`` → invalidate caps + silent legacy fallback; any
-        other ``HomeAssistantCommandError`` (or a ``HomeAssistantCommandTimeout``
-        on the component WS read) → legacy + ``warnings[]`` + ``log.warning``;
-        connection errors propagate.
-
-        A ``found:false`` result (id resolves to nothing, or to a YAML-defined
-        item the component won't serve) raises the same ``RESOURCE_NOT_FOUND``
-        the legacy REST 404 path raises, via ``_raise_script_not_found``.
-        """
-        try:
-            raw = await send_component_config_get(self._client, "script", script_id)
-        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
-            if is_unknown_command(exc):
-                invalidate_caps(self._client)
-                return None
-            legacy = await self._legacy_get_script(script_id)
-            legacy.setdefault("warnings", []).append(
-                f"component config_get path failed ({exc}); served via legacy path"
-            )
-            logger.warning(
-                "ha_mcp_tools/config_get failed; fell back to legacy: %r", exc
-            )
-            return legacy
-
-        result = raw.get("result") or {}
-        if not result.get("found"):
-            await self._raise_script_not_found(script_id)  # raises ToolError
-        config = result.get("config")
-        if not isinstance(config, dict):
-            # Malformed success payload — defer to legacy rather than trust it.
-            return None
-
-        config_hash_value = compute_config_hash(config)
-        entity_id = result.get("entity_id")
-        # The component's item_id/id is the storage key (unique_id), which
-        # survives an entity_id rename — prefer it over deriving from entity_id.
-        storage_key = result.get("item_id") or result.get("id")
-        if not storage_key:
-            storage_key = entity_id.removeprefix("script.") if entity_id else script_id
-
-        # Rebuild the REST-wrapper shape the legacy path returns under ``config``
-        # ({success, script_id, config[, category]}) for byte-parity.
-        config_result: dict[str, Any] = {
-            "success": True,
-            "script_id": storage_key,
-            "config": config,
-        }
-        category = result.get("category")
-        if category:
-            config_result["category"] = str(category)
-
-        return {
-            "success": True,
-            "action": "get",
-            "script_id": storage_key,
             "config": config_result,
             "config_hash": config_hash_value,
         }

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -16,9 +16,9 @@ from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
     HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
-from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -39,6 +39,7 @@ from .component_api import (
     get_component_caps,
     invalidate_caps,
     is_unknown_command,
+    send_component_config_get,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -62,21 +63,6 @@ from .util_helpers import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-async def _send_component_config_get(
-    client: Any, domain: str, item_id: str
-) -> dict[str, Any]:
-    """Send one ``ha_mcp_tools/config_get`` command over the per-client WebSocket.
-
-    Returns the raw ``{success, result}`` envelope; the caller shapes
-    ``result`` onto the legacy response. Raises ``HomeAssistantCommandError``
-    on a ``success:False`` reply (routed by the caller's error taxonomy).
-    """
-    ws = await get_websocket_client(url=client.base_url, token=client.token)
-    return await ws.send_command(
-        "ha_mcp_tools/config_get", domain=domain, item_id=item_id
-    )
 
 
 # Scripts share the automation skill mapping — both use
@@ -256,16 +242,17 @@ class ConfigScriptTools:
 
         Error taxonomy mirrors ``tools_search._ha_search_via_component``:
         ``unknown_command`` → invalidate caps + silent legacy fallback; any
-        other ``HomeAssistantCommandError`` → legacy + ``warnings[]`` +
-        ``log.warning``; connection errors propagate.
+        other ``HomeAssistantCommandError`` (or a ``HomeAssistantCommandTimeout``
+        on the component WS read) → legacy + ``warnings[]`` + ``log.warning``;
+        connection errors propagate.
 
         A ``found:false`` result (id resolves to nothing, or to a YAML-defined
         item the component won't serve) raises the same ``RESOURCE_NOT_FOUND``
         the legacy REST 404 path raises, via ``_raise_script_not_found``.
         """
         try:
-            raw = await _send_component_config_get(self._client, "script", script_id)
-        except HomeAssistantCommandError as exc:
+            raw = await send_component_config_get(self._client, "script", script_id)
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             if is_unknown_command(exc):
                 invalidate_caps(self._client)
                 return None

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -868,6 +868,108 @@ def _shape_component_search_response(
     return _project_response_fields(response, req.parsed_fields)
 
 
+@dataclass(frozen=True)
+class _OverviewInputs:
+    """Resolved ``ha_get_overview`` inputs threaded to the routing/assembly.
+
+    All display params (``detail_level`` … ``offset``) stay server-side — the
+    component returns raw slices independent of them; the two include-flags gate
+    which slices it bothers to snapshot.
+    """
+
+    detail_level: str
+    max_entities_per_domain: int | None
+    include_state: bool | None
+    include_entity_id: bool | None
+    domains_filter: list[str] | None
+    limit: int | None
+    offset: int
+    include_notifications: bool
+    include_dismissed_repairs: bool
+
+
+@dataclass(frozen=True)
+class _OverviewSlices:
+    """The component's raw overview slices, adapted to the assembly's shapes.
+
+    ``registry_slices`` bundles the five ``get_system_overview`` inputs — bare
+    ``states`` / ``services`` lists plus the three registries re-wrapped in the
+    ``{success, result}`` envelope ``_extract_registry_list`` / ``load_hidden_set``
+    unwrap. ``config`` is the bare ``get_config()`` dict. ``notifications`` and
+    ``repairs`` are re-wrapped in the WS ``{success, result}`` envelope the
+    ``_fetch_*`` helpers unwrap (``repairs`` nested under ``result.issues``).
+    """
+
+    registry_slices: dict[str, Any]
+    config: dict[str, Any]
+    notifications: dict[str, Any]
+    repairs: dict[str, Any]
+
+
+def _build_component_overview_request(inputs: _OverviewInputs) -> dict[str, Any]:
+    """Translate resolved ha_get_overview inputs into an ``ha_mcp_tools/overview`` request.
+
+    The component returns raw slices independent of the display params
+    (``detail_level`` / ``domains`` / ``limit`` / ``offset`` /
+    ``max_entities_per_domain`` / ``include_state`` / ``include_entity_id`` stay
+    server-side — the server assembles), so only the two fetch-gating flags cross
+    the wire: ``include_notifications`` mirrors the wrapper's flag;
+    ``include_repairs`` is always ``True`` because the wrapper always assembles
+    repairs (``include_dismissed_repairs`` only filters dismissed ones
+    server-side, it never skips the fetch).
+    """
+    return {
+        "include_notifications": inputs.include_notifications,
+        "include_repairs": True,
+    }
+
+
+def _wrap_registry(slice_value: Any) -> dict[str, Any]:
+    """Wrap a bare registry list in the ``{success, result}`` envelope the assembly expects."""
+    return {
+        "success": True,
+        "result": slice_value if isinstance(slice_value, list) else [],
+    }
+
+
+def _build_overview_slices(component_result: dict[str, Any]) -> _OverviewSlices:
+    """Adapt the component's BARE overview slices into the assembly's shapes.
+
+    The component returns bare in-process data (no ``{success, result}`` WS
+    wrapper — design § ha_mcp_tools/overview); the server's ``get_system_overview``
+    + ``_fetch_*`` were written against the wrapped REST/WS payloads, so the three
+    registries and the notifications/repairs reads are re-wrapped here at the
+    seam. ``states`` / ``services`` / ``config`` already match their bare
+    ``get_states()`` / ``get_services()`` / ``get_config()`` shapes. Every field
+    is type-guarded so a malformed slice degrades to empty rather than raising
+    inside the assembly.
+    """
+    result = component_result if isinstance(component_result, dict) else {}
+    states = result.get("states")
+    services = result.get("services")
+    config = result.get("config")
+    notifications = result.get("notifications")
+    repairs = result.get("repairs")
+    return _OverviewSlices(
+        registry_slices={
+            "states": states if isinstance(states, list) else [],
+            "services": services if isinstance(services, list) else [],
+            "area_registry": _wrap_registry(result.get("area_registry")),
+            "entity_registry": _wrap_registry(result.get("entity_registry")),
+            "device_registry": _wrap_registry(result.get("device_registry")),
+        },
+        config=config if isinstance(config, dict) else {},
+        notifications={
+            "success": True,
+            "result": notifications if isinstance(notifications, list) else [],
+        },
+        repairs={
+            "success": True,
+            "result": {"issues": repairs if isinstance(repairs, list) else []},
+        },
+    )
+
+
 def _normalize_regular_search_result(
     result: dict[str, Any],
     search_type: str,
@@ -2611,23 +2713,19 @@ class SearchTools:
 
         parsed_domains = parse_string_list_param(domains, "domains", allow_csv=True)
 
-        result = await self._smart_tools.get_system_overview(
-            detail_level,
-            max_entities_per_domain,
-            include_state_bool,
-            include_entity_id_bool,
-            domains_filter=parsed_domains,
-            limit=limit,
-            offset=offset,
+        result = await self._collect_overview(
+            _OverviewInputs(
+                detail_level=detail_level,
+                max_entities_per_domain=max_entities_per_domain,
+                include_state=include_state_bool,
+                include_entity_id=include_entity_id_bool,
+                domains_filter=parsed_domains,
+                limit=limit,
+                offset=offset,
+                include_notifications=include_notifications_bool,
+                include_dismissed_repairs=include_dismissed_repairs_bool,
+            )
         )
-        result = cast(dict[str, Any], result)
-
-        await self._fetch_system_info(result, detail_level)
-
-        if include_notifications_bool:
-            await self._fetch_notifications(result)
-
-        await self._fetch_repairs(result, include_dismissed_repairs_bool)
 
         settings = get_global_settings()
         if settings.enable_tool_search:
@@ -2703,11 +2801,23 @@ class SearchTools:
         return projected
 
     async def _fetch_system_info(
-        self, result: dict[str, Any], detail_level: str
+        self,
+        result: dict[str, Any],
+        detail_level: str,
+        *,
+        prefetched_config: dict[str, Any] | None = None,
     ) -> None:
-        """Fetch HA config and populate result['system_info']; tolerates failure."""
+        """Populate result['system_info'] from HA config; tolerates failure.
+
+        ``prefetched_config`` (the component's ``config`` slice, already the bare
+        ``get_config()`` dict) is used verbatim when given, skipping the fetch.
+        """
         try:
-            config = await self._client.get_config()
+            config = (
+                prefetched_config
+                if prefetched_config is not None
+                else await self._client.get_config()
+            )
             system_info: dict[str, Any] = {
                 "base_url": self._client.base_url,
                 "version": config.get("version"),
@@ -2746,13 +2856,27 @@ class SearchTools:
             if "system_summary" in result:
                 result["system_summary"].setdefault("version", "unknown")
 
-    async def _fetch_notifications(self, result: dict[str, Any]) -> None:
-        """Fetch active persistent notifications and attach them to result."""
+    async def _fetch_notifications(
+        self,
+        result: dict[str, Any],
+        *,
+        prefetched_notifications: dict[str, Any] | None = None,
+    ) -> None:
+        """Attach active persistent notifications to result.
+
+        ``prefetched_notifications`` (the component's ``notifications`` slice
+        re-wrapped in the ``{success, result}`` envelope) is unwrapped by the same
+        code as the live fetch when given, skipping the WS call.
+        """
         result["notification_count"] = 0
         result["notifications"] = []
         try:
-            ws_result = await self._client.send_websocket_message(
-                {"type": "persistent_notification/get"}
+            ws_result = (
+                prefetched_notifications
+                if prefetched_notifications is not None
+                else await self._client.send_websocket_message(
+                    {"type": "persistent_notification/get"}
+                )
             )
             if ws_result.get("success"):
                 notifications = ws_result.get("result", [])
@@ -2772,14 +2896,28 @@ class SearchTools:
             )
 
     async def _fetch_repairs(
-        self, result: dict[str, Any], include_dismissed_repairs_bool: bool
+        self,
+        result: dict[str, Any],
+        include_dismissed_repairs_bool: bool,
+        *,
+        prefetched_repairs: dict[str, Any] | None = None,
     ) -> None:
-        """Fetch active repairs issues and attach them to result."""
+        """Attach active repairs issues to result.
+
+        ``prefetched_repairs`` (the component's ``repairs`` slice re-wrapped in the
+        ``{success, result: {issues: [...]}}`` envelope) is unwrapped, filtered
+        (``filter_active_repairs``), and projected by the same code as the live
+        fetch when given, skipping the WS call.
+        """
         result["repair_count"] = 0
         result["repairs"] = []
         try:
-            repairs_result = await self._client.send_websocket_message(
-                {"type": "repairs/list_issues"}
+            repairs_result = (
+                prefetched_repairs
+                if prefetched_repairs is not None
+                else await self._client.send_websocket_message(
+                    {"type": "repairs/list_issues"}
+                )
             )
             if repairs_result.get("success"):
                 all_issues = repairs_result.get("result", {}).get("issues", [])
@@ -2805,6 +2943,125 @@ class SearchTools:
         except Exception as e:
             logger.warning("Failed to fetch repairs for overview: %s", e, exc_info=True)
             result["repairs_error"] = f"Could not fetch repairs: {e}"
+
+    async def _collect_overview(self, inputs: _OverviewInputs) -> dict[str, Any]:
+        """Assemble the HA-sourced overview, preferring the in-process component.
+
+        The component's ``ha_mcp_tools/overview`` returns the eight raw reads the
+        legacy path makes today (states + services + the three registries +
+        config + notifications + repairs) in one WebSocket round-trip; the server
+        feeds those slices into its **unchanged** assembly
+        (``get_system_overview`` + ``system_info`` / ``notifications`` /
+        ``repairs``), so the two paths are byte-identical by construction. Routed
+        all-or-nothing per the ``ha_search`` precedent: gated on the ``overview``
+        capability AND an inactive entity-visibility filter. The filter is applied
+        server-side over the slices either way, so the bypass is a simplification,
+        not a correctness requirement — an active filter that respects Assist
+        exposure would need extra WS reads inside ``load_hidden_set`` that the
+        single round-trip does not carry, so it keeps the legacy path (mirroring
+        search; applying the filter over the slices can come later). The
+        server-side-only fields (``tool_discovery``, ``settings_url``,
+        ``read_only_mode``, ``ha_mcp_update``) and the ``fields=`` projection are
+        applied by ``ha_get_overview`` after this, identically on both paths.
+        """
+        caps = await get_component_caps(self._client)
+        if (
+            component_supports(caps, "overview")
+            and not await visibility_filter_active()
+        ):
+            component_result = await self._overview_via_component(inputs)
+            if component_result is not None:
+                return component_result
+        return await self._assemble_overview(inputs, None)
+
+    async def _overview_via_component(
+        self, inputs: _OverviewInputs
+    ) -> dict[str, Any] | None:
+        """Serve the overview from the component's slices; ``None`` ⇒ run legacy.
+
+        Error taxonomy (design § 4), mirroring ``_ha_search_via_component``:
+
+        - ``unknown_command`` (the component was downgraded mid-session, so the
+          cached positive caps are stale): invalidate the caps and return
+          ``None`` so the caller falls back **silently** — an expected,
+          non-actionable transition.
+        - any other ``HomeAssistantCommandError`` (a component handler bug):
+          serve the correct result from the legacy path, append a ``warnings[]``
+          entry, and ``log.warning`` — correct results now, breakage visible.
+        - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
+          propagates; the legacy path depends on the same socket and would fail
+          identically, so surfacing it is correct.
+        """
+        try:
+            raw = await self._send_component_overview(inputs)
+        except HomeAssistantCommandError as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            legacy = await self._assemble_overview(inputs, None)
+            legacy.setdefault("warnings", []).append(
+                f"component overview path failed ({exc}); served via legacy path"
+            )
+            logger.warning("ha_mcp_tools/overview failed; fell back to legacy: %r", exc)
+            return legacy
+        slices = _build_overview_slices(raw.get("result") or {})
+        return await self._assemble_overview(inputs, slices)
+
+    async def _send_component_overview(self, inputs: _OverviewInputs) -> dict[str, Any]:
+        """Send one ``ha_mcp_tools/overview`` command over the per-client WebSocket."""
+        ws = await get_websocket_client(
+            url=self._client.base_url, token=self._client.token
+        )
+        return await ws.send_command(
+            "ha_mcp_tools/overview",
+            **_build_component_overview_request(inputs),
+        )
+
+    async def _assemble_overview(
+        self, inputs: _OverviewInputs, prefetched: _OverviewSlices | None
+    ) -> dict[str, Any]:
+        """Assemble the overview from slices — prefetched or legacy-fetched.
+
+        Identical assembly either way: ``get_system_overview``'s join plus the
+        wrapper's ``system_info`` / ``notifications`` / ``repairs``, with the
+        entity-visibility filter applied server-side over the (prefetched or
+        fetched) registry + states. ``prefetched`` carries the component's raw
+        slices adapted to the shapes the assembly consumes; ``None`` runs the
+        original per-read REST/WS fetches. Byte-parity between the two is by
+        construction — same code, only the data source differs.
+        """
+        result = await self._smart_tools.get_system_overview(
+            inputs.detail_level,
+            inputs.max_entities_per_domain,
+            inputs.include_state,
+            inputs.include_entity_id,
+            domains_filter=inputs.domains_filter,
+            limit=inputs.limit,
+            offset=inputs.offset,
+            prefetched_slices=prefetched.registry_slices if prefetched else None,
+        )
+        result = cast(dict[str, Any], result)
+
+        await self._fetch_system_info(
+            result,
+            inputs.detail_level,
+            prefetched_config=prefetched.config if prefetched else None,
+        )
+
+        if inputs.include_notifications:
+            await self._fetch_notifications(
+                result,
+                prefetched_notifications=(
+                    prefetched.notifications if prefetched else None
+                ),
+            )
+
+        await self._fetch_repairs(
+            result,
+            inputs.include_dismissed_repairs,
+            prefetched_repairs=prefetched.repairs if prefetched else None,
+        )
+        return result
 
     async def _ha_deep_search(
         self,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1063,13 +1063,12 @@ class SearchTools:
             Field(
                 default=None,
                 description=(
-                    "Project the response to only the specified top-level "
-                    'keys (e.g. ["entities", "automations"]). Diagnostic / '
-                    "pagination keys are always retained regardless of "
-                    "projection, so narrowing the response shape cannot "
-                    "hide partial / error state. None = full response. "
-                    "Distinct from `result_fields` (which projects each "
-                    "entity record's fields). Available keys: success, "
+                    "Project the response to the named top-level keys "
+                    '(e.g. ["entities", "automations"]); None = full '
+                    "response. Diagnostic / pagination keys are always "
+                    "retained so projection cannot hide partial / error "
+                    "state. Distinct from `result_fields` (which projects "
+                    "each entity record's keys). Available keys: success, "
                     "query, entities, automations, scripts, scenes, "
                     "helpers, dashboards, search_types, search_type, "
                     "entity_total_matches, config_total_matches, count, "
@@ -1104,86 +1103,51 @@ class SearchTools:
     ) -> dict[str, Any]:
         """Search for entities (lights, sensors, switches, climate, etc.) by name, domain, or area — AND inside automation/script/scene/helper/dashboard configurations — in one call.
 
-        Searches two surfaces in parallel and returns tagged results:
-          - **entities**: matches from the entity registry (entity_id,
-            friendly name, area). Use `domain_filter` and/or `area_filter` to
-            list/narrow. Omit `query` to enumerate entities by domain/area.
+        Two surfaces run in parallel and return tagged results:
+          - **entities**: entity-registry matches (entity_id, friendly name,
+            area). Filter with `domain_filter`/`area_filter`; omit `query` to
+            enumerate a domain/area.
           - **automations / scripts / scenes / helpers / dashboards**: matches
-            *inside* configuration definitions — triggers, actions, sequences,
-            scene entity-sets, helper bodies, dashboard cards. Use `query`
-            with config-body terms; filter with `search_types`.
+            *inside* config definitions — triggers, actions, sequences, scene
+            entity-sets, helper bodies, dashboard cards. Driven by `query`;
+            narrow with `search_types`.
 
-        Eligibility:
-          - Registry (entity) search runs whenever `query`, `domain_filter`,
-            or `area_filter` is set, except when `search_types` is explicitly
-            set (which pins to config-only).
-          - Config-body search runs only when `query` is non-empty AND the
-            caller's inputs do not signal entity-only intent — i.e. when
-            none of `domain_filter`/`area_filter`/`state_filter` is set, OR
-            when `search_types` is explicitly set as an override. The
-            "filter set ⇒ skip body" rule keeps name-based single-entity
-            lookups (e.g. `ha_search("bedroom motion", domain_filter=
-            "binary_sensor")`) off the expensive config-body backend; pass
-            `search_types=[...]` to opt back in (a warning surfaces in the
-            response when the gate fires so the skip is visible).
-
-        Use this whenever you need to find something in HA — without needing
-        to decide between entity-name search vs config-body search up front.
+        Use this whenever you need to find something in HA without deciding
+        entity-name vs config-body search up front.
 
         When NOT to use:
-          - To fetch the state of a known entity_id: use `ha_get_state` (cheaper,
-            no search overhead).
-          - To inspect a specific automation/script/scene config by id: use the
-            matching `ha_config_get_*` tool.
+          - To read a known entity_id's state: use `ha_get_state` (cheaper).
+          - To inspect one automation/script/scene config by id: use the
+            matching `ha_config_get_*`.
           - To list installed add-ons: use `ha_get_addon`.
 
+        Config-body search is skipped when `domain_filter`/`area_filter`/
+        `state_filter` signal entity-only intent (keeping name lookups off the
+        expensive backend); a `warnings[]` entry names the skip. Pass
+        `search_types=[...]` to force config search.
+
         Caveats:
-          - Both surfaces fan out in parallel; response carries `partial: True`
-            plus an `errors[]` array tagged by surface ("entities" / "configs")
-            when one branch raises. Empty `entities`/`automations`/... combined
-            with `partial: True` means "search failed", not "no results".
-          - `partial: True` is ALSO set (with `partial_reason`) when the
-            config-body branch loses data on the per-type fetch paths —
-            either the per-id wall-clock budget exhausts and skips
-            unfetched configs, OR individual fetches raise exceptions
-            (caught at debug-level so they would otherwise be silent), OR
-            an `input_*` helper-type list fetch fails. Helpers run on every
-            default call, so silent per-type-list failures would otherwise
-            leave callers unable to tell a real zero-match from a partial
-            backend outage.
-          - When `partial: True` is set, the `partial_reason` text is
-            also mirrored into `warnings[]` with an `"incomplete results: "`
-            prefix. Agents that read `warnings` consistently (the
-            entity-intent skip warning lands fine) but ignore `partial`
-            still see the truncation diagnostic this way.
-          - When the body branch is skipped by the entity-intent gate above,
-            the response carries a `warnings[]` entry naming the skip
-            reason; pass `search_types=[...]` to override.
-          - The `fields=` parameter projects the response to only the
-            named top-level keys; diagnostic / pagination keys
-            (`success`, `warnings`, `errors`, `partial`, `partial_reason`,
-            `*_total_matches`, `has_more`, `next_offset`, and per-surface
-            counterparts) are always retained so projection cannot hide
-            incomplete-results state. Distinct from `result_fields=`
-            which projects each entity record's fields.
-          - `count` is items in this response (post-pagination), not total
-            matches across the corpus. Use `entity_total_matches` +
-            `config_total_matches` for the totals.
-          - `limit`/`offset` are applied per-surface independently. The flat
-            `has_more` / `next_offset` keys describe the next caller-page
-            (same offset/limit semantics as a single-surface tool — iterate
-            with `offset = next_offset`). Per-surface
-            `entity_has_more`/`entity_next_offset` and
-            `config_has_more`/`config_next_offset` let callers see which
-            surface still has results when only one of two does.
+          - `partial: True` means results are NOT exhaustive — a surface raised,
+            or the config-body branch lost data (per-id time budget exhausted,
+            an individual fetch failed, or a helper-type list fetch failed).
+            Empty buckets with `partial: True` mean "search failed", not "no
+            results". The cause is in `partial_reason`, also mirrored into
+            `warnings[]` with an "incomplete results: " prefix. Do not treat a
+            partial response as complete.
+          - `count` is items in this response (post-pagination), not corpus
+            totals — use `entity_total_matches` + `config_total_matches`.
+          - `limit`/`offset` apply per-surface. Flat `has_more`/`next_offset`
+            page the next call (iterate `offset = next_offset`); per-surface
+            `entity_*`/`config_*` variants show which surface still has results.
+
+        For parameters, schema, and worked examples, see ha_get_skill_guide.
 
         Examples:
             - List sensors in an area: ha_search(domain_filter="sensor", area_filter="Living Room")
-            - List all calendars: ha_search(domain_filter="calendar")
             - Find a light by name: ha_search("kitchen", domain_filter="light")
-            - Which automations use an entity (no filter, body included): ha_search("light.bed_light")
+            - Which automations use an entity: ha_search("light.bed_light")
             - Scenes touching a light: ha_search("light.kitchen", search_types=["scene"])
-            - Narrow the response to only the entity bucket: ha_search("kitchen", fields=["entities"])
+            - Narrow the response to the entity bucket: ha_search("kitchen", fields=["entities"])
         """
         try:
             parsed_search_types = parse_string_list_param(search_types, "search_types")

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -23,6 +23,7 @@ from ..utils.fuzzy_search import apply_hidden_penalty
 from ..visibility.resolver import (
     device_registry_needed_for_visibility,
     load_hidden_set,
+    visibility_filter_active,
 )
 from .component_api import (
     component_supports,
@@ -1522,9 +1523,22 @@ class SearchTools:
         # differ per mode, and after the request-dedup work they are cheap
         # registry-only calls, so the component round-trip buys nothing worth
         # the shape risk.
+        #
+        # The component also applies no entity-visibility filtering, so an
+        # install with an ACTIVE visibility filter (enabled + a hide dimension)
+        # must keep the legacy path, which excludes hidden entities before the
+        # counts/pagination. ``visibility_filter_active`` reloads the same
+        # opt-in config file the legacy filter uses (fail-closed to legacy on a
+        # malformed config). Checked only when the component would otherwise
+        # serve, so the common (no-component / filter-off) install pays nothing;
+        # visibility-enabled installs are the opt-in minority and stay on legacy
+        # until a later capability passes the hide rules to the component.
         if req.query_text and not (req.area_filter or "").strip():
             caps = await get_component_caps(self._client)
-            if component_supports(caps, "search"):
+            if (
+                component_supports(caps, "search")
+                and not await visibility_filter_active()
+            ):
                 component_response = await self._ha_search_via_component(req, ctx)
                 if component_response is not None:
                     return component_response

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -17,7 +17,10 @@ from ..config import get_global_settings
 from ..errors import create_validation_error
 from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
 from ..utils.fuzzy_search import apply_hidden_penalty
-from ..visibility.resolver import load_hidden_set
+from ..visibility.resolver import (
+    device_registry_needed_for_visibility,
+    load_hidden_set,
+)
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -345,6 +348,38 @@ def _compute_eligibility(
     return registry_eligible, body_eligible, body_skipped_by_intent_gate
 
 
+async def _prefetch_shared_search_snapshots(
+    client: Any,
+    *,
+    registry_eligible: bool,
+    body_eligible: bool,
+) -> tuple[list[dict[str, Any]] | None, Any]:
+    """Pre-fetch ``/api/states`` + the entity-registry list once for ha_search.
+
+    Only pre-fetches when both branches are eligible — a lone branch keeps
+    fetching for itself. Returns ``(shared_states, shared_registry)``; either is
+    ``None`` when not pre-fetched, or when its fetch failed (each branch then
+    fetches and fails on its own, reproducing the per-surface partial-result
+    handling exactly). A cancellation (structured-concurrency teardown)
+    propagates rather than degrading to per-branch fetching.
+    """
+    if not (registry_eligible and body_eligible):
+        return None, None
+    prefetch = await asyncio.gather(
+        client.get_states(),
+        client.send_websocket_message({"type": "config/entity_registry/list"}),
+        return_exceptions=True,
+    )
+    for snap in prefetch:
+        if isinstance(snap, BaseException) and not isinstance(snap, Exception):
+            raise snap
+    shared_states = prefetch[0] if not isinstance(prefetch[0], BaseException) else None
+    shared_registry = (
+        prefetch[1] if not isinstance(prefetch[1], BaseException) else None
+    )
+    return shared_states, shared_registry
+
+
 def _merge_payload_metadata(
     response: dict[str, Any],
     payload: dict[str, Any],
@@ -457,10 +492,12 @@ def _apply_search_outcome(
 ) -> None:
     """Apply one gather outcome (entities or configs) to the response dict in-place.
 
-    ``_ha_search_entities`` wraps its payload via ``add_timezone_metadata``
-    into ``{"data": {...}, "metadata": {...}}``; ``_ha_deep_search`` returns
-    the search dict directly.  Unwrap once so downstream reads see the same
-    shape regardless of which helper produced it.
+    Both ``_ha_search_entities`` and ``_ha_deep_search`` return their search dict
+    directly. The entity builders no longer wrap it via ``add_timezone_metadata``:
+    entity-search records carry none of the timestamp fields that enrichment
+    converts, so it was a discarded ``/api/config`` fetch. The ``{"data": ...}``
+    unwrap is kept as a defensive no-op so a future wrapped payload still reads
+    correctly.
     """
     payload = (
         outcome["data"] if isinstance(outcome, dict) and "data" in outcome else outcome
@@ -753,6 +790,9 @@ async def _exact_match_search(
     offset: int = 0,
     include_hidden: bool = True,
     state_filter: str | None = None,
+    *,
+    prefetched_states: list[dict[str, Any]] | None = None,
+    prefetched_registry: Any = None,
 ) -> dict[str, Any]:
     """
     Search entities by substring on entity_id + friendly_name.
@@ -763,22 +803,49 @@ async def _exact_match_search(
     ``hidden_by`` entities: by default they remain in results but
     receive a score penalty so visible matches sort first; pass
     ``include_hidden=False`` to filter them out entirely.
+
+    ``prefetched_states`` / ``prefetched_registry`` are the snapshots the
+    ha_search orchestrator shares with the config branch when both run (``None``
+    = fetch here). The device registry is fetched only when the loaded visibility
+    config has an area/label dimension that consumes it.
     """
-    # Fetch states + entity registry in parallel. Registry-list failure
-    # is tolerated (we just lose the hidden filter); states-fetch failure
-    # is fatal — auth/connection errors must propagate so the agent sees
-    # "your token is invalid" instead of "zero entities matched".
-    entities_task = client.get_states()
-    registry_task = client.send_websocket_message(
-        {"type": "config/entity_registry/list"}
+    # Fetch states + entity registry in parallel (unless the orchestrator already
+    # shared them). Registry-list failure is tolerated (we just lose the hidden
+    # filter); states-fetch failure is fatal — auth/connection errors must
+    # propagate so the agent sees "your token is invalid" instead of "zero
+    # entities matched". The device registry is gated: it only feeds the
+    # visibility area/label dimensions, so a default/area-free config skips it.
+    need_device = await device_registry_needed_for_visibility()
+    fetch_coros: list[Any] = []
+    fetch_slots: list[str] = []
+    if prefetched_states is None:
+        fetch_coros.append(client.get_states())
+        fetch_slots.append("states")
+    if prefetched_registry is None:
+        fetch_coros.append(
+            client.send_websocket_message({"type": "config/entity_registry/list"})
+        )
+        fetch_slots.append("registry")
+    if need_device:
+        fetch_coros.append(
+            client.send_websocket_message({"type": "config/device_registry/list"})
+        )
+        fetch_slots.append("device")
+    fetched = (
+        await asyncio.gather(*fetch_coros, return_exceptions=True)
+        if fetch_coros
+        else []
     )
-    device_task = client.send_websocket_message({"type": "config/device_registry/list"})
-    gather_results = await asyncio.gather(
-        entities_task, registry_task, device_task, return_exceptions=True
+    slots = dict(zip(fetch_slots, fetched, strict=True))
+    state_result: Any = (
+        prefetched_states if prefetched_states is not None else slots.get("states")
     )
-    state_result: Any = gather_results[0]
-    registry_result: Any = gather_results[1]
-    device_result: Any = gather_results[2]
+    registry_result: Any = (
+        prefetched_registry
+        if prefetched_registry is not None
+        else slots.get("registry")
+    )
+    device_result: Any = slots.get("device")
     _raise_gather_exceptions(state_result, registry_result, device_result)
     all_entities = state_result
     hidden_ids = _build_hidden_ids(registry_result)
@@ -1157,6 +1224,16 @@ class SearchTools:
                 )
             )
 
+        # When both branches run they each independently fetch the full state
+        # machine (/api/states) and the entity-registry list; fetch each once and
+        # thread the snapshots down so the two branches share one of each instead
+        # of fetching two.
+        shared_states, shared_registry = await _prefetch_shared_search_snapshots(
+            self._client,
+            registry_eligible=registry_eligible,
+            body_eligible=body_eligible,
+        )
+
         registry_callable_kwargs: dict[str, Any] = {
             "query": query_text or None,
             "domain_filter": domain_filter,
@@ -1169,6 +1246,8 @@ class SearchTools:
             "per_domain_limit": per_domain_limit,
             "state_filter": state_filter,
             "result_fields": result_fields,
+            "prefetched_states": shared_states,
+            "prefetched_registry": shared_registry,
         }
 
         tasks: list[Any] = []
@@ -1187,6 +1266,8 @@ class SearchTools:
                     exact_match=exact_match,
                     config_time_budget=config_time_budget,
                     ctx=ctx,
+                    prefetched_states=shared_states,
+                    prefetched_registry=shared_registry,
                 )
             )
             labels.append("configs")
@@ -1368,6 +1449,9 @@ class SearchTools:
                 ),
             ),
         ] = None,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> dict[str, Any]:
         """Search for entities (lights, sensors, switches, etc.) by name, domain, or area.
 
@@ -1378,6 +1462,10 @@ class SearchTools:
         To enumerate all entities of a domain, omit `query` and pass `domain_filter`. For
         example, `ha_search_entities(domain_filter="calendar")` lists all calendars. At
         least one of `query`, `domain_filter`, or `area_filter` must be set.
+
+        ``prefetched_states`` / ``prefetched_registry`` are the orchestrator's
+        shared snapshots; they only reach the regular (non-area, non-domain-only)
+        path, which is the only one that can run alongside the config branch.
         """
         query, domain_filter, area_filter, parsed_result_fields = (
             _validate_entity_search_params(
@@ -1427,11 +1515,10 @@ class SearchTools:
                 # carry area_result's warnings; forward them here in one place so a
                 # visibility/registry degradation on the area path is not silently
                 # dropped (mirrors the non-area path's merge_visibility_warnings).
-                # The builders wrap their payload via add_timezone_metadata into
-                # {"data": {...}, "metadata": {...}}, and the ha_search orchestrator
-                # unwraps ["data"] before merging metadata — so the warnings must
-                # live inside ["data"], not at the wrapper's top level, or the
-                # unwrap drops them.
+                # The builders now return the search dict directly (no
+                # add_timezone_metadata wrapper), so warnings merge into that dict;
+                # the ``["data"]`` unwrap is a defensive holdover for a hypothetical
+                # future wrapped payload.
                 warn_target = (
                     area_search["data"]
                     if isinstance(area_search, dict) and "data" in area_search
@@ -1464,6 +1551,8 @@ class SearchTools:
                 group_by_domain_bool,
                 per_domain_limit_int,
                 parsed_result_fields,
+                prefetched_states=prefetched_states,
+                prefetched_registry=prefetched_registry,
             )
 
         except ToolError:
@@ -1636,7 +1725,10 @@ class SearchTools:
         )
         _apply_result_fields_to_response(search_data, parsed_result_fields)
 
-        return await add_timezone_metadata(self._client, search_data)
+        # No add_timezone_metadata: entity records carry no timestamp fields, so
+        # the enrichment converted nothing and its /api/config fetch was pure
+        # waste (the orchestrator discards its metadata wrapper anyway).
+        return search_data
 
     async def _search_area_only_populated(
         self,
@@ -1711,7 +1803,8 @@ class SearchTools:
         )
         _apply_result_fields_to_response(area_search_data, parsed_result_fields)
 
-        return await add_timezone_metadata(self._client, area_search_data)
+        # No add_timezone_metadata — see _search_area_with_query.
+        return area_search_data
 
     async def _search_area_only(
         self,
@@ -1756,7 +1849,8 @@ class SearchTools:
             empty_area_data["state_filter"] = state_filter
         if group_by_domain_bool:
             empty_area_data["by_domain"] = {}
-        return await add_timezone_metadata(self._client, empty_area_data)
+        # No add_timezone_metadata — see _search_area_with_query.
+        return empty_area_data
 
     async def _search_domain_only(
         self,
@@ -1773,20 +1867,26 @@ class SearchTools:
         """List all entities of a single domain (empty query + domain_filter)."""
         # Fetch states + registry list in parallel. Registry-list failure is
         # tolerated (we just lose the hidden filter); states-fetch failure is
-        # fatal — auth/connection errors must propagate.
-        states_task = self._client.get_states()
-        registry_task = self._client.send_websocket_message(
-            {"type": "config/entity_registry/list"}
-        )
-        device_task = self._client.send_websocket_message(
-            {"type": "config/device_registry/list"}
-        )
-        gather_results = await asyncio.gather(
-            states_task, registry_task, device_task, return_exceptions=True
-        )
+        # fatal — auth/connection errors must propagate. The device registry is
+        # gated: it only feeds the visibility area/label dimensions, so a
+        # default/area-free config skips the fetch entirely.
+        need_device = await device_registry_needed_for_visibility()
+        fetch_coros: list[Any] = [
+            self._client.get_states(),
+            self._client.send_websocket_message(
+                {"type": "config/entity_registry/list"}
+            ),
+        ]
+        if need_device:
+            fetch_coros.append(
+                self._client.send_websocket_message(
+                    {"type": "config/device_registry/list"}
+                )
+            )
+        gather_results = await asyncio.gather(*fetch_coros, return_exceptions=True)
         states_result: Any = gather_results[0]
         registry_result: Any = gather_results[1]
-        device_result: Any = gather_results[2]
+        device_result: Any = gather_results[2] if need_device else None
         if isinstance(states_result, BaseException):
             raise states_result
         # CancelledError must propagate; gather captures it like any other
@@ -1862,10 +1962,8 @@ class SearchTools:
                 domain_filter, results, per_domain_limit_int, parsed_result_fields
             )
 
-        return await add_timezone_metadata(
-            self._client,
-            merge_visibility_warnings(domain_list_data, visibility_warnings),
-        )
+        # No add_timezone_metadata — see _search_area_with_query.
+        return merge_visibility_warnings(domain_list_data, visibility_warnings)
 
     async def _search_regular(
         self,
@@ -1879,8 +1977,16 @@ class SearchTools:
         group_by_domain_bool: bool,
         per_domain_limit_int: int | None,
         parsed_result_fields: list[str] | None,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> dict[str, Any]:
-        """Perform exact-match or fuzzy entity search (no area/domain-listing shortcuts)."""
+        """Perform exact-match or fuzzy entity search (no area/domain-listing shortcuts).
+
+        ``prefetched_states`` / ``prefetched_registry`` are the snapshots the
+        ha_search orchestrator shares with the config branch when both run; they
+        are threaded into whichever backend this call uses (``None`` = fetch).
+        """
         result: dict[str, Any]
         warning: str | None = None
         search_type = "exact_match" if exact_match_bool else "fuzzy_search"
@@ -1897,6 +2003,8 @@ class SearchTools:
                 offset,
                 include_hidden=include_hidden_bool,
                 state_filter=state_filter,
+                prefetched_states=prefetched_states,
+                prefetched_registry=prefetched_registry,
             )
         else:
             # Fuzzy mode: BM25 → substring fallback on exception only.
@@ -1907,6 +2015,8 @@ class SearchTools:
                     offset=offset,
                     domain_filter=domain_filter,
                     include_hidden=include_hidden_bool,
+                    prefetched_states=prefetched_states,
+                    prefetched_registry=prefetched_registry,
                 )
                 search_type = "fuzzy_search"
             except asyncio.CancelledError:
@@ -1928,6 +2038,8 @@ class SearchTools:
                     offset,
                     include_hidden=include_hidden_bool,
                     state_filter=state_filter,
+                    prefetched_states=prefetched_states,
+                    prefetched_registry=prefetched_registry,
                 )
                 warning = "Fuzzy search unavailable, using substring match"
                 search_type = "exact_match"
@@ -1967,7 +2079,8 @@ class SearchTools:
 
         _apply_result_fields_to_response(result, parsed_result_fields)
 
-        return await add_timezone_metadata(self._client, result)
+        # No add_timezone_metadata — see _search_area_with_query.
+        return result
 
     @tool(
         name="ha_get_overview",
@@ -2409,6 +2522,9 @@ class SearchTools:
             ),
         ] = None,
         ctx: Context | None = None,
+        *,
+        prefetched_states: list[dict[str, Any]] | None = None,
+        prefetched_registry: Any = None,
     ) -> dict[str, Any]:
         """Search inside automation, script, scene, helper, and dashboard *configurations* — not for finding entity IDs.
 
@@ -2462,6 +2578,8 @@ class SearchTools:
                 exact_match=exact_match_bool,
                 config_time_budget=config_time_budget,
                 ctx=ctx,
+                prefetched_states=prefetched_states,
+                prefetched_registry=prefetched_registry,
             )
             return cast(dict[str, Any], result)
         except ToolError:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -6,6 +6,7 @@ This module provides entity search, system overview, deep search, and state retr
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Annotated, Any, Literal, cast
 
 from fastmcp import Context
@@ -13,6 +14,8 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import HomeAssistantCommandError
+from ..client.websocket_client import get_websocket_client
 from ..config import get_global_settings
 from ..errors import create_validation_error
 from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
@@ -20,6 +23,12 @@ from ..utils.fuzzy_search import apply_hidden_penalty
 from ..visibility.resolver import (
     device_registry_needed_for_visibility,
     load_hidden_set,
+)
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
 )
 from .helpers import (
     exception_to_structured_error,
@@ -567,6 +576,295 @@ def _apply_result_fields_to_response(
     _warn = _result_fields_warning(orig, data["results"], parsed_result_fields)
     if _warn:
         data.setdefault("warnings", []).append(_warn)
+
+
+def _new_search_response(
+    query: str | None, parsed_search_types: list[str] | None
+) -> dict[str, Any]:
+    """Build the base ha_search response envelope shared by both serving paths.
+
+    The component-served and legacy-served paths start from this identical
+    skeleton, so the two responses are shape-parity by construction: every
+    accumulating diagnostic / pagination key gets a typed default here, then is
+    filled by ``_apply_search_outcome`` regardless of which path produced the
+    data.
+    """
+    return {
+        "success": True,
+        "query": query,
+        "entities": [],
+        "entity_total_matches": 0,
+        "automations": [],
+        "scripts": [],
+        "scenes": [],
+        "helpers": [],
+        "search_types": parsed_search_types
+        or ["automation", "script", "scene", "helper"],
+        "config_total_matches": 0,
+        "partial": False,
+        "errors": [],
+        "warnings": [],
+    }
+
+
+@dataclass(frozen=True)
+class _ResolvedSearch:
+    """Parsed + validated ha_search inputs shared by the component and legacy paths.
+
+    ``ha_search`` parses parameters, validates them, and computes branch
+    eligibility exactly once, then hands this immutable bundle to whichever
+    path serves the request so both operate on identical resolved inputs. The
+    filter fields (``domain_filter`` / ``area_filter`` / ``state_filter``) hold
+    the **raw** tool arguments so the legacy path normalises them exactly as
+    before; the component helpers normalise their own copies.
+    """
+
+    query: str | None
+    query_text: str
+    domain_filter: str | None
+    area_filter: str | None
+    state_filter: str | None
+    parsed_search_types: list[str] | None
+    parsed_fields: list[str] | None
+    result_fields: Any
+    limit: int
+    offset: int
+    exact_match: bool
+    include_hidden: bool
+    include_config: bool
+    group_by_domain: bool
+    per_domain_limit: int | None
+    config_time_budget: float | None
+    registry_eligible: bool
+    body_eligible: bool
+    body_skipped_by_intent_gate: bool
+
+
+def _parse_component_result_fields(result_fields: Any) -> list[str] | None:
+    """Parse ``result_fields`` for the component path (mirrors the entity branch).
+
+    The legacy entity branch parses ``result_fields`` inside
+    ``_validate_entity_search_params``; the component path re-uses the identical
+    parse + validation so a bad ``result_fields`` raises the same structured
+    error on either path.
+    """
+    if result_fields is None:
+        return None
+    try:
+        parsed = parse_string_list_param(result_fields, "result_fields", allow_csv=True)
+    except ValueError as exc:
+        raise_tool_error(create_validation_error(str(exc), parameter="result_fields"))
+    if parsed is not None and len(parsed) == 0:
+        raise_tool_error(
+            create_validation_error(
+                "result_fields must contain at least one key",
+                parameter="result_fields",
+            )
+        )
+    return parsed
+
+
+def _as_record_list(value: Any) -> list[dict[str, Any]]:
+    """Coerce a component payload slice to a list of records (defensive)."""
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _normalized_domain_filter(raw: str | None) -> str | None:
+    """Strip + lowercase a domain filter to the entity branch's canonical form.
+
+    Matches ``_validate_entity_search_params`` so the component request and the
+    ``domain_filter`` echo agree with the legacy path.
+    """
+    return ((raw or "").strip().lower()) or None
+
+
+# The documented per-record entity surface (result_fields= "Available keys").
+# Both legacy entity paths emit exactly these; the component path is trimmed
+# to them in _shape_component_search_response.
+_ENTITY_RECORD_KEYS = (
+    "entity_id",
+    "friendly_name",
+    "domain",
+    "state",
+    "score",
+    "match_type",
+)
+
+
+def _normalize_component_config_record(
+    bucket: str, rec: dict[str, Any], include_config: bool
+) -> dict[str, Any]:
+    """Map one component config-bucket record onto the exact legacy key set.
+
+    The component speaks HA-native vocabulary (automations/scripts carry an
+    ``alias``, scenes a ``name``, storage ids ride an ``id`` key, and records
+    add ``source``/``kind``/``object_id`` metadata). The legacy deep-search
+    records that agents, tests, and downstream consumers key on use
+    ``friendly_name`` plus per-bucket id keys (``script_id``/``scene_id``) —
+    so normalize here, at the single seam, rather than teaching the component
+    the MCP envelope's vocabulary. Extra component fields are deliberately
+    dropped for byte-level shape parity with the legacy path; enrichment
+    (e.g. ``source: yaml``) can be added to BOTH paths together later.
+
+    ``config`` key semantics mirror the legacy pipeline's include_config pop:
+    present (possibly ``None`` for YAML/name-only matches) when
+    ``include_config`` is True, absent otherwise. Flow-helper records carry
+    their body under ``options`` component-side (data-minimized
+    ``ConfigEntry.options``); legacy calls the same payload ``config``.
+    """
+    entity_id = rec.get("entity_id")
+    name = rec.get("alias") or rec.get("name") or rec.get("friendly_name")
+    out: dict[str, Any] = {}
+    if bucket == "helpers":
+        if rec.get("kind") == "flow" or (entity_id is None and rec.get("entry_id")):
+            out["entry_id"] = rec.get("entry_id")
+        else:
+            out["entity_id"] = entity_id
+        out["helper_type"] = rec.get("helper_type")
+        out["name"] = name
+    else:
+        out["entity_id"] = entity_id
+        if bucket == "scripts":
+            out["script_id"] = rec.get("id")
+        elif bucket == "scenes":
+            out["scene_id"] = rec.get("id")
+        out["friendly_name"] = name if name is not None else entity_id
+    out["score"] = rec.get("score")
+    out["match_in_name"] = bool(rec.get("match_in_name"))
+    out["match_in_config"] = bool(rec.get("match_in_config"))
+    if include_config:
+        config = rec.get("config")
+        if config is None and "options" in rec:
+            config = rec.get("options")
+        out["config"] = config if config else None
+    return out
+
+
+def _build_component_search_request(req: _ResolvedSearch) -> dict[str, Any]:
+    """Translate resolved ha_search inputs into an ``ha_mcp_tools/search`` request.
+
+    ``search_types`` on the WS command selects surfaces including the entity
+    surface (``"entity"``), so branch eligibility computed server-side maps
+    directly onto which surfaces the component searches — all-or-nothing per
+    command. Optional string filters are omitted when empty to satisfy the
+    component's ``str``-typed voluptuous schema.
+    """
+    search_types: list[str] = []
+    if req.registry_eligible:
+        search_types.append("entity")
+    if req.body_eligible:
+        search_types.extend(
+            req.parsed_search_types or ["automation", "script", "scene", "helper"]
+        )
+    request: dict[str, Any] = {
+        "search_types": search_types,
+        "exact": req.exact_match,
+        "include_hidden": req.include_hidden,
+        "include_config": req.include_config,
+        "limit": req.limit,
+        "offset": req.offset,
+    }
+    if req.query_text:
+        request["query"] = req.query_text
+    domain_filter = _normalized_domain_filter(req.domain_filter)
+    if domain_filter:
+        request["domain_filter"] = domain_filter
+    area_filter = (req.area_filter or "").strip()
+    if area_filter:
+        request["area_filter"] = area_filter
+    state_filter = (req.state_filter or "").strip()
+    if state_filter:
+        request["state_filter"] = state_filter
+    return request
+
+
+def _shape_component_search_response(
+    req: _ResolvedSearch, component_result: dict[str, Any]
+) -> dict[str, Any]:
+    """Map an ``ha_mcp_tools/search`` result into the ha_search envelope.
+
+    The component returns per-surface records already scored and paginated
+    (``entities`` + config buckets with ``*_total_matches`` / ``*_has_more``).
+    Projection (``result_fields`` on entity records, ``fields`` on the
+    response), by-domain grouping, and the flat pagination / partial-mirror
+    finalisation all stay server-side and reuse the same helpers the legacy
+    path uses (``_apply_search_outcome`` and friends), so the shape is
+    identical to the legacy response by construction.
+    """
+    response = _new_search_response(req.query, req.parsed_search_types)
+    _emit_intent_skip_warning(response, req.body_skipped_by_intent_gate)
+
+    if req.registry_eligible:
+        parsed_result_fields = _parse_component_result_fields(req.result_fields)
+        # Normalize to the documented entity-record key set (the same six keys
+        # the legacy paths emit and result_fields= advertises). The component
+        # enriches records with area/floor/labels/aliases joins — dropped here
+        # for shape parity with the legacy path; adding enrichment to BOTH
+        # paths together is a separate change.
+        entities = [
+            {key: rec.get(key) for key in _ENTITY_RECORD_KEYS}
+            for rec in _as_record_list(component_result.get("entities"))
+        ]
+        entity_has_more = bool(component_result.get("entity_has_more", False))
+        entity_payload: dict[str, Any] = {
+            "results": entities,
+            "total_matches": int(
+                component_result.get("entity_total_matches", len(entities)) or 0
+            ),
+            "has_more": entity_has_more,
+            "next_offset": (req.offset + req.limit) if entity_has_more else None,
+            "offset": req.offset,
+            "limit": req.limit,
+            "count": len(entities),
+            "search_type": "exact_match" if req.exact_match else "fuzzy_search",
+        }
+        domain_filter = _normalized_domain_filter(req.domain_filter)
+        if domain_filter:
+            entity_payload["domain_filter"] = domain_filter
+        # Order mirrors _search_regular: group by domain first (it projects its
+        # own records), then project the flat results[].
+        _apply_by_domain_grouping(
+            entity_payload,
+            entities,
+            req.group_by_domain,
+            req.per_domain_limit,
+            parsed_result_fields,
+        )
+        _apply_result_fields_to_response(entity_payload, parsed_result_fields)
+        _apply_search_outcome(response, "entities", entity_payload)
+
+    if req.body_eligible:
+        config_has_more = bool(component_result.get("config_has_more", False))
+        config_payload: dict[str, Any] = {
+            "total_matches": int(component_result.get("config_total_matches", 0) or 0),
+            "has_more": config_has_more,
+            "next_offset": (req.offset + req.limit) if config_has_more else None,
+        }
+        for bucket in _CONFIG_BUCKETS:
+            if bucket in component_result:
+                config_payload[bucket] = [
+                    _normalize_component_config_record(bucket, rec, req.include_config)
+                    for rec in _as_record_list(component_result.get(bucket))
+                ]
+        _apply_search_outcome(response, "configs", config_payload)
+
+    # The component reports a single overall partial flag (design § 1). In-process
+    # joins are effectively never partial, but a body too large to serialize can
+    # set it — carry it through honestly rather than assuming completeness.
+    if component_result.get("partial"):
+        response["partial"] = True
+        reason = component_result.get("partial_reason")
+        if isinstance(reason, str) and reason:
+            _merge_partial_reason(response, reason)
+
+    response["count"] = len(response["entities"]) + sum(
+        len(response.get(bucket, [])) for bucket in _CONFIG_BUCKETS
+    )
+    _synthesize_combined_pagination(response)
+    _mirror_partial_to_warnings(response)
+    return _project_response_fields(response, req.parsed_fields)
 
 
 def _normalize_regular_search_result(
@@ -1188,47 +1486,133 @@ class SearchTools:
                 )
             )
 
+        req = _ResolvedSearch(
+            query=query,
+            query_text=query_text,
+            domain_filter=domain_filter,
+            area_filter=area_filter,
+            state_filter=state_filter,
+            parsed_search_types=parsed_search_types,
+            parsed_fields=parsed_fields,
+            result_fields=result_fields,
+            limit=limit,
+            offset=offset,
+            exact_match=exact_match,
+            include_hidden=include_hidden,
+            include_config=include_config,
+            group_by_domain=group_by_domain,
+            per_domain_limit=per_domain_limit,
+            config_time_budget=config_time_budget,
+            registry_eligible=registry_eligible,
+            body_eligible=body_eligible,
+            body_skipped_by_intent_gate=body_skipped_by_intent_gate,
+        )
+
+        # Prefer the custom component's in-process unified search when it
+        # advertises the capability: one WS round-trip replaces the multi-fetch
+        # legacy pipeline. Route all-or-nothing per command and fall back
+        # cleanly when the component is absent, downlevel, or errors — the
+        # taxonomy lives in ``_ha_search_via_component``.
+        caps = await get_component_caps(self._client)
+        if component_supports(caps, "search"):
+            component_response = await self._ha_search_via_component(req, ctx)
+            if component_response is not None:
+                return component_response
+
+        return await self._legacy_ha_search(req, ctx)
+
+    async def _ha_search_via_component(
+        self, req: _ResolvedSearch, ctx: Context | None
+    ) -> dict[str, Any] | None:
+        """Serve ha_search from the component; ``None`` ⇒ run the legacy path.
+
+        Error taxonomy (design § 4):
+
+        - ``unknown_command`` (component downgraded mid-session, so the cached
+          positive caps are stale): invalidate the caps and return ``None`` so
+          the caller falls back **silently** — an expected, non-actionable
+          transition.
+        - any other ``HomeAssistantCommandError`` (a component handler bug):
+          serve the correct result from the legacy path, append a ``warnings[]``
+          entry, and ``log.warning`` — correct results now, breakage visible.
+        - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
+          propagates; the legacy path depends on the same socket and would fail
+          identically, so surfacing it is correct.
+        """
+        try:
+            raw = await self._send_component_search(req)
+        except HomeAssistantCommandError as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            legacy = await self._legacy_ha_search(req, ctx)
+            legacy.setdefault("warnings", []).append(
+                f"component search path failed ({exc}); served via legacy path"
+            )
+            logger.warning("ha_mcp_tools/search failed; fell back to legacy: %r", exc)
+            return legacy
+        return _shape_component_search_response(req, raw.get("result") or {})
+
+    async def _send_component_search(self, req: _ResolvedSearch) -> dict[str, Any]:
+        """Send one ``ha_mcp_tools/search`` command over the per-client WebSocket."""
+        ws = await get_websocket_client(
+            url=self._client.base_url, token=self._client.token
+        )
+        return await ws.send_command(
+            "ha_mcp_tools/search", **_build_component_search_request(req)
+        )
+
+    async def _legacy_ha_search(
+        self, req: _ResolvedSearch, ctx: Context | None
+    ) -> dict[str, Any]:
+        """Run the multi-fetch REST/WS ha_search orchestration (fallback path).
+
+        Behaviourally unchanged from the pre-component implementation: the two
+        surfaces fan out over shared ``/api/states`` + entity-registry
+        snapshots, gather with per-surface partial handling, and assemble the
+        flat dual-surface envelope.
+        """
         # When both branches run they each independently fetch the full state
         # machine (/api/states) and the entity-registry list; fetch each once and
         # thread the snapshots down so the two branches share one of each instead
         # of fetching two.
         shared_states, shared_registry = await _prefetch_shared_search_snapshots(
             self._client,
-            registry_eligible=registry_eligible,
-            body_eligible=body_eligible,
+            registry_eligible=req.registry_eligible,
+            body_eligible=req.body_eligible,
         )
 
         registry_callable_kwargs: dict[str, Any] = {
-            "query": query_text or None,
-            "domain_filter": domain_filter,
-            "area_filter": area_filter,
-            "limit": limit,
-            "offset": offset,
-            "exact_match": exact_match,
-            "include_hidden": include_hidden,
-            "group_by_domain": group_by_domain,
-            "per_domain_limit": per_domain_limit,
-            "state_filter": state_filter,
-            "result_fields": result_fields,
+            "query": req.query_text or None,
+            "domain_filter": req.domain_filter,
+            "area_filter": req.area_filter,
+            "limit": req.limit,
+            "offset": req.offset,
+            "exact_match": req.exact_match,
+            "include_hidden": req.include_hidden,
+            "group_by_domain": req.group_by_domain,
+            "per_domain_limit": req.per_domain_limit,
+            "state_filter": req.state_filter,
+            "result_fields": req.result_fields,
             "prefetched_states": shared_states,
             "prefetched_registry": shared_registry,
         }
 
         tasks: list[Any] = []
         labels: list[str] = []
-        if registry_eligible:
+        if req.registry_eligible:
             tasks.append(self._ha_search_entities(**registry_callable_kwargs))
             labels.append("entities")
-        if body_eligible:
+        if req.body_eligible:
             tasks.append(
                 self._ha_deep_search(
-                    query=query_text,
-                    search_types=parsed_search_types,
-                    limit=limit,
-                    offset=offset,
-                    include_config=include_config,
-                    exact_match=exact_match,
-                    config_time_budget=config_time_budget,
+                    query=req.query_text,
+                    search_types=req.parsed_search_types,
+                    limit=req.limit,
+                    offset=req.offset,
+                    include_config=req.include_config,
+                    exact_match=req.exact_match,
+                    config_time_budget=req.config_time_budget,
                     ctx=ctx,
                     prefetched_states=shared_states,
                     prefetched_registry=shared_registry,
@@ -1241,31 +1625,11 @@ class SearchTools:
         # cancelled before the tasks complete.
         outcomes = await asyncio.gather(*tasks, return_exceptions=True)
 
-        response: dict[str, Any] = {
-            "success": True,
-            "query": query,
-            "entities": [],
-            "entity_total_matches": 0,
-            "automations": [],
-            "scripts": [],
-            "scenes": [],
-            "helpers": [],
-            "search_types": parsed_search_types
-            or ["automation", "script", "scene", "helper"],
-            "config_total_matches": 0,
-            # Pre-init the accumulating diagnostic keys so callers reading
-            # ``response["errors"]`` / ``response["partial"]`` / ``response
-            # ["warnings"]`` get a typed default instead of ``KeyError`` on
-            # the no-error path, and so ``_merge_payload_metadata`` extends
-            # rather than first-wins.
-            "partial": False,
-            "errors": [],
-            "warnings": [],
-        }
+        response = _new_search_response(req.query, req.parsed_search_types)
         # Surface the body-skip so a caller who actually wanted config
         # matches alongside the entity scope can see why their request
         # returned no automations / scripts / etc.
-        _emit_intent_skip_warning(response, body_skipped_by_intent_gate)
+        _emit_intent_skip_warning(response, req.body_skipped_by_intent_gate)
         partial = False
         errors: list[dict[str, str]] = []
         for label, outcome in zip(labels, outcomes, strict=True):
@@ -1295,7 +1659,7 @@ class SearchTools:
         _finalize_partial_state(response, partial_local=partial, errors_local=errors)
         _mirror_partial_to_warnings(response)
 
-        return _project_response_fields(response, parsed_fields)
+        return _project_response_fields(response, req.parsed_fields)
 
     async def _ha_search_entities(
         self,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1513,11 +1513,21 @@ class SearchTools:
         # legacy pipeline. Route all-or-nothing per command and fall back
         # cleanly when the component is absent, downlevel, or errors — the
         # taxonomy lives in ``_ha_search_via_component``.
-        caps = await get_component_caps(self._client)
-        if component_supports(caps, "search"):
-            component_response = await self._ha_search_via_component(req, ctx)
-            if component_response is not None:
-                return component_response
+        #
+        # Only QUERY-DRIVEN searches route through the component. The listing
+        # modes — empty/whitespace query with domain_filter (legacy
+        # ``search_type: domain_listing``) and any area_filter search (legacy
+        # ``area_only`` / ``area_filtered_query``, with their own area-shaped
+        # response keys) — keep the legacy path: their response contracts
+        # differ per mode, and after the request-dedup work they are cheap
+        # registry-only calls, so the component round-trip buys nothing worth
+        # the shape risk.
+        if req.query_text and not (req.area_filter or "").strip():
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "search"):
+                component_response = await self._ha_search_via_component(req, ctx)
+                if component_response is not None:
+                    return component_response
 
         return await self._legacy_ha_search(req, ctx)
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -14,7 +14,10 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
-from ..client.rest_client import HomeAssistantCommandError
+from ..client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
 from ..client.websocket_client import get_websocket_client
 from ..config import get_global_settings
 from ..errors import create_validation_error
@@ -473,6 +476,27 @@ def _merge_partial_reason(response: dict[str, Any], value: str) -> None:
         response["partial_reason"] = value
 
 
+def _format_search_diagnostics(diagnostics: dict[str, Any]) -> str | None:
+    """Render the component's non-empty search diagnostics into one reason fragment.
+
+    The component reports intentional per-surface diagnostics (e.g.
+    ``config_components_inaccessible: [...]`` — config domains it could not read
+    from HA's in-process registries). Each non-empty entry becomes a
+    human-readable ``"<label>: <values>"`` clause; empty entries are dropped.
+    Returns ``None`` when nothing is reportable.
+    """
+    fragments: list[str] = []
+    for key, value in diagnostics.items():
+        if not value:
+            continue
+        label = key.replace("_", " ")
+        if isinstance(value, (list, tuple, set)):
+            fragments.append(f"{label}: {', '.join(str(v) for v in value)}")
+        else:
+            fragments.append(f"{label}: {value}")
+    return "; ".join(fragments) if fragments else None
+
+
 def _build_hidden_ids(registry_result: Any) -> set[str]:
     """Build a set of hidden entity IDs from a registry/list WS response."""
     hidden_ids: set[str] = set()
@@ -860,6 +884,18 @@ def _shape_component_search_response(
         if isinstance(reason, str) and reason:
             _merge_partial_reason(response, reason)
 
+    # The component also surfaces intentional per-surface diagnostics (e.g. a
+    # config domain it couldn't read) separately from the overall partial flag.
+    # A non-empty diagnostics map is a genuine incompleteness, so mark the
+    # response partial and fold a readable clause into partial_reason rather than
+    # dropping the component's signal.
+    diagnostics = component_result.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        diag_reason = _format_search_diagnostics(diagnostics)
+        if diag_reason:
+            response["partial"] = True
+            _merge_partial_reason(response, diag_reason)
+
     response["count"] = len(response["entities"]) + sum(
         len(response.get(bucket, [])) for bucket in _CONFIG_BUCKETS
     )
@@ -932,7 +968,21 @@ def _wrap_registry(slice_value: Any) -> dict[str, Any]:
     }
 
 
-def _build_overview_slices(component_result: dict[str, Any]) -> _OverviewSlices:
+# The always-present overview slices the component returns independent of any
+# request flag. Each must be a list; ``config`` (a dict) is checked separately.
+# A missing/malformed member means the component couldn't assemble a trustworthy
+# snapshot, so the caller falls back to the legacy fetch path rather than serve a
+# silently-degraded overview.
+_REQUIRED_OVERVIEW_LIST_SLICES = (
+    "states",
+    "services",
+    "area_registry",
+    "entity_registry",
+    "device_registry",
+)
+
+
+def _build_overview_slices(component_result: dict[str, Any]) -> _OverviewSlices | None:
     """Adapt the component's BARE overview slices into the assembly's shapes.
 
     The component returns bare in-process data (no ``{success, result}`` WS
@@ -940,25 +990,38 @@ def _build_overview_slices(component_result: dict[str, Any]) -> _OverviewSlices:
     + ``_fetch_*`` were written against the wrapped REST/WS payloads, so the three
     registries and the notifications/repairs reads are re-wrapped here at the
     seam. ``states`` / ``services`` / ``config`` already match their bare
-    ``get_states()`` / ``get_services()`` / ``get_config()`` shapes. Every field
-    is type-guarded so a malformed slice degrades to empty rather than raising
-    inside the assembly.
+    ``get_states()`` / ``get_services()`` / ``get_config()`` shapes.
+
+    Returns ``None`` (⇒ legacy fallback) when the snapshot can't be trusted: any
+    required slice missing/malformed (see ``_REQUIRED_OVERVIEW_LIST_SLICES`` plus
+    ``config``), or the component reported a non-empty ``slice_errors`` list (a
+    per-slice read failure it surfaced instead of silently emptying). The
+    flag-gated ``notifications`` / ``repairs`` slices stay lenient — absent or
+    malformed degrades to empty, matching a request that never asked for them.
     """
     result = component_result if isinstance(component_result, dict) else {}
-    states = result.get("states")
-    services = result.get("services")
+
+    slice_errors = result.get("slice_errors")
+    if isinstance(slice_errors, list) and slice_errors:
+        return None
+    for key in _REQUIRED_OVERVIEW_LIST_SLICES:
+        if not isinstance(result.get(key), list):
+            return None
     config = result.get("config")
+    if not isinstance(config, dict):
+        return None
+
     notifications = result.get("notifications")
     repairs = result.get("repairs")
     return _OverviewSlices(
         registry_slices={
-            "states": states if isinstance(states, list) else [],
-            "services": services if isinstance(services, list) else [],
-            "area_registry": _wrap_registry(result.get("area_registry")),
-            "entity_registry": _wrap_registry(result.get("entity_registry")),
-            "device_registry": _wrap_registry(result.get("device_registry")),
+            "states": result["states"],
+            "services": result["services"],
+            "area_registry": _wrap_registry(result["area_registry"]),
+            "entity_registry": _wrap_registry(result["entity_registry"]),
+            "device_registry": _wrap_registry(result["device_registry"]),
         },
-        config=config if isinstance(config, dict) else {},
+        config=config,
         notifications={
             "success": True,
             "result": notifications if isinstance(notifications, list) else [],
@@ -1658,7 +1721,8 @@ class SearchTools:
           positive caps are stale): invalidate the caps and return ``None`` so
           the caller falls back **silently** — an expected, non-actionable
           transition.
-        - any other ``HomeAssistantCommandError`` (a component handler bug):
+        - any other ``HomeAssistantCommandError`` (a component handler bug) or a
+          ``HomeAssistantCommandTimeout`` (the component WS search timed out):
           serve the correct result from the legacy path, append a ``warnings[]``
           entry, and ``log.warning`` — correct results now, breakage visible.
         - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
@@ -1667,7 +1731,7 @@ class SearchTools:
         """
         try:
             raw = await self._send_component_search(req)
-        except HomeAssistantCommandError as exc:
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             if is_unknown_command(exc):
                 invalidate_caps(self._client)
                 return None
@@ -2985,16 +3049,21 @@ class SearchTools:
           cached positive caps are stale): invalidate the caps and return
           ``None`` so the caller falls back **silently** — an expected,
           non-actionable transition.
-        - any other ``HomeAssistantCommandError`` (a component handler bug):
+        - any other ``HomeAssistantCommandError`` (a component handler bug) or a
+          ``HomeAssistantCommandTimeout`` (the component WS overview timed out):
           serve the correct result from the legacy path, append a ``warnings[]``
           entry, and ``log.warning`` — correct results now, breakage visible.
+        - a malformed slice payload (a required slice missing/malformed, or a
+          non-empty ``slice_errors`` — ``_build_overview_slices`` returns
+          ``None``): treated like the command-error branch (legacy + warning +
+          log), so a partial snapshot never serves a silently-degraded overview.
         - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
           propagates; the legacy path depends on the same socket and would fail
           identically, so surfacing it is correct.
         """
         try:
             raw = await self._send_component_overview(inputs)
-        except HomeAssistantCommandError as exc:
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             if is_unknown_command(exc):
                 invalidate_caps(self._client)
                 return None
@@ -3005,6 +3074,15 @@ class SearchTools:
             logger.warning("ha_mcp_tools/overview failed; fell back to legacy: %r", exc)
             return legacy
         slices = _build_overview_slices(raw.get("result") or {})
+        if slices is None:
+            legacy = await self._assemble_overview(inputs, None)
+            legacy.setdefault("warnings", []).append(
+                "component overview returned malformed slices; served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/overview returned malformed slices; fell back to legacy"
+            )
+            return legacy
         return await self._assemble_overview(inputs, slices)
 
     async def _send_component_overview(self, inputs: _OverviewInputs) -> dict[str, Any]:

--- a/src/ha_mcp/visibility/persistence.py
+++ b/src/ha_mcp/visibility/persistence.py
@@ -13,19 +13,38 @@ from .model import VisibilityConfig
 
 VISIBILITY_FILENAME = "entity_visibility.json"
 
+# Parsed-config memo keyed by resolved path, invalidated whenever the file's
+# ``(mtime_ns, size)`` changes. ``ha_search`` loads this config up to 3x per
+# call (visibility_filter_active / device_registry_needed_for_visibility /
+# load_hidden_set); the memo turns the repeat reads into one stat() each. A
+# concurrent double-parse across ``asyncio.to_thread`` workers is benign (both
+# compute the same value; last write wins).
+_CONFIG_MEMO: dict[str, tuple[tuple[int, int], VisibilityConfig]] = {}
+
 
 def load_visibility_config(data_dir: Path) -> VisibilityConfig:
     path = data_dir / VISIBILITY_FILENAME
-    if not path.exists():
+    key = str(path)
+    try:
+        stat = path.stat()
+    except OSError:
+        # Missing file → disabled default (not an error). Drop any stale memo.
+        _CONFIG_MEMO.pop(key, None)
         return VisibilityConfig()
+    signature = (stat.st_mtime_ns, stat.st_size)
+    cached = _CONFIG_MEMO.get(key)
+    if cached is not None and cached[0] == signature:
+        return cached[1]
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
         raise ValueError(f"{VISIBILITY_FILENAME} is not valid JSON: {e}") from e
     try:
-        return VisibilityConfig.model_validate(raw)
+        config = VisibilityConfig.model_validate(raw)
     except ValidationError as e:
         raise ValueError(f"{VISIBILITY_FILENAME} failed schema validation: {e}") from e
+    _CONFIG_MEMO[key] = (signature, config)
+    return config
 
 
 def save_visibility_config(data_dir: Path, config: VisibilityConfig) -> None:
@@ -40,3 +59,6 @@ def save_visibility_config(data_dir: Path, config: VisibilityConfig) -> None:
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)
         raise
+    # Evict so the next load re-stats the just-written file rather than risk a
+    # same-signature stale hit (defensive against coarse mtime granularity).
+    _CONFIG_MEMO.pop(str(path), None)

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -467,6 +467,39 @@ async def _fetch_assist_exposure(
         return None, False
 
 
+def config_needs_device_registry(config: VisibilityConfig) -> bool:
+    """Whether an enabled visibility config has a dimension that reads the device registry.
+
+    The device registry (``config/device_registry/list``) only supplies the
+    device-inherited area/labels consumed by the area/label exclude *and* allow
+    dimensions (see ``_effective_area`` / ``_effective_labels``). A disabled
+    config, or an enabled one with none of those four dimensions set (the
+    default), never touches it, so fetching it there is pure waste.
+    """
+    return config.enabled and bool(
+        config.exclude_areas
+        or config.exclude_labels
+        or config.allow_areas
+        or config.allow_labels
+    )
+
+
+async def device_registry_needed_for_visibility() -> bool:
+    """Load the visibility config off-loop and report whether the device-registry
+    fetch is needed by any active area/label dimension.
+
+    Fail-open to ``False``: a default install (no config file) or an unloadable
+    config resolves to disabled, which needs no device registry. The
+    operator-facing load-failure warning is owned by the ``load_hidden_set`` call
+    that runs right after — this gate only decides whether to spend the fetch.
+    """
+    try:
+        config = await asyncio.to_thread(load_visibility_config, get_data_dir())
+    except Exception:
+        return False
+    return config_needs_device_registry(config)
+
+
 async def load_hidden_set(
     registry_result: object,
     states_result: object | None = None,

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -484,6 +484,57 @@ def config_needs_device_registry(config: VisibilityConfig) -> bool:
     )
 
 
+def config_has_active_hide_dimensions(config: VisibilityConfig) -> bool:
+    """Whether an enabled visibility config has any dimension that can hide.
+
+    An ``enabled=True`` config with every dimension cleared (including
+    ``exclude_categories=[]``) hides nothing, so a query search can still route
+    through the in-process ha_mcp_tools component. Any active dimension — a known
+    ``exclude_category``, ``exclude_hidden``, a deny/allow list, an area/label
+    exclude/allow, or ``respect_assist_exposure`` — means the component (which
+    applies no visibility filtering) would surface entities the server hides, so
+    the query must stay on the legacy path. Mirrors the dimension set the
+    ``hidden_entity_ids`` resolver actually consults, so a config that hides
+    something here is exactly one that would hide something there.
+    """
+    if not config.enabled:
+        return False
+    return bool(
+        (set(config.exclude_categories) & KNOWN_ENTITY_CATEGORIES)
+        or config.exclude_hidden
+        or config.deny_entity_ids
+        or config.exclude_areas
+        or config.exclude_labels
+        or config.allow_entity_ids
+        or config.allow_areas
+        or config.allow_labels
+        or config.respect_assist_exposure
+    )
+
+
+async def visibility_filter_active() -> bool:
+    """Load the visibility config off-loop; report whether the filter can hide.
+
+    ``ha_search`` routing gates the component fast path on this: a query search
+    must NOT route through the ha_mcp_tools component while the filter is active,
+    because the component does not apply the server's opt-in visibility filter
+    and would leak entities the legacy path hides. Reuses the same loader the
+    legacy filter uses (``load_visibility_config`` over ``get_data_dir()``), so a
+    test that redirects ``resolver.get_data_dir`` steers both.
+
+    Fails **closed** to ``True`` (keep the legacy, filter-applying path) on a load
+    error: a missing config file returns a disabled default (not an error, → the
+    component), but a *malformed* enabled config raising here would otherwise
+    silently route to the unfiltered component — so on any exception keep legacy,
+    where ``load_hidden_set`` surfaces the load-failure warning.
+    """
+    try:
+        config = await asyncio.to_thread(load_visibility_config, get_data_dir())
+    except Exception:
+        return True
+    return config_has_active_hide_dimensions(config)
+
+
 async def device_registry_needed_for_visibility() -> bool:
     """Load the visibility config off-loop and report whether the device-registry
     fetch is needed by any active area/label dimension.

--- a/tests/src/unit/_component_routing_helpers.py
+++ b/tests/src/unit/_component_routing_helpers.py
@@ -59,8 +59,8 @@ def patch_ws(ws: AsyncMock, tool_module: Any) -> Any:
     The caps probe always resolves through ``component_api.get_websocket_client``,
     so that is patched unconditionally. A tool module also imports its own
     ``get_websocket_client`` when it sends the read command itself (search /
-    overview / helpers_list); the config-get consumers instead route through
-    ``component_api.send_component_config_get``, so those modules no longer bind
+    overview / helpers_list); the config-get consumers are legacy-only (their
+    gets never route through the component at all), so those modules do not bind
     the symbol — patch the tool module only when it actually has it.
     """
     factory = AsyncMock(return_value=ws)

--- a/tests/src/unit/_component_routing_helpers.py
+++ b/tests/src/unit/_component_routing_helpers.py
@@ -1,0 +1,75 @@
+"""Shared WS-mock scaffolding for the ``ha_mcp_tools`` component routing tests.
+
+The four routing suites (``test_ha_search_component_routing`` /
+``test_ha_overview_component_routing`` / ``test_config_get_component_routing`` /
+``test_ha_config_list_helpers_component_routing``) and the cross-seam
+``test_component_readapi_contract`` all mock the same two moving parts: a WS
+client whose ``send_command`` dispatches on the command type (``ha_mcp_tools/info``
+for the caps probe plus one read command), and the ``get_websocket_client``
+factory each tool resolves that WS through. This module owns both so the shape of
+the mock lives in one place; each suite keeps its own ``RoutingClient`` spy,
+which encodes the per-tool legacy-fetch surface and is deliberately NOT shared.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from ha_mcp.tools import component_api
+
+
+def make_ws(
+    command: str,
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+    cmd_result: dict[str, Any] | None = None,
+    cmd_exc: Exception | None = None,
+) -> AsyncMock:
+    """An ``AsyncMock`` WS whose ``send_command`` serves ``info`` + one ``command``.
+
+    ``ha_mcp_tools/info`` returns ``info_result`` (or raises ``info_exc``); the
+    read ``command`` (e.g. ``ha_mcp_tools/search``) returns ``cmd_result`` (or
+    raises ``cmd_exc``). Any other command type is an ``AssertionError`` so a
+    stray frame fails loudly rather than silently no-ops.
+    """
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        if command_type == command:
+            if cmd_exc is not None:
+                raise cmd_exc
+            return {"success": True, "result": cmd_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+@contextlib.contextmanager
+def patch_ws(ws: AsyncMock, tool_module: Any) -> Any:
+    """Patch ``get_websocket_client`` to yield ``ws`` on every resolution path.
+
+    The caps probe always resolves through ``component_api.get_websocket_client``,
+    so that is patched unconditionally. A tool module also imports its own
+    ``get_websocket_client`` when it sends the read command itself (search /
+    overview / helpers_list); the config-get consumers instead route through
+    ``component_api.send_component_config_get``, so those modules no longer bind
+    the symbol — patch the tool module only when it actually has it.
+    """
+    factory = AsyncMock(return_value=ws)
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch.object(component_api, "get_websocket_client", factory)
+        )
+        if hasattr(tool_module, "get_websocket_client"):
+            stack.enter_context(
+                patch.object(tool_module, "get_websocket_client", factory)
+            )
+        yield ws

--- a/tests/src/unit/test_component_api.py
+++ b/tests/src/unit/test_component_api.py
@@ -9,6 +9,7 @@ the command type, mirroring the live component's info/search surface.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -20,6 +21,7 @@ from ha_mcp.client.rest_client import (
 )
 from ha_mcp.tools import component_api
 from ha_mcp.tools.component_api import (
+    SUPPORTED_SCHEMA_VERSION,
     ComponentCaps,
     component_supports,
     get_component_caps,
@@ -168,6 +170,102 @@ async def test_invalidate_caps_forces_reprobe() -> None:
         await get_component_caps(client)
 
     assert ws.send_command.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_supported_schema_version_routes() -> None:
+    """A probe at the supported schema_version yields usable caps."""
+    info = {**_INFO_OK, "schema_version": SUPPORTED_SCHEMA_VERSION}
+    ws = _make_ws(info_result=info)
+    with _patch_ws(ws):
+        caps = await get_component_caps(_client())
+    assert isinstance(caps, ComponentCaps)
+    assert component_supports(caps, "search") is True
+
+
+@pytest.mark.asyncio
+async def test_unsupported_schema_version_caps_none_and_warns(caplog) -> None:
+    """A probe at an unsupported schema_version is a cached negative (logged once)."""
+    info = {**_INFO_OK, "schema_version": SUPPORTED_SCHEMA_VERSION + 1}
+    ws = _make_ws(info_result=info)
+    client = _client()
+    with _patch_ws(ws), caplog.at_level(logging.WARNING, logger=component_api.__name__):
+        first = await get_component_caps(client)
+        second = await get_component_caps(client)
+
+    assert first is None
+    assert second is None
+    # Negative is cached, so the probe (and the warning) happen exactly once.
+    assert ws.send_command.await_count == 1
+    schema_warnings = [r for r in caplog.records if "schema_version" in r.getMessage()]
+    assert len(schema_warnings) == 1
+    assert str(SUPPORTED_SCHEMA_VERSION + 1) in schema_warnings[0].getMessage()
+    assert str(SUPPORTED_SCHEMA_VERSION) in schema_warnings[0].getMessage()
+
+
+def _clock(start: float = 1000.0) -> list[float]:
+    """A one-element mutable clock; tests advance ``holder[0]`` in place."""
+    return [start]
+
+
+@pytest.mark.asyncio
+async def test_fresh_negative_does_not_reprobe(monkeypatch) -> None:
+    """A negative within the TTL window is honored without re-probing."""
+    clock = _clock()
+    monkeypatch.setattr(component_api, "_monotonic", lambda: clock[0])
+    ws = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: x", "unknown_command")
+    )
+    client = _client()
+    with _patch_ws(ws):
+        assert await get_component_caps(client) is None
+        clock[0] += component_api._NEGATIVE_CACHE_TTL_S - 1  # still inside window
+        assert await get_component_caps(client) is None
+    assert ws.send_command.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_negative_reprobes_and_adopts(monkeypatch) -> None:
+    """Past the TTL the negative expires: the next call re-probes and can adopt."""
+    clock = _clock()
+    monkeypatch.setattr(component_api, "_monotonic", lambda: clock[0])
+
+    ws = AsyncMock()
+    probe_count = _clock(0.0)
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        assert command_type == "ha_mcp_tools/info"
+        probe_count[0] += 1
+        if probe_count[0] == 1:
+            raise HomeAssistantCommandError("Command failed: x", "unknown_command")
+        return {"success": True, "result": _INFO_OK}
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    client = _client()
+    with _patch_ws(ws):
+        assert await get_component_caps(client) is None  # negative cached at t0
+        clock[0] += component_api._NEGATIVE_CACHE_TTL_S + 1  # expire it
+        caps = await get_component_caps(client)
+
+    assert isinstance(caps, ComponentCaps)  # mid-session install adopted
+    assert ws.send_command.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_positive_unaffected_by_ttl(monkeypatch) -> None:
+    """A positive entry never expires on the negative TTL timer."""
+    clock = _clock()
+    monkeypatch.setattr(component_api, "_monotonic", lambda: clock[0])
+    ws = _make_ws(info_result=_INFO_OK)
+    client = _client()
+    with _patch_ws(ws):
+        first = await get_component_caps(client)
+        clock[0] += component_api._NEGATIVE_CACHE_TTL_S * 10  # far past any TTL
+        second = await get_component_caps(client)
+
+    assert isinstance(first, ComponentCaps)
+    assert first is second
+    assert ws.send_command.await_count == 1
 
 
 def test_component_supports() -> None:

--- a/tests/src/unit/test_component_api.py
+++ b/tests/src/unit/test_component_api.py
@@ -1,0 +1,199 @@
+"""Unit tests for the ``ha_mcp_tools`` capability gate (``component_api``).
+
+Covers the negotiation the server does before routing a read tool through the
+custom component: the single cached ``ha_mcp_tools/info`` probe, the
+cache-on-failure taxonomy, and the ``code``-based ``unknown_command`` detector.
+The WebSocket client is an ``AsyncMock`` whose ``send_command`` dispatches on
+the command type, mirroring the live component's info/search surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantConnectionError,
+)
+from ha_mcp.tools import component_api
+from ha_mcp.tools.component_api import (
+    ComponentCaps,
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
+)
+
+_INFO_OK = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["search", "overview"],
+    "limits": {"max_results": 500},
+}
+
+
+class _FakeClient:
+    """Weakref-able credentialed client stand-in (real REST client is a class)."""
+
+    def __init__(self, base_url: str = "http://ha.local:8123", token: str = "tok"):
+        self.base_url = base_url
+        self.token = token
+
+
+class _BareClient:
+    """Weakref-able client with no credentials (nothing to negotiate over)."""
+
+
+def _client() -> Any:
+    return _FakeClient()
+
+
+def _make_ws(
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+def _patch_ws(ws: AsyncMock) -> Any:
+    return patch.object(
+        component_api, "get_websocket_client", AsyncMock(return_value=ws)
+    )
+
+
+@pytest.mark.asyncio
+async def test_info_probe_parses_capabilities() -> None:
+    ws = _make_ws(info_result=_INFO_OK)
+    with _patch_ws(ws):
+        caps = await get_component_caps(_client())
+
+    assert isinstance(caps, ComponentCaps)
+    assert caps.capabilities == frozenset({"search", "overview"})
+    assert caps.schema_version == 1
+    assert caps.component_version == "1.1.0"
+    assert caps.limits == {"max_results": 500}
+
+
+@pytest.mark.asyncio
+async def test_caps_cached_one_probe_per_client() -> None:
+    ws = _make_ws(info_result=_INFO_OK)
+    client = _client()
+    with _patch_ws(ws):
+        first = await get_component_caps(client)
+        second = await get_component_caps(client)
+
+    assert first is second
+    info_calls = [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
+    ]
+    assert len(info_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_caches_none_and_does_not_reprobe() -> None:
+    ws = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: x", "unknown_command")
+    )
+    client = _client()
+    with _patch_ws(ws):
+        first = await get_component_caps(client)
+        second = await get_component_caps(client)
+
+    assert first is None
+    assert second is None
+    # Cached negative: the info command is probed exactly once.
+    assert ws.send_command.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_connection_error_is_not_cached_and_reprobes() -> None:
+    ws = _make_ws(info_exc=HomeAssistantConnectionError("WebSocket not authenticated"))
+    client = _client()
+    with _patch_ws(ws):
+        first = await get_component_caps(client)
+        second = await get_component_caps(client)
+
+    assert first is None
+    assert second is None
+    # Transient failure is not cached, so each call re-probes.
+    assert ws.send_command.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_returns_none_without_probing() -> None:
+    ws = _make_ws(info_result=_INFO_OK)
+    bare_client = _BareClient()  # no base_url / token
+    with _patch_ws(ws):
+        caps = await get_component_caps(bare_client)
+
+    assert caps is None
+    ws.send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_info_result_caches_none() -> None:
+    ws = _make_ws(info_result=None)  # success but no result dict
+    client = _client()
+    with _patch_ws(ws):
+        first = await get_component_caps(client)
+        second = await get_component_caps(client)
+
+    assert first is None
+    assert second is None
+    # A responding-but-malformed component is a stable negative → probed once.
+    assert ws.send_command.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidate_caps_forces_reprobe() -> None:
+    ws = _make_ws(info_result=_INFO_OK)
+    client = _client()
+    with _patch_ws(ws):
+        await get_component_caps(client)
+        invalidate_caps(client)
+        await get_component_caps(client)
+
+    assert ws.send_command.await_count == 2
+
+
+def test_component_supports() -> None:
+    caps = ComponentCaps(
+        schema_version=1,
+        component_version="1.1.0",
+        capabilities=frozenset({"search"}),
+        limits={},
+    )
+    assert component_supports(caps, "search") is True
+    assert component_supports(caps, "overview") is False
+    assert component_supports(None, "search") is False
+
+
+def test_is_unknown_command_keys_off_code_not_message() -> None:
+    # Structured code drives the decision.
+    assert is_unknown_command(
+        HomeAssistantCommandError("Command failed: nope", "unknown_command")
+    )
+    # A message that merely mentions "unknown command" but carries no code does
+    # NOT match — routing must not key off the human-readable text.
+    assert not is_unknown_command(
+        HomeAssistantCommandError("Command failed: unknown command foo")
+    )
+    # Some other structured code does not match either.
+    assert not is_unknown_command(
+        HomeAssistantCommandError("Command failed: bad", "invalid_format")
+    )
+    assert not is_unknown_command(ValueError("boom"))

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -13,12 +13,18 @@ each other.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from ha_mcp.tools import tools_config_automations
+from ha_mcp.tools import (
+    component_api,
+    tools_config_automations,
+    tools_config_scripts,
+)
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
+from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
 
 from .test_component_ws_search import (
     FakeArea,
@@ -157,6 +163,106 @@ class TestConfigGetSeam:
         # The not-found raiser fetches available ids for the error context —
         # legacy-parity behavior. What must NOT run is the per-id config fetch.
         assert client.get_automation_config.await_count == 0
+
+    def _script_hass(self) -> FakeHass:
+        storage = FakeConfigEntity(
+            "script.morning",
+            "Morning Script",
+            unique_id="morning",
+            raw_config={
+                "alias": "Morning Script",
+                "sequence": [{"delay": {"seconds": 5}}],
+            },
+        )
+        return FakeHass(
+            states=[FakeState("script.morning", "off", "Morning Script")],
+            data={"script": FakeComponent([storage])},
+        )
+
+    @pytest.mark.asyncio
+    async def test_storage_script_served_by_real_component(self, monkeypatch) -> None:
+        """Script analog of the automation seam: the real component's
+        ``config_get`` output is reshaped into the legacy REST-envelope contract
+        (storage key + category injected) with zero legacy fetches. Scripts run
+        NO root-key canonicalization (unlike automations' action->actions), so
+        the storage ``sequence`` body passes through byte-exact."""
+        hass = self._script_hass()
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "script.morning": FakeRegEntry(
+                        "script.morning", categories={"script": "cat-s"}
+                    )
+                }
+            ),
+        )
+        client = GetRoutingClient()
+        ws = _real_component_ws(hass)
+        with _patch_get_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script("morning")
+        assert resp["success"] is True
+        assert resp["script_id"] == "morning"
+        # The legacy path returns the REST envelope under ``config``; the real
+        # component reconstructs it (storage key + category injected).
+        assert resp["config"]["script_id"] == "morning"
+        assert resp["config"]["category"] == "cat-s"
+        # raw_config served byte-exact — the sequence body is untouched.
+        assert resp["config"]["config"] == {
+            "alias": "Morning Script",
+            "sequence": [{"delay": {"seconds": 5}}],
+        }
+        assert client.legacy_fetch_count() == 0, (
+            "storage get must be fully component-served"
+        )
+
+    @pytest.mark.asyncio
+    async def test_scene_get_stays_legacy_with_full_caps(self, monkeypatch) -> None:
+        """With the real component advertising ``config_get``, a scene get is
+        still served entirely by the legacy path: ``ha_config_get_scene`` skips
+        the caps probe, so the component WS never receives a ``config_get`` for
+        ``domain=scene`` (a ``HomeAssistantScene`` has no raw storage body in
+        memory — its ``scene_config.states`` is runtime State objects)."""
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        client = GetRoutingClient(
+            scene_envelope={
+                "success": True,
+                "scene_id": "movie_night",
+                "config": {
+                    "id": "movie_night",
+                    "name": "Movie Night",
+                    "entities": {"light.living_room": {"state": "on"}},
+                },
+            },
+            categories={"scene": "cat-x"},
+            registry_list=[
+                {"entity_id": "scene.movie_night", "unique_id": "movie_night"}
+            ],
+        )
+        # A real component WS advertising full caps (config_get included). The
+        # scene tool must never reach for it.
+        ws = _real_component_ws(FakeHass())
+        with patch.object(
+            component_api, "get_websocket_client", AsyncMock(return_value=ws)
+        ):
+            resp = await ConfigSceneTools(client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+        assert resp["success"] is True
+        assert resp["scene_id"] == "movie_night"
+        # No ``config_get`` frame was ever sent for a scene...
+        scene_config_get_calls = [
+            c
+            for c in ws.send_command.call_args_list
+            if c.args
+            and c.args[0] == "ha_mcp_tools/config_get"
+            and c.kwargs.get("domain") == "scene"
+        ]
+        assert scene_config_get_calls == []
+        # ...and, more strongly, the component WS was never touched at all.
+        assert ws.send_command.await_count == 0
+        assert client.get_scene_config.await_count == 1
 
 
 # --- overview -------------------------------------------------------------------

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -1,0 +1,282 @@
+"""Cross-seam contract tests for the component read API (non-search commands).
+
+Like ``test_component_search_contract.py``, these wire the REAL component
+functions (``_do_config_get`` / ``_do_overview`` / ``_do_helpers_list``, driven
+against fake hass objects) underneath the mocked WS transport and then invoke
+the REAL server tools — so a vocabulary or shape drift on either side of a
+seam fails here rather than shipping a component-served response the consumer
+mis-shapes. The component and consumer test suites each verify their own side
+against the design doc; this file is the bridge that verifies them against
+each other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.tools import tools_config_automations
+from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+
+from .test_component_ws_search import (
+    FakeArea,
+    FakeComponent,
+    FakeConfig,
+    FakeConfigEntity,
+    FakeDevice,
+    FakeHass,
+    FakeRegEntry,
+    FakeServices,
+    FakeState,
+    make_view,
+    wsapi,
+)
+from .test_config_get_component_routing import (
+    RoutingClient as GetRoutingClient,
+)
+from .test_config_get_component_routing import (
+    _patch_ws as _patch_get_ws,
+)
+from .test_ha_config_list_helpers_component_routing import (
+    RoutingClient as HelpersRoutingClient,
+)
+from .test_ha_config_list_helpers_component_routing import (
+    _build_list_helpers,
+)
+from .test_ha_config_list_helpers_component_routing import (
+    _patch_ws as _patch_helpers_ws,
+)
+from .test_ha_overview_component_routing import (
+    OverviewRoutingClient,
+    _build_overview_tool,
+    _PatchBothWs,
+    _setup_visibility_disabled,
+)
+
+_REAL_FNS = {
+    "ha_mcp_tools/config_get": wsapi._do_config_get,
+    "ha_mcp_tools/overview": wsapi._do_overview,
+    "ha_mcp_tools/helpers_list": wsapi._do_helpers_list,
+}
+
+
+def _real_component_ws(hass: FakeHass) -> AsyncMock:
+    """A WS mock whose commands are served by the REAL component functions.
+
+    ``info`` returns the real ``_do_info()`` (so the caps probe sees the real
+    capability list), and each read command runs the real ``_do_*`` against
+    ``hass`` — the seam under test is everything between that return value and
+    the tool response.
+    """
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            return {"success": True, "result": wsapi._do_info()}
+        fn = _REAL_FNS[command_type]
+        return {"success": True, "result": fn(hass, dict(kwargs))}
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+# --- config_get ---------------------------------------------------------------
+class TestConfigGetSeam:
+    def _hass(self) -> FakeHass:
+        storage = FakeConfigEntity(
+            "automation.ui",
+            "UI Auto",
+            unique_id="uid-1",
+            raw_config={
+                "id": "uid-1",
+                "alias": "UI Auto",
+                "action": [{"service": "light.turn_on"}],
+            },
+        )
+        yaml_auto = FakeConfigEntity(
+            "automation.pkg",
+            "Package Auto",
+            unique_id=None,
+            raw_config={"alias": "Package Auto", "action": []},
+        )
+        return FakeHass(
+            states=[FakeState("automation.ui", "on", "UI Auto")],
+            data={"automation": FakeComponent([storage, yaml_auto])},
+        )
+
+    @pytest.mark.asyncio
+    async def test_storage_automation_served_by_real_component(
+        self, monkeypatch
+    ) -> None:
+        hass = self._hass()
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "automation.ui": FakeRegEntry(
+                        "automation.ui", categories={"automation": "cat-1"}
+                    )
+                }
+            ),
+        )
+        client = GetRoutingClient()
+        ws = _real_component_ws(hass)
+        with _patch_get_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation("uid-1")
+        assert resp["success"] is True
+        assert resp["config"]["alias"] == "UI Auto"
+        # The tool's canonicalization (singular -> plural root keys) runs
+        # identically on the component path — parity includes the normalize.
+        assert resp["config"]["actions"] == [{"service": "light.turn_on"}]
+        assert client.legacy_fetch_count() == 0, (
+            "storage get must be fully component-served"
+        )
+
+    @pytest.mark.asyncio
+    async def test_yaml_automation_not_found_without_legacy_call(
+        self, monkeypatch
+    ) -> None:
+        """A YAML item (found:false from the real component) must produce the
+        legacy not-found error WITHOUT any legacy REST fetch, and its body
+        must appear nowhere."""
+        hass = self._hass()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: make_view())
+        client = GetRoutingClient()
+        ws = _real_component_ws(hass)
+        with (
+            _patch_get_ws(ws, tools_config_automations),
+            pytest.raises(Exception) as excinfo,
+        ):
+            await AutomationConfigTools(client).ha_config_get_automation(
+                "automation.pkg"
+            )
+        assert "not found" in str(excinfo.value).lower()
+        # The not-found raiser fetches available ids for the error context —
+        # legacy-parity behavior. What must NOT run is the per-id config fetch.
+        assert client.get_automation_config.await_count == 0
+
+
+# --- overview -------------------------------------------------------------------
+class TestOverviewSeam:
+    def _hass(self) -> FakeHass:
+        return FakeHass(
+            states=[
+                FakeState("light.lamp", "on", friendly_name="Lamp"),
+                FakeState("sensor.temp", "21", friendly_name="Temp"),
+            ],
+            services=FakeServices({"light": {"turn_on": {}, "turn_off": {}}}),
+            config=FakeConfig(
+                data={
+                    "version": "2026.7.0",
+                    "location_name": "Home",
+                    "time_zone": "UTC",
+                    "language": "en",
+                    "state": "RUNNING",
+                    "country": "US",
+                    "unit_system": {"temperature": "°C"},
+                    "components": ["light", "sensor"],
+                    "internal_url": "http://homeassistant.local:8123",
+                }
+            ),
+            data={"persistent_notification": {}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_overview_assembled_from_real_slices(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        hass = self._hass()
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "light.lamp": FakeRegEntry(
+                        "light.lamp",
+                        area_id="a1",
+                        device_id="d1",
+                        entity_category=None,
+                        hidden_by=None,
+                    )
+                },
+                areas=[FakeArea("a1", "Office", floor_id=None)],
+                devices=[FakeDevice("d1", name="Lamp Device", area_id="a1")],
+            ),
+        )
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = OverviewRoutingClient()
+        ws = _real_component_ws(hass)
+        tool = _build_overview_tool(client)
+        with _PatchBothWs(ws):
+            resp = await tool()
+        assert resp["success"] is True
+        # The server's existing assembly ran over the REAL raw slices: the two
+        # states must be counted and the domain summary populated.
+        assert resp["system_summary"]["total_entities"] == 2
+        assert client.total_legacy_fetches() == 0, (
+            "overview must be fully component-served"
+        )
+
+
+# --- helpers_list ----------------------------------------------------------------
+class TestHelpersListSeam:
+    @pytest.mark.asyncio
+    async def test_collection_helper_records_shaped_from_real_output(
+        self, monkeypatch
+    ) -> None:
+        hass = FakeHass(
+            states=[
+                FakeState(
+                    "input_boolean.guest_mode", "off", friendly_name="Current Guest"
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "input_boolean.guest_mode": FakeRegEntry(
+                        "input_boolean.guest_mode",
+                        name="Current Guest",
+                        original_name="Old Name",
+                        unique_id="guest_mode",
+                    )
+                }
+            ),
+        )
+        client = HelpersRoutingClient()
+        ws = _real_component_ws(hass)
+        tool = _build_list_helpers(client)
+        with _patch_helpers_ws(ws):
+            resp = await tool(helper_type="input_boolean")
+        assert resp["success"] is True
+        assert resp["count"] == 1
+        rec = resp["helpers"][0]
+        # #1794 additive fix through the REAL component output: storage id
+        # preserved, current entity_id + name layered on.
+        assert rec["id"] == "guest_mode"
+        assert rec["entity_id"] == "input_boolean.guest_mode"
+        assert rec["name"] == "Current Guest"
+        assert client.list_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_tag_falls_back_to_legacy_via_real_covered_types(
+        self, monkeypatch
+    ) -> None:
+        """The REAL component response's covered_types excludes tag — the tool
+        must serve tag from the legacy list, not report an empty component
+        result as 'no tags exist'."""
+        hass = FakeHass(states=[])
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: make_view())
+        client = HelpersRoutingClient()  # its tag/list serves a fixed record
+        ws = _real_component_ws(hass)
+        tool = _build_list_helpers(client)
+        with _patch_helpers_ws(ws):
+            resp = await tool(helper_type="tag")
+        assert resp["success"] is True
+        assert [h["id"] for h in resp["helpers"]] == ["tag-42"]
+        assert client.list_calls >= 1, "tag must be served by legacy"

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -1,13 +1,18 @@
 """Cross-seam contract tests for the component read API (non-search commands).
 
 Like ``test_component_search_contract.py``, these wire the REAL component
-functions (``_do_config_get`` / ``_do_overview`` / ``_do_helpers_list``, driven
-against fake hass objects) underneath the mocked WS transport and then invoke
-the REAL server tools — so a vocabulary or shape drift on either side of a
-seam fails here rather than shipping a component-served response the consumer
-mis-shapes. The component and consumer test suites each verify their own side
-against the design doc; this file is the bridge that verifies them against
-each other.
+functions (``_do_overview`` / ``_do_helpers_list``, driven against fake hass
+objects) underneath the mocked WS transport and then invoke the REAL server
+tools — so a vocabulary or shape drift on either side of a seam fails here
+rather than shipping a component-served response the consumer mis-shapes. The
+component and consumer test suites each verify their own side against the design
+doc; this file is the bridge that verifies them against each other.
+
+The config_get seam is the exception: the component's ``config_get`` was
+withdrawn before release (its ``raw_config`` freshness lags the config file
+between a write and the next completed reload), so those pins assert the get
+tools serve automation/script/scene reads from the legacy path and never touch
+the component WS.
 """
 
 from __future__ import annotations
@@ -20,9 +25,7 @@ import pytest
 
 from ha_mcp.tools import (
     component_api,
-    tools_config_automations,
     tools_config_helpers,
-    tools_config_scripts,
     tools_search,
 )
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
@@ -32,9 +35,7 @@ from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
 from ._component_routing_helpers import patch_ws
 from .test_component_ws_search import (
     FakeArea,
-    FakeComponent,
     FakeConfig,
-    FakeConfigEntity,
     FakeConfigEntry,
     FakeDevice,
     FakeHass,
@@ -60,7 +61,6 @@ from .test_ha_overview_component_routing import (
 )
 
 _REAL_FNS = {
-    "ha_mcp_tools/config_get": wsapi._do_config_get,
     "ha_mcp_tools/overview": wsapi._do_overview,
     "ha_mcp_tools/helpers_list": wsapi._do_helpers_list,
 }
@@ -86,124 +86,68 @@ def _real_component_ws(hass: FakeHass) -> AsyncMock:
     return ws
 
 
-# --- config_get ---------------------------------------------------------------
+# --- config_get (withdrawn: automation/script/scene gets are legacy-only) ------
 class TestConfigGetSeam:
-    def _hass(self) -> FakeHass:
-        storage = FakeConfigEntity(
-            "automation.ui",
-            "UI Auto",
-            unique_id="uid-1",
-            raw_config={
+    """The component's ``config_get`` was withdrawn before release — it served an
+    entity's ``raw_config``, whose freshness lags the config file between a write
+    and the next completed reload, so a get racing a reload returned a stale
+    body. All three get tools serve their reads from the legacy REST/WS pipeline
+    (which reads the fresh config file). Even against a REAL component WS whose
+    ``info`` advertises ``config_get``, the get tools skip the caps probe and
+    never send a frame — the component WS is never touched. Scenes were already
+    legacy-only (a ``HomeAssistantScene`` has no raw storage body in memory);
+    automation/script now share the pattern.
+    """
+
+    @pytest.mark.asyncio
+    async def test_automation_get_stays_legacy_with_full_caps(self) -> None:
+        client = GetRoutingClient(
+            automation_config={
                 "id": "uid-1",
                 "alias": "UI Auto",
                 "action": [{"service": "light.turn_on"}],
             },
         )
-        yaml_auto = FakeConfigEntity(
-            "automation.pkg",
-            "Package Auto",
-            unique_id=None,
-            raw_config={"alias": "Package Auto", "action": []},
-        )
-        return FakeHass(
-            states=[FakeState("automation.ui", "on", "UI Auto")],
-            data={"automation": FakeComponent([storage, yaml_auto])},
-        )
-
-    @pytest.mark.asyncio
-    async def test_storage_automation_served_by_real_component(
-        self, monkeypatch
-    ) -> None:
-        hass = self._hass()
-        monkeypatch.setattr(
-            wsapi,
-            "_resolve_registries",
-            lambda h: make_view(
-                entity={
-                    "automation.ui": FakeRegEntry(
-                        "automation.ui", categories={"automation": "cat-1"}
-                    )
-                }
-            ),
-        )
-        client = GetRoutingClient()
-        ws = _real_component_ws(hass)
-        with patch_ws(ws, tools_config_automations):
+        # A real component WS advertising full caps (config_get included). The
+        # automation tool must never reach for it.
+        ws = _real_component_ws(FakeHass())
+        with patch.object(
+            component_api, "get_websocket_client", AsyncMock(return_value=ws)
+        ):
             resp = await AutomationConfigTools(client).ha_config_get_automation("uid-1")
         assert resp["success"] is True
         assert resp["config"]["alias"] == "UI Auto"
-        # The tool's canonicalization (singular -> plural root keys) runs
-        # identically on the component path — parity includes the normalize.
+        # The tool's canonicalization (singular -> plural root keys) runs on the
+        # legacy path.
         assert resp["config"]["actions"] == [{"service": "light.turn_on"}]
-        assert client.legacy_fetch_count() == 0, (
-            "storage get must be fully component-served"
-        )
+        # The component WS was never touched; the legacy config fetch served it.
+        assert ws.send_command.await_count == 0
+        assert client.get_automation_config.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_yaml_automation_not_found_without_legacy_call(
-        self, monkeypatch
-    ) -> None:
-        """A YAML item (found:false from the real component) must produce the
-        legacy not-found error WITHOUT any legacy REST fetch, and its body
-        must appear nowhere."""
-        hass = self._hass()
-        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: make_view())
-        client = GetRoutingClient()
-        ws = _real_component_ws(hass)
-        with (
-            patch_ws(ws, tools_config_automations),
-            pytest.raises(Exception) as excinfo,
-        ):
-            await AutomationConfigTools(client).ha_config_get_automation(
-                "automation.pkg"
-            )
-        assert "not found" in str(excinfo.value).lower()
-        # The not-found raiser fetches available ids for the error context —
-        # legacy-parity behavior. What must NOT run is the per-id config fetch.
-        assert client.get_automation_config.await_count == 0
-
-    def _script_hass(self) -> FakeHass:
-        storage = FakeConfigEntity(
-            "script.morning",
-            "Morning Script",
-            unique_id="morning",
-            raw_config={
-                "alias": "Morning Script",
-                "sequence": [{"delay": {"seconds": 5}}],
+    async def test_script_get_stays_legacy_with_full_caps(self) -> None:
+        """Script analog: the legacy REST envelope is returned under ``config``
+        (storage key + category injected). Scripts run NO root-key
+        canonicalization (unlike automations' action->actions), so the storage
+        ``sequence`` body passes through byte-exact."""
+        client = GetRoutingClient(
+            script_envelope={
+                "success": True,
+                "script_id": "morning",
+                "config": {
+                    "alias": "Morning Script",
+                    "sequence": [{"delay": {"seconds": 5}}],
+                },
             },
+            categories={"script": "cat-s"},
         )
-        return FakeHass(
-            states=[FakeState("script.morning", "off", "Morning Script")],
-            data={"script": FakeComponent([storage])},
-        )
-
-    @pytest.mark.asyncio
-    async def test_storage_script_served_by_real_component(self, monkeypatch) -> None:
-        """Script analog of the automation seam: the real component's
-        ``config_get`` output is reshaped into the legacy REST-envelope contract
-        (storage key + category injected) with zero legacy fetches. Scripts run
-        NO root-key canonicalization (unlike automations' action->actions), so
-        the storage ``sequence`` body passes through byte-exact."""
-        hass = self._script_hass()
-        monkeypatch.setattr(
-            wsapi,
-            "_resolve_registries",
-            lambda h: make_view(
-                entity={
-                    "script.morning": FakeRegEntry(
-                        "script.morning", categories={"script": "cat-s"}
-                    )
-                }
-            ),
-        )
-        client = GetRoutingClient()
-        ws = _real_component_ws(hass)
-        with patch_ws(ws, tools_config_scripts):
+        ws = _real_component_ws(FakeHass())
+        with patch.object(
+            component_api, "get_websocket_client", AsyncMock(return_value=ws)
+        ):
             resp = await ConfigScriptTools(client).ha_config_get_script("morning")
         assert resp["success"] is True
         assert resp["script_id"] == "morning"
-        # The legacy path returns the REST envelope under ``config``; the real
-        # component reconstructs it (storage key + category injected).
         assert resp["config"]["script_id"] == "morning"
         assert resp["config"]["category"] == "cat-s"
         # raw_config served byte-exact — the sequence body is untouched.
@@ -211,17 +155,16 @@ class TestConfigGetSeam:
             "alias": "Morning Script",
             "sequence": [{"delay": {"seconds": 5}}],
         }
-        assert client.legacy_fetch_count() == 0, (
-            "storage get must be fully component-served"
-        )
+        assert ws.send_command.await_count == 0
+        assert client.get_script_config.await_count == 1
 
     @pytest.mark.asyncio
     async def test_scene_get_stays_legacy_with_full_caps(self, monkeypatch) -> None:
         """With the real component advertising ``config_get``, a scene get is
         still served entirely by the legacy path: ``ha_config_get_scene`` skips
-        the caps probe, so the component WS never receives a ``config_get`` for
-        ``domain=scene`` (a ``HomeAssistantScene`` has no raw storage body in
-        memory — its ``scene_config.states`` is runtime State objects)."""
+        the caps probe, so the component WS is never touched (a
+        ``HomeAssistantScene`` has no raw storage body in memory — its
+        ``scene_config.states`` is runtime State objects)."""
         monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
         client = GetRoutingClient(
             scene_envelope={
@@ -249,16 +192,7 @@ class TestConfigGetSeam:
             )
         assert resp["success"] is True
         assert resp["scene_id"] == "movie_night"
-        # No ``config_get`` frame was ever sent for a scene...
-        scene_config_get_calls = [
-            c
-            for c in ws.send_command.call_args_list
-            if c.args
-            and c.args[0] == "ha_mcp_tools/config_get"
-            and c.kwargs.get("domain") == "scene"
-        ]
-        assert scene_config_get_calls == []
-        # ...and, more strongly, the component WS was never touched at all.
+        # The component WS was never touched at all — no caps probe, no frame.
         assert ws.send_command.await_count == 0
         assert client.get_scene_config.await_count == 1
 

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -12,6 +12,7 @@ each other.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -20,17 +21,21 @@ import pytest
 from ha_mcp.tools import (
     component_api,
     tools_config_automations,
+    tools_config_helpers,
     tools_config_scripts,
+    tools_search,
 )
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
 from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
 
+from ._component_routing_helpers import patch_ws
 from .test_component_ws_search import (
     FakeArea,
     FakeComponent,
     FakeConfig,
     FakeConfigEntity,
+    FakeConfigEntry,
     FakeDevice,
     FakeHass,
     FakeRegEntry,
@@ -42,22 +47,15 @@ from .test_component_ws_search import (
 from .test_config_get_component_routing import (
     RoutingClient as GetRoutingClient,
 )
-from .test_config_get_component_routing import (
-    _patch_ws as _patch_get_ws,
-)
 from .test_ha_config_list_helpers_component_routing import (
     RoutingClient as HelpersRoutingClient,
 )
 from .test_ha_config_list_helpers_component_routing import (
     _build_list_helpers,
 )
-from .test_ha_config_list_helpers_component_routing import (
-    _patch_ws as _patch_helpers_ws,
-)
 from .test_ha_overview_component_routing import (
     OverviewRoutingClient,
     _build_overview_tool,
-    _PatchBothWs,
     _setup_visibility_disabled,
 )
 
@@ -130,7 +128,7 @@ class TestConfigGetSeam:
         )
         client = GetRoutingClient()
         ws = _real_component_ws(hass)
-        with _patch_get_ws(ws, tools_config_automations):
+        with patch_ws(ws, tools_config_automations):
             resp = await AutomationConfigTools(client).ha_config_get_automation("uid-1")
         assert resp["success"] is True
         assert resp["config"]["alias"] == "UI Auto"
@@ -153,7 +151,7 @@ class TestConfigGetSeam:
         client = GetRoutingClient()
         ws = _real_component_ws(hass)
         with (
-            _patch_get_ws(ws, tools_config_automations),
+            patch_ws(ws, tools_config_automations),
             pytest.raises(Exception) as excinfo,
         ):
             await AutomationConfigTools(client).ha_config_get_automation(
@@ -200,7 +198,7 @@ class TestConfigGetSeam:
         )
         client = GetRoutingClient()
         ws = _real_component_ws(hass)
-        with _patch_get_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             resp = await ConfigScriptTools(client).ha_config_get_script("morning")
         assert resp["success"] is True
         assert resp["script_id"] == "morning"
@@ -316,7 +314,7 @@ class TestOverviewSeam:
         client = OverviewRoutingClient()
         ws = _real_component_ws(hass)
         tool = _build_overview_tool(client)
-        with _PatchBothWs(ws):
+        with patch_ws(ws, tools_search):
             resp = await tool()
         assert resp["success"] is True
         # The server's existing assembly ran over the REAL raw slices: the two
@@ -357,7 +355,7 @@ class TestHelpersListSeam:
         client = HelpersRoutingClient()
         ws = _real_component_ws(hass)
         tool = _build_list_helpers(client)
-        with _patch_helpers_ws(ws):
+        with patch_ws(ws, tools_config_helpers):
             resp = await tool(helper_type="input_boolean")
         assert resp["success"] is True
         assert resp["count"] == 1
@@ -367,6 +365,55 @@ class TestHelpersListSeam:
         assert rec["id"] == "guest_mode"
         assert rec["entity_id"] == "input_boolean.guest_mode"
         assert rec["name"] == "Current Guest"
+        assert client.list_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_flow_helper_records_shaped_from_real_output(
+        self, monkeypatch
+    ) -> None:
+        """A flow helper (template) round-trips the REAL ``_do_helpers_list`` flow
+        output through the REAL ``ha_config_list_helpers``: entry_id + current
+        registry name + options, with ``entry.data`` never surfacing and no
+        legacy fetch (flow types are component-only)."""
+        entry = FakeConfigEntry(
+            "template",
+            title="Creation Title",
+            options={"state": "{{ is_state('sun.sun', 'above_horizon') }}"},
+            data={"api_key": "DATA_SECRET_XYZ"},
+            entry_id="cfg1",
+        )
+        hass = FakeHass(config_entries=[entry])
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "binary_sensor.sun_up": FakeRegEntry(
+                        "binary_sensor.sun_up",
+                        name="Sun Is Up",  # current display name (post-rename)
+                        config_entry_id="cfg1",
+                    )
+                }
+            ),
+        )
+        client = HelpersRoutingClient()
+        ws = _real_component_ws(hass)
+        tool = _build_list_helpers(client)
+        with patch_ws(ws, tools_config_helpers):
+            resp = await tool(helper_type="template")
+
+        assert resp["success"] is True
+        assert resp["count"] == 1
+        (rec,) = resp["helpers"]
+        assert rec["helper_type"] == "template"
+        assert rec["entry_id"] == "cfg1"
+        assert rec["entity_id"] == "binary_sensor.sun_up"
+        assert rec["name"] == "Sun Is Up"
+        assert rec["options"] == {"state": "{{ is_state('sun.sun', 'above_horizon') }}"}
+        # Flow helpers carry no storage id; entry.data must never leak.
+        assert "id" not in rec
+        assert "DATA_SECRET_XYZ" not in json.dumps(resp)
+        # A flow type is component-only: the legacy list is never consulted.
         assert client.list_calls == 0
 
     @pytest.mark.asyncio
@@ -381,7 +428,7 @@ class TestHelpersListSeam:
         client = HelpersRoutingClient()  # its tag/list serves a fixed record
         ws = _real_component_ws(hass)
         tool = _build_list_helpers(client)
-        with _patch_helpers_ws(ws):
+        with patch_ws(ws, tools_config_helpers):
             resp = await tool(helper_type="tag")
         assert resp["success"] is True
         assert [h["id"] for h in resp["helpers"]] == ["tag-42"]

--- a/tests/src/unit/test_component_search_contract.py
+++ b/tests/src/unit/test_component_search_contract.py
@@ -22,6 +22,9 @@ Legacy per-bucket record keys (the contract being pinned; see
 
 ``config`` is present only under ``include_config=True`` (mirroring the
 legacy pipeline's pop), and YAML-backed records must never carry a body.
+Scene records never carry a body either: a scene's config is always ``None``
+from the component (its ``states`` are runtime objects), and it matches on the
+entity-id KEYS of ``states`` (here ``light.contractmarker_lamp``).
 """
 
 from __future__ import annotations
@@ -153,7 +156,13 @@ def _search_marker_hass() -> FakeHass:
                 _SceneEntity(
                     "scene.contractmarker_scene",
                     "Contractmarker Scene",
-                    {"id": "scn1", "name": "Contractmarker Scene", "states": {}},
+                    # ``states`` keys are entity ids (the scene match corpus); the
+                    # runtime State VALUES are never scored or emitted.
+                    {
+                        "id": "scn1",
+                        "name": "Contractmarker Scene",
+                        "states": {"light.contractmarker_lamp": {"state": "on"}},
+                    },
                     unique_id="scn1",
                 )
             ]
@@ -252,6 +261,9 @@ def test_all_surfaces_match_and_shape_to_legacy_keys(monkeypatch) -> None:
     for rec in _records(shaped, "scenes"):
         assert set(rec) == SCENE_KEYS | {"config"}, f"scene record keys drifted: {rec}"
         assert rec["scene_id"] == "scn1"
+        # Scenes never emit a component-served body: the config key follows the
+        # include_config pop rule, but its value from the component is always None.
+        assert rec["config"] is None
 
     helper_recs = _records(shaped, "helpers")
     by_kind = {("flow" if "entry_id" in r else "collection"): r for r in helper_recs}

--- a/tests/src/unit/test_component_search_contract.py
+++ b/tests/src/unit/test_component_search_contract.py
@@ -1,0 +1,325 @@
+"""Contract test for the component-search seam (ha_mcp_tools/search).
+
+The component's ``_do_search`` and the server's
+``_shape_component_search_response`` were written against the same design
+contract but never against each other's code. This suite pipes the REAL
+component output (fake hass, real joins/scoring) through the REAL server
+shaper and pins the result to the legacy ha_search record shapes — so a
+vocabulary drift on either side (``alias`` vs ``friendly_name``, ``options``
+vs ``config``, id-key renames) fails here instead of shipping a
+component-served response whose records don't match the legacy path.
+
+Legacy per-bucket record keys (the contract being pinned; see
+``smart_search/_deep.py`` / ``_scenes.py`` record builders):
+
+- automations: entity_id, friendly_name, score, match_in_name,
+  match_in_config [, config]
+- scripts: + script_id
+- scenes: + scene_id
+- helpers (collection): entity_id, helper_type, name, score, match_in_name,
+  match_in_config [, config]
+- helpers (flow): entry_id instead of entity_id
+
+``config`` is present only under ``include_config=True`` (mirroring the
+legacy pipeline's pop), and YAML-backed records must never carry a body.
+"""
+
+from __future__ import annotations
+
+from ha_mcp.tools.tools_search import (
+    _ResolvedSearch,
+    _shape_component_search_response,
+)
+
+from .test_component_ws_search import (
+    FakeConfigEntries,
+    FakeHass,
+    FakeState,
+    wsapi,
+)
+
+AUTOMATION_KEYS = {
+    "entity_id",
+    "friendly_name",
+    "score",
+    "match_in_name",
+    "match_in_config",
+}
+SCRIPT_KEYS = AUTOMATION_KEYS | {"script_id"}
+SCENE_KEYS = AUTOMATION_KEYS | {"scene_id"}
+HELPER_COLLECTION_KEYS = {
+    "entity_id",
+    "helper_type",
+    "name",
+    "score",
+    "match_in_name",
+    "match_in_config",
+}
+HELPER_FLOW_KEYS = {
+    "entry_id",
+    "helper_type",
+    "name",
+    "score",
+    "match_in_name",
+    "match_in_config",
+}
+ENTITY_KEYS = {
+    "entity_id",
+    "friendly_name",
+    "domain",
+    "state",
+    "score",
+    "match_type",
+}
+
+
+class _Entity:
+    """Minimal automation/script entity double (raw_config accessor)."""
+
+    def __init__(self, entity_id, name, raw_config, unique_id=None):
+        self.entity_id = entity_id
+        self.name = name
+        self.raw_config = raw_config
+        self.unique_id = unique_id
+
+
+class _SceneEntity:
+    def __init__(self, entity_id, name, scene_config, unique_id=None):
+        self.entity_id = entity_id
+        self.name = name
+        self.scene_config = scene_config
+        self.unique_id = unique_id
+
+
+class _Component:
+    def __init__(self, entities):
+        self.entities = entities
+
+
+class _Entry:
+    def __init__(self, entry_id, domain, title, options, data=None):
+        self.entry_id = entry_id
+        self.domain = domain
+        self.title = title
+        self.options = options
+        self.data = data or {}
+
+
+def _search_marker_hass() -> FakeHass:
+    """A hass where the query 'contractmarker' hits every surface once."""
+    states = [
+        FakeState(
+            "light.contractmarker_lamp", "on", friendly_name="Contractmarker Lamp"
+        ),
+        FakeState(
+            "input_boolean.contractmarker_flag",
+            "off",
+            friendly_name="Contractmarker Flag",
+        ),
+    ]
+    data = {
+        "automation": _Component(
+            [
+                _Entity(
+                    "automation.storage_hit",
+                    "Contractmarker Storage Automation",
+                    {"id": "auto1", "alias": "Contractmarker Storage Automation"},
+                    unique_id="auto1",
+                ),
+                _Entity(
+                    "automation.yaml_hit",
+                    "Yaml Automation",
+                    {
+                        "alias": "Yaml Automation",
+                        "action": [{"service": "notify.contractmarker"}],
+                        "secret_value": "hunter2-contractmarker-secret",
+                    },
+                    unique_id=None,
+                ),
+            ]
+        ),
+        "script": _Component(
+            [
+                _Entity(
+                    "script.contractmarker_script",
+                    "Contractmarker Script",
+                    {"id": "scr1", "alias": "Contractmarker Script"},
+                    unique_id="scr1",
+                )
+            ]
+        ),
+        "scene": _Component(
+            [
+                _SceneEntity(
+                    "scene.contractmarker_scene",
+                    "Contractmarker Scene",
+                    {"id": "scn1", "name": "Contractmarker Scene", "states": {}},
+                    unique_id="scn1",
+                )
+            ]
+        ),
+    }
+    entries = [
+        _Entry(
+            "entry1",
+            "template",
+            "Contractmarker Template Helper",
+            {"template": "{{ 1 }}"},
+            data={"credential": "should-never-appear"},
+        )
+    ]
+    hass = FakeHass(states=states, data=data)
+    hass.config_entries = FakeConfigEntries(entries)
+    return hass
+
+
+def _resolved(include_config: bool) -> _ResolvedSearch:
+    return _ResolvedSearch(
+        query="contractmarker",
+        query_text="contractmarker",
+        domain_filter=None,
+        area_filter=None,
+        state_filter=None,
+        parsed_search_types=None,
+        parsed_fields=None,
+        result_fields=None,
+        limit=10,
+        offset=0,
+        exact_match=True,
+        include_hidden=False,
+        include_config=include_config,
+        group_by_domain=False,
+        per_domain_limit=None,
+        config_time_budget=None,
+        registry_eligible=True,
+        body_eligible=True,
+        body_skipped_by_intent_gate=False,
+    )
+
+
+def _component_result(monkeypatch, include_config: bool):
+    hass = _search_marker_hass()
+    monkeypatch.setattr(
+        wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+    )
+    return wsapi._do_search(
+        hass,
+        {
+            "query": "contractmarker",
+            "search_types": ["entity", "automation", "script", "scene", "helper"],
+            "exact": True,
+            "include_hidden": False,
+            "include_config": include_config,
+            "limit": 10,
+            "offset": 0,
+        },
+    )
+
+
+def _records(shaped, bucket):
+    recs = shaped.get(bucket)
+    assert isinstance(recs, list) and recs, f"expected records in {bucket}: {shaped}"
+    return recs
+
+
+def test_all_surfaces_match_and_shape_to_legacy_keys(monkeypatch) -> None:
+    """Real component output → real server shaper → exact legacy key sets."""
+    result = _component_result(monkeypatch, include_config=True)
+    shaped = _shape_component_search_response(_resolved(True), result)
+
+    assert shaped["success"] is True
+
+    for rec in _records(shaped, "entities"):
+        assert set(rec) == ENTITY_KEYS, f"entity record keys drifted: {rec}"
+
+    autos = _records(shaped, "automations")
+    assert {r["entity_id"] for r in autos} == {
+        "automation.storage_hit",
+        "automation.yaml_hit",
+    }
+    for rec in autos:
+        assert set(rec) == AUTOMATION_KEYS | {"config"}, (
+            f"automation record keys drifted: {rec}"
+        )
+        assert rec["friendly_name"], "friendly_name must be populated from alias"
+
+    for rec in _records(shaped, "scripts"):
+        assert set(rec) == SCRIPT_KEYS | {"config"}, (
+            f"script record keys drifted: {rec}"
+        )
+        assert rec["script_id"] == "scr1"
+
+    for rec in _records(shaped, "scenes"):
+        assert set(rec) == SCENE_KEYS | {"config"}, f"scene record keys drifted: {rec}"
+        assert rec["scene_id"] == "scn1"
+
+    helper_recs = _records(shaped, "helpers")
+    by_kind = {("flow" if "entry_id" in r else "collection"): r for r in helper_recs}
+    assert set(by_kind["collection"]) == HELPER_COLLECTION_KEYS | {"config"}, (
+        f"collection helper keys drifted: {by_kind['collection']}"
+    )
+    assert set(by_kind["flow"]) == HELPER_FLOW_KEYS | {"config"}, (
+        f"flow helper keys drifted: {by_kind['flow']}"
+    )
+    # Flow helper body rides `options` component-side, `config` in the envelope.
+    assert by_kind["flow"]["config"] == {"template": "{{ 1 }}"}
+
+
+def test_yaml_body_withheld_but_matched(monkeypatch) -> None:
+    """A YAML automation matched on its body must carry no config body, and
+    the resolved-secret string must be absent from the whole response."""
+    result = _component_result(monkeypatch, include_config=True)
+    shaped = _shape_component_search_response(_resolved(True), result)
+
+    yaml_rec = next(
+        r for r in shaped["automations"] if r["entity_id"] == "automation.yaml_hit"
+    )
+    assert yaml_rec["match_in_config"] is True
+    assert yaml_rec["config"] is None
+    assert "hunter2-contractmarker-secret" not in repr(shaped)
+    # Storage sibling keeps its body under include_config.
+    storage_rec = next(
+        r for r in shaped["automations"] if r["entity_id"] == "automation.storage_hit"
+    )
+    assert storage_rec["config"] == {
+        "id": "auto1",
+        "alias": "Contractmarker Storage Automation",
+    }
+
+
+def test_include_config_false_strips_config_keys(monkeypatch) -> None:
+    """Without include_config, no record in any bucket carries a config key —
+    mirroring the legacy pipeline's include_config pop."""
+    result = _component_result(monkeypatch, include_config=False)
+    shaped = _shape_component_search_response(_resolved(False), result)
+
+    for bucket in ("automations", "scripts", "scenes", "helpers"):
+        for rec in _records(shaped, bucket):
+            assert "config" not in rec, f"{bucket} record leaked config key: {rec}"
+
+    # entry.data must never surface anywhere, with or without include_config.
+    assert "should-never-appear" not in repr(shaped)
+
+
+def test_envelope_matches_legacy_keys(monkeypatch) -> None:
+    """Envelope keys parity: the component-served response exposes the same
+    top-level keys the legacy path emits for a both-branches query."""
+    result = _component_result(monkeypatch, include_config=False)
+    shaped = _shape_component_search_response(_resolved(False), result)
+    for key in (
+        "success",
+        "query",
+        "entities",
+        "automations",
+        "scripts",
+        "scenes",
+        "helpers",
+        "entity_total_matches",
+        "config_total_matches",
+        "count",
+        "offset",
+        "limit",
+        "has_more",
+        "next_offset",
+    ):
+        assert key in shaped, f"envelope key missing: {key}"

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -1,22 +1,27 @@
-"""Unit tests for the ha_mcp_tools in-process WebSocket search API.
+"""Unit tests for the ha_mcp_tools in-process WebSocket command surface.
 
 Mirrors the established component-test pattern (``test_caller_token_auth.py`` /
 ``test_custom_component_filesystem.py``): the ``homeassistant.*`` imports are
 stubbed with ``MagicMock`` and the pure ``_do_*`` functions are exercised with
 fake hass / registry objects injected through the ``_resolve_registries`` seam.
 
-Coverage:
-* ``_do_info`` handshake shape + manifest/const version parity (drift guard).
-* entity joins (name / alias / area / floor / label / domain / device).
-* config matching: a YAML-loaded automation is indexed but its body is NEVER
-  emitted; a storage-backed body is emitted only under ``include_config``.
-* flow-helper ``options`` indexed while ``entry.data`` never appears anywhere in
-  the serialized response (data-minimization contract).
-* pagination, include_hidden, match-all, search_types gating.
-* admin gate present on both registered commands.
-* scorer parity against the server's ``_match_exact_search_entity`` /
-  ``calculate_ratio`` (golden corpus) so the two scorers never drift.
-* malformed-params rejection via voluptuous.
+Covers all five v1.1.0 commands (info / search / config_get / overview /
+helpers_list). Highlights:
+* ``_do_info`` handshake shape + manifest/const version parity (drift guard);
+  ``info`` advertising all four capabilities.
+* search: entity joins (name / alias / area / floor / label / domain / device);
+  YAML config body indexed but NEVER emitted; storage body only under
+  ``include_config``; flow-helper ``options`` indexed while ``entry.data`` never
+  leaks; pagination / include_hidden / match-all / search_types gating; scorer
+  parity against the server's ``_match_exact_search_entity`` / ``calculate_ratio``.
+* config_get: storage-item full payload; YAML -> structured not-found with the
+  body ABSENT everywhere; id / entity_id / slug resolution.
+* overview: the raw slices (states / services / three registries / config /
+  notifications / repairs) shaped for the server's existing overview logic.
+* helpers_list: collection + flow helpers; ``entry.data`` negative scan; rename
+  (issue #1794) shows current values; helper_types filter.
+* admin gate + async_response on all five registered commands.
+* malformed-params rejection via voluptuous for every command schema.
 """
 
 from __future__ import annotations
@@ -89,11 +94,28 @@ class FakeConfigEntries:
         return list(self._entries)
 
 
+class FakeServices:
+    """Stand-in for ``hass.services`` (``async_services`` mapping)."""
+
+    def __init__(self, services):
+        # services: {domain: {service_name: <anything>}}
+        self._services = {d: dict(s) for d, s in dict(services).items()}
+
+    def async_services(self):
+        return dict(self._services)
+
+
 class FakeHass:
-    def __init__(self, states=(), data=None, config_entries=()):
+    def __init__(
+        self, states=(), data=None, config_entries=(), services=None, config=None
+    ):
         self.states = FakeStates(states)
         self.data = dict(data or {})
         self.config_entries = FakeConfigEntries(config_entries)
+        if services is not None:
+            self.services = services
+        if config is not None:
+            self.config = config
 
 
 class FakeRegEntry:
@@ -106,6 +128,13 @@ class FakeRegEntry:
         labels=(),
         hidden_by=None,
         name=None,
+        unique_id=None,
+        original_name=None,
+        categories=None,
+        config_entry_id=None,
+        entity_category=None,
+        platform=None,
+        disabled_by=None,
     ):
         self.entity_id = entity_id
         self.aliases = set(aliases)
@@ -114,11 +143,21 @@ class FakeRegEntry:
         self.labels = set(labels)
         self.hidden_by = hidden_by
         self.name = name
+        self.unique_id = unique_id
+        self.original_name = original_name
+        self.categories = dict(categories or {})
+        self.config_entry_id = config_entry_id
+        self.entity_category = entity_category
+        self.platform = platform
+        self.disabled_by = disabled_by
 
 
 class FakeEntityReg:
     def __init__(self, entries):
         self._entries = dict(entries)
+        # Real HA exposes ``registry.entities`` as a mapping; overview /
+        # helpers_list iterate it, while search uses ``async_get``.
+        self.entities = dict(entries)
 
     def async_get(self, entity_id):
         return self._entries.get(entity_id)
@@ -137,6 +176,9 @@ class FakeAreaReg:
 
     def async_get_area(self, area_id):
         return self._areas.get(area_id)
+
+    def async_list_areas(self):
+        return list(self._areas.values())
 
 
 class FakeFloor:
@@ -190,6 +232,8 @@ class FakeDevice:
 class FakeDeviceReg:
     def __init__(self, devices):
         self._devices = {d.id: d for d in devices}
+        # Real HA exposes ``registry.devices`` as a mapping (overview reads it).
+        self.devices = dict(self._devices)
 
     def async_get(self, device_id):
         return self._devices.get(device_id)
@@ -230,13 +274,68 @@ class FakeConfigEntry:
 
 
 class FakeConfig:
-    """Stand-in for ``hass.config`` whose ``path()`` roots at a temp dir."""
+    """Stand-in for ``hass.config``: ``path()`` roots at a temp dir; ``as_dict()``
+    returns the injected HA-config payload (overview's system-info slice)."""
 
-    def __init__(self, base_dir):
-        self._base = Path(base_dir)
+    def __init__(self, base_dir=None, data=None):
+        self._base = Path(base_dir) if base_dir is not None else None
+        self._data = dict(data or {})
 
     def path(self, *parts):
         return str(self._base.joinpath(*parts))
+
+    def as_dict(self):
+        return dict(self._data)
+
+
+class FakeIssue:
+    """Stand-in for an issue-registry ``IssueEntry`` (repairs slice)."""
+
+    def __init__(
+        self,
+        issue_id,
+        domain,
+        *,
+        severity="warning",
+        translation_key=None,
+        dismissed_version=None,
+        is_fixable=True,
+        breaks_in_ha_version=None,
+        created=None,
+        issue_domain=None,
+        translation_placeholders=None,
+        learn_more_url=None,
+        active=True,
+    ):
+        self.issue_id = issue_id
+        self.domain = domain
+        self.severity = severity
+        self.translation_key = translation_key
+        self.dismissed_version = dismissed_version
+        self.is_fixable = is_fixable
+        self.breaks_in_ha_version = breaks_in_ha_version
+        self.created = created
+        self.issue_domain = issue_domain
+        self.translation_placeholders = translation_placeholders
+        self.learn_more_url = learn_more_url
+        self.active = active
+
+
+class FakeIssueRegistry:
+    """Stand-in for the issue registry: ``.issues`` maps (domain, id) -> IssueEntry."""
+
+    def __init__(self, issues):
+        self.issues = {(i.domain, i.issue_id): i for i in issues}
+
+
+class FakeIssueRegModule:
+    """Stand-in for the ``issue_registry`` module (``async_get`` seam)."""
+
+    def __init__(self, registry):
+        self._registry = registry
+
+    def async_get(self, hass):
+        return self._registry
 
 
 def make_view(entity=None, areas=(), floors=(), labels=(), devices=()):
@@ -265,7 +364,12 @@ class TestInfo:
         info = wsapi._do_info()
         assert info["schema_version"] == 1
         assert info["component_version"] == COMPONENT_VERSION
-        assert info["capabilities"] == ["search"]
+        assert info["capabilities"] == [
+            "search",
+            "config_get",
+            "overview",
+            "helpers_list",
+        ]
         assert info["limits"] == {"max_results": 500, "max_body_bytes": 1_000_000}
 
     def test_manifest_version_parity(self):
@@ -1109,29 +1213,51 @@ def functional_ws(monkeypatch):
     return fake
 
 
-class TestRegistrationAndAdminGate:
-    def test_both_commands_registered(self, functional_ws):
-        assert set(functional_ws.registered) == {wsapi.WS_INFO, wsapi.WS_SEARCH}
+_ALL_COMMANDS = [
+    "ha_mcp_tools/info",
+    "ha_mcp_tools/search",
+    "ha_mcp_tools/config_get",
+    "ha_mcp_tools/overview",
+    "ha_mcp_tools/helpers_list",
+]
 
-    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+# Minimal well-formed message body per command (Required fields) so the admin
+# gate / async_response wrappers reach the pure handler.
+_CMD_MSG_EXTRA = {
+    "ha_mcp_tools/config_get": {"domain": "automation", "item_id": "nope"},
+}
+
+
+class TestRegistrationAndAdminGate:
+    def test_all_commands_registered(self, functional_ws):
+        assert set(functional_ws.registered) == {
+            wsapi.WS_INFO,
+            wsapi.WS_SEARCH,
+            wsapi.WS_CONFIG_GET,
+            wsapi.WS_OVERVIEW,
+            wsapi.WS_HELPERS_LIST,
+        }
+
+    @pytest.mark.parametrize("command", _ALL_COMMANDS)
     def test_non_admin_rejected(self, functional_ws, command):
         handler = functional_ws.registered[command]
         conn = _FakeConnection(is_admin=False)
         with pytest.raises(_Unauthorized):
             handler(FakeHass(), conn, {"id": 1, "type": command})
 
-    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+    @pytest.mark.parametrize("command", _ALL_COMMANDS)
     def test_no_user_rejected(self, functional_ws, command):
         handler = functional_ws.registered[command]
         conn = _FakeConnection(has_user=False)
         with pytest.raises(_Unauthorized):
             handler(FakeHass(), conn, {"id": 2, "type": command})
 
-    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+    @pytest.mark.parametrize("command", _ALL_COMMANDS)
     def test_admin_call_sends_result(self, functional_ws, command):
         handler = functional_ws.registered[command]
         conn = _FakeConnection(is_admin=True)
-        handler(FakeHass(), conn, {"id": 9, "type": command})
+        msg = {"id": 9, "type": command, **_CMD_MSG_EXTRA.get(command, {})}
+        handler(FakeHass(), conn, msg)
         assert 9 in conn.results
         assert isinstance(conn.results[9], dict)
 
@@ -1164,3 +1290,496 @@ class TestSchemaValidation:
         schema = self._schema(monkeypatch)
         with pytest.raises(_REAL_VOL.Invalid):
             schema(bad)
+
+
+class TestNewCommandSchemas:
+    """Voluptuous validation for config_get / overview / helpers_list."""
+
+    def _schema(self, monkeypatch, schema_fn):
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        return _REAL_VOL.Schema(schema_fn())
+
+    def test_config_get_valid(self, monkeypatch):
+        schema = self._schema(monkeypatch, wsapi._config_get_schema)
+        out = schema(
+            {"type": wsapi.WS_CONFIG_GET, "domain": "script", "item_id": "abc"}
+        )
+        assert out["domain"] == "script"
+        assert out["item_id"] == "abc"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"type": "ha_mcp_tools/config_get", "domain": "light", "item_id": "x"},
+            {"type": "ha_mcp_tools/config_get", "domain": "automation"},  # no item_id
+            {"type": "ha_mcp_tools/config_get", "item_id": "x"},  # no domain
+        ],
+    )
+    def test_config_get_malformed_rejected(self, monkeypatch, bad):
+        schema = self._schema(monkeypatch, wsapi._config_get_schema)
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema(bad)
+
+    def test_overview_defaults(self, monkeypatch):
+        schema = self._schema(monkeypatch, wsapi._overview_schema)
+        out = schema({"type": wsapi.WS_OVERVIEW})
+        assert out["include_notifications"] is True
+        assert out["include_repairs"] is True
+
+    def test_overview_malformed_rejected(self, monkeypatch):
+        schema = self._schema(monkeypatch, wsapi._overview_schema)
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema({"type": wsapi.WS_OVERVIEW, "include_notifications": "yes"})
+
+    def test_helpers_list_defaults(self, monkeypatch):
+        schema = self._schema(monkeypatch, wsapi._helpers_list_schema)
+        out = schema({"type": wsapi.WS_HELPERS_LIST})
+        assert out["include_flow_helpers"] is True
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"type": "ha_mcp_tools/helpers_list", "helper_types": "template"},
+            {"type": "ha_mcp_tools/helpers_list", "include_flow_helpers": "yes"},
+        ],
+    )
+    def test_helpers_list_malformed_rejected(self, monkeypatch, bad):
+        schema = self._schema(monkeypatch, wsapi._helpers_list_schema)
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema(bad)
+
+
+# =============================================================================
+# config_get — storage-only body fetch; YAML -> structured not-found (no body)
+# =============================================================================
+class TestConfigGet:
+    def _storage_hass(self):
+        storage_auto = FakeConfigEntity(
+            "automation.ui",
+            "UI Auto",
+            unique_id="uid-1",
+            raw_config={
+                "id": "uid-1",
+                "alias": "UI Auto",
+                "action": [{"service": "light.turn_on"}],
+            },
+        )
+        yaml_auto = FakeConfigEntity(
+            "automation.pkg",
+            "Package Auto",
+            unique_id=None,
+            raw_config={
+                "alias": "Package Auto",
+                "action": [{"service": "notify.x", "data": {"message": "YAMLSECRET"}}],
+            },
+        )
+        h = FakeHass(
+            states=[FakeState("automation.ui", "on", "UI Auto Live")],
+            data={"automation": FakeComponent([storage_auto, yaml_auto])},
+        )
+        return h
+
+    def _view(self):
+        return make_view(
+            entity={
+                "automation.ui": FakeRegEntry(
+                    "automation.ui", categories={"automation": "cat-morning"}
+                )
+            }
+        )
+
+    def test_storage_item_full_payload(self, monkeypatch):
+        h = self._storage_hass()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": "uid-1"})
+        assert res["found"] is True
+        assert res["source"] == "storage"
+        assert res["domain"] == "automation"
+        assert res["item_id"] == "uid-1"
+        assert res["entity_id"] == "automation.ui"
+        # Current friendly_name comes from the live state, not the storage name.
+        assert res["friendly_name"] == "UI Auto Live"
+        assert res["config"]["id"] == "uid-1"
+        assert res["category"] == "cat-morning"
+
+    @pytest.mark.parametrize("item_id", ["uid-1", "automation.ui", "ui"])
+    def test_resolves_by_id_entity_id_or_slug(self, monkeypatch, item_id):
+        h = self._storage_hass()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": item_id})
+        assert res["found"] is True
+        assert res["entity_id"] == "automation.ui"
+
+    def test_yaml_item_structured_not_found_no_body(self, empty_view):
+        h = self._storage_hass()
+        res = wsapi._do_config_get(
+            h, {"domain": "automation", "item_id": "automation.pkg"}
+        )
+        assert res["found"] is False
+        assert res["source"] == "yaml"
+        assert res["entity_id"] == "automation.pkg"
+        # The YAML body must never appear anywhere in the response.
+        assert "config" not in res
+        assert "YAMLSECRET" not in json.dumps(res)
+
+    def test_absent_item_not_found(self, empty_view):
+        h = self._storage_hass()
+        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": "ghost"})
+        assert res["found"] is False
+        assert res["source"] is None
+        assert "config" not in res
+
+    def test_inaccessible_component_not_found(self, empty_view):
+        res = wsapi._do_config_get(
+            FakeHass(), {"domain": "script", "item_id": "whatever"}
+        )
+        assert res["found"] is False
+        assert res["source"] is None
+
+    def test_scene_storage_body(self, monkeypatch):
+        scene = FakeSceneEntity(
+            "scene.movie",
+            "Movie Night",
+            unique_id="scn-1",
+            scene_config={"id": "scn-1", "name": "Movie Night", "icon": "mdi:movie"},
+        )
+        h = FakeHass(data={"scene": FakeComponent([scene])})
+        monkeypatch.setattr(
+            wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+        )
+        res = wsapi._do_config_get(h, {"domain": "scene", "item_id": "scn-1"})
+        assert res["found"] is True
+        assert res["source"] == "storage"
+        assert res["config"]["name"] == "Movie Night"
+        # No registry -> category degrades to None, not an error.
+        assert res["category"] is None
+
+
+# =============================================================================
+# helpers_list — collection (live attrs) + flow (options, never entry.data)
+# =============================================================================
+class TestHelpersList:
+    def test_collection_helper_listed_with_body(self, empty_view):
+        states = [
+            FakeState(
+                "input_select.house_mode",
+                "day",
+                friendly_name="House Mode",
+                options=["day", "night"],
+            )
+        ]
+        res = wsapi._do_helpers_list(FakeHass(states=states), {})
+        coll = [h for h in res["helpers"] if h["kind"] == "collection"]
+        assert res["count"] == len(res["helpers"]) == 1
+        rec = coll[0]
+        assert rec["helper_type"] == "input_select"
+        assert rec["entity_id"] == "input_select.house_mode"
+        assert rec["object_id"] == "house_mode"
+        assert rec["name"] == "House Mode"
+        assert rec["config"]["options"] == ["day", "night"]
+
+    def test_rename_shows_current_values_issue_1794(self, monkeypatch):
+        # The storage collection name is stale ("Old Name"); the current name
+        # (state friendly_name + registry override) must win — issue #1794.
+        states = [
+            FakeState("input_boolean.guest_mode", "off", friendly_name="Current Guest")
+        ]
+        view = make_view(
+            entity={
+                "input_boolean.guest_mode": FakeRegEntry(
+                    "input_boolean.guest_mode",
+                    name="Current Guest",
+                    original_name="Old Name",
+                    unique_id="guest_mode",
+                )
+            }
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        res = wsapi._do_helpers_list(FakeHass(states=states), {})
+        rec = next(h for h in res["helpers"] if h["kind"] == "collection")
+        assert rec["name"] == "Current Guest"
+        assert rec["storage_id"] == "guest_mode"
+        assert "Old Name" not in json.dumps(res)
+
+    def test_flow_helper_options_and_entity_data_never_leaks(self, monkeypatch):
+        entry = FakeConfigEntry(
+            "template",
+            title="Sun Sensor",
+            options={"state": "{{ is_state('sun.sun', 'above_horizon') }}"},
+            data={"api_key": "DATA_SECRET_XYZ"},
+            entry_id="e1",
+        )
+        # A registry entity bound to the config entry supplies the CURRENT
+        # entity_id + display name (a rename updates the registry, not the entry
+        # title).
+        view = make_view(
+            entity={
+                "binary_sensor.sun_up": FakeRegEntry(
+                    "binary_sensor.sun_up",
+                    name="Sun Is Up",
+                    config_entry_id="e1",
+                )
+            }
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        res = wsapi._do_helpers_list(FakeHass(config_entries=[entry]), {})
+        flow = [h for h in res["helpers"] if h["kind"] == "flow"]
+        assert flow
+        rec = flow[0]
+        assert rec["helper_type"] == "template"
+        assert rec["entry_id"] == "e1"
+        assert rec["storage_id"] == "e1"
+        assert rec["entity_id"] == "binary_sensor.sun_up"
+        assert rec["name"] == "Sun Is Up"
+        assert rec["options"] == {"state": "{{ is_state('sun.sun', 'above_horizon') }}"}
+        serialized = json.dumps(res)
+        assert "DATA_SECRET_XYZ" not in serialized
+        assert "api_key" not in serialized
+
+    def test_flow_helper_without_registered_entity(self, empty_view):
+        entry = FakeConfigEntry(
+            "group", title="Living Room Group", options={"entities": []}, entry_id="e9"
+        )
+        res = wsapi._do_helpers_list(FakeHass(config_entries=[entry]), {})
+        rec = next(h for h in res["helpers"] if h["kind"] == "flow")
+        assert rec["entity_id"] is None
+        assert rec["name"] == "Living Room Group"
+
+    def test_helper_types_filter(self, empty_view):
+        states = [FakeState("input_boolean.guest", "off", "Guest")]
+        entry = FakeConfigEntry(
+            "template", title="Tmpl", options={"state": "x"}, entry_id="e1"
+        )
+        h = FakeHass(states=states, config_entries=[entry])
+        only_tmpl = wsapi._do_helpers_list(h, {"helper_types": ["template"]})
+        assert {r["helper_type"] for r in only_tmpl["helpers"]} == {"template"}
+        only_bool = wsapi._do_helpers_list(h, {"helper_types": ["input_boolean"]})
+        assert {r["helper_type"] for r in only_bool["helpers"]} == {"input_boolean"}
+
+    def test_include_flow_helpers_false(self, empty_view):
+        entry = FakeConfigEntry(
+            "template", title="Tmpl", options={"state": "x"}, entry_id="e1"
+        )
+        res = wsapi._do_helpers_list(
+            FakeHass(config_entries=[entry]), {"include_flow_helpers": False}
+        )
+        assert [r for r in res["helpers"] if r["kind"] == "flow"] == []
+
+    def test_zone_and_person_are_listed_but_search_unaffected(self, empty_view):
+        # helpers_list covers zone/person (consumer parity); search must not.
+        states = [
+            FakeState("zone.home", "zoning", friendly_name="Home"),
+            FakeState("person.alice", "home", friendly_name="Alice"),
+        ]
+        listed = wsapi._do_helpers_list(FakeHass(states=states), {})
+        kinds = {r["helper_type"] for r in listed["helpers"]}
+        assert kinds == {"zone", "person"}
+        assert {"zone", "person"} <= set(listed["covered_types"])
+        # search's helper surface excludes zone/person (unchanged behaviour).
+        searched = wsapi._do_search(
+            FakeHass(states=states), {"query": "home", "search_types": ["helper"]}
+        )
+        assert searched["helpers"] == []
+
+    def test_covered_types_advertises_the_full_enumerable_universe(self, empty_view):
+        # covered_types is the anti-silent-wrong signal the server gates fallback
+        # on: it must name every state-machine collection type + every flow type,
+        # so the server trusts a genuinely-empty result for those.
+        res = wsapi._do_helpers_list(FakeHass(), {})
+        covered = set(res["covered_types"])
+        # All 11 state-machine collection types the consumer accepts.
+        assert {
+            "input_boolean",
+            "input_number",
+            "input_text",
+            "input_select",
+            "input_datetime",
+            "input_button",
+            "counter",
+            "timer",
+            "schedule",
+            "zone",
+            "person",
+        } <= covered
+        # Flow types are covered too (they're enumerated by default).
+        assert {"template", "group", "utility_meter"} <= covered
+
+    def test_tag_is_not_covered_so_empty_is_not_authoritative(self, empty_view):
+        # tag has no state entity, so the component cannot enumerate it. A
+        # tag-only request returns empty AND omits tag from covered_types, telling
+        # the server to fall back to its legacy tag/list rather than trust it.
+        res = wsapi._do_helpers_list(FakeHass(), {"helper_types": ["tag"]})
+        assert res["helpers"] == []
+        assert "tag" not in res["covered_types"]
+
+    def test_covered_types_excludes_flow_when_disabled(self, empty_view):
+        res = wsapi._do_helpers_list(FakeHass(), {"include_flow_helpers": False})
+        covered = set(res["covered_types"])
+        assert "input_boolean" in covered
+        # No flow types are covered when flow enumeration is turned off.
+        assert covered.isdisjoint(wsapi.FLOW_HELPER_DOMAINS)
+
+
+# =============================================================================
+# overview — RAW slices (server runs its existing overview logic over them)
+# =============================================================================
+class _FakeEnum:
+    """StrEnum-ish stand-in: ``.value`` is the wire string."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class TestOverview:
+    def _hass(self):
+        return FakeHass(
+            states=[
+                FakeState(
+                    "light.lamp", "on", friendly_name="Lamp", device_class="light"
+                )
+            ],
+            services=FakeServices({"light": {"turn_on": {}, "turn_off": {}}}),
+            config=FakeConfig(
+                data={
+                    "version": "2026.7.0",
+                    "location_name": "Home",
+                    "time_zone": "UTC",
+                    "language": "en",
+                    "state": "RUNNING",
+                    "country": "US",
+                    "unit_system": {"temperature": "°C"},
+                    "components": ["light", "sensor"],
+                    "allowlist_external_dirs": {"/config/www"},
+                    "internal_url": "http://homeassistant.local:8123",
+                }
+            ),
+            data={
+                "persistent_notification": {
+                    "n1": {
+                        "notification_id": "n1",
+                        "title": "Heads up",
+                        "message": "Something",
+                        "created_at": "2026-07-11T00:00:00+00:00",
+                    }
+                }
+            },
+        )
+
+    def _view(self):
+        return make_view(
+            entity={
+                "light.lamp": FakeRegEntry(
+                    "light.lamp",
+                    area_id="a1",
+                    device_id="d1",
+                    labels={"lb1"},
+                    entity_category=_FakeEnum("config"),
+                    hidden_by=_FakeEnum("user"),
+                )
+            },
+            areas=[FakeArea("a1", "Office", floor_id="f1")],
+            devices=[FakeDevice("d1", name="Lamp Device", area_id="a1")],
+        )
+
+    def test_raw_slices_present_and_shaped(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        res = wsapi._do_overview(self._hass(), {})
+
+        # states: bare list, get_states()-shaped
+        assert isinstance(res["states"], list)
+        st = res["states"][0]
+        assert st["entity_id"] == "light.lamp"
+        assert st["state"] == "on"
+        assert st["attributes"]["friendly_name"] == "Lamp"
+
+        # services: [{domain, services:{name:{}}}]
+        assert res["services"] == [
+            {"domain": "light", "services": {"turn_on": {}, "turn_off": {}}}
+        ]
+
+        # registries: bare lists (NOT the {success, result} WS wrapper)
+        assert isinstance(res["entity_registry"], list)
+        ent = res["entity_registry"][0]
+        assert ent["entity_id"] == "light.lamp"
+        assert ent["area_id"] == "a1"
+        assert ent["device_id"] == "d1"
+        assert ent["labels"] == ["lb1"]
+        # enum-ish registry fields are unwrapped to their wire strings
+        assert ent["entity_category"] == "config"
+        assert ent["hidden_by"] == "user"
+
+        assert res["device_registry"] == [
+            {
+                "id": "d1",
+                "area_id": "a1",
+                "labels": [],
+                "name": "Lamp Device",
+                "name_by_user": None,
+                "manufacturer": None,
+                "model": None,
+            }
+        ]
+        assert res["area_registry"] == [
+            {"area_id": "a1", "name": "Office", "floor_id": "f1"}
+        ]
+
+        # config: HA-config fields, no base_url (server supplies that)
+        assert res["config"]["version"] == "2026.7.0"
+        assert res["config"]["location_name"] == "Home"
+        assert "base_url" not in res["config"]
+        # a set-valued config field is JSON-plainified to a list
+        assert res["config"]["allowlist_external_dirs"] == ["/config/www"]
+
+        # notifications
+        assert res["notifications"] == [
+            {
+                "notification_id": "n1",
+                "title": "Heads up",
+                "message": "Something",
+                "created_at": "2026-07-11T00:00:00+00:00",
+            }
+        ]
+
+    def test_repairs_ignored_derived_from_dismissed_version(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        registry = FakeIssueRegistry(
+            [
+                FakeIssue("active_issue", "mqtt", severity=_FakeEnum("warning")),
+                FakeIssue("old_issue", "zwave", dismissed_version="2026.1.0"),
+            ]
+        )
+        monkeypatch.setattr(wsapi, "ir", FakeIssueRegModule(registry))
+        res = wsapi._do_overview(self._hass(), {})
+        by_id = {r["issue_id"]: r for r in res["repairs"]}
+        assert by_id["active_issue"]["ignored"] is False
+        assert by_id["active_issue"]["severity"] == "warning"
+        assert by_id["old_issue"]["ignored"] is True
+        assert by_id["old_issue"]["dismissed_version"] == "2026.1.0"
+
+    def test_include_flags_skip_sections(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        monkeypatch.setattr(
+            wsapi, "ir", FakeIssueRegModule(FakeIssueRegistry([FakeIssue("x", "y")]))
+        )
+        res = wsapi._do_overview(
+            self._hass(),
+            {"include_notifications": False, "include_repairs": False},
+        )
+        assert res["notifications"] == []
+        assert res["repairs"] == []
+        # core slices still present
+        assert res["states"] and res["entity_registry"]
+
+    def test_degrades_without_registries_or_config(self, monkeypatch):
+        monkeypatch.setattr(
+            wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+        )
+        monkeypatch.setattr(wsapi, "ir", FakeIssueRegModule(FakeIssueRegistry([])))
+        res = wsapi._do_overview(FakeHass(), {})
+        assert res["entity_registry"] == []
+        assert res["device_registry"] == []
+        assert res["area_registry"] == []
+        assert res["services"] == []
+        assert res["config"] == {}
+        assert res["notifications"] == []
+        assert res["repairs"] == []

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -26,8 +26,10 @@ helpers_list). Highlights:
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import json
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -116,6 +118,11 @@ class FakeHass:
             self.services = services
         if config is not None:
             self.config = config
+
+    async def async_add_executor_job(self, func, *args):
+        # The real hass runs ``func`` in a thread pool; the tests run it inline
+        # (the point under test is that the WS prep offloads it, not the pool).
+        return func(*args)
 
 
 class FakeRegEntry:
@@ -257,6 +264,20 @@ class FakeSceneEntity:
         self.name = name
         self.unique_id = unique_id
         self.scene_config = scene_config
+
+
+class FakeCollectionEntity:
+    """Stand-in for a CollectionEntity (input_boolean/schedule/counter/…).
+
+    Real collection helpers keep their full storage config on the entity as
+    ``_config`` (a schedule's weekday blocks, an input_datetime's has_date, …),
+    reachable via the domain's EntityComponent in ``hass.data['entity_components']``.
+    """
+
+    def __init__(self, entity_id, config, unique_id=None):
+        self.entity_id = entity_id
+        self._config = dict(config)
+        self.unique_id = unique_id if unique_id is not None else config.get("id")
 
 
 class FakeComponent:
@@ -591,12 +612,17 @@ class TestConfigSurfaces:
         for rec in res["automations"]:
             assert rec["config"] is None
 
-    def test_scene_matches_via_scene_config(self, empty_view):
+    def test_scene_matches_by_name_config_never_emitted(self, empty_view):
         scene = FakeSceneEntity(
             "scene.movie",
             "Movie Night",
             unique_id="scn-1",
-            scene_config={"id": "scn-1", "name": "Movie Night", "icon": "mdi:movie"},
+            scene_config={
+                "id": "scn-1",
+                "name": "Movie Night",
+                "icon": "mdi:movie",
+                "states": {"light.tv": object(), "media_player.lr": object()},
+            },
         )
         h = FakeHass(data={"scene": FakeComponent([scene])})
         res = wsapi._do_search(h, {"query": "movie", "include_config": True})
@@ -604,7 +630,54 @@ class TestConfigSurfaces:
         rec = res["scenes"][0]
         assert rec["name"] == "Movie Night"
         assert rec["source"] == "storage"
-        assert rec["config"]["id"] == "scn-1"
+        assert rec["match_in_name"] is True
+        # Scenes never emit a component-served body, even under include_config.
+        assert rec["config"] is None
+
+    def test_scene_matches_by_entity_reference(self, empty_view):
+        # The entity-id KEYS of scene_config.states are the match corpus, so a
+        # query for an entity a scene touches finds it ("which scenes touch X").
+        scene = FakeSceneEntity(
+            "scene.evening",
+            "Evening",
+            unique_id="scn-2",
+            scene_config={
+                "id": "scn-2",
+                "name": "Evening",
+                "states": {"light.porch": object()},
+            },
+        )
+        h = FakeHass(data={"scene": FakeComponent([scene])})
+        res = wsapi._do_search(h, {"query": "light.porch", "include_config": True})
+        assert res["scenes"], "a scene must match on an entity-id key of its states"
+        assert res["scenes"][0]["match_in_config"] is True
+        assert res["scenes"][0]["config"] is None
+
+    def test_scene_state_values_not_in_corpus_or_response(self, empty_view):
+        # Runtime State-object VALUES must never reach scoring or the response —
+        # only the entity-id keys and id/name/icon do (no stringified garbage).
+        class _RuntimeState:
+            def __repr__(self):
+                return "<state light.tv=scenegarbagevalue>"
+
+        scene = FakeSceneEntity(
+            "scene.movie",
+            "Movie Night",
+            unique_id="scn-1",
+            scene_config={
+                "id": "scn-1",
+                "name": "Movie Night",
+                "states": {"light.tv": _RuntimeState()},
+            },
+        )
+        h = FakeHass(data={"scene": FakeComponent([scene])})
+        by_value = wsapi._do_search(
+            h, {"query": "scenegarbagevalue", "include_config": True}
+        )
+        assert not by_value["scenes"], "State values must not be in the match corpus"
+        by_name = wsapi._do_search(h, {"query": "movie", "include_config": True})
+        assert by_name["scenes"]
+        assert "scenegarbagevalue" not in json.dumps(by_name)
 
     def test_config_combined_pagination(self, empty_view):
         autos = [
@@ -740,6 +813,36 @@ class TestHelpers:
         assert rec["match_in_name"] is False
         assert "deep_search_option_a" in json.dumps(rec["config"])
 
+    def test_collection_helper_search_matches_storage_body(self, empty_view):
+        # Search must match a schedule on a value that lives ONLY in the storage
+        # ``_config`` body (a weekday block time), not in the state attributes.
+        state = FakeState("schedule.work", "on", friendly_name="Work")
+        sched = FakeCollectionEntity(
+            "schedule.work",
+            {
+                "id": "work",
+                "name": "Work",
+                "monday": [{"from": "07:07:07", "to": "09:00:00"}],
+            },
+            unique_id="work",
+        )
+        h = FakeHass(
+            states=[state],
+            data={"entity_components": {"schedule": FakeComponent([sched])}},
+        )
+        res = wsapi._do_search(
+            h,
+            {
+                "query": "07:07:07",
+                "search_types": ["helper"],
+                "include_config": True,
+            },
+        )
+        coll = [x for x in res["helpers"] if x["kind"] == "collection"]
+        assert coll, "a storage-body-only value must match the collection helper"
+        assert coll[0]["match_in_config"] is True
+        assert "07:07:07" in json.dumps(coll[0]["config"])
+
     def test_collection_helper_body_withheld_without_include_config(self, empty_view):
         states = [
             FakeState(
@@ -815,6 +918,10 @@ class TestSecretScrub:
     """A resolved ``!secret`` value in a config body must never produce a match,
     so ``ha_search`` cannot be used as a probe oracle (query a suspected secret,
     confirm it via ``match_in_config``). The value is blocked, not just unemitted.
+
+    The scrub set is loaded off the event loop by ``_search_prep`` and passed into
+    the pure ``_do_search`` (see :class:`TestSearchPrep` / :class:`TestSecretLoader`
+    for the loader); these tests inject it directly via ``secret_values``.
     """
 
     _SECRET = "s3cr3tprobevaluexyz"
@@ -841,41 +948,38 @@ class TestSecretScrub:
         )
         return FakeHass(data={"automation": FakeComponent([auto])})
 
-    def _write_secrets(self, tmp_path, **values):
-        body = "".join(f"{k}: {v}\n" for k, v in values.items())
-        (tmp_path / "secrets.yaml").write_text(body, encoding="utf-8")
-
-    def test_secret_value_scrubbed_but_normal_token_matches(self, empty_view, tmp_path):
-        self._write_secrets(tmp_path, api_password=self._SECRET)
+    def test_secret_value_scrubbed_but_normal_token_matches(self, empty_view):
         h = self._yaml_automation_hass(self._SECRET)
-        h.config = FakeConfig(tmp_path)
+        scrub = frozenset({self._SECRET})
 
         by_secret = wsapi._do_search(
-            h, {"query": self._SECRET, "search_types": ["automation"]}
+            h,
+            {"query": self._SECRET, "search_types": ["automation"]},
+            secret_values=scrub,
         )
         assert not by_secret["automations"], (
             "a query equal to a resolved secret must not match (probe oracle)"
         )
 
         by_token = wsapi._do_search(
-            h, {"query": "normalbodytoken", "search_types": ["automation"]}
+            h,
+            {"query": "normalbodytoken", "search_types": ["automation"]},
+            secret_values=scrub,
         )
         assert any(a["match_in_config"] for a in by_token["automations"]), (
             "a non-secret body token must still match after scrubbing"
         )
 
-    def test_secret_scrubbed_in_fuzzy_mode(self, empty_view, tmp_path):
-        self._write_secrets(tmp_path, api_password=self._SECRET)
+    def test_secret_scrubbed_in_fuzzy_mode(self, empty_view):
         h = self._yaml_automation_hass(self._SECRET)
-        h.config = FakeConfig(tmp_path)
         res = wsapi._do_search(
             h,
             {"query": self._SECRET, "search_types": ["automation"], "exact": False},
+            secret_values=frozenset({self._SECRET}),
         )
         assert not res["automations"], "fuzzy mode must also scrub the secret leaf"
 
-    def test_flow_helper_option_secret_scrubbed(self, empty_view, tmp_path):
-        self._write_secrets(tmp_path, tmpl_secret=self._SECRET)
+    def test_flow_helper_option_secret_scrubbed(self, empty_view):
         entry = FakeConfigEntry(
             "template",
             title="Sun Sensor",
@@ -883,70 +987,134 @@ class TestSecretScrub:
             entry_id="e1",
         )
         h = FakeHass(config_entries=[entry])
-        h.config = FakeConfig(tmp_path)
-        res = wsapi._do_search(h, {"query": self._SECRET, "search_types": ["helper"]})
+        res = wsapi._do_search(
+            h,
+            {"query": self._SECRET, "search_types": ["helper"]},
+            secret_values=frozenset({self._SECRET}),
+        )
         assert not [x for x in res["helpers"] if x["kind"] == "flow"], (
             "a flow-helper option equal to a secret must not match"
         )
 
-    def test_missing_secrets_file_degrades_without_scrubbing(
-        self, empty_view, tmp_path
-    ):
-        # No secrets.yaml under tmp_path → no scrub → the value matches (proves
-        # the degrade-off path runs without error).
+    def test_empty_scrub_set_lets_the_value_match(self, empty_view):
+        # No scrub set (the default — entity-only search, or an absent secrets.yaml
+        # that degraded to empty) means the value is not blocked. Proves the scrub
+        # is what blocks, and its absence is safe.
         h = self._yaml_automation_hass(self._SECRET)
-        h.config = FakeConfig(tmp_path)
         res = wsapi._do_search(
             h, {"query": self._SECRET, "search_types": ["automation"]}
         )
-        assert res["automations"], (
-            "absent secrets.yaml must degrade to no scrubbing without error"
+        assert res["automations"], "an empty scrub set must not block the match"
+
+
+# =============================================================================
+# secret loader — off-loop read of secrets.yaml; absent silent, broken warns
+# =============================================================================
+class TestSecretLoader:
+    """``_load_secret_values`` reads ``secrets.yaml`` (run in the executor by
+    ``_search_prep``) and degrades safely: an ABSENT file is silent (the common
+    case), a present-but-unreadable/malformed file logs ONE warning; both yield
+    an empty set. Only string values are collected."""
+
+    _SECRET = "s3cr3tprobevaluexyz"
+    _LOGGER_NAME = "custom_components.ha_mcp_tools.websocket_api"
+
+    def _hass(self, tmp_path):
+        h = FakeHass()
+        h.config = FakeConfig(tmp_path)
+        return h
+
+    def test_valid_secrets_collected(self, tmp_path):
+        (tmp_path / "secrets.yaml").write_text(
+            f"api_password: {self._SECRET}\nother: value2\n", encoding="utf-8"
+        )
+        assert wsapi._load_secret_values(self._hass(tmp_path)) == frozenset(
+            {self._SECRET, "value2"}
         )
 
-    def test_malformed_secrets_file_degrades_without_scrubbing(
-        self, empty_view, tmp_path
-    ):
+    def test_missing_file_is_silent(self, tmp_path, caplog):
+        # No secrets.yaml written → FileNotFoundError → empty set, no warning.
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            result = wsapi._load_secret_values(self._hass(tmp_path))
+        assert result == frozenset()
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING] == [], (
+            "an absent secrets.yaml must not warn"
+        )
+
+    def test_malformed_file_warns_once(self, tmp_path, caplog):
         (tmp_path / "secrets.yaml").write_text("{not: valid: yaml: [", encoding="utf-8")
-        h = self._yaml_automation_hass(self._SECRET)
-        h.config = FakeConfig(tmp_path)
-        res = wsapi._do_search(
-            h, {"query": self._SECRET, "search_types": ["automation"]}
-        )
-        assert res["automations"], (
-            "malformed secrets.yaml must degrade to no scrubbing without error"
-        )
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER_NAME):
+            result = wsapi._load_secret_values(self._hass(tmp_path))
+        assert result == frozenset()
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, "a malformed secrets.yaml must warn exactly once"
 
-    def test_non_string_secret_values_ignored(self, empty_view, tmp_path):
-        # A numeric secret is not a plaintext-leak leaf; only string values are
-        # collected, so loading must not choke on it.
+    def test_non_string_values_ignored(self, tmp_path):
+        # A numeric scalar is not a plaintext-leak leaf; only strings are collected
+        # and the load must not choke on the non-string.
         (tmp_path / "secrets.yaml").write_text(
             f"port: 8123\napi_password: {self._SECRET}\n", encoding="utf-8"
         )
-        h = self._yaml_automation_hass(self._SECRET)
-        h.config = FakeConfig(tmp_path)
-        res = wsapi._do_search(
-            h, {"query": self._SECRET, "search_types": ["automation"]}
-        )
-        assert not res["automations"], (
-            "string secret still scrubbed alongside a non-string one"
+        assert wsapi._load_secret_values(self._hass(tmp_path)) == frozenset(
+            {self._SECRET}
         )
 
-    def test_entity_only_search_skips_secrets_read(
-        self, empty_view, tmp_path, monkeypatch
-    ):
-        # Entity-only searches never touch a config body, so the secrets.yaml read
-        # is skipped entirely (perf gate).
+    def test_no_usable_config_path_degrades(self):
+        # A hass without a callable config.path degrades to an empty set, no raise.
+        assert wsapi._load_secret_values(FakeHass()) == frozenset()
+
+
+# =============================================================================
+# search prep — off-loop secret load, skipped for entity-only searches
+# =============================================================================
+class TestSearchPrep:
+    """The ``search`` command's async pre-step loads the scrub set via the
+    executor ONLY when a config/helper surface is requested; an entity-only
+    search skips the file read entirely (perf gate)."""
+
+    def _run(self, hass, msg):
+        return asyncio.run(wsapi._search_prep(hass, msg))
+
+    def test_entity_only_skips_executor(self, monkeypatch, tmp_path):
         calls = {"n": 0}
 
-        def _spy(hass):
+        async def _spy(func, *args):
             calls["n"] += 1
-            return frozenset()
+            return func(*args)
 
-        monkeypatch.setattr(wsapi, "_load_secret_values", _spy)
         h = FakeHass(states=[FakeState("light.k", "on", "Kitchen")])
         h.config = FakeConfig(tmp_path)
-        wsapi._do_search(h, {"query": "kitchen", "search_types": ["entity"]})
+        monkeypatch.setattr(h, "async_add_executor_job", _spy)
+        extra = self._run(h, {"search_types": ["entity"]})
+        assert extra == {"secret_values": frozenset()}
         assert calls["n"] == 0, "entity-only search must not read secrets.yaml"
+
+    def test_config_surface_loads_via_executor(self, monkeypatch, tmp_path):
+        (tmp_path / "secrets.yaml").write_text(
+            "api_password: sekret\n", encoding="utf-8"
+        )
+        calls = {"n": 0}
+
+        async def _spy(func, *args):
+            calls["n"] += 1
+            return func(*args)
+
+        h = FakeHass()
+        h.config = FakeConfig(tmp_path)
+        monkeypatch.setattr(h, "async_add_executor_job", _spy)
+        extra = self._run(h, {"search_types": ["automation"]})
+        assert calls["n"] == 1, "a config surface must offload the secrets read"
+        assert extra["secret_values"] == frozenset({"sekret"})
+
+    def test_default_search_types_load_via_executor(self, tmp_path):
+        # No search_types → defaults to ALL (includes config surfaces) → loads.
+        (tmp_path / "secrets.yaml").write_text(
+            "api_password: sekret\n", encoding="utf-8"
+        )
+        h = FakeHass()
+        h.config = FakeConfig(tmp_path)
+        extra = self._run(h, {})
+        assert extra["secret_values"] == frozenset({"sekret"})
 
 
 # =============================================================================
@@ -1187,13 +1355,9 @@ class _FakeWSApi:
     def async_response(self, func):
         @functools.wraps(func)
         def wrapper(hass, connection, msg):
-            coro = func(hass, connection, msg)
-            try:
-                coro.send(None)
-            except StopIteration:
-                return
-            coro.close()
-            raise AssertionError("handler awaited unexpectedly")
+            # The handler is a coroutine (it awaits the search prep's executor
+            # offload); drive it to completion the way the WS layer would.
+            asyncio.run(func(hass, connection, msg))
 
         return wrapper
 
@@ -1503,6 +1667,82 @@ class TestHelpersList:
         assert rec["storage_id"] == "guest_mode"
         assert "Old Name" not in json.dumps(res)
 
+    def test_body_from_storage_config_surfaces_schedule_blocks(self, empty_view):
+        # Regression for the live e2e schedule-update failure: a schedule's weekday
+        # blocks live in the storage ``_config`` (reached via the EntityComponent),
+        # NOT the live state attributes, so listing must surface them + the real id.
+        state = FakeState(
+            "schedule.work",
+            "on",
+            friendly_name="Work",
+            next_event="2026-07-13T09:00:00+00:00",
+        )
+        sched = FakeCollectionEntity(
+            "schedule.work",
+            {
+                "id": "work",
+                "name": "Work",
+                "monday": [
+                    {"from": "07:00:00", "to": "09:00:00"},
+                    {"from": "17:00:00", "to": "19:00:00"},
+                ],
+            },
+            unique_id="work",
+        )
+        h = FakeHass(
+            states=[state],
+            data={"entity_components": {"schedule": FakeComponent([sched])}},
+        )
+        res = wsapi._do_helpers_list(h, {})
+        rec = next(r for r in res["helpers"] if r["helper_type"] == "schedule")
+        assert rec["storage_id"] == "work"
+        # The weekday blocks are absent from the state attributes but present here.
+        assert "monday" not in state.attributes
+        assert len(rec["config"]["monday"]) == 2
+
+    def test_body_falls_back_to_attrs_without_storage_entity(self, empty_view):
+        # A collection helper with no reachable entity (_config absent, e.g. a
+        # YAML-defined input_boolean or input_number's _attr_* layout) falls back
+        # to the state-attributes body.
+        states = [FakeState("input_boolean.legacy", "off", friendly_name="Legacy Flag")]
+        res = wsapi._do_helpers_list(
+            FakeHass(states=states), {}
+        )  # no entity_components
+        rec = next(r for r in res["helpers"] if r["helper_type"] == "input_boolean")
+        assert rec["config"]["friendly_name"] == "Legacy Flag"
+        assert rec["storage_id"] == "legacy"
+
+    def test_rename_current_name_wins_over_storage_body_name(self, monkeypatch):
+        # With a storage body present, the record ``name`` is still the CURRENT
+        # display name, not the (possibly stale) name inside the storage config.
+        state = FakeState(
+            "input_boolean.guest_mode", "off", friendly_name="Current Guest"
+        )
+        ent = FakeCollectionEntity(
+            "input_boolean.guest_mode",
+            {"id": "guest_mode", "name": "Old Name"},
+            unique_id="guest_mode",
+        )
+        view = make_view(
+            entity={
+                "input_boolean.guest_mode": FakeRegEntry(
+                    "input_boolean.guest_mode", name="Current Guest"
+                )
+            }
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        h = FakeHass(
+            states=[state],
+            data={"entity_components": {"input_boolean": FakeComponent([ent])}},
+        )
+        rec = next(
+            r
+            for r in wsapi._do_helpers_list(h, {})["helpers"]
+            if r["kind"] == "collection"
+        )
+        assert rec["name"] == "Current Guest"
+        assert rec["storage_id"] == "guest_mode"
+
     def test_flow_helper_options_and_entity_data_never_leaks(self, monkeypatch):
         entry = FakeConfigEntry(
             "template",
@@ -1785,3 +2025,31 @@ class TestOverview:
         assert res["config"] == {}
         assert res["notifications"] == []
         assert res["repairs"] == []
+        # Missing/None registries are "nothing here", not a failure: no slice_errors.
+        assert res["slice_errors"] == []
+
+    def test_slice_errors_empty_when_clean(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        monkeypatch.setattr(wsapi, "ir", FakeIssueRegModule(FakeIssueRegistry([])))
+        res = wsapi._do_overview(self._hass(), {})
+        assert res["slice_errors"] == []
+
+    def test_slice_errors_records_degraded_slice(self, monkeypatch):
+        # A registry accessor that RAISES (vs a missing/None registry) is named in
+        # slice_errors so the server can tell "empty" from "failed"; the slice
+        # still degrades to a usable empty default and other slices are unaffected.
+        class _RaisingEntityReg:
+            @property
+            def entities(self):
+                raise RuntimeError("registry read blew up")
+
+            def async_get(self, entity_id):
+                return None
+
+        view = wsapi._RegistryView(entity=_RaisingEntityReg())
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        monkeypatch.setattr(wsapi, "ir", FakeIssueRegModule(FakeIssueRegistry([])))
+        res = wsapi._do_overview(self._hass(), {})
+        assert "entity_registry" in res["slice_errors"]
+        assert res["entity_registry"] == []
+        assert res["states"], "an unrelated slice must still be populated"

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -396,6 +396,35 @@ class TestEntityJoins:
         assert len(last["entities"]) == 1
         assert last["entity_has_more"] is False
 
+    def test_underscore_space_query_equivalence(self, empty_view):
+        """Separator-normalized fuzzy matching: ``input_boolean`` and
+        ``input boolean`` queries must return the same result set (mirrors
+        e2e test_fuzzy_search_underscore_space_equivalence — the server's
+        BM25 tokenizes both sides, so the component's tier scorer compares
+        separator-normalized forms in fuzzy mode)."""
+        states = [
+            FakeState("input_boolean.guests", "off", "We Have Guests"),
+            FakeState("input_boolean.dark_mode", "on", "Dark Mode"),
+            FakeState("light.kitchen", "on", "Kitchen"),
+        ]
+        h = FakeHass(states=states)
+        underscore = wsapi._do_search(
+            h, {"query": "input_boolean", "exact": False, "limit": 20}
+        )
+        space = wsapi._do_search(
+            h, {"query": "input boolean", "exact": False, "limit": 20}
+        )
+        ids_u = {e["entity_id"] for e in underscore["entities"]}
+        ids_s = {e["entity_id"] for e in space["entities"]}
+        assert ids_u == ids_s and len(ids_u) == 2, f"underscore={ids_u} space={ids_s}"
+        assert underscore["entity_total_matches"] == space["entity_total_matches"] == 2
+        # Exact mode keeps raw substring semantics (server parity): the space
+        # form matches nothing exactly.
+        exact_space = wsapi._do_search(
+            h, {"query": "input boolean", "exact": True, "limit": 20}
+        )
+        assert exact_space["entity_total_matches"] == 0
+
     def test_match_all_on_empty_query(self, empty_view):
         states = [FakeState("light.a", "on", "A"), FakeState("light.b", "on", "B")]
         res = wsapi._do_search(FakeHass(states=states), {})

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -1,0 +1,798 @@
+"""Unit tests for the ha_mcp_tools in-process WebSocket search API.
+
+Mirrors the established component-test pattern (``test_caller_token_auth.py`` /
+``test_custom_component_filesystem.py``): the ``homeassistant.*`` imports are
+stubbed with ``MagicMock`` and the pure ``_do_*`` functions are exercised with
+fake hass / registry objects injected through the ``_resolve_registries`` seam.
+
+Coverage:
+* ``_do_info`` handshake shape + manifest/const version parity (drift guard).
+* entity joins (name / alias / area / floor / label / domain / device).
+* config matching: a YAML-loaded automation is indexed but its body is NEVER
+  emitted; a storage-backed body is emitted only under ``include_config``.
+* flow-helper ``options`` indexed while ``entry.data`` never appears anywhere in
+  the serialized response (data-minimization contract).
+* pagination, include_hidden, match-all, search_types gating.
+* admin gate present on both registered commands.
+* scorer parity against the server's ``_match_exact_search_entity`` /
+  ``calculate_ratio`` (golden corpus) so the two scorers never drift.
+* malformed-params rejection via voluptuous.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Force the REAL voluptuous into sys.modules (sibling unit modules stub it with
+# a MagicMock at import time). Captured for the schema / registration tests,
+# which need a working validator and functional decorators.
+sys.modules.pop("voluptuous", None)
+import voluptuous as _REAL_VOL  # noqa: E402
+
+# Stub the HA modules the component imports. The pure search functions never
+# touch them (registries arrive via the monkeypatched _resolve_registries seam).
+for _mod in (
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.persistent_notification",
+    "homeassistant.config",
+    "homeassistant.config_entries",
+    "homeassistant.core",
+    "homeassistant.helpers",
+    "homeassistant.helpers.config_validation",
+    "homeassistant.helpers.storage",
+    "homeassistant.loader",
+):
+    sys.modules.setdefault(_mod, MagicMock())
+
+from custom_components.ha_mcp_tools import websocket_api as wsapi  # noqa: E402
+from custom_components.ha_mcp_tools.const import COMPONENT_VERSION  # noqa: E402
+
+# Server-side scoring path the component must stay in parity with.
+from ha_mcp.tools.tools_search import _match_exact_search_entity  # noqa: E402
+from ha_mcp.utils.fuzzy_search import calculate_ratio  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# =============================================================================
+# Fakes
+# =============================================================================
+class FakeState:
+    def __init__(self, entity_id, state="on", friendly_name=None, **attrs):
+        self.entity_id = entity_id
+        self.state = state
+        self.attributes = dict(attrs)
+        if friendly_name is not None:
+            self.attributes["friendly_name"] = friendly_name
+
+
+class FakeStates:
+    def __init__(self, states):
+        self._states = list(states)
+
+    def async_all(self):
+        return list(self._states)
+
+
+class FakeConfigEntries:
+    def __init__(self, entries):
+        self._entries = list(entries)
+
+    def async_entries(self):
+        return list(self._entries)
+
+
+class FakeHass:
+    def __init__(self, states=(), data=None, config_entries=()):
+        self.states = FakeStates(states)
+        self.data = dict(data or {})
+        self.config_entries = FakeConfigEntries(config_entries)
+
+
+class FakeRegEntry:
+    def __init__(
+        self,
+        entity_id,
+        aliases=(),
+        area_id=None,
+        device_id=None,
+        labels=(),
+        hidden_by=None,
+        name=None,
+    ):
+        self.entity_id = entity_id
+        self.aliases = set(aliases)
+        self.area_id = area_id
+        self.device_id = device_id
+        self.labels = set(labels)
+        self.hidden_by = hidden_by
+        self.name = name
+
+
+class FakeEntityReg:
+    def __init__(self, entries):
+        self._entries = dict(entries)
+
+    def async_get(self, entity_id):
+        return self._entries.get(entity_id)
+
+
+class FakeArea:
+    def __init__(self, area_id, name, floor_id=None):
+        self.id = area_id
+        self.name = name
+        self.floor_id = floor_id
+
+
+class FakeAreaReg:
+    def __init__(self, areas):
+        self._areas = {a.id: a for a in areas}
+
+    def async_get_area(self, area_id):
+        return self._areas.get(area_id)
+
+
+class FakeFloor:
+    def __init__(self, floor_id, name):
+        self.floor_id = floor_id
+        self.name = name
+
+
+class FakeFloorReg:
+    def __init__(self, floors):
+        self._floors = {f.floor_id: f for f in floors}
+
+    def async_get_floor(self, floor_id):
+        return self._floors.get(floor_id)
+
+
+class FakeLabel:
+    def __init__(self, label_id, name):
+        self.label_id = label_id
+        self.name = name
+
+
+class FakeLabelReg:
+    def __init__(self, labels):
+        self._labels = {label.label_id: label for label in labels}
+
+    def async_get_label(self, label_id):
+        return self._labels.get(label_id)
+
+
+class FakeDevice:
+    def __init__(
+        self,
+        device_id,
+        name=None,
+        name_by_user=None,
+        area_id=None,
+        labels=(),
+        manufacturer=None,
+        model=None,
+    ):
+        self.id = device_id
+        self.name = name
+        self.name_by_user = name_by_user
+        self.area_id = area_id
+        self.labels = set(labels)
+        self.manufacturer = manufacturer
+        self.model = model
+
+
+class FakeDeviceReg:
+    def __init__(self, devices):
+        self._devices = {d.id: d for d in devices}
+
+    def async_get(self, device_id):
+        return self._devices.get(device_id)
+
+
+class FakeConfigEntity:
+    """Stand-in for an AutomationEntity / ScriptEntity (raw_config-bearing)."""
+
+    def __init__(self, entity_id, name=None, unique_id=None, raw_config=None):
+        self.entity_id = entity_id
+        self.name = name
+        self.unique_id = unique_id
+        self.raw_config = raw_config
+
+
+class FakeSceneEntity:
+    """Stand-in for HomeAssistantScene (scene_config, not raw_config)."""
+
+    def __init__(self, entity_id, name=None, unique_id=None, scene_config=None):
+        self.entity_id = entity_id
+        self.name = name
+        self.unique_id = unique_id
+        self.scene_config = scene_config
+
+
+class FakeComponent:
+    def __init__(self, entities):
+        self.entities = list(entities)
+
+
+class FakeConfigEntry:
+    def __init__(self, domain, title="", options=None, data=None, entry_id="entry"):
+        self.domain = domain
+        self.title = title
+        self.options = dict(options or {})
+        self.data = dict(data or {})
+        self.entry_id = entry_id
+
+
+def make_view(entity=None, areas=(), floors=(), labels=(), devices=()):
+    return wsapi._RegistryView(
+        entity=FakeEntityReg(entity or {}),
+        area=FakeAreaReg(areas),
+        floor=FakeFloorReg(floors),
+        label=FakeLabelReg(labels),
+        device=FakeDeviceReg(devices),
+    )
+
+
+@pytest.fixture
+def empty_view(monkeypatch):
+    """Patch _resolve_registries to an all-None view (states-only join)."""
+    monkeypatch.setattr(
+        wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+    )
+
+
+# =============================================================================
+# info
+# =============================================================================
+class TestInfo:
+    def test_shape(self):
+        info = wsapi._do_info()
+        assert info["schema_version"] == 1
+        assert info["component_version"] == COMPONENT_VERSION
+        assert info["capabilities"] == ["search"]
+        assert info["limits"] == {"max_results": 500, "max_body_bytes": 1_000_000}
+
+    def test_manifest_version_parity(self):
+        """The manifest version and COMPONENT_VERSION must not drift."""
+        manifest = json.loads(
+            (
+                _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
+            ).read_text(encoding="utf-8")
+        )
+        assert manifest["version"] == COMPONENT_VERSION == "1.1.0"
+
+
+# =============================================================================
+# entity joins
+# =============================================================================
+class TestEntityJoins:
+    def test_joins_and_matches_all_dimensions(self, monkeypatch):
+        states = [FakeState("light.lamp", "on", "Desk Lamp")]
+        entry = FakeRegEntry(
+            "light.lamp",
+            aliases={"reading light"},
+            area_id="a1",
+            device_id="d1",
+            labels={"lb1"},
+        )
+        view = make_view(
+            entity={"light.lamp": entry},
+            areas=[FakeArea("a1", "Office", floor_id="f1")],
+            floors=[FakeFloor("f1", "Upstairs")],
+            labels=[FakeLabel("lb1", "Favorites")],
+            devices=[
+                FakeDevice(
+                    "d1",
+                    name="Lamp Device",
+                    manufacturer="Acme",
+                    model="X1",
+                    area_id="a9",
+                    labels={"lb2"},
+                )
+            ],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        h = FakeHass(states=states)
+
+        by_alias = wsapi._do_search(h, {"query": "reading light"})
+        assert by_alias["entities"][0]["entity_id"] == "light.lamp"
+        assert by_alias["entities"][0]["score"] == 100  # exact alias match
+
+        projected = by_alias["entities"][0]
+        assert projected["area"] == "Office"
+        assert projected["floor"] == "Upstairs"
+        assert "reading light" in projected["aliases"]
+        assert "Favorites" in projected["labels"]
+
+        for query in ("office", "upstairs", "favorites", "acme", "desk lamp"):
+            res = wsapi._do_search(h, {"query": query})
+            assert res["entities"], f"expected a hit for {query!r}"
+            assert res["entities"][0]["entity_id"] == "light.lamp"
+
+    def test_domain_filter_applies_to_entities(self, monkeypatch):
+        states = [
+            FakeState("light.kitchen", "on", "Kitchen"),
+            FakeState("switch.kitchen", "on", "Kitchen"),
+        ]
+        monkeypatch.setattr(
+            wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+        )
+        res = wsapi._do_search(
+            FakeHass(states=states), {"query": "kitchen", "domain_filter": "light"}
+        )
+        ids = {e["entity_id"] for e in res["entities"]}
+        assert ids == {"light.kitchen"}
+
+    def test_state_filter(self, monkeypatch):
+        states = [
+            FakeState("light.a", "on", "Lamp A"),
+            FakeState("light.b", "off", "Lamp B"),
+        ]
+        monkeypatch.setattr(
+            wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+        )
+        res = wsapi._do_search(
+            FakeHass(states=states), {"query": "lamp", "state_filter": "off"}
+        )
+        assert {e["entity_id"] for e in res["entities"]} == {"light.b"}
+
+    def test_area_filter_by_name_or_id(self, monkeypatch):
+        states = [FakeState("light.lamp", "on", "Lamp")]
+        view = make_view(
+            entity={"light.lamp": FakeRegEntry("light.lamp", area_id="a1")},
+            areas=[FakeArea("a1", "Office")],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        h = FakeHass(states=states)
+        assert wsapi._do_search(h, {"query": "lamp", "area_filter": "Office"})[
+            "entities"
+        ]
+        assert wsapi._do_search(h, {"query": "lamp", "area_filter": "a1"})["entities"]
+        assert not wsapi._do_search(h, {"query": "lamp", "area_filter": "Garage"})[
+            "entities"
+        ]
+
+    def test_include_hidden_penalty_and_exclusion(self, monkeypatch):
+        states = [
+            FakeState("light.v", "on", "Visible"),
+            FakeState("light.h", "on", "Hidden One"),
+        ]
+        view = make_view(entity={"light.h": FakeRegEntry("light.h", hidden_by="user")})
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        h = FakeHass(states=states)
+
+        shown = wsapi._do_search(h, {"query": "light", "include_hidden": True})
+        scores = {e["entity_id"]: e["score"] for e in shown["entities"]}
+        assert scores["light.v"] == 80
+        assert scores["light.h"] == 60  # 80 - HIDDEN_SCORE_PENALTY
+
+        filtered = wsapi._do_search(h, {"query": "light", "include_hidden": False})
+        assert {e["entity_id"] for e in filtered["entities"]} == {"light.v"}
+
+    def test_pagination_per_surface(self, empty_view):
+        states = [FakeState(f"light.l{i}", "on", f"Lamp {i}") for i in range(5)]
+        h = FakeHass(states=states)
+        page1 = wsapi._do_search(h, {"query": "lamp", "limit": 2, "offset": 0})
+        assert len(page1["entities"]) == 2
+        assert page1["entity_total_matches"] == 5
+        assert page1["entity_has_more"] is True
+        last = wsapi._do_search(h, {"query": "lamp", "limit": 2, "offset": 4})
+        assert len(last["entities"]) == 1
+        assert last["entity_has_more"] is False
+
+    def test_match_all_on_empty_query(self, empty_view):
+        states = [FakeState("light.a", "on", "A"), FakeState("light.b", "on", "B")]
+        res = wsapi._do_search(FakeHass(states=states), {})
+        assert res["entity_total_matches"] == 2
+        assert all(
+            e["match_type"] == "match_all" and e["score"] == 100
+            for e in res["entities"]
+        )
+
+
+# =============================================================================
+# config surfaces — YAML body withholding, storage emission
+# =============================================================================
+class TestConfigSurfaces:
+    def _hass(self):
+        yaml_auto = FakeConfigEntity(
+            "automation.pkg",
+            "Package Auto",
+            unique_id=None,
+            raw_config={
+                "alias": "Package Auto",
+                "action": [{"service": "notify.x", "data": {"message": "YAMLSECRET"}}],
+            },
+        )
+        storage_auto = FakeConfigEntity(
+            "automation.ui",
+            "UI Auto",
+            unique_id="uid-1",
+            raw_config={
+                "id": "uid-1",
+                "alias": "UI Auto",
+                "action": [{"service": "light.turn_on"}],
+            },
+        )
+        return FakeHass(data={"automation": FakeComponent([yaml_auto, storage_auto])})
+
+    def test_yaml_body_never_emitted_storage_body_emitted(self, empty_view):
+        h = self._hass()
+        res = wsapi._do_search(h, {"query": "auto", "include_config": True})
+        yaml_rec = next(a for a in res["automations"] if a["source"] == "yaml")
+        storage_rec = next(a for a in res["automations"] if a["source"] == "storage")
+        assert yaml_rec["config"] is None
+        assert yaml_rec["id"] is None
+        assert storage_rec["config"] is not None
+        assert storage_rec["config"]["id"] == "uid-1"
+        assert "YAMLSECRET" not in json.dumps(res)
+
+    def test_yaml_body_indexed_for_matching_but_withheld(self, empty_view):
+        h = self._hass()
+        res = wsapi._do_search(h, {"query": "yamlsecret", "include_config": True})
+        hits = [a for a in res["automations"] if a["source"] == "yaml"]
+        assert hits, "YAML body should be indexed for matching"
+        assert hits[0]["match_in_config"] is True
+        assert hits[0]["config"] is None
+        assert "YAMLSECRET" not in json.dumps(res)
+
+    def test_storage_body_withheld_without_include_config(self, empty_view):
+        h = self._hass()
+        res = wsapi._do_search(h, {"query": "auto"})  # include_config defaults False
+        for rec in res["automations"]:
+            assert rec["config"] is None
+
+    def test_scene_matches_via_scene_config(self, empty_view):
+        scene = FakeSceneEntity(
+            "scene.movie",
+            "Movie Night",
+            unique_id="scn-1",
+            scene_config={"id": "scn-1", "name": "Movie Night", "icon": "mdi:movie"},
+        )
+        h = FakeHass(data={"scene": FakeComponent([scene])})
+        res = wsapi._do_search(h, {"query": "movie", "include_config": True})
+        assert res["scenes"]
+        rec = res["scenes"][0]
+        assert rec["name"] == "Movie Night"
+        assert rec["source"] == "storage"
+        assert rec["config"]["id"] == "scn-1"
+
+    def test_config_combined_pagination(self, empty_view):
+        autos = [
+            FakeConfigEntity(
+                f"automation.a{i}",
+                f"Auto {i}",
+                f"u{i}",
+                {"id": f"u{i}", "alias": f"Auto {i}"},
+            )
+            for i in range(3)
+        ]
+        scenes = [
+            FakeSceneEntity(
+                "scene.s0", "Auto Scene", "sid0", {"id": "sid0", "name": "Auto Scene"}
+            )
+        ]
+        h = FakeHass(
+            data={
+                "automation": FakeComponent(autos),
+                "scene": FakeComponent(scenes),
+            }
+        )
+        res = wsapi._do_search(h, {"query": "auto", "limit": 2, "offset": 0})
+        assert res["config_total_matches"] == 4
+        assert res["config_has_more"] is True
+        assert len(res["automations"]) + len(res["scenes"]) == 2
+
+    def test_search_types_gating(self, empty_view):
+        states = [FakeState("light.k", "on", "Kitchen")]
+        auto = FakeConfigEntity(
+            "automation.k",
+            "Kitchen Auto",
+            "uid",
+            {"id": "uid", "alias": "Kitchen Auto"},
+        )
+        h = FakeHass(states=states, data={"automation": FakeComponent([auto])})
+        only_entity = wsapi._do_search(
+            h, {"query": "kitchen", "search_types": ["entity"]}
+        )
+        assert only_entity["entities"] and not only_entity["automations"]
+        only_auto = wsapi._do_search(
+            h, {"query": "kitchen", "search_types": ["automation"]}
+        )
+        assert only_auto["automations"] and not only_auto["entities"]
+
+    def test_inaccessible_component_counted_in_diagnostics(self, empty_view):
+        # No "automation" key in hass.data -> component inaccessible.
+        res = wsapi._do_search(
+            FakeHass(), {"query": "x", "search_types": ["automation"]}
+        )
+        assert res["automations"] == []
+        assert res["diagnostics"]["config_components_inaccessible"] == 1
+
+
+# =============================================================================
+# helpers — flow-helper options indexed; entry.data must never leak
+# =============================================================================
+class TestHelpers:
+    def test_flow_helper_options_indexed_data_never_leaks(self, empty_view):
+        entry = FakeConfigEntry(
+            "template",
+            title="Sun Sensor",
+            options={"state": "{{ is_state('sun.sun', 'above_horizon') }}"},
+            data={"api_key": "DATA_SECRET_XYZ"},
+            entry_id="e1",
+        )
+        h = FakeHass(config_entries=[entry])
+
+        res = wsapi._do_search(h, {"query": "sun", "include_config": True})
+        flow = [x for x in res["helpers"] if x["kind"] == "flow"]
+        assert flow
+        assert flow[0]["helper_type"] == "template"
+        assert flow[0]["entry_id"] == "e1"
+        assert flow[0]["options"] == {
+            "state": "{{ is_state('sun.sun', 'above_horizon') }}"
+        }
+        serialized = json.dumps(res)
+        assert "DATA_SECRET_XYZ" not in serialized
+        assert "api_key" not in serialized
+
+        by_option = wsapi._do_search(h, {"query": "above_horizon"})
+        assert [x for x in by_option["helpers"] if x["kind"] == "flow"]
+
+    def test_flow_helper_options_withheld_without_include_config(self, empty_view):
+        entry = FakeConfigEntry(
+            "template",
+            title="Sun Sensor",
+            options={"state": "x"},
+            data={},
+            entry_id="e1",
+        )
+        res = wsapi._do_search(FakeHass(config_entries=[entry]), {"query": "sun"})
+        flow = [x for x in res["helpers"] if x["kind"] == "flow"]
+        assert flow and flow[0]["options"] is None
+
+    def test_collection_helper_indexed(self, empty_view):
+        states = [FakeState("input_boolean.guest_mode", "off", "Guest Mode")]
+        res = wsapi._do_search(
+            FakeHass(states=states), {"query": "guest", "search_types": ["helper"]}
+        )
+        coll = [x for x in res["helpers"] if x["kind"] == "collection"]
+        assert coll
+        assert coll[0]["helper_type"] == "input_boolean"
+        assert coll[0]["object_id"] == "guest_mode"
+        assert coll[0]["config"] is None
+
+
+# =============================================================================
+# scorer parity (golden corpus)
+# =============================================================================
+_PARITY_CORPUS = [
+    ("light.kitchen", "Kitchen Light"),
+    ("light.kitchen_ceiling", "Kitchen Ceiling"),
+    ("switch.kitchen", "Kitchen Switch"),
+    ("sensor.temperature", "Temperature"),
+    ("light.bedroom", "Bedroom Light"),
+]
+_PARITY_HIDDEN = {"light.bedroom"}
+_PARITY_QUERIES = [
+    "kitchen",
+    "light.kitchen",
+    "temperature",
+    "bedroom",
+    "kitchen light",
+]
+
+
+class TestScorerParity:
+    def _server_ranking(self, query_lower):
+        ranked = []
+        for entity_id, friendly in _PARITY_CORPUS:
+            entity = {
+                "entity_id": entity_id,
+                "attributes": {"friendly_name": friendly},
+                "state": "on",
+            }
+            match = _match_exact_search_entity(
+                entity, query_lower, None, set(), _PARITY_HIDDEN, True
+            )
+            if match:
+                ranked.append((match["entity_id"], match["score"]))
+        ranked.sort(key=lambda x: (-x[1], x[0]))
+        return ranked
+
+    def _component_ranking(self, query_lower):
+        states = [FakeState(eid, "on", fn) for eid, fn in _PARITY_CORPUS]
+        view = make_view(
+            entity={
+                eid: FakeRegEntry(
+                    eid, hidden_by=("user" if eid in _PARITY_HIDDEN else None)
+                )
+                for eid, _ in _PARITY_CORPUS
+            }
+        )
+        recs = wsapi._search_entities(
+            FakeHass(states=states),
+            view,
+            query_lower,
+            match_all=False,
+            exact=True,
+            include_hidden=True,
+            domain_filter=None,
+            area_filter=None,
+            state_filter=None,
+        )
+        recs.sort(key=lambda r: (-r["score"], r["entity_id"]))
+        return [(r["entity_id"], r["score"]) for r in recs]
+
+    def test_exact_mode_ranked_ids_and_scores_match_server(self):
+        for query in _PARITY_QUERIES:
+            ql = query.lower()
+            assert self._component_ranking(ql) == self._server_ranking(ql), (
+                f"parity broke for query={query!r}"
+            )
+
+    def test_fuzzy_tiers_match_calculate_ratio(self):
+        # exact token -> 100
+        assert wsapi._text_tier("kitchen", ["kitchen"], fuzzy=True) == 100
+        # substring -> 80 (not the fuzzy ratio)
+        assert wsapi._text_tier("kit", ["kitchen"], fuzzy=True) == 80
+        # typo within threshold -> the server's calculate_ratio value exactly
+        typo = wsapi._text_tier("kitchne", ["kitchen"], fuzzy=True)
+        assert typo == calculate_ratio("kitchne", "kitchen")
+        assert typo >= wsapi.FUZZY_THRESHOLD
+        # below threshold -> no match
+        assert wsapi._text_tier("zzzzzzzz", ["kitchen"], fuzzy=True) is None
+        # exact mode never fuzzy-matches a typo
+        assert wsapi._text_tier("kitchne", ["kitchen"], fuzzy=False) is None
+
+    def test_config_exact_is_binary_100(self):
+        # config name substring => 100 (not the entity 80 tier)
+        scored = wsapi._config_score(
+            "kit",
+            "automation.kit",
+            "Kitchen Auto",
+            {"alias": "Kitchen Auto"},
+            exact=True,
+        )
+        assert scored is not None
+        total, in_name, in_config = scored
+        assert total == 100 and in_name is True
+
+
+# =============================================================================
+# registration, admin gate, malformed params (functional decorators)
+# =============================================================================
+class _Unauthorized(Exception):
+    pass
+
+
+class _FakeUser:
+    def __init__(self, is_admin):
+        self.is_admin = is_admin
+
+
+class _FakeConnection:
+    def __init__(self, is_admin=True, has_user=True):
+        self.user = _FakeUser(is_admin) if has_user else None
+        self.results = {}
+
+    def send_result(self, msg_id, result):
+        self.results[msg_id] = result
+
+
+class _FakeWSApi:
+    """Functional stand-in for homeassistant.components.websocket_api."""
+
+    def __init__(self):
+        self.registered = {}
+
+    def websocket_command(self, schema):
+        command = next(v for k, v in schema.items() if str(k) == "type")
+
+        def decorate(func):
+            func._ws_command = command
+            func._ws_schema = schema
+            return func
+
+        return decorate
+
+    def require_admin(self, func):
+        @functools.wraps(func)
+        def wrapper(hass, connection, msg):
+            user = connection.user
+            if user is None or not user.is_admin:
+                raise _Unauthorized()
+            return func(hass, connection, msg)
+
+        return wrapper
+
+    def async_response(self, func):
+        @functools.wraps(func)
+        def wrapper(hass, connection, msg):
+            coro = func(hass, connection, msg)
+            try:
+                coro.send(None)
+            except StopIteration:
+                return
+            coro.close()
+            raise AssertionError("handler awaited unexpectedly")
+
+        return wrapper
+
+    def async_register_command(self, hass, handler):
+        self.registered[handler._ws_command] = handler
+
+
+@pytest.fixture
+def functional_ws(monkeypatch):
+    fake = _FakeWSApi()
+    monkeypatch.setattr(wsapi, "websocket_api", fake)
+    monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+    monkeypatch.setattr(
+        wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
+    )
+    wsapi.async_register_commands(FakeHass())
+    return fake
+
+
+class TestRegistrationAndAdminGate:
+    def test_both_commands_registered(self, functional_ws):
+        assert set(functional_ws.registered) == {wsapi.WS_INFO, wsapi.WS_SEARCH}
+
+    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+    def test_non_admin_rejected(self, functional_ws, command):
+        handler = functional_ws.registered[command]
+        conn = _FakeConnection(is_admin=False)
+        with pytest.raises(_Unauthorized):
+            handler(FakeHass(), conn, {"id": 1, "type": command})
+
+    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+    def test_no_user_rejected(self, functional_ws, command):
+        handler = functional_ws.registered[command]
+        conn = _FakeConnection(has_user=False)
+        with pytest.raises(_Unauthorized):
+            handler(FakeHass(), conn, {"id": 2, "type": command})
+
+    @pytest.mark.parametrize("command", ["ha_mcp_tools/info", "ha_mcp_tools/search"])
+    def test_admin_call_sends_result(self, functional_ws, command):
+        handler = functional_ws.registered[command]
+        conn = _FakeConnection(is_admin=True)
+        handler(FakeHass(), conn, {"id": 9, "type": command})
+        assert 9 in conn.results
+        assert isinstance(conn.results[9], dict)
+
+
+class TestSchemaValidation:
+    def _schema(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        return _REAL_VOL.Schema(wsapi._search_schema())
+
+    def test_valid_params_apply_defaults(self, monkeypatch):
+        schema = self._schema(monkeypatch)
+        out = schema({"type": wsapi.WS_SEARCH, "query": "kitchen"})
+        assert out["exact"] is True
+        assert out["include_hidden"] is True
+        assert out["include_config"] is False
+        assert out["limit"] == wsapi.DEFAULT_LIMIT
+        assert out["offset"] == 0
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"type": "ha_mcp_tools/search", "limit": 0},
+            {"type": "ha_mcp_tools/search", "limit": 9999},
+            {"type": "ha_mcp_tools/search", "offset": -1},
+            {"type": "ha_mcp_tools/search", "search_types": ["bogus"]},
+            {"type": "ha_mcp_tools/search", "exact": "yes"},
+        ],
+    )
+    def test_malformed_params_rejected(self, monkeypatch, bad):
+        schema = self._schema(monkeypatch)
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema(bad)

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -387,10 +387,12 @@ class TestInfo:
         assert info["component_version"] == COMPONENT_VERSION
         assert info["capabilities"] == [
             "search",
-            "config_get",
             "overview",
             "helpers_list",
         ]
+        # config_get was withdrawn before release (raw_config freshness lags the
+        # config file between write and reload) — it must not be advertised.
+        assert "config_get" not in info["capabilities"]
         assert info["limits"] == {"max_results": 500, "max_body_bytes": 1_000_000}
 
     def test_manifest_version_parity(self):
@@ -1380,16 +1382,15 @@ def functional_ws(monkeypatch):
 _ALL_COMMANDS = [
     "ha_mcp_tools/info",
     "ha_mcp_tools/search",
-    "ha_mcp_tools/config_get",
     "ha_mcp_tools/overview",
     "ha_mcp_tools/helpers_list",
 ]
 
 # Minimal well-formed message body per command (Required fields) so the admin
-# gate / async_response wrappers reach the pure handler.
-_CMD_MSG_EXTRA = {
-    "ha_mcp_tools/config_get": {"domain": "automation", "item_id": "nope"},
-}
+# gate / async_response wrappers reach the pure handler. Empty now that
+# config_get (which required domain + item_id) is withdrawn — every remaining
+# command has no Required field beyond ``type``.
+_CMD_MSG_EXTRA: dict[str, dict[str, object]] = {}
 
 
 class TestRegistrationAndAdminGate:
@@ -1397,10 +1398,11 @@ class TestRegistrationAndAdminGate:
         assert set(functional_ws.registered) == {
             wsapi.WS_INFO,
             wsapi.WS_SEARCH,
-            wsapi.WS_CONFIG_GET,
             wsapi.WS_OVERVIEW,
             wsapi.WS_HELPERS_LIST,
         }
+        # config_get is withdrawn: no handler is registered for it.
+        assert "ha_mcp_tools/config_get" not in functional_ws.registered
 
     @pytest.mark.parametrize("command", _ALL_COMMANDS)
     def test_non_admin_rejected(self, functional_ws, command):
@@ -1457,34 +1459,11 @@ class TestSchemaValidation:
 
 
 class TestNewCommandSchemas:
-    """Voluptuous validation for config_get / overview / helpers_list."""
+    """Voluptuous validation for overview / helpers_list."""
 
     def _schema(self, monkeypatch, schema_fn):
         monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
         return _REAL_VOL.Schema(schema_fn())
-
-    def test_config_get_valid(self, monkeypatch):
-        schema = self._schema(monkeypatch, wsapi._config_get_schema)
-        out = schema(
-            {"type": wsapi.WS_CONFIG_GET, "domain": "script", "item_id": "abc"}
-        )
-        assert out["domain"] == "script"
-        assert out["item_id"] == "abc"
-
-    @pytest.mark.parametrize(
-        "bad",
-        [
-            {"type": "ha_mcp_tools/config_get", "domain": "light", "item_id": "x"},
-            # scene is excluded from config_get (legacy-only; no in-memory body).
-            {"type": "ha_mcp_tools/config_get", "domain": "scene", "item_id": "x"},
-            {"type": "ha_mcp_tools/config_get", "domain": "automation"},  # no item_id
-            {"type": "ha_mcp_tools/config_get", "item_id": "x"},  # no domain
-        ],
-    )
-    def test_config_get_malformed_rejected(self, monkeypatch, bad):
-        schema = self._schema(monkeypatch, wsapi._config_get_schema)
-        with pytest.raises(_REAL_VOL.Invalid):
-            schema(bad)
 
     def test_overview_defaults(self, monkeypatch):
         schema = self._schema(monkeypatch, wsapi._overview_schema)
@@ -1516,109 +1495,27 @@ class TestNewCommandSchemas:
 
 
 # =============================================================================
-# config_get — storage-only body fetch; YAML -> structured not-found (no body)
+# config_get — withdrawn before release (raw_config freshness lag)
 # =============================================================================
-class TestConfigGet:
-    def _storage_hass(self):
-        storage_auto = FakeConfigEntity(
-            "automation.ui",
-            "UI Auto",
-            unique_id="uid-1",
-            raw_config={
-                "id": "uid-1",
-                "alias": "UI Auto",
-                "action": [{"service": "light.turn_on"}],
-            },
-        )
-        yaml_auto = FakeConfigEntity(
-            "automation.pkg",
-            "Package Auto",
-            unique_id=None,
-            raw_config={
-                "alias": "Package Auto",
-                "action": [{"service": "notify.x", "data": {"message": "YAMLSECRET"}}],
-            },
-        )
-        h = FakeHass(
-            states=[FakeState("automation.ui", "on", "UI Auto Live")],
-            data={"automation": FakeComponent([storage_auto, yaml_auto])},
-        )
-        return h
+class TestConfigGetWithdrawn:
+    """``config_get`` was withdrawn before release: it served an entity's
+    ``raw_config``, whose freshness lags the config file between a write and the
+    next completed reload, so a get racing a reload returned a stale body. The
+    command, its schema, its capability, and its domain gate are all gone — the
+    get tools serve automation/script reads from the legacy REST path (which
+    reads the fresh config file). These pin that nothing component-side still
+    exposes it (issue #1813 tracks a possible file-reading redesign)."""
 
-    def _view(self):
-        return make_view(
-            entity={
-                "automation.ui": FakeRegEntry(
-                    "automation.ui", categories={"automation": "cat-morning"}
-                )
-            }
-        )
+    def test_capability_not_advertised(self):
+        assert "config_get" not in wsapi.CAPABILITIES
 
-    def test_storage_item_full_payload(self, monkeypatch):
-        h = self._storage_hass()
-        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
-        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": "uid-1"})
-        assert res["found"] is True
-        assert res["source"] == "storage"
-        assert res["domain"] == "automation"
-        assert res["item_id"] == "uid-1"
-        assert res["entity_id"] == "automation.ui"
-        # Current friendly_name comes from the live state, not the storage name.
-        assert res["friendly_name"] == "UI Auto Live"
-        assert res["config"]["id"] == "uid-1"
-        assert res["category"] == "cat-morning"
+    def test_no_command_constant_schema_or_domain_gate(self):
+        assert not hasattr(wsapi, "WS_CONFIG_GET")
+        assert not hasattr(wsapi, "_config_get_schema")
+        assert not hasattr(wsapi, "CONFIG_GET_DOMAINS")
 
-    @pytest.mark.parametrize("item_id", ["uid-1", "automation.ui", "ui"])
-    def test_resolves_by_id_entity_id_or_slug(self, monkeypatch, item_id):
-        h = self._storage_hass()
-        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
-        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": item_id})
-        assert res["found"] is True
-        assert res["entity_id"] == "automation.ui"
-
-    def test_yaml_item_structured_not_found_no_body(self, empty_view):
-        h = self._storage_hass()
-        res = wsapi._do_config_get(
-            h, {"domain": "automation", "item_id": "automation.pkg"}
-        )
-        assert res["found"] is False
-        assert res["source"] == "yaml"
-        assert res["entity_id"] == "automation.pkg"
-        # The YAML body must never appear anywhere in the response.
-        assert "config" not in res
-        assert "YAMLSECRET" not in json.dumps(res)
-
-    def test_absent_item_not_found(self, empty_view):
-        h = self._storage_hass()
-        res = wsapi._do_config_get(h, {"domain": "automation", "item_id": "ghost"})
-        assert res["found"] is False
-        assert res["source"] is None
-        assert "config" not in res
-
-    def test_inaccessible_component_not_found(self, empty_view):
-        res = wsapi._do_config_get(
-            FakeHass(), {"domain": "script", "item_id": "whatever"}
-        )
-        assert res["found"] is False
-        assert res["source"] is None
-
-    def test_scene_domain_rejected_by_schema(self, monkeypatch):
-        """Scenes are NOT a valid config_get domain — the voluptuous schema
-        rejects ``domain='scene'``. ``ha_config_get_scene`` stays on its legacy
-        REST path because a ``HomeAssistantScene`` holds no raw storage body in
-        memory (``scene_config.states`` is runtime State objects). config_get is
-        automation/script only."""
-        assert "scene" not in wsapi.CONFIG_GET_DOMAINS
-        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
-        schema = _REAL_VOL.Schema(wsapi._config_get_schema())
-        with pytest.raises(_REAL_VOL.Invalid):
-            schema(
-                {
-                    "type": wsapi.WS_CONFIG_GET,
-                    "domain": "scene",
-                    "item_id": "movie_night",
-                }
-            )
+    def test_no_handler_function(self):
+        assert not hasattr(wsapi, "_do_config_get")
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -1311,6 +1311,8 @@ class TestNewCommandSchemas:
         "bad",
         [
             {"type": "ha_mcp_tools/config_get", "domain": "light", "item_id": "x"},
+            # scene is excluded from config_get (legacy-only; no in-memory body).
+            {"type": "ha_mcp_tools/config_get", "domain": "scene", "item_id": "x"},
             {"type": "ha_mcp_tools/config_get", "domain": "automation"},  # no item_id
             {"type": "ha_mcp_tools/config_get", "item_id": "x"},  # no domain
         ],
@@ -1436,23 +1438,23 @@ class TestConfigGet:
         assert res["found"] is False
         assert res["source"] is None
 
-    def test_scene_storage_body(self, monkeypatch):
-        scene = FakeSceneEntity(
-            "scene.movie",
-            "Movie Night",
-            unique_id="scn-1",
-            scene_config={"id": "scn-1", "name": "Movie Night", "icon": "mdi:movie"},
-        )
-        h = FakeHass(data={"scene": FakeComponent([scene])})
-        monkeypatch.setattr(
-            wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
-        )
-        res = wsapi._do_config_get(h, {"domain": "scene", "item_id": "scn-1"})
-        assert res["found"] is True
-        assert res["source"] == "storage"
-        assert res["config"]["name"] == "Movie Night"
-        # No registry -> category degrades to None, not an error.
-        assert res["category"] is None
+    def test_scene_domain_rejected_by_schema(self, monkeypatch):
+        """Scenes are NOT a valid config_get domain — the voluptuous schema
+        rejects ``domain='scene'``. ``ha_config_get_scene`` stays on its legacy
+        REST path because a ``HomeAssistantScene`` holds no raw storage body in
+        memory (``scene_config.states`` is runtime State objects). config_get is
+        automation/script only."""
+        assert "scene" not in wsapi.CONFIG_GET_DOMAINS
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._config_get_schema())
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema(
+                {
+                    "type": wsapi.WS_CONFIG_GET,
+                    "domain": "scene",
+                    "item_id": "movie_night",
+                }
+            )
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -229,6 +229,16 @@ class FakeConfigEntry:
         self.entry_id = entry_id
 
 
+class FakeConfig:
+    """Stand-in for ``hass.config`` whose ``path()`` roots at a temp dir."""
+
+    def __init__(self, base_dir):
+        self._base = Path(base_dir)
+
+    def path(self, *parts):
+        return str(self._base.joinpath(*parts))
+
+
 def make_view(entity=None, areas=(), floors=(), labels=(), devices=()):
     return wsapi._RegistryView(
         entity=FakeEntityReg(entity or {}),
@@ -568,6 +578,243 @@ class TestHelpers:
         assert coll[0]["object_id"] == "guest_mode"
         assert coll[0]["config"] is None
 
+    def test_collection_helper_body_indexed_by_option_value(self, empty_view):
+        """Mirror e2e ``test_deep_search_helper``: an input_select's option value
+        lives in the state attributes, not the name, and must be searchable +
+        report ``match_in_config`` (parity with the legacy ``<type>/list`` body
+        search) and, under include_config, emit that body."""
+        states = [
+            FakeState(
+                "input_select.house_mode",
+                "day",
+                friendly_name="House Mode",
+                options=["day", "deep_search_option_a", "night"],
+            )
+        ]
+        res = wsapi._do_search(
+            FakeHass(states=states),
+            {
+                "query": "deep_search_option_a",
+                "search_types": ["helper"],
+                "include_config": True,
+            },
+        )
+        coll = [x for x in res["helpers"] if x["kind"] == "collection"]
+        assert coll, "option-value query must find the input_select helper"
+        rec = coll[0]
+        assert rec["helper_type"] == "input_select"
+        assert rec["match_in_config"] is True
+        assert rec["match_in_name"] is False
+        assert "deep_search_option_a" in json.dumps(rec["config"])
+
+    def test_collection_helper_body_withheld_without_include_config(self, empty_view):
+        states = [
+            FakeState(
+                "input_select.house_mode",
+                "day",
+                friendly_name="House Mode",
+                options=["deep_search_option_a"],
+            )
+        ]
+        res = wsapi._do_search(
+            FakeHass(states=states),
+            {"query": "deep_search_option_a", "search_types": ["helper"]},
+        )
+        coll = [x for x in res["helpers"] if x["kind"] == "collection"]
+        assert coll and coll[0]["config"] is None
+
+    def test_flow_helper_mappingproxy_options_indexed(self, empty_view):
+        """Regression: ``ConfigEntry.options`` is a ``MappingProxyType`` in live
+        HA, not a ``dict``. The old ``isinstance(..., dict)`` guard dropped it to
+        ``{}`` so a template helper's body was never searchable — e2e
+        ``test_deep_search_finds_ui_template_helper`` /
+        ``test_deep_search_flow_helper_fuzzy_probes_config`` timed out. A body
+        token must match through a MappingProxy in both exact and fuzzy mode."""
+        from types import MappingProxyType
+
+        marker = "deepsearchtemplatebody4471"
+        entry = FakeConfigEntry(
+            "template",
+            title="Deep Search Template Helper",
+            options={
+                "name": "Deep Search Template Helper",
+                "state": "{{ states('sensor." + marker + "') }}",
+            },
+            data={},
+            entry_id="e1",
+        )
+        # Reproduce the live-HA type exactly: options is a read-only proxy.
+        entry.options = MappingProxyType(dict(entry.options))
+        h = FakeHass(config_entries=[entry])
+
+        for exact in (True, False):
+            res = wsapi._do_search(
+                h,
+                {
+                    "query": marker,
+                    "search_types": ["helper"],
+                    "exact": exact,
+                    "include_config": True,
+                },
+            )
+            flow = [x for x in res["helpers"] if x["kind"] == "flow"]
+            assert flow, f"body token must match through MappingProxy (exact={exact})"
+            assert flow[0]["entry_id"] == "e1"
+            assert flow[0]["helper_type"] == "template"
+            assert flow[0]["match_in_config"] is True
+            assert marker in json.dumps(flow[0]["options"])
+
+
+def test_flow_helper_domains_cover_server_flow_helper_types():
+    """The component must index every domain the server routes as a flow helper,
+    or a UI-created helper of a covered type would be invisible to the component
+    path (e2e ``test_deep_search_finds_non_template_flow_helpers``)."""
+    from ha_mcp.tools.config_entry_flow import FLOW_HELPER_TYPES
+
+    missing = set(FLOW_HELPER_TYPES) - wsapi.FLOW_HELPER_DOMAINS
+    assert not missing, f"component FLOW_HELPER_DOMAINS misses server types: {missing}"
+
+
+# =============================================================================
+# secret scrub — resolved !secret plaintext is BLOCKED from the match corpus
+# =============================================================================
+class TestSecretScrub:
+    """A resolved ``!secret`` value in a config body must never produce a match,
+    so ``ha_search`` cannot be used as a probe oracle (query a suspected secret,
+    confirm it via ``match_in_config``). The value is blocked, not just unemitted.
+    """
+
+    _SECRET = "s3cr3tprobevaluexyz"
+
+    def _yaml_automation_hass(self, secret_value):
+        # A YAML-defined automation (unique_id=None → body never emitted) whose
+        # body carries a resolved secret next to a normal, non-secret token.
+        auto = FakeConfigEntity(
+            "automation.leaky",
+            "Leaky Auto",
+            unique_id=None,
+            raw_config={
+                "alias": "Leaky Auto",
+                "action": [
+                    {
+                        "service": "notify.x",
+                        "data": {
+                            "api_password": secret_value,
+                            "message": "normalbodytoken",
+                        },
+                    }
+                ],
+            },
+        )
+        return FakeHass(data={"automation": FakeComponent([auto])})
+
+    def _write_secrets(self, tmp_path, **values):
+        body = "".join(f"{k}: {v}\n" for k, v in values.items())
+        (tmp_path / "secrets.yaml").write_text(body, encoding="utf-8")
+
+    def test_secret_value_scrubbed_but_normal_token_matches(self, empty_view, tmp_path):
+        self._write_secrets(tmp_path, api_password=self._SECRET)
+        h = self._yaml_automation_hass(self._SECRET)
+        h.config = FakeConfig(tmp_path)
+
+        by_secret = wsapi._do_search(
+            h, {"query": self._SECRET, "search_types": ["automation"]}
+        )
+        assert not by_secret["automations"], (
+            "a query equal to a resolved secret must not match (probe oracle)"
+        )
+
+        by_token = wsapi._do_search(
+            h, {"query": "normalbodytoken", "search_types": ["automation"]}
+        )
+        assert any(a["match_in_config"] for a in by_token["automations"]), (
+            "a non-secret body token must still match after scrubbing"
+        )
+
+    def test_secret_scrubbed_in_fuzzy_mode(self, empty_view, tmp_path):
+        self._write_secrets(tmp_path, api_password=self._SECRET)
+        h = self._yaml_automation_hass(self._SECRET)
+        h.config = FakeConfig(tmp_path)
+        res = wsapi._do_search(
+            h,
+            {"query": self._SECRET, "search_types": ["automation"], "exact": False},
+        )
+        assert not res["automations"], "fuzzy mode must also scrub the secret leaf"
+
+    def test_flow_helper_option_secret_scrubbed(self, empty_view, tmp_path):
+        self._write_secrets(tmp_path, tmpl_secret=self._SECRET)
+        entry = FakeConfigEntry(
+            "template",
+            title="Sun Sensor",
+            options={"state": self._SECRET, "name": "Sun Sensor"},
+            entry_id="e1",
+        )
+        h = FakeHass(config_entries=[entry])
+        h.config = FakeConfig(tmp_path)
+        res = wsapi._do_search(h, {"query": self._SECRET, "search_types": ["helper"]})
+        assert not [x for x in res["helpers"] if x["kind"] == "flow"], (
+            "a flow-helper option equal to a secret must not match"
+        )
+
+    def test_missing_secrets_file_degrades_without_scrubbing(
+        self, empty_view, tmp_path
+    ):
+        # No secrets.yaml under tmp_path → no scrub → the value matches (proves
+        # the degrade-off path runs without error).
+        h = self._yaml_automation_hass(self._SECRET)
+        h.config = FakeConfig(tmp_path)
+        res = wsapi._do_search(
+            h, {"query": self._SECRET, "search_types": ["automation"]}
+        )
+        assert res["automations"], (
+            "absent secrets.yaml must degrade to no scrubbing without error"
+        )
+
+    def test_malformed_secrets_file_degrades_without_scrubbing(
+        self, empty_view, tmp_path
+    ):
+        (tmp_path / "secrets.yaml").write_text("{not: valid: yaml: [", encoding="utf-8")
+        h = self._yaml_automation_hass(self._SECRET)
+        h.config = FakeConfig(tmp_path)
+        res = wsapi._do_search(
+            h, {"query": self._SECRET, "search_types": ["automation"]}
+        )
+        assert res["automations"], (
+            "malformed secrets.yaml must degrade to no scrubbing without error"
+        )
+
+    def test_non_string_secret_values_ignored(self, empty_view, tmp_path):
+        # A numeric secret is not a plaintext-leak leaf; only string values are
+        # collected, so loading must not choke on it.
+        (tmp_path / "secrets.yaml").write_text(
+            f"port: 8123\napi_password: {self._SECRET}\n", encoding="utf-8"
+        )
+        h = self._yaml_automation_hass(self._SECRET)
+        h.config = FakeConfig(tmp_path)
+        res = wsapi._do_search(
+            h, {"query": self._SECRET, "search_types": ["automation"]}
+        )
+        assert not res["automations"], (
+            "string secret still scrubbed alongside a non-string one"
+        )
+
+    def test_entity_only_search_skips_secrets_read(
+        self, empty_view, tmp_path, monkeypatch
+    ):
+        # Entity-only searches never touch a config body, so the secrets.yaml read
+        # is skipped entirely (perf gate).
+        calls = {"n": 0}
+
+        def _spy(hass):
+            calls["n"] += 1
+            return frozenset()
+
+        monkeypatch.setattr(wsapi, "_load_secret_values", _spy)
+        h = FakeHass(states=[FakeState("light.k", "on", "Kitchen")])
+        h.config = FakeConfig(tmp_path)
+        wsapi._do_search(h, {"query": "kitchen", "search_types": ["entity"]})
+        assert calls["n"] == 0, "entity-only search must not read secrets.yaml"
+
 
 # =============================================================================
 # scorer parity (golden corpus)
@@ -663,6 +910,98 @@ class TestScorerParity:
         assert scored is not None
         total, in_name, in_config = scored
         assert total == 100 and in_name is True
+
+
+# =============================================================================
+# match_type taxonomy parity (Group 3 — #1166 / #1170 finding 8)
+# =============================================================================
+class TestMatchTypeTaxonomy:
+    """The component's fuzzy match_type must mirror the server's taxonomy —
+    ``alias_match`` for an alias-driven hit, the ``_get_match_type`` tiers
+    otherwise — while exact mode keeps the server's flat ``exact_match``.
+    """
+
+    def _match_type(self, monkeypatch, entity_id, friendly, aliases, query, *, exact):
+        view = make_view(entity={entity_id: FakeRegEntry(entity_id, aliases=aliases)})
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+        recs = wsapi._search_entities(
+            FakeHass(states=[FakeState(entity_id, "on", friendly)]),
+            view,
+            query.lower(),
+            match_all=False,
+            exact=exact,
+            include_hidden=True,
+            domain_filter=None,
+            area_filter=None,
+            state_filter=None,
+        )
+        assert recs, f"expected a hit for {query!r}"
+        return recs[0]["match_type"]
+
+    def test_alias_match_labeled(self, monkeypatch):
+        # Mirror e2e test_search_finds_entity_by_alias_issue_1170: a fuzzy query
+        # equal to an alias the id/name don't carry is labeled alias_match.
+        mt = self._match_type(
+            monkeypatch,
+            "input_boolean.alias_src",
+            "Alias Source",
+            {"e2e1170aliasabcd"},
+            "e2e1170aliasabcd",
+            exact=False,
+        )
+        assert mt == "alias_match"
+
+    def test_exact_mode_is_flat_exact_match(self, monkeypatch):
+        mt = self._match_type(
+            monkeypatch, "light.kitchen", "Kitchen Light", (), "kitchen", exact=True
+        )
+        assert mt == "exact_match"
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ("light.kitchen", "exact_id"),
+            ("kitchen light", "exact_name"),
+            ("light", "exact_domain"),
+            ("kitch", "partial_id"),
+            ("chen ligh", "partial_name"),
+        ],
+    )
+    def test_fuzzy_tier_mapping(self, monkeypatch, query, expected):
+        mt = self._match_type(
+            monkeypatch, "light.kitchen", "Kitchen Light", (), query, exact=False
+        )
+        assert mt == expected
+
+    def test_alias_match_parity_with_server_engine(self, monkeypatch):
+        """Cross-check the alias case against the server's own
+        ``FuzzyEntitySearcher``: both label it ``alias_match`` for the same
+        entity, so the taxonomies cannot silently drift."""
+        from ha_mcp.utils.fuzzy_search import FuzzyEntitySearcher
+
+        entity_id, friendly, alias = (
+            "input_boolean.alias_src",
+            "Alias Source",
+            "e2e1170aliasabcd",
+        )
+        server_matches, _ = FuzzyEntitySearcher().search_entities(
+            [
+                {
+                    "entity_id": entity_id,
+                    "attributes": {"friendly_name": friendly},
+                    "state": "on",
+                    "_aliases": [alias],
+                }
+            ],
+            alias,
+        )
+        server_mt = next(
+            m["match_type"] for m in server_matches if m["entity_id"] == entity_id
+        )
+        component_mt = self._match_type(
+            monkeypatch, entity_id, friendly, {alias}, alias, exact=False
+        )
+        assert component_mt == server_mt == "alias_match"
 
 
 # =============================================================================

--- a/tests/src/unit/test_config_get_component_routing.py
+++ b/tests/src/unit/test_config_get_component_routing.py
@@ -31,7 +31,6 @@ ran on the component path. Mirrors ``test_ha_search_component_routing.py``.
 
 from __future__ import annotations
 
-import contextlib
 import json
 from collections import Counter
 from typing import Any
@@ -40,7 +39,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import HomeAssistantAPIError, HomeAssistantCommandError
+from ha_mcp.client.rest_client import (
+    HomeAssistantAPIError,
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
 from ha_mcp.tools import (
     component_api,
     tools_config_automations,
@@ -49,6 +52,8 @@ from ha_mcp.tools import (
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
 from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
+
+from ._component_routing_helpers import make_ws, patch_ws
 
 # --- Fixtures / bodies -------------------------------------------------------
 
@@ -144,41 +149,6 @@ class RoutingClient:
             + self.resolve_scene_id.await_count
             + sum(self.ws_types.values())
         )
-
-
-def _make_ws(
-    *,
-    info_result: dict[str, Any] | None = None,
-    info_exc: Exception | None = None,
-    config_get_result: dict[str, Any] | None = None,
-    config_get_exc: Exception | None = None,
-) -> AsyncMock:
-    ws = AsyncMock()
-
-    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
-        if command_type == "ha_mcp_tools/info":
-            if info_exc is not None:
-                raise info_exc
-            return {"success": True, "result": info_result}
-        if command_type == "ha_mcp_tools/config_get":
-            if config_get_exc is not None:
-                raise config_get_exc
-            return {"success": True, "result": config_get_result}
-        raise AssertionError(f"unexpected command {command_type!r}")
-
-    ws.send_command = AsyncMock(side_effect=_send)
-    return ws
-
-
-@contextlib.contextmanager
-def _patch_ws(ws: AsyncMock, tool_module: Any) -> Any:
-    """Patch ``get_websocket_client`` on both the gate and the tool module."""
-    factory = AsyncMock(return_value=ws)
-    with (
-        patch.object(component_api, "get_websocket_client", factory),
-        patch.object(tool_module, "get_websocket_client", factory),
-    ):
-        yield ws
 
 
 def _config_get_calls(ws: AsyncMock) -> list[Any]:
@@ -282,8 +252,12 @@ class TestAutomationConfigGetRouting:
     async def test_fast_path_skips_legacy_fetches(self) -> None:
         """Component serves the read: none of the legacy fetches are awaited."""
         client = _auto_legacy_client()
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
-        with _patch_ws(ws, tools_config_automations):
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_auto_cg_found(),
+        )
+        with patch_ws(ws, tools_config_automations):
             resp = await AutomationConfigTools(client).ha_config_get_automation(
                 identifier="automation.morning"
             )
@@ -299,15 +273,19 @@ class TestAutomationConfigGetRouting:
     async def test_storage_happy_path_parity(self) -> None:
         """Component and legacy responses are byte-identical for a storage item."""
         comp_client = RoutingClient()  # legacy must not be reached on this path
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
-        with _patch_ws(ws, tools_config_automations):
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_auto_cg_found(),
+        )
+        with patch_ws(ws, tools_config_automations):
             component = await AutomationConfigTools(
                 comp_client
             ).ha_config_get_automation(identifier="automation.morning")
 
         legacy_client = _auto_legacy_client()
-        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws_legacy, tools_config_automations):
+        ws_legacy = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
+        with patch_ws(ws_legacy, tools_config_automations):
             legacy = await AutomationConfigTools(
                 legacy_client
             ).ha_config_get_automation(identifier="automation.morning")
@@ -317,9 +295,13 @@ class TestAutomationConfigGetRouting:
     async def test_found_false_raises_resource_not_found(self) -> None:
         """found:false → the exact RESOURCE_NOT_FOUND, without the legacy REST fetch."""
         client = RoutingClient(registry_list=[])
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result={"found": False},
+        )
         with (
-            _patch_ws(ws, tools_config_automations),
+            patch_ws(ws, tools_config_automations),
             pytest.raises(ToolError) as exc_info,
         ):
             await AutomationConfigTools(client).ha_config_get_automation(
@@ -334,13 +316,14 @@ class TestAutomationConfigGetRouting:
     async def test_unknown_command_falls_back_silently(self) -> None:
         """unknown_command on config_get → legacy path, no fallback warning."""
         client = _auto_legacy_client()
-        ws = _make_ws(
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
+            cmd_exc=HomeAssistantCommandError(
                 "Command failed: nope", "unknown_command"
             ),
         )
-        with _patch_ws(ws, tools_config_automations):
+        with patch_ws(ws, tools_config_automations):
             resp = await AutomationConfigTools(client).ha_config_get_automation(
                 identifier="automation.morning"
             )
@@ -351,13 +334,12 @@ class TestAutomationConfigGetRouting:
     async def test_raised_command_falls_back_with_warning(self) -> None:
         """A non-unknown command error → legacy path AND a warnings[] entry."""
         client = _auto_legacy_client()
-        ws = _make_ws(
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
-                "Command failed: boom", "internal_error"
-            ),
+            cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
         )
-        with _patch_ws(ws, tools_config_automations):
+        with patch_ws(ws, tools_config_automations):
             resp = await AutomationConfigTools(client).ha_config_get_automation(
                 identifier="automation.morning"
             )
@@ -368,8 +350,8 @@ class TestAutomationConfigGetRouting:
     async def test_no_capability_uses_legacy_untouched(self) -> None:
         """A component without config_get → legacy path, config_get never sent."""
         client = _auto_legacy_client()
-        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws, tools_config_automations):
+        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
+        with patch_ws(ws, tools_config_automations):
             resp = await AutomationConfigTools(client).ha_config_get_automation(
                 identifier="automation.morning"
             )
@@ -380,13 +362,103 @@ class TestAutomationConfigGetRouting:
     async def test_caps_probed_once_across_calls(self) -> None:
         """The info probe is cached: two reads, one ha_mcp_tools/info call."""
         client = _auto_legacy_client()
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_auto_cg_found(),
+        )
         tools = AutomationConfigTools(client)
-        with _patch_ws(ws, tools_config_automations):
+        with patch_ws(ws, tools_config_automations):
             await tools.ha_config_get_automation(identifier="automation.morning")
             await tools.ha_config_get_automation(identifier="automation.morning")
         assert len(_info_calls(ws)) == 1
         assert len(_config_get_calls(ws)) == 2
+
+    async def test_command_timeout_falls_back_with_warning(self) -> None:
+        """A component WS timeout → legacy path AND a warnings[] entry."""
+        client = _auto_legacy_client()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+        )
+        with patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        assert client.get_automation_config.await_count == 1
+        assert any("served via legacy path" in w for w in resp["warnings"])
+
+    async def test_malformed_success_falls_back_to_legacy(self) -> None:
+        """found:true with a non-dict config → silent legacy fallback (untrusted)."""
+        client = _auto_legacy_client()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result={"found": True, "config": "not-a-dict"},
+        )
+        with patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        # The malformed component body is not trusted; legacy served the read.
+        assert resp["config"]["alias"] == "Morning Routine"
+        assert client.get_automation_config.await_count == 1
+        # A malformed success is a silent fallback (no component-failure warning).
+        assert "warnings" not in resp
+
+    async def test_downgrade_reprobes_and_serves_legacy_without_component(self) -> None:
+        """routed OK → unknown_command → invalidate → re-probe serves legacy only.
+
+        A component dropped mid-session: the first call is component-served, the
+        second's config_get comes back unknown_command (caps invalidated + silent
+        legacy), and the third re-probes ``info`` — now advertising no
+        ``config_get`` — so it serves legacy without ever sending a third
+        config_get frame.
+        """
+        client = _auto_legacy_client()
+        info_probes = [0]
+        config_gets = [0]
+
+        async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+            if command_type == "ha_mcp_tools/info":
+                info_probes[0] += 1
+                caps = _CAPS_CONFIG_GET if info_probes[0] == 1 else _CAPS_NO_CONFIG_GET
+                return {"success": True, "result": caps}
+            if command_type == "ha_mcp_tools/config_get":
+                config_gets[0] += 1
+                if config_gets[0] == 1:
+                    return {"success": True, "result": _auto_cg_found()}
+                raise HomeAssistantCommandError(
+                    "Command failed: gone", "unknown_command"
+                )
+            raise AssertionError(f"unexpected command {command_type!r}")
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(side_effect=_send)
+        tools = AutomationConfigTools(client)
+        with patch_ws(ws, tools_config_automations):
+            first = await tools.ha_config_get_automation(
+                identifier="automation.morning"
+            )
+            second = await tools.ha_config_get_automation(
+                identifier="automation.morning"
+            )
+            third = await tools.ha_config_get_automation(
+                identifier="automation.morning"
+            )
+
+        # Call 1 was component-served (no legacy config fetch yet).
+        assert first["config"]["category"] == "cat_a"
+        assert second["success"] is True and third["success"] is True
+        # config_get was consulted exactly twice (call 1 OK, call 2 unknown); the
+        # re-probed call 3 saw no capability and never sent a third frame.
+        assert config_gets[0] == 2
+        assert info_probes[0] == 2
+        # Legacy served both the downgraded call and the re-probed call.
+        assert client.get_automation_config.await_count == 2
 
 
 # =============================================================================
@@ -397,10 +469,12 @@ class TestAutomationConfigGetRouting:
 class TestScriptConfigGetRouting:
     async def test_fast_path_skips_legacy_fetches(self) -> None:
         client = _script_legacy_client()
-        ws = _make_ws(
-            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_script_cg_found(),
         )
-        with _patch_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             resp = await ConfigScriptTools(client).ha_config_get_script(
                 script_id="morning"
             )
@@ -417,10 +491,12 @@ class TestScriptConfigGetRouting:
     async def test_entity_id_prefix_stripped_before_routing(self) -> None:
         """A ``script.`` prefix is stripped before the component call (parity)."""
         client = RoutingClient()
-        ws = _make_ws(
-            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_script_cg_found(),
         )
-        with _patch_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             await ConfigScriptTools(client).ha_config_get_script(
                 script_id="script.morning"
             )
@@ -428,17 +504,19 @@ class TestScriptConfigGetRouting:
 
     async def test_storage_happy_path_parity(self) -> None:
         comp_client = RoutingClient()
-        ws = _make_ws(
-            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_script_cg_found(),
         )
-        with _patch_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             component = await ConfigScriptTools(comp_client).ha_config_get_script(
                 script_id="morning"
             )
 
         legacy_client = _script_legacy_client()
-        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws_legacy, tools_config_scripts):
+        ws_legacy = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
+        with patch_ws(ws_legacy, tools_config_scripts):
             legacy = await ConfigScriptTools(legacy_client).ha_config_get_script(
                 script_id="morning"
             )
@@ -447,9 +525,13 @@ class TestScriptConfigGetRouting:
 
     async def test_found_false_raises_resource_not_found(self) -> None:
         client = RoutingClient(registry_list=[])
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result={"found": False},
+        )
         with (
-            _patch_ws(ws, tools_config_scripts),
+            patch_ws(ws, tools_config_scripts),
             pytest.raises(ToolError) as exc_info,
         ):
             await ConfigScriptTools(client).ha_config_get_script(script_id="ghost")
@@ -460,13 +542,14 @@ class TestScriptConfigGetRouting:
 
     async def test_unknown_command_falls_back_silently(self) -> None:
         client = _script_legacy_client()
-        ws = _make_ws(
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
+            cmd_exc=HomeAssistantCommandError(
                 "Command failed: nope", "unknown_command"
             ),
         )
-        with _patch_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             resp = await ConfigScriptTools(client).ha_config_get_script(
                 script_id="morning"
             )
@@ -476,13 +559,12 @@ class TestScriptConfigGetRouting:
 
     async def test_raised_command_falls_back_with_warning(self) -> None:
         client = _script_legacy_client()
-        ws = _make_ws(
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
-                "Command failed: boom", "internal_error"
-            ),
+            cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
         )
-        with _patch_ws(ws, tools_config_scripts):
+        with patch_ws(ws, tools_config_scripts):
             resp = await ConfigScriptTools(client).ha_config_get_script(
                 script_id="morning"
             )
@@ -492,14 +574,47 @@ class TestScriptConfigGetRouting:
 
     async def test_no_capability_uses_legacy_untouched(self) -> None:
         client = _script_legacy_client()
-        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws, tools_config_scripts):
+        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
+        with patch_ws(ws, tools_config_scripts):
             resp = await ConfigScriptTools(client).ha_config_get_script(
                 script_id="morning"
             )
         assert resp["success"] is True
         assert client.get_script_config.await_count == 1
         assert _config_get_calls(ws) == []
+
+    async def test_command_timeout_falls_back_with_warning(self) -> None:
+        """A component WS timeout → legacy path AND a warnings[] entry."""
+        client = _script_legacy_client()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+        )
+        with patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert client.get_script_config.await_count == 1
+        assert any("served via legacy path" in w for w in resp["warnings"])
+
+    async def test_malformed_success_falls_back_to_legacy(self) -> None:
+        """found:true with a non-dict config → silent legacy fallback (untrusted)."""
+        client = _script_legacy_client()
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result={"found": True, "config": ["not", "a", "dict"]},
+        )
+        with patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert resp["config"]["config"] == _SCRIPT_BODY  # legacy REST envelope
+        assert client.get_script_config.await_count == 1
+        assert "warnings" not in resp
 
 
 # =============================================================================
@@ -526,7 +641,11 @@ class TestSceneConfigGetAlwaysLegacy:
         client = _scene_legacy_client()
         # A component WS that WOULD serve config_get if asked — the point is that
         # the scene tool never asks it (no caps probe, no config_get frame).
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_scene_cg_found())
+        ws = make_ws(
+            "ha_mcp_tools/config_get",
+            info_result=_CAPS_CONFIG_GET,
+            cmd_result=_scene_cg_found(),
+        )
         factory = AsyncMock(return_value=ws)
         with patch.object(component_api, "get_websocket_client", factory):
             resp = await ConfigSceneTools(client).ha_config_get_scene(
@@ -551,7 +670,7 @@ class TestSceneConfigGetAlwaysLegacy:
                 "Scene not found: ghost", status_code=404
             )
         )
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET)
+        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_CONFIG_GET)
         factory = AsyncMock(return_value=ws)
         with (
             patch.object(component_api, "get_websocket_client", factory),

--- a/tests/src/unit/test_config_get_component_routing.py
+++ b/tests/src/unit/test_config_get_component_routing.py
@@ -1,20 +1,28 @@
 """Routing tests for ha_config_get_{automation,script,scene} over the component gate.
 
 When the ``ha_mcp_tools`` component advertises the ``config_get`` capability,
-each get tool serves the whole read from one ``ha_mcp_tools/config_get``
-WebSocket call and skips the legacy REST/WS pipeline (id resolution + per-id
-config REST + ``fetch_entity_category`` WS). These tests pin:
+the automation and script get tools serve the whole read from one
+``ha_mcp_tools/config_get`` WebSocket call and skip the legacy REST/WS pipeline
+(id resolution + per-id config REST + ``fetch_entity_category`` WS). Scenes are
+the deliberate exception: ``ha_config_get_scene`` NEVER routes through the
+component (a ``HomeAssistantScene`` holds no raw storage body in memory — its
+``scene_config.states`` is runtime State objects, not the storage ``entities``
+dict), so it stays on the legacy path regardless of caps. These tests pin:
 
-- the fast path (legacy fetches never awaited; the ``info`` probe cached),
-- storage happy-path byte-parity between the component and legacy responses
-  for all three domains,
+- the automation/script fast path (legacy fetches never awaited; the ``info``
+  probe cached),
+- storage happy-path byte-parity between the component and legacy responses for
+  automations and scripts,
 - ``found:false`` mapping onto the exact legacy not-found error (automation /
-  script → ``RESOURCE_NOT_FOUND``; scene → ``ENTITY_NOT_FOUND``, the classified
-  404), served without touching the legacy REST fetch,
+  script → ``RESOURCE_NOT_FOUND``), served without touching the legacy REST
+  fetch,
 - the error taxonomy (silent fallback on ``unknown_command``; legacy +
   ``warnings[]`` on any other command error),
-- and that a client whose component has no ``config_get`` capability keeps the
-  legacy path exactly as before.
+- that a client whose component has no ``config_get`` capability keeps the
+  legacy path exactly as before,
+- and that scenes stay legacy-served even when the component advertises
+  ``config_get`` (no ``config_get`` frame is ever sent for a scene), with the
+  scene 404 still classified as ``ENTITY_NOT_FOUND`` on that legacy path.
 
 The WS client is an ``AsyncMock`` dispatching on the command type; the HA
 client is a spy that tallies every legacy fetch so a test can assert it never
@@ -36,7 +44,6 @@ from ha_mcp.client.rest_client import HomeAssistantAPIError, HomeAssistantComman
 from ha_mcp.tools import (
     component_api,
     tools_config_automations,
-    tools_config_scenes,
     tools_config_scripts,
 )
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
@@ -500,11 +507,28 @@ class TestScriptConfigGetRouting:
 # =============================================================================
 
 
-class TestSceneConfigGetRouting:
-    async def test_fast_path_skips_legacy_fetches(self) -> None:
+class TestSceneConfigGetAlwaysLegacy:
+    """Scenes are deliberately legacy-only: even with the component advertising
+    ``config_get``, ``ha_config_get_scene`` never routes through it. A
+    ``HomeAssistantScene`` holds ``scene_config.states`` as runtime State
+    objects, not the storage ``entities`` dict, so a component-served body would
+    break shape parity and ``config_hash`` stability (caught live by the scene
+    lifecycle e2e). The tool skips the caps probe entirely and serves the read
+    from the legacy REST/WS pipeline — so the component WS is never touched.
+    """
+
+    async def test_scene_get_served_by_legacy_despite_config_get_caps(
+        self, monkeypatch
+    ) -> None:
+        """config_get advertised, yet the scene read is fully legacy-served and
+        no ``config_get`` frame ever reaches the component."""
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
         client = _scene_legacy_client()
+        # A component WS that WOULD serve config_get if asked — the point is that
+        # the scene tool never asks it (no caps probe, no config_get frame).
         ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_scene_cg_found())
-        with _patch_ws(ws, tools_config_scenes):
+        factory = AsyncMock(return_value=ws)
+        with patch.object(component_api, "get_websocket_client", factory):
             resp = await ConfigSceneTools(client).ha_config_get_scene(
                 scene_id="movie_night"
             )
@@ -512,103 +536,31 @@ class TestSceneConfigGetRouting:
         assert resp["scene_id"] == "movie_night"
         assert resp["config"] == _SCENE_BODY
         assert resp["category"] == "cat_x"
-        assert client.legacy_fetch_count() == 0
-        call = _config_get_calls(ws)[0]
-        assert call.kwargs == {"domain": "scene", "item_id": "movie_night"}
+        # Legacy pipeline ran; the component WS was never touched.
+        assert client.get_scene_config.await_count == 1
+        assert ws.send_command.await_count == 0
 
-    async def test_storage_happy_path_parity(self, monkeypatch) -> None:
-        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
-        comp_client = RoutingClient()
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_scene_cg_found())
-        with _patch_ws(ws, tools_config_scenes):
-            component = await ConfigSceneTools(comp_client).ha_config_get_scene(
-                scene_id="movie_night"
-            )
-
-        legacy_client = _scene_legacy_client()
-        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws_legacy, tools_config_scenes):
-            legacy = await ConfigSceneTools(legacy_client).ha_config_get_scene(
-                scene_id="movie_night"
-            )
-
-        assert component == legacy
-
-    async def test_found_false_raises_entity_not_found_parity(
+    async def test_scene_not_found_classifies_entity_not_found_on_legacy(
         self, monkeypatch
     ) -> None:
-        """Scene found:false → the SAME classified error the legacy 404 produces."""
+        """A scene 404 stays classified as ENTITY_NOT_FOUND on the legacy path,
+        with ``config_get`` advertised but never sent."""
         monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
-
-        comp_client = RoutingClient()
-        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
-        with (
-            _patch_ws(ws, tools_config_scenes),
-            pytest.raises(ToolError) as comp_exc,
-        ):
-            await ConfigSceneTools(comp_client).ha_config_get_scene(scene_id="ghost")
-        # Component's not-found is authoritative — no legacy REST call.
-        assert comp_client.get_scene_config.await_count == 0
-
-        legacy_client = RoutingClient(
+        client = RoutingClient(
             scene_envelope_exc=HomeAssistantAPIError(
                 "Scene not found: ghost", status_code=404
             )
         )
-        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET)
+        factory = AsyncMock(return_value=ws)
         with (
-            _patch_ws(ws_legacy, tools_config_scenes),
-            pytest.raises(ToolError) as legacy_exc,
+            patch.object(component_api, "get_websocket_client", factory),
+            pytest.raises(ToolError) as exc_info,
         ):
-            await ConfigSceneTools(legacy_client).ha_config_get_scene(scene_id="ghost")
-
-        comp_err = _error_payload(comp_exc.value)
-        legacy_err = _error_payload(legacy_exc.value)
-        assert comp_err["code"] == legacy_err["code"] == "ENTITY_NOT_FOUND"
-        assert comp_err["message"] == legacy_err["message"]
-
-    async def test_unknown_command_falls_back_silently(self, monkeypatch) -> None:
-        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
-        client = _scene_legacy_client()
-        ws = _make_ws(
-            info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
-                "Command failed: nope", "unknown_command"
-            ),
-        )
-        with _patch_ws(ws, tools_config_scenes):
-            resp = await ConfigSceneTools(client).ha_config_get_scene(
-                scene_id="movie_night"
-            )
-        assert resp["success"] is True
-        assert client.get_scene_config.await_count == 1
-        assert "warnings" not in resp
-
-    async def test_raised_command_falls_back_with_warning(self, monkeypatch) -> None:
-        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
-        client = _scene_legacy_client()
-        ws = _make_ws(
-            info_result=_CAPS_CONFIG_GET,
-            config_get_exc=HomeAssistantCommandError(
-                "Command failed: boom", "internal_error"
-            ),
-        )
-        with _patch_ws(ws, tools_config_scenes):
-            resp = await ConfigSceneTools(client).ha_config_get_scene(
-                scene_id="movie_night"
-            )
-        assert resp["success"] is True
-        assert client.get_scene_config.await_count == 1
-        assert any("served via legacy path" in w for w in resp["warnings"])
-
-    async def test_no_capability_uses_legacy_untouched(self, monkeypatch) -> None:
-        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
-        client = _scene_legacy_client()
-        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
-        with _patch_ws(ws, tools_config_scenes):
-            resp = await ConfigSceneTools(client).ha_config_get_scene(
-                scene_id="movie_night"
-            )
-        assert resp["success"] is True
-        assert client.get_scene_config.await_count == 1
-        assert _config_get_calls(ws) == []
+            await ConfigSceneTools(client).ha_config_get_scene(scene_id="ghost")
+        err = _error_payload(exc_info.value)
+        # The legacy REST 404 is classified via the tool's ``except Exception``
+        # (entity_id in context) into the ENTITY_NOT_FOUND taxonomy.
+        assert err["code"] == "ENTITY_NOT_FOUND"
+        assert err["message"] == "Entity 'scene.ghost' not found"
+        assert ws.send_command.await_count == 0

--- a/tests/src/unit/test_config_get_component_routing.py
+++ b/tests/src/unit/test_config_get_component_routing.py
@@ -1,0 +1,614 @@
+"""Routing tests for ha_config_get_{automation,script,scene} over the component gate.
+
+When the ``ha_mcp_tools`` component advertises the ``config_get`` capability,
+each get tool serves the whole read from one ``ha_mcp_tools/config_get``
+WebSocket call and skips the legacy REST/WS pipeline (id resolution + per-id
+config REST + ``fetch_entity_category`` WS). These tests pin:
+
+- the fast path (legacy fetches never awaited; the ``info`` probe cached),
+- storage happy-path byte-parity between the component and legacy responses
+  for all three domains,
+- ``found:false`` mapping onto the exact legacy not-found error (automation /
+  script → ``RESOURCE_NOT_FOUND``; scene → ``ENTITY_NOT_FOUND``, the classified
+  404), served without touching the legacy REST fetch,
+- the error taxonomy (silent fallback on ``unknown_command``; legacy +
+  ``warnings[]`` on any other command error),
+- and that a client whose component has no ``config_get`` capability keeps the
+  legacy path exactly as before.
+
+The WS client is an ``AsyncMock`` dispatching on the command type; the HA
+client is a spy that tallies every legacy fetch so a test can assert it never
+ran on the component path. Mirrors ``test_ha_search_component_routing.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from collections import Counter
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.client.rest_client import HomeAssistantAPIError, HomeAssistantCommandError
+from ha_mcp.tools import (
+    component_api,
+    tools_config_automations,
+    tools_config_scenes,
+    tools_config_scripts,
+)
+from ha_mcp.tools.tools_config_automations import AutomationConfigTools
+from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
+from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
+
+# --- Fixtures / bodies -------------------------------------------------------
+
+# Automation body carries a legacy ``platform`` trigger + ``service`` action so
+# the response-parity check also exercises the roundtrip normalization both
+# paths run (platform→trigger, singular→plural root keys).
+_AUTO_BODY: dict[str, Any] = {
+    "id": "171",
+    "alias": "Morning Routine",
+    "trigger": [{"platform": "time", "at": "07:00:00"}],
+    "action": [{"service": "light.turn_on", "target": {"area_id": "bedroom"}}],
+}
+_SCRIPT_BODY: dict[str, Any] = {
+    "alias": "Morning Script",
+    "sequence": [{"delay": {"seconds": 5}}],
+}
+_SCENE_BODY: dict[str, Any] = {
+    "id": "movie_night",
+    "name": "Movie Night",
+    "entities": {"light.living_room": {"state": "on", "brightness": 50}},
+}
+
+_CAPS_CONFIG_GET = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["config_get"],
+    "limits": {},
+}
+_CAPS_NO_CONFIG_GET = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["search"],
+    "limits": {},
+}
+
+
+class RoutingClient:
+    """Credentialed HA client spy: tallies every legacy fetch the get tools make.
+
+    Every legacy fetch is an ``AsyncMock`` so a test can assert
+    ``await_count == 0`` on the component path. ``send_websocket_message``
+    routes by message type (registry list for id/category resolution) and
+    tallies each type.
+    """
+
+    def __init__(
+        self,
+        *,
+        automation_config: Any = None,
+        automation_config_exc: Exception | None = None,
+        script_envelope: Any = None,
+        script_envelope_exc: Exception | None = None,
+        scene_envelope: Any = None,
+        scene_envelope_exc: Exception | None = None,
+        categories: dict[str, str] | None = None,
+        registry_list: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.ws_types: Counter[str] = Counter()
+        self._categories = categories or {}
+        self._registry_list = registry_list or []
+        self.get_states = AsyncMock(return_value=[])
+        self.get_automation_config = AsyncMock(
+            return_value=automation_config, side_effect=automation_config_exc
+        )
+        self.get_script_config = AsyncMock(
+            return_value=script_envelope, side_effect=script_envelope_exc
+        )
+        self.get_scene_config = AsyncMock(
+            return_value=scene_envelope, side_effect=scene_envelope_exc
+        )
+        self.resolve_scene_id = AsyncMock(
+            side_effect=lambda sid: sid.removeprefix("scene.")
+        )
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        msg_type = msg.get("type", "")
+        self.ws_types[msg_type] += 1
+        if msg_type == "config/entity_registry/list":
+            return {"success": True, "result": self._registry_list}
+        if msg_type == "config/entity_registry/get":
+            return {"success": True, "result": {"categories": dict(self._categories)}}
+        return {"success": False}
+
+    def legacy_fetch_count(self) -> int:
+        """Total awaited legacy REST/WS fetches (for fast-path assertions)."""
+        return (
+            self.get_states.await_count
+            + self.get_automation_config.await_count
+            + self.get_script_config.await_count
+            + self.get_scene_config.await_count
+            + self.resolve_scene_id.await_count
+            + sum(self.ws_types.values())
+        )
+
+
+def _make_ws(
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+    config_get_result: dict[str, Any] | None = None,
+    config_get_exc: Exception | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        if command_type == "ha_mcp_tools/config_get":
+            if config_get_exc is not None:
+                raise config_get_exc
+            return {"success": True, "result": config_get_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+@contextlib.contextmanager
+def _patch_ws(ws: AsyncMock, tool_module: Any) -> Any:
+    """Patch ``get_websocket_client`` on both the gate and the tool module."""
+    factory = AsyncMock(return_value=ws)
+    with (
+        patch.object(component_api, "get_websocket_client", factory),
+        patch.object(tool_module, "get_websocket_client", factory),
+    ):
+        yield ws
+
+
+def _config_get_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args and c.args[0] == "ha_mcp_tools/config_get"
+    ]
+
+
+def _info_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args and c.args[0] == "ha_mcp_tools/info"
+    ]
+
+
+def _error_payload(exc: ToolError) -> dict[str, Any]:
+    return json.loads(str(exc))["error"]
+
+
+# --- Component config_get result builders (component wire vocabulary) --------
+
+
+def _auto_cg_found(category: str | None = "cat_a") -> dict[str, Any]:
+    return {
+        "found": True,
+        "domain": "automation",
+        "item_id": "171",
+        "entity_id": "automation.morning",
+        "source": "storage",
+        "config": dict(_AUTO_BODY),
+        "category": category,
+    }
+
+
+def _script_cg_found(category: str | None = "cat_s") -> dict[str, Any]:
+    return {
+        "found": True,
+        "domain": "script",
+        "item_id": "morning",
+        "entity_id": "script.morning",
+        "source": "storage",
+        "config": dict(_SCRIPT_BODY),
+        "category": category,
+    }
+
+
+def _scene_cg_found(category: str | None = "cat_x") -> dict[str, Any]:
+    return {
+        "found": True,
+        "domain": "scene",
+        "item_id": "movie_night",
+        "entity_id": "scene.movie_night",
+        "source": "storage",
+        "config": dict(_SCENE_BODY),
+        "category": category,
+    }
+
+
+# --- Legacy-serving client builders (no config_get capability) ---------------
+
+
+def _auto_legacy_client(category: str | None = "cat_a") -> RoutingClient:
+    cats = {"automation": category} if category else {}
+    return RoutingClient(automation_config=dict(_AUTO_BODY), categories=cats)
+
+
+def _script_legacy_client(category: str | None = "cat_s") -> RoutingClient:
+    cats = {"script": category} if category else {}
+    return RoutingClient(
+        script_envelope={
+            "success": True,
+            "script_id": "morning",
+            "config": dict(_SCRIPT_BODY),
+        },
+        categories=cats,
+    )
+
+
+def _scene_legacy_client(category: str | None = "cat_x") -> RoutingClient:
+    cats = {"scene": category} if category else {}
+    return RoutingClient(
+        scene_envelope={
+            "success": True,
+            "scene_id": "movie_night",
+            "config": dict(_SCENE_BODY),
+        },
+        categories=cats,
+        registry_list=[{"entity_id": "scene.movie_night", "unique_id": "movie_night"}],
+    )
+
+
+# =============================================================================
+# Automation
+# =============================================================================
+
+
+class TestAutomationConfigGetRouting:
+    async def test_fast_path_skips_legacy_fetches(self) -> None:
+        """Component serves the read: none of the legacy fetches are awaited."""
+        client = _auto_legacy_client()
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
+        with _patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        assert resp["automation_id"] == "automation.morning"
+        assert resp["config"]["category"] == "cat_a"
+        assert client.legacy_fetch_count() == 0
+        assert len(_config_get_calls(ws)) == 1
+        # The component receives the domain + the caller identifier verbatim.
+        call = _config_get_calls(ws)[0]
+        assert call.kwargs == {"domain": "automation", "item_id": "automation.morning"}
+
+    async def test_storage_happy_path_parity(self) -> None:
+        """Component and legacy responses are byte-identical for a storage item."""
+        comp_client = RoutingClient()  # legacy must not be reached on this path
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
+        with _patch_ws(ws, tools_config_automations):
+            component = await AutomationConfigTools(
+                comp_client
+            ).ha_config_get_automation(identifier="automation.morning")
+
+        legacy_client = _auto_legacy_client()
+        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws_legacy, tools_config_automations):
+            legacy = await AutomationConfigTools(
+                legacy_client
+            ).ha_config_get_automation(identifier="automation.morning")
+
+        assert component == legacy
+
+    async def test_found_false_raises_resource_not_found(self) -> None:
+        """found:false → the exact RESOURCE_NOT_FOUND, without the legacy REST fetch."""
+        client = RoutingClient(registry_list=[])
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
+        with (
+            _patch_ws(ws, tools_config_automations),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.ghost"
+            )
+        err = _error_payload(exc_info.value)
+        assert err["code"] == "RESOURCE_NOT_FOUND"
+        assert err["message"] == "Automation not found: automation.ghost"
+        # The component's not-found is authoritative — no legacy config REST call.
+        assert client.get_automation_config.await_count == 0
+
+    async def test_unknown_command_falls_back_silently(self) -> None:
+        """unknown_command on config_get → legacy path, no fallback warning."""
+        client = _auto_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: nope", "unknown_command"
+            ),
+        )
+        with _patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        assert client.get_automation_config.await_count == 1
+        assert "warnings" not in resp
+
+    async def test_raised_command_falls_back_with_warning(self) -> None:
+        """A non-unknown command error → legacy path AND a warnings[] entry."""
+        client = _auto_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: boom", "internal_error"
+            ),
+        )
+        with _patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        assert client.get_automation_config.await_count == 1
+        assert any("served via legacy path" in w for w in resp["warnings"])
+
+    async def test_no_capability_uses_legacy_untouched(self) -> None:
+        """A component without config_get → legacy path, config_get never sent."""
+        client = _auto_legacy_client()
+        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws, tools_config_automations):
+            resp = await AutomationConfigTools(client).ha_config_get_automation(
+                identifier="automation.morning"
+            )
+        assert resp["success"] is True
+        assert client.get_automation_config.await_count == 1
+        assert _config_get_calls(ws) == []
+
+    async def test_caps_probed_once_across_calls(self) -> None:
+        """The info probe is cached: two reads, one ha_mcp_tools/info call."""
+        client = _auto_legacy_client()
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_auto_cg_found())
+        tools = AutomationConfigTools(client)
+        with _patch_ws(ws, tools_config_automations):
+            await tools.ha_config_get_automation(identifier="automation.morning")
+            await tools.ha_config_get_automation(identifier="automation.morning")
+        assert len(_info_calls(ws)) == 1
+        assert len(_config_get_calls(ws)) == 2
+
+
+# =============================================================================
+# Script
+# =============================================================================
+
+
+class TestScriptConfigGetRouting:
+    async def test_fast_path_skips_legacy_fetches(self) -> None:
+        client = _script_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        )
+        with _patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert resp["script_id"] == "morning"
+        # The legacy path returns the REST envelope under ``config``; the
+        # component path reconstructs it (with category injected).
+        assert resp["config"]["script_id"] == "morning"
+        assert resp["config"]["category"] == "cat_s"
+        assert client.legacy_fetch_count() == 0
+        call = _config_get_calls(ws)[0]
+        assert call.kwargs == {"domain": "script", "item_id": "morning"}
+
+    async def test_entity_id_prefix_stripped_before_routing(self) -> None:
+        """A ``script.`` prefix is stripped before the component call (parity)."""
+        client = RoutingClient()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        )
+        with _patch_ws(ws, tools_config_scripts):
+            await ConfigScriptTools(client).ha_config_get_script(
+                script_id="script.morning"
+            )
+        assert _config_get_calls(ws)[0].kwargs["item_id"] == "morning"
+
+    async def test_storage_happy_path_parity(self) -> None:
+        comp_client = RoutingClient()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET, config_get_result=_script_cg_found()
+        )
+        with _patch_ws(ws, tools_config_scripts):
+            component = await ConfigScriptTools(comp_client).ha_config_get_script(
+                script_id="morning"
+            )
+
+        legacy_client = _script_legacy_client()
+        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws_legacy, tools_config_scripts):
+            legacy = await ConfigScriptTools(legacy_client).ha_config_get_script(
+                script_id="morning"
+            )
+
+        assert component == legacy
+
+    async def test_found_false_raises_resource_not_found(self) -> None:
+        client = RoutingClient(registry_list=[])
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
+        with (
+            _patch_ws(ws, tools_config_scripts),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await ConfigScriptTools(client).ha_config_get_script(script_id="ghost")
+        err = _error_payload(exc_info.value)
+        assert err["code"] == "RESOURCE_NOT_FOUND"
+        assert err["message"] == "Script not found: ghost"
+        assert client.get_script_config.await_count == 0
+
+    async def test_unknown_command_falls_back_silently(self) -> None:
+        client = _script_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: nope", "unknown_command"
+            ),
+        )
+        with _patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert client.get_script_config.await_count == 1
+        assert "warnings" not in resp
+
+    async def test_raised_command_falls_back_with_warning(self) -> None:
+        client = _script_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: boom", "internal_error"
+            ),
+        )
+        with _patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert client.get_script_config.await_count == 1
+        assert any("served via legacy path" in w for w in resp["warnings"])
+
+    async def test_no_capability_uses_legacy_untouched(self) -> None:
+        client = _script_legacy_client()
+        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws, tools_config_scripts):
+            resp = await ConfigScriptTools(client).ha_config_get_script(
+                script_id="morning"
+            )
+        assert resp["success"] is True
+        assert client.get_script_config.await_count == 1
+        assert _config_get_calls(ws) == []
+
+
+# =============================================================================
+# Scene
+# =============================================================================
+
+
+class TestSceneConfigGetRouting:
+    async def test_fast_path_skips_legacy_fetches(self) -> None:
+        client = _scene_legacy_client()
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_scene_cg_found())
+        with _patch_ws(ws, tools_config_scenes):
+            resp = await ConfigSceneTools(client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+        assert resp["success"] is True
+        assert resp["scene_id"] == "movie_night"
+        assert resp["config"] == _SCENE_BODY
+        assert resp["category"] == "cat_x"
+        assert client.legacy_fetch_count() == 0
+        call = _config_get_calls(ws)[0]
+        assert call.kwargs == {"domain": "scene", "item_id": "movie_night"}
+
+    async def test_storage_happy_path_parity(self, monkeypatch) -> None:
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        comp_client = RoutingClient()
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result=_scene_cg_found())
+        with _patch_ws(ws, tools_config_scenes):
+            component = await ConfigSceneTools(comp_client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+
+        legacy_client = _scene_legacy_client()
+        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws_legacy, tools_config_scenes):
+            legacy = await ConfigSceneTools(legacy_client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+
+        assert component == legacy
+
+    async def test_found_false_raises_entity_not_found_parity(
+        self, monkeypatch
+    ) -> None:
+        """Scene found:false → the SAME classified error the legacy 404 produces."""
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+
+        comp_client = RoutingClient()
+        ws = _make_ws(info_result=_CAPS_CONFIG_GET, config_get_result={"found": False})
+        with (
+            _patch_ws(ws, tools_config_scenes),
+            pytest.raises(ToolError) as comp_exc,
+        ):
+            await ConfigSceneTools(comp_client).ha_config_get_scene(scene_id="ghost")
+        # Component's not-found is authoritative — no legacy REST call.
+        assert comp_client.get_scene_config.await_count == 0
+
+        legacy_client = RoutingClient(
+            scene_envelope_exc=HomeAssistantAPIError(
+                "Scene not found: ghost", status_code=404
+            )
+        )
+        ws_legacy = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with (
+            _patch_ws(ws_legacy, tools_config_scenes),
+            pytest.raises(ToolError) as legacy_exc,
+        ):
+            await ConfigSceneTools(legacy_client).ha_config_get_scene(scene_id="ghost")
+
+        comp_err = _error_payload(comp_exc.value)
+        legacy_err = _error_payload(legacy_exc.value)
+        assert comp_err["code"] == legacy_err["code"] == "ENTITY_NOT_FOUND"
+        assert comp_err["message"] == legacy_err["message"]
+
+    async def test_unknown_command_falls_back_silently(self, monkeypatch) -> None:
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        client = _scene_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: nope", "unknown_command"
+            ),
+        )
+        with _patch_ws(ws, tools_config_scenes):
+            resp = await ConfigSceneTools(client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+        assert resp["success"] is True
+        assert client.get_scene_config.await_count == 1
+        assert "warnings" not in resp
+
+    async def test_raised_command_falls_back_with_warning(self, monkeypatch) -> None:
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        client = _scene_legacy_client()
+        ws = _make_ws(
+            info_result=_CAPS_CONFIG_GET,
+            config_get_exc=HomeAssistantCommandError(
+                "Command failed: boom", "internal_error"
+            ),
+        )
+        with _patch_ws(ws, tools_config_scenes):
+            resp = await ConfigSceneTools(client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+        assert resp["success"] is True
+        assert client.get_scene_config.await_count == 1
+        assert any("served via legacy path" in w for w in resp["warnings"])
+
+    async def test_no_capability_uses_legacy_untouched(self, monkeypatch) -> None:
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        client = _scene_legacy_client()
+        ws = _make_ws(info_result=_CAPS_NO_CONFIG_GET)
+        with _patch_ws(ws, tools_config_scenes):
+            resp = await ConfigSceneTools(client).ha_config_get_scene(
+                scene_id="movie_night"
+            )
+        assert resp["success"] is True
+        assert client.get_scene_config.await_count == 1
+        assert _config_get_calls(ws) == []

--- a/tests/src/unit/test_config_get_component_routing.py
+++ b/tests/src/unit/test_config_get_component_routing.py
@@ -1,32 +1,29 @@
-"""Routing tests for ha_config_get_{automation,script,scene} over the component gate.
+"""Always-legacy pins for ha_config_get_{automation,script,scene}.
 
-When the ``ha_mcp_tools`` component advertises the ``config_get`` capability,
-the automation and script get tools serve the whole read from one
-``ha_mcp_tools/config_get`` WebSocket call and skip the legacy REST/WS pipeline
-(id resolution + per-id config REST + ``fetch_entity_category`` WS). Scenes are
-the deliberate exception: ``ha_config_get_scene`` NEVER routes through the
-component (a ``HomeAssistantScene`` holds no raw storage body in memory — its
-``scene_config.states`` is runtime State objects, not the storage ``entities``
-dict), so it stays on the legacy path regardless of caps. These tests pin:
+The ``ha_mcp_tools`` component's in-process ``config_get`` was withdrawn before
+release: it served an entity's ``raw_config``, which is only the storage body as
+of the last COMPLETED async reload, with no version marker to tell a fresh body
+from a stale one. A get racing a reload returned the pre-edit body and broke the
+get -> python_transform -> set round-trip (caught live by the automation/script
+config e2e on the arm/HAOS runners). All three get tools now serve their reads
+from the legacy REST/WS pipeline (which reads the fresh config FILE), exactly as
+scenes always have. Scenes were already legacy-only for a different reason — a
+``HomeAssistantScene`` holds no raw storage body in memory at all — so they lead
+the pattern the automation/script gets now follow. A file-reading ``config_get``
+may return later (issue #1813).
 
-- the automation/script fast path (legacy fetches never awaited; the ``info``
-  probe cached),
-- storage happy-path byte-parity between the component and legacy responses for
-  automations and scripts,
-- ``found:false`` mapping onto the exact legacy not-found error (automation /
-  script → ``RESOURCE_NOT_FOUND``), served without touching the legacy REST
-  fetch,
-- the error taxonomy (silent fallback on ``unknown_command``; legacy +
-  ``warnings[]`` on any other command error),
-- that a client whose component has no ``config_get`` capability keeps the
-  legacy path exactly as before,
-- and that scenes stay legacy-served even when the component advertises
-  ``config_get`` (no ``config_get`` frame is ever sent for a scene), with the
-  scene 404 still classified as ``ENTITY_NOT_FOUND`` on that legacy path.
+These pin, for all three domains, that:
 
-The WS client is an ``AsyncMock`` dispatching on the command type; the HA
-client is a spy that tallies every legacy fetch so a test can assert it never
-ran on the component path. Mirrors ``test_ha_search_component_routing.py``.
+- the get is fully served by the legacy path EVEN WHEN the component advertises
+  ``config_get`` — the tool skips the caps probe entirely, so the component WS is
+  never touched (no ``info`` frame, no ``config_get`` frame),
+- a missing item still maps onto the exact legacy not-found error (automation /
+  script -> ``RESOURCE_NOT_FOUND``; scene -> ``ENTITY_NOT_FOUND``), served
+  without any component involvement.
+
+The WS client is an ``AsyncMock`` dispatching on the command type (built so it
+WOULD serve ``config_get`` if asked — the point is that it is never asked); the
+HA client is a spy that tallies every legacy fetch. Mirrors the scene precedent.
 """
 
 from __future__ import annotations
@@ -39,27 +36,19 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import (
-    HomeAssistantAPIError,
-    HomeAssistantCommandError,
-    HomeAssistantCommandTimeout,
-)
-from ha_mcp.tools import (
-    component_api,
-    tools_config_automations,
-    tools_config_scripts,
-)
+from ha_mcp.client.rest_client import HomeAssistantAPIError
+from ha_mcp.tools import component_api
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
 from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
 
-from ._component_routing_helpers import make_ws, patch_ws
+from ._component_routing_helpers import make_ws
 
 # --- Fixtures / bodies -------------------------------------------------------
 
 # Automation body carries a legacy ``platform`` trigger + ``service`` action so
-# the response-parity check also exercises the roundtrip normalization both
-# paths run (platform→trigger, singular→plural root keys).
+# the response check also exercises the roundtrip normalization the legacy path
+# runs (platform->trigger, singular->plural root keys).
 _AUTO_BODY: dict[str, Any] = {
     "id": "171",
     "alias": "Morning Routine",
@@ -76,16 +65,13 @@ _SCENE_BODY: dict[str, Any] = {
     "entities": {"light.living_room": {"state": "on", "brightness": 50}},
 }
 
+# A component advertising the full (now-defunct) capability set INCLUDING
+# config_get. The pins wire a WS that would serve it precisely to prove the get
+# tools never reach for it.
 _CAPS_CONFIG_GET = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["config_get"],
-    "limits": {},
-}
-_CAPS_NO_CONFIG_GET = {
-    "schema_version": 1,
-    "component_version": "1.1.0",
-    "capabilities": ["search"],
     "limits": {},
 }
 
@@ -151,27 +137,14 @@ class RoutingClient:
         )
 
 
-def _config_get_calls(ws: AsyncMock) -> list[Any]:
-    return [
-        c
-        for c in ws.send_command.call_args_list
-        if c.args and c.args[0] == "ha_mcp_tools/config_get"
-    ]
-
-
-def _info_calls(ws: AsyncMock) -> list[Any]:
-    return [
-        c
-        for c in ws.send_command.call_args_list
-        if c.args and c.args[0] == "ha_mcp_tools/info"
-    ]
-
-
 def _error_payload(exc: ToolError) -> dict[str, Any]:
     return json.loads(str(exc))["error"]
 
 
 # --- Component config_get result builders (component wire vocabulary) --------
+# These are what the mocked WS WOULD return if a get tool asked for config_get.
+# It never does — they exist only to make "the WS was never consulted" a
+# meaningful assertion (the WS is fully capable of answering).
 
 
 def _auto_cg_found(category: str | None = "cat_a") -> dict[str, Any]:
@@ -210,7 +183,7 @@ def _scene_cg_found(category: str | None = "cat_x") -> dict[str, Any]:
     }
 
 
-# --- Legacy-serving client builders (no config_get capability) ---------------
+# --- Legacy-serving client builders ------------------------------------------
 
 
 def _auto_legacy_client(category: str | None = "cat_a") -> RoutingClient:
@@ -248,60 +221,54 @@ def _scene_legacy_client(category: str | None = "cat_x") -> RoutingClient:
 # =============================================================================
 
 
-class TestAutomationConfigGetRouting:
-    async def test_fast_path_skips_legacy_fetches(self) -> None:
-        """Component serves the read: none of the legacy fetches are awaited."""
+class TestAutomationConfigGetAlwaysLegacy:
+    """Automation gets are legacy-only: the component's config_get was withdrawn
+    (its ``raw_config`` freshness lagged the config file between write and
+    reload), so ``ha_config_get_automation`` never routes through it. The tool
+    skips the caps probe entirely and serves the read from the legacy REST/WS
+    pipeline — so the component WS is never touched, even with ``config_get``
+    advertised.
+    """
+
+    async def test_get_served_by_legacy_despite_config_get_caps(self) -> None:
+        """config_get advertised, yet the automation read is fully legacy-served
+        and no frame ever reaches the component."""
         client = _auto_legacy_client()
+        # A component WS that WOULD serve config_get if asked — the point is that
+        # the automation tool never asks it (no caps probe, no config_get frame).
         ws = make_ws(
             "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
             cmd_result=_auto_cg_found(),
         )
-        with patch_ws(ws, tools_config_automations):
+        factory = AsyncMock(return_value=ws)
+        with patch.object(component_api, "get_websocket_client", factory):
             resp = await AutomationConfigTools(client).ha_config_get_automation(
                 identifier="automation.morning"
             )
         assert resp["success"] is True
         assert resp["automation_id"] == "automation.morning"
+        # Legacy path canonicalizes (platform->trigger, singular->plural) and
+        # injects the category from the registry.
+        assert resp["config"]["triggers"] == [{"trigger": "time", "at": "07:00:00"}]
         assert resp["config"]["category"] == "cat_a"
-        assert client.legacy_fetch_count() == 0
-        assert len(_config_get_calls(ws)) == 1
-        # The component receives the domain + the caller identifier verbatim.
-        call = _config_get_calls(ws)[0]
-        assert call.kwargs == {"domain": "automation", "item_id": "automation.morning"}
+        # Legacy pipeline ran; the component WS was never touched.
+        assert client.get_automation_config.await_count == 1
+        assert ws.send_command.await_count == 0
 
-    async def test_storage_happy_path_parity(self) -> None:
-        """Component and legacy responses are byte-identical for a storage item."""
-        comp_client = RoutingClient()  # legacy must not be reached on this path
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result=_auto_cg_found(),
+    async def test_not_found_raises_resource_not_found_on_legacy(self) -> None:
+        """A missing automation raises the exact legacy RESOURCE_NOT_FOUND, with
+        ``config_get`` advertised but never sent."""
+        client = RoutingClient(
+            automation_config_exc=HomeAssistantAPIError(
+                "Automation not found", status_code=404
+            ),
+            registry_list=[],
         )
-        with patch_ws(ws, tools_config_automations):
-            component = await AutomationConfigTools(
-                comp_client
-            ).ha_config_get_automation(identifier="automation.morning")
-
-        legacy_client = _auto_legacy_client()
-        ws_legacy = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
-        with patch_ws(ws_legacy, tools_config_automations):
-            legacy = await AutomationConfigTools(
-                legacy_client
-            ).ha_config_get_automation(identifier="automation.morning")
-
-        assert component == legacy
-
-    async def test_found_false_raises_resource_not_found(self) -> None:
-        """found:false → the exact RESOURCE_NOT_FOUND, without the legacy REST fetch."""
-        client = RoutingClient(registry_list=[])
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result={"found": False},
-        )
+        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_CONFIG_GET)
+        factory = AsyncMock(return_value=ws)
         with (
-            patch_ws(ws, tools_config_automations),
+            patch.object(component_api, "get_websocket_client", factory),
             pytest.raises(ToolError) as exc_info,
         ):
             await AutomationConfigTools(client).ha_config_get_automation(
@@ -310,155 +277,7 @@ class TestAutomationConfigGetRouting:
         err = _error_payload(exc_info.value)
         assert err["code"] == "RESOURCE_NOT_FOUND"
         assert err["message"] == "Automation not found: automation.ghost"
-        # The component's not-found is authoritative — no legacy config REST call.
-        assert client.get_automation_config.await_count == 0
-
-    async def test_unknown_command_falls_back_silently(self) -> None:
-        """unknown_command on config_get → legacy path, no fallback warning."""
-        client = _auto_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandError(
-                "Command failed: nope", "unknown_command"
-            ),
-        )
-        with patch_ws(ws, tools_config_automations):
-            resp = await AutomationConfigTools(client).ha_config_get_automation(
-                identifier="automation.morning"
-            )
-        assert resp["success"] is True
-        assert client.get_automation_config.await_count == 1
-        assert "warnings" not in resp
-
-    async def test_raised_command_falls_back_with_warning(self) -> None:
-        """A non-unknown command error → legacy path AND a warnings[] entry."""
-        client = _auto_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
-        )
-        with patch_ws(ws, tools_config_automations):
-            resp = await AutomationConfigTools(client).ha_config_get_automation(
-                identifier="automation.morning"
-            )
-        assert resp["success"] is True
-        assert client.get_automation_config.await_count == 1
-        assert any("served via legacy path" in w for w in resp["warnings"])
-
-    async def test_no_capability_uses_legacy_untouched(self) -> None:
-        """A component without config_get → legacy path, config_get never sent."""
-        client = _auto_legacy_client()
-        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
-        with patch_ws(ws, tools_config_automations):
-            resp = await AutomationConfigTools(client).ha_config_get_automation(
-                identifier="automation.morning"
-            )
-        assert resp["success"] is True
-        assert client.get_automation_config.await_count == 1
-        assert _config_get_calls(ws) == []
-
-    async def test_caps_probed_once_across_calls(self) -> None:
-        """The info probe is cached: two reads, one ha_mcp_tools/info call."""
-        client = _auto_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result=_auto_cg_found(),
-        )
-        tools = AutomationConfigTools(client)
-        with patch_ws(ws, tools_config_automations):
-            await tools.ha_config_get_automation(identifier="automation.morning")
-            await tools.ha_config_get_automation(identifier="automation.morning")
-        assert len(_info_calls(ws)) == 1
-        assert len(_config_get_calls(ws)) == 2
-
-    async def test_command_timeout_falls_back_with_warning(self) -> None:
-        """A component WS timeout → legacy path AND a warnings[] entry."""
-        client = _auto_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
-        )
-        with patch_ws(ws, tools_config_automations):
-            resp = await AutomationConfigTools(client).ha_config_get_automation(
-                identifier="automation.morning"
-            )
-        assert resp["success"] is True
-        assert client.get_automation_config.await_count == 1
-        assert any("served via legacy path" in w for w in resp["warnings"])
-
-    async def test_malformed_success_falls_back_to_legacy(self) -> None:
-        """found:true with a non-dict config → silent legacy fallback (untrusted)."""
-        client = _auto_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result={"found": True, "config": "not-a-dict"},
-        )
-        with patch_ws(ws, tools_config_automations):
-            resp = await AutomationConfigTools(client).ha_config_get_automation(
-                identifier="automation.morning"
-            )
-        assert resp["success"] is True
-        # The malformed component body is not trusted; legacy served the read.
-        assert resp["config"]["alias"] == "Morning Routine"
-        assert client.get_automation_config.await_count == 1
-        # A malformed success is a silent fallback (no component-failure warning).
-        assert "warnings" not in resp
-
-    async def test_downgrade_reprobes_and_serves_legacy_without_component(self) -> None:
-        """routed OK → unknown_command → invalidate → re-probe serves legacy only.
-
-        A component dropped mid-session: the first call is component-served, the
-        second's config_get comes back unknown_command (caps invalidated + silent
-        legacy), and the third re-probes ``info`` — now advertising no
-        ``config_get`` — so it serves legacy without ever sending a third
-        config_get frame.
-        """
-        client = _auto_legacy_client()
-        info_probes = [0]
-        config_gets = [0]
-
-        async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
-            if command_type == "ha_mcp_tools/info":
-                info_probes[0] += 1
-                caps = _CAPS_CONFIG_GET if info_probes[0] == 1 else _CAPS_NO_CONFIG_GET
-                return {"success": True, "result": caps}
-            if command_type == "ha_mcp_tools/config_get":
-                config_gets[0] += 1
-                if config_gets[0] == 1:
-                    return {"success": True, "result": _auto_cg_found()}
-                raise HomeAssistantCommandError(
-                    "Command failed: gone", "unknown_command"
-                )
-            raise AssertionError(f"unexpected command {command_type!r}")
-
-        ws = AsyncMock()
-        ws.send_command = AsyncMock(side_effect=_send)
-        tools = AutomationConfigTools(client)
-        with patch_ws(ws, tools_config_automations):
-            first = await tools.ha_config_get_automation(
-                identifier="automation.morning"
-            )
-            second = await tools.ha_config_get_automation(
-                identifier="automation.morning"
-            )
-            third = await tools.ha_config_get_automation(
-                identifier="automation.morning"
-            )
-
-        # Call 1 was component-served (no legacy config fetch yet).
-        assert first["config"]["category"] == "cat_a"
-        assert second["success"] is True and third["success"] is True
-        # config_get was consulted exactly twice (call 1 OK, call 2 unknown); the
-        # re-probed call 3 saw no capability and never sent a third frame.
-        assert config_gets[0] == 2
-        assert info_probes[0] == 2
-        # Legacy served both the downgraded call and the re-probed call.
-        assert client.get_automation_config.await_count == 2
+        assert ws.send_command.await_count == 0
 
 
 # =============================================================================
@@ -466,155 +285,67 @@ class TestAutomationConfigGetRouting:
 # =============================================================================
 
 
-class TestScriptConfigGetRouting:
-    async def test_fast_path_skips_legacy_fetches(self) -> None:
+class TestScriptConfigGetAlwaysLegacy:
+    """Script analog of the automation pins — always legacy-served, component WS
+    never consulted even with ``config_get`` advertised.
+    """
+
+    async def test_get_served_by_legacy_despite_config_get_caps(self) -> None:
         client = _script_legacy_client()
         ws = make_ws(
             "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
             cmd_result=_script_cg_found(),
         )
-        with patch_ws(ws, tools_config_scripts):
+        factory = AsyncMock(return_value=ws)
+        with patch.object(component_api, "get_websocket_client", factory):
             resp = await ConfigScriptTools(client).ha_config_get_script(
                 script_id="morning"
             )
         assert resp["success"] is True
         assert resp["script_id"] == "morning"
-        # The legacy path returns the REST envelope under ``config``; the
-        # component path reconstructs it (with category injected).
+        # The legacy path returns the REST envelope under ``config`` (script_id +
+        # category injected).
         assert resp["config"]["script_id"] == "morning"
         assert resp["config"]["category"] == "cat_s"
-        assert client.legacy_fetch_count() == 0
-        call = _config_get_calls(ws)[0]
-        assert call.kwargs == {"domain": "script", "item_id": "morning"}
+        assert client.get_script_config.await_count == 1
+        assert ws.send_command.await_count == 0
 
-    async def test_entity_id_prefix_stripped_before_routing(self) -> None:
-        """A ``script.`` prefix is stripped before the component call (parity)."""
-        client = RoutingClient()
+    async def test_entity_id_prefix_stripped_on_legacy(self) -> None:
+        """A ``script.`` prefix is stripped before the legacy fetch (parity),
+        with the component still never consulted."""
+        client = _script_legacy_client()
         ws = make_ws(
             "ha_mcp_tools/config_get",
             info_result=_CAPS_CONFIG_GET,
             cmd_result=_script_cg_found(),
         )
-        with patch_ws(ws, tools_config_scripts):
+        factory = AsyncMock(return_value=ws)
+        with patch.object(component_api, "get_websocket_client", factory):
             await ConfigScriptTools(client).ha_config_get_script(
                 script_id="script.morning"
             )
-        assert _config_get_calls(ws)[0].kwargs["item_id"] == "morning"
+        assert client.get_script_config.call_args.args == ("morning",)
+        assert ws.send_command.await_count == 0
 
-    async def test_storage_happy_path_parity(self) -> None:
-        comp_client = RoutingClient()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result=_script_cg_found(),
+    async def test_not_found_raises_resource_not_found_on_legacy(self) -> None:
+        client = RoutingClient(
+            script_envelope_exc=HomeAssistantAPIError(
+                "Script not found", status_code=404
+            ),
+            registry_list=[],
         )
-        with patch_ws(ws, tools_config_scripts):
-            component = await ConfigScriptTools(comp_client).ha_config_get_script(
-                script_id="morning"
-            )
-
-        legacy_client = _script_legacy_client()
-        ws_legacy = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
-        with patch_ws(ws_legacy, tools_config_scripts):
-            legacy = await ConfigScriptTools(legacy_client).ha_config_get_script(
-                script_id="morning"
-            )
-
-        assert component == legacy
-
-    async def test_found_false_raises_resource_not_found(self) -> None:
-        client = RoutingClient(registry_list=[])
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result={"found": False},
-        )
+        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_CONFIG_GET)
+        factory = AsyncMock(return_value=ws)
         with (
-            patch_ws(ws, tools_config_scripts),
+            patch.object(component_api, "get_websocket_client", factory),
             pytest.raises(ToolError) as exc_info,
         ):
             await ConfigScriptTools(client).ha_config_get_script(script_id="ghost")
         err = _error_payload(exc_info.value)
         assert err["code"] == "RESOURCE_NOT_FOUND"
         assert err["message"] == "Script not found: ghost"
-        assert client.get_script_config.await_count == 0
-
-    async def test_unknown_command_falls_back_silently(self) -> None:
-        client = _script_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandError(
-                "Command failed: nope", "unknown_command"
-            ),
-        )
-        with patch_ws(ws, tools_config_scripts):
-            resp = await ConfigScriptTools(client).ha_config_get_script(
-                script_id="morning"
-            )
-        assert resp["success"] is True
-        assert client.get_script_config.await_count == 1
-        assert "warnings" not in resp
-
-    async def test_raised_command_falls_back_with_warning(self) -> None:
-        client = _script_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
-        )
-        with patch_ws(ws, tools_config_scripts):
-            resp = await ConfigScriptTools(client).ha_config_get_script(
-                script_id="morning"
-            )
-        assert resp["success"] is True
-        assert client.get_script_config.await_count == 1
-        assert any("served via legacy path" in w for w in resp["warnings"])
-
-    async def test_no_capability_uses_legacy_untouched(self) -> None:
-        client = _script_legacy_client()
-        ws = make_ws("ha_mcp_tools/config_get", info_result=_CAPS_NO_CONFIG_GET)
-        with patch_ws(ws, tools_config_scripts):
-            resp = await ConfigScriptTools(client).ha_config_get_script(
-                script_id="morning"
-            )
-        assert resp["success"] is True
-        assert client.get_script_config.await_count == 1
-        assert _config_get_calls(ws) == []
-
-    async def test_command_timeout_falls_back_with_warning(self) -> None:
-        """A component WS timeout → legacy path AND a warnings[] entry."""
-        client = _script_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
-        )
-        with patch_ws(ws, tools_config_scripts):
-            resp = await ConfigScriptTools(client).ha_config_get_script(
-                script_id="morning"
-            )
-        assert resp["success"] is True
-        assert client.get_script_config.await_count == 1
-        assert any("served via legacy path" in w for w in resp["warnings"])
-
-    async def test_malformed_success_falls_back_to_legacy(self) -> None:
-        """found:true with a non-dict config → silent legacy fallback (untrusted)."""
-        client = _script_legacy_client()
-        ws = make_ws(
-            "ha_mcp_tools/config_get",
-            info_result=_CAPS_CONFIG_GET,
-            cmd_result={"found": True, "config": ["not", "a", "dict"]},
-        )
-        with patch_ws(ws, tools_config_scripts):
-            resp = await ConfigScriptTools(client).ha_config_get_script(
-                script_id="morning"
-            )
-        assert resp["success"] is True
-        assert resp["config"]["config"] == _SCRIPT_BODY  # legacy REST envelope
-        assert client.get_script_config.await_count == 1
-        assert "warnings" not in resp
+        assert ws.send_command.await_count == 0
 
 
 # =============================================================================
@@ -623,12 +354,12 @@ class TestScriptConfigGetRouting:
 
 
 class TestSceneConfigGetAlwaysLegacy:
-    """Scenes are deliberately legacy-only: even with the component advertising
-    ``config_get``, ``ha_config_get_scene`` never routes through it. A
-    ``HomeAssistantScene`` holds ``scene_config.states`` as runtime State
-    objects, not the storage ``entities`` dict, so a component-served body would
-    break shape parity and ``config_hash`` stability (caught live by the scene
-    lifecycle e2e). The tool skips the caps probe entirely and serves the read
+    """Scenes have always been legacy-only, for a different reason than the
+    withdrawn config_get: a ``HomeAssistantScene`` holds ``scene_config.states``
+    as runtime State objects, not the storage ``entities`` dict, so a
+    component-served body would break shape parity and ``config_hash`` stability
+    (caught live by the scene lifecycle e2e). Like the automation/script gets,
+    ``ha_config_get_scene`` skips the caps probe entirely and serves the read
     from the legacy REST/WS pipeline — so the component WS is never touched.
     """
 

--- a/tests/src/unit/test_deep_search_error_handling.py
+++ b/tests/src/unit/test_deep_search_error_handling.py
@@ -52,6 +52,12 @@ class TestDeepSearchErrorHandling:
         client = MagicMock()
         client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
         client.get_states = AsyncMock(return_value=[])
+        # ha_search now shares one entity-registry list between both branches by
+        # pre-fetching it in the orchestrator, so the client must support the WS
+        # call directly (previously the entity branch's copy was swallowed).
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
         return client
 
     @pytest.fixture

--- a/tests/src/unit/test_deep_search_helper_rename_1794.py
+++ b/tests/src/unit/test_deep_search_helper_rename_1794.py
@@ -1,0 +1,304 @@
+"""Unit tests for the deep-search helper name-staleness fix (issue #1794).
+
+HA's storage-level helper record (``<type>/list``) carries the immutable
+``id`` (== registry ``unique_id``) and the creation-time entity_id slug + name.
+A UI rename updates *only* the entity registry, so a helper searched by its
+CURRENT name / entity_id was invisible to the deep-search helper branch, which
+scored the storage-derived values. The fix reuses the ha_search orchestrator's
+already-fetched entity-registry snapshot (no new request) to map each helper's
+``unique_id`` to its current ``(entity_id, name)`` and score/emit those, while
+still scoring the storage name so config-body references and un-renamed helpers
+never regress.
+
+Two levels:
+- **Component**: ``_build_helper_registry_map`` parses the snapshot; a
+  renamed helper matches by its current name via ``_search_helper_type``,
+  an un-renamed one still matches, the storage name still matches, and the
+  no-snapshot path is byte-for-byte today's behaviour.
+- **Seam**: a rename driven through the public ``deep_search`` entrypoint with
+  a ``prefetched_registry`` snapshot surfaces the current name — and the same
+  query without the snapshot does not (proving the snapshot is what fixes it).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.tools.smart_search import SmartSearchTools
+
+_INPUT_TYPES = {
+    "input_boolean",
+    "input_number",
+    "input_select",
+    "input_text",
+    "input_datetime",
+    "input_button",
+}
+
+
+def _make_tools(client) -> SmartSearchTools:
+    """Construct SmartSearchTools without loading global settings."""
+    with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+        mock_settings.return_value.fuzzy_threshold = 60
+        return SmartSearchTools(client=client)
+
+
+def _registry(*entries: dict) -> dict:
+    """Wrap registry entries in the WS ``entity_registry/list`` success shape."""
+    return {"success": True, "result": list(entries)}
+
+
+# --------------------------------------------------------------------------
+# Component: _build_helper_registry_map
+# --------------------------------------------------------------------------
+
+
+class TestBuildHelperRegistryMap:
+    def test_none_snapshot_is_empty_map(self) -> None:
+        """No snapshot handed down (direct deep_search caller) → empty map."""
+        assert SmartSearchTools._build_helper_registry_map(None, _INPUT_TYPES) == {}
+
+    def test_soft_failure_snapshot_is_empty_map(self) -> None:
+        """A ``{"success": False}`` snapshot is a soft failure → empty map, so
+        the caller degrades to storage-name matching rather than trusting a
+        failed registry."""
+        assert (
+            SmartSearchTools._build_helper_registry_map(
+                {"success": False}, _INPUT_TYPES
+            )
+            == {}
+        )
+
+    def test_maps_uid_to_current_entity_id_and_name(self) -> None:
+        """A registry ``name`` override maps unique_id → (entity_id, name)."""
+        snap = _registry(
+            {
+                "entity_id": "input_boolean.new_name",
+                "platform": "input_boolean",
+                "unique_id": "abc123",
+                "name": "New Name",
+                "original_name": "Old Name",
+            }
+        )
+        out = SmartSearchTools._build_helper_registry_map(snap, _INPUT_TYPES)
+        assert out == {"abc123": ("input_boolean.new_name", "New Name")}
+
+    def test_name_falls_back_to_original_name(self) -> None:
+        """A null registry ``name`` falls back to ``original_name``."""
+        snap = _registry(
+            {
+                "entity_id": "input_boolean.kitchen_light",
+                "platform": "input_boolean",
+                "unique_id": "kitchen_light",
+                "name": None,
+                "original_name": "Kitchen Light",
+            }
+        )
+        out = SmartSearchTools._build_helper_registry_map(snap, _INPUT_TYPES)
+        assert out == {
+            "kitchen_light": ("input_boolean.kitchen_light", "Kitchen Light")
+        }
+
+    def test_missing_both_names_stores_none(self) -> None:
+        """Both names absent → name is None so the caller keeps the storage name;
+        the corrected entity_id is still captured."""
+        snap = _registry(
+            {
+                "entity_id": "input_boolean.x",
+                "platform": "input_boolean",
+                "unique_id": "x",
+            }
+        )
+        out = SmartSearchTools._build_helper_registry_map(snap, _INPUT_TYPES)
+        assert out == {"x": ("input_boolean.x", None)}
+
+    def test_non_input_platform_and_malformed_entries_skipped(self) -> None:
+        """Non-input_* platforms, entries missing unique_id/entity_id, and
+        non-dict rows are all skipped."""
+        snap = _registry(
+            {
+                "entity_id": "light.kitchen",
+                "platform": "hue",
+                "unique_id": "hue-1",
+                "name": "Kitchen",
+            },
+            {"entity_id": "input_boolean.no_uid", "platform": "input_boolean"},
+            {"platform": "input_boolean", "unique_id": "no_eid"},
+            "not-a-dict",
+            {
+                "entity_id": "input_number.temp",
+                "platform": "input_number",
+                "unique_id": "temp",
+                "name": "Temp",
+            },
+        )
+        out = SmartSearchTools._build_helper_registry_map(snap, _INPUT_TYPES)
+        assert out == {"temp": ("input_number.temp", "Temp")}
+
+
+# --------------------------------------------------------------------------
+# Component: _search_helper_type registry override
+# --------------------------------------------------------------------------
+
+
+def _client_listing(records: list[dict]) -> MagicMock:
+    """Client whose ``<type>/list`` returns ``records`` (any input_* type)."""
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": records}
+    )
+    return client
+
+
+@pytest.mark.asyncio
+class TestSearchHelperTypeRegistryOverride:
+    async def test_renamed_helper_matches_by_current_name(self) -> None:
+        """A helper renamed in the UI (registry name/entity_id differ from the
+        storage record) matches a search for its CURRENT name and emits the
+        current name + entity_id."""
+        tools = _make_tools(_client_listing([{"id": "abc123", "name": "Old Name"}]))
+        registry_by_uid = {"abc123": ("input_boolean.new_name", "New Name")}
+
+        matches, failed = await tools._search_helper_type(
+            "input_boolean",
+            "new name",
+            True,
+            asyncio.Semaphore(4),
+            registry_by_uid=registry_by_uid,
+        )
+
+        assert failed is False
+        assert len(matches) == 1
+        m = matches[0]
+        assert m["entity_id"] == "input_boolean.new_name"
+        assert m["name"] == "New Name"
+        assert m["match_in_name"] is True
+
+    async def test_unrenamed_helper_still_matches(self) -> None:
+        """An un-renamed helper (registry name == storage name) still matches by
+        name — no regression."""
+        tools = _make_tools(
+            _client_listing([{"id": "kitchen_light", "name": "Kitchen Light"}])
+        )
+        registry_by_uid = {
+            "kitchen_light": ("input_boolean.kitchen_light", "Kitchen Light")
+        }
+
+        matches, failed = await tools._search_helper_type(
+            "input_boolean",
+            "kitchen light",
+            True,
+            asyncio.Semaphore(4),
+            registry_by_uid=registry_by_uid,
+        )
+
+        assert failed is False
+        assert len(matches) == 1
+        assert matches[0]["entity_id"] == "input_boolean.kitchen_light"
+        assert matches[0]["name"] == "Kitchen Light"
+        assert matches[0]["match_in_name"] is True
+
+    async def test_storage_name_still_matches_after_rename(self) -> None:
+        """Searching the PRE-rename (storage / config-body) name still finds the
+        helper — via the config-body scan — while the emitted name is the
+        current one. Guards the "config references must not regress" contract."""
+        tools = _make_tools(_client_listing([{"id": "abc123", "name": "Old Name"}]))
+        registry_by_uid = {"abc123": ("input_boolean.new_name", "New Name")}
+
+        matches, failed = await tools._search_helper_type(
+            "input_boolean",
+            "old name",
+            True,
+            asyncio.Semaphore(4),
+            registry_by_uid=registry_by_uid,
+        )
+
+        assert failed is False
+        assert len(matches) == 1
+        assert matches[0]["name"] == "New Name"
+        assert matches[0]["match_in_config"] is True
+
+    async def test_no_snapshot_path_is_todays_behaviour(self) -> None:
+        """Without a registry map the branch scores the storage-derived
+        entity_id + name exactly as before: the current name does NOT match,
+        the storage name does."""
+        tools = _make_tools(_client_listing([{"id": "abc123", "name": "Old Name"}]))
+
+        # Current name misses (the #1794 bug, unfixed on the no-snapshot path).
+        miss, miss_failed = await tools._search_helper_type(
+            "input_boolean", "new name", True, asyncio.Semaphore(4)
+        )
+        assert miss_failed is False
+        assert miss == []
+
+        # Storage name still matches, with the storage-derived entity_id/name.
+        hit, hit_failed = await tools._search_helper_type(
+            "input_boolean", "old name", True, asyncio.Semaphore(4)
+        )
+        assert hit_failed is False
+        assert len(hit) == 1
+        assert hit[0]["entity_id"] == "input_boolean.abc123"
+        assert hit[0]["name"] == "Old Name"
+
+
+# --------------------------------------------------------------------------
+# Seam: rename surfaces through public deep_search with prefetched_registry
+# --------------------------------------------------------------------------
+
+
+def _seam_client(storage_record: dict) -> MagicMock:
+    """Client for a helper-only deep_search: one input_boolean storage record,
+    every other input_*/list clean-empty, flow-helper entries clean-empty."""
+
+    async def _ws(msg):
+        if msg.get("type") == "input_boolean/list":
+            return {"success": True, "result": [storage_record]}
+        return {"success": True, "result": []}
+
+    client = MagicMock()
+    client.get_states = AsyncMock(return_value=[])
+    client.send_websocket_message = AsyncMock(side_effect=_ws)
+    client._request = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.mark.asyncio
+class TestRenameThroughDeepSearch:
+    _REGISTRY = _registry(
+        {
+            "entity_id": "input_boolean.new_name",
+            "platform": "input_boolean",
+            "unique_id": "abc123",
+            "name": "New Name",
+            "original_name": "Old Name",
+        }
+    )
+
+    async def test_prefetched_registry_surfaces_current_name(self) -> None:
+        """A renamed helper is found by its current name when deep_search is
+        handed the registry snapshot, with the current entity_id + name."""
+        tools = _make_tools(_seam_client({"id": "abc123", "name": "Old Name"}))
+
+        result = await tools.deep_search(
+            query="New Name",
+            search_types=["helper"],
+            limit=10,
+            prefetched_registry=self._REGISTRY,
+        )
+
+        helpers = result["helpers"]
+        assert len(helpers) == 1, f"expected the renamed helper; got {helpers!r}"
+        assert helpers[0]["entity_id"] == "input_boolean.new_name"
+        assert helpers[0]["name"] == "New Name"
+
+    async def test_without_registry_current_name_is_invisible(self) -> None:
+        """The same current-name query with NO snapshot finds nothing — the bug
+        the snapshot fixes (storage name is "Old Name", entity slug "abc123")."""
+        tools = _make_tools(_seam_client({"id": "abc123", "name": "Old Name"}))
+
+        result = await tools.deep_search(
+            query="New Name", search_types=["helper"], limit=10
+        )
+
+        assert result["helpers"] == []

--- a/tests/src/unit/test_fields_projection_docstring_completeness.py
+++ b/tests/src/unit/test_fields_projection_docstring_completeness.py
@@ -201,7 +201,7 @@ _PAREN_NOTE_RE = re.compile(r"\([^)]*\)")
 
 
 def _read_module(rel_path: str) -> ast.Module:
-    return ast.parse((SRC_ROOT / rel_path).read_text())
+    return ast.parse((SRC_ROOT / rel_path).read_text(encoding="utf-8"))
 
 
 def _find_function(
@@ -618,7 +618,7 @@ def test_tool_specs_covers_every_fields_using_tool() -> None:
     tools_dir = SRC_ROOT / "tools"
     discovered: set[str] = set()
     for path in sorted(tools_dir.glob("tools_*.py")):
-        module = ast.parse(path.read_text())
+        module = ast.parse(path.read_text(encoding="utf-8"))
         for node in ast.walk(module):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -1,0 +1,478 @@
+"""Routing tests for ``ha_config_list_helpers`` over the ``ha_mcp_tools`` gate.
+
+When the component advertises the ``helpers_list`` capability,
+``ha_config_list_helpers`` serves the whole listing from one
+``ha_mcp_tools/helpers_list`` WebSocket call and skips the legacy
+``{helper_type}/list`` fetch entirely. The component-served records ship the
+issue #1794 stale-id fix additively: each keeps the legacy storage ``id`` and
+gains the current ``entity_id`` + display ``name`` from the entity registry.
+
+These tests pin that fast path, the record shape (storage id preserved, current
+entity_id/name added), envelope parity with the legacy path, and the
+error-taxonomy fallbacks (silent on ``unknown_command``; legacy + ``warnings[]``
+on any other command error; legacy pin when the component has no WS surface).
+
+Flow-based helper types (``template``, ``group``, ...) have no legacy
+``{type}/list`` command, so they are served exclusively through the component:
+the tests pin the flow happy path (``entry_id`` + current name + ``options``
+records) and that any missing/failed component path raises a hard
+``COMPONENT_NOT_INSTALLED`` error — never a legacy fallback, never a silent
+empty list.
+
+The component reports ``covered_types`` (the types a response authoritatively
+enumerated). A requested type outside that list (e.g. ``tag``, which has no
+state entity for the component's scan) — or a response with no ``covered_types``
+at all (older component) — is treated as a component miss: storage types fall
+back to the legacy ``{type}/list`` path, flow types raise.
+
+The WS client is an ``AsyncMock`` whose ``send_command`` dispatches on the
+command type. The HA client is a spy that tallies the legacy ``{type}/list``
+fetch so a test can assert it never ran on the component path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.tools import component_api, tools_config_helpers
+from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+# One collection helper renamed after creation: storage name "Old Name",
+# current registry display name "New Name", entity_id input_boolean.foo — the
+# exact #1794 shape (legacy list would emit only the storage id + stale name).
+_LEGACY_ITEMS = [{"id": "abc123", "name": "Old Name", "icon": "mdi:flash"}]
+
+_CAPS_HELPERS = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["helpers_list"],
+    "limits": {},
+}
+
+
+def _component_helpers_result() -> dict[str, Any]:
+    return {
+        "helpers": [
+            {
+                "helper_type": "input_boolean",
+                "object_id": "abc123",
+                "entity_id": "input_boolean.foo",
+                "name": "New Name",
+                "kind": "collection",
+                "config": {"id": "abc123", "name": "Old Name", "icon": "mdi:flash"},
+            }
+        ],
+        "count": 1,
+        "covered_types": ["input_boolean"],
+    }
+
+
+def _component_flow_result() -> dict[str, Any]:
+    return {
+        "helpers": [
+            {
+                "helper_type": "template",
+                "entry_id": "cfgentry123",
+                "entity_id": "sensor.templated",
+                "name": "Templated Sensor",
+                "kind": "flow",
+                "options": {"state": "{{ 1 + 1 }}"},
+            }
+        ],
+        "count": 1,
+        "covered_types": ["template"],
+    }
+
+
+class RoutingClient:
+    """Credentialed HA client spy: tallies every legacy ``{type}/list`` fetch."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.list_calls = 0
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        self.list_calls += 1
+        msg_type = msg.get("type", "")
+        if msg_type == "input_boolean/list":
+            return {"success": True, "result": [dict(i) for i in _LEGACY_ITEMS]}
+        if msg_type == "tag/list":
+            return {"success": True, "result": [{"id": "tag-42", "name": "Front Door"}]}
+        return {"success": False, "error": "unexpected list type"}
+
+
+def _make_ws(
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+    helpers_result: dict[str, Any] | None = None,
+    helpers_exc: Exception | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        if command_type == "ha_mcp_tools/helpers_list":
+            if helpers_exc is not None:
+                raise helpers_exc
+            return {"success": True, "result": helpers_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+@contextlib.contextmanager
+def _patch_ws(ws: AsyncMock) -> Any:
+    """Patch both module references to ``get_websocket_client`` to yield ``ws``."""
+    factory = AsyncMock(return_value=ws)
+    with (
+        patch.object(component_api, "get_websocket_client", factory),
+        patch.object(tools_config_helpers, "get_websocket_client", factory),
+    ):
+        yield ws
+
+
+def _build_list_helpers(client: Any) -> Any:
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp = MagicMock()
+    mcp.add_tool = capture_add_tool
+    register_config_helper_tools(mcp, client)
+    return registered["ha_config_list_helpers"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache() -> Any:
+    """Isolate the module-global caps cache between tests."""
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+    yield
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+
+
+def _helpers_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args[0] == "ha_mcp_tools/helpers_list"
+    ]
+
+
+def _info_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_component_fast_path_skips_legacy_and_probes_caps_once() -> None:
+    """Component serves the listing: no legacy fetch, and info probed once."""
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result())
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+        resp2 = await list_helpers(helper_type="input_boolean")
+
+    assert resp["success"] is True
+    assert resp["helper_type"] == "input_boolean"
+    assert resp["count"] == 1
+    assert resp2["count"] == 1
+    # The legacy {type}/list fetch is never issued on the component path.
+    assert client.list_calls == 0
+    # Exactly one component helpers_list command per call, one cached info probe.
+    assert len(_helpers_calls(ws)) == 2
+    assert len(_info_calls(ws)) == 1
+    # The command carries only the requested collection type, no flow helpers.
+    first_helpers_call = _helpers_calls(ws)[0]
+    assert first_helpers_call.kwargs["helper_types"] == ["input_boolean"]
+    assert first_helpers_call.kwargs["include_flow_helpers"] is False
+
+
+@pytest.mark.asyncio
+async def test_rename_case_record_keeps_storage_id_and_adds_entity_id_name() -> None:
+    """#1794 shape: storage id kept, current entity_id + name added additively."""
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result())
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    (record,) = resp["helpers"]
+    # Legacy keys keep their legacy meanings: id is the storage id, type-specific
+    # keys survive.
+    assert record["id"] == "abc123"
+    assert record["icon"] == "mdi:flash"
+    # Added: current entity_id, and name reflects the current display name
+    # (overriding the stale creation-time "Old Name").
+    assert record["entity_id"] == "input_boolean.foo"
+    assert record["name"] == "New Name"
+
+
+@pytest.mark.asyncio
+async def test_component_and_legacy_envelope_parity() -> None:
+    """Both serving paths return the same top-level envelope keys."""
+    ws_component = _make_ws(
+        info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result()
+    )
+    with _patch_ws(ws_component):
+        component = await _build_list_helpers(RoutingClient())(
+            helper_type="input_boolean"
+        )
+
+    # info → unknown_command yields no caps, so this run takes the legacy path.
+    ws_legacy = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    with _patch_ws(ws_legacy):
+        legacy = await _build_list_helpers(RoutingClient())(helper_type="input_boolean")
+
+    assert set(component.keys()) == set(legacy.keys())
+    assert component["success"] == legacy["success"] is True
+    assert component["helper_type"] == legacy["helper_type"] == "input_boolean"
+    assert component["count"] == legacy["count"] == 1
+    # Neither happy path emits a fallback warning.
+    assert "warnings" not in component
+    assert "warnings" not in legacy
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_falls_back_silently() -> None:
+    """unknown_command on the helpers_list call → legacy path, no warning."""
+    ws = _make_ws(
+        info_result=_CAPS_HELPERS,
+        helpers_exc=HomeAssistantCommandError(
+            "Command failed: gone", "unknown_command"
+        ),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    assert resp["success"] is True
+    # Legacy inventory served the request.
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    # Silent fallback: no component-failure warning.
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_raised_command_falls_back_with_warning() -> None:
+    """A non-unknown command error → legacy path AND a warnings[] entry."""
+    ws = _make_ws(
+        info_result=_CAPS_HELPERS,
+        helpers_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    assert resp["success"] is True
+    assert client.list_calls == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_capsless_component_pins_legacy_path() -> None:
+    """Old component (info unknown_command) → legacy path, helpers_list never sent."""
+    ws = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    assert resp["success"] is True
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    # The component listing command must never be attempted without the capability.
+    assert not _helpers_calls(ws)
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_flow_records_are_dropped_from_component_output() -> None:
+    """A flow-helper record must not surface in this collection-only tool."""
+    mixed = {
+        "helpers": [
+            _component_helpers_result()["helpers"][0],
+            {
+                "helper_type": "template",
+                "entry_id": "e1",
+                "entity_id": "sensor.templated",
+                "name": "Templated",
+                "kind": "flow",
+                "options": {"state": "{{ 1 }}"},
+            },
+        ],
+        "count": 2,
+        "covered_types": ["input_boolean"],
+    }
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=mixed)
+    client = _build_list_helpers(RoutingClient())
+
+    with _patch_ws(ws):
+        resp = await client(helper_type="input_boolean")
+
+    assert resp["count"] == 1
+    (record,) = resp["helpers"]
+    assert record["id"] == "abc123"
+    assert "entry_id" not in record
+    assert "options" not in record
+
+
+@pytest.mark.asyncio
+async def test_flow_type_served_only_by_component() -> None:
+    """A flow type is served through the component: entry_id + name + options."""
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_flow_result())
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="template")
+
+    assert resp["success"] is True
+    assert resp["helper_type"] == "template"
+    assert resp["count"] == 1
+    (record,) = resp["helpers"]
+    assert record["helper_type"] == "template"
+    assert record["entry_id"] == "cfgentry123"
+    assert record["entity_id"] == "sensor.templated"
+    assert record["name"] == "Templated Sensor"
+    assert record["options"] == {"state": "{{ 1 + 1 }}"}
+    # No storage id (flow helpers have none) and never any legacy fetch.
+    assert "id" not in record
+    assert client.list_calls == 0
+    # The component command requests flow helpers for this type.
+    (call,) = _helpers_calls(ws)
+    assert call.kwargs["helper_types"] == ["template"]
+    assert call.kwargs["include_flow_helpers"] is True
+
+
+@pytest.mark.asyncio
+async def test_flow_type_capsless_raises_component_required() -> None:
+    """Flow type without a component surface → hard error, no legacy, no empty."""
+    ws = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="template")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    assert "flow-based" in str(excinfo.value)
+    # Never falls back to the legacy path and never issues the component command.
+    assert client.list_calls == 0
+    assert not _helpers_calls(ws)
+
+
+@pytest.mark.asyncio
+async def test_flow_type_component_error_raises_no_legacy_fallback() -> None:
+    """A component handler error on a flow type → same hard error, no legacy."""
+    ws = _make_ws(
+        info_result=_CAPS_HELPERS,
+        helpers_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="template")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    # The legacy path cannot serve flow helpers, so it must not be attempted.
+    assert client.list_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_flow_type_unknown_command_raises_component_required() -> None:
+    """A downgraded component (unknown_command) on a flow type → same hard error."""
+    ws = _make_ws(
+        info_result=_CAPS_HELPERS,
+        helpers_exc=HomeAssistantCommandError(
+            "Command failed: gone", "unknown_command"
+        ),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="template")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    assert client.list_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_uncovered_storage_type_falls_back_to_legacy() -> None:
+    """A storage type absent from covered_types (tag) → legacy serves it."""
+    # The component ran but its from-states scan can't see tags, so tag is not
+    # in covered_types even though the command succeeded with an empty list.
+    result = {"helpers": [], "count": 0, "covered_types": ["zone", "person"]}
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=result)
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="tag")
+
+    # The component was consulted exactly once, then legacy tag/list served.
+    assert len(_helpers_calls(ws)) == 1
+    assert client.list_calls == 1
+    assert resp["helper_type"] == "tag"
+    assert resp["count"] == 1
+    assert resp["helpers"][0]["id"] == "tag-42"
+    # Silent fallback: no component-failure warning.
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_missing_covered_types_falls_back_to_legacy() -> None:
+    """An older component with no covered_types → conservative legacy fallback."""
+    result = {
+        "helpers": _component_helpers_result()["helpers"],
+        "count": 1,
+    }  # no covered_types key
+    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=result)
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with _patch_ws(ws):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    # Component consulted once, but its list isn't trusted → legacy serves.
+    assert len(_helpers_calls(ws)) == 1
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    assert resp["helpers"][0]["id"] == "abc123"

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -32,16 +32,23 @@ fetch so a test can assert it never ran on the component path.
 
 from __future__ import annotations
 
-import contextlib
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
 from ha_mcp.tools import component_api, tools_config_helpers
-from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+from ha_mcp.tools.tools_config_helpers import (
+    _shape_collection_helper_record,
+    register_config_helper_tools,
+)
+
+from ._component_routing_helpers import make_ws, patch_ws
 
 # One collection helper renamed after creation: storage name "Old Name",
 # current registry display name "New Name", entity_id input_boolean.foo — the
@@ -108,41 +115,6 @@ class RoutingClient:
         return {"success": False, "error": "unexpected list type"}
 
 
-def _make_ws(
-    *,
-    info_result: dict[str, Any] | None = None,
-    info_exc: Exception | None = None,
-    helpers_result: dict[str, Any] | None = None,
-    helpers_exc: Exception | None = None,
-) -> AsyncMock:
-    ws = AsyncMock()
-
-    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
-        if command_type == "ha_mcp_tools/info":
-            if info_exc is not None:
-                raise info_exc
-            return {"success": True, "result": info_result}
-        if command_type == "ha_mcp_tools/helpers_list":
-            if helpers_exc is not None:
-                raise helpers_exc
-            return {"success": True, "result": helpers_result}
-        raise AssertionError(f"unexpected command {command_type!r}")
-
-    ws.send_command = AsyncMock(side_effect=_send)
-    return ws
-
-
-@contextlib.contextmanager
-def _patch_ws(ws: AsyncMock) -> Any:
-    """Patch both module references to ``get_websocket_client`` to yield ``ws``."""
-    factory = AsyncMock(return_value=ws)
-    with (
-        patch.object(component_api, "get_websocket_client", factory),
-        patch.object(tools_config_helpers, "get_websocket_client", factory),
-    ):
-        yield ws
-
-
 def _build_list_helpers(client: Any) -> Any:
     registered: dict[str, Any] = {}
 
@@ -187,11 +159,15 @@ def _info_calls(ws: AsyncMock) -> list[Any]:
 @pytest.mark.asyncio
 async def test_component_fast_path_skips_legacy_and_probes_caps_once() -> None:
     """Component serves the listing: no legacy fetch, and info probed once."""
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result())
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_helpers_result(),
+    )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
         resp2 = await list_helpers(helper_type="input_boolean")
 
@@ -213,11 +189,15 @@ async def test_component_fast_path_skips_legacy_and_probes_caps_once() -> None:
 @pytest.mark.asyncio
 async def test_rename_case_record_keeps_storage_id_and_adds_entity_id_name() -> None:
     """#1794 shape: storage id kept, current entity_id + name added additively."""
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result())
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_helpers_result(),
+    )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
 
     (record,) = resp["helpers"]
@@ -234,19 +214,24 @@ async def test_rename_case_record_keeps_storage_id_and_adds_entity_id_name() -> 
 @pytest.mark.asyncio
 async def test_component_and_legacy_envelope_parity() -> None:
     """Both serving paths return the same top-level envelope keys."""
-    ws_component = _make_ws(
-        info_result=_CAPS_HELPERS, helpers_result=_component_helpers_result()
+    ws_component = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_helpers_result(),
     )
-    with _patch_ws(ws_component):
+    with patch_ws(ws_component, tools_config_helpers):
         component = await _build_list_helpers(RoutingClient())(
             helper_type="input_boolean"
         )
 
     # info → unknown_command yields no caps, so this run takes the legacy path.
-    ws_legacy = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws_legacy = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
     )
-    with _patch_ws(ws_legacy):
+    with patch_ws(ws_legacy, tools_config_helpers):
         legacy = await _build_list_helpers(RoutingClient())(helper_type="input_boolean")
 
     assert set(component.keys()) == set(legacy.keys())
@@ -261,16 +246,15 @@ async def test_component_and_legacy_envelope_parity() -> None:
 @pytest.mark.asyncio
 async def test_unknown_command_falls_back_silently() -> None:
     """unknown_command on the helpers_list call → legacy path, no warning."""
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
         info_result=_CAPS_HELPERS,
-        helpers_exc=HomeAssistantCommandError(
-            "Command failed: gone", "unknown_command"
-        ),
+        cmd_exc=HomeAssistantCommandError("Command failed: gone", "unknown_command"),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
 
     assert resp["success"] is True
@@ -284,14 +268,15 @@ async def test_unknown_command_falls_back_silently() -> None:
 @pytest.mark.asyncio
 async def test_raised_command_falls_back_with_warning() -> None:
     """A non-unknown command error → legacy path AND a warnings[] entry."""
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
         info_result=_CAPS_HELPERS,
-        helpers_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
 
     assert resp["success"] is True
@@ -302,13 +287,16 @@ async def test_raised_command_falls_back_with_warning() -> None:
 @pytest.mark.asyncio
 async def test_capsless_component_pins_legacy_path() -> None:
     """Old component (info unknown_command) → legacy path, helpers_list never sent."""
-    ws = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
 
     assert resp["success"] is True
@@ -337,10 +325,12 @@ async def test_flow_records_are_dropped_from_component_output() -> None:
         "count": 2,
         "covered_types": ["input_boolean"],
     }
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=mixed)
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list", info_result=_CAPS_HELPERS, cmd_result=mixed
+    )
     client = _build_list_helpers(RoutingClient())
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await client(helper_type="input_boolean")
 
     assert resp["count"] == 1
@@ -353,11 +343,15 @@ async def test_flow_records_are_dropped_from_component_output() -> None:
 @pytest.mark.asyncio
 async def test_flow_type_served_only_by_component() -> None:
     """A flow type is served through the component: entry_id + name + options."""
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=_component_flow_result())
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_flow_result(),
+    )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="template")
 
     assert resp["success"] is True
@@ -381,13 +375,16 @@ async def test_flow_type_served_only_by_component() -> None:
 @pytest.mark.asyncio
 async def test_flow_type_capsless_raises_component_required() -> None:
     """Flow type without a component surface → hard error, no legacy, no empty."""
-    ws = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
         await list_helpers(helper_type="template")
 
     assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
@@ -400,14 +397,15 @@ async def test_flow_type_capsless_raises_component_required() -> None:
 @pytest.mark.asyncio
 async def test_flow_type_component_error_raises_no_legacy_fallback() -> None:
     """A component handler error on a flow type → same hard error, no legacy."""
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
         info_result=_CAPS_HELPERS,
-        helpers_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
         await list_helpers(helper_type="template")
 
     assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
@@ -418,16 +416,15 @@ async def test_flow_type_component_error_raises_no_legacy_fallback() -> None:
 @pytest.mark.asyncio
 async def test_flow_type_unknown_command_raises_component_required() -> None:
     """A downgraded component (unknown_command) on a flow type → same hard error."""
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
         info_result=_CAPS_HELPERS,
-        helpers_exc=HomeAssistantCommandError(
-            "Command failed: gone", "unknown_command"
-        ),
+        cmd_exc=HomeAssistantCommandError("Command failed: gone", "unknown_command"),
     )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws), pytest.raises(ToolError) as excinfo:
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
         await list_helpers(helper_type="template")
 
     assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
@@ -440,11 +437,13 @@ async def test_uncovered_storage_type_falls_back_to_legacy() -> None:
     # The component ran but its from-states scan can't see tags, so tag is not
     # in covered_types even though the command succeeded with an empty list.
     result = {"helpers": [], "count": 0, "covered_types": ["zone", "person"]}
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=result)
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list", info_result=_CAPS_HELPERS, cmd_result=result
+    )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="tag")
 
     # The component was consulted exactly once, then legacy tag/list served.
@@ -464,11 +463,13 @@ async def test_missing_covered_types_falls_back_to_legacy() -> None:
         "helpers": _component_helpers_result()["helpers"],
         "count": 1,
     }  # no covered_types key
-    ws = _make_ws(info_result=_CAPS_HELPERS, helpers_result=result)
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list", info_result=_CAPS_HELPERS, cmd_result=result
+    )
     client = RoutingClient()
     list_helpers = _build_list_helpers(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_config_helpers):
         resp = await list_helpers(helper_type="input_boolean")
 
     # Component consulted once, but its list isn't trusted → legacy serves.
@@ -476,3 +477,100 @@ async def test_missing_covered_types_falls_back_to_legacy() -> None:
     assert client.list_calls == 1
     assert resp["count"] == 1
     assert resp["helpers"][0]["id"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_storage_command_timeout_falls_back_with_warning() -> None:
+    """A storage-type component WS timeout → legacy path AND a warnings[] entry."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers):
+        resp = await list_helpers(helper_type="input_boolean")
+
+    assert resp["success"] is True
+    assert client.list_calls == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_flow_command_timeout_raises_component_required() -> None:
+    """A flow-type component WS timeout → hard component-required error, no legacy."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="template")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    assert client.list_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_flow_type_missing_covered_types_raises_component_required() -> None:
+    """Flow type + response with no covered_types → component-required, not empty.
+
+    A flow type is always covered when the component enumerated it; a response
+    that omits covered_types can't be trusted as "no such helpers", and there is
+    no legacy path for flow types, so the tool raises rather than returning an
+    empty list.
+    """
+    result = {"helpers": [], "count": 0}  # no covered_types key
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list", info_result=_CAPS_HELPERS, cmd_result=result
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="template")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    assert client.list_calls == 0
+
+
+def test_collection_record_prefers_storage_id_over_object_id() -> None:
+    """``_shape_collection_helper_record`` consumes the authoritative storage_id.
+
+    person/zone bodies don't carry their own ``id``; the component reads it from
+    the real storage collection as ``storage_id``, which must win over both the
+    (absent) body ``id`` and the record-level ``object_id``.
+    """
+    rec = {
+        "helper_type": "person",
+        "storage_id": "person.abc",
+        "object_id": "derived_from_entity",
+        "entity_id": "person.alice",
+        "name": "Alice",
+        "kind": "collection",
+        "config": {"name": "Alice", "user_id": "u1"},  # no ``id`` in the body
+    }
+    out = _shape_collection_helper_record(rec)
+    assert out["id"] == "person.abc"
+    assert out["entity_id"] == "person.alice"
+    assert out["name"] == "Alice"
+    assert out["user_id"] == "u1"
+
+
+def test_collection_record_falls_back_to_object_id_without_storage_id() -> None:
+    """Older component (no storage_id) still keys ``id`` off ``object_id``."""
+    rec = {
+        "helper_type": "input_boolean",
+        "object_id": "guest_mode",
+        "entity_id": "input_boolean.guest_mode",
+        "name": "Guest",
+        "kind": "collection",
+        "config": {"name": "Guest"},
+    }
+    out = _shape_collection_helper_record(rec)
+    assert out["id"] == "guest_mode"

--- a/tests/src/unit/test_ha_overview_component_routing.py
+++ b/tests/src/unit/test_ha_overview_component_routing.py
@@ -1,0 +1,438 @@
+"""Routing tests for ``ha_get_overview`` over the ``ha_mcp_tools`` component gate.
+
+When the component advertises the ``overview`` capability, ``ha_get_overview``
+fetches the eight raw reads (states + services + the three registries + config +
+notifications + repairs) in one ``ha_mcp_tools/overview`` WebSocket call and
+feeds those slices into its unchanged assembly, skipping the legacy ~8-fetch
+pipeline. These tests pin that fast path, the error-taxonomy fallbacks (silent
+on ``unknown_command``; legacy + ``warnings[]`` on any other command error), the
+active-visibility bypass (an active filter keeps the legacy path), and
+byte-identical parity between the two serving paths (same assembly, different
+data source).
+
+Harness mirrors ``test_ha_search_component_routing.py``: the WS client is an
+``AsyncMock`` whose ``send_command`` dispatches on the command type, and the HA
+client is a spy that tallies every legacy fetch so a test can assert none ran on
+the component path.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.tools import component_api, tools_search
+from ha_mcp.tools.smart_search import SmartSearchTools
+from ha_mcp.tools.tools_search import register_search_tools
+from ha_mcp.visibility import resolver
+from ha_mcp.visibility.model import VisibilityConfig
+from ha_mcp.visibility.persistence import save_visibility_config
+
+_STATES = [
+    {
+        "entity_id": "light.kitchen",
+        "state": "on",
+        "attributes": {"friendly_name": "Kitchen"},
+    },
+    {
+        "entity_id": "sensor.kitchen_temp",
+        "state": "21",
+        "attributes": {"friendly_name": "Kitchen Temp", "device_class": "temperature"},
+    },
+]
+_SERVICES = [{"domain": "light", "services": {"turn_on": {}, "turn_off": {}}}]
+_AREA_REGISTRY = {
+    "success": True,
+    "result": [{"area_id": "kitchen", "name": "Kitchen"}],
+}
+_ENTITY_REGISTRY = {
+    "success": True,
+    "result": [
+        {"entity_id": "light.kitchen", "area_id": "kitchen", "entity_category": None},
+        {
+            "entity_id": "sensor.kitchen_temp",
+            "area_id": "kitchen",
+            "entity_category": None,
+        },
+    ],
+}
+_CONFIG = {
+    "version": "2026.7.0",
+    "location_name": "Home",
+    "time_zone": "UTC",
+    "language": "en",
+    "state": "RUNNING",
+}
+
+_CAPS_OVERVIEW = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["overview"],
+    "limits": {},
+}
+
+
+class OverviewRoutingClient:
+    """Credentialed HA client spy: tallies every legacy fetch ha_get_overview makes."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.get_states_calls = 0
+        self.get_services_calls = 0
+        self.get_config_calls = 0
+        self.ws_types: Counter[str] = Counter()
+
+    async def get_states(self) -> list[dict[str, Any]]:
+        self.get_states_calls += 1
+        return [dict(s) for s in _STATES]
+
+    async def get_services(self) -> list[dict[str, Any]]:
+        self.get_services_calls += 1
+        return [dict(s) for s in _SERVICES]
+
+    async def get_config(self) -> dict[str, Any]:
+        self.get_config_calls += 1
+        return dict(_CONFIG)
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        msg_type = msg.get("type", "")
+        self.ws_types[msg_type] += 1
+        if msg_type == "config/area_registry/list":
+            return _AREA_REGISTRY
+        if msg_type == "config/entity_registry/list":
+            return _ENTITY_REGISTRY
+        if msg_type == "config/device_registry/list":
+            return {"success": True, "result": []}
+        if msg_type == "persistent_notification/get":
+            return {"success": True, "result": []}
+        if msg_type == "repairs/list_issues":
+            return {"success": True, "result": {"issues": []}}
+        return {"success": False}
+
+    def total_legacy_fetches(self) -> int:
+        return (
+            self.get_states_calls
+            + self.get_services_calls
+            + self.get_config_calls
+            + sum(self.ws_types.values())
+        )
+
+
+def _make_ws(
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+    overview_result: dict[str, Any] | None = None,
+    overview_exc: Exception | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        if command_type == "ha_mcp_tools/overview":
+            if overview_exc is not None:
+                raise overview_exc
+            return {"success": True, "result": overview_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+class _PatchBothWs:
+    """Context manager patching the caps-probe and overview-send WS factories."""
+
+    def __init__(self, ws: AsyncMock) -> None:
+        self._factory = AsyncMock(return_value=ws)
+
+    def __enter__(self) -> AsyncMock:
+        self._p1 = patch.object(component_api, "get_websocket_client", self._factory)
+        self._p2 = patch.object(tools_search, "get_websocket_client", self._factory)
+        self._p1.start()
+        self._p2.start()
+        return self._factory
+
+    def __exit__(self, *exc: Any) -> None:
+        self._p1.stop()
+        self._p2.stop()
+
+
+def _build_overview_tool(client: Any) -> Any:
+    mcp = MagicMock()
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp.add_tool = capture_add_tool
+    register_search_tools(mcp, client, smart_tools=SmartSearchTools(client=client))
+    return registered["ha_get_overview"]
+
+
+def _setup_visibility_disabled(tmp_path: Any, monkeypatch: Any) -> None:
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+
+def _quiet_tail(monkeypatch: Any) -> None:
+    """Make the wrapper's server-side-only tail deterministic + I/O-free.
+
+    ``ha_mcp_update`` is already off (the unit conftest sets
+    ``HA_MCP_DISABLE_UPDATE_CHECK``); pin the sidecar / HTTP-mount lookups to
+    absent so a real settings sidecar on the host machine can't leak a
+    ``settings_url`` into the assertions.
+    """
+    monkeypatch.setattr("ha_mcp.stdio_settings_sidecar.read_sidecar_url", lambda: None)
+    monkeypatch.setattr("ha_mcp.settings_ui.get_http_settings_prefix", lambda: None)
+
+
+def _overview_slices() -> dict[str, Any]:
+    """The component's BARE ``ha_mcp_tools/overview`` slices for the fixture data.
+
+    Registries are bare lists (no ``{success, result}`` WS wrapper), config is
+    the bare ``get_config()`` dict, notifications/repairs are bare lists —
+    exactly the raw-slice response design § ha_mcp_tools/overview specifies. The
+    server wraps and assembles them into the overview envelope.
+    """
+    return {
+        "states": [dict(s) for s in _STATES],
+        "services": [dict(s) for s in _SERVICES],
+        "area_registry": [dict(a) for a in _AREA_REGISTRY["result"]],
+        "entity_registry": [dict(e) for e in _ENTITY_REGISTRY["result"]],
+        "device_registry": [],
+        "config": dict(_CONFIG),
+        "notifications": [],
+        "repairs": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -> None:
+    """When the component serves overview, none of the ~8 legacy fetches run."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert resp["system_summary"]["total_entities"] == 2
+    assert resp["system_info"]["version"] == "2026.7.0"
+    # The legacy inventory is untouched: no states/services/config/registry/
+    # notification/repairs fetches.
+    assert client.total_legacy_fetches() == 0
+    # Exactly one component overview command was issued.
+    overview_calls = [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args[0] == "ha_mcp_tools/overview"
+    ]
+    assert len(overview_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_caps_probed_once_across_overviews(tmp_path, monkeypatch) -> None:
+    """The info probe is cached: two overviews, one ha_mcp_tools/info call."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        await overview(detail_level="standard")
+        await overview(detail_level="standard")
+
+    info_calls = [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
+    ]
+    assert len(info_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_falls_back_silently(tmp_path, monkeypatch) -> None:
+    """unknown_command on the overview call → legacy path, no fallback warning."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(
+        info_result=_CAPS_OVERVIEW,
+        overview_exc=HomeAssistantCommandError(
+            "Command failed: nope", "unknown_command"
+        ),
+    )
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    # Legacy inventory served the request.
+    assert client.get_states_calls == 1
+    assert client.get_config_calls == 1
+    assert client.ws_types["config/entity_registry/list"] == 1
+    assert client.ws_types["repairs/list_issues"] == 1
+    # Silent fallback: no component-failure warning.
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A non-unknown command error → legacy path AND a warnings[] entry."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(
+        info_result=_CAPS_OVERVIEW,
+        overview_exc=HomeAssistantCommandError(
+            "Command failed: boom", "internal_error"
+        ),
+    )
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert any(
+        "component overview path failed" in w and "served via legacy path" in w
+        for w in resp["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_capsless_client_uses_legacy(tmp_path, monkeypatch) -> None:
+    """info → unknown_command yields no caps, so overview runs the legacy path."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    # The overview command must never be attempted without the capability.
+    assert not any(
+        c.args[0] == "ha_mcp_tools/overview" for c in ws.send_command.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_visibility_active_bypasses_component(tmp_path, monkeypatch) -> None:
+    """An ACTIVE entity-visibility filter forces the legacy path.
+
+    The filter is applied server-side over the slices either way, so this is a
+    retained simplification (mirroring search): an active filter with
+    ``respect_assist_exposure`` needs extra WS reads inside ``load_hidden_set``
+    that the single overview round-trip doesn't carry, so a visibility-enabled
+    install keeps the legacy path. Either way the denied entity is excluded from
+    the counts / samples.
+    """
+    save_visibility_config(
+        tmp_path,
+        VisibilityConfig(
+            enabled=True,
+            exclude_categories=[],
+            deny_entity_ids=["light.kitchen"],
+        ),
+    )
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        resp = await overview(detail_level="standard")
+
+    # The component overview command must never run while the filter is active.
+    assert not any(
+        c.args[0] == "ha_mcp_tools/overview" for c in ws.send_command.call_args_list
+    ), "component overview must not run while the visibility filter is active"
+    # Legacy inventory served the request, and the denied entity is gone from
+    # the (visibility-filtered) domain stats.
+    assert client.get_states_calls == 1
+    assert resp["system_summary"]["total_entities"] == 1
+    assert "light" not in resp["domain_stats"]
+
+
+@pytest.mark.asyncio
+async def test_enabled_but_no_active_dimension_still_uses_component(
+    tmp_path, monkeypatch
+) -> None:
+    """enabled=True with every dimension cleared hides nothing → component serves."""
+    save_visibility_config(
+        tmp_path, VisibilityConfig(enabled=True, exclude_categories=[])
+    )
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    _quiet_tail(monkeypatch)
+    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with _PatchBothWs(ws):
+        await overview(detail_level="standard")
+
+    assert any(
+        c.args[0] == "ha_mcp_tools/overview" for c in ws.send_command.call_args_list
+    ), "no active hide dimension → component should still serve"
+    assert client.total_legacy_fetches() == 0
+
+
+@pytest.mark.asyncio
+async def test_component_and_legacy_response_parity(tmp_path, monkeypatch) -> None:
+    """The component (raw-slice) path is byte-identical to the legacy path.
+
+    The component returns the same eight reads the legacy path fetches; the
+    server feeds them into its unchanged assembly. Over identical fixture data
+    the two final ha_get_overview responses must be equal — same assembly code,
+    only the data source differs. Pins that the raw-slice adaptation
+    (bare→wrapped registries/notifications/repairs + prefetched threading) drops
+    or reshapes nothing.
+    """
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+
+    # Legacy run (info → unknown_command ⇒ no caps ⇒ legacy per-read fetch path).
+    ws_legacy = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    client_legacy = OverviewRoutingClient()
+    with _PatchBothWs(ws_legacy):
+        legacy = await _build_overview_tool(client_legacy)(detail_level="standard")
+
+    # Component run: the same eight reads, delivered as raw slices in one call.
+    ws_component = _make_ws(
+        info_result=_CAPS_OVERVIEW, overview_result=_overview_slices()
+    )
+    client_component = OverviewRoutingClient()
+    with _PatchBothWs(ws_component):
+        component = await _build_overview_tool(client_component)(
+            detail_level="standard"
+        )
+
+    assert component == legacy
+    # And the component path did not touch the legacy fetch inventory.
+    assert client_component.total_legacy_fetches() == 0

--- a/tests/src/unit/test_ha_overview_component_routing.py
+++ b/tests/src/unit/test_ha_overview_component_routing.py
@@ -20,17 +20,22 @@ from __future__ import annotations
 
 from collections import Counter
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
-from ha_mcp.tools import component_api, tools_search
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
+from ha_mcp.tools import tools_search
 from ha_mcp.tools.smart_search import SmartSearchTools
 from ha_mcp.tools.tools_search import register_search_tools
 from ha_mcp.visibility import resolver
 from ha_mcp.visibility.model import VisibilityConfig
 from ha_mcp.visibility.persistence import save_visibility_config
+
+from ._component_routing_helpers import make_ws, patch_ws
 
 _STATES = [
     {
@@ -123,48 +128,6 @@ class OverviewRoutingClient:
         )
 
 
-def _make_ws(
-    *,
-    info_result: dict[str, Any] | None = None,
-    info_exc: Exception | None = None,
-    overview_result: dict[str, Any] | None = None,
-    overview_exc: Exception | None = None,
-) -> AsyncMock:
-    ws = AsyncMock()
-
-    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
-        if command_type == "ha_mcp_tools/info":
-            if info_exc is not None:
-                raise info_exc
-            return {"success": True, "result": info_result}
-        if command_type == "ha_mcp_tools/overview":
-            if overview_exc is not None:
-                raise overview_exc
-            return {"success": True, "result": overview_result}
-        raise AssertionError(f"unexpected command {command_type!r}")
-
-    ws.send_command = AsyncMock(side_effect=_send)
-    return ws
-
-
-class _PatchBothWs:
-    """Context manager patching the caps-probe and overview-send WS factories."""
-
-    def __init__(self, ws: AsyncMock) -> None:
-        self._factory = AsyncMock(return_value=ws)
-
-    def __enter__(self) -> AsyncMock:
-        self._p1 = patch.object(component_api, "get_websocket_client", self._factory)
-        self._p2 = patch.object(tools_search, "get_websocket_client", self._factory)
-        self._p1.start()
-        self._p2.start()
-        return self._factory
-
-    def __exit__(self, *exc: Any) -> None:
-        self._p1.stop()
-        self._p2.stop()
-
-
 def _build_overview_tool(client: Any) -> Any:
     mcp = MagicMock()
     registered: dict[str, Any] = {}
@@ -224,11 +187,15 @@ async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -
     """When the component serves overview, none of the ~8 legacy fetches run."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
+    )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
     assert resp["success"] is True
@@ -251,11 +218,15 @@ async def test_caps_probed_once_across_overviews(tmp_path, monkeypatch) -> None:
     """The info probe is cached: two overviews, one ha_mcp_tools/info call."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
+    )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         await overview(detail_level="standard")
         await overview(detail_level="standard")
 
@@ -270,16 +241,15 @@ async def test_unknown_command_falls_back_silently(tmp_path, monkeypatch) -> Non
     """unknown_command on the overview call → legacy path, no fallback warning."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/overview",
         info_result=_CAPS_OVERVIEW,
-        overview_exc=HomeAssistantCommandError(
-            "Command failed: nope", "unknown_command"
-        ),
+        cmd_exc=HomeAssistantCommandError("Command failed: nope", "unknown_command"),
     )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
     assert resp["success"] is True
@@ -297,16 +267,15 @@ async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> 
     """A non-unknown command error → legacy path AND a warnings[] entry."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/overview",
         info_result=_CAPS_OVERVIEW,
-        overview_exc=HomeAssistantCommandError(
-            "Command failed: boom", "internal_error"
-        ),
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
     )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
     assert resp["success"] is True
@@ -318,17 +287,93 @@ async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_capsless_client_uses_legacy(tmp_path, monkeypatch) -> None:
-    """info → unknown_command yields no caps, so overview runs the legacy path."""
+async def test_command_timeout_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A component WS overview timeout → legacy path AND a warnings[] entry."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
     )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert any(
+        "component overview path failed" in w and "served via legacy path" in w
+        for w in resp["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_malformed_slice_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A required slice of the wrong type → legacy path AND a warnings[] entry.
+
+    ``_build_overview_slices`` returns None on a malformed required slice, so a
+    partial snapshot never serves a silently-degraded overview.
+    """
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    slices = _overview_slices()
+    slices["states"] = "not a list"  # malformed required slice
+    ws = make_ws("ha_mcp_tools/overview", info_result=_CAPS_OVERVIEW, cmd_result=slices)
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    # Legacy inventory served the request instead of the malformed slices.
+    assert client.get_states_calls == 1
+    assert any(
+        "malformed slices" in w and "served via legacy path" in w
+        for w in resp["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_slice_errors_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A non-empty ``slice_errors`` list → legacy path AND a warnings[] entry."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    slices = _overview_slices()  # every required slice well-formed...
+    slices["slice_errors"] = ["entity_registry read failed"]  # ...but flagged bad
+    ws = make_ws("ha_mcp_tools/overview", info_result=_CAPS_OVERVIEW, cmd_result=slices)
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert any(
+        "malformed slices" in w and "served via legacy path" in w
+        for w in resp["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_capsless_client_uses_legacy(tmp_path, monkeypatch) -> None:
+    """info → unknown_command yields no caps, so overview runs the legacy path."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
+    )
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
     assert resp["success"] is True
@@ -360,11 +405,15 @@ async def test_visibility_active_bypasses_component(tmp_path, monkeypatch) -> No
     )
     monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
+    )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
     # The component overview command must never run while the filter is active.
@@ -388,11 +437,15 @@ async def test_enabled_but_no_active_dimension_still_uses_component(
     )
     monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
     _quiet_tail(monkeypatch)
-    ws = _make_ws(info_result=_CAPS_OVERVIEW, overview_result=_overview_slices())
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
+    )
     client = OverviewRoutingClient()
     overview = _build_overview_tool(client)
 
-    with _PatchBothWs(ws):
+    with patch_ws(ws, tools_search):
         await overview(detail_level="standard")
 
     assert any(
@@ -416,19 +469,24 @@ async def test_component_and_legacy_response_parity(tmp_path, monkeypatch) -> No
     _quiet_tail(monkeypatch)
 
     # Legacy run (info → unknown_command ⇒ no caps ⇒ legacy per-read fetch path).
-    ws_legacy = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws_legacy = make_ws(
+        "ha_mcp_tools/overview",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
     )
     client_legacy = OverviewRoutingClient()
-    with _PatchBothWs(ws_legacy):
+    with patch_ws(ws_legacy, tools_search):
         legacy = await _build_overview_tool(client_legacy)(detail_level="standard")
 
     # Component run: the same eight reads, delivered as raw slices in one call.
-    ws_component = _make_ws(
-        info_result=_CAPS_OVERVIEW, overview_result=_overview_slices()
+    ws_component = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
     )
     client_component = OverviewRoutingClient()
-    with _PatchBothWs(ws_component):
+    with patch_ws(ws_component, tools_search):
         component = await _build_overview_tool(client_component)(
             detail_level="standard"
         )

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -13,20 +13,24 @@ can assert they never ran on the component path.
 
 from __future__ import annotations
 
-import contextlib
 from collections import Counter
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
-from ha_mcp.tools import component_api, tools_search
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
+from ha_mcp.tools import tools_search
 from ha_mcp.tools.smart_search import SmartSearchTools
 from ha_mcp.tools.tools_search import register_search_tools
 from ha_mcp.visibility import resolver
 from ha_mcp.visibility.model import VisibilityConfig
 from ha_mcp.visibility.persistence import save_visibility_config
+
+from ._component_routing_helpers import make_ws, patch_ws
 
 _STATES = [
     {
@@ -93,41 +97,6 @@ class RoutingClient:
         return {"config": {}}
 
 
-def _make_ws(
-    *,
-    info_result: dict[str, Any] | None = None,
-    info_exc: Exception | None = None,
-    search_result: dict[str, Any] | None = None,
-    search_exc: Exception | None = None,
-) -> AsyncMock:
-    ws = AsyncMock()
-
-    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
-        if command_type == "ha_mcp_tools/info":
-            if info_exc is not None:
-                raise info_exc
-            return {"success": True, "result": info_result}
-        if command_type == "ha_mcp_tools/search":
-            if search_exc is not None:
-                raise search_exc
-            return {"success": True, "result": search_result}
-        raise AssertionError(f"unexpected command {command_type!r}")
-
-    ws.send_command = AsyncMock(side_effect=_send)
-    return ws
-
-
-@contextlib.contextmanager
-def _patch_ws(ws: AsyncMock) -> Any:
-    """Patch both module references to ``get_websocket_client`` to yield ``ws``."""
-    factory = AsyncMock(return_value=ws)
-    with (
-        patch.object(component_api, "get_websocket_client", factory),
-        patch.object(tools_search, "get_websocket_client", factory),
-    ):
-        yield ws
-
-
 def _build_ha_search(client: Any) -> Any:
     mcp = MagicMock()
     registered: dict[str, Any] = {}
@@ -174,11 +143,15 @@ def _entity_search_result() -> dict[str, Any]:
 async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -> None:
     """When the component serves search, none of the legacy fetches are awaited."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
-    ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+    ws = make_ws(
+        "ha_mcp_tools/search",
+        info_result=_CAPS_SEARCH,
+        cmd_result=_entity_search_result(),
+    )
     client = RoutingClient()
     ha_search = _build_ha_search(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_search):
         resp = await ha_search(query="kitchen")
 
     assert resp["success"] is True
@@ -198,14 +171,15 @@ async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -
 async def test_unknown_command_falls_back_silently(tmp_path, monkeypatch) -> None:
     """unknown_command on the search call → legacy path, no fallback warning."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/search",
         info_result=_CAPS_SEARCH,
-        search_exc=HomeAssistantCommandError("Command failed: nope", "unknown_command"),
+        cmd_exc=HomeAssistantCommandError("Command failed: nope", "unknown_command"),
     )
     client = RoutingClient()
     ha_search = _build_ha_search(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_search):
         resp = await ha_search(query="kitchen")
 
     assert resp["success"] is True
@@ -220,14 +194,15 @@ async def test_unknown_command_falls_back_silently(tmp_path, monkeypatch) -> Non
 async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> None:
     """A non-unknown command error → legacy path AND a warnings[] entry."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
-    ws = _make_ws(
+    ws = make_ws(
+        "ha_mcp_tools/search",
         info_result=_CAPS_SEARCH,
-        search_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
     )
     client = RoutingClient()
     ha_search = _build_ha_search(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_search):
         resp = await ha_search(query="kitchen")
 
     assert resp["success"] is True
@@ -239,11 +214,15 @@ async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> 
 async def test_caps_probed_once_across_searches(tmp_path, monkeypatch) -> None:
     """The info probe is cached: two searches, one ha_mcp_tools/info call."""
     _setup_visibility_disabled(tmp_path, monkeypatch)
-    ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+    ws = make_ws(
+        "ha_mcp_tools/search",
+        info_result=_CAPS_SEARCH,
+        cmd_result=_entity_search_result(),
+    )
     client = RoutingClient()
     ha_search = _build_ha_search(client)
 
-    with _patch_ws(ws):
+    with patch_ws(ws, tools_search):
         await ha_search(query="kitchen")
         await ha_search(query="kitchen")
 
@@ -251,6 +230,49 @@ async def test_caps_probed_once_across_searches(tmp_path, monkeypatch) -> None:
         c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
     ]
     assert len(info_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A component WS timeout → legacy path AND a warnings[] entry (not aborted)."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = make_ws(
+        "ha_mcp_tools/search",
+        info_result=_CAPS_SEARCH,
+        cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+    )
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_component_diagnostics_mark_partial(tmp_path, monkeypatch) -> None:
+    """Non-empty component ``diagnostics`` → partial True + reason names the surface."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    result = {
+        **_entity_search_result(),
+        "diagnostics": {"config_components_inaccessible": ["automation", "script"]},
+    }
+    ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result=result)
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["partial"] is True
+    reason = resp["partial_reason"]
+    assert "config components inaccessible" in reason
+    assert "automation" in reason and "script" in reason
+    # The partial reason is mirrored onto the warnings channel agents read.
+    assert any("config components inaccessible" in w for w in resp["warnings"])
 
 
 @pytest.mark.asyncio
@@ -266,21 +288,26 @@ async def test_component_and_legacy_response_shape_parity(
     """
     _setup_visibility_disabled(tmp_path, monkeypatch)
 
-    ws_component = _make_ws(
-        info_result=_CAPS_SEARCH, search_result=_entity_search_result()
+    ws_component = make_ws(
+        "ha_mcp_tools/search",
+        info_result=_CAPS_SEARCH,
+        cmd_result=_entity_search_result(),
     )
     client_component = RoutingClient()
-    with _patch_ws(ws_component):
+    with patch_ws(ws_component, tools_search):
         component = await _build_ha_search(client_component)(
             query="kitchen", domain_filter="light"
         )
 
     # info → unknown_command yields no caps, so this run takes the legacy path.
-    ws_legacy = _make_ws(
-        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    ws_legacy = make_ws(
+        "ha_mcp_tools/search",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
     )
     client_legacy = RoutingClient()
-    with _patch_ws(ws_legacy):
+    with patch_ws(ws_legacy, tools_search):
         legacy = await _build_ha_search(client_legacy)(
             query="kitchen", domain_filter="light"
         )
@@ -354,8 +381,8 @@ class TestListingModesBypassComponent:
         _setup_visibility_disabled(tmp_path, monkeypatch)
         client = ListingModeClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
-        with _patch_ws(ws):
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result={})
+        with patch_ws(ws, tools_search):
             data = await ha_search(domain_filter="light")
         assert data.get("search_type") == "domain_listing", data
         assert not ws.send_command.await_count, (
@@ -369,8 +396,8 @@ class TestListingModesBypassComponent:
         _setup_visibility_disabled(tmp_path, monkeypatch)
         client = ListingModeClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
-        with _patch_ws(ws):
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result={})
+        with patch_ws(ws, tools_search):
             data = await ha_search(query="   ", domain_filter="light")
         assert data.get("search_type") == "domain_listing", data
         assert not ws.send_command.await_count
@@ -382,8 +409,8 @@ class TestListingModesBypassComponent:
         _setup_visibility_disabled(tmp_path, monkeypatch)
         client = ListingModeClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
-        with _patch_ws(ws):
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result={})
+        with patch_ws(ws, tools_search):
             data = await ha_search(area_filter="Kitchen")
         assert data.get("search_type") == "area_only", data
         assert not ws.send_command.await_count, (
@@ -397,8 +424,8 @@ class TestListingModesBypassComponent:
         _setup_visibility_disabled(tmp_path, monkeypatch)
         client = ListingModeClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
-        with _patch_ws(ws):
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result={})
+        with patch_ws(ws, tools_search):
             data = await ha_search(query="kitchen", area_filter="Kitchen")
         assert data.get("search_type") == "area_filtered_query", data
         assert not ws.send_command.await_count, (
@@ -433,9 +460,13 @@ class TestVisibilityFilterBypassesComponent:
         monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
         client = RoutingClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+        ws = make_ws(
+            "ha_mcp_tools/search",
+            info_result=_CAPS_SEARCH,
+            cmd_result=_entity_search_result(),
+        )
 
-        with _patch_ws(ws):
+        with patch_ws(ws, tools_search):
             data = await ha_search(query="kitchen")
 
         # The component search command must never run while the filter is active.
@@ -460,9 +491,13 @@ class TestVisibilityFilterBypassesComponent:
         monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
         client = RoutingClient()
         ha_search = _build_ha_search(client)
-        ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+        ws = make_ws(
+            "ha_mcp_tools/search",
+            info_result=_CAPS_SEARCH,
+            cmd_result=_entity_search_result(),
+        )
 
-        with _patch_ws(ws):
+        with patch_ws(ws, tools_search):
             await ha_search(query="kitchen")
 
         assert any(

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -404,3 +404,68 @@ class TestListingModesBypassComponent:
         assert not ws.send_command.await_count, (
             "component must not be consulted for area-scoped queries"
         )
+
+
+class TestVisibilityFilterBypassesComponent:
+    """An ACTIVE entity-visibility filter must force the legacy path.
+
+    The component applies no visibility filtering, so a query search on a
+    visibility-enabled install has to stay on the legacy pipeline that excludes
+    hidden entities before the counts/pagination — otherwise a denied entity
+    reappears in ha_search. Regression for the first live component e2e run
+    (test_entity_visibility.py::test_visibility_denylist_hides_entity_from_
+    search_but_get_state_returns_it and ::test_visibility_label_dimension_hides_
+    entity_from_search).
+    """
+
+    @pytest.mark.asyncio
+    async def test_active_deny_filter_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        save_visibility_config(
+            tmp_path,
+            VisibilityConfig(
+                enabled=True,
+                exclude_categories=[],
+                deny_entity_ids=["light.kitchen"],
+            ),
+        )
+        monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+        client = RoutingClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+
+        with _patch_ws(ws):
+            data = await ha_search(query="kitchen")
+
+        # The component search command must never run while the filter is active.
+        assert not any(
+            c.args[0] == "ha_mcp_tools/search" for c in ws.send_command.call_args_list
+        ), "component search must not run while the visibility filter is active"
+        # Legacy inventory served the request and the denied entity is gone.
+        assert client.get_states_calls == 1
+        entity_ids = {e["entity_id"] for e in data["entities"]}
+        assert "light.kitchen" not in entity_ids
+        assert "sensor.kitchen_temp" in entity_ids
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_no_active_dimension_still_uses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # enabled=True with every dimension cleared hides nothing → the fast
+        # component path is still eligible (no needless legacy fallback).
+        save_visibility_config(
+            tmp_path, VisibilityConfig(enabled=True, exclude_categories=[])
+        )
+        monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+        client = RoutingClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+
+        with _patch_ws(ws):
+            await ha_search(query="kitchen")
+
+        assert any(
+            c.args[0] == "ha_mcp_tools/search" for c in ws.send_command.call_args_list
+        ), "no active hide dimension → component should still serve"
+        assert client.get_states_calls == 0

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -295,3 +295,112 @@ async def test_component_and_legacy_response_shape_parity(
     skip = "config-body search skipped"
     assert any(skip in w for w in component["warnings"])
     assert any(skip in w for w in legacy["warnings"])
+
+
+class ListingModeClient(RoutingClient):
+    """RoutingClient + area/floor registries so the area listing path works."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.registry_with_area = {
+            "success": True,
+            "result": [
+                {
+                    "entity_id": "light.kitchen",
+                    "entity_category": None,
+                    "area_id": "kitchen",
+                },
+                {
+                    "entity_id": "sensor.kitchen_temp",
+                    "entity_category": None,
+                    "area_id": "kitchen",
+                },
+            ],
+        }
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        msg_type = msg.get("type", "")
+        if msg_type == "config/area_registry/list":
+            self.ws_types[msg_type] += 1
+            return {
+                "success": True,
+                "result": [{"area_id": "kitchen", "name": "Kitchen"}],
+            }
+        if msg_type == "config/floor_registry/list":
+            self.ws_types[msg_type] += 1
+            return {"success": True, "result": []}
+        if msg_type == "config/entity_registry/list":
+            self.ws_types[msg_type] += 1
+            return self.registry_with_area
+        return await super().send_websocket_message(msg)
+
+
+class TestListingModesBypassComponent:
+    """The three legacy listing modes must NEVER route through the component.
+
+    Regression for the first live e2e run of the component path
+    (test_search_entities.py::test_search_entities_{empty,whitespace}_query_
+    with_domain_filter and ::test_search_entities_area_filter_only): the
+    component path stamped ``search_type: exact_match`` onto responses the
+    legacy path labels ``domain_listing`` / ``area_only`` — and those modes
+    carry mode-specific response shapes the component does not replicate.
+    Only query-driven, non-area searches may route through the component.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_query_domain_listing_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = ListingModeClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
+        with _patch_ws(ws):
+            data = await ha_search(domain_filter="light")
+        assert data.get("search_type") == "domain_listing", data
+        assert not ws.send_command.await_count, (
+            "component must not be consulted for domain listings"
+        )
+
+    @pytest.mark.asyncio
+    async def test_whitespace_query_domain_listing_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = ListingModeClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
+        with _patch_ws(ws):
+            data = await ha_search(query="   ", domain_filter="light")
+        assert data.get("search_type") == "domain_listing", data
+        assert not ws.send_command.await_count
+
+    @pytest.mark.asyncio
+    async def test_area_filter_only_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = ListingModeClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
+        with _patch_ws(ws):
+            data = await ha_search(area_filter="Kitchen")
+        assert data.get("search_type") == "area_only", data
+        assert not ws.send_command.await_count, (
+            "component must not be consulted for area listings"
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_with_area_filter_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = ListingModeClient()
+        ha_search = _build_ha_search(client)
+        ws = _make_ws(info_result=_CAPS_SEARCH, search_result={})
+        with _patch_ws(ws):
+            data = await ha_search(query="kitchen", area_filter="Kitchen")
+        assert data.get("search_type") == "area_filtered_query", data
+        assert not ws.send_command.await_count, (
+            "component must not be consulted for area-scoped queries"
+        )

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -1,0 +1,297 @@
+"""Routing tests for ``ha_search`` over the ``ha_mcp_tools`` component gate.
+
+When the component advertises the ``search`` capability, ``ha_search`` serves
+the whole query from one ``ha_mcp_tools/search`` WebSocket call and skips the
+legacy REST/WS fetch pipeline entirely. These tests pin that fast path and the
+error-taxonomy fallbacks (silent on ``unknown_command``; legacy + ``warnings[]``
+on any other command error), plus response-shape parity between the two paths.
+
+The WS client is an ``AsyncMock`` whose ``send_command`` dispatches on the
+command type. The HA client is a spy that tallies the legacy fetches so a test
+can assert they never ran on the component path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections import Counter
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.tools import component_api, tools_search
+from ha_mcp.tools.smart_search import SmartSearchTools
+from ha_mcp.tools.tools_search import register_search_tools
+from ha_mcp.visibility import resolver
+from ha_mcp.visibility.model import VisibilityConfig
+from ha_mcp.visibility.persistence import save_visibility_config
+
+_STATES = [
+    {
+        "entity_id": "light.kitchen",
+        "state": "on",
+        "attributes": {"friendly_name": "Kitchen"},
+    },
+    {
+        "entity_id": "sensor.kitchen_temp",
+        "state": "21",
+        "attributes": {"friendly_name": "Kitchen Temp"},
+    },
+]
+_ENTITY_REGISTRY = {
+    "success": True,
+    "result": [
+        {"entity_id": "light.kitchen", "entity_category": None},
+        {"entity_id": "sensor.kitchen_temp", "entity_category": None},
+    ],
+}
+
+_CAPS_SEARCH = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["search"],
+    "limits": {},
+}
+
+
+class RoutingClient:
+    """Credentialed HA client spy: tallies every legacy fetch ha_search makes."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.get_states_calls = 0
+        self.ws_types: Counter[str] = Counter()
+
+    async def get_states(self) -> list[dict[str, Any]]:
+        self.get_states_calls += 1
+        return [dict(s) for s in _STATES]
+
+    async def get_config(self) -> dict[str, Any]:
+        return {"time_zone": "UTC"}
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        msg_type = msg.get("type", "")
+        self.ws_types[msg_type] += 1
+        if msg_type == "config/entity_registry/list":
+            return _ENTITY_REGISTRY
+        if msg_type == "config/device_registry/list":
+            return {"success": True, "result": []}
+        if msg_type == "config/entity_registry/get_entries":
+            return {"success": True, "result": {}}
+        return {"success": False}
+
+    async def _request(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("bulk config REST must not be hit on the component path")
+
+    async def get_scene_config(self, scene_id: str) -> dict[str, Any]:
+        return {"config": {}}
+
+    async def get_script_config(self, script_id: str) -> dict[str, Any]:
+        return {"config": {}}
+
+
+def _make_ws(
+    *,
+    info_result: dict[str, Any] | None = None,
+    info_exc: Exception | None = None,
+    search_result: dict[str, Any] | None = None,
+    search_exc: Exception | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            if info_exc is not None:
+                raise info_exc
+            return {"success": True, "result": info_result}
+        if command_type == "ha_mcp_tools/search":
+            if search_exc is not None:
+                raise search_exc
+            return {"success": True, "result": search_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+@contextlib.contextmanager
+def _patch_ws(ws: AsyncMock) -> Any:
+    """Patch both module references to ``get_websocket_client`` to yield ``ws``."""
+    factory = AsyncMock(return_value=ws)
+    with (
+        patch.object(component_api, "get_websocket_client", factory),
+        patch.object(tools_search, "get_websocket_client", factory),
+    ):
+        yield ws
+
+
+def _build_ha_search(client: Any) -> Any:
+    mcp = MagicMock()
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp.add_tool = capture_add_tool
+    register_search_tools(mcp, client, smart_tools=SmartSearchTools(client=client))
+    return registered["ha_search"]
+
+
+def _setup_visibility_disabled(tmp_path: Any, monkeypatch: Any) -> None:
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+
+def _entity_search_result() -> dict[str, Any]:
+    return {
+        "entities": [
+            {
+                "entity_id": "light.kitchen",
+                "friendly_name": "Kitchen",
+                "domain": "light",
+                "state": "on",
+                "score": 100,
+                "match_type": "exact",
+            }
+        ],
+        "entity_total_matches": 1,
+        "entity_has_more": False,
+        "config_total_matches": 0,
+        "config_has_more": False,
+        "partial": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -> None:
+    """When the component serves search, none of the legacy fetches are awaited."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with _patch_ws(ws):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    assert resp["entities"][0]["entity_id"] == "light.kitchen"
+    assert resp["entity_total_matches"] == 1
+    # The legacy inventory is untouched: no /api/states, no registry list.
+    assert client.get_states_calls == 0
+    assert client.ws_types == Counter()
+    # Exactly one component search command was issued.
+    search_calls = [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/search"
+    ]
+    assert len(search_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_falls_back_silently(tmp_path, monkeypatch) -> None:
+    """unknown_command on the search call → legacy path, no fallback warning."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = _make_ws(
+        info_result=_CAPS_SEARCH,
+        search_exc=HomeAssistantCommandError("Command failed: nope", "unknown_command"),
+    )
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with _patch_ws(ws):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    # Legacy inventory served the request.
+    assert client.get_states_calls == 1
+    assert client.ws_types["config/entity_registry/list"] == 1
+    # Silent fallback: no component-failure warning.
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_raised_command_falls_back_with_warning(tmp_path, monkeypatch) -> None:
+    """A non-unknown command error → legacy path AND a warnings[] entry."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = _make_ws(
+        info_result=_CAPS_SEARCH,
+        search_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+    )
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with _patch_ws(ws):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_caps_probed_once_across_searches(tmp_path, monkeypatch) -> None:
+    """The info probe is cached: two searches, one ha_mcp_tools/info call."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = _make_ws(info_result=_CAPS_SEARCH, search_result=_entity_search_result())
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with _patch_ws(ws):
+        await ha_search(query="kitchen")
+        await ha_search(query="kitchen")
+
+    info_calls = [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
+    ]
+    assert len(info_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_component_and_legacy_response_shape_parity(
+    tmp_path, monkeypatch
+) -> None:
+    """Same query resolves to the same envelope shape on both serving paths.
+
+    A body-skipped entity query (query + domain_filter) is served (a) by the
+    component and (b) by the legacy pipeline over equivalent fixture data; the
+    two responses must agree on their key set, pagination axis, and partial
+    semantics.
+    """
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+
+    ws_component = _make_ws(
+        info_result=_CAPS_SEARCH, search_result=_entity_search_result()
+    )
+    client_component = RoutingClient()
+    with _patch_ws(ws_component):
+        component = await _build_ha_search(client_component)(
+            query="kitchen", domain_filter="light"
+        )
+
+    # info → unknown_command yields no caps, so this run takes the legacy path.
+    ws_legacy = _make_ws(
+        info_exc=HomeAssistantCommandError("Command failed: no info", "unknown_command")
+    )
+    client_legacy = RoutingClient()
+    with _patch_ws(ws_legacy):
+        legacy = await _build_ha_search(client_legacy)(
+            query="kitchen", domain_filter="light"
+        )
+
+    assert set(component.keys()) == set(legacy.keys())
+    assert component["partial"] == legacy["partial"] is False
+    assert component["entity_total_matches"] == legacy["entity_total_matches"] == 1
+    assert component["count"] == legacy["count"] == 1
+    assert component["has_more"] == legacy["has_more"] is False
+    assert component["next_offset"] == legacy["next_offset"]
+    # Both paths surface the entity-intent body-skip warning.
+    skip = "config-body search skipped"
+    assert any(skip in w for w in component["warnings"])
+    assert any(skip in w for w in legacy["warnings"])

--- a/tests/src/unit/test_ha_search_request_count.py
+++ b/tests/src/unit/test_ha_search_request_count.py
@@ -1,0 +1,201 @@
+"""Request-cost regression tests for ``ha_search``.
+
+Pins the fetch economy of the default query-only path so a future refactor that
+re-introduces a duplicate or discarded fetch fails loudly:
+
+- ITEM 1 — no ``/api/config`` timezone fetch on the entity branch (entity records
+  carry no timestamp fields, so the enrichment was discarded).
+- ITEM 2 — a single ``/api/states`` shared by the entity + config branches.
+- ITEM 3 — a single ``config/entity_registry/list`` shared the same way.
+- ITEM 5 — ``config/device_registry/list`` is fetched only when the visibility
+  config has an area/label dimension that consumes it; ``get_entities_by_area``
+  still fetches it regardless (entity->device->area fallback).
+- ITEM 4 — the fuzzy path fetches aliases only for entities that survive the
+  domain filter.
+
+The default path is exact-match, so it exercises ``_exact_match_search`` +
+``deep_search``; the config-body sub-fetches fail against these minimal mocks
+(``partial: True``), which does not affect the shared/gated counts under test.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ha_mcp.tools.smart_search import SmartSearchTools
+from ha_mcp.tools.tools_search import register_search_tools
+from ha_mcp.visibility import resolver
+from ha_mcp.visibility.model import VisibilityConfig
+from ha_mcp.visibility.persistence import save_visibility_config
+
+_STATES = [
+    {
+        "entity_id": "light.kitchen",
+        "state": "on",
+        "attributes": {"friendly_name": "Kitchen"},
+    },
+    {
+        "entity_id": "sensor.kitchen_temp",
+        "state": "21",
+        "attributes": {"friendly_name": "Kitchen Temp"},
+    },
+    {
+        "entity_id": "scene.movie",
+        "state": "scening",
+        "attributes": {"friendly_name": "Movie"},
+    },
+]
+_ENTITY_REGISTRY = {
+    "success": True,
+    "result": [
+        {"entity_id": "light.kitchen", "entity_category": None},
+        {"entity_id": "sensor.kitchen_temp", "entity_category": None},
+        {"entity_id": "scene.movie", "unique_id": "movie", "platform": "homeassistant"},
+    ],
+}
+
+
+class CountingClient:
+    """Mock HA client that tallies the fetches ha_search makes.
+
+    Only the shared/gated fetches under test return usable payloads; every other
+    config-body list fetch returns a soft failure so ``deep_search`` degrades to
+    ``partial: True`` instead of hanging on an un-mocked method.
+    """
+
+    def __init__(self) -> None:
+        self.get_states_calls = 0
+        self.get_config_calls = 0
+        self.ws_types: Counter[str] = Counter()
+        self.get_entries_entity_ids: list[list[str]] = []
+
+    async def get_states(self) -> list[dict[str, Any]]:
+        self.get_states_calls += 1
+        return [dict(s) for s in _STATES]
+
+    async def get_config(self) -> dict[str, Any]:
+        self.get_config_calls += 1
+        return {"time_zone": "UTC"}
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        msg_type = msg.get("type", "")
+        self.ws_types[msg_type] += 1
+        if msg_type == "config/entity_registry/list":
+            return _ENTITY_REGISTRY
+        if msg_type == "config/device_registry/list":
+            return {"success": True, "result": []}
+        if msg_type == "config/entity_registry/get_entries":
+            self.get_entries_entity_ids.append(list(msg.get("entity_ids", [])))
+            return {"success": True, "result": {}}
+        # Config-body list fetches (automation/script/scene/helper) — soft-fail.
+        return {"success": False}
+
+    async def _request(self, *args: Any, **kwargs: Any) -> Any:
+        raise Exception("bulk config REST unavailable")
+
+    async def get_scene_config(self, scene_id: str) -> dict[str, Any]:
+        return {"config": {}}
+
+    async def get_script_config(self, script_id: str) -> dict[str, Any]:
+        return {"config": {}}
+
+
+def _build_ha_search(client: CountingClient):
+    mcp = MagicMock()
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp.add_tool = capture_add_tool
+    smart_tools = SmartSearchTools(client=client)
+    register_search_tools(mcp, client, smart_tools=smart_tools)
+    return registered["ha_search"]
+
+
+@pytest.mark.asyncio
+async def test_default_query_path_shares_snapshots_and_skips_gated_fetches(
+    tmp_path, monkeypatch
+):
+    """Default disabled install: one /api/states, one entity-registry list, no
+    /api/config on the entity branch, and no device registry."""
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+    client = CountingClient()
+    ha_search = _build_ha_search(client)
+    resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    # ITEM 2: both branches share one state-machine fetch (was 2).
+    assert client.get_states_calls == 1
+    # ITEM 1: the entity branch no longer fetches /api/config for timezone.
+    assert client.get_config_calls == 0
+    # ITEM 3: both branches share one entity-registry list (was 2).
+    assert client.ws_types["config/entity_registry/list"] == 1
+    # ITEM 5: device registry is pure waste when visibility is disabled.
+    assert client.ws_types["config/device_registry/list"] == 0
+
+
+@pytest.mark.asyncio
+async def test_visibility_area_rule_fetches_device_registry(tmp_path, monkeypatch):
+    """An enabled config with an area exclude consumes the device registry, so the
+    fetch returns — while the shared /api/states + registry economy is unchanged."""
+    save_visibility_config(
+        tmp_path, VisibilityConfig(enabled=True, exclude_areas=["garage"])
+    )
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+    client = CountingClient()
+    ha_search = _build_ha_search(client)
+    resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert client.get_config_calls == 0
+    assert client.ws_types["config/entity_registry/list"] == 1
+    # ITEM 5: the area dimension needs device-inherited areas, so it is fetched.
+    assert client.ws_types["config/device_registry/list"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_entities_by_area_fetches_device_registry_when_visibility_disabled(
+    tmp_path, monkeypatch
+):
+    """CRITICAL EXCLUSION: get_entities_by_area resolves entity->device->area via
+    the device registry, so it must fetch it even with visibility disabled."""
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+    client = CountingClient()
+    smart_tools = SmartSearchTools(client=client)
+    await smart_tools.get_entities_by_area("Kitchen", group_by_domain=False)
+
+    assert client.ws_types["config/device_registry/list"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_domain_filter_fetches_aliases_only_for_survivors(
+    tmp_path, monkeypatch
+):
+    """ITEM 4: the domain filter runs before the alias fetch, so get_entries only
+    covers the domain survivors — not every entity in the state machine."""
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+    client = CountingClient()
+    smart_tools = SmartSearchTools(client=client)
+    await smart_tools.smart_entity_search("kitchen", domain_filter="light")
+
+    # Aliases fetched exactly once, and only for the surviving light entity —
+    # the sensor and scene are filtered out before the alias fan-out.
+    assert client.get_entries_entity_ids == [["light.kitchen"]]

--- a/tests/src/unit/test_websocket_client.py
+++ b/tests/src/unit/test_websocket_client.py
@@ -241,6 +241,67 @@ class TestSendCommandErrorContract:
         assert "Command failed:" in str(exc_info.value)
         assert "system_health failure" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_send_command_attaches_structured_error_code(self):
+        """send_command threads HA's error ``code`` onto the exception.
+
+        The ``code`` lets routing (e.g. the component gate) key off the stable
+        HA error code instead of matching the message string.
+        """
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        client = self._prepare_client()
+
+        async def _resolve_with_failure(message: dict) -> None:
+            message_id = message["id"]
+            future = client._state._pending_requests.get(message_id)
+            assert future is not None, "send_command did not register a pending future"
+            future.set_result(
+                {
+                    "id": message_id,
+                    "type": "result",
+                    "success": False,
+                    "error": {
+                        "code": "unknown_command",
+                        "message": "Unknown command.",
+                    },
+                }
+            )
+
+        client.send_json_message = _resolve_with_failure  # type: ignore[method-assign]
+
+        with pytest.raises(HomeAssistantCommandError) as exc_info:
+            await client.send_command("ha_mcp_tools/info")
+        assert exc_info.value.code == "unknown_command"
+        # Message contract is unchanged.
+        assert "Command failed:" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_send_command_string_error_leaves_code_none(self):
+        """A bare-string error payload carries no code, so ``code`` stays None."""
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        client = self._prepare_client()
+
+        async def _resolve_with_failure(message: dict) -> None:
+            message_id = message["id"]
+            future = client._state._pending_requests.get(message_id)
+            assert future is not None, "send_command did not register a pending future"
+            future.set_result(
+                {
+                    "id": message_id,
+                    "type": "result",
+                    "success": False,
+                    "error": "bare string error",
+                }
+            )
+
+        client.send_json_message = _resolve_with_failure  # type: ignore[method-assign]
+
+        with pytest.raises(HomeAssistantCommandError) as exc_info:
+            await client.send_command("test/ping")
+        assert exc_info.value.code is None
+
 
 class TestSendCommandWaitTimeout:
     """``send_command``'s local await honors the ``_wait_timeout`` argument.

--- a/tests/src/unit/visibility/test_persistence.py
+++ b/tests/src/unit/visibility/test_persistence.py
@@ -1,7 +1,11 @@
+import os
+
 import pytest
 
+from ha_mcp.visibility import persistence
 from ha_mcp.visibility.model import VisibilityConfig
 from ha_mcp.visibility.persistence import (
+    VISIBILITY_FILENAME,
     load_visibility_config,
     save_visibility_config,
 )
@@ -22,3 +26,41 @@ def test_corrupt_json_raises_valueerror(tmp_path):
     (tmp_path / "entity_visibility.json").write_text("{ not json")
     with pytest.raises(ValueError):
         load_visibility_config(tmp_path)
+
+
+def test_same_signature_reuses_parsed_config(tmp_path, monkeypatch):
+    """Two loads of an unchanged file parse once and hand back the same object."""
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=True))
+
+    parse_calls = 0
+    real_loads = persistence.json.loads
+
+    def counting_loads(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return real_loads(*args, **kwargs)
+
+    monkeypatch.setattr(persistence.json, "loads", counting_loads)
+    first = load_visibility_config(tmp_path)
+    second = load_visibility_config(tmp_path)
+
+    assert first.enabled is True
+    assert second is first  # cached parse reused, not re-validated
+    assert parse_calls == 1  # parsed exactly once across the two loads
+
+
+def test_changed_mtime_reloads(tmp_path):
+    """A same-size rewrite with a bumped mtime invalidates the memo (reloads)."""
+    path = tmp_path / VISIBILITY_FILENAME
+    # Two 17-byte payloads so only the mtime axis of the signature moves.
+    path.write_text('{"enabled": true}', encoding="utf-8")
+    first = load_visibility_config(tmp_path)
+    assert first.enabled is True
+
+    path.write_text('{"enabled":false}', encoding="utf-8")
+    st = path.stat()
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 5_000_000_000))
+    second = load_visibility_config(tmp_path)
+
+    assert second.enabled is False  # stale parse not served
+    assert second is not first

--- a/tests/src/unit/visibility/test_resolver.py
+++ b/tests/src/unit/visibility/test_resolver.py
@@ -1,7 +1,14 @@
+import asyncio
 import logging
 
+from ha_mcp.visibility import resolver
 from ha_mcp.visibility.model import VisibilityConfig
-from ha_mcp.visibility.resolver import hidden_entity_ids
+from ha_mcp.visibility.persistence import save_visibility_config
+from ha_mcp.visibility.resolver import (
+    config_has_active_hide_dimensions,
+    hidden_entity_ids,
+    visibility_filter_active,
+)
 
 
 def _reg(*entries):
@@ -66,6 +73,83 @@ def test_category_exclude():
     )
     cfg = VisibilityConfig(enabled=True, exclude_categories=["diagnostic"])
     assert _hidden(reg, cfg) == {"sensor.batt"}
+
+
+# ---------------------------------------------------------------------------
+# config_has_active_hide_dimensions / visibility_filter_active — the ha_search
+# component-routing gate (a query search must NOT hit the visibility-blind
+# component while the filter can hide something).
+# ---------------------------------------------------------------------------
+def test_active_dimensions_disabled_is_inactive():
+    # Even with every dimension populated, a disabled config hides nothing.
+    cfg = VisibilityConfig(enabled=False, deny_entity_ids=["light.x"])
+    assert config_has_active_hide_dimensions(cfg) is False
+
+
+def test_active_dimensions_enabled_but_all_cleared_is_inactive():
+    # enabled=True with exclude_categories emptied and no other dimension hides
+    # nothing → the component may still serve.
+    cfg = VisibilityConfig(enabled=True, exclude_categories=[])
+    assert config_has_active_hide_dimensions(cfg) is False
+
+
+def test_active_dimensions_default_enabled_is_active():
+    # The bare enabled config keeps its default exclude_categories
+    # (diagnostic/config) — an active dimension.
+    assert config_has_active_hide_dimensions(VisibilityConfig(enabled=True)) is True
+
+
+def test_active_dimensions_each_dimension_activates():
+    for kwargs in (
+        {"deny_entity_ids": ["light.x"]},
+        {"exclude_hidden": True},
+        {"exclude_areas": ["garage"]},
+        {"exclude_labels": ["hidden"]},
+        {"allow_entity_ids": ["light.only"]},
+        {"allow_areas": ["kitchen"]},
+        {"allow_labels": ["ok"]},
+        {"respect_assist_exposure": True},
+    ):
+        cfg = VisibilityConfig(enabled=True, exclude_categories=[], **kwargs)
+        assert config_has_active_hide_dimensions(cfg) is True, kwargs
+
+
+def test_active_dimensions_unknown_category_only_is_inactive():
+    # A typo'd category is not one the resolver would ever hide on, so it does
+    # not, by itself, force the legacy path.
+    cfg = VisibilityConfig(enabled=True, exclude_categories=["typo_not_a_category"])
+    assert config_has_active_hide_dimensions(cfg) is False
+
+
+def _active(tmp_path, monkeypatch, config=None):
+    if config is not None:
+        save_visibility_config(tmp_path, config)
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    return asyncio.run(visibility_filter_active())
+
+
+def test_filter_active_missing_file_routes_to_component(tmp_path, monkeypatch):
+    # No config file → disabled default → inactive (component may serve).
+    assert _active(tmp_path, monkeypatch) is False
+
+
+def test_filter_active_enabled_deny_is_active(tmp_path, monkeypatch):
+    cfg = VisibilityConfig(
+        enabled=True, exclude_categories=[], deny_entity_ids=["input_boolean.probe"]
+    )
+    assert _active(tmp_path, monkeypatch, cfg) is True
+
+
+def test_filter_active_disabled_is_inactive(tmp_path, monkeypatch):
+    assert _active(tmp_path, monkeypatch, VisibilityConfig(enabled=False)) is False
+
+
+def test_filter_active_malformed_config_fails_closed_to_legacy(tmp_path, monkeypatch):
+    # A malformed enabled config must NOT silently route to the unfiltered
+    # component: visibility_filter_active fails closed to True (keep legacy).
+    (tmp_path / "entity_visibility.json").write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    assert asyncio.run(visibility_filter_active()) is True
 
 
 def test_denylist_and_area_and_label_union():

--- a/tests/src/unit/visibility/test_search_filter.py
+++ b/tests/src/unit/visibility/test_search_filter.py
@@ -81,8 +81,10 @@ def test_corrupt_config_fails_open_returns_both(tmp_path, monkeypatch):
 
 
 class _DomainClient:
-    """Client for the domain-listing path: states + registry + get_config
-    (the domain path wraps its result via add_timezone_metadata)."""
+    """Client for the domain-listing path: states + entity registry.
+
+    The domain path returns its search dict directly (no add_timezone_metadata
+    wrapper) since entity records carry no timestamp fields."""
 
     def __init__(self, states, registry):
         self._states = states
@@ -94,9 +96,6 @@ class _DomainClient:
     async def send_websocket_message(self, msg):
         assert msg == {"type": "config/entity_registry/list"}
         return self._registry
-
-    async def get_config(self):
-        return {"time_zone": "UTC"}
 
 
 def test_domain_only_search_excludes_denied_and_counts_stay_coherent(
@@ -134,10 +133,9 @@ def test_domain_only_search_excludes_denied_and_counts_stay_coherent(
             parsed_result_fields=None,
         )
     )
-    data = res["data"]
-    ids = [r["entity_id"] for r in data["results"]]
+    ids = [r["entity_id"] for r in res["results"]]
     assert ids == ["sensor.keep"]  # diagnostic sensor.drop excluded
-    assert data["total_matches"] == 1  # count reflects post-filter set, not raw 2
+    assert res["total_matches"] == 1  # count reflects post-filter set, not raw 2
 
 
 class _GetStateClient:


### PR DESCRIPTION
## What does this PR do?

Reworks the search stack for cost and capability, in phased commits:

- [x] **Request cuts** (`6046ecb4`): a verified audit counted 16 HA round-trips on a plain `ha_search` call. Now: `/states` and the entity registry are fetched once and shared across both branches, the discarded timezone fetch is removed from the 5 entity-search builders (the #1590/#1592 UTC→local conversion is untouched where records carry timestamps), `domain_filter` applies before alias hydration, and the device registry is fetched only when the opt-in visibility config uses its area/label dimensions. Request-count regression tests pin the new inventory. All output-identical.
- [x] **Catalog cost** (`046ff4d3`): ha_search was the largest pinned tool description (4,721 chars) with no lite variant — trimmed to 2,525 chars and added to `_LITE_DOCSTRINGS`, preserving the partial-results honesty caveats and the test-pinned `fields` key manifest.
- [x] **Deep-search helper names** (`a63af1ea`): score helpers by current entity-registry names (UI-renamed helpers currently mismatch; same root cause as #1794, whose `ha_config_list_helpers` half is handed off separately).
- [x] **Component read API v1** (`e41a920c` + `c10f5811`): the custom component (→ 1.1.0) registers versioned `ha_mcp_tools/*` WS commands doing in-process joins (states + registries + `ConfigEntry.options` + loaded YAML configs); the server routes to them via the existing version handshake with graceful fallback everywhere — consumers landed:
  - [x] `ha_search` (query-driven, non-area, visibility-filter-off installs; all-or-nothing with graceful fallback; secret values scrubbed from the YAML match corpus)
  - ~~`ha_config_get_*`~~ — capability WITHDRAWN after live e2e: `raw_config` is reload-fresh, not file-fresh, so get-after-set raced HA's async reload and returned stale bodies. All config gets are legacy-served; a file-reading design may revive it (#1813)
  - [x] `ha_get_overview` (~8 round-trips → 1 via raw slices; server assembly unchanged)
  - [x] `ha_config_list_helpers` (current registry names additively — the #1794 fix; flow-helper types now listable on component installs, `COMPONENT_NOT_INSTALLED` error otherwise; `tag` falls back to legacy via the component's `covered_types` signal)

Cross-seam contract tests pin every component↔server seam (real component output through the real tools). Rebased over #1815 (component manifest resolved to 1.1.0).

Stacked on #1810 — its commits appear here until it merges.

## Why this PR is ~10.4k lines — review guide

The number overstates the product-code surface; here's the honest breakdown:

| Slice | Lines | What it is |
|---|---|---|
| Tests | **~6.0k (58%)** | See below — the parity evidence |
| Stacked #1810 | ~1.1k | Not this PR's; vanishes when #1810 merges |
| Custom component | ~1.85k | `websocket_api.py`: five WS commands, in-process joins, server-parity scorer, secret scrub |
| Net server code | ~2.1k | Request dedup, catalog trim, caps gate, four thin consumers reusing legacy assembly |

**Why tests dominate:** this PR reroutes core read tools through a new in-process backend while guaranteeing byte-level response parity with the legacy paths. Every seam carries three layers: per-side unit suites, **cross-seam contract tests that drive the REAL component functions through the REAL server tools** (these caught three contract drifts before CI), and behavioral pins (request-count inventories, scorer golden parity, secret-scrub negatives). Each live e2e failure found during development also got a permanent unit mirror. The contract tests double as the specification of what's guaranteed — reading them is the fastest way to review the seams.

**Suggested review order:** `websocket_api.py` module docstring (the contract) → `component_api.py` (the gate) → the `ha_search` consumer in `tools_search.py` → `test_component_search_contract.py` / `test_component_readapi_contract.py` → remaining consumers.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Future improvements

- `ha_config_list_helpers` registry join for stale ids after UI rename (#1794) — maintainer-confirmed handoff to a separate PR; fix sketch posted on the issue.

## Checklist
- [x] I have updated documentation if needed



