### PR TITLE
Add GitHub Action to request @codex review on new PRs or comment trigger

### DIFF
--- a/.github/workflows/pr-codex-review-request.yml
+++ b/.github/workflows/pr-codex-review-request.yml
@@ -1,0 +1,44 @@
+name: Request Codex PR Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  request-codex-review:
+    name: Comment @codex review
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == '/review' || github.event.comment.body == '@ghhamcp review')) }}
+    steps:
+      - name: Ensure comment token is configured
+        env:
+          GH_TOKEN_CODEX_COMMENT: ${{ secrets.GH_TOKEN_CODEX_COMMENT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN_CODEX_COMMENT:-}" ]]; then
+            echo '::error::GH_TOKEN_CODEX_COMMENT secret is not configured.'
+            exit 1
+          fi
+
+      - name: Post Codex review request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN_CODEX_COMMENT }}
+          script: |
+            const issueNumber = context.eventName === 'pull_request_target'
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: '@codex review',
+            });


### PR DESCRIPTION
### Motivation
- Add an automated workflow to notify the Codex reviewer by posting `@codex review` when a pull request is opened or when a maintainer posts a review trigger comment.  

### Description
- Introduce `.github/workflows/pr-codex-review-request.yml` which triggers on `pull_request_target` (opened, ready_for_review) and `issue_comment` (created) and posts `@codex review` to the PR when triggered, requiring the `GH_TOKEN_CODEX_COMMENT` secret and using `actions/github-script@v7`.  

### Testing
- No automated tests were run for this workflow addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52edd821ec832cb8b984b48ab418fa)