### PR TITLE
feat: drive integration config flows and options flows from ha_set_integration

### DIFF
--- a/src/ha_mcp/policy/value_sources.py
+++ b/src/ha_mcp/policy/value_sources.py
@@ -40,7 +40,7 @@ VALUE_SOURCE_REGISTRY: dict[tuple[str, str], str] = {
     ("ha_get_history", "args.entity_ids"): "ha_entities",
     ("ha_remove_entity", "args.entity_id"): "ha_entities",
     ("ha_get_entity_exposure", "args.entity_id"): "ha_entities",
-    ("ha_set_integration_enabled", "args.entity_id"): "ha_entities",
+    ("ha_set_integration", "args.entry_id"): "ha_config_entries",
 }
 
 # Fetched-value TTL cache so the UI can click through path options
@@ -171,8 +171,24 @@ async def _fetch_ha_entities(client: Any, params: dict[str, str]) -> list[str]:
     return out
 
 
+async def _fetch_ha_config_entries(client: Any, _params: dict[str, str]) -> list[str]:
+    entries = await client._request("GET", "/config/config_entries/entry")
+    if not isinstance(entries, list):
+        logger.warning(
+            "ha_config_entries: config entry list returned unexpected shape %s",
+            type(entries).__name__,
+        )
+        return []
+    return [
+        e["entry_id"]
+        for e in entries
+        if isinstance(e, dict) and isinstance(e.get("entry_id"), str)
+    ]
+
+
 _FETCHERS: dict[str, Callable[[Any, dict[str, str]], Awaitable[list[str]]]] = {
     "ha_domains": _fetch_ha_domains,
     "ha_services": _fetch_ha_services,
     "ha_entities": _fetch_ha_entities,
+    "ha_config_entries": _fetch_ha_config_entries,
 }

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -65,6 +65,13 @@ FLOW_HELPER_TYPES: frozenset[str] = frozenset(
 
 # Keys used to specify a menu selection — stripped before submitting form data.
 _MENU_SELECTION_KEYS = frozenset({"group_type", "next_step_id", "menu_option"})
+
+# Flow step types an MCP client cannot drive: external steps need a browser
+# (OAuth / cloud authorization), progress steps wait on HA-side async work.
+# Surfaced as structured errors instead of attempted (issue #1814).
+_UNDRIVABLE_STEP_TYPES = frozenset(
+    {"external", "external_done", "progress", "progress_done"}
+)
 _RECONFIGURE_SUCCESS_REASONS = frozenset(
     {
         "reauth_successful",
@@ -722,6 +729,21 @@ async def _handle_flow_steps(
                 current_step=current_step,
             )
 
+        elif result_type in _UNDRIVABLE_STEP_TYPES:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Flow reached a '{result_type}' step that cannot be "
+                    "completed via MCP (browser/OAuth authorization or an "
+                    "asynchronous provider step)",
+                    suggestions=[
+                        "Complete this flow in the Home Assistant UI "
+                        "(Settings > Devices & Services)."
+                    ],
+                    context={"flow_id": flow_id, "details": current_step},
+                )
+            )
+
         else:
             raise_tool_error(
                 create_error_response(
@@ -981,30 +1003,35 @@ async def get_user_step_field_names(client: Any, helper_type: str) -> set[str] |
                 )
 
 
-async def update_flow_helper(
+async def update_config_entry_options(
     client: Any,
-    helper_type: str,
-    config_dict: dict[str, Any],
     entry_id: str,
+    config_dict: dict[str, Any],
+    *,
+    expected_domain: str | None = None,
+    noun: str = "integration",
 ) -> dict[str, Any]:
-    """Update an existing flow-based helper via its options flow.
+    """Update an existing config entry via its options flow.
 
-    Verifies the entry domain matches helper_type, starts an options flow,
-    walks the flow steps, and returns the result. Aborts the flow on error.
+    When ``expected_domain`` is provided, verifies the entry's domain matches
+    it first (the helper path passes the helper_type; the generic
+    ``ha_set_integration`` path passes ``None`` to accept any domain). Starts
+    an options flow, walks the flow steps, and returns the result. Aborts the
+    flow on error. ``noun`` only affects response wording.
     """
     config_entry = await client.get_config_entry(entry_id)
     actual_domain = config_entry.get("domain")
-    if actual_domain != helper_type:
+    if expected_domain is not None and actual_domain != expected_domain:
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
-                f"entry_id '{entry_id}' belongs to domain '{actual_domain}', not '{helper_type}'",
+                f"entry_id '{entry_id}' belongs to domain '{actual_domain}', not '{expected_domain}'",
                 suggestions=[
-                    f"Use ha_get_integration(domain='{helper_type}') to find valid entry IDs",
+                    f"Use ha_get_integration(domain='{expected_domain}') to find valid entry IDs",
                 ],
                 context={
                     "entry_id": entry_id,
-                    "expected": helper_type,
+                    "expected": expected_domain,
                     "actual": actual_domain,
                 },
             )
@@ -1032,7 +1059,7 @@ async def update_flow_helper(
             flow_result,
             config_dict,
             submit_fn=client.submit_options_flow_step,
-            helper_type=helper_type,
+            helper_type=expected_domain,
         )
     except Exception:
         try:
@@ -1048,9 +1075,87 @@ async def update_flow_helper(
         "success": True,
         "entry_id": entry_id,
         "title": entry.get("title"),
-        "domain": helper_type,
-        "message": f"{helper_type} helper updated successfully",
+        "domain": actual_domain,
+        "message": f"{actual_domain} {noun} updated successfully",
         "updated": True,
+    }
+    if result.get("warnings"):
+        response["warnings"] = result["warnings"]
+    return response
+
+
+async def update_flow_helper(
+    client: Any,
+    helper_type: str,
+    config_dict: dict[str, Any],
+    entry_id: str,
+) -> dict[str, Any]:
+    """Update an existing flow-based helper via its options flow.
+
+    Verifies the entry domain matches helper_type, starts an options flow,
+    walks the flow steps, and returns the result. Aborts the flow on error.
+    """
+    return await update_config_entry_options(
+        client,
+        entry_id,
+        config_dict,
+        expected_domain=helper_type,
+        noun="helper",
+    )
+
+
+async def create_config_entry(
+    client: Any,
+    domain: str,
+    config_dict: dict[str, Any],
+    *,
+    noun: str = "integration",
+) -> dict[str, Any]:
+    """Create a config entry by driving ``domain``'s config flow.
+
+    Starts a config flow, walks the flow steps (menus and multi-step forms),
+    and returns the result. Aborts the flow on error. ``noun`` only affects
+    response wording.
+    """
+    flow_result = await client.start_config_flow(domain)
+    flow_id = flow_result.get("flow_id")
+
+    if not flow_id:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Failed to start config flow",
+                suggestions=[
+                    f"Check that the {noun} domain exists and Home Assistant is reachable"
+                ],
+                context={"domain": domain, "details": flow_result},
+            )
+        )
+
+    try:
+        result = await _handle_flow_steps(
+            client,
+            flow_id,
+            flow_result,
+            config_dict,
+            helper_type=domain,
+        )
+    except Exception:
+        try:
+            await asyncio.wait_for(client.abort_config_flow(flow_id), timeout=5.0)
+        except Exception as abort_err:
+            logger.warning(
+                f"Failed to abort config flow {flow_id} after error: {abort_err}"
+            )
+        raise
+
+    entry = result["entry"].get("result", {})
+    response = {
+        "success": True,
+        "entry_id": entry.get("entry_id"),
+        "title": entry.get("title"),
+        "domain": domain,
+        "message": f"{domain} {noun} created successfully",
     }
     if result.get("warnings"):
         response["warnings"] = result["warnings"]
@@ -1067,46 +1172,4 @@ async def create_flow_helper(
     Starts a config flow, walks the flow steps, and returns the result.
     Aborts the flow on error.
     """
-    flow_result = await client.start_config_flow(helper_type)
-    flow_id = flow_result.get("flow_id")
-
-    if not flow_id:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                "Failed to start config flow",
-                suggestions=[
-                    "Check that the helper type is supported and Home Assistant is reachable"
-                ],
-                context={"helper_type": helper_type, "details": flow_result},
-            )
-        )
-
-    try:
-        result = await _handle_flow_steps(
-            client,
-            flow_id,
-            flow_result,
-            config_dict,
-            helper_type=helper_type,
-        )
-    except Exception:
-        try:
-            await asyncio.wait_for(client.abort_config_flow(flow_id), timeout=5.0)
-        except Exception as abort_err:
-            logger.warning(
-                f"Failed to abort config flow {flow_id} after error: {abort_err}"
-            )
-        raise
-
-    entry = result["entry"].get("result", {})
-    response = {
-        "success": True,
-        "entry_id": entry.get("entry_id"),
-        "title": entry.get("title"),
-        "domain": helper_type,
-        "message": f"{helper_type} helper created successfully",
-    }
-    if result.get("warnings"):
-        response["warnings"] = result["warnings"]
-    return response
+    return await create_config_entry(client, helper_type, config_dict, noun="helper")

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -679,10 +679,21 @@ async def _handle_flow_steps(
             return response
 
         if result_type == _FlowType.ABORT:
+            reason = current_step.get("reason")
+            abort_suggestions: list[str] = []
+            if reason in ("already_configured", "single_instance_allowed"):
+                # Common benign aborts on the add-integration path (#1814):
+                # give the caller a route to the existing entry instead of a
+                # bare failure.
+                abort_suggestions.append(
+                    "The integration is already set up — use "
+                    "ha_get_integration() to find the existing entry."
+                )
             raise_tool_error(
                 create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
-                    f"Flow aborted: {current_step.get('reason')}",
+                    f"Flow aborted: {reason}",
+                    suggestions=abort_suggestions or None,
                     context={"flow_id": flow_id, "details": current_step},
                 )
             )

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from collections.abc import Iterator
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 
 from ..client.rest_client import HomeAssistantAPIError
 from ..errors import ErrorCode, create_error_response
@@ -625,6 +625,74 @@ async def _submit_step(
         raise
 
 
+def _finish_flow_entry(
+    flow_id: str,
+    current_step: dict[str, Any],
+    *,
+    supplied_keys: list[str],
+    saw_form_step: bool,
+    any_form_key_consumed: bool,
+    ignored_config_keys: set[str],
+    remaining_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the CREATE_ENTRY success response, or raise on total key miss.
+
+    When the flow presented at least one form step, the caller supplied
+    config keys, and NONE were consumed by any form (typos / wrong field
+    names), the flow was walked on empty forms and HA saved form defaults —
+    not the caller's values. A success + warning there reads as "done" to an
+    LLM caller, so fail loudly with the schema route instead. Partial
+    consumption — and flows that complete without any form step (instant
+    creates) — keep the established success + warnings contract.
+    """
+    if supplied_keys and saw_form_step and not any_form_key_consumed:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "Flow completed without consuming any of the supplied "
+                "config keys — every form step was submitted empty, so "
+                "the flow saved its defaults, not your values",
+                suggestions=[
+                    "Check the field names against the flow's data_schema — "
+                    "ha_get_integration(entry_id=..., include_schema=True) "
+                    "shows the accepted fields — then retry with corrected "
+                    "keys.",
+                ],
+                context={
+                    "flow_id": flow_id,
+                    "supplied_keys": supplied_keys,
+                    "details": current_step,
+                },
+            )
+        )
+    response: dict[str, Any] = {"success": True, "entry": current_step}
+    warnings = _ignored_keys_warnings(ignored_config_keys, remaining_config)
+    if warnings:
+        response["warnings"] = warnings
+    return response
+
+
+def _raise_flow_abort(flow_id: str, current_step: dict[str, Any]) -> NoReturn:
+    """Raise the structured error for an ABORT flow step."""
+    reason = current_step.get("reason")
+    abort_suggestions: list[str] = []
+    if reason in ("already_configured", "single_instance_allowed"):
+        # Common benign aborts on the add-integration path (#1814): give the
+        # caller a route to the existing entry instead of a bare failure.
+        abort_suggestions.append(
+            "The integration is already set up — use "
+            "ha_get_integration() to find the existing entry."
+        )
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            f"Flow aborted: {reason}",
+            suggestions=abort_suggestions or None,
+            context={"flow_id": flow_id, "details": current_step},
+        )
+    )
+
+
 async def _handle_flow_steps(
     client: Any,
     flow_id: str,
@@ -657,8 +725,12 @@ async def _handle_flow_steps(
 
     Returns:
         ``{"success": True, "entry": result}`` on success, plus ``warnings``
-        when caller-supplied config keys were not declared by any flow step.
-        Raises ToolError on any failure.
+        when SOME caller-supplied config keys were not declared by any flow
+        step. When the flow presented at least one form step and NONE of the
+        supplied keys were consumed, raises ``VALIDATION_INVALID_PARAMETER``
+        instead of reporting a misleading success — the flow completed on
+        empty forms (defaults), applying nothing the caller asked for (see
+        :func:`_finish_flow_entry`). Raises ToolError on any failure.
     """
     if submit_fn is None:
         submit_fn = client.submit_config_flow_step
@@ -666,37 +738,27 @@ async def _handle_flow_steps(
     current_step = initial_step
     last_menu_choice: str | None = None
     ignored_config_keys: set[str] = set()
+    supplied_keys = sorted(k for k in config if k not in _MENU_SELECTION_KEYS)
+    saw_form_step = False
+    any_form_key_consumed = False
     max_steps = 10
 
     for step_num in range(max_steps):
         result_type = current_step.get("type")
 
         if result_type == _FlowType.CREATE_ENTRY:
-            response: dict[str, Any] = {"success": True, "entry": current_step}
-            warnings = _ignored_keys_warnings(ignored_config_keys, remaining_config)
-            if warnings:
-                response["warnings"] = warnings
-            return response
+            return _finish_flow_entry(
+                flow_id,
+                current_step,
+                supplied_keys=supplied_keys,
+                saw_form_step=saw_form_step,
+                any_form_key_consumed=any_form_key_consumed,
+                ignored_config_keys=ignored_config_keys,
+                remaining_config=remaining_config,
+            )
 
         if result_type == _FlowType.ABORT:
-            reason = current_step.get("reason")
-            abort_suggestions: list[str] = []
-            if reason in ("already_configured", "single_instance_allowed"):
-                # Common benign aborts on the add-integration path (#1814):
-                # give the caller a route to the existing entry instead of a
-                # bare failure.
-                abort_suggestions.append(
-                    "The integration is already set up — use "
-                    "ha_get_integration() to find the existing entry."
-                )
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Flow aborted: {reason}",
-                    suggestions=abort_suggestions or None,
-                    context={"flow_id": flow_id, "details": current_step},
-                )
-            )
+            _raise_flow_abort(flow_id, current_step)
 
         if result_type == _FlowType.MENU:
             menu_choice = _handle_menu_step(flow_id, current_step, remaining_config)
@@ -720,12 +782,15 @@ async def _handle_flow_steps(
             # step's data_schema, leaving any other keys in remaining_config
             # for subsequent steps (HA can present multi-step forms, e.g.
             # statistics: user step then pick-characteristic step).
+            saw_form_step = True
             form_data = _handle_form_step(
                 flow_id,
                 current_step,
                 remaining_config,
                 ignored_config_keys,
             )
+            if form_data:
+                any_form_key_consumed = True
             logger.debug(
                 f"Flow step {step_num}: form submit "
                 f"(step_id={current_step.get('step_id')}, keys={list(form_data.keys())})"

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -20,7 +20,12 @@ from ..client.rest_client import (
 )
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
-from .config_entry_flow import FLOW_HELPER_TYPES, iter_schema_fields
+from .config_entry_flow import (
+    FLOW_HELPER_TYPES,
+    create_config_entry,
+    iter_schema_fields,
+    update_config_entry_options,
+)
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -1181,25 +1186,139 @@ class IntegrationTools:
         return [match[1] for match in matches]
 
     @tool(
-        name="ha_set_integration_enabled",
+        name="ha_set_integration",
         tags={"Integrations"},
-        annotations={"destructiveHint": True, "title": "Set Integration Enabled"},
+        annotations={"destructiveHint": True, "title": "Set Integration"},
     )
     @with_auto_backup(domain="integration", id_param="entry_id")
     @log_tool_usage
-    async def ha_set_integration_enabled(
+    async def ha_set_integration(
         self,
-        entry_id: Annotated[str, Field(description="Config entry ID")],
-        enabled: Annotated[bool, Field(description="True to enable, False to disable")],
+        entry_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Config entry ID of an existing integration (enable/disable "
+                    "and options-update modes). Omit when adding via 'domain'."
+                ),
+                default=None,
+            ),
+        ] = None,
+        enabled: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True to enable, False to disable the entry. Requires "
+                    "entry_id; mutually exclusive with 'domain' and 'config'."
+                ),
+                default=None,
+            ),
+        ] = None,
+        domain: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Integration domain to add (e.g. 'workday', "
+                    "'local_calendar') — starts and drives that domain's "
+                    "config flow. Pass the flow's form fields in 'config'."
+                ),
+                default=None,
+            ),
+        ] = None,
+        config: Annotated[
+            dict[str, Any] | None,
+            JSON_STRING_COERCION,
+            Field(
+                description=(
+                    "Flow form data. With 'domain': input for the new "
+                    "integration's config flow. With 'entry_id' alone: input "
+                    "for the entry's options flow (updates its options). "
+                    "Multi-step flows consume keys per step; menu steps take "
+                    "'next_step_id'. The step's data_schema is returned on "
+                    "validation errors so field names can be corrected."
+                ),
+                default=None,
+            ),
+        ] = None,
     ) -> dict[str, Any]:
