### PR TITLE
feat: add options to disable the server startup notification and sidebar panel

### DIFF
--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -59,6 +59,8 @@ from .const import (
     OPT_AUTO_UPDATE,
     OPT_BIND_HOST,
     OPT_CHANNEL,
+    OPT_ENABLE_SIDEBAR_PANEL,
+    OPT_ENABLE_STARTUP_NOTIFICATION,
     OPT_ENABLE_WEBHOOK,
     OPT_EXTERNAL_URL,
     OPT_PIP_SPEC,
@@ -267,6 +269,14 @@ class HaMcpServerOptionsFlow(OptionsFlow):
                     OPT_ENABLE_WEBHOOK,
                     default=bool(opts.get(OPT_ENABLE_WEBHOOK, True)),
                 ): bool,
+                vol.Required(
+                    OPT_ENABLE_STARTUP_NOTIFICATION,
+                    default=bool(opts.get(OPT_ENABLE_STARTUP_NOTIFICATION, True)),
+                ): bool,
+                vol.Required(
+                    OPT_ENABLE_SIDEBAR_PANEL,
+                    default=bool(opts.get(OPT_ENABLE_SIDEBAR_PANEL, True)),
+                ): bool,
                 vol.Optional(
                     OPT_EXTERNAL_URL,
                     default=opts.get(OPT_EXTERNAL_URL, ""),
@@ -285,12 +295,24 @@ class HaMcpServerOptionsFlow(OptionsFlow):
                 ): bool,
             }
         )
+        # The sidebar-panel sentence in the description is only truthful while
+        # the panel is registered; drop it (from the CURRENT stored options, not
+        # the unsaved form state) when the panel is off so the link cannot point
+        # at a route that 404s. The trailing space keeps the surrounding prose
+        # spaced correctly whether the sentence is present or empty.
+        panel_hint = (
+            "Open the [HA-MCP settings panel](/ha-mcp) for tool management and "
+            "server settings. "
+            if bool(opts.get(OPT_ENABLE_SIDEBAR_PANEL, True))
+            else ""
+        )
         return self.async_show_form(
             step_id="init",
             data_schema=schema,
             description_placeholders={
                 "versions": await self._versions_hint(),
                 "connect_url": self._connect_url_hint(),
+                "panel_hint": panel_hint,
             },
         )
 

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -288,6 +288,12 @@ OPT_REGENERATE_SECRETS = "regenerate_secrets"
 # server through Home Assistant; only the direct server port (+ the
 # admin-only sidebar panel, which proxies over loopback) remains.
 OPT_ENABLE_WEBHOOK = "enable_webhook"
+# When False, the persistent notification created on every server bring-up is
+# suppressed; the connect URLs still reach the admin-only Home Assistant log.
+OPT_ENABLE_STARTUP_NOTIFICATION = "enable_startup_notification"
+# When False, the admin-only "HA-MCP" sidebar settings panel is not registered;
+# the server's options stay reachable on the entry's Configure screen.
+OPT_ENABLE_SIDEBAR_PANEL = "enable_sidebar_panel"
 
 # entry.data keys (persisted ids + secrets; entry.data is fine for secrets).
 DATA_WEBHOOK_ID = "webhook_id"

