### PR TITLE
fix: join entity registry in ha_config_list_helpers so renamed helpers show current entity_id/name

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1398,6 +1398,74 @@ async def _find_collision_in_simple_helpers(
     return None
 
 
+_REGISTRY_JOIN_STALE_WARNING = (
+    "Could not read the entity registry, so a renamed helper's 'name' may be the "
+    "creation-time name and no current 'entity_id' is shown; use ha_get_entity for "
+    "the authoritative current values."
+)
+
+
+async def _enrich_helpers_with_current_registry(
+    client: Any, helper_type: str, items: list[Any]
+) -> list[str]:
+    """Join the entity registry onto storage-collection helper records.
+
+    The ``{helper_type}/list`` response carries the immutable storage ``id``
+    (the unique_id) and the creation-time ``name``; after a UI rename the
+    current ``entity_id`` and display name live only in the entity registry, so
+    the raw list goes stale (issue #1794). For each record matched by
+    ``unique_id`` **and** ``platform == helper_type`` this adds the current
+    ``entity_id``, moves the storage name to ``original_name``, and sets
+    ``name`` to the current display name (registry ``name``, falling back to
+    ``original_name``). ``items`` is mutated in place.
+
+    Storage types without a matching entity (e.g. ``tag``) and platform
+    mismatches are left untouched. Returns a warnings list — non-empty only
+    when the registry read failed, so the caller can flag the un-enriched
+    result instead of silently returning stale values.
+    """
+    if not items:
+        # Nothing to enrich — skip the full-registry fetch entirely.
+        return []
+    try:
+        reg_result = await client.send_websocket_message(
+            {"type": "config/entity_registry/list"}
+        )
+    except (HomeAssistantAPIError, ConnectionError, TimeoutError) as e:
+        logger.debug(f"list_helpers registry enrichment: registry read failed: {e}")
+        return [_REGISTRY_JOIN_STALE_WARNING]
+    # A missing / non-list ``result`` (or a non-dict / unsuccessful response) is
+    # a malformed read, not an empty registry — flag it rather than silently
+    # returning un-enriched records. A present-but-empty ``[]`` is a legitimate
+    # no-match and passes through below without a warning.
+    if not (
+        isinstance(reg_result, dict)
+        and reg_result.get("success")
+        and isinstance(reg_result.get("result"), list)
+    ):
+        return [_REGISTRY_JOIN_STALE_WARNING]
+    registry = reg_result["result"]
+    reg_by_uid = {
+        entry["unique_id"]: entry
+        for entry in registry
+        if isinstance(entry, dict)
+        and entry.get("platform") == helper_type
+        and entry.get("unique_id")
+    }
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        entry = reg_by_uid.get(item.get("id"))
+        if entry is None:
+            continue
+        item["entity_id"] = entry.get("entity_id")
+        item["original_name"] = item.get("name")
+        item["name"] = (
+            entry.get("name") or entry.get("original_name") or item.get("name")
+        )
+    return []
+
+
 async def _check_name_collision(
     client: Any,
     helper_type: str,
@@ -3537,10 +3605,15 @@ class HelperConfigTools:
         List all Home Assistant helpers of a specific type with their configurations.
 
         Returns complete configuration for all helpers of the specified type including:
-        - ID (storage id), name, icon
-        - entity_id and current display name (where available)
+        - id (immutable storage key), entity_id (current — address the helper by
+          this, where available), name (current display name), original_name
+          (creation-time name), icon
         - Type-specific settings (min/max for input_number, options for input_select, etc.)
         - Area and label assignments
+
+        For a helper renamed in the UI, id/original_name keep the storage values while
+        entity_id/name reflect the current entity registry (entity_id is the identifier
+        ha_config_set_helper resolves against, so prefer it over id for a renamed helper).
 
         SUPPORTED HELPER TYPES:
         - input_button: Virtual buttons for triggering automations
@@ -3601,14 +3674,25 @@ class HelperConfigTools:
                 {"type": f"{helper_type}/list"}
             )
             if result.get("success"):
-                items = result.get("result", [])
-                return {
+                # Flatten first: person/list returns {"storage": [...],
+                # "config": [...]} rather than a flat list, so a raw
+                # result["result"] would be a dict here — breaking both the
+                # count and the registry enrichment below (which iterates
+                # records). _flatten_helper_list_result normalises both shapes.
+                items = _flatten_helper_list_result(result)
+                warnings = await _enrich_helpers_with_current_registry(
+                    self._client, helper_type, items
+                )
+                response: dict[str, Any] = {
                     "success": True,
                     "helper_type": helper_type,
                     "count": len(items),
                     "helpers": items,
                     "message": f"Found {len(items)} {helper_type} helper(s)",
                 }
+                if warnings:
+                    response["warnings"] = warnings
+                return response
             raise_tool_error(
                 create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3469,6 +3469,14 @@ def _shape_collection_helper_record(rec: dict[str, Any]) -> dict[str, Any]:
         out["entity_id"] = entity_id
     name = rec.get("name")
     if name is not None:
+        # The storage body's ``name`` is the creation-time name (a rename
+        # updates the registry, not the body — #1794); preserve it as
+        # ``original_name`` before the current display name overrides it, so a
+        # component-served record carries the same additive shape as the legacy
+        # join (both paths promise entity_id/original_name in the docstring).
+        original_name = out.get("name")
+        if original_name is not None:
+            out["original_name"] = original_name
         out["name"] = name
     return out
 

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1400,8 +1400,8 @@ async def _find_collision_in_simple_helpers(
 
 _REGISTRY_JOIN_STALE_WARNING = (
     "Could not read the entity registry, so a renamed helper's 'name' may be the "
-    "creation-time name and no current 'entity_id' is shown; use ha_get_entity for "
-    "the authoritative current values."
+    "creation-time name and no current 'entity_id' is shown; use ha_search to find "
+    "the helper by name for the authoritative current values."
 )
 
 
@@ -1427,42 +1427,53 @@ async def _enrich_helpers_with_current_registry(
     if not items:
         # Nothing to enrich — skip the full-registry fetch entirely.
         return []
+    # Degrade-open: enrichment is cosmetic, so any failure — the registry read,
+    # an unexpected registry shape (e.g. a non-hashable ``id`` breaking the
+    # lookup), or a malformed response — flags the result rather than raising
+    # out and letting the caller's handler turn a list call into a failure.
+    # Mirrors _get_entities_for_config_entry, which reads the same endpoint.
+    # send_websocket_message returns {"success": false, ...} instead of raising,
+    # so the malformed-response check below is the branch production takes.
     try:
         reg_result = await client.send_websocket_message(
             {"type": "config/entity_registry/list"}
         )
-    except (HomeAssistantAPIError, ConnectionError, TimeoutError) as e:
-        logger.debug(f"list_helpers registry enrichment: registry read failed: {e}")
+        # A missing / non-list ``result`` (or a non-dict / unsuccessful response)
+        # is a malformed read, not an empty registry — flag it rather than
+        # silently returning un-enriched records. A present-but-empty ``[]`` is a
+        # legitimate no-match and passes through below without a warning.
+        if not (
+            isinstance(reg_result, dict)
+            and reg_result.get("success")
+            and isinstance(reg_result.get("result"), list)
+        ):
+            logger.debug(
+                "list_helpers registry enrichment: malformed registry response: %r",
+                reg_result,
+            )
+            return [_REGISTRY_JOIN_STALE_WARNING]
+        registry = reg_result["result"]
+        reg_by_uid = {
+            entry["unique_id"]: entry
+            for entry in registry
+            if isinstance(entry, dict)
+            and entry.get("platform") == helper_type
+            and entry.get("unique_id")
+        }
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            entry = reg_by_uid.get(item.get("id"))
+            if entry is None:
+                continue
+            item["entity_id"] = entry.get("entity_id")
+            item["original_name"] = item.get("name")
+            item["name"] = (
+                entry.get("name") or entry.get("original_name") or item.get("name")
+            )
+    except Exception as e:
+        logger.debug(f"list_helpers registry enrichment failed: {e}")
         return [_REGISTRY_JOIN_STALE_WARNING]
-    # A missing / non-list ``result`` (or a non-dict / unsuccessful response) is
-    # a malformed read, not an empty registry — flag it rather than silently
-    # returning un-enriched records. A present-but-empty ``[]`` is a legitimate
-    # no-match and passes through below without a warning.
-    if not (
-        isinstance(reg_result, dict)
-        and reg_result.get("success")
-        and isinstance(reg_result.get("result"), list)
-    ):
-        return [_REGISTRY_JOIN_STALE_WARNING]
-    registry = reg_result["result"]
-    reg_by_uid = {
-        entry["unique_id"]: entry
-        for entry in registry
-        if isinstance(entry, dict)
-        and entry.get("platform") == helper_type
-        and entry.get("unique_id")
-    }
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        entry = reg_by_uid.get(item.get("id"))
-        if entry is None:
-            continue
-        item["entity_id"] = entry.get("entity_id")
-        item["original_name"] = item.get("name")
-        item["name"] = (
-            entry.get("name") or entry.get("original_name") or item.get("name")
-        )
     return []
 
 
@@ -3614,6 +3625,9 @@ class HelperConfigTools:
         For a helper renamed in the UI, id/original_name keep the storage values while
         entity_id/name reflect the current entity registry (entity_id is the identifier
         ha_config_set_helper resolves against, so prefer it over id for a renamed helper).
+        entity_id/original_name are present only for storage-collection helpers matched in
+        the entity registry — types with no backing entity (e.g. tag), and every record when
+        the registry read degrades, carry only id/name (a warning flags the degraded case).
 
         SUPPORTED HELPER TYPES:
         - input_button: Virtual buttons for triggering automations

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -148,6 +148,107 @@ class TestInputBooleanCRUD:
             )
         logger.info("Input boolean deletion verified")
 
+    async def test_renamed_helper_surfaces_current_registry_values(
+        self, mcp_client, cleanup_tracker
+    ):
+        """#1794 regression: after a rename the storage collection keeps the
+        creation-time id/name, while ha_config_list_helpers must surface the
+        registry's current entity_id/name — and that surfaced entity_id must be a
+        working key for ha_config_set_helper.
+
+        A dedicated test rather than an extension of the lifecycle case above:
+        the rename swaps the entity_id, so folding it into that flow would leave
+        its later update/delete steps pointing at the stale id.
+        """
+        original_name = "E2E Rename Join"
+        original_entity_id = "input_boolean.e2e_rename_join"
+        new_entity_id = "input_boolean.e2e_rename_join_renamed"
+        new_name = "E2E Rename Join Renamed"
+
+        # CREATE
+        create_data = assert_mcp_success(
+            await mcp_client.call_tool(
+                "ha_config_set_helper",
+                {"helper_type": "input_boolean", "name": original_name},
+            ),
+            "Create input_boolean",
+        )
+        assert (
+            get_entity_id_from_response(create_data, "input_boolean")
+            == original_entity_id
+        ), f"unexpected creation entity_id: {create_data}"
+        cleanup_tracker.track("input_boolean", new_entity_id)
+        assert await wait_for_entity_registration(mcp_client, original_entity_id), (
+            f"Entity not registered: {original_entity_id}"
+        )
+
+        # RENAME entity_id + display name (diverges the registry from storage)
+        assert_mcp_success(
+            await mcp_client.call_tool(
+                "ha_set_entity",
+                {
+                    "entity_id": original_entity_id,
+                    "new_entity_id": new_entity_id,
+                    "name": new_name,
+                },
+            ),
+            "Rename input_boolean",
+        )
+        assert await wait_for_entity_registration(mcp_client, new_entity_id), (
+            f"Renamed entity not registered: {new_entity_id}"
+        )
+
+        # LIST — the join must surface the renamed entity_id/name; storage keeps
+        # its creation-time id/original_name (the exact divergence #1794 is about).
+        list_data = assert_mcp_success(
+            await mcp_client.call_tool(
+                "ha_config_list_helpers", {"helper_type": "input_boolean"}
+            ),
+            "List after rename",
+        )
+        record = next(
+            (
+                h
+                for h in list_data.get("helpers", [])
+                if h.get("original_name") == original_name
+            ),
+            None,
+        )
+        assert record, f"renamed helper not found by original_name: {list_data}"
+        assert record.get("entity_id") == new_entity_id, (
+            f"list must surface the renamed entity_id, got: {record}"
+        )
+        assert record.get("name") == new_name, (
+            f"list must surface the current display name, got: {record}"
+        )
+        assert record.get("entity_id") != f"input_boolean.{record.get('id')}", (
+            f"entity_id should diverge from the storage-id slug after rename: {record}"
+        )
+
+        # ROUND-TRIP — the surfaced entity_id is the working key for set_helper.
+        assert_mcp_success(
+            await mcp_client.call_tool(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "input_boolean",
+                    "helper_id": record["entity_id"],
+                    "icon": "mdi:check",
+                },
+            ),
+            "Update via surfaced entity_id",
+        )
+        logger.info("Round-tripped set_helper via the surfaced entity_id")
+
+        # CLEANUP
+        await mcp_client.call_tool(
+            "ha_remove_helpers_integrations",
+            {
+                "helper_type": "input_boolean",
+                "target": new_entity_id,
+                "confirm": True,
+            },
+        )
+
     async def test_input_boolean_with_initial_state(self, mcp_client, cleanup_tracker):
         """Test creating input_boolean with initial state."""
         logger.info("Testing input_boolean with initial state")

--- a/tests/src/e2e/workflows/config/test_helper_crud.py
+++ b/tests/src/e2e/workflows/config/test_helper_crud.py
@@ -97,12 +97,17 @@ class TestInputBooleanCRUD:
         )
         list_data = assert_mcp_success(list_result, "List after create")
 
-        found = False
+        found_helper = None
         for helper in list_data.get("helpers", []):
             if helper.get("name") == helper_name:
-                found = True
+                found_helper = helper
                 break
-        assert found, f"Created helper not found in list: {helper_name}"
+        assert found_helper, f"Created helper not found in list: {helper_name}"
+        # #1794: the list joins the entity registry, so each record carries the
+        # current entity_id (not just the storage id / creation name).
+        assert found_helper.get("entity_id") == entity_id, (
+            f"list_helpers should surface the current entity_id, got: {found_helper}"
+        )
         logger.info("Input boolean verified in list")
 
         # UPDATE

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -55,6 +55,21 @@ from ._component_routing_helpers import make_ws, patch_ws
 # exact #1794 shape (legacy list would emit only the storage id + stale name).
 _LEGACY_ITEMS = [{"id": "abc123", "name": "Old Name", "icon": "mdi:flash"}]
 
+# Entity-registry entry the legacy path joins onto ``_LEGACY_ITEMS`` (#1794):
+# unique_id ``abc123`` on platform ``input_boolean`` currently lives at
+# ``input_boolean.foo`` with display name "New Name". Enriching the legacy list
+# with this yields the same record the component path emits, so the two paths
+# stay parity-equal instead of the legacy body degrading on an unhandled read.
+_LEGACY_REGISTRY = [
+    {
+        "entity_id": "input_boolean.foo",
+        "unique_id": "abc123",
+        "platform": "input_boolean",
+        "name": "New Name",
+        "original_name": "Old Name",
+    }
+]
+
 _CAPS_HELPERS = {
     "schema_version": 1,
     "component_version": "1.1.0",
@@ -106,8 +121,13 @@ class RoutingClient:
         self.list_calls = 0
 
     async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
-        self.list_calls += 1
         msg_type = msg.get("type", "")
+        # The legacy body joins the entity registry (#1794); serve it, but don't
+        # tally it as a {type}/list fetch — the counter tracks the helper-list
+        # round-trip the routing assertions care about.
+        if msg_type == "config/entity_registry/list":
+            return {"success": True, "result": [dict(e) for e in _LEGACY_REGISTRY]}
+        self.list_calls += 1
         if msg_type == "input_boolean/list":
             return {"success": True, "result": [dict(i) for i in _LEGACY_ITEMS]}
         if msg_type == "tag/list":

--- a/tests/src/unit/test_helper_list_registry_join.py
+++ b/tests/src/unit/test_helper_list_registry_join.py
@@ -214,6 +214,60 @@ class TestListHelpersRegistryJoin:
         assert "entity_id" not in helper
         assert any("registry" in w.lower() for w in result.get("warnings", []))
 
+    async def test_registry_unsuccessful_response_degrades_open_with_warning(
+        self, register_tools, mock_client
+    ):
+        """The registry read never raises in production — the client returns
+        ``{"success": False, ...}`` on failure rather than throwing. That
+        unsuccessful response is a malformed read: the tool must flag it and
+        return the un-enriched list (the branch production actually takes)."""
+
+        async def handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/list":
+                return {"success": False, "error": "registry unavailable"}
+            if msg_type.endswith("/list"):
+                return {"success": True, "result": [{"id": "x", "name": "X"}]}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=handler)
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        helper = result["helpers"][0]
+        assert helper == {"id": "x", "name": "X"}
+        assert "entity_id" not in helper
+        assert any("registry" in w.lower() for w in result.get("warnings", []))
+
+    async def test_registry_unexpected_shape_degrades_open_without_raising(
+        self, register_tools, mock_client
+    ):
+        """An unexpected record shape (here a non-hashable ``id`` that breaks the
+        registry lookup) must degrade open. Enrichment is cosmetic, so a raise
+        from the join must never turn a list call into a failure — the broad
+        guard converts it to the un-enriched list plus a warning."""
+        list_items = [{"id": ["not", "hashable"], "name": "X"}]
+        registry = [
+            {
+                "entity_id": "input_boolean.x",
+                "unique_id": "x",
+                "platform": "input_boolean",
+                "name": "X",
+            }
+        ]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, registry)
+        )
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        assert result["success"] is True
+        assert any("registry" in w.lower() for w in result.get("warnings", []))
+
     async def test_person_dict_shaped_list_is_flattened_and_enriched(
         self, register_tools, mock_client
     ):

--- a/tests/src/unit/test_helper_list_registry_join.py
+++ b/tests/src/unit/test_helper_list_registry_join.py
@@ -1,0 +1,272 @@
+"""
+Unit tests for ha_config_list_helpers entity-registry enrichment (issue #1794).
+
+``ha_config_list_helpers`` builds its records from the ``{helper_type}/list``
+storage-collection WebSocket response, which carries the immutable ``id``
+(unique_id) and creation-time ``name``. After a UI rename those go stale — the
+current ``entity_id`` and display name live in the entity registry. These tests
+pin that the tool joins the entity registry so a renamed helper surfaces its
+current ``entity_id`` and ``name`` (keeping the storage ``id`` and the original
+name for reference), and that the join degrades gracefully.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_client():
+    """Mock client whose WS handler is assembled per-test from canned responses."""
+    return MagicMock()
+
+
+@pytest.fixture
+def register_tools(mock_client):
+    """Register helper config tools and return the captured tool callables."""
+    from ha_mcp.tools.tools_config_helpers import register_config_helper_tools
+
+    registered_tools: dict[str, Any] = {}
+
+    def capture_add_tool(method):
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered_tools[name] = method
+
+    mock_mcp = MagicMock()
+    mock_mcp.add_tool = capture_add_tool
+    register_config_helper_tools(mock_mcp, mock_client)
+    return registered_tools
+
+
+def _ws_handler(list_items: list[dict], registry: list[dict] | Exception):
+    """Build a send_websocket_message side_effect for list + registry responses."""
+
+    async def handler(msg: dict) -> dict:
+        msg_type = msg.get("type", "")
+        if msg_type == "config/entity_registry/list":
+            if isinstance(registry, Exception):
+                raise registry
+            return {"success": True, "result": registry}
+        if msg_type.endswith("/list"):
+            return {"success": True, "result": list_items}
+        return {"success": True, "result": {}}
+
+    return handler
+
+
+class TestListHelpersRegistryJoin:
+    async def test_renamed_helper_surfaces_current_entity_id_and_name(
+        self, register_tools, mock_client
+    ):
+        """A helper renamed in the UI (entity_id + name changed, unique_id kept)
+        must surface the current entity_id and display name, not the stale
+        storage values."""
+        list_items = [
+            {"id": "dark_enough", "name": "Dark Enough", "icon": "mdi:brightness-6"}
+        ]
+        registry = [
+            {
+                "entity_id": "input_boolean.dark_enough_mode",
+                "unique_id": "dark_enough",
+                "platform": "input_boolean",
+                "name": "Dark Enough Mode",
+                "original_name": "Dark Enough",
+            }
+        ]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, registry)
+        )
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        assert result["success"] is True
+        helper = result["helpers"][0]
+        # Storage id preserved (still the key HA's collection uses).
+        assert helper["id"] == "dark_enough"
+        # Current values surfaced from the registry.
+        assert helper["entity_id"] == "input_boolean.dark_enough_mode"
+        assert helper["name"] == "Dark Enough Mode"
+        # Original creation-time name kept, labeled.
+        assert helper["original_name"] == "Dark Enough"
+
+    async def test_registry_name_null_falls_back_to_original_name(
+        self, register_tools, mock_client
+    ):
+        """When the registry entry has no custom name (name is null), the current
+        name falls back to original_name and entity_id is still surfaced."""
+        list_items = [{"id": "guest_mode", "name": "Guest Mode"}]
+        registry = [
+            {
+                "entity_id": "input_boolean.guest_mode",
+                "unique_id": "guest_mode",
+                "platform": "input_boolean",
+                "name": None,
+                "original_name": "Guest Mode",
+            }
+        ]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, registry)
+        )
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        helper = result["helpers"][0]
+        assert helper["entity_id"] == "input_boolean.guest_mode"
+        assert helper["name"] == "Guest Mode"
+
+    async def test_no_registry_match_keeps_storage_values(
+        self, register_tools, mock_client
+    ):
+        """A helper with no matching registry entry (e.g. a tag, which has no
+        entity) keeps its storage id/name and gains no entity_id."""
+        list_items = [{"id": "abc123", "name": "My Tag"}]
+        registry: list[dict] = []
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, registry)
+        )
+
+        result = await register_tools["ha_config_list_helpers"](helper_type="tag")
+
+        helper = result["helpers"][0]
+        assert helper["id"] == "abc123"
+        assert helper["name"] == "My Tag"
+        assert "entity_id" not in helper
+
+    async def test_platform_mismatch_is_not_joined(self, register_tools, mock_client):
+        """A registry entry sharing the unique_id but on a different platform must
+        not be joined (guards against cross-platform unique_id collision)."""
+        list_items = [{"id": "shared", "name": "Storage Name"}]
+        registry = [
+            {
+                "entity_id": "sensor.shared_thing",
+                "unique_id": "shared",
+                "platform": "sensor",
+                "name": "Some Sensor",
+                "original_name": "Some Sensor",
+            }
+        ]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, registry)
+        )
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        helper = result["helpers"][0]
+        assert helper["name"] == "Storage Name"
+        assert "entity_id" not in helper
+
+    async def test_registry_fetch_failure_degrades_open_with_warning(
+        self, register_tools, mock_client
+    ):
+        """If the entity_registry/list call fails, the tool still returns the
+        helper list (as before the join) and flags the degradation."""
+        list_items = [{"id": "dark_enough", "name": "Dark Enough"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_ws_handler(list_items, TimeoutError("ws boom"))
+        )
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        helper = result["helpers"][0]
+        assert helper["id"] == "dark_enough"
+        # No enrichment, but the list still works.
+        assert "entity_id" not in helper
+        assert any("registry" in w.lower() for w in result.get("warnings", []))
+
+    async def test_success_without_result_key_degrades_open_with_warning(
+        self, register_tools, mock_client
+    ):
+        """A registry response that reports success but omits ``result`` is a
+        malformed read, not an empty registry: the tool must flag it rather than
+        silently returning un-enriched records."""
+
+        async def handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/list":
+                return {"success": True}  # no "result" key
+            if msg_type.endswith("/list"):
+                return {"success": True, "result": [{"id": "x", "name": "X"}]}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=handler)
+
+        result = await register_tools["ha_config_list_helpers"](
+            helper_type="input_boolean"
+        )
+
+        helper = result["helpers"][0]
+        assert helper == {"id": "x", "name": "X"}
+        assert "entity_id" not in helper
+        assert any("registry" in w.lower() for w in result.get("warnings", []))
+
+    async def test_person_dict_shaped_list_is_flattened_and_enriched(
+        self, register_tools, mock_client
+    ):
+        """person/list returns {"storage": [...], "config": [...]} rather than a
+        flat list; the tool must flatten it (so count and shape are right) and
+        still enrich each record from the entity registry."""
+
+        async def handler(msg: dict) -> dict:
+            msg_type = msg.get("type", "")
+            if msg_type == "config/entity_registry/list":
+                return {
+                    "success": True,
+                    "result": [
+                        {
+                            "entity_id": "person.mirko",
+                            "unique_id": "mirko",
+                            "platform": "person",
+                            "name": "Mirko Renamed",
+                            "original_name": "Mirko",
+                        },
+                        {
+                            "entity_id": "person.guest",
+                            "unique_id": "guest",
+                            "platform": "person",
+                            "name": None,
+                            "original_name": "Guest",
+                        },
+                    ],
+                }
+            if msg_type == "person/list":
+                # Both storage- and config-entry-backed persons must be merged.
+                return {
+                    "success": True,
+                    "result": {
+                        "storage": [{"id": "mirko", "name": "Mirko"}],
+                        "config": [{"id": "guest", "name": "Guest"}],
+                    },
+                }
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=handler)
+
+        result = await register_tools["ha_config_list_helpers"](helper_type="person")
+
+        # Flattened across storage + config: count is the person count, not
+        # len({"storage", "config"}) == 2 by coincidence here — assert the ids.
+        assert result["count"] == 2
+        assert isinstance(result["helpers"], list)
+        by_id = {h["id"]: h for h in result["helpers"]}
+        assert by_id.keys() == {"mirko", "guest"}
+        assert by_id["mirko"]["entity_id"] == "person.mirko"
+        assert by_id["mirko"]["name"] == "Mirko Renamed"
+        assert by_id["mirko"]["original_name"] == "Mirko"
+        # config-entry person is enriched too (registry name null -> original_name).
+        assert by_id["guest"]["entity_id"] == "person.guest"
+        assert by_id["guest"]["name"] == "Guest"

--- a/tests/src/unit/test_helper_list_registry_join.py
+++ b/tests/src/unit/test_helper_list_registry_join.py
@@ -18,8 +18,18 @@ import pytest
 
 @pytest.fixture
 def mock_client():
-    """Mock client whose WS handler is assembled per-test from canned responses."""
-    return MagicMock()
+    """Mock client for the legacy storage-list path.
+
+    #1812 added a component-backed ``helpers_list`` path ahead of the legacy
+    ``{type}/list`` body these tests target. Leaving ``base_url``/``token``
+    unset makes ``get_component_caps`` return ``None`` via its no-credentials
+    guard, so the tool falls through to the legacy body and the registry join
+    under test actually runs (rather than the component path short-circuiting
+    it). The WS handler is assembled per-test from canned responses."""
+    client = MagicMock()
+    client.base_url = None
+    client.token = None
+    return client
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #1794

## What does this PR do?

`ha_config_list_helpers` returned the `{helper_type}/list` storage-collection response verbatim, which carries the immutable `id` (the unique_id) and creation-time `name` and never consults the entity registry. After a UI rename those go stale. That is more than cosmetic: `ha_config_set_helper` resolves a helper by building an entity_id from the passed id and reading the entity registry, so passing the stale `id` back in fails with `ENTITY_NOT_FOUND` – the current `entity_id` is the identifier that actually works.

This joins `config/entity_registry/list` onto each record (matching by `unique_id` and `platform`): it adds the current `entity_id`, moves the storage name to `original_name`, and sets `name` to the current display name (registry `name`, falling back to `original_name`). The storage `id` is kept for reference. Storage types without a matching entity (e.g. `tag`) and platform mismatches are left untouched, and a failed or malformed registry read degrades open with a `warnings` entry rather than dropping the list.

The tool docstring now steers callers to `entity_id` for a renamed helper.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