-        """Enable/disable integration (config entry).
+        """Manage an integration (config entry): enable/disable, add, or update options.
 
-        Use ha_get_integration() to find entry IDs.
+        Modes (pick one):
+        - Enable/disable: entry_id + enabled.
+        - Add integration: domain (+ config) — drives the domain's config
+          flow, including menus and multi-step forms.
+        - Update options: entry_id + config — drives the entry's options
+          flow (what the "Configure" button does in the HA UI).
+
+        WHEN NOT TO USE:
+        - Helpers (template, group, utility_meter, ...): use
+          ha_config_set_helper.
+        - Config subentries: use
+          ha_config_set_helper(helper_type='config_subentry').
+        - Removing an entry: use ha_remove_helpers_integrations.
+
+        Use ha_get_integration() to find entry IDs, and
+        ha_get_integration(entry_id=..., include_schema=True) to inspect the
+        options fields before an update.
+
+        Caveats: adding an integration runs its config flow exactly as the HA
+        UI would (may pair devices, scan the network, create entities). Flows
+        requiring a browser step (OAuth) or an asynchronous provider step
+        return a structured error instead of being attempted.
+
+        EXAMPLES:
+        - Disable: ha_set_integration(entry_id="abc123", enabled=False)
+        - Add: ha_set_integration(domain="workday", config={"name": "Workday"})
+        - Update options: ha_set_integration(entry_id="abc123", config={"scan_interval": 30})
         """
         try:
+            if domain is not None and entry_id is not None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Pass either 'domain' (add a new integration) or "
+                        "'entry_id' (modify an existing one), not both",
+                        context={"entry_id": entry_id, "domain": domain},
+                    )
+                )
+            if enabled is not None and (domain is not None or config is not None):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "'enabled' is mutually exclusive with 'domain' and "
+                        "'config' — enable/disable is a separate call",
+                        context={"entry_id": entry_id, "domain": domain},
+                    )
+                )
+
+            if domain is not None:
+                # Add mode: drive the domain's config flow.
+                validate_identifier_not_empty(
+                    domain,
+                    "domain",
+                    suggestions=[
+                        "Pass the integration domain, e.g. 'workday' or "
+                        "'local_calendar'",
+                    ],
+                )
+                return await create_config_entry(self._client, domain, config or {})
+
+            if entry_id is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Nothing to do — provide 'domain' to add an "
+                        "integration, or 'entry_id' with 'enabled' "
+                        "(enable/disable) or 'config' (update options)",
+                        suggestions=[
+                            "Use ha_get_integration() to find valid config entry IDs",
+                        ],
+                    )
+                )
+
             # Empty/whitespace entry_id would surface as a misleading HA
-            # "config entry not found" from ``config_entries/disable``.
-            validate_identifier_not_empty(
+            # "config entry not found" from the backend call.
+            entry_id = validate_identifier_not_empty(
                 entry_id,
                 "entry_id",
                 suggestions=[
@@ -1207,52 +1326,87 @@ class IntegrationTools:
                 ],
             )
 
-            message = {
-                "type": "config_entries/disable",
-                "entry_id": entry_id,
-                "disabled_by": None if enabled else "user",
-            }
+            if enabled is not None:
+                return await self._set_entry_enabled(entry_id, enabled)
 
-            result = await self._client.send_websocket_message(message)
+            if config is not None:
+                # Options mode: drive the entry's options flow.
+                return await update_config_entry_options(self._client, entry_id, config)
 
-            if not result.get("success"):
-                error_msg = result.get("error", {})
-                if isinstance(error_msg, dict):
-                    error_msg = error_msg.get("message", str(error_msg))
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        f"Failed to {'enable' if enabled else 'disable'} integration: {error_msg}",
-                        context={"entry_id": entry_id},
-                    )
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Nothing to do — pass 'enabled' to enable/disable the "
+                    "entry, or 'config' to update its options",
+                    context={"entry_id": entry_id},
                 )
-
-            # Get updated entry info
-            require_restart = result.get("result", {}).get("require_restart", False)
-
-            if require_restart:
-                note = "Home Assistant restart required for changes to take effect."
-            else:
-                note = (
-                    "Integration has been loaded."
-                    if enabled
-                    else "Integration has been unloaded."
-                )
-
-            return {
-                "success": True,
-                "message": f"Integration {'enabled' if enabled else 'disabled'} successfully",
-                "entry_id": entry_id,
-                "require_restart": require_restart,
-                "note": note,
-            }
+            )
+            return None  # unreachable: raise_tool_error raises
 
         except ToolError:
             raise
         except Exception as e:
-            logger.error(f"Failed to set integration enabled: {e}")
-            exception_to_structured_error(e, context={"entry_id": entry_id})
+            logger.error(f"Failed to set integration: {e}")
+            error_context: dict[str, Any] = {}
+            if entry_id is not None:
+                error_context["entry_id"] = entry_id
+            if domain is not None:
+                error_context["domain"] = domain
+            exception_to_structured_error(
+                e,
+                context=error_context,
+                suggestions=[
+                    "Verify the integration domain is spelled correctly and "
+                    "is installed (custom integrations must be installed "
+                    "before a config flow can start)",
+                ]
+                if domain is not None
+                else [
+                    "Use ha_get_integration() to find valid config entry IDs",
+                ],
+            )
             return None  # unreachable: exception_to_structured_error raises
+
+    async def _set_entry_enabled(self, entry_id: str, enabled: bool) -> dict[str, Any]:
+        """Enable or disable a config entry via ``config_entries/disable``."""
+        message = {
+            "type": "config_entries/disable",
+            "entry_id": entry_id,
+            "disabled_by": None if enabled else "user",
+        }
+
+        result = await self._client.send_websocket_message(message)
+
+        if not result.get("success"):
+            error_msg = result.get("error", {})
+            if isinstance(error_msg, dict):
+                error_msg = error_msg.get("message", str(error_msg))
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to {'enable' if enabled else 'disable'} integration: {error_msg}",
+                    context={"entry_id": entry_id},
+                )
+            )
+
+        require_restart = result.get("result", {}).get("require_restart", False)
+
+        if require_restart:
+            note = "Home Assistant restart required for changes to take effect."
+        else:
+            note = (
+                "Integration has been loaded."
+                if enabled
+                else "Integration has been unloaded."
+            )
+
+        return {
+            "success": True,
+            "message": f"Integration {'enabled' if enabled else 'disabled'} successfully",
+            "entry_id": entry_id,
+            "require_restart": require_restart,
+            "note": note,
+        }
 
     @tool(
         name="ha_remove_helpers_integrations",

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -1264,7 +1264,7 @@ class IntegrationTools:
         Caveats: adding an integration runs its config flow exactly as the HA
         UI would (may pair devices, scan the network, create entities). Flows
         requiring a browser step (OAuth) or an asynchronous provider step
-        return a structured error instead of being attempted.
+        error out at that step with a structured error instead of completing.
 
         EXAMPLES:
         - Disable: ha_set_integration(entry_id="abc123", enabled=False)
@@ -1389,7 +1389,7 @@ class IntegrationTools:
                 )
             )
 
-        require_restart = result.get("result", {}).get("require_restart", False)
+        require_restart = (result.get("result") or {}).get("require_restart", False)
 
         if require_restart:
             note = "Home Assistant restart required for changes to take effect."

--- a/tests/src/e2e/haos_only/test_integration_setup.py
+++ b/tests/src/e2e/haos_only/test_integration_setup.py
@@ -1,11 +1,10 @@
 """HAOS-only integration setup coverage (issue #1349 item 2).
 
 These tests verify integration surfaces that the testcontainer tier physically
-cannot reach because they depend on either (a) an HA Supervisor that installed
-companion addons whose containers register HA integrations on first boot
-(ESPHome Device Builder → ``esphome`` integration; Node-RED addon → the
-``nodered`` integration), or (b) HA's real Sun-position math (the testcontainer
-stub returns static values from a frozen world clock).
+cannot reach because they depend on either (a) HA's real Sun-position math
+(the testcontainer stub returns static values from a frozen world clock), or
+(b) a Supervisor-backed HA to drive the Local Calendar config-entry lifecycle
+end to end.
 
 Layout:
 