--- a/custom_components/ha_mcp_tools/embedded_entry.py
+++ b/custom_components/ha_mcp_tools/embedded_entry.py
@@ -30,6 +30,7 @@ from .const import (
     DATA_UPDATE_COORDINATOR,
     DATA_WEBHOOK_ID,
     DOMAIN,
+    OPT_ENABLE_SIDEBAR_PANEL,
     OPT_REGENERATE_SECRETS,
     OPT_SECRET_PATH_OVERRIDE,
     OPT_WEBHOOK_ID_OVERRIDE,
@@ -67,8 +68,11 @@ async def async_setup_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
     # Admin-only "Open Web UI" sidebar panel + proxy. Registered while the entry
     # exists (its proxy returns 503 until the server is actually running), so the
-    # user sees the panel immediately and it reflects the running state.
-    await async_register_ui_panel(hass)
+    # user sees the panel immediately and it reflects the running state. Gated on
+    # the sidebar-panel option; a change to it reloads the entry, and unload's
+    # unconditional async_unregister_ui_panel then removes the panel this skips.
+    if bool(entry.options.get(OPT_ENABLE_SIDEBAR_PANEL, True)):
+        await async_register_ui_panel(hass)
 
     domain_data = hass.data.setdefault(DOMAIN, {})
     # Snapshot the options so the update listener reloads only on a genuine

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -49,6 +49,8 @@ from .const import (
     ISSUE_UPDATE_HELD,
     OPT_AUTO_UPDATE,
     OPT_BIND_HOST,
+    OPT_ENABLE_SIDEBAR_PANEL,
+    OPT_ENABLE_STARTUP_NOTIFICATION,
     OPT_ENABLE_WEBHOOK,
     OPT_EXTERNAL_URL,
     OPT_PIP_SPEC,
@@ -264,6 +266,20 @@ def _surface_connect_urls(
         url_lines,
         auth_note,
     )
+    if not bool(entry.options.get(OPT_ENABLE_STARTUP_NOTIFICATION, True)):
+        # Notification suppressed by option: clear any notification created
+        # before the toggle was turned off, then skip creating a fresh one. The
+        # connect URLs still reached the admin-only log above.
+        persistent_notification.async_dismiss(hass, _NOTIFICATION_ID)
+        return
+    # The sidebar-panel line is included only while the panel is registered:
+    # with the panel option off the /ha-mcp route does not exist and the link
+    # would 404.
+    panel_line = (
+        "Manage it from the [HA-MCP settings panel](/ha-mcp) in the sidebar.\n\n"
+        if bool(entry.options.get(OPT_ENABLE_SIDEBAR_PANEL, True))
+        else ""
+    )
     # SECURITY (review finding): persistent notifications are visible to EVERY
     # authenticated Home Assistant user - core's persistent_notification/get
     # and /subscribe carry no admin gate. In the default posture the connect
@@ -274,7 +290,7 @@ def _surface_connect_urls(
     # as the add-on printing its URL to the admin-only add-on log.
     message = (
         "The HA-MCP Server is now running inside Home Assistant.\n\n"
-        "Manage it from the [HA-MCP settings panel](/ha-mcp) in the sidebar.\n\n"
+        f"{panel_line}"
         "The connect URL is shown on the entry's Configure screen "
         "(Settings - Devices & Services - HA-MCP Custom Component - "
         "HA-MCP Server - Configure) and in the Home Assistant log - both "

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -19,5 +19,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.0.4"
+    "version": "1.0.5"
 }

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -29,7 +29,7 @@
         "step": {
             "init": {
                 "title": "HA-MCP Server",
-                "description": "Configure the HA-MCP server. Open the [HA-MCP settings panel](/ha-mcp) for tool management and server settings. Changes here are applied on save.\n\n{versions}\n\n{connect_url}",
+                "description": "Configure the HA-MCP server. {panel_hint}Changes here are applied on save.\n\n{versions}\n\n{connect_url}",
                 "data": {
                     "channel": "Release channel",
                     "auto_update": "Automatic server updates",
@@ -42,7 +42,9 @@
                     "webhook_id_override": "Custom webhook secret (optional)",
                     "secret_path_override": "Custom direct-access path (optional)",
                     "regenerate_secrets": "Regenerate connect secrets now",
-                    "enable_webhook": "Remote access via webhook"
+                    "enable_webhook": "Remote access via webhook",
+                    "enable_startup_notification": "Startup notification",
+                    "enable_sidebar_panel": "Sidebar settings panel"
                 },
                 "data_description": {
                     "channel": "Stable installs the latest stable release; Development installs the newest development build. When automatic updates are on, a reload or restart, plus a periodic check, install the newest build of the selected channel. A developer package override below takes precedence and disables automatic updates.",
@@ -56,7 +58,9 @@
                     "webhook_id_override": "Replaces the random webhook secret in the connect URL (/api/webhook/...). The URL is the credential - use a long, hard-to-guess value. Leave empty to keep the current one.",
                     "secret_path_override": "Replaces the random path used for direct access on the server port. Same rule: the path is the credential. Leave empty to keep the current one.",
                     "regenerate_secrets": "One-time action: mints a fresh random webhook secret and direct-access path, invalidating the old connect URLs immediately. Also clears the two override fields above.",
-                    "enable_webhook": "Turn off for local-only mode: the Home Assistant webhook is not registered at all, so nothing - including Nabu Casa - can reach the server through Home Assistant. The direct server port and the sidebar panel keep working."
+                    "enable_webhook": "Turn off for local-only mode: the Home Assistant webhook is not registered at all, so nothing - including Nabu Casa - can reach the server through Home Assistant. The direct server port and the sidebar panel keep working.",
+                    "enable_startup_notification": "Show a notification each time the server starts, pointing at the admin-only settings surfaces. Turn off to start silently - the connect URLs still appear in the Home Assistant log.",
+                    "enable_sidebar_panel": "Show the HA-MCP settings panel in the sidebar (administrators only). Turn off to remove the sidebar entry - server options stay available on this screen."
                 }
             }
         }

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -29,7 +29,7 @@
         "step": {
             "init": {
                 "title": "HA-MCP Server",
-                "description": "Configure the HA-MCP server. Open the [HA-MCP settings panel](/ha-mcp) for tool management and server settings. Changes here are applied on save.\n\n{versions}\n\n{connect_url}",
+                "description": "Configure the HA-MCP server. {panel_hint}Changes here are applied on save.\n\n{versions}\n\n{connect_url}",
                 "data": {
                     "channel": "Release channel",
                     "auto_update": "Automatic server updates",
@@ -42,7 +42,9 @@
                     "webhook_id_override": "Custom webhook secret (optional)",
                     "secret_path_override": "Custom direct-access path (optional)",
                     "regenerate_secrets": "Regenerate connect secrets now",
-                    "enable_webhook": "Remote access via webhook"
+                    "enable_webhook": "Remote access via webhook",
+                    "enable_startup_notification": "Startup notification",
+                    "enable_sidebar_panel": "Sidebar settings panel"
                 },
                 "data_description": {
                     "channel": "Stable installs the latest stable release; Development installs the newest development build. When automatic updates are on, a reload or restart, plus a periodic check, install the newest build of the selected channel. A developer package override below takes precedence and disables automatic updates.",
@@ -56,7 +58,9 @@
                     "webhook_id_override": "Replaces the random webhook secret in the connect URL (/api/webhook/...). The URL is the credential - use a long, hard-to-guess value. Leave empty to keep the current one.",
                     "secret_path_override": "Replaces the random path used for direct access on the server port. Same rule: the path is the credential. Leave empty to keep the current one.",
                     "regenerate_secrets": "One-time action: mints a fresh random webhook secret and direct-access path, invalidating the old connect URLs immediately. Also clears the two override fields above.",
-                    "enable_webhook": "Turn off for local-only mode: the Home Assistant webhook is not registered at all, so nothing - including Nabu Casa - can reach the server through Home Assistant. The direct server port and the sidebar panel keep working."
+                    "enable_webhook": "Turn off for local-only mode: the Home Assistant webhook is not registered at all, so nothing - including Nabu Casa - can reach the server through Home Assistant. The direct server port and the sidebar panel keep working.",
+                    "enable_startup_notification": "Show a notification each time the server starts, pointing at the admin-only settings surfaces. Turn off to start silently - the connect URLs still appear in the Home Assistant log.",
+                    "enable_sidebar_panel": "Show the HA-MCP settings panel in the sidebar (administrators only). Turn off to remove the sidebar entry - server options stay available on this screen."
                 }
             }
         }

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -326,11 +326,16 @@ class TestServerOptionsFlow:
         form = asyncio.run(flow.async_step_init(None))
         defaults = {m.schema: m.default() for m in form["data_schema"].schema}
         # regenerate_secrets is a one-shot action, never pre-filled True;
-        # enable_webhook defaults on when unsaved.
+        # enable_webhook / enable_startup_notification / enable_sidebar_panel
+        # default on when unsaved.
         regenerate_default = defaults.pop(const.OPT_REGENERATE_SECRETS)
         assert regenerate_default is False
         webhook_default = defaults.pop(const.OPT_ENABLE_WEBHOOK)
         assert webhook_default is True
+        notification_default = defaults.pop(const.OPT_ENABLE_STARTUP_NOTIFICATION)
+        assert notification_default is True
+        panel_default = defaults.pop(const.OPT_ENABLE_SIDEBAR_PANEL)
+        assert panel_default is True
         assert defaults == saved
 
     def test_init_submit_round_trips_input_into_entry(self):
@@ -388,6 +393,75 @@ class TestServerOptionsFlow:
         # Regression guard for the single-instance pivot: the enable/disable
         # toggle was dropped (entry-exists = server runs).
         assert not hasattr(const, "OPT_EMBEDDED_ENABLED")
+
+    def test_new_toggles_default_on_for_fresh_entry(self):
+        # Both UX toggles (start-up notification, sidebar panel) are present in
+        # the rendered schema and default on when the entry has never stored
+        # them.
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        form = asyncio.run(flow.async_step_init(None))
+        markers = {m.schema: m for m in form["data_schema"].schema}
+        assert const.OPT_ENABLE_STARTUP_NOTIFICATION in markers
+        assert markers[const.OPT_ENABLE_STARTUP_NOTIFICATION].default() is True
+        assert const.OPT_ENABLE_SIDEBAR_PANEL in markers
+        assert markers[const.OPT_ENABLE_SIDEBAR_PANEL].default() is True
+
+    def test_new_toggles_placed_right_after_enable_webhook(self):
+        # Contract: both toggles sit immediately after the enable_webhook field.
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        form = asyncio.run(flow.async_step_init(None))
+        keys = [m.schema for m in form["data_schema"].schema]
+        webhook_idx = keys.index(const.OPT_ENABLE_WEBHOOK)
+        assert set(keys[webhook_idx + 1 : webhook_idx + 3]) == {
+            const.OPT_ENABLE_STARTUP_NOTIFICATION,
+            const.OPT_ENABLE_SIDEBAR_PANEL,
+        }
+
+    def test_new_toggles_prefill_stored_false(self):
+        # Re-opening the form after saving False shows the stored False, not the
+        # default True (a regression here silently re-enables an opted-out UI).
+        flow = _make_options_flow(
+            data={const.DATA_WEBHOOK_ID: "mcp_abc"},
+            options={
+                const.OPT_ENABLE_STARTUP_NOTIFICATION: False,
+                const.OPT_ENABLE_SIDEBAR_PANEL: False,
+            },
+        )
+        form = asyncio.run(flow.async_step_init(None))
+        markers = {m.schema: m for m in form["data_schema"].schema}
+        assert markers[const.OPT_ENABLE_STARTUP_NOTIFICATION].default() is False
+        assert markers[const.OPT_ENABLE_SIDEBAR_PANEL].default() is False
+
+    def test_submitting_false_stores_false_for_new_toggles(self):
+        # Submitting the form with both toggles unchecked persists False.
+        flow = _make_options_flow()
+        user_input = {
+            const.OPT_CHANNEL: const.CHANNEL_STABLE,
+            const.OPT_ENABLE_STARTUP_NOTIFICATION: False,
+            const.OPT_ENABLE_SIDEBAR_PANEL: False,
+        }
+        result = asyncio.run(flow.async_step_init(user_input))
+        assert result["type"] == "entry"
+        assert result["data"][const.OPT_ENABLE_STARTUP_NOTIFICATION] is False
+        assert result["data"][const.OPT_ENABLE_SIDEBAR_PANEL] is False
+
+    def test_panel_hint_contains_panel_url_when_sidebar_enabled(self):
+        # panel_hint is a non-empty sentence naming the panel URL when the
+        # sidebar option is enabled (absent counts as enabled).
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        form = asyncio.run(flow.async_step_init(None))
+        hint = form["description_placeholders"]["panel_hint"]
+        assert hint
+        assert "(/ha-mcp)" in hint
+
+    def test_panel_hint_empty_when_sidebar_disabled(self):
+        # With the sidebar option stored False, the panel hint collapses to "".
+        flow = _make_options_flow(
+            data={const.DATA_WEBHOOK_ID: "mcp_abc"},
+            options={const.OPT_ENABLE_SIDEBAR_PANEL: False},
+        )
+        form = asyncio.run(flow.async_step_init(None))
+        assert form["description_placeholders"]["panel_hint"] == ""
 
     def test_connect_url_hint_uses_configured_port(self):
         flow = _make_options_flow(

--- a/tests/src/unit/test_embedded_entry.py
+++ b/tests/src/unit/test_embedded_entry.py
@@ -27,6 +27,7 @@ from ._embedded_stubs import install
 install()
 
 import custom_components.ha_mcp_tools.embedded_entry as eentry  # noqa: E402
+from custom_components.ha_mcp_tools import const  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_SECRET_PATH,
     DATA_UPDATE_COORDINATOR,
@@ -252,6 +253,31 @@ class TestSetup:
         hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
             entry, [eentry.Platform.UPDATE]
         )
+
+    async def test_default_registers_ui_panel(self, fake_collaborators):
+        # enable_sidebar_panel absent (default on): the admin-only "Open Web UI"
+        # sidebar panel is registered during entry setup.
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        fake_collaborators.panel.async_register_ui_panel.assert_awaited_once()
+
+    async def test_sidebar_panel_off_skips_ui_panel_registration(
+        self, fake_collaborators
+    ):
+        # enable_sidebar_panel=False: entry setup must not register the sidebar
+        # panel (the user opted out of the sidebar entry point).
+        hass = _make_hass()
+        entry = _make_entry()
+        entry.options = {const.OPT_ENABLE_SIDEBAR_PANEL: False}
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        fake_collaborators.panel.async_register_ui_panel.assert_not_awaited()
 
 
 class TestUnload:

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -494,6 +494,83 @@ class TestSurfaceConnectUrls:
             esetup._surface_connect_urls(hass, entry, "none")
         assert "http://192.168.1.5:8123/api/webhook/mcp_id" in caplog.text
 
+    def test_default_options_create_notification_with_panel_line(
+        self, monkeypatch, caplog
+    ):
+        # Baseline for the two UX toggles: with neither option stored, the
+        # start-up notification is created (async_create) and its message links
+        # the sidebar settings panel; nothing is dismissed.
+        import logging
+
+        dismiss = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_dismiss", dismiss)
+        _install_network_cloud(cloud_url=None, local_url="http://192.168.1.5:8123")
+        hass = _make_hass()
+        entry = _make_entry(data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"})
+        with caplog.at_level(logging.INFO):
+            esetup._surface_connect_urls(hass, entry, "none")
+        self.notif.assert_called_once()
+        assert "[HA-MCP settings panel](/ha-mcp)" in self._message()
+        dismiss.assert_not_called()
+
+    def test_startup_notification_off_dismisses_and_skips_create(
+        self, monkeypatch, caplog
+    ):
+        # enable_startup_notification=False: no persistent notification is
+        # created; instead any stale one is dismissed by its id. The connect
+        # URLs still reach the admin-only INFO log unchanged.
+        import logging
+
+        dismiss = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_dismiss", dismiss)
+        _install_network_cloud(cloud_url=None, local_url="http://192.168.1.5:8123")
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"},
+            options={esetup.OPT_ENABLE_STARTUP_NOTIFICATION: False},
+        )
+        with caplog.at_level(logging.INFO):
+            esetup._surface_connect_urls(hass, entry, "none")
+        # No notification created.
+        self.notif.assert_not_called()
+        # The stale one is dismissed by the connect notification's id.
+        dismiss.assert_called_once()
+        dismissed_id = dismiss.call_args.kwargs.get("notification_id") or (
+            dismiss.call_args.args[1] if len(dismiss.call_args.args) > 1 else None
+        )
+        assert dismissed_id == esetup._NOTIFICATION_ID == "ha_mcp_tools_server_connect"
+        assert dismiss.call_args.args[0] is hass
+        # The INFO connect-URL log still happens.
+        assert "HA-MCP in-process server is running" in caplog.text
+        assert "http://192.168.1.5:8123/api/webhook/mcp_id" in caplog.text
+
+    def test_sidebar_panel_off_omits_panel_line_from_notification(
+        self, monkeypatch, caplog
+    ):
+        # enable_sidebar_panel=False (start-up notification still on): the
+        # notification is created, but its message drops the sidebar panel line
+        # (there is no panel to link to). The rest of the notification stays.
+        import logging
+
+        dismiss = MagicMock()
+        monkeypatch.setattr(esetup.persistent_notification, "async_dismiss", dismiss)
+        _install_network_cloud(cloud_url=None, local_url="http://192.168.1.5:8123")
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"},
+            options={esetup.OPT_ENABLE_SIDEBAR_PANEL: False},
+        )
+        with caplog.at_level(logging.INFO):
+            esetup._surface_connect_urls(hass, entry, "none")
+        self.notif.assert_called_once()
+        dismiss.assert_not_called()
+        message = self._message()
+        assert "[HA-MCP settings panel](/ha-mcp)" not in message
+        assert "(/ha-mcp)" not in message
+        # Still a real notification: the admin-only Configure pointer remains.
+        assert "Configure" in message
+        assert self.notif.call_args.kwargs.get("title") == "HA-MCP Server"
+
 
 class TestBuildConnectUrls:
     """Direct coverage of ``build_connect_urls`` — the shared URL resolver that


### PR DESCRIPTION
## What does this PR do?

Adds two toggles to the HA-MCP Server entry's options flow, both enabled by default:

- **Startup notification** — when turned off, the persistent notification created on every server bring-up is suppressed. The connect URLs still go to the admin-only Home Assistant log, and turning the toggle off also dismisses a lingering notification from before the change.
- **Sidebar settings panel** — when turned off, the admin-only "HA-MCP" sidebar panel is not registered. Server options stay available on the entry's Configure screen. An options change reloads the entry, so the toggle takes effect immediately.

The panel links in the startup notification and in the options-screen description are now conditional, so disabling the panel leaves no dead `/ha-mcp` links.

Component `manifest.json` bumped to 1.0.5. No new server-consumed services, so `MIN_COMPONENT_VERSION` is unchanged.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

11 new unit tests cover the notification gate (create/dismiss/message content), the panel registration gate, and the options-flow schema defaults, prefill, and `panel_hint` placeholder.

## Checklist
- [x] I have updated documentation if needed
