### PR TITLE
ci: avoid duplicate Codex reviews

### DIFF
--- a/.github/workflows/pr-codex-review-request.yml
+++ b/.github/workflows/pr-codex-review-request.yml
@@ -32,9 +32,32 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN_CODEX_COMMENT }}
           script: |
+            const pullRequest = context.payload.pull_request;
             const issueNumber = context.eventName === 'pull_request_target'
-              ? context.payload.pull_request.number
+              ? pullRequest.number
               : context.payload.issue.number;
+
+            if (context.payload.action === 'ready_for_review') {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100,
+                },
+              );
+              const headSha = pullRequest.head.sha;
+              const alreadyReviewed = comments.some(comment =>
+                comment.user?.login === 'chatgpt-codex-connector[bot]' &&
+                comment.body?.includes(headSha)
+              );
+
+              if (alreadyReviewed) {
+                core.info(`Codex already reviewed head commit ${headSha}; skipping duplicate request.`);
+                return;
+              }
+            }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## What changed

- Check completed Codex review comments when a pull request becomes ready for review.
- Skip posting another `@codex review` request when the Codex bot already reviewed the current head commit.

## Why

Opening a pull request and later marking it ready could request two Codex reviews for the same commit. The ready-for-review event now avoids that duplicate while still requesting a new review when the head SHA changed.

## Validation

- `git diff --check`
- Parsed the workflow with PyYAML.