--- a/tests/src/e2e/haos_only/test_integration_setup.py
+++ b/tests/src/e2e/haos_only/test_integration_setup.py
@@ -9,14 +9,13 @@ stub returns static values from a frozen world clock).
 
 Layout:
 
-* ESPHome companion integration loaded (auto-registered by addon install).
-* ESPHome surfaces at least one entity (proves background platform setup ran).
-* Node-RED companion integration loaded (auto-registered by addon install).
-* Node-RED disable / re-enable round-trip via ``ha_set_integration_enabled``.
 * Sun integration's ``sun.sun`` exposes realistic next_dawn / next_dusk
   attributes within 24h of the test-process clock.
 * Local Calendar config-entry lifecycle: create entry → entity registers →
   add event → retrieve event → tear down the config entry.
+
+(The ESPHome / Node-RED companion-integration tests this module originally
+held were deleted — see the NOTE below.)
 
 All tests are marker-gated to the HAOS backend and run without ``pytest.skip``;
 absent fixtures fail loudly.
@@ -41,16 +40,6 @@ from ..utilities.wait_helpers import wait_for_tool_result
 LOG = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.haos_only]
-
-
-def _find_entry_for_domain(
-    entries: list[dict[str, Any]], domain: str
-) -> dict[str, Any] | None:
-    """Return the first entry in ``entries`` whose domain matches ``domain``."""
-    for entry in entries:
-        if entry.get("domain") == domain:
-            return entry
-    return None
 
 
 # NOTE: ``test_esphome_companion_integration_loaded``,

--- a/tests/src/e2e/workflows/integrations/test_integration_management.py
+++ b/tests/src/e2e/workflows/integrations/test_integration_management.py
@@ -42,7 +42,7 @@ class TestIntegrationManagement:
 
         # DISABLE
         disable_result = await mcp_client.call_tool(
-            "ha_set_integration_enabled", {"entry_id": entry_id, "enabled": False}
+            "ha_set_integration", {"entry_id": entry_id, "enabled": False}
         )
         assert_mcp_success(disable_result, "Disable integration")
 
@@ -56,7 +56,7 @@ class TestIntegrationManagement:
 
         # RE-ENABLE
         enable_result = await mcp_client.call_tool(
-            "ha_set_integration_enabled", {"entry_id": entry_id, "enabled": True}
+            "ha_set_integration", {"entry_id": entry_id, "enabled": True}
         )
         assert_mcp_success(enable_result, "Re-enable integration")
 
@@ -144,11 +144,110 @@ class TestIntegrationManagement:
         """Test error handling for non-existent integration."""
         data = await safe_call_tool(
             mcp_client,
-            "ha_set_integration_enabled",
+            "ha_set_integration",
             {"entry_id": "nonexistent_entry_id", "enabled": True},
         )
         # Should fail - either through validation or API error
         assert not data.get("success", False)
