### PR TITLE
ci: publish dev component builds as HACS pre-releases on the mirror

### DIFF
--- a/.github/integration-mirror-readme-prefix.md
+++ b/.github/integration-mirror-readme-prefix.md
@@ -6,7 +6,10 @@ source of truth is the main repository -
 which syncs this repository automatically.
 
 - **Stable**: install the latest release (default in HACS).
-- **Development**: pick the `main` branch in HACS to track the newest build.
+- **Development**: enable this repository's **Pre-release** switch in HACS
+  (an entity HACS creates per downloaded repository, disabled by default)
+  to receive `-dev.N` pre-release builds. Their new features may require a
+  newer server and only become fully usable with the next stable release.
 
 Please open issues and pull requests on the
 [main repository](https://github.com/homeassistant-ai/ha-mcp/issues) -

--- a/.github/integration-mirror-workflows/release-on-tag.yml
+++ b/.github/integration-mirror-workflows/release-on-tag.yml
@@ -5,7 +5,8 @@ name: Release on tag
 # into the ha-mcp-integration mirror by sync-integration-mirror.yml. Do not
 # hand-edit it in the mirror -- edits are overwritten on the next sync.
 #
-# The monorepo sync pushes vX.Y.Z tags (deploy keys cannot call the GitHub
+# The monorepo sync pushes vX.Y.Z stable tags and vX.Y.Z-dev.N pre-release
+# tags (deploy keys cannot call the GitHub
 # API to create a release directly, only push git refs -- including
 # annotated tags and, per this same sync workflow, this file). Since the
 # deploy key can't set a release body via the API either, the tag itself
@@ -20,6 +21,16 @@ on:
 
 permissions:
   contents: write
+
+# Serialize runs: a dev pre-release tag and the stable tag that supersedes
+# it can arrive minutes apart, each starting its own run. Without
+# serialization the stable run's retire scan can list releases before the
+# dev run has published its pre-release, orphaning it until the next
+# stable release. cancel-in-progress stays false so a queued stable run
+# is never evicted.
+concurrency:
+  group: release-on-tag
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -94,14 +105,25 @@ jobs:
           # "nothing to retire" and pass silently.
           TAGS=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
             --jq '.[] | select(.prerelease) | .tag_name')
+          # Process every tag, THEN fail if any deletion errored: aborting
+          # mid-loop (plain set -e) leaves later tags unprocessed, while
+          # `|| echo warning` would mask a persistent failure forever - the
+          # same anti-pattern the create step's history warns about. A red
+          # run here is self-healing (the release is already published and
+          # the next stable release re-runs the full scan).
+          FAILED=0
           for TAG in $TAGS; do
             case "$TAG" in *-dev.*) ;; *) continue ;; esac
             BASE="${TAG#v}"
             BASE="${BASE%%-dev.*}"
             if [ "$(printf '%s\n%s\n' "$BASE" "$VER" | sort -V | tail -n1)" = "$VER" ]; then
               echo "retiring superseded pre-release ${TAG}"
-              gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+              gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag || FAILED=1
             else
               echo "keeping ${TAG} (newer than ${VER})"
             fi
           done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::one or more pre-release retirements failed; the next stable release re-runs the scan"
+            exit 1
+          fi

--- a/.github/integration-mirror-workflows/release-on-tag.yml
+++ b/.github/integration-mirror-workflows/release-on-tag.yml
@@ -64,5 +64,44 @@ jobs:
             echo "release exists"
             exit 0
           fi
+          # -dev. tags are the dev channel: the prerelease flag is what keeps
+          # them away from stable HACS users (HACS filters on it unless the
+          # repository's "Pre-release" switch entity is on) and out of
+          # GitHub's "latest" release.
+          PRERELEASE_FLAG=""
+          case "$GITHUB_REF_NAME" in
+            *-dev.*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-            --title "$VER" -F /tmp/notes.md
+            --title "$VER" -F /tmp/notes.md $PRERELEASE_FLAG
+
+      - name: Retire superseded dev pre-releases
+        # A stable release supersedes every dev pre-release cut before it:
+        # the component version on master only moves forward, so when the
+        # bare v<version> lands, any existing -dev. tag is for a version at
+        # or below it. HACS's newest-first scan already stops offering those
+        # builds once the stable release exists - this step just keeps the
+        # releases page and the HACS version dropdown from accumulating
+        # stale dev builds. The base-version guard (not a blanket wipe)
+        # protects a dev build for a HIGHER version that races in between.
+        if: ${{ !contains(github.ref_name, '-dev.') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          # Capture instead of piping into the loop: the default GHA shell
+          # has no pipefail, so a failed gh api would otherwise read as
+          # "nothing to retire" and pass silently.
+          TAGS=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq '.[] | select(.prerelease) | .tag_name')
+          for TAG in $TAGS; do
+            case "$TAG" in *-dev.*) ;; *) continue ;; esac
+            BASE="${TAG#v}"
+            BASE="${BASE%%-dev.*}"
+            if [ "$(printf '%s\n%s\n' "$BASE" "$VER" | sort -V | tail -n1)" = "$VER" ]; then
+              echo "retiring superseded pre-release ${TAG}"
+              gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+            else
+              echo "keeping ${TAG} (newer than ${VER})"
+            fi
+          done

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -46,6 +46,8 @@ on:
           stable re-tags the current component version as a full release
           (recovery path when a release run flaked); dev cuts a
           v<version>-dev.N pre-release from the current master snapshot.
+          Dispatch from master only - the tag version is read from the
+          checked-out ref's manifest.json.
         type: choice
         options: [stable, dev]
         default: stable
@@ -219,7 +221,12 @@ jobs:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |
           VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
-          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}" | grep -q .; then
+          # Capture instead of `| grep -q .`: without pipefail a FAILED
+          # ls-remote looks identical to "tag absent" and the step would
+          # proceed on a network blip; a bare assignment under set -e
+          # aborts loud instead.
+          existing=$(git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}")
+          if [ -n "$existing" ]; then
             echo "mirror tag v${VER} exists"
             exit 0
           fi
@@ -241,9 +248,11 @@ jobs:
         # tags the bare v<version>, HACS's newest-first release scan puts
         # everyone - including pre-release users - back on the stable build.
         #
-        # The dev tag MUST NOT be the bare v<version>: the stable tag step
-        # above is idempotent and would skip on the existing tag, leaving the
-        # version permanently marked pre-release. run_number keeps successive
+        # The dev tag MUST NOT be the bare v<version>: release-on-tag.yml
+        # keys --prerelease off the -dev. suffix, so a bare tag would publish
+        # the dev snapshot as a FULL release to every stable HACS user, and
+        # the idempotent stable tag step above would then skip on the
+        # existing tag, blocking the real stable release. run_number keeps successive
         # dev builds of one version ordered and unique; a re-run of the same
         # run number hits the existing-tag check and no-ops.
         if: >-
@@ -257,13 +266,21 @@ jobs:
           # the last stable release, so there is nothing dev-only to publish:
           # a v<VER>-dev.N tag would hide behind the stable release in HACS's
           # newest-first scan. Component changes are required to bump
-          # manifest.json in the same PR (AGENTS.md "Custom Component").
-          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}" | grep -q .; then
+          # manifest.json in the same PR (AGENTS.md "Custom Component") - if
+          # that rule is ever violated, this skip means pre-release users
+          # silently miss that build until the next bump.
+          # Captures instead of `| grep -q .`: without pipefail a FAILED
+          # ls-remote is indistinguishable from "tag absent", and here that
+          # would cut a dev tag for an already-stable version on a network
+          # blip; bare assignments under set -e abort loud instead.
+          stable_exists=$(git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}")
+          if [ -n "$stable_exists" ]; then
             echo "v${VER} is already released as stable - skipping dev tag"
             exit 0
           fi
           TAG="v${VER}-dev.${{ github.run_number }}"
-          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+          tag_exists=$(git -C /tmp/mirror ls-remote --tags origin "refs/tags/${TAG}")
+          if [ -n "$tag_exists" ]; then
             echo "mirror tag ${TAG} exists"
             exit 0
           fi

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -1,8 +1,12 @@
 name: Sync Integration Mirror
 
 # Keeps homeassistant-ai/ha-mcp-integration (the HACS distribution mirror)
-# in lockstep: master pushes sync the dev channel (mirror main), and a stable
-# release cuts a matching mirror release (stable channel). The mirror's README
+# in lockstep: master pushes sync the dev channel (mirror main, plus a
+# v<version>-dev.N pre-release tag whenever the snapshot changed the
+# component), and a stable release cuts a matching mirror release (stable
+# channel). HACS keys on the GitHub prerelease flag, so stable users never
+# see dev builds; users who enable the repository's HACS "Pre-release"
+# switch entity receive them. The mirror's README
 # is composed from a permanent prefix blurb plus the main repo README (with
 # relative links/images absolutized) so the HACS page mirrors the main docs.
 # The mirror carries no hand-made changes.
@@ -36,6 +40,15 @@ on:
     workflows: ["SemVer Release", "Hotfix Release"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      channel:
+        description: >-
+          stable re-tags the current component version as a full release
+          (recovery path when a release run flaked); dev cuts a
+          v<version>-dev.N pre-release from the current master snapshot.
+        type: choice
+        options: [stable, dev]
+        default: stable
 
 # Serialize mirror syncs. A real hotfix that touches the component triggers
 # BOTH legs — the master push (paths) and the workflow_run — nearly at once,
@@ -156,6 +169,7 @@ jobs:
             /tmp/mirror/.github/workflows/release-on-tag.yml
 
       - name: Commit and push
+        id: push
         env:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |
@@ -163,6 +177,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
+          # The dev pre-release step keys on component changes specifically:
+          # README/LICENSE/workflow-only syncs must not cut a new pre-release.
+          if git diff --cached --quiet -- custom_components; then
+            echo "component_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "component_changed=true" >> "$GITHUB_OUTPUT"
+          fi
           if git diff --cached --quiet; then
             echo "mirror already current"
           else
@@ -189,9 +210,11 @@ jobs:
         # release happened (checking workflow_run.conclusion again would
         # re-introduce the suppressed-tag bug the gate fixes — an unrelated
         # failed leg fails the RUN even when Semantic Release succeeded). The
-        # only event that reaches this job and must not tag is the push-leg
-        # code snapshot.
-        if: github.event_name != 'push'
+        # events that reach this job and must not tag stable are the push-leg
+        # code snapshot and a dev-channel dispatch.
+        if: >-
+          github.event_name == 'workflow_run' ||
+          (github.event_name == 'workflow_dispatch' && inputs.channel == 'stable')
         env:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |
@@ -208,3 +231,54 @@ jobs:
           cd /tmp/mirror
           git tag -a "v${VER}" -F /tmp/mirror_notes.md --cleanup=verbatim
           git push origin "v${VER}"
+
+      - name: Tag mirror dev pre-release
+        # Publishes the master component snapshot as a HACS pre-release
+        # whenever the component moved past the last stable tag. The mirror's
+        # release-on-tag.yml marks -dev. tags with --prerelease, so stable
+        # HACS users never see them; dev users opt in via the repository's
+        # HACS "Pre-release" switch entity. When the biweekly release later
+        # tags the bare v<version>, HACS's newest-first release scan puts
+        # everyone - including pre-release users - back on the stable build.
+        #
+        # The dev tag MUST NOT be the bare v<version>: the stable tag step
+        # above is idempotent and would skip on the existing tag, leaving the
+        # version permanently marked pre-release. run_number keeps successive
+        # dev builds of one version ordered and unique; a re-run of the same
+        # run number hits the existing-tag check and no-ops.
+        if: >-
+          (github.event_name == 'push' && steps.push.outputs.component_changed == 'true') ||
+          (github.event_name == 'workflow_dispatch' && inputs.channel == 'dev')
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
+        run: |
+          VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
+          # A bare v<VER> tag means master hasn't bumped the component since
+          # the last stable release, so there is nothing dev-only to publish:
+          # a v<VER>-dev.N tag would hide behind the stable release in HACS's
+          # newest-first scan. Component changes are required to bump
+          # manifest.json in the same PR (AGENTS.md "Custom Component").
+          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}" | grep -q .; then
+            echo "v${VER} is already released as stable - skipping dev tag"
+            exit 0
+          fi
+          TAG="v${VER}-dev.${{ github.run_number }}"
+          if git -C /tmp/mirror ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "mirror tag ${TAG} exists"
+            exit 0
+          fi
+          {
+            echo "## HA-MCP Custom Component ${VER} (development pre-release)"
+            echo
+            echo "Snapshot of the custom component from" \
+              "${GITHUB_REPOSITORY}@${GITHUB_SHA}, ahead of the latest stable" \
+              "release. New features in this build may require a newer server" \
+              "and only become fully usable with the next stable release."
+            echo
+            echo "You receive these builds because the HACS **Pre-release**" \
+              "switch is enabled for this repository; turn it off to stay on" \
+              "stable releases."
+          } > /tmp/dev_notes.md
+          cd /tmp/mirror
+          git tag -a "${TAG}" -F /tmp/dev_notes.md --cleanup=verbatim
+          git push origin "${TAG}"


### PR DESCRIPTION
## What does this PR do?

Master pushes that change the custom component now also tag the ha-mcp-integration mirror with `v<version>-dev.<run>`, published as a GitHub **pre-release** — HACS stable users are unaffected, while users who enable the repository's HACS "Pre-release" switch receive dev builds. The stable release flow is unchanged (the bare `v<version>` tag supersedes the dev builds, which are then retired), and `workflow_dispatch` gains a stable/dev channel input; a one-time `channel=dev` dispatch after merge publishes 1.0.6 as the first dev pre-release.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
Workflow-only change — YAML validated locally; the live path gets exercised by the post-merge `channel=dev` dispatch.
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed