### PR TITLE
fix: make demo server setup self-healing

### DIFF
--- a/tests/lab-setup/README.md
+++ b/tests/lab-setup/README.md
@@ -36,8 +36,8 @@ The setup script is **idempotent** (safe to re-run) and performs:
 2. **Packages** — Installs curl, git, ca-certificates, gnupg
 3. **Docker** — Via official get.docker.com script
 4. **uv** — Python package manager for running ha-mcp
-5. **ha-mcp repo** — Clones to `~/ha-mcp` (or pulls if it already exists)
-6. **Systemd service** — Creates `hamcp-demo.service` (starts on boot, exits+restarts if HA container dies) and two timers: `hamcp-demo-reset.timer` (daily at 19:00 UTC: fresh HA restart, 2h before nightly CI check) and `hamcp-demo-update.timer` (daily at 03:00 UTC: git pull, docker image prune, service restart)
+5. **ha-mcp repo** — Clones to `~/ha-mcp`, pulls an existing checkout, or safely replaces an incomplete checkout left by an interrupted deployment
+6. **Systemd service** — Removes legacy user/root cron deployments, then creates `hamcp-demo.service` (starts on boot, exits+restarts if HA container dies) and two timers: `hamcp-demo-reset.timer` (daily at 19:00 UTC: fresh HA restart, 2h before nightly CI check) and `hamcp-demo-update.timer` (daily at 03:00 UTC: git pull, docker image prune, service restart)
 7. **Caddy** — Reverse proxy with automatic Let's Encrypt TLS for your domain
 8. **Unattended upgrades** — Auto-updates OS packages, reboots at 4am if needed
 9. **Container cleanup** — Removes stale HA containers and any leaked processes

--- a/tests/lab-setup/setup-ha-mcp.sh
+++ b/tests/lab-setup/setup-ha-mcp.sh
@@ -20,6 +20,28 @@ info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
+remove_legacy_cron_entries() {
+    local owner="$1"
+    local current filtered
+
+    current=$(crontab -u "$owner" -l 2>/dev/null || true)
+    [[ -z "$current" ]] && return
+
+    # Remove both generations of the old cron deployment: the original direct
+    # hamcp-test-env invocation and the later destructive re-clone job. The
+    # latter predates systemd and deletes the live checkout before setup runs.
+    filtered=$(printf '%s\n' "$current" | grep -Ev \
+        'hamcp-test-env|ha-mcp-cron\.log|rm -rf (ha-mcp/?|[^ ]*/ha-mcp/?)' || true)
+    if [[ "$filtered" != "$current" ]]; then
+        info "Removing legacy ha-mcp cron entries for $owner..."
+        if [[ -n "$filtered" ]]; then
+            printf '%s\n' "$filtered" | crontab -u "$owner" -
+        else
+            crontab -u "$owner" -r 2>/dev/null || true
+        fi
+    fi
+}
+
 #=============================================================================
 [[ $EUID -ne 0 ]] && error "Run as root: sudo $0 [domain]"
 [[ "$SETUP_USER" == "root" ]] && error "Do not run as root directly. Use: sudo $0 [domain]\nIf calling from a root cron job, set: SUDO_USER=youruser $0 [domain]"
@@ -74,22 +96,28 @@ fi
 
 #=============================================================================
 # 5. HA-MCP REPO
-if [[ ! -d "$SETUP_HOME/ha-mcp" ]]; then
+if [[ -e "$SETUP_HOME/ha-mcp" && ! -d "$SETUP_HOME/ha-mcp/.git" ]]; then
+    BROKEN_REPO="$SETUP_HOME/ha-mcp.incomplete.$(date +%Y%m%d%H%M%S)"
+    warn "$SETUP_HOME/ha-mcp is not a git checkout; moving it to $BROKEN_REPO"
+    mv "$SETUP_HOME/ha-mcp" "$BROKEN_REPO"
+fi
+
+if [[ ! -d "$SETUP_HOME/ha-mcp/.git" ]]; then
     info "Cloning ha-mcp..."
     sudo -u "$SETUP_USER" git clone https://github.com/homeassistant-ai/ha-mcp "$SETUP_HOME/ha-mcp"
 else
     info "ha-mcp repo exists, pulling latest..."
-    sudo -u "$SETUP_USER" git -C "$SETUP_HOME/ha-mcp" pull --ff-only || true
+    sudo -u "$SETUP_USER" git -C "$SETUP_HOME/ha-mcp" pull --ff-only
 fi
 
 #=============================================================================
 # 6. SYSTEMD SERVICE (replaces cron - ensures only one instance runs, auto-restarts)
 info "Setting up systemd service..."
 
-# Remove old cron entries if they exist (migration from cron-based setup)
-if sudo -u "$SETUP_USER" crontab -l 2>/dev/null | grep -q "hamcp-test-env"; then
-    sudo -u "$SETUP_USER" crontab -l 2>/dev/null | { grep -v "hamcp-test-env" || true; } | sudo -u "$SETUP_USER" crontab -
-fi
+# Remove old cron entries for both the configured user and root. Some early
+# installs placed a destructive nightly re-clone in root's crontab.
+remove_legacy_cron_entries "$SETUP_USER"
+[[ "$SETUP_USER" != "root" ]] && remove_legacy_cron_entries root
 
 cat > /etc/systemd/system/hamcp-demo.service << SVCEOF
 [Unit]

--- a/tests/lab-setup/setup-ha-mcp.sh
+++ b/tests/lab-setup/setup-ha-mcp.sh
@@ -31,7 +31,7 @@ remove_legacy_cron_entries() {
     # hamcp-test-env invocation and the later destructive re-clone job. The
     # latter predates systemd and deletes the live checkout before setup runs.
     filtered=$(printf '%s\n' "$current" | grep -Ev \
-        'hamcp-test-env|ha-mcp-cron\.log|rm -rf (ha-mcp/?|[^ ]*/ha-mcp/?)' || true)
+        'hamcp-test-env|ha-mcp-cron\.log|rm -rf (ha-mcp|[^ ]*/ha-mcp)/?([[:space:]]|$)' || true)
     if [[ "$filtered" != "$current" ]]; then
         info "Removing legacy ha-mcp cron entries for $owner..."
         if [[ -n "$filtered" ]]; then
@@ -96,7 +96,7 @@ fi
 
 #=============================================================================
 # 5. HA-MCP REPO
-if [[ -e "$SETUP_HOME/ha-mcp" && ! -d "$SETUP_HOME/ha-mcp/.git" ]]; then
+if [[ ( -e "$SETUP_HOME/ha-mcp" || -L "$SETUP_HOME/ha-mcp" ) && ! -d "$SETUP_HOME/ha-mcp/.git" ]]; then
     BROKEN_REPO="$SETUP_HOME/ha-mcp.incomplete.$(date +%Y%m%d%H%M%S)"
     warn "$SETUP_HOME/ha-mcp is not a git checkout; moving it to $BROKEN_REPO"
     mv "$SETUP_HOME/ha-mcp" "$BROKEN_REPO"

--- a/tests/lab-setup/test_setup_script.py
+++ b/tests/lab-setup/test_setup_script.py
@@ -1,0 +1,22 @@
+"""Regression tests for the demo-server setup script."""
+
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("setup-ha-mcp.sh")
+
+
+def test_setup_recovers_incomplete_checkout() -> None:
+    content = SCRIPT.read_text()
+
+    assert '[[ -e "$SETUP_HOME/ha-mcp" && ! -d "$SETUP_HOME/ha-mcp/.git" ]]' in content
+    assert 'mv "$SETUP_HOME/ha-mcp" "$BROKEN_REPO"' in content
+    assert 'git -C "$SETUP_HOME/ha-mcp" pull --ff-only || true' not in content
+
+
+def test_setup_removes_all_legacy_cron_variants() -> None:
+    content = SCRIPT.read_text()
+
+    assert 'remove_legacy_cron_entries "$SETUP_USER"' in content
+    assert "remove_legacy_cron_entries root" in content
+    assert "ha-mcp-cron\\.log" in content
+    assert "hamcp-test-env" in content

--- a/tests/lab-setup/test_setup_script.py
+++ b/tests/lab-setup/test_setup_script.py
@@ -8,7 +8,8 @@ SCRIPT = Path(__file__).with_name("setup-ha-mcp.sh")
 def test_setup_recovers_incomplete_checkout() -> None:
     content = SCRIPT.read_text()
 
-    assert '[[ -e "$SETUP_HOME/ha-mcp" && ! -d "$SETUP_HOME/ha-mcp/.git" ]]' in content
+    assert '-L "$SETUP_HOME/ha-mcp"' in content
+    assert '! -d "$SETUP_HOME/ha-mcp/.git"' in content
     assert 'mv "$SETUP_HOME/ha-mcp" "$BROKEN_REPO"' in content
     assert 'git -C "$SETUP_HOME/ha-mcp" pull --ff-only || true' not in content
 
@@ -20,3 +21,4 @@ def test_setup_removes_all_legacy_cron_variants() -> None:
     assert "remove_legacy_cron_entries root" in content
     assert "ha-mcp-cron\\.log" in content
     assert "hamcp-test-env" in content
+    assert "(ha-mcp|[^ ]*/ha-mcp)/?([[:space:]]|$)" in content


### PR DESCRIPTION
## Summary

- remove both legacy user and root cron deployment variants, including the destructive nightly re-clone job
- detect and preserve incomplete `ha-mcp` directories before cloning a fresh checkout
- stop masking `git pull --ff-only` failures
- document recovery behavior and add regression coverage

## Root cause

An old root cron job survived the cron-to-systemd migration because cleanup only matched `hamcp-test-env`. The legacy job deleted the live checkout before rebuilding it. When reconstruction was interrupted, only `.venv` remained; setup treated the directory as valid and ignored the failed `git pull`, leaving systemd in a restart loop.

## Validation

- `bash -n tests/lab-setup/setup-ha-mcp.sh`
- `uv run pytest tests/lab-setup/test_setup_script.py -q`
- `uv run ruff check tests/lab-setup/test_setup_script.py`
- deployed recovery script to the demo VM and confirmed authenticated Home Assistant API HTTP 200
- reran failed Test Installer Scripts workflow successfully