+
+    async def test_add_integration_and_update_options_cycle(self, mcp_client):
+        """Add-mode + options-mode round-trip via ha_set_integration (#1814).
+
+        Uses the ``group`` domain because it is always present in the test
+        container and its config flow exercises both a menu step
+        (``group_type``) and a form step through the generic (non-helper)
+        driver. The mechanics are identical for any integration domain —
+        the tool no longer gates the handler on the helper allowlist.
+        """
+        # ADD: drive the config flow (menu -> form -> create_entry)
+        create_result = await mcp_client.call_tool(
+            "ha_set_integration",
+            {
+                "domain": "group",
+                "config": {
+                    "group_type": "light",
+                    "name": "test_set_integration_add_e2e",
+                    "entities": [],
+                    "hide_members": False,
+                },
+            },
+        )
+        data = assert_mcp_success(create_result, "Add integration via config flow")
+        entry_id = data["entry_id"]
+        assert data["domain"] == "group"
+
+        try:
+            # Wait until the entry is registered
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_integration",
+                arguments={"entry_id": entry_id},
+                predicate=lambda d: d.get("success") is True,
+                description="added integration entry is registered",
+            )
+
+            # UPDATE OPTIONS: drive the options flow on the same entry
+            update_result = await mcp_client.call_tool(
+                "ha_set_integration",
+                {
+                    "entry_id": entry_id,
+                    "config": {"entities": [], "hide_members": True},
+                },
+            )
+            update_data = assert_mcp_success(
+                update_result, "Update integration options via options flow"
+            )
+            assert update_data.get("updated") is True
+            assert update_data.get("entry_id") == entry_id
+
+            # Verify the option persisted (single-entry mode probes options)
+            verify_data = await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_integration",
+                arguments={"entry_id": entry_id},
+                predicate=lambda d: (
+                    d.get("entry", {}).get("options", {}).get("hide_members") is True
+                ),
+                description="updated option is readable back",
+            )
+            assert verify_data["entry"]["options"]["hide_members"] is True
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
+
+    async def test_add_integration_unknown_domain_fails(self, mcp_client):
+        """Add mode surfaces a structured error for an unknown domain."""
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_set_integration",
+            {"domain": "definitely_not_a_real_domain_xyz"},
+        )
+        assert not data.get("success", False)
+
+    async def test_update_options_unsupported_entry_fails(self, mcp_client):
+        """Options mode surfaces a structured error when the entry has no
+        options flow (supports_options=false)."""
+        list_result = await mcp_client.call_tool("ha_get_integration", {})
+        data = assert_mcp_success(list_result, "List integrations")
+        no_options_entry = next(
+            (e for e in data.get("entries", []) if not e.get("supports_options")),
+            None,
+        )
+        if no_options_entry is None:
+            pytest.skip("No integration without options flow found")
+
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_set_integration",
+            {
+                "entry_id": no_options_entry["entry_id"],
+                "config": {"anything": True},
+            },
+        )
+        assert not result.get("success", False)
 
     async def test_delete_config_entry_nonexistent_raises(self, mcp_client):
         """

--- a/tests/src/e2e/workflows/integrations/test_integration_management.py
+++ b/tests/src/e2e/workflows/integrations/test_integration_management.py
@@ -157,7 +157,8 @@ class TestIntegrationManagement:
         container and its config flow exercises both a menu step
         (``group_type``) and a form step through the generic (non-helper)
         driver. The mechanics are identical for any integration domain —
-        the tool no longer gates the handler on the helper allowlist.
+        unlike ha_config_set_helper, the tool does not gate the handler on
+        the helper allowlist.
         """
         # ADD: drive the config flow (menu -> form -> create_entry)
         create_result = await mcp_client.call_tool(

--- a/tests/src/unit/policy/test_schema_handlers.py
+++ b/tests/src/unit/policy/test_schema_handlers.py
@@ -233,6 +233,55 @@ def test_value_source_handles_list_shape_services_payload(tmp_path):
     assert r.json()["values"] == ["light", "lock"]
 
 
+def test_value_source_ha_config_entries_filters_malformed(tmp_path):
+    # ha_config_entries (mapped from ha_set_integration's args.entry_id)
+    # keeps only dict entries carrying a string entry_id.
+    client = MagicMock()
+    client._request = AsyncMock(
+        return_value=[
+            {"entry_id": "abc123", "domain": "hue"},
+            {"entry_id": "def456", "domain": "group"},
+            {"no_entry_id": True},
+            "junk",
+            {"entry_id": 42},
+        ]
+    )
+    c = _make_app(tmp_path, _make_server(tools=[], client=client))
+    r = c.get("/api/policy/value-source?source=ha_config_entries")
+    assert r.status_code == 200
+    assert r.json()["values"] == ["abc123", "def456"]
+    client._request.assert_awaited_once_with("GET", "/config/config_entries/entry")
+
+
+def test_value_source_ha_config_entries_non_list_returns_empty(tmp_path):
+    client = MagicMock()
+    client._request = AsyncMock(return_value={"unexpected": "shape"})
+    c = _make_app(tmp_path, _make_server(tools=[], client=client))
+    r = c.get("/api/policy/value-source?source=ha_config_entries")
+    assert r.status_code == 200
+    assert r.json()["values"] == []
+
+
+def test_tool_schema_set_integration_maps_entry_id_value_source(tmp_path):
+    tool = _make_fake_tool(
+        "ha_set_integration",
+        parameters={
+            "properties": {
+                "entry_id": {"type": "string"},
+                "enabled": {"type": "boolean"},
+                "domain": {"type": "string"},
+                "config": {"type": "object"},
+            },
+        },
+        destructive=True,
+    )
+    c = _make_app(tmp_path, _make_server(tools=[tool]))
+    r = c.get("/api/policy/tool-schema?name=ha_set_integration")
+    assert r.status_code == 200
+    vs = r.json()["value_sources"]
+    assert vs["args.entry_id"] == "ha_config_entries"
+
+
 def test_value_source_fetcher_exception_returns_502(tmp_path):
     client = MagicMock()
     client.get_services = AsyncMock(side_effect=RuntimeError("HA unreachable"))

--- a/tests/src/unit/test_flow_error_parsing.py
+++ b/tests/src/unit/test_flow_error_parsing.py
@@ -313,3 +313,78 @@ class TestHandleFlowStepsOptionsFlowError:
         # Issue #1149: data_schema is now attached alongside field_errors.
         assert body.get("data_schema") == intro_schema
         assert body.get("flow_id") == "opt-flow"
+
+
+# ---------------------------------------------------------------------------
+# 5. Undrivable step types (issue #1814)
+# ---------------------------------------------------------------------------
+
+
+class TestUndrivableStepTypes:
+    """External (browser/OAuth) and progress steps cannot be driven over MCP.
+
+    ``_handle_flow_steps`` must surface them as SERVICE_CALL_FAILED with an
+    actionable "complete in the HA UI" suggestion — NOT fall through to the
+    INTERNAL_UNEXPECTED "Unexpected flow result type" branch, which loses
+    the error code the ha_set_integration docstring documents.
+    """
+
+    @pytest.mark.parametrize(
+        "step_type", ["external", "external_done", "progress", "progress_done"]
+    )
+    async def test_undrivable_step_raises_structured_error(
+        self, step_type: str
+    ) -> None:
+        client = AsyncMock()
+        initial_step = {
+            "type": step_type,
+            "flow_id": "oauth-flow",
+            "step_id": "auth",
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=client,
+                flow_id="oauth-flow",
+                initial_step=initial_step,
+                config={},
+                helper_type="some_oauth_integration",
+            )
+
+        body = _parse_tool_error(exc_info.value)
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "cannot be completed via MCP" in body["error"]["message"]
+        assert step_type in body["error"]["message"]
+        # The actionable pointer to the HA UI must survive. A single
+        # suggestion is emitted as the singular ``suggestion`` key.
+        assert "Home Assistant UI" in body["error"].get("suggestion", "")
+        # Nothing was submitted — the step is surfaced, not attempted.
+        client.submit_config_flow_step.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "reason", ["already_configured", "single_instance_allowed"]
+    )
+    async def test_benign_abort_carries_existing_entry_hint(self, reason: str) -> None:
+        # Add-mode drives arbitrary domains, so common benign aborts
+        # (integration already set up) must point the caller at the
+        # existing entry rather than surface as a bare failure.
+        client = AsyncMock()
+        initial_step = {
+            "type": "abort",
+            "flow_id": "dup-flow",
+            "reason": reason,
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=client,
+                flow_id="dup-flow",
+                initial_step=initial_step,
+                config={},
+                helper_type="sun",
+            )
+
+        body = _parse_tool_error(exc_info.value)
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert reason in body["error"]["message"]
+        assert "already set up" in body["error"].get("suggestion", "")

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -584,3 +584,113 @@ class TestSubmitStep:
 
         assert exc_info.value is err
         assert exc_info.value.status_code == 500
+
+
+class TestAllKeysIgnoredIsAnError:
+    """When NONE of the supplied config keys match any step's schema, the
+    walker must raise instead of reporting a misleading "updated
+    successfully" — the flow completed on empty forms (defaults), applying
+    nothing the caller asked for. Partial consumption keeps the established
+    success + warnings contract (covered above).
+    """
+
+    async def test_all_supplied_keys_ignored_raises(self) -> None:
+        import json
+
+        from fastmcp.exceptions import ToolError
+
+        final_entry = {"type": "create_entry", "result": {"entry_id": "e1"}}
+        submit_fn = AsyncMock(side_effect=[final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-typo",
+            "step_id": "init",
+            "data_schema": [{"name": "hide_members"}, {"name": "entities"}],
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=None,
+                flow_id="flow-typo",
+                initial_step=initial_step,
+                config={"typo_key": 5, "another_typo": True},
+                submit_fn=submit_fn,
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "without consuming any" in body["error"]["message"]
+        assert body.get("supplied_keys") == ["another_typo", "typo_key"]
+        # The empty form WAS submitted (single-step flows commit before the
+        # mismatch is knowable) — the error is about the outcome contract.
+        submit_fn.assert_awaited_once()
+        assert submit_fn.await_args.args[1] == {}
+
+    async def test_empty_config_still_succeeds(self) -> None:
+        # config={} supplies nothing, so nothing was ignored — deliberate
+        # empty submits (confirm-only flows) must keep working.
+        final_entry = {"type": "create_entry", "result": {"entry_id": "e1"}}
+        submit_fn = AsyncMock(side_effect=[final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-confirm",
+            "step_id": "confirm",
+            "data_schema": [],
+        }
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-confirm",
+            initial_step=initial_step,
+            config={},
+            submit_fn=submit_fn,
+        )
+
+        assert result["success"] is True
+        assert "warnings" not in result
+
+    async def test_menu_only_selection_still_succeeds(self) -> None:
+        # A caller whose config is JUST a menu selection consumed by a menu
+        # step supplied no form keys — that's a complete, valid intent.
+        final_entry = {"type": "create_entry", "result": {"entry_id": "e1"}}
+        submit_fn = AsyncMock(side_effect=[final_entry])
+        initial_step = {
+            "type": "menu",
+            "flow_id": "flow-menu",
+            "step_id": "user",
+            "menu_options": ["light", "switch"],
+        }
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-menu",
+            initial_step=initial_step,
+            config={"group_type": "light"},
+            submit_fn=submit_fn,
+        )
+
+        assert result["success"] is True
+        assert submit_fn.await_args.args[1] == {"next_step_id": "light"}
+
+    async def test_instant_create_entry_keeps_success_with_warning(self) -> None:
+        # Flows that complete with NO form step (instant creates — the mock
+        # shape used across test_helper_update_persistence, and real
+        # confirm-less integrations) had no form for the keys to match, so
+        # the established success + ignored-keys warning contract holds.
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-instant",
+            initial_step={
+                "type": "create_entry",
+                "flow_id": "flow-instant",
+                "result": {"entry_id": "e1"},
+            },
+            config={"name": "x", "source": "sensor.a"},
+            submit_fn=AsyncMock(),
+        )
+
+        assert result["success"] is True
+        assert result["warnings"] == [
+            "Ignored config keys not declared by the Home Assistant flow "
+            "schema: name, source"
+        ]

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -885,7 +885,7 @@ class TestFlowHelperDirectGuard:
 #      would reach the destructive backend call on every routing path
 #      (simple-helper WS delete, flow-helper entry-resolution, direct
 #      config-entry delete). Single up-front guard closes all three.
-#   2. ``ha_set_integration_enabled`` — empty/whitespace ``entry_id`` would
+#   2. ``ha_set_integration`` — empty/whitespace ``entry_id`` would
 #      reach the ``config_entries/disable`` WS message and surface as a
 #      misleading HA "config entry not found".
 
@@ -921,15 +921,26 @@ class TestIntegrationsIdentifierValidation:
         tools._client.delete_config_entry.assert_not_called()
 
     @pytest.mark.parametrize("bad", ["", "   "])
-    async def test_set_integration_enabled_rejects_empty_entry_id(self, tools, bad):
+    async def test_set_integration_rejects_empty_entry_id(self, tools, bad):
         # ``entry_id`` is passed straight into ``config_entries/disable``;
         # without the guard, ``entry_id=""`` would surface as a misleading
         # HA "config entry not found".
         with pytest.raises(ToolError) as excinfo:
-            await tools.ha_set_integration_enabled(entry_id=bad, enabled=False)
+            await tools.ha_set_integration(entry_id=bad, enabled=False)
         _assert_invalid_param(excinfo)
         assert '"parameter": "entry_id"' in str(excinfo.value), str(excinfo.value)
         tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    async def test_set_integration_rejects_empty_domain(self, tools, bad):
+        # ``domain`` is passed straight into ``start_config_flow``; without
+        # the guard, ``domain=""`` would surface as a misleading HA
+        # "Invalid handler specified".
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_set_integration(domain=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "domain"' in str(excinfo.value), str(excinfo.value)
+        tools._client.start_config_flow.assert_not_called()
 
 
 # --- tools_calendar.py (Round-4 sibling sweep) ---------------------------

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1818,3 +1818,132 @@ class TestIncludeKnxProject:
 
         assert result.get("warnings")
         assert any("include_knx_project" in w for w in result["warnings"])
+
+
+class TestSetIntegrationModes:
+    """Unit tests for ha_set_integration mode routing (issue #1814).
+
+    The three modes — enable/disable, add (config flow), update options
+    (options flow) — are mutually exclusive; the flow drivers themselves
+    are covered by test_flow_error_parsing and the e2e suite, so these
+    tests pin only the routing and parameter-validation layer.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": {"require_restart": False}}
+        )
+        client.start_config_flow = AsyncMock()
+        client.start_options_flow = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def tools(self, mock_client):
+        return IntegrationTools(mock_client)
+
+    async def _assert_invalid(self, coro, fragment: str):
+        with pytest.raises(ToolError) as exc_info:
+            await coro
+        err = json.loads(str(exc_info.value))
+        assert err["success"] is False
+        assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert fragment in err["error"]["message"], err["error"]["message"]
+
+    # === Mutual exclusion ===
+
+    async def test_domain_and_entry_id_rejected(self, tools, mock_client):
+        await self._assert_invalid(
+            tools.ha_set_integration(entry_id="abc", domain="hue"),
+            "not both",
+        )
+        mock_client.start_config_flow.assert_not_called()
+        mock_client.send_websocket_message.assert_not_called()
+
+    async def test_enabled_and_domain_rejected(self, tools, mock_client):
+        await self._assert_invalid(
+            tools.ha_set_integration(domain="hue", enabled=True),
+            "mutually exclusive",
+        )
+        mock_client.start_config_flow.assert_not_called()
+
+    async def test_enabled_and_config_rejected(self, tools, mock_client):
+        await self._assert_invalid(
+            tools.ha_set_integration(entry_id="abc", enabled=True, config={"x": 1}),
+            "mutually exclusive",
+        )
+        mock_client.send_websocket_message.assert_not_called()
+        mock_client.start_options_flow.assert_not_called()
+
+    # === Nothing-to-do guards ===
+
+    async def test_no_arguments_rejected(self, tools):
+        await self._assert_invalid(tools.ha_set_integration(), "Nothing to do")
+
+    async def test_entry_id_alone_rejected(self, tools):
+        await self._assert_invalid(
+            tools.ha_set_integration(entry_id="abc"), "Nothing to do"
+        )
+
+    # === Mode delegation ===
+
+    async def test_add_mode_delegates_to_create_config_entry(self, tools, mock_client):
+        sentinel = {"success": True, "entry_id": "new123", "domain": "workday"}
+        with patch(
+            "ha_mcp.tools.tools_integrations.create_config_entry",
+            new=AsyncMock(return_value=sentinel),
+        ) as create_mock:
+            result = await tools.ha_set_integration(
+                domain="workday", config={"name": "Workday"}
+            )
+        create_mock.assert_awaited_once_with(
+            mock_client, "workday", {"name": "Workday"}
+        )
+        assert result is sentinel
+
+    async def test_add_mode_defaults_config_to_empty_dict(self, tools, mock_client):
+        with patch(
+            "ha_mcp.tools.tools_integrations.create_config_entry",
+            new=AsyncMock(return_value={"success": True}),
+        ) as create_mock:
+            await tools.ha_set_integration(domain="sun")
+        create_mock.assert_awaited_once_with(mock_client, "sun", {})
+
+    async def test_options_mode_delegates_to_update_config_entry_options(
+        self, tools, mock_client
+    ):
+        sentinel = {"success": True, "entry_id": "abc", "updated": True}
+        with patch(
+            "ha_mcp.tools.tools_integrations.update_config_entry_options",
+            new=AsyncMock(return_value=sentinel),
+        ) as update_mock:
+            result = await tools.ha_set_integration(
+                entry_id="abc", config={"scan_interval": 30}
+            )
+        update_mock.assert_awaited_once_with(mock_client, "abc", {"scan_interval": 30})
+        assert result is sentinel
+
+    async def test_enable_disable_mode_still_works(self, tools, mock_client):
+        result = await tools.ha_set_integration(entry_id="abc", enabled=False)
+        assert result["success"] is True
+        assert result["entry_id"] == "abc"
+        assert result["require_restart"] is False
+        mock_client.send_websocket_message.assert_awaited_once_with(
+            {
+                "type": "config_entries/disable",
+                "entry_id": "abc",
+                "disabled_by": "user",
+            }
+        )
+
+    async def test_enable_mode_sends_disabled_by_none(self, tools, mock_client):
+        result = await tools.ha_set_integration(entry_id="abc", enabled=True)
+        assert result["success"] is True
+        mock_client.send_websocket_message.assert_awaited_once_with(
+            {
+                "type": "config_entries/disable",
+                "entry_id": "abc",
+                "disabled_by": None,
+            }
+        )

--- a/tests/src/unit/test_tools_integrations.py
+++ b/tests/src/unit/test_tools_integrations.py
@@ -1845,7 +1845,7 @@ class TestSetIntegrationModes:
 
     async def _assert_invalid(self, coro, fragment: str):
         with pytest.raises(ToolError) as exc_info:
-            await coro
+            _ = await coro
         err = json.loads(str(exc_info.value))
         assert err["success"] is False
         assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"


### PR DESCRIPTION
## What does this PR do?

Renames `ha_set_integration_enabled` to `ha_set_integration` and folds in the two gaps from #1814: adding an integration (`domain` + `config` drives the domain's config flow — menus and multi-step forms — through the same generic flow driver that powers `ha_config_set_helper`, with no helper-domain allowlist) and editing an existing entry's options (`entry_id` + `config` drives the options flow). Enable/disable stays as `entry_id` + `enabled`; the three modes are mutually exclusive with structured validation errors.

Per the issue's design notes, external (browser/OAuth) and progress steps now surface as structured errors instead of `INTERNAL_UNEXPECTED`, and the existing validation-error contract (step `data_schema` returned for self-correction) carries over unchanged. Also fixes the stale policy value-source registry key (pointed at a nonexistent `args.entity_id` path) by mapping `args.entry_id` to a new `ha_config_entries` source.

Post-review hardening: a flow that presents form steps but consumes none of the supplied config keys now raises `VALIDATION_INVALID_PARAMETER` instead of reporting "updated successfully" over empty-form defaults (shared walker — `ha_config_set_helper` gets the same contract; partial matches and zero-form instant creates keep success + warnings), and benign aborts (`already_configured` / `single_instance_allowed`) carry an existing-entry hint.

Closes #1814

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed