### PR TITLE
fix: preserve malformed JSON decoder details

### DIFF
--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -142,15 +142,21 @@ def parse_json_param(
 def _loads_if_json_container_str(value: Any) -> Any:
     """Parse a JSON-encoded object/array string into its container value.
 
-    Anything that isn't a string encoding a JSON object or array passes
-    through unchanged, so Pydantic still raises dict_type/list_type for
-    genuinely-malformed input (which ValidationErrorMiddleware rewrites
-    into an actionable message).
+    A string that starts like an object or array but contains malformed JSON
+    raises with the decoder location so ValidationErrorMiddleware can return
+    an actionable error. Other strings pass through unchanged, leaving
+    Pydantic to report the expected parameter type.
     """
     if isinstance(value, str):
         try:
             parsed = json.loads(value)
-        except (ValueError, RecursionError):
+        except json.JSONDecodeError as exc:
+            if value.lstrip().startswith(("{", "[")):
+                raise ValueError(
+                    f"Invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}"
+                ) from exc
+            return value
+        except RecursionError:
             # RecursionError (deeply-nested input) must not escape: Pydantic
             # only converts ValueError/AssertionError into ValidationError.
             return value

--- a/tests/src/unit/test_json_string_param_coercion.py
+++ b/tests/src/unit/test_json_string_param_coercion.py
@@ -127,6 +127,27 @@ def test_dict_param_rejects_unparseable_string(
 
 
 @pytest.mark.parametrize(
+    ("malformed", "detail"),
+    [
+        ('{"alias": "Test",}', "line 1 column 17"),
+        ("  [1, 2,]", "line 1 column 8"),
+    ],
+)
+def test_json_like_malformed_string_preserves_decode_location(malformed, detail):
+    """Malformed container JSON reports its parse location instead of dict_type."""
+    module, register_fn, tool_name, param_name = _DICT_PARAMS[0]
+    ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
+
+    with pytest.raises(ValidationError) as exc_info:
+        TypeAdapter(ann).validate_python(malformed)
+
+    error = exc_info.value.errors(include_url=False)[0]
+    assert error["type"] == "value_error"
+    assert "Invalid JSON" in error["msg"]
+    assert detail in error["msg"]
+
+
+@pytest.mark.parametrize(
     ("module", "register_fn", "tool_name", "param_name"),
     _DICT_PARAMS,
 )

--- a/tests/src/unit/test_validation_middleware.py
+++ b/tests/src/unit/test_validation_middleware.py
@@ -93,6 +93,31 @@ async def test_string_for_list_gives_actionable_message():
 
 
 @pytest.mark.asyncio
+async def test_malformed_json_container_preserves_decoder_location():
+    """JSON-like strings retain the decoder detail through FastMCP middleware."""
+    from typing import Annotated
+
+    from ha_mcp.tools.util_helpers import JSON_STRING_COERCION
+
+    mcp = FastMCP("test")
+    mcp.add_middleware(ValidationErrorMiddleware())
+
+    @mcp.tool()
+    async def ha_test_coerced_dict(
+        config: Annotated[dict, JSON_STRING_COERCION],
+    ) -> dict:
+        return {"ok": True}
+
+    with pytest.raises(ToolError) as exc_info:
+        await mcp.call_tool("ha_test_coerced_dict", {"config": '{"key": }'})
+
+    msg = json.loads(str(exc_info.value))["error"]["message"]
+    assert "config" in msg
+    assert "Invalid JSON" in msg
+    assert "line 1 column 9" in msg
+
+
+@pytest.mark.asyncio
 async def test_multiple_type_errors_are_joined():
     """Multiple bad params surface together, joined by ';'."""
     mcp = _make_mcp()


### PR DESCRIPTION
## Summary

- preserve `JSONDecodeError` line, column, and reason for malformed object/array strings
- keep ordinary non-JSON strings and deeply nested inputs on the existing validation path
- verify detailed errors survive FastMCP validation middleware without changing advertised MCP schemas

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest tests/src/unit/test_json_string_param_coercion.py tests/src/unit/test_validation_middleware.py tests/src/unit/test_config_param_no_string_schema.py -q --tb=short` (83 passed)
- The same commit passed all GitHub E2E and HAOS E2E variants before this PR was recreated; the new PR checks will rerun independently.