### PR TITLE
docs: clarify saved custom tools are shared, out of scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -201,6 +201,11 @@ the proxy returns 503 whenever the server is not running.
   (see [Threat Model](#threat-model) above).
 - OAuth token revocation not preventing further HA API access: revoke the LLAT
   in Home Assistant instead.
+- Saved custom tools (code mode, off by default) visible to other clients of the
+  same server process: they are shared, persistent scaffolding — not per-user
+  data — and `run_saved` executes with the caller's own HA token, granting no
+  access the caller lacks. Any client that can reach ha-mcp is a trusted
+  principal (see [Threat Model](#threat-model) above).
 - Vulnerabilities that are only exploitable due to a misconfigured deployment
   (e.g., standard-mode instance exposed to the internet without TLS, or a
   network-reachable HTTP entrypoint using the default `MCP_SECRET_PATH`).

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -126,7 +126,8 @@ configuration:
       existing MCP tools (call_tool), or remove a saved tool
       (delete_saved_tool). Saved tools persist to
       /data/saved_tools.json by default so they survive add-on
-      restarts. See docs/beta.md for known limitations. Requires
+      restarts, and are visible to any client that can connect. See
+      docs/beta.md for known limitations. Requires
       restart to take effect. REQUIRES the master "Enable beta
       features" toggle above (and in the web UI) to be on — otherwise
       this sub-flag is ignored at runtime regardless of its value

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -1553,7 +1553,7 @@ const FEATURE_META = {
   },
   enable_code_mode: {
     label: "Enable code-mode sandbox (beta)",
-    help: "Beta feature, disabled by default. Enables ha_manage_custom_tool, a sandboxed Python interpreter (pydantic-monty) that lets AI assistants write/run/save/delete custom tools when no built-in tool covers the request. Sandbox cannot touch the filesystem or arbitrary network, but CAN call any registered MCP tool, hit the HA REST API, or send HA WebSocket commands, effectively 'do whatever existing tools allow you to do, in any combination'. See docs/beta.md for known limitations. Requires restart to take effect.",
+    help: "Beta feature, disabled by default. Enables ha_manage_custom_tool, a sandboxed Python interpreter (pydantic-monty) that lets AI assistants write/run/save/delete custom tools when no built-in tool covers the request. Sandbox cannot touch the filesystem or arbitrary network, but CAN call any registered MCP tool, hit the HA REST API, or send HA WebSocket commands, effectively 'do whatever existing tools allow you to do, in any combination'. Saved tools persist and are visible to any client that can connect to ha-mcp. See docs/beta.md for known limitations. Requires restart to take effect.",
   },
   enable_lite_docstrings: {
     label: "Enable lite tool docstrings (beta)",


### PR DESCRIPTION
## What does this PR do?

Documents that code-mode saved custom tools are shared, persistent state scoped to the server process — not per-user data. Adds an out-of-scope bullet to `SECURITY.md` and a one-line note on the code-mode toggle help (web settings UI + dev add-on translation), so "cross-user saved tool exposure" reports can be closed by citation. `run_saved` already executes with the caller's own HA token, so this is a documentation clarification only — no behavior change.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

n/a — copy-only change (Markdown, a JS help string, and a YAML description); no code paths touched.

## Checklist
- [x] I have updated documentation if needed
